### PR TITLE
[Synthetics] Refactor screenshot block route to not return 404 !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/browser_journey/api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/browser_journey/api.ts
@@ -24,9 +24,13 @@ export interface FetchJourneyStepsParams {
 }
 
 export async function fetchScreenshotBlockSet(params: string[]): Promise<ScreenshotBlockDoc[]> {
-  return apiService.post<ScreenshotBlockDoc[]>(SYNTHETICS_API_URLS.JOURNEY_SCREENSHOT_BLOCKS, {
-    hashes: params,
-  });
+  const response = await apiService.post<{ result: ScreenshotBlockDoc[] }>(
+    SYNTHETICS_API_URLS.JOURNEY_SCREENSHOT_BLOCKS,
+    {
+      hashes: params,
+    }
+  );
+  return response.result;
 }
 
 export async function fetchBrowserJourney(


### PR DESCRIPTION
## Summary

Refactor screenshot block route to not return 404 !!

Route will return empty list instead of 404 for missing screenshot blocks !!

This also updates to enable _inspect on route !!

### Testing
Screenshot still works as expected 

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/9a2b887d-9091-4bff-97e6-3c0775e6f6bd" />


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->