### PR TITLE
[Synthetics] Fix flaky tests for default rules !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/custom_status_alert.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/custom_status_alert.journey.ts
@@ -50,13 +50,13 @@ journey(`CustomStatusAlert`, async ({ page, params }) => {
     await page.getByTestId('manageStatusRuleName').click();
     await page.getByTestId('createNewStatusRule').click();
 
-    await page.getByTestId('ruleNameInput').fill('Synthetics status rule');
     let requestMade = false;
     page.on('request', (request) => {
       if (request.url().includes('api/alerting/rule') && request.method() === 'POST') {
         requestMade = true;
       }
     });
+    await page.waitForSelector('[data-test-subj="saveRuleButton"]');
     await page.getByTestId('saveRuleButton').click();
     await page.getByTestId('confirmModalConfirmButton').click();
     expect(requestMade).toBe(true);
@@ -64,6 +64,6 @@ journey(`CustomStatusAlert`, async ({ page, params }) => {
 
   step('verify rule creation', async () => {
     await syntheticsApp.goToRulesPage();
-    await page.waitForSelector(`text='Synthetics status rule'`);
+    await page.waitForSelector(`text='Synthetics monitor status rule'`);
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/services/synthetics_services.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/services/synthetics_services.ts
@@ -68,23 +68,18 @@ export class SyntheticsServices {
       ...(data || {}),
       name,
     };
-    try {
-      const response = await axios.post(
-        this.kibanaUrl +
-          (configId
-            ? `${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}?id=${configId}`
-            : SYNTHETICS_API_URLS.SYNTHETICS_MONITORS),
-        testData,
-        {
-          auth: { username: 'elastic', password: 'changeme' },
-          headers: { 'kbn-xsrf': 'true', 'x-elastic-internal-origin': 'synthetics-e2e' },
-        }
-      );
-      return response.data.id;
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.log(JSON.stringify(e));
-    }
+    const response = await axios.post(
+      this.kibanaUrl +
+        (configId
+          ? `${SYNTHETICS_API_URLS.SYNTHETICS_MONITORS}?id=${configId}`
+          : SYNTHETICS_API_URLS.SYNTHETICS_MONITORS),
+      testData,
+      {
+        auth: { username: 'elastic', password: 'changeme' },
+        headers: { 'kbn-xsrf': 'true', 'x-elastic-internal-origin': 'synthetics-e2e' },
+      }
+    );
+    return response.data.id;
   }
 
   async deleteTestMonitorByQuery(query: string) {

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/step_details.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/step_details.journey.ts
@@ -21,11 +21,12 @@ journey(`StepDetailsPage`, async ({ page, params }) => {
       'https://www.google.com',
       {
         type: 'browser',
-        urls: 'https://www.google.com',
         custom_heartbeat_id: 'a47bfc4e-361a-4eb0-83f3-b5bb68781b5b',
         locations: [
           { id: 'us_central', label: 'North America - US Central', isServiceManaged: true },
         ],
+        'source.inline.script':
+          "step('step1', async ({ page }) => { await page.goto('https://www.google.com'); });",
       },
       'a47bfc4e-361a-4eb0-83f3-b5bb68781b5b'
     );


### PR DESCRIPTION
## Summary

Fix flaky tests for custom rule and step detail !!


## Changes

`custom_status_alert.journey.ts
`

Rule name filling was flaky so sometimes it was keeping the default name value, so i have removed it to simplify and keep default rule name always which is "Synthetics monitor status rule"

`step_details.journey.ts
`

Monitor wasn't being created due to a bad request on browser monitor payload, which was causing this test to fail, monitor absence was causing test to fail.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->