### PR TITLE
[SLOs] Always show inspect slo button !!

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/slo_inspect/slo_inspect.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/slo_inspect/slo_inspect.tsx
@@ -26,10 +26,8 @@ import { useFetcher } from '@kbn/observability-shared-plugin/public';
 import { GetSLOResponse } from '@kbn/slo-schema';
 import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { enableInspectEsQueries } from '@kbn/observability-plugin/common';
 import { useKibana } from '../../../../../hooks/use_kibana';
 import { useFetchSloInspect } from '../../../../../hooks/use_fetch_slo_inspect';
-import { usePluginContext } from '../../../../../hooks/use_plugin_context';
 import { transformCreateSLOFormToCreateSLOInput } from '../../../helpers/process_slo_form_values';
 import { CreateSLOForm } from '../../../types';
 import { CodeBlockAccordion } from './code_block_accordion';
@@ -41,18 +39,7 @@ interface Props {
   disabled: boolean;
 }
 
-export function SLOInspectWrapper({ slo, disabled }: Props) {
-  const {
-    services: { uiSettings },
-  } = useKibana();
-
-  const { isDev } = usePluginContext();
-  const isInspectorEnabled = uiSettings?.get<boolean>(enableInspectEsQueries);
-
-  return isDev || isInspectorEnabled ? <SLOInspect slo={slo} disabled={disabled} /> : null;
-}
-
-function SLOInspect({ slo, disabled }: Props) {
+export function SLOInspect({ slo, disabled }: Props) {
   const { share, http } = useKibana().services;
   const { trigger, getValues } = useFormContext<CreateSLOForm>();
 

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form_footer.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/slo_edit_form_footer.tsx
@@ -25,7 +25,7 @@ import {
 } from '../helpers/process_slo_form_values';
 import { CreateSLOForm } from '../types';
 import { EquivalentApiRequest } from './common/equivalent_api_request';
-import { SLOInspectWrapper } from './common/slo_inspect/slo_inspect';
+import { SLOInspect } from './common/slo_inspect/slo_inspect';
 
 export interface Props {
   slo?: GetSLOResponse;
@@ -133,7 +133,7 @@ export function SloEditFormFooter({ slo, onSave }: Props) {
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <SLOInspectWrapper
+              <SLOInspect
                 slo={slo}
                 disabled={isCreateSloLoading || isUpdateSloLoading || isCreateBurnRateRuleLoading}
               />

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.test.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/slo_edit.test.tsx
@@ -9,7 +9,7 @@ import { ILicense } from '@kbn/licensing-plugin/common/types';
 import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
 import { observabilityAIAssistantPluginMock } from '@kbn/observability-ai-assistant-plugin/public/mock';
 import { useFetchDataViews } from '@kbn/observability-plugin/public';
-import { HeaderMenuPortal } from '@kbn/observability-shared-plugin/public';
+import { HeaderMenuPortal, useFetcher } from '@kbn/observability-shared-plugin/public';
 import { cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { createBrowserHistory } from 'history';
 import React from 'react';
@@ -30,6 +30,7 @@ import { kibanaStartMock } from '../../utils/kibana_react.mock';
 import { render } from '../../utils/test_helper';
 import { SLO_EDIT_FORM_DEFAULT_VALUES } from './constants';
 import { SloEditPage } from './slo_edit';
+import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -63,6 +64,7 @@ const useUpdateSloMock = useUpdateSlo as jest.Mock;
 const useCreateRuleMock = useCreateRule as jest.Mock;
 const useFetchApmSuggestionsMock = useFetchApmSuggestions as jest.Mock;
 const usePermissionsMock = usePermissions as jest.Mock;
+const useFetcherMock = useFetcher as jest.Mock;
 
 const HeaderMenuPortalMock = HeaderMenuPortal as jest.Mock;
 HeaderMenuPortalMock.mockReturnValue(<div>Portal node</div>);
@@ -144,6 +146,7 @@ const mockKibana = (license: ILicense | null = licenseMock) => {
       licensing: {
         license$: new BehaviorSubject(license),
       },
+      share: sharePluginMock.createStartContract(),
     },
   });
 };
@@ -221,6 +224,7 @@ describe('SLO Edit Page', () => {
       },
     });
     licenseMock.hasAtLeast.mockReturnValue(true);
+    useFetcherMock.mockReturnValue({ data: undefined, isLoading: false });
   });
 
   afterEach(cleanup);

--- a/x-pack/solutions/observability/plugins/slo/public/utils/test_helper.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/utils/test_helper.tsx
@@ -16,6 +16,7 @@ import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render as testLibRender } from '@testing-library/react';
 import React from 'react';
+import { i18n } from '@kbn/i18n';
 import type { SLORouteRepository } from '../../server/routes/get_slo_server_route_repository';
 import { PluginContext } from '../context/plugin_context';
 
@@ -54,7 +55,13 @@ export const render = (component: React.ReactNode) => {
             createExploratoryViewUrl: jest.fn(),
             getAppDataView: jest.fn(),
 
-            ExploratoryViewEmbeddable: () => <div>Embeddable exploratory view</div>,
+            ExploratoryViewEmbeddable: () => (
+              <div>
+                {i18n.translate('xpack.slo.render.div.embeddableExploratoryViewLabel', {
+                  defaultMessage: 'Embeddable exploratory view',
+                })}
+              </div>
+            ),
           },
         }}
       >


### PR DESCRIPTION
## Summary

 Always show inspect slo button !!

It's extremely useful when doing an investigation so i think it don't makes sense to hide it behind settings.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b19fe5c8-2dd1-4817-81d2-6ce8864b3c27" />


<img width="1728" alt="image" src="https://github.com/user-attachments/assets/faa07522-5b52-4c56-961a-4ebc6d0fc759" />



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->