### PR TITLE
[dashboard] remove DashboardContainerInput type

### DIFF
--- a/src/platform/plugins/shared/dashboard/common/dashboard_container/types.ts
+++ b/src/platform/plugins/shared/dashboard/common/dashboard_container/types.ts
@@ -12,13 +12,9 @@ import {
   EmbeddableInput,
   SavedObjectEmbeddableInput,
 } from '@kbn/embeddable-plugin/common';
-import { Filter, Query, TimeRange } from '@kbn/es-query';
 import type { Reference } from '@kbn/content-management-utils';
-import { RefreshInterval } from '@kbn/data-plugin/common';
-import { KibanaExecutionContext } from '@kbn/core-execution-context-common';
-import type { ViewMode } from '@kbn/presentation-publishing';
 
-import type { DashboardOptions, GridData } from '../../server/content_management';
+import type { GridData } from '../../server/content_management';
 
 export interface DashboardPanelMap {
   [key: string]: DashboardPanelState;
@@ -43,30 +39,3 @@ export interface DashboardPanelState<
 }
 
 export type DashboardContainerByReferenceInput = SavedObjectEmbeddableInput;
-
-export interface DashboardContainerInput extends Omit<EmbeddableInput, 'viewMode'> {
-  // filter context to be passed to children
-  query: Query;
-  filters: Filter[];
-  timeRestore: boolean;
-  timeRange?: TimeRange;
-  timeslice?: [number, number];
-  refreshInterval?: RefreshInterval;
-
-  // dashboard meta info
-  title: string;
-  tags: string[];
-  viewMode: ViewMode;
-  description?: string;
-  executionContext: KibanaExecutionContext;
-
-  // dashboard options: TODO, build a new system to avoid all shared state appearing here. See https://github.com/elastic/kibana/issues/144532 for more information.
-  hidePanelTitles: DashboardOptions['hidePanelTitles'];
-  syncTooltips: DashboardOptions['syncTooltips'];
-  useMargins: DashboardOptions['useMargins'];
-  syncColors: DashboardOptions['syncColors'];
-  syncCursor: DashboardOptions['syncCursor'];
-
-  // dashboard contents
-  panels: DashboardPanelMap;
-}

--- a/src/platform/plugins/shared/dashboard/common/index.ts
+++ b/src/platform/plugins/shared/dashboard/common/index.ts
@@ -7,12 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type { DashboardCapabilities, SharedDashboardState } from './types';
+export type { DashboardCapabilities } from './types';
 
 export type {
   DashboardPanelMap,
   DashboardPanelState,
-  DashboardContainerInput,
   DashboardContainerByReferenceInput,
 } from './dashboard_container/types';
 

--- a/src/platform/plugins/shared/dashboard/common/types.ts
+++ b/src/platform/plugins/shared/dashboard/common/types.ts
@@ -9,8 +9,8 @@
 
 import type { Reference } from '@kbn/content-management-utils';
 import type { EmbeddableStateWithType } from '@kbn/embeddable-plugin/common';
