### PR TITLE
[Search] Increase search timeout toast lifetime to 1 week

### DIFF
--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -622,6 +622,7 @@ export class SearchInterceptor {
     this.deps.toasts.addDanger({
       title: 'Timed out',
       text: toMountPoint(e.getErrorMessage(this.application), this.startRenderServices),
+      toastLifeTimeMs: 1000 * 60 * 60,
     });
   };
 

--- a/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/platform/plugins/shared/data/public/search/search_interceptor/search_interceptor.ts
@@ -622,7 +622,8 @@ export class SearchInterceptor {
     this.deps.toasts.addDanger({
       title: 'Timed out',
       text: toMountPoint(e.getErrorMessage(this.application), this.startRenderServices),
-      toastLifeTimeMs: 1000 * 60 * 60,
+      // TODO: explore possibility of "Infinity" without hiding the toast on mouse leave (see https://github.com/elastic/kibana/pull/210576#discussion_r1952215353)
+      toastLifeTimeMs: 1000 * 60 * 60 * 24 * 7, // 7 days
     });
   };
 


### PR DESCRIPTION
## Summary

Closes #128365 

Searching time out toast was displayed for 10 seconds only. It was increased to 1 week, so it can be easier noticed even if someone is AFK for some time.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->