### PR TITLE
[8.x] [APM] Remove `error.id` in `getErrorGroupMainStatistics` query as it's not used (#210613)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
@@ -17,7 +17,6 @@ import {
   ERROR_EXC_TYPE,
   ERROR_GROUP_ID,
   ERROR_GROUP_NAME,
-  ERROR_ID,
   ERROR_LOG_MESSAGE,
   SERVICE_NAME,
   TRACE_ID,
@@ -97,7 +96,7 @@ export async function getErrorGroupMainStatistics({
       ]
     : [];
 
-  const requiredFields = asMutableArray([AT_TIMESTAMP, ERROR_GROUP_ID, ERROR_ID] as const);
+  const requiredFields = asMutableArray([AT_TIMESTAMP, ERROR_GROUP_ID] as const);
 
   const optionalFields = asMutableArray([
     TRACE_ID,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[APM] Remove &#x60;error.id&#x60; in &#x60;getErrorGroupMainStatistics&#x60; query as it&#x27;s not used (#210613)](https://github.com/elastic/kibana/pull/210613)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-02-11T18:13:51Z","message":"[APM] Remove `error.id` in `getErrorGroupMainStatistics` query as it's not used (#210613)\n\n## Summary\n\nCloses #210610\n\nThis PR removes `error.id` field from being queried at\n`getErrorGroupMainStatistics`, as it was not being used, as it was\nrequired. If we didn't have this field, the endpoint call would crash.","sha":"46cd29e60be24fa3d39b2b364973e0e9b10659b7","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","apm","Team:obs-ux-infra_services","backport:version","backport:8.17","v9.1.0","backport:8.18"],"title":"[APM] Remove `error.id` in `getErrorGroupMainStatistics` query as it's not used","number":210613,"url":"https://github.com/elastic/kibana/pull/210613","mergeCommit":{"message":"[APM] Remove `error.id` in `getErrorGroupMainStatistics` query as it's not used (#210613)\n\n## Summary\n\nCloses #210610\n\nThis PR removes `error.id` field from being queried at\n`getErrorGroupMainStatistics`, as it was not being used, as it was\nrequired. If we didn't have this field, the endpoint call would crash.","sha":"46cd29e60be24fa3d39b2b364973e0e9b10659b7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210677","number":210677,"state":"MERGED","mergeCommit":{"sha":"dbe7cc3b4f4b21484f5bb4b26e47fbe541b83fab","message":"[9.0] [APM] Remove &#x60;error.id&#x60; in &#x60;getErrorGroupMainStatistics&#x60; query as it&#x27;s not used (#210613) (#210677)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[APM] Remove &#x60;error.id&#x60; in\n&#x60;getErrorGroupMainStatistics&#x60; query as it&#x27;s not used\n(#210613)](https://github.com/elastic/kibana/pull/210613)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Sergi\nRomeu\",\"email\":\"sergi.romeu@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-11T18:13:51Z\",\"message\":\"[APM]\nRemove `error.id` in `getErrorGroupMainStatistics` query as it's not\nused (#210613)\\n\\n## Summary\\n\\nCloses #210610\\n\\nThis PR removes\n`error.id` field from being queried at\\n`getErrorGroupMainStatistics`,\nas it was not being used, as it was\\nrequired. If we didn't have this\nfield, the endpoint call would\ncrash.\",\"sha\":\"46cd29e60be24fa3d39b2b364973e0e9b10659b7\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"v9.0.0\",\"apm\",\"Team:obs-ux-infra_services\",\"backport:version\",\"backport:8.17\",\"v9.1.0\",\"backport:8.18\"],\"title\":\"[APM]\nRemove `error.id` in `getErrorGroupMainStatistics` query as it's not\nused\",\"number\":210613,\"url\":\"https://github.com/elastic/kibana/pull/210613\",\"mergeCommit\":{\"message\":\"[APM]\nRemove `error.id` in `getErrorGroupMainStatistics` query as it's not\nused (#210613)\\n\\n## Summary\\n\\nCloses #210610\\n\\nThis PR removes\n`error.id` field from being queried at\\n`getErrorGroupMainStatistics`,\nas it was not being used, as it was\\nrequired. If we didn't have this\nfield, the endpoint call would\ncrash.\",\"sha\":\"46cd29e60be24fa3d39b2b364973e0e9b10659b7\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"9.0\"],\"targetPullRequestStates\":[{\"branch\":\"9.0\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/210613\",\"number\":210613,\"mergeCommit\":{\"message\":\"[APM]\nRemove `error.id` in `getErrorGroupMainStatistics` query as it's not\nused (#210613)\\n\\n## Summary\\n\\nCloses #210610\\n\\nThis PR removes\n`error.id` field from being queried at\\n`getErrorGroupMainStatistics`,\nas it was not being used, as it was\\nrequired. If we didn't have this\nfield, the endpoint call would\ncrash.\",\"sha\":\"46cd29e60be24fa3d39b2b364973e0e9b10659b7\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210613","number":210613,"mergeCommit":{"message":"[APM] Remove `error.id` in `getErrorGroupMainStatistics` query as it's not used (#210613)\n\n## Summary\n\nCloses #210610\n\nThis PR removes `error.id` field from being queried at\n`getErrorGroupMainStatistics`, as it was not being used, as it was\nrequired. If we didn't have this field, the endpoint call would crash.","sha":"46cd29e60be24fa3d39b2b364973e0e9b10659b7"}}]}] BACKPORT-->