### PR TITLE
[Search] Fix notebooks config path

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -113,7 +113,7 @@ xpack.ml.compatibleModuleType: 'search'
 data_visualizer.resultLinks.fileBeat.enabled: false
 
 # Search Notebooks
-xpack.search.notebooks.catalog.url: https://elastic-enterprise-search.s3.us-east-2.amazonaws.com/serverless/catalog.json
+xpack.searchNotebooks.catalog.url: https://elastic-enterprise-search.s3.us-east-2.amazonaws.com/serverless/catalog.json
 
 # Semantic text UI
 

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -6,7 +6,7 @@ xpack.cloudSecurityPosture.enabled: false
 xpack.infra.enabled: true
 xpack.uptime.enabled: true
 xpack.securitySolution.enabled: false
-xpack.search.notebooks.enabled: false
+xpack.searchNotebooks.enabled: false
 xpack.searchPlayground.enabled: false
 xpack.searchInferenceEndpoints.enabled: false
 xpack.searchIndices.enabled: false

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -7,7 +7,7 @@ xpack.infra.enabled: false
 xpack.observabilityLogsExplorer.enabled: false
 xpack.observability.enabled: false
 xpack.observabilityAIAssistant.enabled: false
-xpack.search.notebooks.enabled: false
+xpack.searchNotebooks.enabled: false
 xpack.searchPlayground.enabled: false
 xpack.searchInferenceEndpoints.enabled: false
 xpack.inventory.enabled: false

--- a/x-pack/solutions/search/plugins/search_notebooks/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/search_notebooks/kibana.jsonc
@@ -11,8 +11,7 @@
     "browser": true,
     "configPath": [
       "xpack",
-      "search",
-      "notebooks"
+      "searchNotebooks"
     ],
     "requiredPlugins": [
       "console"

--- a/x-pack/solutions/search/plugins/search_notebooks/server/config.ts
+++ b/x-pack/solutions/search/plugins/search_notebooks/server/config.ts
@@ -24,6 +24,9 @@ const configSchema = schema.object({
 type SearchNotebooksSchema = TypeOf<typeof configSchema>;
 
 export const config: PluginConfigDescriptor<SearchNotebooksSchema> = {
+  deprecations: ({ renameFromRoot }) => [
+    renameFromRoot('xpack.search.notebooks', 'xpack.searchNotebooks', { level: 'critical' }),
+  ],
   schema: configSchema,
 };
 


### PR DESCRIPTION
## Summary

This updates the Search notebooks config path to fix a config conflict, now that the main search plugin owns `xpack.search`. This config should only have been used in Serverless and was never pushed to other users, but I've added a rename and deprecation warning just in case anyone used it..

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->