### PR TITLE
[visualizations] remove visualizations.chunk from kibana page load

### DIFF
--- a/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/gauge.test.ts
+++ b/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/gauge.test.ts
@@ -24,7 +24,7 @@ jest.mock('../services', () => ({
 }));
 
 jest.mock('@kbn/visualizations-plugin/public', () => ({
-  convertToLensModule: Promise.resolve({
+  getConvertToLensModule: () => Promise.resolve({
     getColumnsFromVis: jest.fn(() => mockGetColumnsFromVis()),
     getPercentageColumnFormulaColumn: jest.fn(() => mockGetPercentageColumnFormulaColumn()),
     getPercentageModeConfig: jest.fn(() => mockGetPercentageModeConfig()),

--- a/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/gauge.test.ts
+++ b/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/gauge.test.ts
@@ -24,7 +24,7 @@ jest.mock('../services', () => ({
 }));
 
 jest.mock('@kbn/visualizations-plugin/public', () => ({
-  getConvertToLensModule: () => Promise.resolve({
+  getConvertToLensModule: async () => ({
     getColumnsFromVis: jest.fn(() => mockGetColumnsFromVis()),
     getPercentageColumnFormulaColumn: jest.fn(() => mockGetPercentageColumnFormulaColumn()),
     getPercentageModeConfig: jest.fn(() => mockGetPercentageModeConfig()),

--- a/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/gauge.ts
+++ b/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/gauge.ts
@@ -10,7 +10,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { PercentageModeConfigWithMinMax } from '@kbn/visualizations-plugin/common';
 import {
-  convertToLensModule,
+  getConvertToLensModule,
   getDataViewByIndexPatternId,
 } from '@kbn/visualizations-plugin/public';
 import { excludeMetaFromColumn } from '@kbn/visualizations-plugin/common/convert_to_lens';
@@ -31,7 +31,7 @@ export const convertToLens: ConvertGaugeVisToLensVisualization = async (vis, tim
   }
 
   const { getColumnsFromVis, createStaticValueColumn, getPalette, getPercentageModeConfig } =
-    await convertToLensModule;
+    await getConvertToLensModule();
 
   const percentageModeConfig = getPercentageModeConfig(vis.params.gauge, false);
 

--- a/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/goal.test.ts
+++ b/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/goal.test.ts
@@ -24,7 +24,7 @@ jest.mock('../services', () => ({
 }));
 
 jest.mock('@kbn/visualizations-plugin/public', () => ({
-  convertToLensModule: Promise.resolve({
+  getConvertToLensModule: async () => ({
     getColumnsFromVis: jest.fn(() => mockGetColumnsFromVis()),
     getPercentageColumnFormulaColumn: jest.fn(() => mockGetPercentageColumnFormulaColumn()),
     getPercentageModeConfig: jest.fn(() => mockGetPercentageModeConfig()),

--- a/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/goal.ts
+++ b/src/platform/plugins/private/vis_types/gauge/public/convert_to_lens/goal.ts
@@ -10,7 +10,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { PercentageModeConfigWithMinMax } from '@kbn/visualizations-plugin/common';
 import {
-  convertToLensModule,
+  getConvertToLensModule,
   getDataViewByIndexPatternId,
 } from '@kbn/visualizations-plugin/public';
 import { excludeMetaFromColumn } from '@kbn/visualizations-plugin/common/convert_to_lens';
@@ -31,7 +31,7 @@ export const convertToLens: ConvertGoalVisToLensVisualization = async (vis, time
   }
 
   const { getColumnsFromVis, getPalette, getPercentageModeConfig, createStaticValueColumn } =
-    await convertToLensModule;
+    await getConvertToLensModule();
 
   const percentageModeConfig = getPercentageModeConfig(vis.params.gauge, false);
 

--- a/src/platform/plugins/private/vis_types/heatmap/public/convert_to_lens/configurations/palette.ts
+++ b/src/platform/plugins/private/vis_types/heatmap/public/convert_to_lens/configurations/palette.ts
@@ -8,7 +8,7 @@
  */
 
 import { Range } from '@kbn/expressions-plugin/common';
-import { convertToLensModule } from '@kbn/visualizations-plugin/public';
+import { getConvertToLensModule } from '@kbn/visualizations-plugin/public';
 import { HeatmapVisParams } from '../../types';
 import { getStopsWithColorsFromColorsNumber } from '../../utils/palette';
 
@@ -24,7 +24,7 @@ const isHeatmapVisParamsWithRanges = (
 
 export const getPaletteForHeatmap = async (params: HeatmapVisParams) => {
   const { getPalette, getPaletteFromStopsWithColors, getPercentageModeConfig } =
-    await convertToLensModule;
+    await getConvertToLensModule();
 
   if (isHeatmapVisParamsWithRanges(params)) {
     const percentageModeConfig = getPercentageModeConfig(params, false);

--- a/src/platform/plugins/private/vis_types/heatmap/public/convert_to_lens/index.test.ts
+++ b/src/platform/plugins/private/vis_types/heatmap/public/convert_to_lens/index.test.ts
@@ -22,7 +22,7 @@ jest.mock('../services', () => ({
 }));
 
 jest.mock('@kbn/visualizations-plugin/public', () => ({
-  convertToLensModule: Promise.resolve({
+  getConvertToLensModule: async () => ({
     getColumnsFromVis: jest.fn(() => mockGetColumnsFromVis()),
     convertToFiltersColumn: jest.fn(() => mockConvertToFiltersColumn()),
   }),

--- a/src/platform/plugins/private/vis_types/heatmap/public/convert_to_lens/index.ts
+++ b/src/platform/plugins/private/vis_types/heatmap/public/convert_to_lens/index.ts
@@ -8,7 +8,7 @@
  */
 
 import {
-  convertToLensModule,
+  getConvertToLensModule,
   getDataViewByIndexPatternId,
 } from '@kbn/visualizations-plugin/public';
 import { excludeMetaFromColumn } from '@kbn/visualizations-plugin/common/convert_to_lens';
@@ -29,7 +29,7 @@ export const convertToLens: ConvertHeatmapToLensVisualization = async (vis, time
     return null;
   }
 
-  const { getColumnsFromVis, convertToFiltersColumn } = await convertToLensModule;
+  const { getColumnsFromVis, convertToFiltersColumn } = await getConvertToLensModule();
   const layers = getColumnsFromVis(vis, timefilter, dataView, {
     buckets: ['segment'],
     splits: ['group'],

--- a/src/platform/plugins/private/vis_types/metric/public/convert_to_lens/index.test.ts
+++ b/src/platform/plugins/private/vis_types/metric/public/convert_to_lens/index.test.ts
@@ -23,7 +23,7 @@ jest.mock('../services', () => ({
 }));
 
 jest.mock('@kbn/visualizations-plugin/public', () => ({
-  convertToLensModule: Promise.resolve({
+  getConvertToLensModule: async () => ({
     getColumnsFromVis: jest.fn(() => mockGetColumnsFromVis()),
     getPercentageColumnFormulaColumn: jest.fn(() => mockGetPercentageColumnFormulaColumn()),
     getPercentageModeConfig: jest.fn(() => mockGetPercentageModeConfig()),

--- a/src/platform/plugins/private/vis_types/metric/public/convert_to_lens/index.ts
+++ b/src/platform/plugins/private/vis_types/metric/public/convert_to_lens/index.ts
@@ -9,7 +9,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import {
-  convertToLensModule,
+  getConvertToLensModule,
   getDataViewByIndexPatternId,
 } from '@kbn/visualizations-plugin/public';
 import { excludeMetaFromColumn } from '@kbn/visualizations-plugin/common/convert_to_lens';
@@ -29,7 +29,7 @@ export const convertToLens: ConvertMetricVisToLensVisualization = async (vis, ti
     return null;
   }
 
-  const { getColumnsFromVis, getPalette, getPercentageModeConfig } = await convertToLensModule;
+  const { getColumnsFromVis, getPalette, getPercentageModeConfig } = await getConvertToLensModule();
 
   const percentageModeConfig = getPercentageModeConfig(vis.params.metric);
   const layers = getColumnsFromVis(

--- a/src/platform/plugins/private/vis_types/pie/public/convert_to_lens/index.test.ts
+++ b/src/platform/plugins/private/vis_types/pie/public/convert_to_lens/index.test.ts
@@ -18,7 +18,7 @@ jest.mock('../services', () => ({
 }));
 
 jest.mock('@kbn/visualizations-plugin/public', () => ({
-  convertToLensModule: Promise.resolve({
+  getConvertToLensModule: async () => ({
     getColumnsFromVis: jest.fn(() => mockGetColumnsFromVis()),
   }),
   getDataViewByIndexPatternId: jest.fn(() => ({ id: 'index-pattern' })),

--- a/src/platform/plugins/private/vis_types/pie/public/convert_to_lens/index.ts
+++ b/src/platform/plugins/private/vis_types/pie/public/convert_to_lens/index.ts
@@ -8,7 +8,7 @@
  */
 
 import {
-  convertToLensModule,
+  getConvertToLensModule,
   getDataViewByIndexPatternId,
 } from '@kbn/visualizations-plugin/public';
 import { excludeMetaFromColumn } from '@kbn/visualizations-plugin/common/convert_to_lens';
@@ -29,7 +29,7 @@ export const convertToLens: ConvertPieToLensVisualization = async (vis, timefilt
     return null;
   }
 
-  const { getColumnsFromVis } = await convertToLensModule;
+  const { getColumnsFromVis } = await getConvertToLensModule();
   const layers = getColumnsFromVis(vis, timefilter, dataView, {
     buckets: [],
     splits: ['segment'],

--- a/src/platform/plugins/private/vis_types/table/public/convert_to_lens/index.test.ts
+++ b/src/platform/plugins/private/vis_types/table/public/convert_to_lens/index.test.ts
@@ -19,7 +19,7 @@ jest.mock('../services', () => ({
 }));
 
 jest.mock('@kbn/visualizations-plugin/public', () => ({
-  convertToLensModule: Promise.resolve({
+  getConvertToLensModule: async () => ({
     getColumnsFromVis: jest.fn(() => mockGetColumnsFromVis()),
     getPercentageColumnFormulaColumn: jest.fn(() => mockGetPercentageColumnFormulaColumn()),
   }),

--- a/src/platform/plugins/private/vis_types/table/public/convert_to_lens/index.ts
+++ b/src/platform/plugins/private/vis_types/table/public/convert_to_lens/index.ts
@@ -10,7 +10,7 @@
 import { METRIC_TYPES } from '@kbn/data-plugin/common';
 import { SchemaConfig } from '@kbn/visualizations-plugin/common';
 import {
-  convertToLensModule,
+  getConvertToLensModule,
   getVisSchemas,
   getDataViewByIndexPatternId,
 } from '@kbn/visualizations-plugin/public';
@@ -32,7 +32,7 @@ export const convertToLens: ConvertTableToLensVisualization = async (vis, timefi
     return null;
   }
 
-  const { getColumnsFromVis, getPercentageColumnFormulaColumn } = await convertToLensModule;
+  const { getColumnsFromVis, getPercentageColumnFormulaColumn } = await getConvertToLensModule();
   const layers = getColumnsFromVis(
     vis,
     timefilter,

--- a/src/platform/plugins/private/vis_types/tagcloud/public/convert_to_lens/index.test.ts
+++ b/src/platform/plugins/private/vis_types/tagcloud/public/convert_to_lens/index.test.ts
@@ -12,7 +12,7 @@ jest.mock('uuid', () => ({
 }));
 
 jest.mock('@kbn/visualizations-plugin/public', () => ({
-  convertToLensModule: Promise.resolve({
+  getConvertToLensModule: async () => ({
     getColumnsFromVis: jest.fn(() => {
       return [
         {

--- a/src/platform/plugins/private/vis_types/tagcloud/public/convert_to_lens/index.ts
+++ b/src/platform/plugins/private/vis_types/tagcloud/public/convert_to_lens/index.ts
@@ -9,7 +9,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import {
-  convertToLensModule,
+  getConvertToLensModule,
   getDataViewByIndexPatternId,
 } from '@kbn/visualizations-plugin/public';
 import { excludeMetaFromColumn } from '@kbn/visualizations-plugin/common/convert_to_lens';
@@ -34,7 +34,7 @@ export const convertToLens = async (
     return null;
   }
 
-  const { getColumnsFromVis } = await convertToLensModule;
+  const { getColumnsFromVis } = await getConvertToLensModule();
   const layers = getColumnsFromVis(vis, timefilter, dataView, {
     splits: ['segment'],
   });

--- a/src/platform/plugins/private/vis_types/xy/public/convert_to_lens/index.test.ts
+++ b/src/platform/plugins/private/vis_types/xy/public/convert_to_lens/index.test.ts
@@ -26,7 +26,7 @@ jest.mock('../utils/get_series_params', () => ({
 }));
 
 jest.mock('@kbn/visualizations-plugin/public', () => ({
-  convertToLensModule: Promise.resolve({
+  getConvertToLensModule: async () => ({
     getColumnsFromVis: jest.fn(() => mockGetColumnsFromVis()),
     createStaticValueColumn: jest.fn(() => mockCreateStaticValueColumn()),
   }),

--- a/src/platform/plugins/private/vis_types/xy/public/convert_to_lens/index.ts
+++ b/src/platform/plugins/private/vis_types/xy/public/convert_to_lens/index.ts
@@ -10,7 +10,7 @@
 import { METRIC_TYPES } from '@kbn/data-plugin/public';
 import { CollapseFunction, Column } from '@kbn/visualizations-plugin/common';
 import {
-  convertToLensModule,
+  getConvertToLensModule,
   getVisSchemas,
   getDataViewByIndexPatternId,
 } from '@kbn/visualizations-plugin/public';
@@ -74,7 +74,7 @@ export const convertToLens: ConvertXYToLensVisualization = async (vis, timefilte
     (param) => param.show && visSchemas.metric.some((m) => m.aggId?.split('.')[0] === param.data.id)
   );
 
-  const { getColumnsFromVis, createStaticValueColumn } = await convertToLensModule;
+  const { getColumnsFromVis, createStaticValueColumn } = await getConvertToLensModule();
   const dataLayers = getColumnsFromVis(
     vis,
     timefilter,

--- a/src/platform/plugins/shared/visualizations/public/index.ts
+++ b/src/platform/plugins/shared/visualizations/public/index.ts
@@ -88,5 +88,5 @@ export {
 
 export const getConvertToLensModule = async () => {
   return await import('./convert_to_lens');
-}
+};
 export { getDataViewByIndexPatternId } from './convert_to_lens/datasource';

--- a/src/platform/plugins/shared/visualizations/public/index.ts
+++ b/src/platform/plugins/shared/visualizations/public/index.ts
@@ -86,5 +86,7 @@ export {
   ACTION_CONVERT_DASHBOARD_PANEL_TO_LENS,
 } from './triggers';
 
-export const convertToLensModule = import('./convert_to_lens');
+export const getConvertToLensModule = async () => {
+  return await import('./convert_to_lens');
+}
 export { getDataViewByIndexPatternId } from './convert_to_lens/datasource';


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/194171

### Test steps
1) start kibana 
2) open network tab and filter requests to `visualizations.chunk`
3) open home page. Verify `visualizations.chunk` is not loaded. Screen shot is from main and shows the chunk getting loaded.
<img width="600" alt="Screenshot 2025-02-10 at 8 53 19 AM" src="https://github.com/user-attachments/assets/5a8f634f-60ca-46ff-b52b-0df2eb5f2c9e" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->