### PR TITLE
Delete 'critical services' count from Entity Analytics Dashboard header

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_analytics_header/index.tsx
@@ -10,7 +10,6 @@ import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
 import { capitalize, sumBy } from 'lodash/fp';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { SEVERITY_COLOR } from '../../../overview/components/detection_response/utils';
 import { LinkAnchor, useGetSecuritySolutionLinkProps } from '../../../common/components/links';
 import {
@@ -45,7 +44,6 @@ const StyledEuiTitle = styled(EuiTitle)`
 // This is not used by the inspect feature but required by the refresh button
 const HOST_RISK_QUERY_ID = 'hostRiskScoreKpiQuery';
 const USER_RISK_QUERY_ID = 'userRiskScoreKpiQuery';
-const SERVICE_RISK_QUERY_ID = 'serviceRiskScoreKpiQuery';
 
 export const EntityAnalyticsHeader = () => {
   const { from, to } = useGlobalTime();
@@ -57,7 +55,6 @@ export const EntityAnalyticsHeader = () => {
     }),
     [from, to]
   );
-  const isServiceEntityStoreEnabled = useIsExperimentalFeatureEnabled('serviceEntityStoreEnabled');
 
   const {
     severityCount: hostsSeverityCount,
@@ -79,17 +76,6 @@ export const EntityAnalyticsHeader = () => {
     filterQuery,
     timerange,
     riskEntity: EntityType.user,
-  });
-
-  const {
-    severityCount: servicesSeverityCount,
-    loading: serviceRiskLoading,
-    refetch: refetchServiceRiskScore,
-    inspect: inspectServiceRiskScore,
-  } = useRiskScoreKpi({
-    filterQuery,
-    timerange,
-    riskEntity: EntityType.service,
   });
 
   const { data } = useAggregatedAnomaliesByJob({ skip: false, from, to });
@@ -163,15 +149,6 @@ export const EntityAnalyticsHeader = () => {
     inspect: inspectHostRiskScore,
   });
 
-  useQueryInspector({
-    queryId: SERVICE_RISK_QUERY_ID,
-    loading: serviceRiskLoading,
-    refetch: refetchServiceRiskScore,
-    setQuery,
-    deleteQuery,
-    inspect: inspectServiceRiskScore,
-  });
-
   // Anomaly jobs are enabled if at least one job is started or has data
   const areJobsEnabled = useMemo(
     () =>
@@ -216,15 +193,6 @@ export const EntityAnalyticsHeader = () => {
                 href={userRiskTabUrl}
               />
             </EuiFlexItem>
-
-            {isServiceEntityStoreEnabled && (
-              <EuiFlexItem grow={false}>
-                <CriticalEntitiesCount
-                  entityType={EntityType.service}
-                  severityCount={servicesSeverityCount}
-                />
-              </EuiFlexItem>
-            )}
           </>
         )}
 


### PR DESCRIPTION
## Summary

This PR deletes the "Critical Services" component from the Entity Analytics Dashboard header.
 
![Screenshot 2025-02-12 at 10 33 40](https://github.com/user-attachments/assets/07e57c40-e6c7-4c7f-9546-92274ad9ccf4)


The component was included with the service entity store, but Product and QA consider it confusing and not very valuable to our users.


### How to test it?
* Start Kibana with security data
* Go to the security solution/entity analytics dashboard
* The component shouldn't be there

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->