### PR TITLE
[8.x] fetch-mock upgrade to 10.1.0 version (#208702)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1763,7 +1763,7 @@
     "expose-loader": "^0.7.5",
     "express": "^4.21.2",
     "faker": "^5.1.0",
-    "fetch-mock": "^7.3.9",
+    "fetch-mock": "^10.1.0",
     "file-loader": "^4.2.0",
     "find-cypress-specs": "^1.41.4",
     "form-data": "^4.0.0",

--- a/src/core/packages/http/browser-internal/src/fetch.test.ts
+++ b/src/core/packages/http/browser-internal/src/fetch.test.ts
@@ -7,8 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// @ts-expect-error
-import fetchMock from 'fetch-mock/es5/client';
+import fetchMock from 'fetch-mock';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { first } from 'rxjs';
@@ -215,7 +214,7 @@ describe('Fetch', () => {
         headers: { myHeader: 'foo' },
       });
 
-      expect(fetchMock.lastOptions()!.headers['kbn-system-request']).toBeUndefined();
+      expect(fetchMock.lastOptions()!.headers?.['kbn-system-request']).toBeUndefined();
     });
 
     it('should not set kbn-system-request header when asSystemRequest: false', async () => {
@@ -225,7 +224,7 @@ describe('Fetch', () => {
         asSystemRequest: false,
       });
 
-      expect(fetchMock.lastOptions()!.headers['kbn-system-request']).toBeUndefined();
+      expect(fetchMock.lastOptions()!.headers?.['kbn-system-request']).toBeUndefined();
     });
 
     it('should set kbn-system-request header when asSystemRequest: true', async () => {
@@ -338,7 +337,7 @@ describe('Fetch', () => {
 
       const lastCall = fetchMock.lastCall();
 
-      expect(lastCall!.request.credentials).toBe('same-origin');
+      expect(lastCall!.request!.credentials).toBe('same-origin');
       expect(lastCall![1]).toMatchObject({
         method: 'GET',
         headers: {
@@ -754,7 +753,7 @@ describe('Fetch', () => {
       expect(createRequest.mock.calls[0][0].path).toContain('/my/route');
       expect(createRequest.mock.calls[1][0].path).toContain('/api/alpha');
       expect(createRequest.mock.calls[2][0].path).toContain('/api/beta');
-      expect(fetchMock.lastCall()!.request.url).toContain('/api/gamma');
+      expect(fetchMock.lastCall()!.request!.url).toContain('/api/gamma');
     });
 
     it('should accumulate response information', async () => {

--- a/src/core/packages/http/browser-internal/src/http_service.test.ts
+++ b/src/core/packages/http/browser-internal/src/http_service.test.ts
@@ -8,8 +8,7 @@
  */
 
 import { Observable } from 'rxjs';
-// @ts-expect-error
-import fetchMock from 'fetch-mock/es5/client';
+import fetchMock from 'fetch-mock';
 
 import { loadingServiceMock } from './http_service.test.mocks';
 import { executionContextServiceMock } from '@kbn/core-execution-context-browser-mocks';

--- a/src/core/packages/ui-settings/browser-internal/src/__snapshots__/ui_settings_api.test.ts.snap
+++ b/src/core/packages/ui-settings/browser-internal/src/__snapshots__/ui_settings_api.test.ts.snap
@@ -5,6 +5,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -17,6 +18,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -34,6 +36,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -46,6 +49,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -63,6 +67,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -75,6 +80,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -115,6 +121,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -132,6 +139,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/global_settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -144,6 +152,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/global_settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -161,6 +170,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/global_settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -173,6 +183,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/global_settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -190,6 +201,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/global_settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -202,6 +214,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/global_settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -242,6 +255,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/global_settings",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",
@@ -265,6 +279,7 @@ Array [
   Array [
     "/foo/bar/internal/kibana/settings/foo/validate",
     Object {
+      "body": Promise {},
       "headers": Object {
         "accept": "application/json",
         "content-type": "application/json",

--- a/src/core/packages/ui-settings/browser-internal/src/ui_settings_api.test.ts
+++ b/src/core/packages/ui-settings/browser-internal/src/ui_settings_api.test.ts
@@ -7,8 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// @ts-expect-error
-import fetchMock from 'fetch-mock/es5/client';
+import fetchMock from 'fetch-mock';
 import * as Rx from 'rxjs';
 import { takeUntil, toArray } from 'rxjs';
 

--- a/src/platform/plugins/shared/newsfeed/public/lib/driver.test.ts
+++ b/src/platform/plugins/shared/newsfeed/public/lib/driver.test.ts
@@ -8,8 +8,8 @@
  */
 
 import { convertItemsMock } from './driver.test.mocks';
-// @ts-expect-error
-import fetchMock from 'fetch-mock/es5/client';
+
+import fetchMock from 'fetch-mock';
 import { take } from 'rxjs';
 import { NewsfeedApiDriver } from './driver';
 import { storageMock } from './storage.mock';
@@ -67,9 +67,12 @@ describe('NewsfeedApiDriver', () => {
         .toPromise();
 
       expect(fetchMock.lastUrl()).toEqual('http://newsfeed.com/8.0.0/news');
-      expect(fetchMock.lastOptions()).toEqual({
-        method: 'GET',
-      });
+      expect(fetchMock.lastOptions()).toMatchInlineSnapshot(`
+        Object {
+          "body": Promise {},
+          "method": "GET",
+        }
+      `);
     });
 
     it('calls `convertItems` with the correct parameters', async () => {

--- a/x-pack/platform/plugins/shared/security/public/session/unauthorized_response_http_interceptor.test.ts
+++ b/x-pack/platform/plugins/shared/security/public/session/unauthorized_response_http_interceptor.test.ts
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-// @ts-ignore
-import fetchMock from 'fetch-mock/es5/client';
+import fetchMock from 'fetch-mock';
 
 import type { HttpSetup } from '@kbn/core/public';
 import { applicationServiceMock } from '@kbn/core/public/mocks';

--- a/yarn.lock
+++ b/yarn.lock
@@ -14275,15 +14275,6 @@ babel-plugin-transform-typescript-metadata@^0.3.2:
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-babel-polyfill@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    regenerator-runtime "^0.10.5"
-
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.0.tgz#cf5feef29551253471cfa82fc8e0f5063df07a77"
@@ -14310,7 +14301,7 @@ babel-preset-jest@^29.6.3:
     babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
 
-babel-runtime@6.x, babel-runtime@^6.26.0:
+babel-runtime@6.x:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
@@ -16002,7 +15993,7 @@ core-js-pure@^3.8.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.0.tgz#7ad8a5dd7d910756f3124374b50026e23265ca9a"
   integrity sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.9:
+core-js@^2.4.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -19092,16 +19083,16 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
-fetch-mock@^7.3.9:
-  version "7.3.9"
-  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.3.9.tgz#a80fd2a1728f72e0634ef7a9734bc61200096487"
-  integrity sha512-PgsTbiQBNapFz2P2UwDl3gowK3nZqfV4HdyDZ1dI4eTGGH9MLAeBglIPbyDbbNQoGYBOfla6/9uaiq7az2z4Aw==
+fetch-mock@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-10.1.0.tgz#b2cabb4f587eca747e395e97de28c62364f301fc"
+  integrity sha512-/2DFdUrn2afOifgXuq3ppTGOg/S8YAvjeEOlBJ4QgWiT24pYGozju3Hz5UQm1ynumY9hlzBHE2z0jd0PHD+fRg==
   dependencies:
-    babel-polyfill "^6.26.0"
-    core-js "^2.6.9"
-    glob-to-regexp "^0.4.0"
-    path-to-regexp "^2.2.1"
-    whatwg-url "^6.5.0"
+    debug "^4.1.1"
+    dequal "^2.0.3"
+    globrex "^0.1.2"
+    is-subset "^0.1.1"
+    regexparam "^3.0.0"
 
 fetch-retry@^5.0.2:
   version "5.0.3"
@@ -19967,7 +19958,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob-to-regexp@^0.4.0, glob-to-regexp@^0.4.1:
+glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
@@ -20145,6 +20136,11 @@ globjoin@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
+
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 gonzales-pe@^4.3.0:
   version "4.3.0"
@@ -26150,11 +26146,6 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
-path-to-regexp@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz"
-  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
-
 path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
@@ -28265,11 +28256,6 @@ regenerate@^1.4.0, regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
-
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
@@ -28314,6 +28300,11 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.4.3, regexp.prototype.f
     define-properties "^1.2.1"
     es-errors "^1.3.0"
     set-function-name "^2.0.1"
+
+regexparam@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/regexparam/-/regexparam-3.0.0.tgz#1673e09d41cb7fd41eaafd4040a6aa90daa0a21a"
+  integrity sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==
 
 regexpp@^3.0.0:
   version "3.2.0"
@@ -33197,15 +33188,6 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
-
-whatwg-url@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
-  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
 
 whatwg-url@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [fetch-mock upgrade to 10.1.0 version (#208702)](https://github.com/elastic/kibana/pull/208702)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
