### PR TITLE
[8.17] [APM] Missing items in the trace waterfall shouldn't break it entirely (#210210)

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/orphan_item_tooltip_icon.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/orphan_item_tooltip_icon.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiIcon, EuiToolTip } from '@elastic/eui';
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+
+interface Props {
+  docType: 'transaction' | 'span';
+}
+
+export function OrphanItemTooltipIcon({ docType }: Props) {
+  return (
+    <EuiToolTip
+      title={i18n.translate('xpack.apm.waterfallItem.euiToolTip.orphanLabel', {
+        defaultMessage: 'Orphan',
+      })}
+      content={i18n.translate('xpack.apm.waterfallItem.euiToolTip.orphanDescriotion', {
+        defaultMessage:
+          'This {type} was initially orphaned due to missing trace context but has been reparented to the root transaction to restore the execution flow',
+        values: { type: docType },
+      })}
+    >
+      <EuiIcon type="unlink" size="s" color="danger" />
+    </EuiToolTip>
+  );
+}

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -73,6 +73,7 @@ interface IWaterfallItemBase<TDocument, TDoctype> {
   duration: number;
   legendValues: Record<WaterfallLegendType, string>;
   spanLinksCount: SpanLinksCount;
+  isOrphan?: boolean;
 }
 
 export type IWaterfallError = Omit<
@@ -401,25 +402,27 @@ function getErrorCountByParentId(errorDocs: TraceAPIResponse['traceItems']['erro
   }, {});
 }
 
