### PR TITLE
[APM] Remove `error.id` in `getErrorGroupMainStatistics` query as it's not used

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
@@ -17,7 +17,6 @@ import {
   ERROR_EXC_TYPE,
   ERROR_GROUP_ID,
   ERROR_GROUP_NAME,
-  ERROR_ID,
   ERROR_LOG_MESSAGE,
   SERVICE_NAME,
   TRACE_ID,
@@ -97,7 +96,7 @@ export async function getErrorGroupMainStatistics({
       ]
     : [];
 
-  const requiredFields = asMutableArray([AT_TIMESTAMP, ERROR_GROUP_ID, ERROR_ID] as const);
+  const requiredFields = asMutableArray([AT_TIMESTAMP, ERROR_GROUP_ID] as const);
 
   const optionalFields = asMutableArray([
     TRACE_ID,


### PR DESCRIPTION
## Summary

Closes #210610

This PR removes `error.id` field from being queried at `getErrorGroupMainStatistics`, as it was not being used, as it was required. If we didn't have this field, the endpoint call would crash.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->