### PR TITLE
[POC][ResponseOps][Alerts] Replace ECS flat with fields metadata plugin in fields browser

### DIFF
--- a/packages/response-ops/alerts_fields_browser/components/field_browser/field_browser.tsx
+++ b/packages/response-ops/alerts_fields_browser/components/field_browser/field_browser.tsx
@@ -33,6 +33,9 @@ export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
   onToggleColumn,
   options,
   width,
+  services: {
+    fieldsMetadata: { useFieldsMetadata },
+  },
 }) => {
   const initialCategories = useMemo(
     () => options?.preselectedCategoryIds ?? [],
@@ -123,6 +126,12 @@ export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
     [setFilterSelectedEnabled]
   );
 
+  const fieldsMetadata = useFieldsMetadata({
+    fieldNames: filteredBrowserFields
+      ? Object.values(filteredBrowserFields).flatMap(({ fields }) => Object.keys(fields ?? {}))
+      : undefined,
+  });
+
   return (
     <div css={styles.buttonContainer} data-test-subj="fields-browser-button-container">
       <EuiToolTip content={i18n.FIELDS_BROWSER}>
@@ -146,6 +155,7 @@ export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
           filteredBrowserFields={
             filteredBrowserFields != null ? filteredBrowserFields : browserFields
           }
+          fieldsMetadata={fieldsMetadata.fieldsMetadata}
           filterSelectedEnabled={filterSelectedEnabled}
           isSearching={isSearching}
           setSelectedCategoryIds={setSelectedCategoryIds}

--- a/packages/response-ops/alerts_fields_browser/components/field_browser_modal/field_browser_modal.tsx
+++ b/packages/response-ops/alerts_fields_browser/components/field_browser_modal/field_browser_modal.tsx
@@ -22,6 +22,7 @@ import {
 import React, { useCallback } from 'react';
 
 import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import { FindFieldsMetadataResponsePayload } from '@kbn/fields-metadata-plugin/common/fields_metadata/v1';
 import type { FieldBrowserProps } from '../../types';
 import { Search } from '../search';
 
@@ -86,6 +87,8 @@ export type FieldBrowserModalProps = Pick<
    * of the popover.
    */
   restoreFocusTo: React.MutableRefObject<HTMLButtonElement | null>;
+
+  fieldsMetadata?: FindFieldsMetadataResponsePayload['fields'];
 };
 
 /**
@@ -109,6 +112,7 @@ const FieldBrowserModalComponent: React.FC<FieldBrowserModalProps> = ({
   searchInput,
   selectedCategoryIds,
   width = FIELD_BROWSER_WIDTH,
+  fieldsMetadata,
 }) => {
   const closeAndRestoreFocus = useCallback(() => {
     onHide();
@@ -182,6 +186,7 @@ const FieldBrowserModalComponent: React.FC<FieldBrowserModalProps> = ({
             onToggleColumn={onToggleColumn}
             getFieldTableColumns={getFieldTableColumns}
             onHide={onHide}
+            fieldsMetadata={fieldsMetadata}
           />
         </EuiModalBody>
 

--- a/packages/response-ops/alerts_fields_browser/components/field_items/field_items.tsx
+++ b/packages/response-ops/alerts_fields_browser/components/field_items/field_items.tsx
@@ -19,10 +19,9 @@ import {
 } from '@elastic/eui';
 import { uniqBy } from 'lodash/fp';
 import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
-import { EcsFlat } from '@elastic/ecs';
-import { EcsMetadata } from '@kbn/alerts-as-data-utils/src/field_maps/types';
 
 import { ALERT_CASE_IDS, ALERT_MAINTENANCE_WINDOW_IDS } from '@kbn/rule-data-utils';
+import { FindFieldsMetadataResponsePayload } from '@kbn/fields-metadata-plugin/common/fields_metadata/v1';
 import type { BrowserFieldItem, FieldTableColumns, GetFieldTableColumns } from '../../types';
 import { FieldName } from '../field_name';
 import * as i18n from '../../translations';
@@ -58,10 +57,12 @@ export const getFieldItemsData = ({
   browserFields,
   selectedCategoryIds,
   columnIds,
+  fieldsMetadata,
 }: {
   browserFields: BrowserFields;
   selectedCategoryIds: string[];
   columnIds: string[];
+  fieldsMetadata?: FindFieldsMetadataResponsePayload['fields'];
 }): { fieldItems: BrowserFieldItem[] } => {
   const categoryIds =
     selectedCategoryIds.length > 0 ? selectedCategoryIds : Object.keys(browserFields);
@@ -77,7 +78,7 @@ export const getFieldItemsData = ({
             return {
               name,
               type: field.type,
-              description: getDescription(name, EcsFlat as Record<string, EcsMetadata>),
+              description: getDescription(name, fieldsMetadata),
               example: field.example?.toString(),
               category: getCategory(name),
               selected: selectedFieldIds.has(name),

--- a/packages/response-ops/alerts_fields_browser/components/field_table/field_table.tsx
+++ b/packages/response-ops/alerts_fields_browser/components/field_table/field_table.tsx
@@ -16,6 +16,7 @@ import {
   CriteriaWithPagination,
 } from '@elastic/eui';
 import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import { FindFieldsMetadataResponsePayload } from '@kbn/fields-metadata-plugin/common/fields_metadata/v1';
 import { getFieldColumns, getFieldItemsData } from '../field_items';
 import { CATEGORY_TABLE_CLASS_NAME, TABLE_HEIGHT } from '../../helpers';
 import type { BrowserFieldItem, FieldBrowserProps, GetFieldTableColumns } from '../../types';
@@ -52,6 +53,8 @@ export interface FieldTableProps extends Pick<FieldBrowserProps, 'columnIds' | '
    * Hides the field browser when invoked
    */
   onHide: () => void;
+
+  fieldsMetadata?: FindFieldsMetadataResponsePayload['fields'];
 }
 
 const FieldTableComponent: React.FC<FieldTableProps> = ({
@@ -64,6 +67,7 @@ const FieldTableComponent: React.FC<FieldTableProps> = ({
   onToggleColumn,
   searchInput,
   selectedCategoryIds,
+  fieldsMetadata,
 }) => {
   const { euiTheme } = useEuiTheme();
   const [pageIndex, setPageIndex] = useState(0);
@@ -78,8 +82,9 @@ const FieldTableComponent: React.FC<FieldTableProps> = ({
         browserFields: filteredBrowserFields,
         selectedCategoryIds,
         columnIds,
+        fieldsMetadata,
       }),
-    [columnIds, filteredBrowserFields, selectedCategoryIds]
+    [columnIds, fieldsMetadata, filteredBrowserFields, selectedCategoryIds]
   );
 
   /**

--- a/packages/response-ops/alerts_fields_browser/helpers.ts
+++ b/packages/response-ops/alerts_fields_browser/helpers.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EcsMetadata } from '@kbn/alerts-as-data-utils/src/field_maps/types';
 import {
   ALERT_CASE_IDS,
   ALERT_MAINTENANCE_WINDOW_IDS,
@@ -15,6 +14,7 @@ import {
 } from '@kbn/rule-data-utils';
 import type { BrowserField, BrowserFields } from '@kbn/rule-registry-plugin/common';
 import { isEmpty } from 'lodash/fp';
+import { FindFieldsMetadataResponsePayload } from '@kbn/fields-metadata-plugin/common/fields_metadata/v1';
 import { CASES, MAINTENANCE_WINDOWS } from './translations';
 
 export const FIELD_BROWSER_WIDTH = 925;
@@ -195,8 +195,10 @@ export const getCategory = (fieldName: string) => {
   return fieldNameArray?.[0] ?? '(unknown)';
 };
 
-export const getDescription = (fieldName: string, ecsFlat: Record<string, EcsMetadata>) =>
-  ecsFlat[fieldName]?.description ?? '';
+export const getDescription = (
+  fieldName: string,
+  fieldsMetadata?: FindFieldsMetadataResponsePayload['fields']
+) => fieldsMetadata?.[fieldName]?.description ?? '';
 
 /** Returns example text, or an empty string if the field does not have an example */
 export const getExampleText = (example: string | number | null | undefined): string =>

--- a/packages/response-ops/alerts_fields_browser/types.ts
+++ b/packages/response-ops/alerts_fields_browser/types.ts
@@ -9,6 +9,7 @@
 
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 
 /**
  * An item rendered in the table
@@ -57,4 +58,10 @@ export interface FieldBrowserProps {
   options?: FieldBrowserOptions;
   /** The width of the field browser */
   width?: number;
+  /**
+   * Services
+   */
+  services: {
+    fieldsMetadata: FieldsMetadataPublicStart;
+  };
 }

--- a/packages/response-ops/alerts_table/components/alerts_data_grid.tsx
+++ b/packages/response-ops/alerts_table/components/alerts_data_grid.tsx
@@ -98,7 +98,7 @@ export const AlertsDataGrid = typedMemo(
       refresh: refreshQueries,
       columns,
       dataGridRef,
-      services: { http, notifications, application, cases: casesService, settings },
+      services: { http, notifications, application, cases: casesService, settings, fieldsMetadata },
     } = renderContext;
 
     const { colorMode } = useEuiTheme();
@@ -149,6 +149,7 @@ export const AlertsDataGrid = typedMemo(
       showInspectButton,
       toolbarVisibilityProp,
       settings,
+      fieldsMetadata,
     });
 
     const leadingControlColumns: EuiDataGridControlColumn[] | undefined = useMemo(() => {

--- a/packages/response-ops/alerts_table/hooks/use_toolbar_visibility.tsx
+++ b/packages/response-ops/alerts_table/hooks/use_toolbar_visibility.tsx
@@ -15,6 +15,7 @@ import React, { lazy, memo, ReactNode, Suspense, useMemo } from 'react';
 import { Alert, BrowserFields, EsQuerySnapshot } from '@kbn/alerting-types';
 import { FieldBrowser, FieldBrowserOptions } from '@kbn/response-ops-alerts-fields-browser';
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
+import { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import { AlertsCount } from '../components/alerts_count';
 import { useAlertsTableContext } from '../contexts/alerts_table_context';
 import type { BulkActionsPanelConfig, RowSelection } from '../types';
@@ -61,6 +62,7 @@ const LeftAppendControl = memo(
     onResetColumns,
     onToggleColumn,
     fieldsBrowserOptions,
+    fieldsMetadata,
   }: {
     alertsCount: number;
     columnIds: string[];
@@ -70,6 +72,7 @@ const LeftAppendControl = memo(
     fieldsBrowserOptions?: FieldBrowserOptions;
     hasBrowserFields: boolean;
     browserFields: BrowserFields;
+    fieldsMetadata: FieldsMetadataPublicStart;
   }) => {
     return (
       <>
@@ -81,6 +84,7 @@ const LeftAppendControl = memo(
             onResetColumns={onResetColumns}
             onToggleColumn={onToggleColumn}
             options={fieldsBrowserOptions}
+            services={{ fieldsMetadata }}
           />
         )}
       </>
@@ -99,6 +103,7 @@ const useGetDefaultVisibility = ({
   alertsQuerySnapshot,
   showInspectButton,
   toolbarVisibilityProp,
+  fieldsMetadata,
 }: {
   alertsCount: number;
   columnIds: string[];
@@ -110,6 +115,7 @@ const useGetDefaultVisibility = ({
   alertsQuerySnapshot?: EsQuerySnapshot;
   showInspectButton: boolean;
   toolbarVisibilityProp?: EuiDataGridToolBarVisibilityOptions;
+  fieldsMetadata: FieldsMetadataPublicStart;
 }): EuiDataGridToolBarVisibilityOptions => {
   return useMemo(() => {
     const hasBrowserFields = Object.keys(browserFields).length > 0;
@@ -132,6 +138,7 @@ const useGetDefaultVisibility = ({
               onResetColumns={onResetColumns}
               onToggleColumn={onToggleColumn}
               fieldsBrowserOptions={fieldsBrowserOptions}
+              fieldsMetadata={fieldsMetadata}
             />
           ),
         },
@@ -142,15 +149,16 @@ const useGetDefaultVisibility = ({
       showSortSelector: true,
     };
   }, [
-    alertsCount,
     browserFields,
-    columnIds,
-    fieldsBrowserOptions,
+    additionalToolbarControls,
     alertsQuerySnapshot,
+    showInspectButton,
+    alertsCount,
+    columnIds,
     onResetColumns,
     onToggleColumn,
-    showInspectButton,
-    additionalToolbarControls,
+    fieldsBrowserOptions,
+    fieldsMetadata,
   ]);
 };
 
@@ -173,6 +181,7 @@ export const useGetToolbarVisibility = ({
   showInspectButton,
   toolbarVisibilityProp,
   settings,
+  fieldsMetadata,
 }: {
   bulkActions: BulkActionsPanelConfig[];
   alertsCount: number;
@@ -192,6 +201,7 @@ export const useGetToolbarVisibility = ({
   showInspectButton: boolean;
   toolbarVisibilityProp?: EuiDataGridToolBarVisibilityOptions;
   settings: SettingsStart;
+  fieldsMetadata: FieldsMetadataPublicStart;
 }): EuiDataGridToolBarVisibilityOptions => {
   const selectedRowsCount = rowSelection.size;
   const defaultVisibilityProps = useMemo(() => {
@@ -205,6 +215,7 @@ export const useGetToolbarVisibility = ({
       fieldsBrowserOptions,
       alertsQuerySnapshot,
       showInspectButton,
+      fieldsMetadata,
     };
   }, [
     alertsCount,
@@ -216,6 +227,7 @@ export const useGetToolbarVisibility = ({
     fieldsBrowserOptions,
     alertsQuerySnapshot,
     showInspectButton,
+    fieldsMetadata,
   ]);
   const defaultVisibility = useGetDefaultVisibility(defaultVisibilityProps);
   const options = useMemo(() => {

--- a/packages/response-ops/alerts_table/types.ts
+++ b/packages/response-ops/alerts_table/types.ts
@@ -55,6 +55,7 @@ import type { NotificationsStart } from '@kbn/core-notifications-browser';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/public';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
+import { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { Case } from './apis/bulk_get_cases';
 
 export interface Consumer {
@@ -248,6 +249,7 @@ export interface AlertsTableProps<AC extends AdditionalContext = AdditionalConte
     application: ApplicationStart;
     licensing: LicensingPluginStart;
     settings: SettingsStart;
+    fieldsMetadata: FieldsMetadataPublicStart;
     /**
      * The cases service is optional: cases features will be disabled if not provided
      */

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/kibana.jsonc
@@ -22,6 +22,7 @@
       "kibanaUtils",
       "unifiedSearch",
       "fieldFormats",
+      "fieldsMetadata",
       "dataViews",
       "dataViewEditor",
       "alerting",

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/rules_app.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/rules_app.tsx
@@ -36,6 +36,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { DashboardStart } from '@kbn/dashboard-plugin/public';
 import { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import { CloudSetup } from '@kbn/cloud-plugin/public';
+import { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import { suspendedComponentWithProps } from './lib/suspended_component_with_props';
 import { ActionTypeRegistryContract, RuleTypeRegistryContract } from '../types';
 import {
@@ -85,6 +86,7 @@ export interface TriggersAndActionsUiServices extends CoreStart {
   isServerless: boolean;
   fieldFormats: FieldFormatsStart;
   lens: LensPublicStart;
+  fieldsMetadata: FieldsMetadataPublicStart;
 }
 
 export const renderApp = (deps: TriggersAndActionsUiServices) => {

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/components/stack_alerts_page.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alerts_page/components/stack_alerts_page.tsx
@@ -112,8 +112,16 @@ const PageContentComponent: React.FC<PageContentProps> = ({
   authorizedToReadAnyRules,
   ruleTypeIdsByFeatureId,
 }) => {
-  const { data, http, notifications, fieldFormats, application, licensing, settings } =
-    useKibana().services;
+  const {
+    data,
+    http,
+    notifications,
+    fieldFormats,
+    application,
+    licensing,
+    settings,
+    fieldsMetadata,
+  } = useKibana().services;
   const ruleTypeIdsByFeatureIdEntries = Object.entries(ruleTypeIdsByFeatureId);
 
   const [esQuery, setEsQuery] = useState({ bool: {} } as { bool: BoolQuery });
@@ -271,6 +279,7 @@ const PageContentComponent: React.FC<PageContentProps> = ({
               application,
               licensing,
               settings,
+              fieldsMetadata,
             }}
           />
         </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
@@ -33,6 +33,7 @@ import { LensPublicStart } from '@kbn/lens-plugin/public';
 import { RuleAction } from '@kbn/alerting-plugin/common';
 import { TypeRegistry } from '@kbn/alerts-ui-shared/src/common/type_registry';
 import { CloudSetup } from '@kbn/cloud-plugin/public';
+import { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { RuleUiAction } from './types';
 import type { AlertsSearchBarProps } from './application/sections/alerts_search_bar';
 
@@ -169,6 +170,7 @@ interface PluginsStart {
   serverless?: ServerlessPluginStart;
   fieldFormats: FieldFormatsRegistry;
   lens: LensPublicStart;
+  fieldsMetadata: FieldsMetadataPublicStart;
 }
 
 export class Plugin
@@ -306,6 +308,7 @@ export class Plugin
           isServerless: !!pluginsStart.serverless,
           fieldFormats: pluginsStart.fieldFormats,
           lens: pluginsStart.lens,
+          fieldsMetadata: pluginsStart.fieldsMetadata,
         });
       },
     });
@@ -402,6 +405,7 @@ export class Plugin
             isServerless: !!pluginsStart.serverless,
             fieldFormats: pluginsStart.fieldFormats,
             lens: pluginsStart.lens,
+            fieldsMetadata: pluginsStart.fieldsMetadata,
           });
         },
       });


### PR DESCRIPTION
> [!WARNING]
> 🚧 POC PR

## Summary

Replaces the ECS flat import with calls to the fields metadata plugin in order to retrieve field descriptions for the alerts table fields browser.