-import type { DashboardContainerInput, DashboardPanelMap } from './dashboard_container/types';
-import type { DashboardAttributes, DashboardPanel } from '../server/content_management';
+import type { DashboardPanelMap } from './dashboard_container/types';
+import type { DashboardAttributes } from '../server/content_management';
 
 export interface DashboardCapabilities {
   showWriteControls: boolean;
@@ -18,13 +18,6 @@ export interface DashboardCapabilities {
   show: boolean;
   [key: string]: boolean;
 }
-
-/**
- * For BWC reasons, dashboard state is stored with panels as an array instead of a map
- */
-export type SharedDashboardState = Partial<
-  Omit<DashboardContainerInput, 'panels'> & { panels: DashboardPanel[] }
->;
 
 /**
  * A partially parsed version of the Dashboard Attributes used for inject and extract logic for both the Dashboard Container and the Dashboard Saved Object.

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/default_dashboard_state.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/default_dashboard_state.ts
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { DashboardContainerInput } from '../../common';
+import { DashboardState } from './types';
 
-export const DEFAULT_DASHBOARD_INPUT: Omit<DashboardContainerInput, 'id'> = {
+export const DEFAULT_DASHBOARD_STATE: DashboardState = {
   viewMode: 'view',
   timeRestore: false,
   query: { query: '', language: 'kuery' },
@@ -18,9 +18,6 @@ export const DEFAULT_DASHBOARD_INPUT: Omit<DashboardContainerInput, 'id'> = {
   panels: {},
   title: '',
   tags: [],
-  executionContext: {
-    type: 'dashboard',
-  },
 
   // options
   useMargins: true,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -25,7 +25,7 @@ import { getDashboardContentManagementService } from '../services/dashboard_cont
 import { LoadDashboardReturn } from '../services/dashboard_content_management_service/types';
 import { initializeDataLoadingManager } from './data_loading_manager';
 import { initializeDataViewsManager } from './data_views_manager';
-import { DEFAULT_DASHBOARD_INPUT } from './default_dashboard_input';
+import { DEFAULT_DASHBOARD_STATE } from './default_dashboard_state';
 import { getSerializedState } from './get_serialized_state';
 import { openSaveModal } from './open_save_modal';
 import { initializePanelsManager } from './panels_manager';
@@ -110,7 +110,7 @@ export function getDashboardApi({
     creationOptions,
     controlGroupApi$,
     lastSavedState: omit(savedObjectResult?.dashboardInput, 'controlGroupInput') ?? {
-      ...DEFAULT_DASHBOARD_INPUT,
+      ...DEFAULT_DASHBOARD_STATE,
     },
     panelsManager,
     savedObjectId$,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/load_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/load_dashboard_api.ts
@@ -20,7 +20,7 @@ import {
   getDashboardBackupService,
 } from '../services/dashboard_backup_service';
 import { UnsavedPanelState } from '../dashboard_container/types';
-import { DEFAULT_DASHBOARD_INPUT } from './default_dashboard_input';
+import { DEFAULT_DASHBOARD_STATE } from './default_dashboard_state';
 
 export async function loadDashboardApi({
   getCreationOptions,
@@ -62,7 +62,7 @@ export async function loadDashboardApi({
   })();
 
   const combinedSessionState: DashboardState = {
-    ...DEFAULT_DASHBOARD_INPUT,
+    ...DEFAULT_DASHBOARD_STATE,
     ...(savedObjectResult?.dashboardInput ?? {}),
     ...sessionStorageInput,
   };

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/settings_manager.ts
@@ -11,40 +11,40 @@ import fastIsEqual from 'fast-deep-equal';
 import { StateComparators, initializeTitleManager } from '@kbn/presentation-publishing';
 import { BehaviorSubject } from 'rxjs';
 import { DashboardSettings, DashboardState } from './types';
-import { DEFAULT_DASHBOARD_INPUT } from './default_dashboard_input';
+import { DEFAULT_DASHBOARD_STATE } from './default_dashboard_state';
 
 export function initializeSettingsManager(initialState?: DashboardState) {
   const syncColors$ = new BehaviorSubject<boolean>(
-    initialState?.syncColors ?? DEFAULT_DASHBOARD_INPUT.syncColors
+    initialState?.syncColors ?? DEFAULT_DASHBOARD_STATE.syncColors
   );
   function setSyncColors(syncColors: boolean) {
     if (syncColors !== syncColors$.value) syncColors$.next(syncColors);
   }
   const syncCursor$ = new BehaviorSubject<boolean>(
-    initialState?.syncCursor ?? DEFAULT_DASHBOARD_INPUT.syncCursor
+    initialState?.syncCursor ?? DEFAULT_DASHBOARD_STATE.syncCursor
   );
   function setSyncCursor(syncCursor: boolean) {
     if (syncCursor !== syncCursor$.value) syncCursor$.next(syncCursor);
   }
   const syncTooltips$ = new BehaviorSubject<boolean>(
-    initialState?.syncTooltips ?? DEFAULT_DASHBOARD_INPUT.syncTooltips
+    initialState?.syncTooltips ?? DEFAULT_DASHBOARD_STATE.syncTooltips
   );
   function setSyncTooltips(syncTooltips: boolean) {
     if (syncTooltips !== syncTooltips$.value) syncTooltips$.next(syncTooltips);
   }
-  const tags$ = new BehaviorSubject<string[]>(initialState?.tags ?? DEFAULT_DASHBOARD_INPUT.tags);
+  const tags$ = new BehaviorSubject<string[]>(initialState?.tags ?? DEFAULT_DASHBOARD_STATE.tags);
   function setTags(tags: string[]) {
     if (!fastIsEqual(tags, tags$.value)) tags$.next(tags);
   }
   const titleManager = initializeTitleManager(initialState ?? {});
   const timeRestore$ = new BehaviorSubject<boolean | undefined>(
-    initialState?.timeRestore ?? DEFAULT_DASHBOARD_INPUT.timeRestore
+    initialState?.timeRestore ?? DEFAULT_DASHBOARD_STATE.timeRestore
   );
   function setTimeRestore(timeRestore: boolean) {
     if (timeRestore !== timeRestore$.value) timeRestore$.next(timeRestore);
   }
   const useMargins$ = new BehaviorSubject<boolean>(
-    initialState?.useMargins ?? DEFAULT_DASHBOARD_INPUT.useMargins
+    initialState?.useMargins ?? DEFAULT_DASHBOARD_STATE.useMargins
   );
   function setUseMargins(useMargins: boolean) {
     if (useMargins !== useMargins$.value) useMargins$.next(useMargins);
@@ -102,8 +102,8 @@ export function initializeSettingsManager(initialState?: DashboardState) {
         return {
           ...settings,
           title: settings.title ?? '',
-          timeRestore: settings.timeRestore ?? DEFAULT_DASHBOARD_INPUT.timeRestore,
-          hidePanelTitles: settings.hidePanelTitles ?? DEFAULT_DASHBOARD_INPUT.hidePanelTitles,
+          timeRestore: settings.timeRestore ?? DEFAULT_DASHBOARD_STATE.timeRestore,
+          hidePanelTitles: settings.hidePanelTitles ?? DEFAULT_DASHBOARD_STATE.hidePanelTitles,
         };
       },
       reset: (lastSavedState: DashboardState) => {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/unified_search_manager.ts
@@ -46,7 +46,7 @@ import {
 import { dataService } from '../services/kibana_services';
 import { cleanFiltersForSerialize } from '../utils/clean_filters_for_serialize';
 import { GLOBAL_STATE_STORAGE_KEY } from '../utils/urls';
-import { DEFAULT_DASHBOARD_INPUT } from './default_dashboard_input';
+import { DEFAULT_DASHBOARD_STATE } from './default_dashboard_state';
 import { DashboardCreationOptions, DashboardState } from './types';
 
 export function initializeUnifiedSearchManager(
@@ -357,11 +357,11 @@ export function initializeUnifiedSearchManager(
         });
         return {
           state: {
-            filters: filter ?? DEFAULT_DASHBOARD_INPUT.filters,
-            query: (query as Query) ?? DEFAULT_DASHBOARD_INPUT.query,
+            filters: filter ?? DEFAULT_DASHBOARD_STATE.filters,
+            query: (query as Query) ?? DEFAULT_DASHBOARD_STATE.query,
             refreshInterval: refreshInterval$.value,
             timeRange: timeRange$.value,
-            timeRestore: timeRestore$.value ?? DEFAULT_DASHBOARD_INPUT.timeRestore,
+            timeRestore: timeRestore$.value ?? DEFAULT_DASHBOARD_STATE.timeRestore,
           },
           references,
         };

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/dashboard_app.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/dashboard_app.tsx
@@ -18,7 +18,6 @@ import { useExecutionContext } from '@kbn/kibana-react-plugin/public';
 import { createKbnUrlStateStorage, withNotifyOnErrors } from '@kbn/kibana-utils-plugin/public';
 import { ViewMode } from '@kbn/presentation-publishing';
 import { DashboardApi, DashboardCreationOptions } from '..';
-import { SharedDashboardState } from '../../common';
 import { DASHBOARD_APP_ID } from '../plugin_constants';
 import { DashboardRedirect } from '../dashboard_container/types';
 import { DashboardTopNav } from '../dashboard_top_nav';
@@ -45,7 +44,11 @@ import {
   getSessionURLObservable,
   removeSearchSessionIdFromURL,
 } from './url/search_sessions_integration';
-import { loadAndRemoveDashboardState, startSyncingExpandedPanelState } from './url/url_utils';
+import {
+  loadAndRemoveDashboardState,
+  startSyncingExpandedPanelState,
+  type SharedDashboardState,
+} from './url/url_utils';
 import { DashboardRenderer } from '../dashboard_container/external_api/dashboard_renderer';
 import { DASHBOARD_STATE_STORAGE_KEY, createDashboardEditUrl } from '../utils/urls';
 

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/locator/load_dashboard_history_location_state.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/locator/load_dashboard_history_location_state.ts
@@ -10,11 +10,12 @@
 import { ScopedHistory } from '@kbn/core-application-browser';
 
 import { ForwardedDashboardState } from './locator';
-import { convertPanelsArrayToPanelMap, DashboardContainerInput } from '../../../common';
+import { convertPanelsArrayToPanelMap } from '../../../common';
+import { DashboardState } from '../../dashboard_api/types';
 
 export const loadDashboardHistoryLocationState = (
   getScopedHistory: () => ScopedHistory
-): Partial<DashboardContainerInput> => {
+): Partial<DashboardState> => {
   const state = getScopedHistory().location.state as undefined | ForwardedDashboardState;
 
   if (!state) {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.test.tsx
@@ -68,9 +68,7 @@ describe('ShowShareModal', () => {
     jest.clearAllMocks();
   });
 
-  const getPropsAndShare = (
-    unsavedState?: Partial<DashboardState>
-  ): ShowShareModalProps => {
+  const getPropsAndShare = (unsavedState?: Partial<DashboardState>): ShowShareModalProps => {
     dashboardBackupService.getState = jest.fn().mockReturnValue({ dashboardState: unsavedState });
     return {
       isDirty: true,

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.test.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/share/show_share_modal.test.tsx
@@ -8,12 +8,13 @@
  */
 
 import { Capabilities } from '@kbn/core/public';
-import { convertPanelMapToPanelsArray, DashboardContainerInput } from '../../../../common';
+import { convertPanelMapToPanelsArray } from '../../../../common';
 import { DashboardLocatorParams } from '../../../dashboard_container/types';
 
 import { shareService } from '../../../services/kibana_services';
 import { showPublicUrlSwitch, ShowShareModal, ShowShareModalProps } from './show_share_modal';
 import { getDashboardBackupService } from '../../../services/dashboard_backup_service';
+import { DashboardState } from '../../../dashboard_api/types';
 
 describe('showPublicUrlSwitch', () => {
   test('returns false if "dashboard_v2" app is not available', () => {
@@ -68,7 +69,7 @@ describe('ShowShareModal', () => {
   });
 
   const getPropsAndShare = (
-    unsavedState?: Partial<DashboardContainerInput>
+    unsavedState?: Partial<DashboardState>
   ): ShowShareModalProps => {
     dashboardBackupService.getState = jest.fn().mockReturnValue({ dashboardState: unsavedState });
     return {
@@ -93,7 +94,7 @@ describe('ShowShareModal', () => {
   });
 
   it('locatorParams unsaved state is properly propagated to locator', () => {
-    const unsavedDashboardState: DashboardContainerInput = {
+    const unsavedDashboardState = {
       panels: {
         panel_1: {
           type: 'panel_type',
@@ -120,7 +121,7 @@ describe('ShowShareModal', () => {
         },
       ],
       query: { query: 'bye', language: 'kuery' },
-    } as unknown as DashboardContainerInput;
+    };
     const showModalProps = getPropsAndShare(unsavedDashboardState);
     showModalProps.getPanelsState = () => {
       return {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/url_utils.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/url_utils.ts
@@ -16,18 +16,23 @@ import { replaceUrlHashQuery } from '@kbn/kibana-utils-plugin/common';
 import { IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 
 import {
-  DashboardContainerInput,
   DashboardPanelMap,
-  SharedDashboardState,
   convertPanelsArrayToPanelMap,
 } from '../../../common';
 import type { DashboardPanel } from '../../../server/content_management';
 import type { SavedDashboardPanel } from '../../../server/dashboard_saved_object';
-import { DashboardApi } from '../../dashboard_api/types';
+import { DashboardApi, DashboardState } from '../../dashboard_api/types';
 import { DASHBOARD_STATE_STORAGE_KEY, createDashboardEditUrl } from '../../utils/urls';
 import { migrateLegacyQuery } from '../../services/dashboard_content_management_service/lib/load_dashboard_state';
 import { coreServices } from '../../services/kibana_services';
 import { getPanelTooOldErrorString } from '../_dashboard_app_strings';
+
+/**
+ * For BWC reasons, dashboard state is stored with panels as an array instead of a map
+ */
+export type SharedDashboardState = Partial<
+  Omit<DashboardState, 'panels'> & { panels: DashboardPanel[] }
+>;
 
 const panelIsLegacy = (panel: unknown): panel is SavedDashboardPanel => {
   return (panel as SavedDashboardPanel).embeddableConfig !== undefined;
@@ -49,22 +54,22 @@ export const isPanelVersionTooOld = (panels: DashboardPanel[] | SavedDashboardPa
   return false;
 };
 
-function getPanelsMap(appStateInUrl: SharedDashboardState): DashboardPanelMap | undefined {
-  if (!appStateInUrl.panels) {
+function getPanelsMap(panels?: DashboardPanel[]): DashboardPanelMap | undefined {
+  if (!panels) {
     return undefined;
   }
 
-  if (appStateInUrl.panels.length === 0) {
+  if (panels.length === 0) {
     return {};
   }
 
-  if (isPanelVersionTooOld(appStateInUrl.panels)) {
+  if (isPanelVersionTooOld(panels)) {
     coreServices.notifications.toasts.addWarning(getPanelTooOldErrorString());
     return undefined;
   }
 
   // convert legacy embeddableConfig keys to panelConfig
-  const panels = appStateInUrl.panels.map((panel) => {
+  const standardizedPanels = panels.map((panel) => {
     if (panelIsLegacy(panel)) {
       const { embeddableConfig, ...rest } = panel;
       return {
@@ -75,7 +80,7 @@ function getPanelsMap(appStateInUrl: SharedDashboardState): DashboardPanelMap | 
     return panel;
   });
 
-  return convertPanelsArrayToPanelMap(panels);
+  return convertPanelsArrayToPanelMap(standardizedPanels);
 }
 
 /**
@@ -83,20 +88,20 @@ function getPanelsMap(appStateInUrl: SharedDashboardState): DashboardPanelMap | 
  */
 export const loadAndRemoveDashboardState = (
   kbnUrlStateStorage: IKbnUrlStateStorage
-): Partial<DashboardContainerInput> => {
+): Partial<DashboardState> => {
   const rawAppStateInUrl = kbnUrlStateStorage.get<SharedDashboardState>(
     DASHBOARD_STATE_STORAGE_KEY
   );
   if (!rawAppStateInUrl) return {};
 
-  const panelsMap = getPanelsMap(rawAppStateInUrl);
+  const panelsMap = getPanelsMap(rawAppStateInUrl.panels);
 
   const nextUrl = replaceUrlHashQuery(window.location.href, (hashQuery) => {
     delete hashQuery[DASHBOARD_STATE_STORAGE_KEY];
     return hashQuery;
   });
   kbnUrlStateStorage.kbnUrlControls.update(nextUrl, true);
-  const partialState: Partial<DashboardContainerInput> = {
+  const partialState: Partial<DashboardState> = {
     ..._.omit(rawAppStateInUrl, ['panels', 'query']),
     ...(panelsMap ? { panels: panelsMap } : {}),
     ...(rawAppStateInUrl.query ? { query: migrateLegacyQuery(rawAppStateInUrl.query) } : {}),

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/url/url_utils.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/url/url_utils.ts
@@ -15,10 +15,7 @@ import semverSatisfies from 'semver/functions/satisfies';
 import { replaceUrlHashQuery } from '@kbn/kibana-utils-plugin/common';
 import { IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 
-import {
-  DashboardPanelMap,
-  convertPanelsArrayToPanelMap,
-} from '../../../common';
+import { DashboardPanelMap, convertPanelsArrayToPanelMap } from '../../../common';
 import type { DashboardPanel } from '../../../server/content_management';
 import type { SavedDashboardPanel } from '../../../server/dashboard_saved_object';
 import { DashboardApi, DashboardState } from '../../dashboard_api/types';

--- a/src/platform/plugins/shared/dashboard/public/dashboard_container/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_container/types.ts
@@ -10,8 +10,8 @@
 import { SerializableRecord } from '@kbn/utility-types';
 
 import { ControlGroupRuntimeState } from '@kbn/controls-plugin/public';
-import type { DashboardContainerInput } from '../../common';
 import type { DashboardPanel } from '../../server/content_management';
+import { DashboardState } from '../dashboard_api/types';
 
 export interface UnsavedPanelState {
   [key: string]: object | undefined;
@@ -50,7 +50,7 @@ export interface DashboardSaveOptions {
 }
 
 export type DashboardLocatorParams = Partial<
-  Omit<DashboardContainerInput, 'panels' | 'controlGroupInput' | 'executionContext'>
+  Omit<DashboardState, 'panels' | 'controlGroupInput' | 'references'>
 > & {
   /**
    * If given, the dashboard saved object with this id will be loaded. If not given,

--- a/src/platform/plugins/shared/dashboard/public/mocks.tsx
+++ b/src/platform/plugins/shared/dashboard/public/mocks.tsx
@@ -13,7 +13,6 @@ import { DashboardStart } from './plugin';
 import { DashboardState } from './dashboard_api/types';
 import { getDashboardApi } from './dashboard_api/get_dashboard_api';
 import { DashboardPanelState } from '../common';
-import { SavedDashboardInput } from './services/dashboard_content_management_service/types';
 
 export type Start = jest.Mocked<DashboardStart>;
 
@@ -96,9 +95,7 @@ export function buildMockDashboardApi({
       managed: false,
       dashboardInput: {
         ...initialState,
-        executionContext: { type: 'dashboard' },
-        id: savedObjectId ?? '123',
-      } as SavedDashboardInput,
+      },
       references: [],
     },
   });

--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_backup_service.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_backup_service.ts
@@ -18,7 +18,7 @@ import { ViewMode } from '@kbn/presentation-publishing';
 import { UnsavedPanelState } from '../dashboard_container/types';
 import { coreServices, spacesService } from './kibana_services';
 import { DashboardState } from '../dashboard_api/types';
-import { DEFAULT_DASHBOARD_INPUT } from '../dashboard_api/default_dashboard_input';
+import { DEFAULT_DASHBOARD_STATE } from '../dashboard_api/default_dashboard_state';
 
 export const DASHBOARD_PANELS_UNSAVED_ID = 'unsavedDashboard';
 export const PANELS_CONTROL_GROUP_KEY = 'controlGroup';
@@ -73,7 +73,7 @@ class DashboardBackupService implements DashboardBackupServiceType {
   }
 
   public getViewMode = (): ViewMode => {
-    return this.localStorage.get(DASHBOARD_VIEWMODE_LOCAL_KEY) ?? DEFAULT_DASHBOARD_INPUT.viewMode;
+    return this.localStorage.get(DASHBOARD_VIEWMODE_LOCAL_KEY) ?? DEFAULT_DASHBOARD_STATE.viewMode;
   };
 
   public storeViewMode = (viewMode: ViewMode) => {

--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/load_dashboard_state.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/load_dashboard_state.ts
@@ -8,7 +8,6 @@
  */
 
 import { has } from 'lodash';
-import { v4 as uuidv4 } from 'uuid';
 
 import { injectSearchSourceReferences } from '@kbn/data-plugin/public';
 import { Filter, Query } from '@kbn/es-query';
@@ -19,7 +18,7 @@ import { getDashboardContentManagementCache } from '..';
 import { convertPanelsArrayToPanelMap, injectReferences } from '../../../../common';
 import type { DashboardGetIn, DashboardGetOut } from '../../../../server/content_management';
 import { DASHBOARD_CONTENT_ID } from '../../../utils/telemetry_constants';
-import { DEFAULT_DASHBOARD_INPUT } from '../../../dashboard_api/default_dashboard_input';
+import { DEFAULT_DASHBOARD_STATE } from '../../../dashboard_api/default_dashboard_state';
 import {
   contentManagementService,
   dataService,
@@ -52,9 +51,8 @@ export const loadDashboardState = async ({
   const dashboardContentManagementCache = getDashboardContentManagementCache();
 
   const savedObjectId = id;
-  const embeddableId = uuidv4();
 
-  const newDashboardState = { ...DEFAULT_DASHBOARD_INPUT, id: embeddableId };
+  const newDashboardState = { ...DEFAULT_DASHBOARD_STATE };
 
   /**
    * This is a newly created dashboard, so there is no saved object state to load.
@@ -175,10 +173,8 @@ export const loadDashboardState = async ({
     references,
     resolveMeta,
     dashboardInput: {
-      ...DEFAULT_DASHBOARD_INPUT,
+      ...DEFAULT_DASHBOARD_STATE,
       ...options,
-
-      id: embeddableId,
       refreshInterval,
       timeRestore,
       description,

--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/save_dashboard_state.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/lib/save_dashboard_state.test.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { DashboardContainerInput } from '../../../../common';
 import { getSampleDashboardState } from '../../../mocks';
 import {
   contentManagementService,
@@ -16,6 +15,7 @@ import {
   embeddableService,
 } from '../../kibana_services';
 import { saveDashboardState } from './save_dashboard_state';
+import { DashboardPanelMap } from '../../../../common/dashboard_container/types';
 
 contentManagementService.client.create = jest.fn().mockImplementation(({ options }) => {
   if (options.id === undefined) {
@@ -50,7 +50,7 @@ describe('Save dashboard state', () => {
       dashboardState: {
         ...getSampleDashboardState(),
         title: 'BOO',
-      } as unknown as DashboardContainerInput,
+      },
       lastSavedId: 'Boogaloo',
       saveOptions: {},
     });
@@ -71,7 +71,7 @@ describe('Save dashboard state', () => {
       dashboardState: {
         ...getSampleDashboardState(),
         title: 'BooToo',
-      } as unknown as DashboardContainerInput,
+      },
       lastSavedId: 'Boogaloonie',
       saveOptions: { saveAsCopy: true },
     });
@@ -95,8 +95,8 @@ describe('Save dashboard state', () => {
       dashboardState: {
         ...getSampleDashboardState(),
         title: 'BooThree',
-        panels: { aVerySpecialVeryUniqueId: { type: 'boop' } },
-      } as unknown as DashboardContainerInput,
+        panels: { aVerySpecialVeryUniqueId: { type: 'boop' } } as unknown as DashboardPanelMap,
+      },
       lastSavedId: 'Boogatoonie',
       saveOptions: { saveAsCopy: true },
     });
@@ -121,8 +121,8 @@ describe('Save dashboard state', () => {
       dashboardState: {
         ...getSampleDashboardState(),
         title: 'BooFour',
-        panels: { idOne: { type: 'boop' } },
-      } as unknown as DashboardContainerInput,
+        panels: { idOne: { type: 'boop' } } as unknown as DashboardPanelMap,
+      },
       panelReferences: [{ name: 'idOne:panel_idOne', type: 'boop', id: 'idOne' }],
       lastSavedId: 'Boogatoonie',
       saveOptions: { saveAsCopy: true },
@@ -149,8 +149,8 @@ describe('Save dashboard state', () => {
       dashboardState: {
         ...getSampleDashboardState(),
         title: 'BooThree',
-        panels: { idOne: { type: 'boop' } },
-      } as unknown as DashboardContainerInput,
+        panels: { idOne: { type: 'boop' } } as unknown as DashboardPanelMap,
+      },
       lastSavedId: 'Boogatoonie',
       saveOptions: { saveAsCopy: true },
     });

--- a/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/services/dashboard_content_management_service/types.ts
@@ -9,10 +9,8 @@
 
 import type { Reference } from '@kbn/content-management-utils';
 import type { Query, SerializedSearchSourceFields } from '@kbn/data-plugin/common';
-import { ControlGroupRuntimeState } from '@kbn/controls-plugin/public';
 import { SavedObjectSaveOpts } from '@kbn/saved-objects-plugin/public';
 
-import { DashboardContainerInput } from '../../../common';
 import type { DashboardAttributes, DashboardGetOut } from '../../../server/content_management';
 import { DashboardDuplicateTitleCheckProps } from './lib/check_for_duplicate_dashboard_title';
 import {
@@ -41,20 +39,6 @@ export interface LoadDashboardFromSavedObjectProps {
 
 type DashboardResolveMeta = DashboardGetOut['meta'];
 
-export type SavedDashboardInput = DashboardContainerInput & {
-  /**
-   * Serialized control group state.
-   * Contains state loaded from dashboard saved object
-   */
-  controlGroupInput?: DashboardAttributes['controlGroupInput'] | undefined;
-  /**
-   * Runtime control group state.
-   * Contains state passed from dashboard locator
-   * Use runtime state when building input for portable dashboards
-   */
-  controlGroupState?: Partial<ControlGroupRuntimeState>;
-};
-
 export type DashboardSearchSource = Omit<SerializedSearchSourceFields, 'query'> & {
   query?: Query;
 };
@@ -65,7 +49,7 @@ export interface LoadDashboardReturn {
   dashboardId?: string;
   managed?: boolean;
   resolveMeta?: DashboardResolveMeta;
-  dashboardInput: SavedDashboardInput;
+  dashboardInput: DashboardState;
 
   /**
    * Raw references returned directly from the Dashboard saved object. These

--- a/src/platform/plugins/shared/dashboard/tsconfig.json
+++ b/src/platform/plugins/shared/dashboard/tsconfig.json
@@ -44,7 +44,6 @@
     "@kbn/analytics",
     "@kbn/safer-lodash-set",
     "@kbn/task-manager-plugin",
-    "@kbn/core-execution-context-common",
     "@kbn/core-custom-branding-browser",
     "@kbn/shared-ux-router",
     "@kbn/saved-objects-management-plugin",

--- a/test/functional/apps/dashboard/group3/dashboard_state.ts
+++ b/test/functional/apps/dashboard/group3/dashboard_state.ts
@@ -11,7 +11,7 @@ import expect from '@kbn/expect';
 import chroma from 'chroma-js';
 import rison from '@kbn/rison';
 import { DEFAULT_PANEL_WIDTH } from '@kbn/dashboard-plugin/common/content_management/constants';
-import type { SharedDashboardState } from '@kbn/dashboard-plugin/common';
+import type { SharedDashboardState } from '@kbn/dashboard-plugin/public/dashboard_app/url/url_utils';
 import { PIE_CHART_VIS_NAME, AREA_CHART_VIS_NAME } from '../../../page_objects/dashboard_page';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/components/dashboard_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/components/dashboard_renderer.tsx
@@ -27,7 +27,9 @@ import { inputsActions } from '../../common/store/inputs';
 import { InputsModelId } from '../../common/store/inputs/constants';
 import { useSecurityTags } from '../context/dashboard_context';
 
-const initialInput = new BehaviorSubject<ReturnType<NonNullable<DashboardCreationOptions['getInitialInput']>>>({});
+const initialInput = new BehaviorSubject<
+  ReturnType<NonNullable<DashboardCreationOptions['getInitialInput']>>
+>({});
 
 const DashboardRendererComponent = ({
   canReadDashboard,

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/components/dashboard_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/components/dashboard_renderer.tsx
@@ -7,7 +7,6 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { DashboardContainerInput } from '@kbn/dashboard-plugin/common';
 import type {
   DashboardApi,
   DashboardCreationOptions,
@@ -28,7 +27,7 @@ import { inputsActions } from '../../common/store/inputs';
 import { InputsModelId } from '../../common/store/inputs/constants';
 import { useSecurityTags } from '../context/dashboard_context';
 
-const initialInput = new BehaviorSubject<Partial<DashboardContainerInput>>({});
+const initialInput = new BehaviorSubject<ReturnType<NonNullable<DashboardCreationOptions['getInitialInput']>>>({});
 
 const DashboardRendererComponent = ({
   canReadDashboard,


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/204249

Clean up work from embeddable refactor. PR removes `DashboardContainerInput` type, which is a duplicate of `DashboardState`

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->