### PR TITLE
[8.17] [Automatic Import] Fix package name validation (#210770)

### DIFF
--- a/x-pack/plugins/integration_assistant/common/constants.ts
+++ b/x-pack/plugins/integration_assistant/common/constants.ts
@@ -47,4 +47,7 @@ export const CATEGORIZATION_REVIEW_MAX_CYCLES = 5;
 export const CATEGORIZATION_RECURSION_LIMIT = 50;
 
 // Name regex pattern
-export const NAME_REGEX_PATTERN = /^[a-z0-9_]+$/;
+export const NAME_REGEX_PATTERN = /^[a-z_][a-z0-9_]+$/;
+
+// Datastream name regex pattern. Same regex that for the name validation in elastic-package
+export const DATASTREAM_NAME_REGEX_PATTERN = /^([a-z0-9]{2}|[a-z0-9][a-z0-9_]+[a-z0-9])$/;

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/data_stream_step.tsx
@@ -170,7 +170,7 @@ export const DataStreamStep = React.memo<DataStreamStepProps>(
                   <EuiFieldText
                     name="name"
                     data-test-subj="nameInput"
-                    value={name}
+                    value={isValidName(name) ? name : ''}
                     onChange={onChange.name}
                     isInvalid={invalidFields.name}
                     isLoading={isLoadingPackageNames}

--- a/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/translations.ts
+++ b/x-pack/plugins/integration_assistant/public/components/create_integration/create_integration_assistant/steps/data_stream_step/translations.ts
@@ -45,7 +45,8 @@ export const INTEGRATION_NAME_LABEL = i18n.translate(
 export const NO_SPACES_HELP = i18n.translate(
   'xpack.integrationAssistant.step.dataStream.noSpacesHelpText',
   {
-    defaultMessage: 'Name can only contain lowercase letters, numbers, and underscore (_)',
+    defaultMessage:
+      'Name must be at least 2 characters long, start with a letter, and can only contain lowercase letters, numbers, and underscores (_)',
   }
 );
 export const PACKAGE_NAMES_FETCH_ERROR = i18n.translate(

--- a/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.test.ts
@@ -286,6 +286,23 @@ describe('isValidName', () => {
     expect(isValidName('valid_name')).toBe(true);
     expect(isValidName('anothervalidname')).toBe(true);
   });
+  it('should return false for names starting with numbers', () => {
+    expect(isValidName('123name')).toBe(false);
+    expect(isValidName('1name')).toBe(false);
+    expect(isValidName('999invalid')).toBe(false);
+  });
+
+  it('should return false for names starting with underscore', () => {
+    expect(isValidName('_name')).toBe(true);
+    expect(isValidName('_invalid_name')).toBe(true);
+    expect(isValidName('__name')).toBe(true);
+  });
+
+  it('should return true for names starting with letters followed by numbers', () => {
+    expect(isValidName('name123')).toBe(true);
+    expect(isValidName('valid1')).toBe(true);
+    expect(isValidName('valid_123')).toBe(true);
+  });
 
   it('should return false for empty string', () => {
     expect(isValidName('')).toBe(false);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Automatic Import] Fix package name validation (#210770)](https://github.com/elastic/kibana/pull/210770)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bharat Pasupula","email":"123897612+bhapas@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-12T11:48:20Z","message":"[Automatic Import] Fix package name validation (#210770)\n\n## Release Note\r\n\r\nFix package name validation on Datastream page.\r\n\r\n## Summary\r\n\r\nCloses - #199893\r\n\r\nIf the package name starts with a number [ Only number , alphabet ,\r\nunderscore are allowed ] then some of the script processors in the\r\npipeline fail with dot annotation since the fields are formed like\r\n`ctx.123_abc.something` which fails with `Illegal Argument Exception` in\r\nscript processor.\r\n\r\nHence the package name has additional validation on Data stream page to\r\nrestrict it to start with an alphabet or underscore instead.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"9c87ded7d1e1f5c9fe8b3accce1beda01268d5cf","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","backport:prev-major","Team:Security-Scalability","Feature:AutomaticImport","v9.1.0"],"title":"[Automatic Import] Fix package name validation","number":210770,"url":"https://github.com/elastic/kibana/pull/210770","mergeCommit":{"message":"[Automatic Import] Fix package name validation (#210770)\n\n## Release Note\r\n\r\nFix package name validation on Datastream page.\r\n\r\n## Summary\r\n\r\nCloses - #199893\r\n\r\nIf the package name starts with a number [ Only number , alphabet ,\r\nunderscore are allowed ] then some of the script processors in the\r\npipeline fail with dot annotation since the fields are formed like\r\n`ctx.123_abc.something` which fails with `Illegal Argument Exception` in\r\nscript processor.\r\n\r\nHence the package name has additional validation on Data stream page to\r\nrestrict it to start with an alphabet or underscore instead.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"9c87ded7d1e1f5c9fe8b3accce1beda01268d5cf"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210770","number":210770,"mergeCommit":{"message":"[Automatic Import] Fix package name validation (#210770)\n\n## Release Note\r\n\r\nFix package name validation on Datastream page.\r\n\r\n## Summary\r\n\r\nCloses - #199893\r\n\r\nIf the package name starts with a number [ Only number , alphabet ,\r\nunderscore are allowed ] then some of the script processors in the\r\npipeline fail with dot annotation since the fields are formed like\r\n`ctx.123_abc.something` which fails with `Illegal Argument Exception` in\r\nscript processor.\r\n\r\nHence the package name has additional validation on Data stream page to\r\nrestrict it to start with an alphabet or underscore instead.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"9c87ded7d1e1f5c9fe8b3accce1beda01268d5cf"}},{"url":"https://github.com/elastic/kibana/pull/210801","number":210801,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->