### PR TITLE
[8.18] [Security Solution][Alert Flyout] Update entity insight badge to open entity flyouts (#208287)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/host_details.tsx
@@ -29,13 +29,16 @@ import {
   MISCONFIGURATION_INSIGHT_HOST_DETAILS,
   VULNERABILITIES_INSIGHT_HOST_DETAILS,
 } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
+import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
+import { useHasVulnerabilities } from '@kbn/cloud-security-posture/src/hooks/use_has_vulnerabilities';
+import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use_non_closed_alerts';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import type { RelatedUser } from '../../../../../common/search_strategy/security_solution/related_entities/related_users';
 import type { RiskSeverity } from '../../../../../common/search_strategy';
 import { HostOverview } from '../../../../overview/components/host_overview';
 import { AnomalyTableProvider } from '../../../../common/components/ml/anomaly/anomaly_table_provider';
 import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
-import { EntityType } from '../../../../../common/entity_analytics/types';
+import { EntityIdentifierFields, EntityType } from '../../../../../common/entity_analytics/types';
 import { RiskScoreLevel } from '../../../../entity_analytics/components/severity/common';
 import { DefaultFieldRenderer } from '../../../../timelines/components/field_renderers/default_renderer';
 import { InputsModelId } from '../../../../common/store/inputs/constants';
@@ -74,9 +77,13 @@ import { MisconfigurationsInsight } from '../../shared/components/misconfigurati
 import { VulnerabilitiesInsight } from '../../shared/components/vulnerabilities_insight';
 import { AlertCountInsight } from '../../shared/components/alert_count_insight';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
+import { useNavigateToHostDetails } from '../../../entity_details/host_right/hooks/use_navigate_to_host_details';
+import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
+import { buildHostNamesFilter } from '../../../../../common/search_strategy';
 
 const HOST_DETAILS_ID = 'entities-hosts-details';
 const RELATED_USERS_ID = 'entities-hosts-related-users';
+const HOST_DETAILS_INSIGHTS_ID = 'host-details-insights';
 
 const HostOverviewManage = manageQuery(HostOverview);
 const RelatedUsersManage = manageQuery(InspectButtonContainer);
@@ -112,6 +119,14 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
   const isEntityAnalyticsAuthorized = isPlatinumOrTrialLicense && hasEntityAnalyticsCapability;
 
   const { openPreviewPanel } = useExpandableFlyoutApi();
+
+  const timerange = useMemo(
+    () => ({
+      from,
+      to,
+    }),
+    [from, to]
+  );
 
   const narrowDateRange = useCallback<NarrowDateRange>(
     (score, interval) => {
@@ -149,6 +164,40 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
     hostName,
     indexNames: selectedPatterns,
     skip: selectedPatterns.length === 0,
+  });
+
+  const filterQuery = useMemo(
+    () => (hostName ? buildHostNamesFilter([hostName]) : undefined),
+    [hostName]
+  );
+  const { data: hostRisk } = useRiskScore({
+    filterQuery,
+    riskEntity: EntityType.host,
+    skip: hostName == null,
+    timerange,
+  });
+  const hostRiskData = hostRisk && hostRisk.length > 0 ? hostRisk[0] : undefined;
+  const isRiskScoreExist = !!hostRiskData?.host.risk;
+
+  const { hasNonClosedAlerts } = useNonClosedAlerts({
+    field: EntityIdentifierFields.hostName,
+    value: hostName,
+    to,
+    from,
+    queryId: 'HostEntityOverview',
+  });
+  const { hasMisconfigurationFindings } = useHasMisconfigurations('host.name', hostName);
+  const { hasVulnerabilitiesFindings } = useHasVulnerabilities('host.name', hostName);
+
+  const { openDetailsPanel } = useNavigateToHostDetails({
+    hostName,
+    scopeId,
+    isRiskScoreExist,
+    hasMisconfigurationFindings,
+    hasVulnerabilitiesFindings,
+    hasNonClosedAlerts,
+    isPreviewMode: true, // setting to true to always open a new host flyout
+    contextID: HOST_DETAILS_INSIGHTS_ID,
   });
 
   const {
@@ -343,18 +392,21 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
             fieldName={'host.name'}
             name={hostName}
             direction="column"
+            openDetailsPanel={openDetailsPanel}
             data-test-subj={HOST_DETAILS_ALERT_COUNT_TEST_ID}
           />
           <MisconfigurationsInsight
             fieldName={'host.name'}
             name={hostName}
             direction="column"
+            openDetailsPanel={openDetailsPanel}
             data-test-subj={HOST_DETAILS_MISCONFIGURATIONS_TEST_ID}
             telemetryKey={MISCONFIGURATION_INSIGHT_HOST_DETAILS}
           />
           <VulnerabilitiesInsight
             hostName={hostName}
             direction="column"
+            openDetailsPanel={openDetailsPanel}
             data-test-subj={HOST_DETAILS_VULNERABILITIES_TEST_ID}
             telemetryKey={VULNERABILITIES_INSIGHT_HOST_DETAILS}
           />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
@@ -26,13 +26,15 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { MISCONFIGURATION_INSIGHT_USER_DETAILS } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
+import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
+import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use_non_closed_alerts';
 import { ExpandablePanel } from '../../../shared/components/expandable_panel';
 import type { RelatedHost } from '../../../../../common/search_strategy/security_solution/related_entities/related_hosts';
 import type { RiskSeverity } from '../../../../../common/search_strategy';
 import { UserOverview } from '../../../../overview/components/user_overview';
 import { AnomalyTableProvider } from '../../../../common/components/ml/anomaly/anomaly_table_provider';
 import { InspectButton, InspectButtonContainer } from '../../../../common/components/inspect';
-import { EntityType } from '../../../../../common/entity_analytics/types';
+import { EntityIdentifierFields, EntityType } from '../../../../../common/entity_analytics/types';
 import { RiskScoreLevel } from '../../../../entity_analytics/components/severity/common';
 import { DefaultFieldRenderer } from '../../../../timelines/components/field_renderers/default_renderer';
 import { CellActions } from '../../shared/components/cell_actions';
@@ -69,9 +71,13 @@ import type { NarrowDateRange } from '../../../../common/components/ml/types';
 import { MisconfigurationsInsight } from '../../shared/components/misconfiguration_insight';
 import { AlertCountInsight } from '../../shared/components/alert_count_insight';
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
+import { useNavigateToUserDetails } from '../../../entity_details/user_right/hooks/use_navigate_to_user_details';
+import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
+import { buildUserNamesFilter } from '../../../../../common/search_strategy';
 
 const USER_DETAILS_ID = 'entities-users-details';
 const RELATED_HOSTS_ID = 'entities-users-related-hosts';
+const USER_DETAILS_INSIGHTS_ID = 'user-details-insights';
 
 const UserOverviewManage = manageQuery(UserOverview);
 const RelatedHostsManage = manageQuery(InspectButtonContainer);
@@ -109,6 +115,14 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
 
   const { openPreviewPanel } = useExpandableFlyoutApi();
 
+  const timerange = useMemo(
+    () => ({
+      from,
+      to,
+    }),
+    [from, to]
+  );
+
   const narrowDateRange = useCallback<NarrowDateRange>(
     (score, interval) => {
       const fromTo = scoreIntervalToDateTime(score, interval);
@@ -137,6 +151,41 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
       panel: 'preview',
     });
   }, [openPreviewPanel, userName, scopeId, telemetry]);
