### PR TITLE
[Security Solution][Expandable flyout] remove unused state property on flyoutPanelProps

### DIFF
--- a/x-pack/solutions/security/packages/expandable-flyout/src/store/reducers.test.ts
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/store/reducers.test.ts
@@ -38,7 +38,7 @@ const leftPanel1: FlyoutPanelProps = {
 };
 const previewPanel1: FlyoutPanelProps = {
   id: 'preview1',
-  state: { id: 'state' },
+  params: { id: 'id' },
 };
 
 const rightPanel2: FlyoutPanelProps = {
@@ -51,7 +51,7 @@ const leftPanel2: FlyoutPanelProps = {
 };
 const previewPanel2: FlyoutPanelProps = {
   id: 'preview2',
-  state: { id: 'state' },
+  params: { id: 'id' },
 };
 
 describe('panelsReducer', () => {

--- a/x-pack/solutions/security/packages/expandable-flyout/src/types.ts
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/types.ts
@@ -74,10 +74,6 @@ export interface FlyoutPanelProps {
    * Tracks the path for what to show in a panel, such as activated tab and subtab
    */
   path?: PanelPath;
-  /**
-   * Tracks visual state such as whether the panel is collapsed
-   */
-  state?: Record<string, unknown>;
 }
 
 export interface Panel {


### PR DESCRIPTION
## Summary

While working on improving the history feature of the expandable flyout package, I realized that we've kept a `state` property on. our `flyoutPanelProps` interface that has been unused since the flyout got released. This property was intended to be used for some scenario we had imagined, but over the last couple of years of using the expandable flyout, it was never needed.
This PR makes a very small cleanup to remove that `state` property. We can add it back on day if a need arises.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->