### PR TITLE
[8.18] [Obs AI Assistant] Default to "native" function calling if the connector config is not exposed (#210455)

### DIFF
--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/function_calling_support.test.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/function_calling_support.test.ts
@@ -60,5 +60,13 @@ describe('isNativeFunctionCallingSupported', () => {
       });
       expect(isNativeFunctionCallingSupported(connector)).toBe(false);
     });
+
+    it('returns true if the config is not exposed', () => {
+      const connector = createConnector({
+        type: InferenceConnectorType.OpenAI,
+        config: {},
+      });
+      expect(isNativeFunctionCallingSupported(connector)).toBe(true);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/function_calling_support.ts
+++ b/x-pack/platform/plugins/shared/inference/server/chat_complete/utils/function_calling_support.ts
@@ -11,9 +11,9 @@ import { OpenAiProviderType } from '../adapters/openai/types';
 export const isNativeFunctionCallingSupported = (connector: InferenceConnector): boolean => {
   switch (connector.type) {
     case InferenceConnectorType.OpenAI:
-      const apiProvider =
-        (connector.config.apiProvider as OpenAiProviderType) ?? OpenAiProviderType.Other;
-      return apiProvider !== OpenAiProviderType.Other;
+      const apiProvider = (connector.config.apiProvider as OpenAiProviderType) ?? undefined;
+      // defaulting to `true` when the config is not accessible
+      return apiProvider ? apiProvider !== OpenAiProviderType.Other : true;
     case InferenceConnectorType.Inference:
       // note: later we might need to check the provider type, for now let's assume support
       //       will be handled by ES and that all providers will support native FC.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Obs AI Assistant] Default to &quot;native&quot; function calling if the connector config is not exposed (#210455)](https://github.com/elastic/kibana/pull/210455)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-02-11T12:47:15Z","message":"[Obs AI Assistant] Default to \"native\" function calling if the connector config is not exposed (#210455)\n\nCloses https://github.com/elastic/kibana/issues/210451\n\n## Summary\n\nIf the connector config is not exposed (e.g.: in a pre-configured\nconnector), default to `native` function calling.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"d36df89025e5a72262ef3ab4d7af87cd1316ec37","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","v9.0.0","Team:Obs AI Assistant","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Obs AI Assistant] Default to \"native\" function calling if the connector config is not exposed","number":210455,"url":"https://github.com/elastic/kibana/pull/210455","mergeCommit":{"message":"[Obs AI Assistant] Default to \"native\" function calling if the connector config is not exposed (#210455)\n\nCloses https://github.com/elastic/kibana/issues/210451\n\n## Summary\n\nIf the connector config is not exposed (e.g.: in a pre-configured\nconnector), default to `native` function calling.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"d36df89025e5a72262ef3ab4d7af87cd1316ec37"}},"sourceBranch":"main","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210564","number":210564,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210455","number":210455,"mergeCommit":{"message":"[Obs AI Assistant] Default to \"native\" function calling if the connector config is not exposed (#210455)\n\nCloses https://github.com/elastic/kibana/issues/210451\n\n## Summary\n\nIf the connector config is not exposed (e.g.: in a pre-configured\nconnector), default to `native` function calling.\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"d36df89025e5a72262ef3ab4d7af87cd1316ec37"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210563","number":210563,"state":"OPEN"}]}] BACKPORT-->