### PR TITLE
[8.x] [Security Solution][THI] - replace deprecated EUI color variables (#205173)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_css.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/compare_documents/hooks/use_comparison_css.ts
@@ -61,7 +61,7 @@ export const useComparisonCss = ({
         .${CELL_CLASS} {
           &,
           & * {
-            color: ${euiTheme.colors.successText} !important;
+            color: ${euiTheme.colors.textSuccess} !important;
           }
         }
       }
@@ -70,7 +70,7 @@ export const useComparisonCss = ({
         .${CELL_CLASS} {
           &,
           & * {
-            color: ${euiTheme.colors.dangerText} !important;
+            color: ${euiTheme.colors.textDanger} !important;
           }
         }
       }
@@ -82,12 +82,12 @@ export const useComparisonCss = ({
 
     .${ADDED_SEGMENT_CLASS} {
       background-color: ${matchSegmentBackgroundColor};
-      color: ${euiTheme.colors.successText};
+      color: ${euiTheme.colors.textSuccess};
     }
 
     .${REMOVED_SEGMENT_CLASS} {
       background-color: ${diffSegmentBackgroundColor};
-      color: ${euiTheme.colors.dangerText};
+      color: ${euiTheme.colors.textDanger};
     }
 
     ${(diffMode === 'chars' || diffMode === 'words') &&

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_title.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/shared/components/flyout_title.tsx
@@ -63,12 +63,12 @@ export const FlyoutTitle: FC<FlyoutTitleProps> = memo(
     const titleComponent = useMemo(() => {
       return (
         <EuiTitle size="s" data-test-subj={`${dataTestSubj}Text`}>
-          <EuiTextColor color={isLink ? euiTheme.colors.primaryText : undefined}>
+          <EuiTextColor color={isLink ? euiTheme.colors.textPrimary : undefined}>
             <span>{title}</span>
           </EuiTextColor>
         </EuiTitle>
       );
-    }, [dataTestSubj, title, isLink, euiTheme.colors.primaryText]);
+    }, [dataTestSubj, title, isLink, euiTheme.colors.textPrimary]);
 
     const linkIcon = useMemo(() => {
       return (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][THI] - replace deprecated EUI color variables (#205173)](https://github.com/elastic/kibana/pull/205173)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-01-10T23:59:17Z","message":"[Security Solution][THI] - replace deprecated EUI color variables (#205173)\n\n## Summary\r\n\r\nThis PR is part of a list of PRs to perform the changes necessary to get\r\nthe new Borealis theme working correctly. It focuses on replacing the\r\ndeprecated color variables with the new ones:\r\n\r\n#### previous color token -> new color token:\r\n- primaryText -> textPrimary\r\n- accentText -> textAccent\r\n- warningText -> textWarning\r\n- dangerText -> textDanger\r\n- text -> textParagraph\r\n- title -> textHeading\r\n- subduedText -> textSubdued\r\n- disabledText -> textDisabled\r\n\r\nNo UI changes are visible.\r\n\r\nhttps://github.com/elastic/kibana/issues/201881","sha":"f833b18d195c3a0ab1a1d1bc8f0a372d1a4b5935","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","Team:Threat Hunting:Investigations","EUI Visual Refresh"],"title":"[Security Solution][THI] - replace deprecated EUI color variables","number":205173,"url":"https://github.com/elastic/kibana/pull/205173","mergeCommit":{"message":"[Security Solution][THI] - replace deprecated EUI color variables (#205173)\n\n## Summary\r\n\r\nThis PR is part of a list of PRs to perform the changes necessary to get\r\nthe new Borealis theme working correctly. It focuses on replacing the\r\ndeprecated color variables with the new ones:\r\n\r\n#### previous color token -> new color token:\r\n- primaryText -> textPrimary\r\n- accentText -> textAccent\r\n- warningText -> textWarning\r\n- dangerText -> textDanger\r\n- text -> textParagraph\r\n- title -> textHeading\r\n- subduedText -> textSubdued\r\n- disabledText -> textDisabled\r\n\r\nNo UI changes are visible.\r\n\r\nhttps://github.com/elastic/kibana/issues/201881","sha":"f833b18d195c3a0ab1a1d1bc8f0a372d1a4b5935"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/205173","number":205173,"mergeCommit":{"message":"[Security Solution][THI] - replace deprecated EUI color variables (#205173)\n\n## Summary\r\n\r\nThis PR is part of a list of PRs to perform the changes necessary to get\r\nthe new Borealis theme working correctly. It focuses on replacing the\r\ndeprecated color variables with the new ones:\r\n\r\n#### previous color token -> new color token:\r\n- primaryText -> textPrimary\r\n- accentText -> textAccent\r\n- warningText -> textWarning\r\n- dangerText -> textDanger\r\n- text -> textParagraph\r\n- title -> textHeading\r\n- subduedText -> textSubdued\r\n- disabledText -> textDisabled\r\n\r\nNo UI changes are visible.\r\n\r\nhttps://github.com/elastic/kibana/issues/201881","sha":"f833b18d195c3a0ab1a1d1bc8f0a372d1a4b5935"}}]}] BACKPORT-->