### PR TITLE
[8.x] [Security Solution][THI] - remove usages of EUI tint, shade and transparentize functions (#205223)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/__snapshots__/use_comparison_css.test.ts.snap
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/__snapshots__/use_comparison_css.test.ts.snap
@@ -215,7 +215,7 @@ Object {
 exports[`useComparisonCss should render with lines diff mode and diff decorations 1`] = `
 Object {
   "map": undefined,
-  "name": "nlhk3s",
+  "name": "1nu19hw",
   "next": undefined,
   "styles": "
     .unifiedDataTable__cellValue {
@@ -280,7 +280,7 @@ Object {
     line-height: 1;
     font-weight: 500;
   ;
-          background-color: #ce5d56;
+          background-color: #BD271E;
           color: #F1F4FA;
         }
       ;

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_css.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_css.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { tint, useEuiBackgroundColor, useEuiTheme } from '@elastic/eui';
+import { useEuiBackgroundColor, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { CELL_CLASS } from '../../../utils/get_render_cell_value';
 import { DocumentDiffMode } from '../types';
@@ -120,7 +120,7 @@ export const useComparisonCss = ({
         .${REMOVED_SEGMENT_CLASS}:before {
           content: '-';
           ${indicatorCss}
-          background-color: ${tint(euiTheme.colors.danger, 0.25)};
+          background-color: ${euiTheme.colors.backgroundFilledDanger};
           color: ${euiTheme.colors.lightestShade};
         }
       `}

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.scss
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.scss
@@ -79,7 +79,7 @@
   }
 
   .euiDataGrid--rowHoverHighlight .euiDataGridRow:hover {
-    background-color: tintOrShade($euiColorLightShade, 50%, 0);
+    background-color: $euiColorBackgroundBaseInteractiveHover;
   }
 
   .euiDataGrid__scrollOverlay .euiDataGrid__scrollBarOverlayRight {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][THI] - remove usages of EUI tint, shade and transparentize functions (#205223)](https://github.com/elastic/kibana/pull/205223)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-01-14T08:30:33Z","message":"[Security Solution][THI] - remove usages of EUI tint, shade and transparentize functions (#205223)\n\n## Summary\r\n\r\nThis PR is part of a list of PRs to perform the changes necessary to get\r\nthe new Borealis theme working correctly. It focuses on removing the\r\n`shade()`, `tint()`, `shadeOrTint()`, `tintOrShade()` and\r\n`transparentize()` functions.\r\n\r\n2 places have been impacted:\r\n\r\n- the expandable flyout preview shadow\r\n\r\n#### Light\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![flyout-preview-main-light](https://github.com/user-attachments/assets/f305263c-8163-4752-8699-40aad36bbb51)\r\n|\r\n![flyout-preview-new-light](https://github.com/user-attachments/assets/1fd9c640-91c5-4ca6-9b2a-137d3d72f943)\r\n|\r\n\r\n#### Dark\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![flyout-preview-main-dark](https://github.com/user-attachments/assets/54d60c07-812b-48da-9d43-3e0b2f50184d)\r\n|\r\n![flyout-preview-new-dark](https://github.com/user-attachments/assets/2e4307ba-8616-40c3-b07e-0284a228806b)\r\n|\r\n\r\n- the unified data table\r\n- for row hover background color (I tried a few options here, this\r\nchange is the one that looked the best to me, despite being identical\r\ncolor to the odd row background... I'm opened to suggestions here!)\r\n\r\n#### Light\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-hover-main-light](https://github.com/user-attachments/assets/7d4e3629-ed06-4688-a2b1-e10065c863c0)\r\n|\r\n![table-hover-new-light](https://github.com/user-attachments/assets/74fc0b16-2167-4605-a940-cf4750bd1401)\r\n|\r\n\r\n#### Dark\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-hover-main-dark](https://github.com/user-attachments/assets/5c1d0981-0cee-4dae-a67a-c129ec200940)\r\n|\r\n![table-hover-new-dark](https://github.com/user-attachments/assets/2d92df66-0185-4661-aae8-a209e89df60f)\r\n|\r\n\r\n  - for row comparison\r\n\r\n#### Light\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-compare-main-light](https://github.com/user-attachments/assets/965e7a60-5105-48ed-891a-95f5c386cd18)\r\n|\r\n![table-compare-new-light](https://github.com/user-attachments/assets/ce1f600b-9f1a-4832-b775-5d53b016539a)\r\n|\r\n\r\n#### Dark\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-compare-main-dark](https://github.com/user-attachments/assets/04b3edac-f0a3-4d56-91e8-3d0dea8b1218)\r\n|\r\n![table-compare-new-dark](https://github.com/user-attachments/assets/6607b4cf-d19e-45e5-af78-bace6475b9fa)\r\n|\r\n\r\n_Notes: one usage of the `transparentize` function was left untouched\r\n[here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx#L30).\r\nThis is a custom OverlayMask and this code replicates what's being done\r\nin the EUI codebase. I checked and EUI is still using the\r\n`transparentize` method with that color, so I figured I would keep this\r\nuntouched for now..._\r\n\r\nhttps://github.com/elastic/kibana/issues/201888\r\n\r\n---------\r\n\r\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"3057eacf378a3567cafa0e0610fd695e7564c524","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","Team:Threat Hunting:Investigations","EUI Visual Refresh"],"title":"[Security Solution][THI] - remove usages of EUI tint, shade and transparentize functions","number":205223,"url":"https://github.com/elastic/kibana/pull/205223","mergeCommit":{"message":"[Security Solution][THI] - remove usages of EUI tint, shade and transparentize functions (#205223)\n\n## Summary\r\n\r\nThis PR is part of a list of PRs to perform the changes necessary to get\r\nthe new Borealis theme working correctly. It focuses on removing the\r\n`shade()`, `tint()`, `shadeOrTint()`, `tintOrShade()` and\r\n`transparentize()` functions.\r\n\r\n2 places have been impacted:\r\n\r\n- the expandable flyout preview shadow\r\n\r\n#### Light\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![flyout-preview-main-light](https://github.com/user-attachments/assets/f305263c-8163-4752-8699-40aad36bbb51)\r\n|\r\n![flyout-preview-new-light](https://github.com/user-attachments/assets/1fd9c640-91c5-4ca6-9b2a-137d3d72f943)\r\n|\r\n\r\n#### Dark\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![flyout-preview-main-dark](https://github.com/user-attachments/assets/54d60c07-812b-48da-9d43-3e0b2f50184d)\r\n|\r\n![flyout-preview-new-dark](https://github.com/user-attachments/assets/2e4307ba-8616-40c3-b07e-0284a228806b)\r\n|\r\n\r\n- the unified data table\r\n- for row hover background color (I tried a few options here, this\r\nchange is the one that looked the best to me, despite being identical\r\ncolor to the odd row background... I'm opened to suggestions here!)\r\n\r\n#### Light\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-hover-main-light](https://github.com/user-attachments/assets/7d4e3629-ed06-4688-a2b1-e10065c863c0)\r\n|\r\n![table-hover-new-light](https://github.com/user-attachments/assets/74fc0b16-2167-4605-a940-cf4750bd1401)\r\n|\r\n\r\n#### Dark\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-hover-main-dark](https://github.com/user-attachments/assets/5c1d0981-0cee-4dae-a67a-c129ec200940)\r\n|\r\n![table-hover-new-dark](https://github.com/user-attachments/assets/2d92df66-0185-4661-aae8-a209e89df60f)\r\n|\r\n\r\n  - for row comparison\r\n\r\n#### Light\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-compare-main-light](https://github.com/user-attachments/assets/965e7a60-5105-48ed-891a-95f5c386cd18)\r\n|\r\n![table-compare-new-light](https://github.com/user-attachments/assets/ce1f600b-9f1a-4832-b775-5d53b016539a)\r\n|\r\n\r\n#### Dark\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-compare-main-dark](https://github.com/user-attachments/assets/04b3edac-f0a3-4d56-91e8-3d0dea8b1218)\r\n|\r\n![table-compare-new-dark](https://github.com/user-attachments/assets/6607b4cf-d19e-45e5-af78-bace6475b9fa)\r\n|\r\n\r\n_Notes: one usage of the `transparentize` function was left untouched\r\n[here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx#L30).\r\nThis is a custom OverlayMask and this code replicates what's being done\r\nin the EUI codebase. I checked and EUI is still using the\r\n`transparentize` method with that color, so I figured I would keep this\r\nuntouched for now..._\r\n\r\nhttps://github.com/elastic/kibana/issues/201888\r\n\r\n---------\r\n\r\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"3057eacf378a3567cafa0e0610fd695e7564c524"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205223","number":205223,"mergeCommit":{"message":"[Security Solution][THI] - remove usages of EUI tint, shade and transparentize functions (#205223)\n\n## Summary\r\n\r\nThis PR is part of a list of PRs to perform the changes necessary to get\r\nthe new Borealis theme working correctly. It focuses on removing the\r\n`shade()`, `tint()`, `shadeOrTint()`, `tintOrShade()` and\r\n`transparentize()` functions.\r\n\r\n2 places have been impacted:\r\n\r\n- the expandable flyout preview shadow\r\n\r\n#### Light\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![flyout-preview-main-light](https://github.com/user-attachments/assets/f305263c-8163-4752-8699-40aad36bbb51)\r\n|\r\n![flyout-preview-new-light](https://github.com/user-attachments/assets/1fd9c640-91c5-4ca6-9b2a-137d3d72f943)\r\n|\r\n\r\n#### Dark\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![flyout-preview-main-dark](https://github.com/user-attachments/assets/54d60c07-812b-48da-9d43-3e0b2f50184d)\r\n|\r\n![flyout-preview-new-dark](https://github.com/user-attachments/assets/2e4307ba-8616-40c3-b07e-0284a228806b)\r\n|\r\n\r\n- the unified data table\r\n- for row hover background color (I tried a few options here, this\r\nchange is the one that looked the best to me, despite being identical\r\ncolor to the odd row background... I'm opened to suggestions here!)\r\n\r\n#### Light\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-hover-main-light](https://github.com/user-attachments/assets/7d4e3629-ed06-4688-a2b1-e10065c863c0)\r\n|\r\n![table-hover-new-light](https://github.com/user-attachments/assets/74fc0b16-2167-4605-a940-cf4750bd1401)\r\n|\r\n\r\n#### Dark\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-hover-main-dark](https://github.com/user-attachments/assets/5c1d0981-0cee-4dae-a67a-c129ec200940)\r\n|\r\n![table-hover-new-dark](https://github.com/user-attachments/assets/2d92df66-0185-4661-aae8-a209e89df60f)\r\n|\r\n\r\n  - for row comparison\r\n\r\n#### Light\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-compare-main-light](https://github.com/user-attachments/assets/965e7a60-5105-48ed-891a-95f5c386cd18)\r\n|\r\n![table-compare-new-light](https://github.com/user-attachments/assets/ce1f600b-9f1a-4832-b775-5d53b016539a)\r\n|\r\n\r\n#### Dark\r\n| before  | after |\r\n| ------------- | ------------- |\r\n|\r\n![table-compare-main-dark](https://github.com/user-attachments/assets/04b3edac-f0a3-4d56-91e8-3d0dea8b1218)\r\n|\r\n![table-compare-new-dark](https://github.com/user-attachments/assets/6607b4cf-d19e-45e5-af78-bace6475b9fa)\r\n|\r\n\r\n_Notes: one usage of the `transparentize` function was left untouched\r\n[here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx#L30).\r\nThis is a custom OverlayMask and this code replicates what's being done\r\nin the EUI codebase. I checked and EUI is still using the\r\n`transparentize` method with that color, so I figured I would keep this\r\nuntouched for now..._\r\n\r\nhttps://github.com/elastic/kibana/issues/201888\r\n\r\n---------\r\n\r\nCo-authored-by: Davis McPhee <davis.mcphee@elastic.co>","sha":"3057eacf378a3567cafa0e0610fd695e7564c524"}}]}] BACKPORT-->