### PR TITLE
feat(slo): group by slo id

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/find_group.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/find_group.ts
@@ -14,6 +14,7 @@ const groupBySchema = t.union([
   t.literal('slo.indicator.type'),
   t.literal('slo.instanceId'),
   t.literal('_index'),
+  t.literal('slo.id'),
 ]);
 
 const findSLOGroupsParamsSchema = t.partial({

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/common/quick_filters.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/common/quick_filters.tsx
@@ -59,6 +59,9 @@ export function QuickFilters({
           align-items: flex-start;
           min-height: initial;
         }
+        .controlPanel {
+          height: initial;
+        }
         .controlGroup {
           min-height: initial;
         }

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/grouped_slos/hooks/use_group_name.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/grouped_slos/hooks/use_group_name.ts
@@ -18,6 +18,7 @@ export function useGroupName(groupBy: GroupByField, group: string, summary?: Gro
     case 'ungrouped':
     case 'slo.tags':
     case 'status':
+    case 'slo.id':
       return groupName;
     case 'slo.instanceId':
       if (groupName === ALL_VALUE || !summary?.worst?.slo?.groupings) {

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list_group_by.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list_group_by.tsx
@@ -81,6 +81,16 @@ export function SloGroupBy({ onStateChange, state, loading }: Props) {
       },
     },
     {
+      label: i18n.translate('xpack.slo.list.groupBy.sloId', {
+        defaultMessage: 'SLO definition id',
+      }),
+      checked: groupBy === 'slo.id',
+      value: 'slo.id',
+      onClick: () => {
+        handleChangeGroupBy('slo.id');
+      },
+    },
+    {
       label: i18n.translate('xpack.slo.list.groupBy.sloInstanceId', {
         defaultMessage: 'SLO instance id',
       }),

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/types.ts
@@ -12,7 +12,8 @@ export type GroupByField =
   | 'status'
   | 'slo.indicator.type'
   | 'slo.instanceId'
-  | '_index';
+  | '_index'
+  | 'slo.id';
 export type SortDirection = 'asc' | 'desc';
 export type SortField =
   | 'sli_value'


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/210467

## 🏎️ Summary

This PR adds a group by option on `slo.id`, allowing customer to navigate a large amount of SLO instances more easily by grouping on the SLO definition id.


![image](https://github.com/user-attachments/assets/db35863d-b5bd-430d-9bc7-70ff1440340a)


## Manual testing

Create some SLO with many groups that yield a lot of instances. Wait for the summary instances to be generated and group by "SLO definition id" on the UI view.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->