### PR TITLE
[8.x] [Security Solution][THI] - replace usages of EUI vis colors (#205218)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/group_panel_renderers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/group_panel_renderers.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  EuiAvatar,
   EuiBadge,
   EuiFlexGroup,
   EuiFlexItem,
@@ -16,7 +15,6 @@ import {
   EuiTextColor,
   EuiTitle,
 } from '@elastic/eui';
-import { euiThemeVars } from '@kbn/ui-theme';
 import { isArray } from 'lodash/fp';
 import React from 'react';
 import type { GroupPanelRenderer } from '@kbn/grouping/src';
@@ -43,11 +41,32 @@ export const renderGroupPanel: GroupPanelRenderer<AlertsGroupingAggregation> = (
         />
       ) : undefined;
     case 'host.name':
-      return <HostNameGroupContent hostName={bucket.key} nullGroupMessage={nullGroupMessage} />;
+      return (
+        <GroupContent
+          title={bucket.key}
+          icon="storage"
+          nullGroupMessage={nullGroupMessage}
+          dataTestSubj="host-name"
+        />
+      );
     case 'user.name':
-      return <UserNameGroupContent userName={bucket.key} nullGroupMessage={nullGroupMessage} />;
+      return (
+        <GroupContent
+          title={bucket.key}
+          icon="user"
+          nullGroupMessage={nullGroupMessage}
+          dataTestSubj="user-name"
+        />
+      );
     case 'source.ip':
-      return <SourceIpGroupContent sourceIp={bucket.key} nullGroupMessage={nullGroupMessage} />;
+      return (
+        <GroupContent
+          title={bucket.key}
+          icon="globe"
+          nullGroupMessage={nullGroupMessage}
+          dataTestSubj="source-ip"
+        />
+      );
   }
 };
 
@@ -63,7 +82,7 @@ const RuleNameGroupContent = React.memo<{
   );
   return (
     <div style={{ display: 'table', tableLayout: 'fixed', width: '100%' }}>
-      <EuiFlexGroup data-test-subj="rule-name-group-renderer" gutterSize="m" alignItems="center">
+      <EuiFlexGroup data-test-subj="rule-name-group-renderer" gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false} style={{ display: 'contents' }}>
           <EuiTitle size="xs">
             <h5 className="eui-textTruncate">{ruleName.trim()}</h5>
@@ -93,82 +112,30 @@ const RuleNameGroupContent = React.memo<{
 });
 RuleNameGroupContent.displayName = 'RuleNameGroup';
 
