### PR TITLE
[ES|QL] Fix WHERE autocomplete with MATCH before LIMIT

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.where.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.where.test.ts
@@ -136,6 +136,17 @@ describe('WHERE <expression>', () => {
       }
     });
 
+    test('filters suggestions based on previous commands', async () => {
+      const { assertSuggestions } = await setup();
+
+      await assertSuggestions('from a | where / | limit 3', [
+        ...getFieldNamesByType('any')
+          .map((field) => `${field} `)
+          .map(attachTriggerCommand),
+        ...allEvalFns,
+      ]);
+    });
+
     test('suggests operators after a field name', async () => {
       const { assertSuggestions } = await setup();
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.where.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.where.test.ts
@@ -145,6 +145,13 @@ describe('WHERE <expression>', () => {
           .map(attachTriggerCommand),
         ...allEvalFns,
       ]);
+
+      await assertSuggestions('from a | limit 3 | where / ', [
+        ...getFieldNamesByType('any')
+          .map((field) => `${field} `)
+          .map(attachTriggerCommand),
+        ...allEvalFns.filter((fn) => fn.label !== 'QSTR' && fn.label !== 'MATCH'),
+      ]);
     });
 
     test('suggests operators after a field name', async () => {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -123,7 +123,7 @@ export const policies = [
 /**
  * Utility to filter down the function list for the given type
  * It is mainly driven by the return type, but it can be filtered upon with the last optional argument "paramsTypes"
- * jsut make sure to pass the arguments in the right order
+ * just make sure to pass the arguments in the right order
  * @param command current command context
  * @param expectedReturnType the expected type returned by the function
  * @param functionCategories

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -10,7 +10,6 @@
 import { uniq, uniqBy } from 'lodash';
 import type {
   AstProviderFn,
-  ESQLAst,
   ESQLAstItem,
   ESQLCommand,
   ESQLCommandOption,
@@ -163,10 +162,6 @@ export async function suggest(
   const { ast } = await astProvider(correctedQuery);
   const astContext = getAstContext(innerText, ast, offset);
 
-  // But we also need the full ast for the full query
-  const correctedFullQuery = correctQuerySyntax(fullText, context);
-  const { ast: fullAst } = await astProvider(correctedFullQuery);
-
   if (astContext.type === 'comment') {
     return [];
   }
@@ -230,7 +225,6 @@ export async function suggest(
       getPolicies,
       getPolicyMetadata,
       resourceRetriever?.getPreferences,
-      fullAst,
       resourceRetriever
     );
   }
@@ -417,7 +411,6 @@ async function getSuggestionsWithinCommandExpression(
   getPolicies: GetPoliciesFn,
   getPolicyMetadata: GetPolicyMetadataFn,
   getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
-  fullAst?: ESQLAst,
   callbacks?: ESQLCallbacks
 ) {
   const commandDef = getCommandDefinition(command.name);
@@ -438,7 +431,7 @@ async function getSuggestionsWithinCommandExpression(
       (expression: ESQLAstItem | undefined) =>
         getExpressionType(expression, references.fields, references.variables),
       getPreferences,
-      fullAst,
+      commands,
       commandDef,
       callbacks
     );

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { type ESQLAstItem, ESQLAst, ESQLCommand, mutate, LeafPrinter } from '@kbn/esql-ast';
+import { type ESQLAstItem, ESQLCommand, mutate, LeafPrinter } from '@kbn/esql-ast';
 import type { ESQLAstJoinCommand } from '@kbn/esql-ast';
 import type { ESQLCallbacks } from '../../../shared/types';
 import {
@@ -104,7 +104,7 @@ export const suggest: CommandBaseDefinition<'join'>['suggest'] = async (
   getSuggestedVariableName: () => string,
   getExpressionType: (expression: ESQLAstItem | undefined) => SupportedDataType | 'unknown',
   getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
-  fullTextAst?: ESQLAst,
+  previousCommands?: ESQLCommand[],
   definition?: CommandDefinition<'join'>,
   callbacks?: ESQLCallbacks
 ): Promise<SuggestionRawDefinition[]> => {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/where/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/where/index.ts
@@ -163,7 +163,8 @@ export async function suggest(
 
     case 'empty_expression':
       // Don't suggest MATCH or QSTR after unsupported commands
-      const priorCommands = fullTextAst?.map((a) => a.name) ?? [];
+      const priorCommands =
+        fullTextAst?.filter((a) => a.location.max < command.location.min).map((a) => a.name) ?? [];
       const ignored = [];
       if (priorCommands.some((c) => UNSUPPORTED_COMMANDS_BEFORE_MATCH.has(c))) {
         ignored.push('match');

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/where/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/where/index.ts
@@ -41,7 +41,7 @@ export async function suggest(
   _getSuggestedVariableName: () => string,
   getExpressionType: (expression: ESQLAstItem | undefined) => SupportedDataType | 'unknown',
   _getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
-  previousCommands?: ESQLCommand[],
+  previousCommands?: ESQLCommand[]
 ): Promise<SuggestionRawDefinition[]> {
   const suggestions: SuggestionRawDefinition[] = [];
 
@@ -162,8 +162,7 @@ export async function suggest(
 
     case 'empty_expression':
       // Don't suggest MATCH or QSTR after unsupported commands
-      const priorCommands =
-        previousCommands?.map((a) => a.name) ?? [];
+      const priorCommands = previousCommands?.map((a) => a.name) ?? [];
       const ignored = [];
       if (priorCommands.some((c) => UNSUPPORTED_COMMANDS_BEFORE_MATCH.has(c))) {
         ignored.push('match');

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/where/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/where/index.ts
@@ -13,7 +13,6 @@ import {
   type ESQLCommand,
   type ESQLSingleAstItem,
   type ESQLFunction,
-  ESQLAst,
 } from '@kbn/esql-ast';
 import { logicalOperators } from '../../../definitions/builtin';
 import { isParameterType, type SupportedDataType } from '../../../definitions/types';
@@ -42,7 +41,7 @@ export async function suggest(
   _getSuggestedVariableName: () => string,
   getExpressionType: (expression: ESQLAstItem | undefined) => SupportedDataType | 'unknown',
   _getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
-  fullTextAst?: ESQLAst
+  previousCommands?: ESQLCommand[],
 ): Promise<SuggestionRawDefinition[]> {
   const suggestions: SuggestionRawDefinition[] = [];
 
@@ -164,7 +163,7 @@ export async function suggest(
     case 'empty_expression':
       // Don't suggest MATCH or QSTR after unsupported commands
       const priorCommands =
-        fullTextAst?.filter((a) => a.location.max < command.location.min).map((a) => a.name) ?? [];
+        previousCommands?.map((a) => a.name) ?? [];
       const ignored = [];
       if (priorCommands.some((c) => UNSUPPORTED_COMMANDS_BEFORE_MATCH.has(c))) {
         ignored.push('match');
@@ -172,7 +171,7 @@ export async function suggest(
       if (priorCommands.some((c) => UNSUPPORTED_COMMANDS_BEFORE_QSTR.has(c))) {
         ignored.push('qstr');
       }
-      const last = fullTextAst?.[fullTextAst.length - 1];
+      const last = previousCommands?.[previousCommands.length - 1];
       let columnSuggestions: SuggestionRawDefinition[] = [];
       if (!last?.text?.endsWith(`:${EDITOR_MARKER}`)) {
         columnSuggestions = await getColumnsByType('any', [], {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
@@ -8,7 +8,6 @@
  */
 
 import type {
-  ESQLAst,
   ESQLAstItem,
   ESQLCommand,
   ESQLCommandOption,
@@ -210,7 +209,7 @@ export interface CommandBaseDefinition<CommandName extends string> {
     getSuggestedVariableName: () => string,
     getExpressionType: (expression: ESQLAstItem | undefined) => SupportedDataType | 'unknown',
     getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
-    fullTextAst?: ESQLAst,
+    previousCommands?: ESQLCommand[],
     definition?: CommandDefinition<CommandName>,
     callbacks?: ESQLCallbacks
   ) => Promise<SuggestionRawDefinition[]>;


### PR DESCRIPTION
## Summary

Related PR https://github.com/elastic/kibana/pull/199032


Fixes `WHERE` autocomplete with `MATCH` before `LIMIT`.

The previous check was filtering suggestions based on all present commands, not just the previous one.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->