### PR TITLE
[8.x] [Security Solution][Alerts] - change top alerts by chart color (#209031)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
@@ -5,18 +5,19 @@
  * 2.0.
  */
 import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiLink,
+  EuiPopover,
+  EuiPopoverTitle,
   EuiProgress,
   EuiSpacer,
   EuiText,
-  EuiHorizontalRule,
-  EuiPopoverTitle,
-  EuiLink,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPopover,
-  EuiButtonIcon,
+  useEuiTheme,
 } from '@elastic/eui';
-import React, { useState, useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { AlertsProgressBarData, GroupBySelection } from './types';
@@ -24,10 +25,10 @@ import type { AddFilterProps } from '../common/types';
 import { getAggregateData } from './helpers';
 import * as i18n from './translations';
 import {
-  SecurityCellActionType,
   CellActionsMode,
-  SecurityCellActionsTrigger,
   SecurityCellActions,
+  SecurityCellActionsTrigger,
+  SecurityCellActionType,
 } from '../../../../common/components/cell_actions';
 import { getSourcererScopeId } from '../../../../helpers';
 
@@ -60,6 +61,15 @@ const EmptyAction = styled.div`
  * Individual progress bar per row
  */
 const ProgressBarRow: React.FC<{ item: AlertsProgressBarData }> = ({ item }) => {
+  const { euiTheme } = useEuiTheme();
+  const color = useMemo(
+    () =>
+      euiTheme.themeName === 'EUI_THEME_BOREALIS'
+        ? euiTheme.colors.vis.euiColorVis6
+        : euiTheme.colors.vis.euiColorVis9,
+    [euiTheme]
+  );
+
   return (
     <EuiProgress
       valueText={
@@ -68,7 +78,7 @@ const ProgressBarRow: React.FC<{ item: AlertsProgressBarData }> = ({ item }) => 
         </EuiText>
       }
       max={1}
-      color={'vis9'}
+      color={color}
       size="s"
       value={item.percentage}
       label={


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Alerts] - change top alerts by chart color (#209031)](https://github.com/elastic/kibana/pull/209031)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-02-03T18:17:59Z","message":"[Security Solution][Alerts] - change top alerts by chart color (#209031)\n\n## Summary\r\n\r\nThis PR makes the smallest change requested by the UIUX team, to the\r\n_Top alerts by_ chart on the Alert page. The `vis9` color is changed to\r\n`vis6`.\r\n\r\n| Before  | After |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-01-30 at 4 51\r\n05 PM](https://github.com/user-attachments/assets/5b06932d-ef68-4a3d-a778-bb3043fce7b1)\r\n| ![Screenshot 2025-01-30 at 4 51\r\n54 PM](https://github.com/user-attachments/assets/2385a5af-fe4a-40ce-b5d5-fee7fd44aae1)\r\n|","sha":"04eebd2cba649859e36565de1abdc722f853285f","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Threat Hunting:Investigations","backport:version","v8.18.0","v9.1.0"],"title":"[Security Solution][Alerts] - change top alerts by chart color","number":209031,"url":"https://github.com/elastic/kibana/pull/209031","mergeCommit":{"message":"[Security Solution][Alerts] - change top alerts by chart color (#209031)\n\n## Summary\r\n\r\nThis PR makes the smallest change requested by the UIUX team, to the\r\n_Top alerts by_ chart on the Alert page. The `vis9` color is changed to\r\n`vis6`.\r\n\r\n| Before  | After |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-01-30 at 4 51\r\n05 PM](https://github.com/user-attachments/assets/5b06932d-ef68-4a3d-a778-bb3043fce7b1)\r\n| ![Screenshot 2025-01-30 at 4 51\r\n54 PM](https://github.com/user-attachments/assets/2385a5af-fe4a-40ce-b5d5-fee7fd44aae1)\r\n|","sha":"04eebd2cba649859e36565de1abdc722f853285f"}},"sourceBranch":"main","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209395","number":209395,"state":"MERGED","mergeCommit":{"sha":"ebe5fca6d8af814265a89279a1c298ca5c620024","message":"[9.0] [Security Solution][Alerts] - change top alerts by chart color (#209031) (#209395)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution][Alerts] - change top alerts by chart color\n(#209031)](https://github.com/elastic/kibana/pull/209031)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Philippe\nOberti\",\"email\":\"philippe.oberti@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-03T18:17:59Z\",\"message\":\"[Security\nSolution][Alerts] - change top alerts by chart color (#209031)\\n\\n##\nSummary\\r\\n\\r\\nThis PR makes the smallest change requested by the UIUX\nteam, to the\\r\\n_Top alerts by_ chart on the Alert page. The `vis9`\ncolor is changed to\\r\\n`vis6`.\\r\\n\\r\\n| Before | After |\\r\\n|\n------------- | ------------- |\\r\\n| ![Screenshot 2025-01-30 at 4\n51\\r\\n05 PM](https://github.com/user-attachments/assets/5b06932d-ef68-4a3d-a778-bb3043fce7b1)\\r\\n|\n![Screenshot 2025-01-30 at 4\n51\\r\\n54 PM](https://github.com/user-attachments/assets/2385a5af-fe4a-40ce-b5d5-fee7fd44aae1)\\r\\n|\",\"sha\":\"04eebd2cba649859e36565de1abdc722f853285f\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Team:Threat\nHunting:Investigations\",\"backport:version\",\"v8.18.0\",\"v9.1.0\"],\"title\":\"[Security\nSolution][Alerts] - change top alerts by chart\ncolor\",\"number\":209031,\"url\":\"https://github.com/elastic/kibana/pull/209031\",\"mergeCommit\":{\"message\":\"[Security\nSolution][Alerts] - change top alerts by chart color (#209031)\\n\\n##\nSummary\\r\\n\\r\\nThis PR makes the smallest change requested by the UIUX\nteam, to the\\r\\n_Top alerts by_ chart on the Alert page. The `vis9`\ncolor is changed to\\r\\n`vis6`.\\r\\n\\r\\n| Before | After |\\r\\n|\n------------- | ------------- |\\r\\n| ![Screenshot 2025-01-30 at 4\n51\\r\\n05 PM](https://github.com/user-attachments/assets/5b06932d-ef68-4a3d-a778-bb3043fce7b1)\\r\\n|\n![Screenshot 2025-01-30 at 4\n51\\r\\n54 PM](https://github.com/user-attachments/assets/2385a5af-fe4a-40ce-b5d5-fee7fd44aae1)\\r\\n|\",\"sha\":\"04eebd2cba649859e36565de1abdc722f853285f\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"9.0\",\"8.18\"],\"targetPullRequestStates\":[{\"branch\":\"9.0\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.18\",\"label\":\"v8.18.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/209031\",\"number\":209031,\"mergeCommit\":{\"message\":\"[Security\nSolution][Alerts] - change top alerts by chart color (#209031)\\n\\n##\nSummary\\r\\n\\r\\nThis PR makes the smallest change requested by the UIUX\nteam, to the\\r\\n_Top alerts by_ chart on the Alert page. The `vis9`\ncolor is changed to\\r\\n`vis6`.\\r\\n\\r\\n| Before | After |\\r\\n|\n------------- | ------------- |\\r\\n| ![Screenshot 2025-01-30 at 4\n51\\r\\n05 PM](https://github.com/user-attachments/assets/5b06932d-ef68-4a3d-a778-bb3043fce7b1)\\r\\n|\n![Screenshot 2025-01-30 at 4\n51\\r\\n54 PM](https://github.com/user-attachments/assets/2385a5af-fe4a-40ce-b5d5-fee7fd44aae1)\\r\\n|\",\"sha\":\"04eebd2cba649859e36565de1abdc722f853285f\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209031","number":209031,"mergeCommit":{"message":"[Security Solution][Alerts] - change top alerts by chart color (#209031)\n\n## Summary\r\n\r\nThis PR makes the smallest change requested by the UIUX team, to the\r\n_Top alerts by_ chart on the Alert page. The `vis9` color is changed to\r\n`vis6`.\r\n\r\n| Before  | After |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-01-30 at 4 51\r\n05 PM](https://github.com/user-attachments/assets/5b06932d-ef68-4a3d-a778-bb3043fce7b1)\r\n| ![Screenshot 2025-01-30 at 4 51\r\n54 PM](https://github.com/user-attachments/assets/2385a5af-fe4a-40ce-b5d5-fee7fd44aae1)\r\n|","sha":"04eebd2cba649859e36565de1abdc722f853285f"}}]}] BACKPORT-->