### PR TITLE
[ci] enable Scout reporter for on-merge-unsupported-ftrs

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
@@ -21,6 +21,7 @@ spec:
       env:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-unsupported-ftrs-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SCOUT_REPORTER_ENABLED: 'true'
       allow_rebuilds: true
       branch_configuration: main 9.0 8.x 8.18 8.17 8.16 7.17
       default_branch: main


### PR DESCRIPTION
## Summary

In #210425 we added Scout UI tests to be run for on-merge pipeline, but test results are not ingested by default.

This PR enables Scout reporter for that pipeline

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->