### PR TITLE
[9.0] Only show data warning screen on Serverless (#201920)

### DIFF
--- a/x-pack/plugins/security_solution_serverless/public/components/enablement_modal_callout/enablement_modal_callout.tsx
+++ b/x-pack/plugins/security_solution_serverless/public/components/enablement_modal_callout/enablement_modal_callout.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiText } from '@elastic/eui';
+import { ADDITIONAL_CHARGES_MESSAGE } from '../../upselling/translations';
+
+export const EnablementModalCallout: React.FC = () => {
+  return (
+    <div>
+      <EuiText>{ADDITIONAL_CHARGES_MESSAGE}</EuiText>
+    </div>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default EnablementModalCallout;

--- a/x-pack/plugins/security_solution_serverless/public/components/enablement_modal_callout/index.tsx
+++ b/x-pack/plugins/security_solution_serverless/public/components/enablement_modal_callout/index.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import type { Services } from '../../common/services';
+import { ServicesProvider } from '../../common/services';
+import { EnablementModalCallout } from './lazy';
+
+export const getEnablementModalCallout = (services: Services): React.ComponentType =>
+  function EnablementModalCalloutComponent() {
+    return (
+      <ServicesProvider services={services}>
+        <EnablementModalCallout />
+      </ServicesProvider>
+    );
+  };

--- a/x-pack/plugins/security_solution_serverless/public/components/enablement_modal_callout/lazy.tsx
+++ b/x-pack/plugins/security_solution_serverless/public/components/enablement_modal_callout/lazy.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { lazy, Suspense } from 'react';
+import { EuiLoadingSpinner } from '@elastic/eui';
+
+const EnablementModalCalloutLazy = lazy(() => import('./enablement_modal_callout'));
+
+export const EnablementModalCallout = () => (
+  <Suspense fallback={<EuiLoadingSpinner size="s" />}>
+    <EnablementModalCalloutLazy />
+  </Suspense>
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.test.tsx
@@ -7,7 +7,6 @@
 
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { act } from 'react-dom/test-utils';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { EntityStoreEnablementModal } from './enablement_modal';
 import { TestProviders } from '../../../../common/mock';
@@ -25,11 +24,6 @@ jest.mock('../hooks/use_entity_engine_privileges', () => ({
 const mockUseMissingRiskEnginePrivileges = jest.fn();
 jest.mock('../../../hooks/use_missing_risk_engine_privileges', () => ({
   useMissingRiskEnginePrivileges: () => mockUseMissingRiskEnginePrivileges(),
-}));
-
-const mockUseContractComponents = jest.fn(() => ({}));
-jest.mock('../../../../common/hooks/use_contract_component', () => ({
-  useContractComponents: () => mockUseContractComponents(),
 }));
 
 const mockUseContractComponents = jest.fn(() => ({}));
@@ -89,10 +83,6 @@ const missingRiskEnginePrivileges: RiskEngineMissingPrivilegesResponse = {
   },
 };
 
-const renderComponent = async (props = defaultProps) => {
-  await act(async () => {
-    return render(<EntityStoreEnablementModal {...props} />, { wrapper: TestProviders });
-  });
 const renderComponent = async (props = defaultProps) => {
   await act(async () => {
     return render(<EntityStoreEnablementModal {...props} />, { wrapper: TestProviders });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { act } from 'react-dom/test-utils';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { EntityStoreEnablementModal } from './enablement_modal';
 import { TestProviders } from '../../../../common/mock';
@@ -24,6 +25,11 @@ jest.mock('../hooks/use_entity_engine_privileges', () => ({
 const mockUseMissingRiskEnginePrivileges = jest.fn();
 jest.mock('../../../hooks/use_missing_risk_engine_privileges', () => ({
   useMissingRiskEnginePrivileges: () => mockUseMissingRiskEnginePrivileges(),
+}));
+
+const mockUseContractComponents = jest.fn(() => ({}));
+jest.mock('../../../../common/hooks/use_contract_component', () => ({
+  useContractComponents: () => mockUseContractComponents(),
 }));
 
 const mockUseContractComponents = jest.fn(() => ({}));
@@ -83,6 +89,10 @@ const missingRiskEnginePrivileges: RiskEngineMissingPrivilegesResponse = {
   },
 };
 
+const renderComponent = async (props = defaultProps) => {
+  await act(async () => {
+    return render(<EntityStoreEnablementModal {...props} />, { wrapper: TestProviders });
+  });
 const renderComponent = async (props = defaultProps) => {
   await act(async () => {
     return render(<EntityStoreEnablementModal {...props} />, { wrapper: TestProviders });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Only show data warning screen on Serverless (#201920)](https://github.com/elastic/kibana/pull/201920)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

