### PR TITLE
[8.x] [kbn-grid-layout] Cleanup memoization and styling (#210285)

### DIFF
--- a/src/platform/packages/private/kbn-grid-layout/grid/drag_preview.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/drag_preview.tsx
@@ -14,54 +14,51 @@ import { css } from '@emotion/react';
 
 import { GridLayoutStateManager } from './types';
 
-export const DragPreview = ({
-  rowIndex,
-  gridLayoutStateManager,
-}: {
-  rowIndex: number;
-  gridLayoutStateManager: GridLayoutStateManager;
-}) => {
-  const dragPreviewRef = useRef<HTMLDivElement | null>(null);
+export const DragPreview = React.memo(
+  ({
+    rowIndex,
+    gridLayoutStateManager,
+  }: {
+    rowIndex: number;
+    gridLayoutStateManager: GridLayoutStateManager;
+  }) => {
+    const dragPreviewRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(
-    () => {
-      /** Update the styles of the drag preview via a subscription to prevent re-renders */
-      const styleSubscription = combineLatest([
-        gridLayoutStateManager.activePanel$,
-        gridLayoutStateManager.proposedGridLayout$,
-      ])
-        .pipe(skip(1)) // skip the first emit because the drag preview is only rendered after a user action
-        .subscribe(([activePanel, proposedGridLayout]) => {
-          if (!dragPreviewRef.current) return;
+    useEffect(
+      () => {
+        /** Update the styles of the drag preview via a subscription to prevent re-renders */
+        const styleSubscription = combineLatest([
+          gridLayoutStateManager.activePanel$,
+          gridLayoutStateManager.proposedGridLayout$,
+        ])
+          .pipe(skip(1)) // skip the first emit because the drag preview is only rendered after a user action
+          .subscribe(([activePanel, proposedGridLayout]) => {
+            if (!dragPreviewRef.current) return;
 
-          if (!activePanel || !proposedGridLayout?.[rowIndex].panels[activePanel.id]) {
-            dragPreviewRef.current.style.display = 'none';
-          } else {
-            const panel = proposedGridLayout[rowIndex].panels[activePanel.id];
-            dragPreviewRef.current.style.display = 'block';
-            dragPreviewRef.current.style.gridColumnStart = `${panel.column + 1}`;
-            dragPreviewRef.current.style.gridColumnEnd = `${panel.column + 1 + panel.width}`;
-            dragPreviewRef.current.style.gridRowStart = `${panel.row + 1}`;
-            dragPreviewRef.current.style.gridRowEnd = `${panel.row + 1 + panel.height}`;
-          }
-        });
+            if (!activePanel || !proposedGridLayout?.[rowIndex].panels[activePanel.id]) {
+              dragPreviewRef.current.style.display = 'none';
+            } else {
+              const panel = proposedGridLayout[rowIndex].panels[activePanel.id];
+              dragPreviewRef.current.style.display = 'block';
+              dragPreviewRef.current.style.gridColumnStart = `${panel.column + 1}`;
+              dragPreviewRef.current.style.gridColumnEnd = `${panel.column + 1 + panel.width}`;
+              dragPreviewRef.current.style.gridRowStart = `${panel.row + 1}`;
+              dragPreviewRef.current.style.gridRowEnd = `${panel.row + 1 + panel.height}`;
+            }
+          });
 
-      return () => {
-        styleSubscription.unsubscribe();
-      };
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
+        return () => {
+          styleSubscription.unsubscribe();
+        };
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      []
+    );
 
-  return (
-    <div
-      ref={dragPreviewRef}
-      className={'kbnGridPanel--dragPreview'}
-      css={css`
-        display: none;
-        pointer-events: none;
-      `}
-    />
-  );
-};
+    return <div ref={dragPreviewRef} className={'kbnGridPanel--dragPreview'} css={styles} />;
+  }
+);
+
+const styles = css({ display: 'none', pointerEvents: 'none' });
+
+DragPreview.displayName = 'KbnGridLayoutDragPreview';

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_height_smoother.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_height_smoother.tsx
@@ -12,58 +12,67 @@ import React, { PropsWithChildren, useEffect, useRef } from 'react';
 import { combineLatest } from 'rxjs';
 import { GridLayoutStateManager } from './types';
 
-export const GridHeightSmoother = ({
-  children,
-  gridLayoutStateManager,
-}: PropsWithChildren<{ gridLayoutStateManager: GridLayoutStateManager }>) => {
-  // set the parent div size directly to smooth out height changes.
-  const smoothHeightRef = useRef<HTMLDivElement | null>(null);
+export const GridHeightSmoother = React.memo(
+  ({
+    children,
+    gridLayoutStateManager,
+  }: PropsWithChildren<{ gridLayoutStateManager: GridLayoutStateManager }>) => {
+    // set the parent div size directly to smooth out height changes.
+    const smoothHeightRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    /**
-     * When the user is interacting with an element, the page can grow, but it cannot
-     * shrink. This is to stop a behaviour where the page would scroll up automatically
-     * making the panel shrink or grow unpredictably.
-     */
-    const interactionStyleSubscription = combineLatest([
-      gridLayoutStateManager.gridDimensions$,
-      gridLayoutStateManager.interactionEvent$,
-    ]).subscribe(([dimensions, interactionEvent]) => {
-      if (!smoothHeightRef.current || gridLayoutStateManager.expandedPanelId$.getValue()) return;
+    useEffect(() => {
+      /**
+       * When the user is interacting with an element, the page can grow, but it cannot
+       * shrink. This is to stop a behaviour where the page would scroll up automatically
+       * making the panel shrink or grow unpredictably.
+       */
+      const interactionStyleSubscription = combineLatest([
+        gridLayoutStateManager.gridDimensions$,
+        gridLayoutStateManager.interactionEvent$,
+      ]).subscribe(([dimensions, interactionEvent]) => {
+        if (!smoothHeightRef.current || gridLayoutStateManager.expandedPanelId$.getValue()) return;
 
-      if (!interactionEvent) {
-        smoothHeightRef.current.style.minHeight = `${dimensions.height}px`;
-        return;
-      }
-      smoothHeightRef.current.style.minHeight = `${
-        smoothHeightRef.current.getBoundingClientRect().height
-      }px`;
-    });
-
-    return () => {
-      interactionStyleSubscription.unsubscribe();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  return (
-    <div
-      ref={smoothHeightRef}
-      className={'kbnGridWrapper'}
-      css={css`
-        height: 100%;
-        overflow-anchor: none;
-        transition: min-height 500ms linear;
-
-        &:has(.kbnGridPanel--expanded) {
-          min-height: 100% !important;
-          max-height: 100vh; // fallback in case if the parent doesn't set the height correctly
-          position: relative;
-          transition: none;
+        if (!interactionEvent) {
+          smoothHeightRef.current.style.minHeight = `${dimensions.height}px`;
+          return;
         }
-      `}
-    >
-      {children}
-    </div>
-  );
+        smoothHeightRef.current.style.minHeight = `${
+          smoothHeightRef.current.getBoundingClientRect().height
+        }px`;
+      });
+
+      return () => {
+        interactionStyleSubscription.unsubscribe();
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+      <div
+        ref={smoothHeightRef}
+        className={'kbnGridWrapper'}
+        css={[styles.heightSmoothing, styles.hasActivePanel]}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+const styles = {
+  heightSmoothing: css({
+    height: '100%',
+    overflowAnchor: 'none',
+    transition: 'min-height 500ms linear',
+  }),
+  hasActivePanel: css({
+    '&:has(.kbnGridPanel--expanded)': {
+      minHeight: '100% !important',
+      maxHeight: '100vh', // fallback in case if the parent doesn't set the height correctly
+      position: 'relative',
+      transition: 'none',
+    },
+  }),
 };
+
+GridHeightSmoother.displayName = 'KbnGridLayoutHeightSmoother';

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/drag_handle/default_drag_handle.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/drag_handle/default_drag_handle.tsx
@@ -7,61 +7,57 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React from 'react';
-import { EuiIcon, useEuiTheme } from '@elastic/eui';
+import { EuiIcon, type UseEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
 import { UserInteractionEvent } from '../../use_grid_layout_events/types';
 
-export const DefaultDragHandle = ({
-  onDragStart,
-}: {
-  onDragStart: (e: UserInteractionEvent) => void;
-}) => {
-  const { euiTheme } = useEuiTheme();
+export const DefaultDragHandle = React.memo(
+  ({ onDragStart }: { onDragStart: (e: UserInteractionEvent) => void }) => {
+    return (
+      <button
+        onMouseDown={onDragStart}
+        onTouchStart={onDragStart}
+        aria-label={i18n.translate('kbnGridLayout.dragHandle.ariaLabel', {
+          defaultMessage: 'Drag to move',
+        })}
+        className="kbnGridPanel__dragHandle"
+        css={styles}
+      >
+        <EuiIcon type="grabOmnidirectional" />
+      </button>
+    );
+  }
+);
 
-  return (
-    <button
-      onMouseDown={onDragStart}
-      onTouchStart={onDragStart}
-      aria-label={i18n.translate('kbnGridLayout.dragHandle.ariaLabel', {
-        defaultMessage: 'Drag to move',
-      })}
-      className="kbnGridPanel__dragHandle"
-      css={css`
-        opacity: 0;
-        display: flex;
-        cursor: move;
-        position: absolute;
-        align-items: center;
-        justify-content: center;
-        top: -${euiTheme.size.l};
-        width: ${euiTheme.size.l};
-        height: ${euiTheme.size.l};
-        z-index: ${euiTheme.levels.modal};
-        margin-left: ${euiTheme.size.s};
-        border: 1px solid ${euiTheme.border.color};
-        border-bottom: none;
-        background-color: ${euiTheme.colors.backgroundBasePlain};
-        border-radius: ${euiTheme.border.radius} ${euiTheme.border.radius} 0 0;
-        cursor: grab;
-        transition: ${euiTheme.animation.slow} opacity;
-        .kbnGridPanel:hover &,
-        .kbnGridPanel:focus-within &,
-        &:active,
-        &:focus {
-          opacity: 1 !important;
-        }
-        &:active {
-          cursor: grabbing;
-        }
-        .kbnGrid--static &,
-        .kbnGridPanel--expanded & {
-          display: none;
-        }
-        touch-action: none;
-      `}
-    >
-      <EuiIcon type="grabOmnidirectional" />
-    </button>
-  );
-};
+const styles = ({ euiTheme }: UseEuiTheme) =>
+  css({
+    opacity: 0,
+    display: 'flex',
+    cursor: 'grab',
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center',
+    top: `-${euiTheme.size.l}`,
+    width: euiTheme.size.l,
+    height: euiTheme.size.l,
+    zIndex: euiTheme.levels.modal,
+    marginLeft: euiTheme.size.s,
+    border: `1px solid ${euiTheme.border.color}`,
+    borderBottom: 'none',
+    backgroundColor: euiTheme.colors.backgroundBasePlain,
+    borderRadius: `${euiTheme.border.radius} ${euiTheme.border.radius} 0 0`,
+    transition: `${euiTheme.animation.slow} opacity`,
+    touchAction: 'none',
+    '.kbnGridPanel:hover &, .kbnGridPanel:focus-within &, &:active, &:focus': {
+      opacity: '1 !important',
+    },
+    '&:active': {
+      cursor: 'grabbing',
+    },
+    '.kbnGrid--static &, .kbnGridPanel--expanded &': {
+      display: 'none',
+    },
+  });
+
+DefaultDragHandle.displayName = 'KbnGridLayoutDefaultDragHandle';

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/drag_handle/index.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/drag_handle/index.tsx
@@ -17,53 +17,57 @@ export interface DragHandleApi {
   setDragHandles: (refs: Array<HTMLElement | null>) => void;
 }
 
-export const DragHandle = React.forwardRef<
-  DragHandleApi,
-  {
-    gridLayoutStateManager: GridLayoutStateManager;
-    panelId: string;
-    rowIndex: number;
-  }
->(({ gridLayoutStateManager, panelId, rowIndex }, ref) => {
-  const startInteraction = useGridLayoutEvents({
-    interactionType: 'drag',
-    gridLayoutStateManager,
-    panelId,
-    rowIndex,
-  });
+export const DragHandle = React.memo(
+  React.forwardRef<
+    DragHandleApi,
+    {
+      gridLayoutStateManager: GridLayoutStateManager;
+      panelId: string;
+      rowIndex: number;
+    }
+  >(({ gridLayoutStateManager, panelId, rowIndex }, ref) => {
+    const startInteraction = useGridLayoutEvents({
+      interactionType: 'drag',
+      gridLayoutStateManager,
+      panelId,
+      rowIndex,
+    });
 
-  const [dragHandleCount, setDragHandleCount] = useState<number>(0);
-  const removeEventListenersRef = useRef<(() => void) | null>(null);
+    const [dragHandleCount, setDragHandleCount] = useState<number>(0);
+    const removeEventListenersRef = useRef<(() => void) | null>(null);
 
-  const setDragHandles = useCallback(
-    (dragHandles: Array<HTMLElement | null>) => {
-      setDragHandleCount(dragHandles.length);
-      for (const handle of dragHandles) {
-        if (handle === null) return;
-        handle.addEventListener('mousedown', startInteraction, { passive: true });
-        handle.addEventListener('touchstart', startInteraction, { passive: true });
-        handle.style.touchAction = 'none';
-      }
-      removeEventListenersRef.current = () => {
+    const setDragHandles = useCallback(
+      (dragHandles: Array<HTMLElement | null>) => {
+        setDragHandleCount(dragHandles.length);
         for (const handle of dragHandles) {
           if (handle === null) return;
-          handle.removeEventListener('mousedown', startInteraction);
-          handle.removeEventListener('touchstart', startInteraction);
+          handle.addEventListener('mousedown', startInteraction, { passive: true });
+          handle.addEventListener('touchstart', startInteraction, { passive: true });
+          handle.style.touchAction = 'none';
         }
-      };
-    },
-    [startInteraction]
-  );
+        removeEventListenersRef.current = () => {
+          for (const handle of dragHandles) {
+            if (handle === null) return;
+            handle.removeEventListener('mousedown', startInteraction);
+            handle.removeEventListener('touchstart', startInteraction);
+          }
+        };
+      },
+      [startInteraction]
+    );
 
-  useEffect(
-    () => () => {
-      // on unmount, remove all drag handle event listeners
-      removeEventListenersRef.current?.();
-    },
-    []
-  );
+    useEffect(
+      () => () => {
+        // on unmount, remove all drag handle event listeners
+        removeEventListenersRef.current?.();
+      },
+      []
+    );
 
-  useImperativeHandle(ref, () => ({ setDragHandles }), [setDragHandles]);
+    useImperativeHandle(ref, () => ({ setDragHandles }), [setDragHandles]);
 
-  return Boolean(dragHandleCount) ? null : <DefaultDragHandle onDragStart={startInteraction} />;
-});
+    return Boolean(dragHandleCount) ? null : <DefaultDragHandle onDragStart={startInteraction} />;
+  })
+);
+
+DragHandle.displayName = 'KbnGridLayoutDragHandle';

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/grid_panel.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/grid_panel.tsx
@@ -27,166 +27,165 @@ export interface GridPanelProps {
   gridLayoutStateManager: GridLayoutStateManager;
 }
 
-export const GridPanel = ({
-  panelId,
-  rowIndex,
-  renderPanelContents,
-  gridLayoutStateManager,
-}: GridPanelProps) => {
-  const [dragHandleApi, setDragHandleApi] = useState<DragHandleApi | null>(null);
-  const { euiTheme } = useEuiTheme();
+export const GridPanel = React.memo(
+  ({ panelId, rowIndex, renderPanelContents, gridLayoutStateManager }: GridPanelProps) => {
+    const [dragHandleApi, setDragHandleApi] = useState<DragHandleApi | null>(null);
+    const { euiTheme } = useEuiTheme();
 
-  /** Set initial styles based on state at mount to prevent styles from "blipping" */
-  const initialStyles = useMemo(() => {
-    const initialPanel = (gridLayoutStateManager.proposedGridLayout$.getValue() ??
-      gridLayoutStateManager.gridLayout$.getValue())[rowIndex].panels[panelId];
-    return css`
-      position: relative;
-      height: calc(
-        1px *
-          (
-            ${initialPanel.height} * (var(--kbnGridRowHeight) + var(--kbnGridGutterSize)) -
-              var(--kbnGridGutterSize)
-          )
-      );
-      grid-column-start: ${initialPanel.column + 1};
-      grid-column-end: ${initialPanel.column + 1 + initialPanel.width};
-      grid-row-start: ${initialPanel.row + 1};
-      grid-row-end: ${initialPanel.row + 1 + initialPanel.height};
-    `;
-  }, [gridLayoutStateManager, rowIndex, panelId]);
+    /** Set initial styles based on state at mount to prevent styles from "blipping" */
+    const initialStyles = useMemo(() => {
+      const initialPanel = (gridLayoutStateManager.proposedGridLayout$.getValue() ??
+        gridLayoutStateManager.gridLayout$.getValue())[rowIndex].panels[panelId];
+      return css`
+        position: relative;
+        height: calc(
+          1px *
+            (
+              ${initialPanel.height} * (var(--kbnGridRowHeight) + var(--kbnGridGutterSize)) -
+                var(--kbnGridGutterSize)
+            )
+        );
+        grid-column-start: ${initialPanel.column + 1};
+        grid-column-end: ${initialPanel.column + 1 + initialPanel.width};
+        grid-row-start: ${initialPanel.row + 1};
+        grid-row-end: ${initialPanel.row + 1 + initialPanel.height};
+      `;
+    }, [gridLayoutStateManager, rowIndex, panelId]);
 
-  useEffect(
-    () => {
-      /** Update the styles of the panel via a subscription to prevent re-renders */
-      const activePanelStyleSubscription = combineLatest([
-        gridLayoutStateManager.activePanel$,
-        gridLayoutStateManager.gridLayout$,
-        gridLayoutStateManager.proposedGridLayout$,
-      ])
-        .pipe(skip(1)) // skip the first emit because the `initialStyles` will take care of it
-        .subscribe(([activePanel, gridLayout, proposedGridLayout]) => {
-          const ref = gridLayoutStateManager.panelRefs.current[rowIndex][panelId];
-          const panel = (proposedGridLayout ?? gridLayout)[rowIndex].panels[panelId];
-          if (!ref || !panel) return;
+    useEffect(
+      () => {
+        /** Update the styles of the panel via a subscription to prevent re-renders */
+        const activePanelStyleSubscription = combineLatest([
+          gridLayoutStateManager.activePanel$,
+          gridLayoutStateManager.gridLayout$,
+          gridLayoutStateManager.proposedGridLayout$,
+        ])
+          .pipe(skip(1)) // skip the first emit because the `initialStyles` will take care of it
+          .subscribe(([activePanel, gridLayout, proposedGridLayout]) => {
+            const ref = gridLayoutStateManager.panelRefs.current[rowIndex][panelId];
+            const panel = (proposedGridLayout ?? gridLayout)[rowIndex].panels[panelId];
+            if (!ref || !panel) return;
 
-          const currentInteractionEvent = gridLayoutStateManager.interactionEvent$.getValue();
+            const currentInteractionEvent = gridLayoutStateManager.interactionEvent$.getValue();
 
-          if (panelId === activePanel?.id) {
-            ref.classList.add('kbnGridPanel--active');
+            if (panelId === activePanel?.id) {
+              ref.classList.add('kbnGridPanel--active');
 
-            // if the current panel is active, give it fixed positioning depending on the interaction event
-            const { position: draggingPosition } = activePanel;
-            const runtimeSettings = gridLayoutStateManager.runtimeSettings$.getValue();
+              // if the current panel is active, give it fixed positioning depending on the interaction event
+              const { position: draggingPosition } = activePanel;
+              const runtimeSettings = gridLayoutStateManager.runtimeSettings$.getValue();
 
-            ref.style.zIndex = `${euiTheme.levels.modal}`;
-            if (currentInteractionEvent?.type === 'resize') {
-              // if the current panel is being resized, ensure it is not shrunk past the size of a single cell
-              ref.style.width = `${Math.max(
-                draggingPosition.right - draggingPosition.left,
-                runtimeSettings.columnPixelWidth
-              )}px`;
-              ref.style.height = `${Math.max(
-                draggingPosition.bottom - draggingPosition.top,
-                runtimeSettings.rowHeight
-              )}px`;
+              ref.style.zIndex = `${euiTheme.levels.modal}`;
+              if (currentInteractionEvent?.type === 'resize') {
+                // if the current panel is being resized, ensure it is not shrunk past the size of a single cell
+                ref.style.width = `${Math.max(
+                  draggingPosition.right - draggingPosition.left,
+                  runtimeSettings.columnPixelWidth
+                )}px`;
+                ref.style.height = `${Math.max(
+                  draggingPosition.bottom - draggingPosition.top,
+                  runtimeSettings.rowHeight
+                )}px`;
 
-              // undo any "lock to grid" styles **except** for the top left corner, which stays locked
-              ref.style.gridColumnStart = `${panel.column + 1}`;
-              ref.style.gridRowStart = `${panel.row + 1}`;
-              ref.style.gridColumnEnd = `auto`;
-              ref.style.gridRowEnd = `auto`;
+                // undo any "lock to grid" styles **except** for the top left corner, which stays locked
+                ref.style.gridColumnStart = `${panel.column + 1}`;
+                ref.style.gridRowStart = `${panel.row + 1}`;
+                ref.style.gridColumnEnd = `auto`;
+                ref.style.gridRowEnd = `auto`;
+              } else {
+                // if the current panel is being dragged, render it with a fixed position + size
+                ref.style.position = 'fixed';
+
+                ref.style.left = `${draggingPosition.left}px`;
+                ref.style.top = `${draggingPosition.top}px`;
+                ref.style.width = `${draggingPosition.right - draggingPosition.left}px`;
+                ref.style.height = `${draggingPosition.bottom - draggingPosition.top}px`;
+
+                // undo any "lock to grid" styles
+                ref.style.gridArea = `auto`; // shortcut to set all grid styles to `auto`
+              }
             } else {
-              // if the current panel is being dragged, render it with a fixed position + size
-              ref.style.position = 'fixed';
+              ref.classList.remove('kbnGridPanel--active');
 
-              ref.style.left = `${draggingPosition.left}px`;
-              ref.style.top = `${draggingPosition.top}px`;
-              ref.style.width = `${draggingPosition.right - draggingPosition.left}px`;
-              ref.style.height = `${draggingPosition.bottom - draggingPosition.top}px`;
+              ref.style.zIndex = `auto`;
 
-              // undo any "lock to grid" styles
-              ref.style.gridArea = `auto`; // shortcut to set all grid styles to `auto`
+              // if the panel is not being dragged and/or resized, undo any fixed position styles
+              ref.style.position = '';
+              ref.style.left = ``;
+              ref.style.top = ``;
+              ref.style.width = ``;
+              // setting the height is necessary for mobile mode
+              ref.style.height = `calc(1px * (${panel.height} * (var(--kbnGridRowHeight) + var(--kbnGridGutterSize)) - var(--kbnGridGutterSize)))`;
+
+              // and render the panel locked to the grid
+              ref.style.gridColumnStart = `${panel.column + 1}`;
+              ref.style.gridColumnEnd = `${panel.column + 1 + panel.width}`;
+              ref.style.gridRowStart = `${panel.row + 1}`;
+              ref.style.gridRowEnd = `${panel.row + 1 + panel.height}`;
             }
-          } else {
-            ref.classList.remove('kbnGridPanel--active');
+          });
 
-            ref.style.zIndex = `auto`;
+        /**
+         * This subscription adds and/or removes the necessary class name for expanded panel styling
+         */
+        const expandedPanelSubscription = gridLayoutStateManager.expandedPanelId$.subscribe(
+          (expandedPanelId) => {
+            const ref = gridLayoutStateManager.panelRefs.current[rowIndex][panelId];
+            const gridLayout = gridLayoutStateManager.gridLayout$.getValue();
+            const panel = gridLayout[rowIndex].panels[panelId];
+            if (!ref || !panel) return;
 
-            // if the panel is not being dragged and/or resized, undo any fixed position styles
-            ref.style.position = '';
-            ref.style.left = ``;
-            ref.style.top = ``;
-            ref.style.width = ``;
-            // setting the height is necessary for mobile mode
-            ref.style.height = `calc(1px * (${panel.height} * (var(--kbnGridRowHeight) + var(--kbnGridGutterSize)) - var(--kbnGridGutterSize)))`;
-
-            // and render the panel locked to the grid
-            ref.style.gridColumnStart = `${panel.column + 1}`;
-            ref.style.gridColumnEnd = `${panel.column + 1 + panel.width}`;
-            ref.style.gridRowStart = `${panel.row + 1}`;
-            ref.style.gridRowEnd = `${panel.row + 1 + panel.height}`;
+            if (expandedPanelId && expandedPanelId === panelId) {
+              ref.classList.add('kbnGridPanel--expanded');
+            } else {
+              ref.classList.remove('kbnGridPanel--expanded');
+            }
           }
-        });
+        );
 
-      /**
-       * This subscription adds and/or removes the necessary class name for expanded panel styling
-       */
-      const expandedPanelSubscription = gridLayoutStateManager.expandedPanelId$.subscribe(
-        (expandedPanelId) => {
-          const ref = gridLayoutStateManager.panelRefs.current[rowIndex][panelId];
-          const gridLayout = gridLayoutStateManager.gridLayout$.getValue();
-          const panel = gridLayout[rowIndex].panels[panelId];
-          if (!ref || !panel) return;
+        return () => {
+          expandedPanelSubscription.unsubscribe();
+          activePanelStyleSubscription.unsubscribe();
+        };
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      []
+    );
 
-          if (expandedPanelId && expandedPanelId === panelId) {
-            ref.classList.add('kbnGridPanel--expanded');
-          } else {
-            ref.classList.remove('kbnGridPanel--expanded');
+    /**
+     * Memoize panel contents to prevent unnecessary re-renders
+     */
+    const panelContents = useMemo(() => {
+      if (!dragHandleApi) return <></>; // delays the rendering of the panel until after dragHandleApi is defined
+      return renderPanelContents(panelId, dragHandleApi.setDragHandles);
+    }, [panelId, renderPanelContents, dragHandleApi]);
+
+    return (
+      <div
+        ref={(element) => {
+          if (!gridLayoutStateManager.panelRefs.current[rowIndex]) {
+            gridLayoutStateManager.panelRefs.current[rowIndex] = {};
           }
-        }
-      );
+          gridLayoutStateManager.panelRefs.current[rowIndex][panelId] = element;
+        }}
+        css={initialStyles}
+        className="kbnGridPanel"
+      >
+        <DragHandle
+          ref={setDragHandleApi}
+          gridLayoutStateManager={gridLayoutStateManager}
+          panelId={panelId}
+          rowIndex={rowIndex}
+        />
+        {panelContents}
+        <ResizeHandle
+          gridLayoutStateManager={gridLayoutStateManager}
+          panelId={panelId}
+          rowIndex={rowIndex}
+        />
+      </div>
+    );
+  }
+);
 
-      return () => {
-        expandedPanelSubscription.unsubscribe();
-        activePanelStyleSubscription.unsubscribe();
-      };
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
-
-  /**
-   * Memoize panel contents to prevent unnecessary re-renders
-   */
-  const panelContents = useMemo(() => {
-    if (!dragHandleApi) return <></>; // delays the rendering of the panel until after dragHandleApi is defined
-    return renderPanelContents(panelId, dragHandleApi.setDragHandles);
-  }, [panelId, renderPanelContents, dragHandleApi]);
-
-  return (
-    <div
-      ref={(element) => {
-        if (!gridLayoutStateManager.panelRefs.current[rowIndex]) {
-          gridLayoutStateManager.panelRefs.current[rowIndex] = {};
-        }
-        gridLayoutStateManager.panelRefs.current[rowIndex][panelId] = element;
-      }}
-      css={initialStyles}
-      className="kbnGridPanel"
-    >
-      <DragHandle
-        ref={setDragHandleApi}
-        gridLayoutStateManager={gridLayoutStateManager}
-        panelId={panelId}
-        rowIndex={rowIndex}
-      />
-      {panelContents}
-      <ResizeHandle
-        gridLayoutStateManager={gridLayoutStateManager}
-        panelId={panelId}
-        rowIndex={rowIndex}
-      />
-    </div>
-  );
-};
+GridPanel.displayName = 'KbnGridLayoutPanel';

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/resize_handle.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_panel/resize_handle.tsx
@@ -8,56 +8,63 @@
  */
 
 import React from 'react';
-import { useEuiTheme } from '@elastic/eui';
+
+import type { UseEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
+
 import { GridLayoutStateManager } from '../types';
 import { useGridLayoutEvents } from '../use_grid_layout_events';
 
-export const ResizeHandle = ({
-  gridLayoutStateManager,
-  rowIndex,
-  panelId,
-}: {
-  gridLayoutStateManager: GridLayoutStateManager;
-  rowIndex: number;
-  panelId: string;
-}) => {
-  const { euiTheme } = useEuiTheme();
-  const startInteraction = useGridLayoutEvents({
-    interactionType: 'resize',
+export const ResizeHandle = React.memo(
+  ({
     gridLayoutStateManager,
-    panelId,
     rowIndex,
+    panelId,
+  }: {
+    gridLayoutStateManager: GridLayoutStateManager;
+    rowIndex: number;
+    panelId: string;
+  }) => {
+    const startInteraction = useGridLayoutEvents({
+      interactionType: 'resize',
+      gridLayoutStateManager,
+      panelId,
+      rowIndex,
+    });
+
+    return (
+      <button
+        css={styles}
+        onMouseDown={startInteraction}
+        onTouchStart={startInteraction}
+        className="kbnGridPanel--resizeHandle"
+        aria-label={i18n.translate('kbnGridLayout.resizeHandle.ariaLabel', {
+          defaultMessage: 'Resize panel',
+        })}
+      />
+    );
+  }
+);
+
+const styles = ({ euiTheme }: UseEuiTheme) =>
+  css({
+    right: '0',
+    bottom: '0',
+    margin: '-2px',
+    position: 'absolute',
+    width: euiTheme.size.l,
+    maxWidth: '100%',
+    maxHeight: '100%',
+    height: euiTheme.size.l,
+    zIndex: euiTheme.levels.toast,
+    touchAction: 'none',
+    '&:hover, &:focus': {
+      cursor: 'se-resize',
+    },
+    '.kbnGrid--static &, .kbnGridPanel--expanded &': {
+      display: 'none',
+    },
   });
-  return (
-    <button
-      onMouseDown={startInteraction}
-      onTouchStart={startInteraction}
-      className="kbnGridPanel--resizeHandle"
-      aria-label={i18n.translate('kbnGridLayout.resizeHandle.ariaLabel', {
-        defaultMessage: 'Resize panel',
-      })}
-      css={css`
-        right: 0;
-        bottom: 0;
-        margin: -2px;
-        position: absolute;
-        width: ${euiTheme.size.l};
-        max-width: 100%;
-        max-height: 100%;
-        height: ${euiTheme.size.l};
-        z-index: ${euiTheme.levels.toast};
-        &:hover,
-        &:focus {
-          cursor: se-resize;
-        }
-        .kbnGrid--static &,
-        .kbnGridPanel--expanded & {
-          display: none;
-        }
-        touch-action: none;
-      `}
-    />
-  );
-};
+
+ResizeHandle.displayName = 'KbnGridLayoutResizeHandle';

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_row/grid_row.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_row/grid_row.tsx
@@ -8,8 +8,9 @@
  */
 
 import { cloneDeep } from 'lodash';
-import React, { useEffect, useMemo, useState } from 'react';
-import { map, pairwise, skip, combineLatest } from 'rxjs';
+import React, { useEffect, useState } from 'react';
+import { combineLatest, distinctUntilChanged, map, pairwise, skip } from 'rxjs';
+
 import { css } from '@emotion/react';
 
 import { DragPreview } from '../drag_preview';
@@ -27,173 +28,167 @@ export interface GridRowProps {
   gridLayoutStateManager: GridLayoutStateManager;
 }
 
-export const GridRow = ({
-  rowIndex,
-  renderPanelContents,
-  gridLayoutStateManager,
-}: GridRowProps) => {
-  const currentRow = gridLayoutStateManager.gridLayout$.value[rowIndex];
+export const GridRow = React.memo(
+  ({ rowIndex, renderPanelContents, gridLayoutStateManager }: GridRowProps) => {
+    const currentRow = gridLayoutStateManager.gridLayout$.value[rowIndex];
 
-  const [panelIds, setPanelIds] = useState<string[]>(Object.keys(currentRow.panels));
-  const [panelIdsInOrder, setPanelIdsInOrder] = useState<string[]>(() =>
-    getKeysInOrder(currentRow.panels)
-  );
-  const [rowTitle, setRowTitle] = useState<string>(currentRow.title);
-  const [isCollapsed, setIsCollapsed] = useState<boolean>(currentRow.isCollapsed);
-
-  /** Set initial styles based on state at mount to prevent styles from "blipping" */
-  const initialStyles = useMemo(() => {
-    const { columnCount } = gridLayoutStateManager.runtimeSettings$.getValue();
-    return css`
-      grid-auto-rows: calc(var(--kbnGridRowHeight) * 1px);
-      grid-template-columns: repeat(
-        ${columnCount},
-        calc((100% - (var(--kbnGridGutterSize) * ${columnCount - 1}px)) / ${columnCount})
-      );
-      gap: calc(var(--kbnGridGutterSize) * 1px);
-    `;
-  }, [gridLayoutStateManager]);
-
-  useEffect(
-    () => {
-      /** Update the styles of the grid row via a subscription to prevent re-renders */
-      const interactionStyleSubscription = gridLayoutStateManager.interactionEvent$
-        .pipe(skip(1)) // skip the first emit because the `initialStyles` will take care of it
-        .subscribe((interactionEvent) => {
-          const rowRef = gridLayoutStateManager.rowRefs.current[rowIndex];
-          if (!rowRef) return;
-
-          const targetRow = interactionEvent?.targetRowIndex;
-          if (rowIndex === targetRow && interactionEvent) {
-            rowRef.classList.add('kbnGridRow--targeted');
-          } else {
-            rowRef.classList.remove('kbnGridRow--targeted');
-          }
-        });
-
-      /**
-       * This subscription ensures that the row will re-render when one of the following changes:
-       * - Title
-       * - Collapsed state
-       * - Panel IDs (adding/removing/replacing, but not reordering)
-       */
-      const rowStateSubscription = combineLatest([
-        gridLayoutStateManager.proposedGridLayout$,
-        gridLayoutStateManager.gridLayout$,
-      ])
-        .pipe(
-          map(([proposedGridLayout, gridLayout]) => {
-            const displayedGridLayout = proposedGridLayout ?? gridLayout;
-            return {
-              title: displayedGridLayout[rowIndex].title,
-              isCollapsed: displayedGridLayout[rowIndex].isCollapsed,
-              panelIds: Object.keys(displayedGridLayout[rowIndex].panels),
-            };
-          }),
-          pairwise()
-        )
-        .subscribe(([oldRowData, newRowData]) => {
-          if (oldRowData.title !== newRowData.title) setRowTitle(newRowData.title);
-          if (oldRowData.isCollapsed !== newRowData.isCollapsed)
-            setIsCollapsed(newRowData.isCollapsed);
-          if (
-            oldRowData.panelIds.length !== newRowData.panelIds.length ||
-            !(
-              oldRowData.panelIds.every((p) => newRowData.panelIds.includes(p)) &&
-              newRowData.panelIds.every((p) => oldRowData.panelIds.includes(p))
-            )
-          ) {
-            setPanelIds(newRowData.panelIds);
-            setPanelIdsInOrder(
-              getKeysInOrder(
-                (gridLayoutStateManager.proposedGridLayout$.getValue() ??
-                  gridLayoutStateManager.gridLayout$.getValue())[rowIndex].panels
-              )
-            );
-          }
-        });
-
-      /**
-       * Ensure the row re-renders to reflect the new panel order after a drag-and-drop interaction, since
-       * the order of rendered panels need to be aligned with how they are displayed in the grid for accessibility
-       * reasons (screen readers and focus management).
-       */
-      const gridLayoutSubscription = gridLayoutStateManager.gridLayout$.subscribe((gridLayout) => {
-        const newPanelIdsInOrder = getKeysInOrder(gridLayout[rowIndex].panels);
-        if (panelIdsInOrder.join() !== newPanelIdsInOrder.join()) {
-          setPanelIdsInOrder(newPanelIdsInOrder);
-        }
-      });
-
-      return () => {
-        interactionStyleSubscription.unsubscribe();
-        gridLayoutSubscription.unsubscribe();
-        rowStateSubscription.unsubscribe();
-      };
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [rowIndex]
-  );
-
-  /**
-   * Memoize panel children components (independent of their order) to prevent unnecessary re-renders
-   */
-  const children: { [panelId: string]: React.ReactNode } = useMemo(() => {
-    return panelIds.reduce(
-      (prev, panelId) => ({
-        ...prev,
-        [panelId]: (
-          <GridPanel
-            key={panelId}
-            panelId={panelId}
-            rowIndex={rowIndex}
-            gridLayoutStateManager={gridLayoutStateManager}
-            renderPanelContents={renderPanelContents}
-          />
-        ),
-      }),
-      {}
+    const [panelIdsInOrder, setPanelIdsInOrder] = useState<string[]>(() =>
+      getKeysInOrder(currentRow.panels)
     );
-  }, [panelIds, gridLayoutStateManager, renderPanelContents, rowIndex]);
+    const [rowTitle, setRowTitle] = useState<string>(currentRow.title);
+    const [isCollapsed, setIsCollapsed] = useState<boolean>(currentRow.isCollapsed);
 
-  return (
-    <div
-      css={css`
-        height: 100%;
-      `}
-      className="kbnGridRowContainer"
-    >
-      {rowIndex !== 0 && (
-        <GridRowHeader
-          isCollapsed={isCollapsed}
-          toggleIsCollapsed={() => {
-            const newLayout = cloneDeep(gridLayoutStateManager.gridLayout$.value);
-            newLayout[rowIndex].isCollapsed = !newLayout[rowIndex].isCollapsed;
-            gridLayoutStateManager.gridLayout$.next(newLayout);
-          }}
-          rowTitle={rowTitle}
-        />
-      )}
-      {!isCollapsed && (
-        <div
-          className={'kbnGridRow'}
-          ref={(element: HTMLDivElement | null) =>
-            (gridLayoutStateManager.rowRefs.current[rowIndex] = element)
+    useEffect(
+      () => {
+        /** Update the styles of the grid row via a subscription to prevent re-renders */
+        const interactionStyleSubscription = gridLayoutStateManager.interactionEvent$
+          .pipe(skip(1)) // skip the first emit because the `initialStyles` will take care of it
+          .subscribe((interactionEvent) => {
+            const rowRef = gridLayoutStateManager.rowRefs.current[rowIndex];
+            if (!rowRef) return;
+
+            const targetRow = interactionEvent?.targetRowIndex;
+            if (rowIndex === targetRow && interactionEvent) {
+              rowRef.classList.add('kbnGridRow--targeted');
+            } else {
+              rowRef.classList.remove('kbnGridRow--targeted');
+            }
+          });
+
+        /**
+         * This subscription ensures that the row will re-render when one of the following changes:
+         * - Title
+         * - Collapsed state
+         * - Panel IDs (adding/removing/replacing, but not reordering)
+         */
+        const rowStateSubscription = combineLatest([
+          gridLayoutStateManager.proposedGridLayout$,
+          gridLayoutStateManager.gridLayout$,
+        ])
+          .pipe(
+            map(([proposedGridLayout, gridLayout]) => {
+              const displayedGridLayout = proposedGridLayout ?? gridLayout;
+              return {
+                title: displayedGridLayout[rowIndex].title,
+                isCollapsed: displayedGridLayout[rowIndex].isCollapsed,
+                panelIds: Object.keys(displayedGridLayout[rowIndex].panels),
+              };
+            }),
+            pairwise()
+          )
+          .subscribe(([oldRowData, newRowData]) => {
+            if (oldRowData.title !== newRowData.title) setRowTitle(newRowData.title);
+            if (oldRowData.isCollapsed !== newRowData.isCollapsed)
+              setIsCollapsed(newRowData.isCollapsed);
+            if (
+              oldRowData.panelIds.length !== newRowData.panelIds.length ||
+              !(
+                oldRowData.panelIds.every((p) => newRowData.panelIds.includes(p)) &&
+                newRowData.panelIds.every((p) => oldRowData.panelIds.includes(p))
+              )
+            ) {
+              setPanelIdsInOrder(
+                getKeysInOrder(
+                  (gridLayoutStateManager.proposedGridLayout$.getValue() ??
+                    gridLayoutStateManager.gridLayout$.getValue())[rowIndex].panels
+                )
+              );
+            }
+          });
+
+        /**
+         * Ensure the row re-renders to reflect the new panel order after a drag-and-drop interaction, since
+         * the order of rendered panels need to be aligned with how they are displayed in the grid for accessibility
+         * reasons (screen readers and focus management).
+         */
+        const gridLayoutSubscription = gridLayoutStateManager.gridLayout$.subscribe(
+          (gridLayout) => {
+            const newPanelIdsInOrder = getKeysInOrder(gridLayout[rowIndex].panels);
+            if (panelIdsInOrder.join() !== newPanelIdsInOrder.join()) {
+              setPanelIdsInOrder(newPanelIdsInOrder);
+            }
           }
-          css={css`
-            height: 100%;
-            display: grid;
-            position: relative;
-            justify-items: stretch;
-            transition: background-color 300ms linear;
-            ${initialStyles};
-          `}
-        >
-          {/* render the panels **in order** for accessibility, using the memoized panel components */}
-          {panelIdsInOrder.map((panelId) => children[panelId])}
-          <DragPreview rowIndex={rowIndex} gridLayoutStateManager={gridLayoutStateManager} />
-        </div>
-      )}
-    </div>
-  );
+        );
+
+        const columnCountSubscription = gridLayoutStateManager.runtimeSettings$
+          .pipe(
+            map(({ columnCount }) => columnCount),
+            distinctUntilChanged()
+          )
+          .subscribe((columnCount) => {
+            const rowRef = gridLayoutStateManager.rowRefs.current[rowIndex];
+            if (!rowRef) return;
+            rowRef.style.setProperty('--kbnGridRowColumnCount', `${columnCount}`);
+          });
+
+        return () => {
+          interactionStyleSubscription.unsubscribe();
+          gridLayoutSubscription.unsubscribe();
+          rowStateSubscription.unsubscribe();
+          columnCountSubscription.unsubscribe();
+        };
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [rowIndex]
+    );
+
+    return (
+      <div css={styles.fullHeight} className="kbnGridRowContainer">
+        {rowIndex !== 0 && (
+          <GridRowHeader
+            isCollapsed={isCollapsed}
+            toggleIsCollapsed={() => {
+              const newLayout = cloneDeep(gridLayoutStateManager.gridLayout$.value);
+              newLayout[rowIndex].isCollapsed = !newLayout[rowIndex].isCollapsed;
+              gridLayoutStateManager.gridLayout$.next(newLayout);
+            }}
+            rowTitle={rowTitle}
+          />
+        )}
+        {!isCollapsed && (
+          <div
+            className={'kbnGridRow'}
+            ref={(element: HTMLDivElement | null) =>
+              (gridLayoutStateManager.rowRefs.current[rowIndex] = element)
+            }
+            css={[styles.fullHeight, styles.grid]}
+          >
+            {/* render the panels **in order** for accessibility, using the memoized panel components */}
+            {panelIdsInOrder.map((panelId) => (
+              <GridPanel
+                key={panelId}
+                panelId={panelId}
+                rowIndex={rowIndex}
+                gridLayoutStateManager={gridLayoutStateManager}
+                renderPanelContents={renderPanelContents}
+              />
+            ))}
+            <DragPreview rowIndex={rowIndex} gridLayoutStateManager={gridLayoutStateManager} />
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+const styles = {
+  fullHeight: css({
+    height: '100%',
+  }),
+  grid: css({
+    position: 'relative',
+    justifyItems: 'stretch',
+    display: 'grid',
+    gap: 'calc(var(--kbnGridGutterSize) * 1px)',
+    gridAutoRows: 'calc(var(--kbnGridRowHeight) * 1px)',
+    gridTemplateColumns: `repeat(
+          var(--kbnGridRowColumnCount),
+          calc(
+            (100% - (var(--kbnGridGutterSize) * (var(--kbnGridRowColumnCount) - 1) * 1px)) /
+              var(--kbnGridRowColumnCount)
+          )
+        )`,
+  }),
 };
+
+GridRow.displayName = 'KbnGridLayoutRow';

--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_row/grid_row_header.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_row/grid_row_header.tsx
@@ -10,32 +10,36 @@ import React from 'react';
 import { EuiButtonIcon, EuiFlexGroup, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
-export const GridRowHeader = ({
-  isCollapsed,
-  toggleIsCollapsed,
-  rowTitle,
-}: {
-  isCollapsed: boolean;
-  toggleIsCollapsed: () => void;
-  rowTitle?: string;
-}) => {
-  return (
-    <div className="kbnGridRowHeader">
-      <EuiSpacer size="s" />
-      <EuiFlexGroup gutterSize="s">
-        <EuiButtonIcon
-          color="text"
-          aria-label={i18n.translate('kbnGridLayout.row.toggleCollapse', {
-            defaultMessage: 'Toggle collapse',
-          })}
-          iconType={isCollapsed ? 'arrowRight' : 'arrowDown'}
-          onClick={toggleIsCollapsed}
-        />
-        <EuiTitle size="xs">
-          <h2>{rowTitle}</h2>
-        </EuiTitle>
-      </EuiFlexGroup>
-      <EuiSpacer size="s" />
-    </div>
-  );
-};
+export const GridRowHeader = React.memo(
+  ({
+    isCollapsed,
+    toggleIsCollapsed,
+    rowTitle,
+  }: {
+    isCollapsed: boolean;
+    toggleIsCollapsed: () => void;
+    rowTitle?: string;
+  }) => {
+    return (
+      <div className="kbnGridRowHeader">
+        <EuiSpacer size="s" />
+        <EuiFlexGroup gutterSize="s">
+          <EuiButtonIcon
+            color="text"
+            aria-label={i18n.translate('kbnGridLayout.row.toggleCollapse', {
+              defaultMessage: 'Toggle collapse',
+            })}
+            iconType={isCollapsed ? 'arrowRight' : 'arrowDown'}
+            onClick={toggleIsCollapsed}
+          />
+          <EuiTitle size="xs">
+            <h2>{rowTitle}</h2>
+          </EuiTitle>
+        </EuiFlexGroup>
+        <EuiSpacer size="s" />
+      </div>
+    );
+  }
+);
+
+GridRowHeader.displayName = 'KbnGridLayoutRowHeader';

--- a/src/platform/packages/private/kbn-grid-layout/tsconfig.json
+++ b/src/platform/packages/private/kbn-grid-layout/tsconfig.json
@@ -1,16 +1,9 @@
 {
   "extends": "../../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "target/types",
+    "outDir": "target/types"
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-  ],
-  "exclude": [
-    "target/**/*"
-  ],
-  "kbn_references": [
-    "@kbn/i18n",
-  ]
+  "include": ["**/*.ts", "**/*.tsx", "../../../../../typings/emotion.d.ts"],
+  "exclude": ["target/**/*"],
+  "kbn_references": ["@kbn/i18n"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[kbn-grid-layout] Cleanup memoization and styling (#210285)](https://github.com/elastic/kibana/pull/210285)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Mudge","email":"Heenawter@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-05T22:18:04Z","message":"[Dashboard] Presentation panel refactor (#207275)\n\nCloses https://github.com/elastic/kibana/issues/206686\r\nCloses https://github.com/elastic/kibana/issues/197897\r\nPart of https://github.com/elastic/kibana/issues/207852\r\n\r\n## Summary\r\n\r\nThis PR is a major refactor of the `PresentationPanel` component,\r\nincluding an overhaul of the hover action and panel title components.\r\nSome notable highlights include:\r\n- All styles in the `PresentationPanel` component were moved from SASS\r\nto Emotion\r\n- The over-complicated logic to combine hover actions when the panel\r\nshrinks was removed in favour of CSS, driven by a [container\r\nquery](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries)\r\nRemoving the `updateCombineHoverActions` function (which was defined in\r\na React component and not memoized) also made a difference in\r\nperformance when dragging:\r\n    \r\n   | Before | After |\r\n   |--------|--------|\r\n|\r\n![image](https://github.com/user-attachments/assets/e66898d6-a6fc-42c7-9e24-f116d3bd85a6)\r\n|\r\n![image](https://github.com/user-attachments/assets/1f1d75ba-2ebc-4def-9d2e-14dfd5e1a585)\r\n|\r\n      \r\n\r\n- The over-complicated logic defined in\r\n`usePresentationPanelTitleClickHandle`, which was meant to ignore the\r\n`onClick` that would trigger after a panel was dragged, was converted to\r\n2 lines of CSS\r\n\r\n### Small usability improvements\r\n\r\nThis PR also includes a few small usability improvements, such as:\r\n\r\n- Ensuring that only the **first** row of hover actions overlaps with\r\nthe Dashboard's sticky top navigation bar, and this only happens when\r\nthe dashboard has no controls. This results in much better behaviour in\r\nmost scenarios:\r\n  \r\n  | Before | After |\r\n  |--------|--------|\r\n| ![Jan-27-2025\r\n16-14-26](https://github.com/user-attachments/assets/2bf5eaa0-06ab-4d87-897f-d217f189daf7)\r\n| ![Jan-27-2025\r\n16-13-41](https://github.com/user-attachments/assets/61b0f06a-1363-4bfc-8a2b-c57a3e736552)\r\n|\r\n\r\n- Adding a small delay for hiding the hover actions on mouse leave,\r\nwhich makes it a lot easier to grab the drag handle:\r\n\r\n  | Before | After |\r\n  |--------|--------|\r\n| ![Jan-27-2025\r\n16-21-11](https://github.com/user-attachments/assets/65138e53-1856-44f0-913f-01383b8aa6c2)\r\n| ![Jan-27-2025\r\n16-20-17](https://github.com/user-attachments/assets/7c8ba4d8-8b77-4bc5-85af-a082cace1f96)\r\n|\r\n\r\n- Preventing the resize handle from overlapping Dashboard's stick top\r\nnavigation:\r\n\r\n  | Before | After |\r\n  |--------|--------|\r\n| ![Jan-27-2025\r\n16-24-31](https://github.com/user-attachments/assets/5363a302-5f6a-4483-9782-516023567d87)\r\n| ![Jan-27-2025\r\n16-25-04](https://github.com/user-attachments/assets/8614d025-b45b-4af2-81d6-c62a086ca427)\r\n|\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c35698bcf81314f833467fde2d3c14785b83c1ad","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["performance","Team:Presentation","loe:medium","technical debt","release_note:skip","impact:high","backport:version","v9.1.0","v8.19.0"],"title":"[Dashboard] Presentation panel refactor","number":207275,"url":"https://github.com/elastic/kibana/pull/207275","mergeCommit":{"message":"[Dashboard] Presentation panel refactor (#207275)\n\nCloses https://github.com/elastic/kibana/issues/206686\r\nCloses https://github.com/elastic/kibana/issues/197897\r\nPart of https://github.com/elastic/kibana/issues/207852\r\n\r\n## Summary\r\n\r\nThis PR is a major refactor of the `PresentationPanel` component,\r\nincluding an overhaul of the hover action and panel title components.\r\nSome notable highlights include:\r\n- All styles in the `PresentationPanel` component were moved from SASS\r\nto Emotion\r\n- The over-complicated logic to combine hover actions when the panel\r\nshrinks was removed in favour of CSS, driven by a [container\r\nquery](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries)\r\nRemoving the `updateCombineHoverActions` function (which was defined in\r\na React component and not memoized) also made a difference in\r\nperformance when dragging:\r\n    \r\n   | Before | After |\r\n   |--------|--------|\r\n|\r\n![image](https://github.com/user-attachments/assets/e66898d6-a6fc-42c7-9e24-f116d3bd85a6)\r\n|\r\n![image](https://github.com/user-attachments/assets/1f1d75ba-2ebc-4def-9d2e-14dfd5e1a585)\r\n|\r\n      \r\n\r\n- The over-complicated logic defined in\r\n`usePresentationPanelTitleClickHandle`, which was meant to ignore the\r\n`onClick` that would trigger after a panel was dragged, was converted to\r\n2 lines of CSS\r\n\r\n### Small usability improvements\r\n\r\nThis PR also includes a few small usability improvements, such as:\r\n\r\n- Ensuring that only the **first** row of hover actions overlaps with\r\nthe Dashboard's sticky top navigation bar, and this only happens when\r\nthe dashboard has no controls. This results in much better behaviour in\r\nmost scenarios:\r\n  \r\n  | Before | After |\r\n  |--------|--------|\r\n| ![Jan-27-2025\r\n16-14-26](https://github.com/user-attachments/assets/2bf5eaa0-06ab-4d87-897f-d217f189daf7)\r\n| ![Jan-27-2025\r\n16-13-41](https://github.com/user-attachments/assets/61b0f06a-1363-4bfc-8a2b-c57a3e736552)\r\n|\r\n\r\n- Adding a small delay for hiding the hover actions on mouse leave,\r\nwhich makes it a lot easier to grab the drag handle:\r\n\r\n  | Before | After |\r\n  |--------|--------|\r\n| ![Jan-27-2025\r\n16-21-11](https://github.com/user-attachments/assets/65138e53-1856-44f0-913f-01383b8aa6c2)\r\n| ![Jan-27-2025\r\n16-20-17](https://github.com/user-attachments/assets/7c8ba4d8-8b77-4bc5-85af-a082cace1f96)\r\n|\r\n\r\n- Preventing the resize handle from overlapping Dashboard's stick top\r\nnavigation:\r\n\r\n  | Before | After |\r\n  |--------|--------|\r\n| ![Jan-27-2025\r\n16-24-31](https://github.com/user-attachments/assets/5363a302-5f6a-4483-9782-516023567d87)\r\n| ![Jan-27-2025\r\n16-25-04](https://github.com/user-attachments/assets/8614d025-b45b-4af2-81d6-c62a086ca427)\r\n|\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c35698bcf81314f833467fde2d3c14785b83c1ad"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/207275","number":207275,"mergeCommit":{"message":"[Dashboard] Presentation panel refactor (#207275)\n\nCloses https://github.com/elastic/kibana/issues/206686\r\nCloses https://github.com/elastic/kibana/issues/197897\r\nPart of https://github.com/elastic/kibana/issues/207852\r\n\r\n## Summary\r\n\r\nThis PR is a major refactor of the `PresentationPanel` component,\r\nincluding an overhaul of the hover action and panel title components.\r\nSome notable highlights include:\r\n- All styles in the `PresentationPanel` component were moved from SASS\r\nto Emotion\r\n- The over-complicated logic to combine hover actions when the panel\r\nshrinks was removed in favour of CSS, driven by a [container\r\nquery](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries)\r\nRemoving the `updateCombineHoverActions` function (which was defined in\r\na React component and not memoized) also made a difference in\r\nperformance when dragging:\r\n    \r\n   | Before | After |\r\n   |--------|--------|\r\n|\r\n![image](https://github.com/user-attachments/assets/e66898d6-a6fc-42c7-9e24-f116d3bd85a6)\r\n|\r\n![image](https://github.com/user-attachments/assets/1f1d75ba-2ebc-4def-9d2e-14dfd5e1a585)\r\n|\r\n      \r\n\r\n- The over-complicated logic defined in\r\n`usePresentationPanelTitleClickHandle`, which was meant to ignore the\r\n`onClick` that would trigger after a panel was dragged, was converted to\r\n2 lines of CSS\r\n\r\n### Small usability improvements\r\n\r\nThis PR also includes a few small usability improvements, such as:\r\n\r\n- Ensuring that only the **first** row of hover actions overlaps with\r\nthe Dashboard's sticky top navigation bar, and this only happens when\r\nthe dashboard has no controls. This results in much better behaviour in\r\nmost scenarios:\r\n  \r\n  | Before | After |\r\n  |--------|--------|\r\n| ![Jan-27-2025\r\n16-14-26](https://github.com/user-attachments/assets/2bf5eaa0-06ab-4d87-897f-d217f189daf7)\r\n| ![Jan-27-2025\r\n16-13-41](https://github.com/user-attachments/assets/61b0f06a-1363-4bfc-8a2b-c57a3e736552)\r\n|\r\n\r\n- Adding a small delay for hiding the hover actions on mouse leave,\r\nwhich makes it a lot easier to grab the drag handle:\r\n\r\n  | Before | After |\r\n  |--------|--------|\r\n| ![Jan-27-2025\r\n16-21-11](https://github.com/user-attachments/assets/65138e53-1856-44f0-913f-01383b8aa6c2)\r\n| ![Jan-27-2025\r\n16-20-17](https://github.com/user-attachments/assets/7c8ba4d8-8b77-4bc5-85af-a082cace1f96)\r\n|\r\n\r\n- Preventing the resize handle from overlapping Dashboard's stick top\r\nnavigation:\r\n\r\n  | Before | After |\r\n  |--------|--------|\r\n| ![Jan-27-2025\r\n16-24-31](https://github.com/user-attachments/assets/5363a302-5f6a-4483-9782-516023567d87)\r\n| ![Jan-27-2025\r\n16-25-04](https://github.com/user-attachments/assets/8614d025-b45b-4af2-81d6-c62a086ca427)\r\n|\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c35698bcf81314f833467fde2d3c14785b83c1ad"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->