### PR TITLE
[Automatic Import] Fix package name validation

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/common/constants.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/common/constants.ts
@@ -48,7 +48,7 @@ export const CATEGORIZATION_REVIEW_MAX_CYCLES = 5;
 export const CATEGORIZATION_RECURSION_LIMIT = 50;
 
 // Name regex pattern
-export const NAME_REGEX_PATTERN = /^[a-z0-9_]+$/;
+export const NAME_REGEX_PATTERN = /^[a-z_][a-z0-9_]+$/;
 
 // Datastream name regex pattern. Same regex that for the name validation in elastic-package
 export const DATASTREAM_NAME_REGEX_PATTERN = /^([a-z0-9]{2}|[a-z0-9][a-z0-9_]+[a-z0-9])$/;

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/data_stream_step/data_stream_step.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/data_stream_step/data_stream_step.tsx
@@ -195,7 +195,7 @@ export const DataStreamStep = React.memo<DataStreamStepProps>(
                   <EuiFieldText
                     name="name"
                     data-test-subj="nameInput"
-                    value={name}
+                    value={isValidName(name) ? name : ''}
                     onChange={onChange.name}
                     isInvalid={invalidFields.name}
                     isLoading={isLoadingPackageNames}

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/data_stream_step/translations.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/data_stream_step/translations.ts
@@ -46,7 +46,7 @@ export const NO_SPACES_HELP = i18n.translate(
   'xpack.automaticImport.step.dataStream.noSpacesHelpText',
   {
     defaultMessage:
-      'Name must be at least 2 characters long and can only contain lowercase letters, numbers, and underscores (_)',
+      'Name must be at least 2 characters long, start with a letter, and can only contain lowercase letters, numbers, and underscores (_)',
   }
 );
 export const PACKAGE_NAMES_FETCH_ERROR = i18n.translate(

--- a/x-pack/platform/plugins/shared/automatic_import/server/integration_builder/build_integration.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/integration_builder/build_integration.test.ts
@@ -304,6 +304,23 @@ describe('isValidName', () => {
     expect(isValidName('valid_name')).toBe(true);
     expect(isValidName('anothervalidname')).toBe(true);
   });
+  it('should return false for names starting with numbers', () => {
+    expect(isValidName('123name')).toBe(false);
+    expect(isValidName('1name')).toBe(false);
+    expect(isValidName('999invalid')).toBe(false);
+  });
+
+  it('should return false for names starting with underscore', () => {
+    expect(isValidName('_name')).toBe(true);
+    expect(isValidName('_invalid_name')).toBe(true);
+    expect(isValidName('__name')).toBe(true);
+  });
+
+  it('should return true for names starting with letters followed by numbers', () => {
+    expect(isValidName('name123')).toBe(true);
+    expect(isValidName('valid1')).toBe(true);
+    expect(isValidName('valid_123')).toBe(true);
+  });
 
   it('should return false for empty string', () => {
     expect(isValidName('')).toBe(false);


### PR DESCRIPTION
## Release Note

Fix package name validation on Datastream page.

## Summary

Closes - #199893

If the package name starts with a number [ Only number , alphabet , underscore are allowed ] then some of the script processors in the pipeline fail with dot annotation since the fields are formed like `ctx.123_abc.something` which fails with `Illegal Argument Exception` in script processor.

Hence the package name has additional validation on Data stream page to restrict it to start with an alphabet or underscore instead.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->