### PR TITLE
[Search Connectors]: Disable option to create multiple policies for a single integration

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_configure_package.tsx
@@ -74,7 +74,7 @@ export const StepConfigurePackagePolicy: React.FunctionComponent<{
             return inputs.map((packageInput) => {
               const packagePolicyInput = packagePolicyInputs.find(
                 (input) =>
-                  input.type === packageInput.type &&
+                  input.type === packageInput.type && 
                   (hasIntegrations ? input.policy_template === policyTemplate.name : true)
               );
               const packageInputStreams = getRegistryStreamWithDataStreamForInputType(

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -219,7 +219,7 @@ export const EditPackagePolicyForm = memo<{
         setImpactedAgentCount(0);
       }
     };
-
+    
     if (
       isFleetEnabled &&
       (packagePolicy.policy_ids.length > 0 || agentPoliciesToRemoveIds.length > 0)
@@ -378,9 +378,14 @@ export const EditPackagePolicyForm = memo<{
     );
   }
 
+  const enabledInput = useMemo(() => {
+    return packagePolicy.inputs?.find(
+      (input) => input.enabled
+    )?.policy_template;
+  }, [packagePolicy.inputs]);
+
   const tabsViews = extensionTabsView?.tabs;
   const [selectedTab, setSelectedTab] = useState(0);
-
   const layoutProps = {
     from: extensionView?.useLatestPackageVersion && isUpgrade ? 'upgrade-from-extension' : from,
     cancelUrl,
@@ -407,7 +412,6 @@ export const EditPackagePolicyForm = memo<{
         ]
       : [],
   };
-
   const configurePackage = useMemo(
     () =>
       agentPolicies && packageInfo ? (
@@ -430,6 +434,7 @@ export const EditPackagePolicyForm = memo<{
               packageInfo={packageInfo}
               packagePolicy={packagePolicy}
               updatePackagePolicy={updatePackagePolicy}
+              showOnlyIntegration={enabledInput}
               validationResults={validationResults}
               submitAttempted={formState === 'INVALID'}
               isEditPage={true}


### PR DESCRIPTION
## Summary
A list of all types of connectors that can be ran is rendered when configuring, which when one is enabled by the user things break :( Made it so only one Type is shown
![image](https://github.com/user-attachments/assets/dbc59bf4-d71a-4fae-8045-3ec0d61f6fa5)


#### Closes https://github.com/orgs/elastic/projects/740/views/1?pane=issue&itemId=96600219&issue=elastic%7Csearch-team%7C9227

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