-const HostNameGroupContent = React.memo<{ hostName: string | string[]; nullGroupMessage?: string }>(
-  ({ hostName, nullGroupMessage }) => (
-    <EuiFlexGroup data-test-subj="host-name-group-renderer" gutterSize="s" alignItems="center">
-      <EuiFlexItem
-        grow={false}
-        style={{
-          backgroundColor: euiThemeVars.euiColorVis1_behindText,
-          borderRadius: '50%',
-        }}
-      >
-        <EuiIcon type="database" size="l" style={{ padding: 4 }} />
-      </EuiFlexItem>
-
+const GroupContent = React.memo<{
+  title: string | string[];
+  icon: string;
+  nullGroupMessage?: string;
+  dataTestSubj?: string;
+}>(({ title, icon, nullGroupMessage, dataTestSubj }) => (
+  <EuiFlexGroup
+    data-test-subj={`${dataTestSubj}-group-renderer`}
+    gutterSize="s"
+    alignItems="center"
+  >
+    <EuiFlexItem grow={false}>
+      <EuiIcon type={icon} size="m" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiTitle size="xs">
+        <h5>{title}</h5>
+      </EuiTitle>
+    </EuiFlexItem>
+    {nullGroupMessage && (
       <EuiFlexItem grow={false}>
-        <EuiTitle size="xs">
-          <h5>{hostName}</h5>
-        </EuiTitle>
+        <EuiIconTip content={nullGroupMessage} position="right" />
       </EuiFlexItem>
-      {nullGroupMessage && (
-        <EuiFlexItem grow={false}>
-          <EuiIconTip content={nullGroupMessage} position="right" />
-        </EuiFlexItem>
-      )}
-    </EuiFlexGroup>
-  )
-);
-HostNameGroupContent.displayName = 'HostNameGroupContent';
-
-const UserNameGroupContent = React.memo<{ userName: string | string[]; nullGroupMessage?: string }>(
-  ({ userName, nullGroupMessage }) => {
-    const userNameValue = firstNonNullValue(userName) ?? '-';
-    return (
-      <EuiFlexGroup data-test-subj="user-name-group-renderer" gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiAvatar name={userNameValue} color={euiThemeVars.euiColorVis0} />
-        </EuiFlexItem>
-
-        <EuiFlexItem grow={false}>
-          <EuiTitle size="xs">
-            <h5>{userName}</h5>
-          </EuiTitle>
-        </EuiFlexItem>
-        {nullGroupMessage && (
-          <EuiFlexItem grow={false}>
-            <EuiIconTip content={nullGroupMessage} position="right" />
-          </EuiFlexItem>
-        )}
-      </EuiFlexGroup>
-    );
-  }
-);
-UserNameGroupContent.displayName = 'UserNameGroupContent';
-
-const SourceIpGroupContent = React.memo<{ sourceIp: string | string[]; nullGroupMessage?: string }>(
-  ({ sourceIp, nullGroupMessage }) => (
-    <EuiFlexGroup data-test-subj="source-ip-group-renderer" gutterSize="s" alignItems="center">
-      <EuiFlexItem
-        grow={false}
-        style={{
-          backgroundColor: euiThemeVars.euiColorVis3_behindText,
-          borderRadius: '50%',
-        }}
-      >
-        <EuiIcon style={{ padding: 4 }} type="ip" size="l" />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiTitle size="xs">
-          <h5>{sourceIp}</h5>
-        </EuiTitle>
-      </EuiFlexItem>
-      {nullGroupMessage && (
-        <EuiFlexItem grow={false}>
-          <EuiIconTip content={nullGroupMessage} position="right" />
-        </EuiFlexItem>
-      )}
-    </EuiFlexGroup>
-  )
-);
-SourceIpGroupContent.displayName = 'SourceIpGroupContent';
+    )}
+  </EuiFlexGroup>
+));
+GroupContent.displayName = 'GroupContent';

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/index.styles.tsx
@@ -56,10 +56,6 @@ export const usePaneStyles = () => {
     &:not(.timeline-portal-overlay-mask--full-screen) .timeline-container {
       margin: ${euiTheme.size.m};
       border-radius: ${euiTheme.border.radius.medium};
-
-      .timeline-template-badge {
-        border-radius: ${euiTheme.border.radius.medium} ${euiTheme.border.radius.medium} 0 0; // top corners only
-      }
     }
   `;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/data_providers/provider_badge.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/data_providers/provider_badge.tsx
@@ -63,13 +63,13 @@ ProviderBadgeStyled.displayName = 'ProviderBadgeStyled';
 
 const ProviderFieldBadge = styled.div`
   display: block;
-  color: #fff;
-  padding: 6px 8px;
+  padding: ${({ theme }) => `${theme.eui.euiSizeXS} ${theme.eui.euiSizeS}`};
   font-size: 0.6em;
 `;
 
 const StyledTemplateFieldBadge = styled(ProviderFieldBadge)`
-  background: ${({ theme }) => theme.eui.euiColorVis3_behindText};
+  background: ${({ theme }) => theme.eui.euiPanelBackgroundColorModifiers.accent};
+  color: ${({ theme }) => theme.eui.euiColorAccentText};
   text-transform: uppercase;
 `;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { pick } from 'lodash/fp';
-import { EuiProgress } from '@elastic/eui';
+import { EuiPanel, EuiProgress, EuiText } from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useRef, createContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
@@ -30,13 +30,6 @@ import { EXIT_FULL_SCREEN_CLASS_NAME } from '../../../common/components/exit_ful
 import { useResolveConflict } from '../../../common/hooks/use_resolve_conflict';
 import { sourcererSelectors } from '../../../common/store';
 import { defaultUdtHeaders } from './body/column_headers/default_headers';
-
-const TimelineTemplateBadge = styled.div`
-  background: ${({ theme }) => theme.eui.euiColorVis3_behindText};
-  color: #fff;
-  padding: 10px 15px;
-  font-size: 0.8em;
-`;
 
 const TimelineBody = styled.div`
   height: 100%;
@@ -206,9 +199,11 @@ const StatefulTimelineComponent: React.FC<Props> = ({
         <TimelineSavingProgress timelineId={timelineId} />
         <TimelineBody data-test-subj="timeline-body">
           {timelineType === TimelineTypeEnum.template && (
-            <TimelineTemplateBadge className="timeline-template-badge">
-              {i18n.TIMELINE_TEMPLATE}
-            </TimelineTemplateBadge>
+            <EuiPanel color="accent" grow={false} paddingSize="s">
+              <EuiText size="xs" color="accent">
+                {i18n.TIMELINE_TEMPLATE}
+              </EuiText>
+            </EuiPanel>
           )}
           {resolveConflictComponent}
           <HideShowContainer


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][THI] - replace usages of EUI vis colors (#205218)](https://github.com/elastic/kibana/pull/205218)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-01-10T22:30:49Z","message":"[Security Solution][THI] - replace usages of EUI vis colors (#205218)\n\n## Summary\r\n\r\nThis PR is part of a list of PRs to perform the changes necessary to get\r\nthe new Borealis theme working correctly. It focuses on replace the vis\r\ncolors for non-visualization usages by correct EUI color tokens.\r\n\r\n2 places have been impacted:\r\n\r\n- the alerts data table in grouping mode (for host, user and network).\r\nThe background colors are removed as they don't really mean anything,\r\nand are not used anywhere else in Kibana. Also the icons have been\r\nupdated to match the ones used in other places (like in the flyout)\r\n\r\n#### Host\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![data-table-host-main](https://github.com/user-attachments/assets/eb15300e-6694-4fd0-a77d-09fbb7b8a5dd)\r\n|\r\n![data-table-host-new](https://github.com/user-attachments/assets/405eb0a5-cd17-4a50-b008-d31a0654887e)\r\n|\r\n\r\n#### User\r\n| before | after |\r\n| ------------- | ------------- |\r\n\r\n|![data-table-user-main](https://github.com/user-attachments/assets/70d05724-610f-4c87-b2ae-cdd0be98d4b0)\r\n|\r\n![data-table-user-new](https://github.com/user-attachments/assets/315467f2-ea84-4c8c-a25f-f5d7d1f060b5)\r\n|\r\n\r\n#### Network\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![data-table-network-main](https://github.com/user-attachments/assets/a26f4aad-ae24-4d67-99ec-3cd677ebf4d6)\r\n|\r\n![data-table-network-new](https://github.com/user-attachments/assets/eba9df1a-fe8a-484c-bfa4-c445659ab8f6)\r\n|\r\n\r\n- the dataprovider badge in timeline\r\n\r\n#### Dark mode\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![timeline-main-dark](https://github.com/user-attachments/assets/29f1b5a7-c9f7-46e9-b4a6-76b262102f83)\r\n|\r\n![timeline-new-dark](https://github.com/user-attachments/assets/1628e046-eeae-42d8-81c6-dc530114490d)\r\n|\r\n\r\n#### Light mode\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![timeline-main-light](https://github.com/user-attachments/assets/b89f24e2-67cc-44ce-be0e-41b6a5b89bfb)\r\n|\r\n![timeline-new-light](https://github.com/user-attachments/assets/156a80c1-c31d-4cd6-a72c-544402beb9ab)\r\n|\r\n\r\nThe changes have been reviewed and approved by @codearos 😄 \r\n\r\nhttps://github.com/elastic/kibana/issues/201883","sha":"cebd201981b54e62b9f50561d13617ac261cad67","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","Team:Threat Hunting:Investigations","EUI Visual Refresh"],"title":"[Security Solution][THI] - replace usages of EUI vis colors","number":205218,"url":"https://github.com/elastic/kibana/pull/205218","mergeCommit":{"message":"[Security Solution][THI] - replace usages of EUI vis colors (#205218)\n\n## Summary\r\n\r\nThis PR is part of a list of PRs to perform the changes necessary to get\r\nthe new Borealis theme working correctly. It focuses on replace the vis\r\ncolors for non-visualization usages by correct EUI color tokens.\r\n\r\n2 places have been impacted:\r\n\r\n- the alerts data table in grouping mode (for host, user and network).\r\nThe background colors are removed as they don't really mean anything,\r\nand are not used anywhere else in Kibana. Also the icons have been\r\nupdated to match the ones used in other places (like in the flyout)\r\n\r\n#### Host\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![data-table-host-main](https://github.com/user-attachments/assets/eb15300e-6694-4fd0-a77d-09fbb7b8a5dd)\r\n|\r\n![data-table-host-new](https://github.com/user-attachments/assets/405eb0a5-cd17-4a50-b008-d31a0654887e)\r\n|\r\n\r\n#### User\r\n| before | after |\r\n| ------------- | ------------- |\r\n\r\n|![data-table-user-main](https://github.com/user-attachments/assets/70d05724-610f-4c87-b2ae-cdd0be98d4b0)\r\n|\r\n![data-table-user-new](https://github.com/user-attachments/assets/315467f2-ea84-4c8c-a25f-f5d7d1f060b5)\r\n|\r\n\r\n#### Network\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![data-table-network-main](https://github.com/user-attachments/assets/a26f4aad-ae24-4d67-99ec-3cd677ebf4d6)\r\n|\r\n![data-table-network-new](https://github.com/user-attachments/assets/eba9df1a-fe8a-484c-bfa4-c445659ab8f6)\r\n|\r\n\r\n- the dataprovider badge in timeline\r\n\r\n#### Dark mode\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![timeline-main-dark](https://github.com/user-attachments/assets/29f1b5a7-c9f7-46e9-b4a6-76b262102f83)\r\n|\r\n![timeline-new-dark](https://github.com/user-attachments/assets/1628e046-eeae-42d8-81c6-dc530114490d)\r\n|\r\n\r\n#### Light mode\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![timeline-main-light](https://github.com/user-attachments/assets/b89f24e2-67cc-44ce-be0e-41b6a5b89bfb)\r\n|\r\n![timeline-new-light](https://github.com/user-attachments/assets/156a80c1-c31d-4cd6-a72c-544402beb9ab)\r\n|\r\n\r\nThe changes have been reviewed and approved by @codearos 😄 \r\n\r\nhttps://github.com/elastic/kibana/issues/201883","sha":"cebd201981b54e62b9f50561d13617ac261cad67"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205218","number":205218,"mergeCommit":{"message":"[Security Solution][THI] - replace usages of EUI vis colors (#205218)\n\n## Summary\r\n\r\nThis PR is part of a list of PRs to perform the changes necessary to get\r\nthe new Borealis theme working correctly. It focuses on replace the vis\r\ncolors for non-visualization usages by correct EUI color tokens.\r\n\r\n2 places have been impacted:\r\n\r\n- the alerts data table in grouping mode (for host, user and network).\r\nThe background colors are removed as they don't really mean anything,\r\nand are not used anywhere else in Kibana. Also the icons have been\r\nupdated to match the ones used in other places (like in the flyout)\r\n\r\n#### Host\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![data-table-host-main](https://github.com/user-attachments/assets/eb15300e-6694-4fd0-a77d-09fbb7b8a5dd)\r\n|\r\n![data-table-host-new](https://github.com/user-attachments/assets/405eb0a5-cd17-4a50-b008-d31a0654887e)\r\n|\r\n\r\n#### User\r\n| before | after |\r\n| ------------- | ------------- |\r\n\r\n|![data-table-user-main](https://github.com/user-attachments/assets/70d05724-610f-4c87-b2ae-cdd0be98d4b0)\r\n|\r\n![data-table-user-new](https://github.com/user-attachments/assets/315467f2-ea84-4c8c-a25f-f5d7d1f060b5)\r\n|\r\n\r\n#### Network\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![data-table-network-main](https://github.com/user-attachments/assets/a26f4aad-ae24-4d67-99ec-3cd677ebf4d6)\r\n|\r\n![data-table-network-new](https://github.com/user-attachments/assets/eba9df1a-fe8a-484c-bfa4-c445659ab8f6)\r\n|\r\n\r\n- the dataprovider badge in timeline\r\n\r\n#### Dark mode\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![timeline-main-dark](https://github.com/user-attachments/assets/29f1b5a7-c9f7-46e9-b4a6-76b262102f83)\r\n|\r\n![timeline-new-dark](https://github.com/user-attachments/assets/1628e046-eeae-42d8-81c6-dc530114490d)\r\n|\r\n\r\n#### Light mode\r\n| before | after |\r\n| ------------- | ------------- |\r\n|\r\n![timeline-main-light](https://github.com/user-attachments/assets/b89f24e2-67cc-44ce-be0e-41b6a5b89bfb)\r\n|\r\n![timeline-new-light](https://github.com/user-attachments/assets/156a80c1-c31d-4cd6-a72c-544402beb9ab)\r\n|\r\n\r\nThe changes have been reviewed and approved by @codearos 😄 \r\n\r\nhttps://github.com/elastic/kibana/issues/201883","sha":"cebd201981b54e62b9f50561d13617ac261cad67"}}]}] BACKPORT-->