-export const getOrphanTraceItemsCount = (
-  traceDocs: Array<WaterfallTransaction | WaterfallSpan>
-) => {
-  const waterfallItemsIds = new Set(
-    traceDocs.map((doc) =>
-      doc.processor.event === 'span'
-        ? (doc?.span as WaterfallSpan['span']).id
-        : doc?.transaction?.id
-    )
-  );
+export function getOrphanItemsIds(waterfall: IWaterfallSpanOrTransaction[]) {
+  const waterfallItemsIds = new Set(waterfall.map((item) => item.id));
+  return waterfall
+    .filter((item) => item.parentId && !waterfallItemsIds.has(item.parentId))
+    .map((item) => item.id);
+}
 
-  let missingTraceItemsCounter = 0;
-  traceDocs.some((item) => {
-    if (item.parent?.id && !waterfallItemsIds.has(item.parent.id)) {
-      missingTraceItemsCounter++;
+export function reparentOrphanItems(
+  orphanItemsIds: string[],
+  waterfallItems: IWaterfallSpanOrTransaction[],
+  newParentId?: string
+) {
+  const orphanIdsMap = new Set(orphanItemsIds);
+  return waterfallItems.map((item) => {
+    if (orphanIdsMap.has(item.id)) {
+      item.parentId = newParentId;
+      item.isOrphan = true;
     }
+    return item;
   });
-  return missingTraceItemsCounter;
-};
+}
 
 export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
   const { traceItems, entryTransaction } = apiResponse;
@@ -446,11 +449,18 @@ export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
     traceItems.spanLinksCountById
   );
 
-  const childrenByParentId = getChildrenGroupedByParentId(reparentSpans(waterfallItems));
-
   const entryWaterfallTransaction = getEntryWaterfallTransaction(
     entryTransaction.transaction.id,
     waterfallItems
+  );
+
+  const orphanItemsIds = getOrphanItemsIds(waterfallItems);
+  const childrenByParentId = getChildrenGroupedByParentId(
+    reparentOrphanItems(
+      orphanItemsIds,
+      reparentSpans(waterfallItems),
+      entryWaterfallTransaction?.id
+    )
   );
 
   const items = getOrderedWaterfallItems(childrenByParentId, entryWaterfallTransaction);
@@ -460,8 +470,6 @@ export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
 
   const duration = getWaterfallDuration(items);
   const legends = getLegends(items);
-
-  const orphanTraceItemsCount = getOrphanTraceItemsCount(traceItems.traceDocs);
 
   return {
     entryWaterfallTransaction,
@@ -477,7 +485,7 @@ export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
     totalErrorsCount: traceItems.errorDocs.length,
     traceDocsTotal: traceItems.traceDocsTotal,
     maxTraceItems: traceItems.maxTraceItems,
-    orphanTraceItemsCount,
+    orphanTraceItemsCount: orphanItemsIds.length,
   };
 }
 

--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_item.tsx
@@ -22,6 +22,7 @@ import { IWaterfallSpanOrTransaction } from './waterfall_helpers/waterfall_helpe
 import { FailureBadge } from './failure_badge';
 import { useApmRouter } from '../../../../../../hooks/use_apm_router';
 import { useAnyOfApmParams } from '../../../../../../hooks/use_apm_params';
+import { OrphanItemTooltipIcon } from './orphan_item_tooltip_icon';
 
 type ItemType = 'transaction' | 'span' | 'error';
 
@@ -283,6 +284,7 @@ export function WaterfallItem({
         <SpanActionToolTip item={item}>
           <PrefixIcon item={item} />
         </SpanActionToolTip>
+        {item.isOrphan ? <OrphanItemTooltipIcon docType={item.docType} /> : null}
         <HttpStatusCode item={item} />
         <NameLabel item={item} />
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[APM] Missing items in the trace waterfall shouldn&#x27;t break it entirely (#210210)](https://github.com/elastic/kibana/pull/210210)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cauê Marcondes","email":"55978943+cauemarcondes@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-10T14:04:33Z","message":"[APM] Missing items in the trace waterfall shouldn't break it entirely (#210210)\n\ncloses https://github.com/elastic/kibana/issues/120464\r\n\r\nWhen orphan items are found, I am re-parenting them to the root\r\ntransaction and adding an indication.\r\n\r\nTest architecture:\r\nAPP_A -> APP_B -> APP_C\r\n\r\n`APP_B` is not instrumented with Elastic APM, so it is not available in\r\nthe trace, thus APP_C has a parent which is not available in the current\r\ntrace. `APP_C` is reparented to point to `APP_A`.\r\n\r\nBefore:\r\n<img width=\"1509\" alt=\"Screenshot 2025-02-07 at 12 55 06\"\r\nsrc=\"https://github.com/user-attachments/assets/a973fa5d-1acf-4fff-b525-01957490494e\"\r\n/>\r\n\r\n\r\nAfter [1]:\r\n<img width=\"1499\" alt=\"Screenshot 2025-02-07 at 12 03 34\"\r\nsrc=\"https://github.com/user-attachments/assets/8c49df04-de09-4d17-b6f8-f4b848e89f91\"\r\n/>\r\n\r\nAfter [2]:\r\n<img width=\"712\" alt=\"Screenshot 2025-02-07 at 11 35 28\"\r\nsrc=\"https://github.com/user-attachments/assets/2b62a7cf-5979-4636-bc05-c25c96e9d71b\"\r\n/>\r\n\r\n## How to test it:\r\n- Run synthtrace `distributed_trace.ts` scenario.\r\n- Find a trace.id\r\n- Remove one of the elements from the trace.","sha":"9bc9643e80d8b0dc7e2a81bf79c450446c16fcb7","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","backport:prev-major","Team:obs-ux-infra_services","v9.1.0"],"title":"[APM] Missing items in the trace waterfall shouldn't break it entirely","number":210210,"url":"https://github.com/elastic/kibana/pull/210210","mergeCommit":{"message":"[APM] Missing items in the trace waterfall shouldn't break it entirely (#210210)\n\ncloses https://github.com/elastic/kibana/issues/120464\r\n\r\nWhen orphan items are found, I am re-parenting them to the root\r\ntransaction and adding an indication.\r\n\r\nTest architecture:\r\nAPP_A -> APP_B -> APP_C\r\n\r\n`APP_B` is not instrumented with Elastic APM, so it is not available in\r\nthe trace, thus APP_C has a parent which is not available in the current\r\ntrace. `APP_C` is reparented to point to `APP_A`.\r\n\r\nBefore:\r\n<img width=\"1509\" alt=\"Screenshot 2025-02-07 at 12 55 06\"\r\nsrc=\"https://github.com/user-attachments/assets/a973fa5d-1acf-4fff-b525-01957490494e\"\r\n/>\r\n\r\n\r\nAfter [1]:\r\n<img width=\"1499\" alt=\"Screenshot 2025-02-07 at 12 03 34\"\r\nsrc=\"https://github.com/user-attachments/assets/8c49df04-de09-4d17-b6f8-f4b848e89f91\"\r\n/>\r\n\r\nAfter [2]:\r\n<img width=\"712\" alt=\"Screenshot 2025-02-07 at 11 35 28\"\r\nsrc=\"https://github.com/user-attachments/assets/2b62a7cf-5979-4636-bc05-c25c96e9d71b\"\r\n/>\r\n\r\n## How to test it:\r\n- Run synthtrace `distributed_trace.ts` scenario.\r\n- Find a trace.id\r\n- Remove one of the elements from the trace.","sha":"9bc9643e80d8b0dc7e2a81bf79c450446c16fcb7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210210","number":210210,"mergeCommit":{"message":"[APM] Missing items in the trace waterfall shouldn't break it entirely (#210210)\n\ncloses https://github.com/elastic/kibana/issues/120464\r\n\r\nWhen orphan items are found, I am re-parenting them to the root\r\ntransaction and adding an indication.\r\n\r\nTest architecture:\r\nAPP_A -> APP_B -> APP_C\r\n\r\n`APP_B` is not instrumented with Elastic APM, so it is not available in\r\nthe trace, thus APP_C has a parent which is not available in the current\r\ntrace. `APP_C` is reparented to point to `APP_A`.\r\n\r\nBefore:\r\n<img width=\"1509\" alt=\"Screenshot 2025-02-07 at 12 55 06\"\r\nsrc=\"https://github.com/user-attachments/assets/a973fa5d-1acf-4fff-b525-01957490494e\"\r\n/>\r\n\r\n\r\nAfter [1]:\r\n<img width=\"1499\" alt=\"Screenshot 2025-02-07 at 12 03 34\"\r\nsrc=\"https://github.com/user-attachments/assets/8c49df04-de09-4d17-b6f8-f4b848e89f91\"\r\n/>\r\n\r\nAfter [2]:\r\n<img width=\"712\" alt=\"Screenshot 2025-02-07 at 11 35 28\"\r\nsrc=\"https://github.com/user-attachments/assets/2b62a7cf-5979-4636-bc05-c25c96e9d71b\"\r\n/>\r\n\r\n## How to test it:\r\n- Run synthtrace `distributed_trace.ts` scenario.\r\n- Find a trace.id\r\n- Remove one of the elements from the trace.","sha":"9bc9643e80d8b0dc7e2a81bf79c450446c16fcb7"}},{"url":"https://github.com/elastic/kibana/pull/210390","number":210390,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/210391","number":210391,"branch":"8.x","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/210393","number":210393,"branch":"9.0","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/210395","number":210395,"branch":"8.16","state":"OPEN"}]}] BACKPORT-->