### PR TITLE
[Lens][Embeddable] Make sure to not serialize searchSessionId

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_integrations.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_integrations.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { faker } from '@faker-js/faker';
 import { createEmptyLensState } from '../helper';
 import { makeEmbeddableServices, getLensRuntimeStateMock } from '../mocks';
 import { LensRuntimeState } from '../types';
@@ -54,6 +55,16 @@ describe('Dashboard services API', () => {
       );
       // * references should be at root level
       expect(references).toEqual(attributes.references);
+    });
+
+    it('should remove the searchSessionId from the serializedState', async () => {
+      const attributes = createAttributesWithReferences();
+      const api = setupIntegrationsApi({
+        attributes,
+        searchSessionId: faker.string.uuid(),
+      });
+      const { rawState } = api.serializeState();
+      expect('searchSessionId' in rawState).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes a regression in the `serializeState` function used to pass the embeddable attributes to the dashboard to save the panel. In the refactor this function started to leak the `searchSessionId` in the serialized state and even if not used after worse it could lead to issues and in general it's a waste of disk space.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

## Release notes
It fixes a regression for the serialized state for the Lens embeddable saving attributes who should not be in the serialized state.


<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->