+
+  const filterQuery = useMemo(
+    () => (userName ? buildUserNamesFilter([userName]) : undefined),
+    [userName]
+  );
+
+  const { data: userRisk } = useRiskScore({
+    filterQuery,
+    riskEntity: EntityType.user,
+    timerange,
+  });
+  const userRiskData = userRisk && userRisk.length > 0 ? userRisk[0] : undefined;
+  const isRiskScoreExist = !!userRiskData?.user.risk;
+
+  const { hasMisconfigurationFindings } = useHasMisconfigurations(
+    EntityIdentifierFields.userName,
+    userName
+  );
+  const { hasNonClosedAlerts } = useNonClosedAlerts({
+    field: EntityIdentifierFields.userName,
+    value: userName,
+    to,
+    from,
+    queryId: USER_DETAILS_INSIGHTS_ID,
+  });
+
+  const { openDetailsPanel } = useNavigateToUserDetails({
+    userName,
+    scopeId,
+    isRiskScoreExist,
+    hasMisconfigurationFindings,
+    hasNonClosedAlerts,
+    isPreviewMode: true, // setting to true to always open a new user flyout
+    contextID: USER_DETAILS_INSIGHTS_ID,
+  });
 
   const [isUserLoading, { inspect, userDetails, refetch }] = useObservedUserDetails({
     id: userDetailsQueryId,
@@ -340,12 +389,14 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
             fieldName={'user.name'}
             name={userName}
             direction="column"
+            openDetailsPanel={openDetailsPanel}
             data-test-subj={USER_DETAILS_ALERT_COUNT_TEST_ID}
           />
           <MisconfigurationsInsight
             fieldName={'user.name'}
             name={userName}
             direction="column"
+            openDetailsPanel={openDetailsPanel}
             data-test-subj={USER_DETAILS_MISCONFIGURATIONS_TEST_ID}
             telemetryKey={MISCONFIGURATION_INSIGHT_USER_DETAILS}
           />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
@@ -22,6 +22,9 @@ import {
   MISCONFIGURATION_INSIGHT_HOST_ENTITY_OVERVIEW,
   VULNERABILITIES_INSIGHT_HOST_ENTITY_OVERVIEW,
 } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
+import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
+import { useHasVulnerabilities } from '@kbn/cloud-security-posture/src/hooks/use_has_vulnerabilities';
+import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use_non_closed_alerts';
 import { buildHostNamesFilter } from '../../../../../common/search_strategy';
 import { HOST_NAME_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
@@ -31,7 +34,7 @@ import {
   FirstLastSeen,
   FirstLastSeenType,
 } from '../../../../common/components/first_last_seen/first_last_seen';
-import { EntityType } from '../../../../../common/entity_analytics/types';
+import { EntityIdentifierFields, EntityType } from '../../../../../common/entity_analytics/types';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { DescriptionListStyled } from '../../../../common/components/page';
 import { OverviewDescriptionList } from '../../../../common/components/overview_description_list';
@@ -62,8 +65,10 @@ import { PreviewLink } from '../../../shared/components/preview_link';
 import { MisconfigurationsInsight } from '../../shared/components/misconfiguration_insight';
 import { VulnerabilitiesInsight } from '../../shared/components/vulnerabilities_insight';
 import { AlertCountInsight } from '../../shared/components/alert_count_insight';
+import { useNavigateToHostDetails } from '../../../entity_details/host_right/hooks/use_navigate_to_host_details';
 
 const HOST_ICON = 'storage';
+const HOST_ENTITY_OVERVIEW_ID = 'host-entity-overview';
 
 export interface HostEntityOverviewProps {
   /**
@@ -111,6 +116,8 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName
     skip: hostName == null,
     timerange,
   });
+  const hostRiskData = hostRisk && hostRisk.length > 0 ? hostRisk[0] : undefined;
+  const isRiskScoreExist = !!hostRiskData?.host.risk;
 
   const [isHostDetailsLoading, { hostDetails }] = useHostDetails({
     hostName,
@@ -159,9 +166,8 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName
   const { euiTheme } = useEuiTheme();
   const xsFontSize = useEuiFontSize('xs').fontSize;
 
-  const [hostRiskLevel] = useMemo(() => {
-    const hostRiskData = hostRisk && hostRisk.length > 0 ? hostRisk[0] : undefined;
-    return [
+  const [hostRiskLevel] = useMemo(
+    () => [
       {
         title: (
           <EuiFlexGroup alignItems="flexEnd" gutterSize="none" responsive={false}>
@@ -181,8 +187,30 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName
           </>
         ),
       },
-    ];
-  }, [hostRisk]);
+    ],
+    [hostRiskData]
+  );
+
+  const { hasNonClosedAlerts } = useNonClosedAlerts({
+    field: EntityIdentifierFields.hostName,
+    value: hostName,
+    to,
+    from,
+    queryId: HOST_ENTITY_OVERVIEW_ID,
+  });
+  const { hasMisconfigurationFindings } = useHasMisconfigurations('host.name', hostName);
+  const { hasVulnerabilitiesFindings } = useHasVulnerabilities('host.name', hostName);
+
+  const { openDetailsPanel } = useNavigateToHostDetails({
+    hostName,
+    scopeId,
+    isRiskScoreExist,
+    hasMisconfigurationFindings,
+    hasVulnerabilitiesFindings,
+    hasNonClosedAlerts,
+    isPreviewMode: true, // setting to true to always open a new host flyout
+    contextID: 'HostEntityOverview',
+  });
 
   return (
     <EuiFlexGroup
@@ -251,16 +279,19 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName
       <AlertCountInsight
         fieldName={'host.name'}
         name={hostName}
+        openDetailsPanel={openDetailsPanel}
         data-test-subj={ENTITIES_HOST_OVERVIEW_ALERT_COUNT_TEST_ID}
       />
       <MisconfigurationsInsight
         fieldName={'host.name'}
         name={hostName}
+        openDetailsPanel={openDetailsPanel}
         data-test-subj={ENTITIES_HOST_OVERVIEW_MISCONFIGURATIONS_TEST_ID}
         telemetryKey={MISCONFIGURATION_INSIGHT_HOST_ENTITY_OVERVIEW}
       />
       <VulnerabilitiesInsight
         hostName={hostName}
+        openDetailsPanel={openDetailsPanel}
         data-test-subj={ENTITIES_HOST_OVERVIEW_VULNERABILITIES_TEST_ID}
         telemetryKey={VULNERABILITIES_INSIGHT_HOST_ENTITY_OVERVIEW}
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
@@ -19,6 +19,8 @@ import { css } from '@emotion/react';
 import { getOr } from 'lodash/fp';
 import { i18n } from '@kbn/i18n';
 import { MISCONFIGURATION_INSIGHT_USER_ENTITY_OVERVIEW } from '@kbn/cloud-security-posture-common/utils/ui_metrics';
+import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/use_has_misconfigurations';
+import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use_non_closed_alerts';
 import { buildUserNamesFilter } from '../../../../../common/search_strategy';
 import { useDocumentDetailsContext } from '../../shared/context';
 import type { DescriptionList } from '../../../../../common/utility_types';
@@ -29,7 +31,7 @@ import {
   FirstLastSeen,
   FirstLastSeenType,
 } from '../../../../common/components/first_last_seen/first_last_seen';
-import { EntityType } from '../../../../../common/entity_analytics/types';
+import { EntityIdentifierFields, EntityType } from '../../../../../common/entity_analytics/types';
 import { getEmptyTagValue } from '../../../../common/components/empty_value';
 import { DescriptionListStyled } from '../../../../common/components/page';
 import { OverviewDescriptionList } from '../../../../common/components/overview_description_list';
@@ -57,8 +59,10 @@ import { RiskScoreDocTooltip } from '../../../../overview/components/common';
 import { PreviewLink } from '../../../shared/components/preview_link';
 import { MisconfigurationsInsight } from '../../shared/components/misconfiguration_insight';
 import { AlertCountInsight } from '../../shared/components/alert_count_insight';
+import { useNavigateToUserDetails } from '../../../entity_details/user_right/hooks/use_navigate_to_user_details';
 
 const USER_ICON = 'user';
+const USER_ENTITY_OVERVIEW_ID = 'user-entity-overview';
 
 export interface UserEntityOverviewProps {
   /**
@@ -111,6 +115,30 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName
     riskEntity: EntityType.user,
     timerange,
   });
+  const userRiskData = userRisk && userRisk.length > 0 ? userRisk[0] : undefined;
+  const isRiskScoreExist = !!userRiskData?.user.risk;
+
+  const { hasMisconfigurationFindings } = useHasMisconfigurations(
+    EntityIdentifierFields.userName,
+    userName
+  );
+  const { hasNonClosedAlerts } = useNonClosedAlerts({
+    field: EntityIdentifierFields.userName,
+    value: userName,
+    to,
+    from,
+    queryId: USER_ENTITY_OVERVIEW_ID,
+  });
+
+  const { openDetailsPanel } = useNavigateToUserDetails({
+    userName,
+    scopeId,
+    isRiskScoreExist,
+    hasMisconfigurationFindings,
+    hasNonClosedAlerts,
+    isPreviewMode: true, // setting to true to always open a new user flyout
+    contextID: 'UserEntityOverview',
+  });
 
   const userDomainValue = useMemo(
     () => getField(getOr([], 'user.domain', userDetails)),
@@ -152,10 +180,8 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName
   const { euiTheme } = useEuiTheme();
   const xsFontSize = useEuiFontSize('xs').fontSize;
 
-  const [userRiskLevel] = useMemo(() => {
-    const userRiskData = userRisk && userRisk.length > 0 ? userRisk[0] : undefined;
-
-    return [
+  const [userRiskLevel] = useMemo(
+    () => [
       {
         title: (
           <EuiFlexGroup alignItems="flexEnd" gutterSize="none" responsive={false}>
@@ -175,8 +201,9 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName
           </>
         ),
       },
-    ];
-  }, [userRisk]);
+    ],
+    [userRiskData]
+  );
 
   return (
     <EuiFlexGroup
@@ -245,11 +272,13 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName
       <AlertCountInsight
         fieldName={'user.name'}
         name={userName}
+        openDetailsPanel={openDetailsPanel}
         data-test-subj={ENTITIES_USER_OVERVIEW_ALERT_COUNT_TEST_ID}
       />
       <MisconfigurationsInsight
         fieldName={'user.name'}
         name={userName}
+        openDetailsPanel={openDetailsPanel}
         data-test-subj={ENTITIES_USER_OVERVIEW_MISCONFIGURATIONS_TEST_ID}
         telemetryKey={MISCONFIGURATION_INSIGHT_USER_ENTITY_OVERVIEW}
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.test.tsx
@@ -15,13 +15,16 @@ import { SEVERITY_COLOR } from '../../../../overview/components/detection_respon
 import {
   INSIGHTS_ALERTS_COUNT_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID,
   INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID,
+  INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID,
 } from './test_ids';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useSignalIndex } from '../../../../detections/containers/detection_engine/alerts/use_signal_index';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../../detections/containers/detection_engine/alerts/use_signal_index');
 jest.mock('../../../../common/components/user_privileges');
+jest.mock('../../../../common/hooks/use_experimental_features');
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -65,10 +68,17 @@ const mockAlertData: ParsedAlertsData = {
   },
 };
 
+const openDetailsPanel = jest.fn();
+
 const renderAlertCountInsight = () => {
   return render(
     <TestProviders>
-      <AlertCountInsight name={name} fieldName={fieldName} data-test-subj={testId} />
+      <AlertCountInsight
+        name={name}
+        fieldName={fieldName}
+        data-test-subj={testId}
+        openDetailsPanel={openDetailsPanel}
+      />
     </TestProviders>
   );
 };
@@ -77,6 +87,7 @@ describe('AlertCountInsight', () => {
   beforeEach(() => {
     (useSignalIndex as jest.Mock).mockReturnValue({ signalIndexName: '' });
     (useUserPrivileges as jest.Mock).mockReturnValue({ timelinePrivileges: { read: true } });
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(false);
   });
 
   it('renders', () => {
@@ -94,6 +105,17 @@ describe('AlertCountInsight', () => {
       getByTestId(INSIGHTS_ALERTS_COUNT_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID)
     ).toBeInTheDocument();
     expect(queryByTestId(INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('open entity details panel when clicking on the count if new navigation is enabled', () => {
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+    (useAlertsByStatus as jest.Mock).mockReturnValue({
+      isLoading: false,
+      items: mockAlertData,
+    });
+    const { getByTestId } = renderAlertCountInsight();
+    getByTestId(INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID).click();
+    expect(openDetailsPanel).toHaveBeenCalled();
   });
 
   it('renders the count as text instead of button', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
@@ -13,7 +13,7 @@ import {
   EuiText,
   type EuiFlexGroupProps,
   EuiLink,
-  EuiToolTip
+  EuiToolTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { InsightDistributionBar } from './insight_distribution_bar';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
@@ -7,7 +7,14 @@
 
 import React, { useMemo } from 'react';
 import { capitalize } from 'lodash';
-import { EuiLoadingSpinner, EuiFlexItem, EuiText, type EuiFlexGroupProps } from '@elastic/eui';
+import {
+  EuiLoadingSpinner,
+  EuiFlexItem,
+  EuiText,
+  type EuiFlexGroupProps,
+  EuiLink,
+  EuiToolTip
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { InsightDistributionBar } from './insight_distribution_bar';
 import { getSeverityColor } from '../../../../detections/components/alerts_kpis/severity_level_panel/helpers';
@@ -30,7 +37,14 @@ import { useUserPrivileges } from '../../../../common/components/user_privileges
 import {
   INSIGHTS_ALERTS_COUNT_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID,
   INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID,
+  INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID,
 } from './test_ids';
+import type { EntityDetailsPath } from '../../../entity_details/shared/components/left_panel/left_panel_header';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import {
+  CspInsightLeftPanelSubTab,
+  EntityDetailsLeftPanelTab,
+} from '../../../entity_details/shared/components/left_panel/left_panel_header';
 
 interface AlertCountInsightProps {
   /**
@@ -49,6 +63,10 @@ interface AlertCountInsightProps {
    * The data-test-subj to use for the component.
    */
   ['data-test-subj']?: string;
+  /**
+   * The function to open the details panel.
+   */
+  openDetailsPanel: (path: EntityDetailsPath) => void;
 }
 
 /**
@@ -85,12 +103,16 @@ export const AlertCountInsight: React.FC<AlertCountInsightProps> = ({
   name,
   fieldName,
   direction,
+  openDetailsPanel,
   'data-test-subj': dataTestSubj,
 }) => {
   const {
     timelinePrivileges: { read: canUseTimeline },
   } = useUserPrivileges();
 
+  const isNewNavigationEnabled = useIsExperimentalFeatureEnabled(
+    'newExpandableFlyoutNavigationEnabled'
+  );
   const entityFilter = useMemo(() => ({ field: fieldName, value: name }), [fieldName, name]);
   const { to, from } = useGlobalTime();
   const { signalIndexName } = useSignalIndex();
@@ -128,9 +150,34 @@ export const AlertCountInsight: React.FC<AlertCountInsightProps> = ({
     [fieldName, name]
   );
 
-  // renders either a button to open timeline or just plain text depending on the user's timeline privileges
+  // renders either a button to go to host alert details, open timeline or just plain text depending on the user's timeline privileges
   const alertCount = useMemo(() => {
     const formattedAlertCount = <FormattedCount count={totalAlertCount} />;
+
+    if (isNewNavigationEnabled) {
+      return (
+        <EuiToolTip
+          content={
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.insights.alert.alertCountTooltip"
+              defaultMessage="Opens list of alerts in a new flyout"
+            />
+          }
+        >
+          <EuiLink
+            data-test-subj={INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID}
+            onClick={() =>
+              openDetailsPanel({
+                tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
+                subTab: CspInsightLeftPanelSubTab.ALERTS,
+              })
+            }
+          >
+            {formattedAlertCount}
+          </EuiLink>
+        </EuiToolTip>
+      );
+    }
 
     if (!canUseTimeline) {
       return (
@@ -149,7 +196,7 @@ export const AlertCountInsight: React.FC<AlertCountInsightProps> = ({
         {formattedAlertCount}
       </InvestigateInTimelineButton>
     );
-  }, [canUseTimeline, dataProviders, totalAlertCount]);
+  }, [canUseTimeline, dataProviders, totalAlertCount, isNewNavigationEnabled, openDetailsPanel]);
 
   if (!isLoading && totalAlertCount === 0) return null;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/misconfiguration_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/misconfiguration_insight.tsx
@@ -6,7 +6,14 @@
  */
 
 import React, { useEffect, useMemo } from 'react';
-import { EuiFlexItem, type EuiFlexGroupProps, useEuiTheme, useGeneratedHtmlId } from '@elastic/eui';
+import {
+  EuiFlexItem,
+  type EuiFlexGroupProps,
+  useEuiTheme,
+  useGeneratedHtmlId,
+  EuiLink,
+  EuiToolTip,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { useMisconfigurationPreview } from '@kbn/cloud-security-posture/src/hooks/use_misconfiguration_preview';
@@ -21,6 +28,12 @@ import { getFindingsStats } from '../../../../cloud_security_posture/components/
 import { FormattedCount } from '../../../../common/components/formatted_number';
 import { PreviewLink } from '../../../shared/components/preview_link';
 import { useDocumentDetailsContext } from '../context';
+import type { EntityDetailsPath } from '../../../entity_details/shared/components/left_panel/left_panel_header';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import {
+  CspInsightLeftPanelSubTab,
+  EntityDetailsLeftPanelTab,
+} from '../../../entity_details/shared/components/left_panel/left_panel_header';
 
 interface MisconfigurationsInsightProps {
   /**
@@ -43,6 +56,10 @@ interface MisconfigurationsInsightProps {
    * used to track the instance of this component, prefer kebab-case
    */
   telemetryKey?: CloudSecurityUiCounters;
+  /**
+   * The function to open the details panel.
+   */
+  openDetailsPanel: (path: EntityDetailsPath) => void;
 }
 
 /*
@@ -54,6 +71,7 @@ export const MisconfigurationsInsight: React.FC<MisconfigurationsInsightProps> =
   direction,
   'data-test-subj': dataTestSubj,
   telemetryKey,
+  openDetailsPanel,
 }) => {
   const renderingId = useGeneratedHtmlId();
   const { scopeId, isPreview } = useDocumentDetailsContext();
@@ -64,6 +82,10 @@ export const MisconfigurationsInsight: React.FC<MisconfigurationsInsightProps> =
     enabled: true,
     pageSize: 1,
   });
+
+  const isNewNavigationEnabled = useIsExperimentalFeatureEnabled(
+    'newExpandableFlyoutNavigationEnabled'
+  );
 
   useEffect(() => {
     if (telemetryKey) {
@@ -92,18 +114,51 @@ export const MisconfigurationsInsight: React.FC<MisconfigurationsInsightProps> =
           margin-bottom: ${euiTheme.size.xs};
         `}
       >
-        <PreviewLink
-          field={fieldName}
-          value={name}
-          scopeId={scopeId}
-          isPreview={isPreview}
-          data-test-subj={`${dataTestSubj}-count`}
-        >
-          <FormattedCount count={totalFindings} />
-        </PreviewLink>
+        {isNewNavigationEnabled ? (
+          <EuiToolTip
+            content={
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.insights.misconfiguration.misconfigurationCountTooltip"
+                defaultMessage="Opens list of misconfigurations in a new flyout"
+              />
+            }
+          >
+            <EuiLink
+              data-test-subj={`${dataTestSubj}-count`}
+              onClick={() =>
+                openDetailsPanel({
+                  tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
+                  subTab: CspInsightLeftPanelSubTab.MISCONFIGURATIONS,
+                })
+              }
+            >
+              <FormattedCount count={totalFindings} />
+            </EuiLink>
+          </EuiToolTip>
+        ) : (
+          <PreviewLink
+            field={fieldName}
+            value={name}
+            scopeId={scopeId}
+            isPreview={isPreview}
+            data-test-subj={`${dataTestSubj}-count`}
+          >
+            <FormattedCount count={totalFindings} />
+          </PreviewLink>
+        )}
       </div>
     ),
-    [totalFindings, fieldName, name, scopeId, isPreview, dataTestSubj, euiTheme.size]
+    [
+      totalFindings,
+      fieldName,
+      name,
+      scopeId,
+      isPreview,
+      dataTestSubj,
+      euiTheme.size,
+      isNewNavigationEnabled,
+      openDetailsPanel,
+    ]
   );
 
   if (!hasMisconfigurationFindings) return null;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/test_ids.ts
@@ -14,5 +14,7 @@ const INSIGHTS_TEST_ID = `${PREFIX}Insights` as const;
 export const INSIGHTS_ALERTS_COUNT_TEXT_TEST_ID = `${INSIGHTS_TEST_ID}AlertsCount` as const;
 export const INSIGHTS_ALERTS_COUNT_INVESTIGATE_IN_TIMELINE_BUTTON_TEST_ID =
   `${INSIGHTS_TEST_ID}AlertsCountInvestigateInTimelineButton` as const;
+export const INSIGHTS_ALERTS_COUNT_NAVIGATION_BUTTON_TEST_ID =
+  `${INSIGHTS_TEST_ID}AlertsCountNavigationButton` as const;
 
 export const FLYOUT_FOOTER_DROPDOWN_BUTTON_TEST_ID = `${PREFIX}FooterDropdownButton` as const;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/vulnerabilities_insight.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/vulnerabilities_insight.test.tsx
@@ -16,18 +16,25 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { mockContextValue } from '../mocks/mock_context';
 import { HostPreviewPanelKey } from '../../../entity_details/host_right';
 import { HOST_PREVIEW_BANNER } from '../../right/components/host_entity_overview';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 jest.mock('@kbn/expandable-flyout');
 jest.mock('@kbn/cloud-security-posture/src/hooks/use_vulnerabilities_preview');
+jest.mock('../../../../common/hooks/use_experimental_features');
 
 const hostName = 'test host';
 const testId = 'test';
+const openDetailsPanel = jest.fn();
 
 const renderVulnerabilitiesInsight = () => {
   return render(
     <TestProviders>
       <DocumentDetailsContext.Provider value={mockContextValue}>
-        <VulnerabilitiesInsight hostName={hostName} data-test-subj={testId} />
+        <VulnerabilitiesInsight
+          hostName={hostName}
+          data-test-subj={testId}
+          openDetailsPanel={openDetailsPanel}
+        />
       </DocumentDetailsContext.Provider>
     </TestProviders>
   );
@@ -48,7 +55,7 @@ describe('VulnerabilitiesInsight', () => {
     expect(getByTestId(`${testId}-distribution-bar`)).toBeInTheDocument();
   });
 
-  it('opens host preview when click on count badge', () => {
+  it('opens host preview when click on count badge if new navigation is disabled', () => {
     (useVulnerabilitiesPreview as jest.Mock).mockReturnValue({
       data: { count: { CRITICAL: 1, HIGH: 2, MEDIUM: 1, LOW: 2, NONE: 2 } },
     });
@@ -64,6 +71,16 @@ describe('VulnerabilitiesInsight', () => {
         scopeId: mockContextValue.scopeId,
       },
     });
+  });
+
+  it('open entity details panel when clicking on the count if new navigation is enabled', () => {
+    (useIsExperimentalFeatureEnabled as jest.Mock).mockReturnValue(true);
+    (useVulnerabilitiesPreview as jest.Mock).mockReturnValue({
+      data: { count: { CRITICAL: 1, HIGH: 2, MEDIUM: 1, LOW: 2, NONE: 2 } },
+    });
+    const { getByTestId } = renderVulnerabilitiesInsight();
+    getByTestId(`${testId}-count`).click();
+    expect(openDetailsPanel).toHaveBeenCalled();
   });
 
   it('renders null when data is not available', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/vulnerabilities_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/vulnerabilities_insight.tsx
@@ -6,7 +6,14 @@
  */
 
 import React, { useEffect, useMemo } from 'react';
-import { EuiFlexItem, type EuiFlexGroupProps, useEuiTheme, useGeneratedHtmlId } from '@elastic/eui';
+import {
+  EuiFlexItem,
+  type EuiFlexGroupProps,
+  useEuiTheme,
+  useGeneratedHtmlId,
+  EuiLink,
+  EuiToolTip,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import { useVulnerabilitiesPreview } from '@kbn/cloud-security-posture/src/hooks/use_vulnerabilities_preview';
@@ -21,6 +28,12 @@ import { InsightDistributionBar } from './insight_distribution_bar';
 import { FormattedCount } from '../../../../common/components/formatted_number';
 import { PreviewLink } from '../../../shared/components/preview_link';
 import { useDocumentDetailsContext } from '../context';
+import {
+  EntityDetailsLeftPanelTab,
+  CspInsightLeftPanelSubTab,
+} from '../../../entity_details/shared/components/left_panel/left_panel_header';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import type { EntityDetailsPath } from '../../../entity_details/shared/components/left_panel/left_panel_header';
 
 interface VulnerabilitiesInsightProps {
   /**
@@ -39,6 +52,10 @@ interface VulnerabilitiesInsightProps {
    * used to track the instance of this component, prefer kebab-case
    */
   telemetryKey?: CloudSecurityUiCounters;
+  /**
+   * The function to open the details panel.
+   */
+  openDetailsPanel: (path: EntityDetailsPath) => void;
 }
 
 /*
@@ -49,6 +66,7 @@ export const VulnerabilitiesInsight: React.FC<VulnerabilitiesInsightProps> = ({
   direction,
   'data-test-subj': dataTestSubj,
   telemetryKey,
+  openDetailsPanel,
 }) => {
   const renderingId = useGeneratedHtmlId();
   const { scopeId, isPreview } = useDocumentDetailsContext();
@@ -59,6 +77,10 @@ export const VulnerabilitiesInsight: React.FC<VulnerabilitiesInsightProps> = ({
     enabled: true,
     pageSize: 1,
   });
+
+  const isNewNavigationEnabled = useIsExperimentalFeatureEnabled(
+    'newExpandableFlyoutNavigationEnabled'
+  );
 
   useEffect(() => {
     if (telemetryKey) {
@@ -104,18 +126,50 @@ export const VulnerabilitiesInsight: React.FC<VulnerabilitiesInsightProps> = ({
           margin-bottom: ${euiTheme.size.xs};
         `}
       >
-        <PreviewLink
-          field={'host.name'}
-          value={hostName}
-          scopeId={scopeId}
-          isPreview={isPreview}
-          data-test-subj={`${dataTestSubj}-count`}
-        >
-          <FormattedCount count={totalVulnerabilities} />
-        </PreviewLink>
+        {isNewNavigationEnabled ? (
+          <EuiToolTip
+            content={
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.insights.vulnerabilities.vulnerabilitiesCountTooltip"
+                defaultMessage="Opens list of vulnerabilities in a new flyout"
+              />
+            }
+          >
+            <EuiLink
+              data-test-subj={`${dataTestSubj}-count`}
+              onClick={() =>
+                openDetailsPanel({
+                  tab: EntityDetailsLeftPanelTab.CSP_INSIGHTS,
+                  subTab: CspInsightLeftPanelSubTab.VULNERABILITIES,
+                })
+              }
+            >
+              <FormattedCount count={totalVulnerabilities} />
+            </EuiLink>
+          </EuiToolTip>
+        ) : (
+          <PreviewLink
+            field={'host.name'}
+            value={hostName}
+            scopeId={scopeId}
+            isPreview={isPreview}
+            data-test-subj={`${dataTestSubj}-count`}
+          >
+            <FormattedCount count={totalVulnerabilities} />
+          </PreviewLink>
+        )}
       </div>
     ),
-    [totalVulnerabilities, hostName, scopeId, isPreview, dataTestSubj, euiTheme.size]
+    [
+      totalVulnerabilities,
+      hostName,
+      scopeId,
+      isPreview,
+      dataTestSubj,
+      euiTheme.size,
+      isNewNavigationEnabled,
+      openDetailsPanel,
+    ]
   );
 
   if (!hasVulnerabilitiesFindings) return null;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security Solution][Alert Flyout] Update entity insight badge to open entity flyouts (#208287)](https://github.com/elastic/kibana/pull/208287)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-10T22:11:13Z","message":"[Security Solution][Alert Flyout] Update entity insight badge to open entity flyouts (#208287)\n\n## Summary\r\n\r\nThis PR updates the cloud insights in entity section to open to entity\r\nflyout. When examining the insights (for example, the host is shown to\r\nhave 50 alerts, instead of opening the preview, and user click on the\r\ndetails and go to respective tabs, this PR updated the behavior to open\r\nthe details tab via 1 click. The goal is to reduce friction for users\r\nduring investigation.\r\n\r\nFeature flag: `newExpandableFlyoutNavigationEnabled`\r\n\r\nWhen flag is off:\r\n- Click on alert count should open timeline (if user has timeline\r\nprivileage)\r\n- Click on misconfigurations and vulnerabilities badge should open\r\nhost/user preview\r\n\r\n\r\nhttps://github.com/user-attachments/assets/23e0cc40-129d-4e75-b5be-26a49dcad710\r\n\r\n\r\nWhen flag is on:\r\n- Click on count badges should open the respective entity flyout and the\r\ninsights details tab\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/5dfc39b7-edae-4b76-9a3a-79326337cb3b\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6e61f526a75de7a654fbb0760edf2efec3a611bb","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","v9.0.0","Team:Threat Hunting","Team:Threat Hunting:Investigations","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Security Solution][Alert Flyout] Update entity insight badge to open entity flyouts","number":208287,"url":"https://github.com/elastic/kibana/pull/208287","mergeCommit":{"message":"[Security Solution][Alert Flyout] Update entity insight badge to open entity flyouts (#208287)\n\n## Summary\r\n\r\nThis PR updates the cloud insights in entity section to open to entity\r\nflyout. When examining the insights (for example, the host is shown to\r\nhave 50 alerts, instead of opening the preview, and user click on the\r\ndetails and go to respective tabs, this PR updated the behavior to open\r\nthe details tab via 1 click. The goal is to reduce friction for users\r\nduring investigation.\r\n\r\nFeature flag: `newExpandableFlyoutNavigationEnabled`\r\n\r\nWhen flag is off:\r\n- Click on alert count should open timeline (if user has timeline\r\nprivileage)\r\n- Click on misconfigurations and vulnerabilities badge should open\r\nhost/user preview\r\n\r\n\r\nhttps://github.com/user-attachments/assets/23e0cc40-129d-4e75-b5be-26a49dcad710\r\n\r\n\r\nWhen flag is on:\r\n- Click on count badges should open the respective entity flyout and the\r\ninsights details tab\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/5dfc39b7-edae-4b76-9a3a-79326337cb3b\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6e61f526a75de7a654fbb0760edf2efec3a611bb"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210472","number":210472,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208287","number":208287,"mergeCommit":{"message":"[Security Solution][Alert Flyout] Update entity insight badge to open entity flyouts (#208287)\n\n## Summary\r\n\r\nThis PR updates the cloud insights in entity section to open to entity\r\nflyout. When examining the insights (for example, the host is shown to\r\nhave 50 alerts, instead of opening the preview, and user click on the\r\ndetails and go to respective tabs, this PR updated the behavior to open\r\nthe details tab via 1 click. The goal is to reduce friction for users\r\nduring investigation.\r\n\r\nFeature flag: `newExpandableFlyoutNavigationEnabled`\r\n\r\nWhen flag is off:\r\n- Click on alert count should open timeline (if user has timeline\r\nprivileage)\r\n- Click on misconfigurations and vulnerabilities badge should open\r\nhost/user preview\r\n\r\n\r\nhttps://github.com/user-attachments/assets/23e0cc40-129d-4e75-b5be-26a49dcad710\r\n\r\n\r\nWhen flag is on:\r\n- Click on count badges should open the respective entity flyout and the\r\ninsights details tab\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/5dfc39b7-edae-4b76-9a3a-79326337cb3b\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6e61f526a75de7a654fbb0760edf2efec3a611bb"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->