### PR TITLE
[Rules migration][Integration test] Get migration rules API (#11232)

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/get.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/get.ts
@@ -8,9 +8,17 @@
 import expect from 'expect';
 import { v4 as uuidv4 } from 'uuid';
 import {
+  RuleTranslationResult,
+  SiemMigrationStatus,
+} from '@kbn/security-solution-plugin/common/siem_migrations/constants';
+import {
+  RuleMigrationDocument,
   createMigrationRules,
+  defaultElasticRule,
+  defaultOriginalRule,
   deleteAllMigrationRules,
   getMigrationRuleDocument,
+  getMigrationRuleDocuments,
   migrationRulesRouteHelpersFactory,
 } from '../../utils';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
@@ -25,18 +33,652 @@ export default ({ getService }: FtrProviderContext) => {
       await deleteAllMigrationRules(es);
     });
 
-    it('should fetch existing rules within specified migration', async () => {
-      // create a document
-      const migrationId = uuidv4();
-      const migrationRuleDocument = getMigrationRuleDocument({ migration_id: migrationId });
-      await createMigrationRules(es, [migrationRuleDocument]);
+    describe('Basic', () => {
+      it('should fetch existing rules within specified migration', async () => {
+        // create a document
+        const migrationId = uuidv4();
+        const migrationRuleDocument = getMigrationRuleDocument({ migration_id: migrationId });
+        await createMigrationRules(es, [migrationRuleDocument]);
 
-      const { '@timestamp': timestamp, updated_at: updatedAt, ...rest } = migrationRuleDocument;
+        const { '@timestamp': timestamp, updated_at: updatedAt, ...rest } = migrationRuleDocument;
 
-      // fetch migration rule
-      const response = await migrationRulesRoutes.get(migrationId);
-      expect(response.body.total).toEqual(1);
-      expect(response.body.data).toEqual(expect.arrayContaining([expect.objectContaining(rest)]));
+        // fetch migration rule
+        const response = await migrationRulesRoutes.get({ migrationId });
+        expect(response.body.total).toEqual(1);
+        expect(response.body.data).toEqual(expect.arrayContaining([expect.objectContaining(rest)]));
+      });
+    });
+
+    describe('Filtering', () => {
+      it('should fetch rules filtered by `searchTerm`', async () => {
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const title = `${index < 5 ? 'Elastic' : 'Splunk'} rule - ${index}`;
+          const originalRule = { ...defaultOriginalRule, title };
+          const elasticRule = { ...defaultElasticRule, title };
+          return {
+            migration_id: migrationId,
+            original_rule: originalRule,
+            elastic_rule: elasticRule,
+          };
+        };
+        const migrationRuleDocuments = getMigrationRuleDocuments(10, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // Search by word `Elastic`
+        let expectedRuleDocuments = expect.arrayContaining(
+          migrationRuleDocuments
+            .slice(0, 5)
+            .map(({ '@timestamp': timestamp, updated_at: updatedAt, ...rest }) =>
+              expect.objectContaining(rest)
+            )
+        );
+
+        // fetch migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { searchTerm: 'Elastic' },
+        });
+        expect(response.body.total).toEqual(5);
+        expect(response.body.data).toEqual(expectedRuleDocuments);
+
+        // Search by word `Splunk`
+        expectedRuleDocuments = expect.arrayContaining(
+          migrationRuleDocuments
+            .slice(5)
+            .map(({ '@timestamp': timestamp, updated_at: updatedAt, ...rest }) =>
+              expect.objectContaining(rest)
+            )
+        );
+
+        // fetch migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { searchTerm: 'Splunk' },
+        });
+        expect(response.body.total).toEqual(5);
+        expect(response.body.data).toEqual(expectedRuleDocuments);
+      });
+
+      it('should fetch rules filtered by `ids`', async () => {
+        // create a document
+        const migrationId = uuidv4();
+
+        const migrationRuleDocuments = getMigrationRuleDocuments(10, () => ({
+          migration_id: migrationId,
+        }));
+        const createdDocumentIds = await createMigrationRules(es, migrationRuleDocuments);
+
+        const expectedIds = createdDocumentIds.slice(0, 3).sort();
+
+        // fetch migration rules by existing ids
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { ids: expectedIds },
+        });
+        expect(response.body.total).toEqual(3);
+        expect(response.body.data.map(({ id }) => id).sort()).toEqual(expectedIds);
+
+        // fetch migration rules by non-existing id
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { ids: [uuidv4()] },
+        });
+        expect(response.body.total).toEqual(0);
+      });
+
+      it('should fetch rules filtered by `prebuilt`', async () => {
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const prebuiltRuleId = index < 3 ? uuidv4() : undefined;
+          const elasticRule = { ...defaultElasticRule, prebuilt_rule_id: prebuiltRuleId };
+          return {
+            migration_id: migrationId,
+            elastic_rule: elasticRule,
+          };
+        };
+
+        const migrationRuleDocuments = getMigrationRuleDocuments(10, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch migration rules matched Elastic prebuilt rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { prebuilt: true },
+        });
+        expect(response.body.total).toEqual(3);
+
+        // fetch custom translated migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { prebuilt: false },
+        });
+        expect(response.body.total).toEqual(7);
+      });
+
+      it('should fetch rules filtered by `installed`', async () => {
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const installedRuleId = index < 2 ? uuidv4() : undefined;
+          const elasticRule = { ...defaultElasticRule, id: installedRuleId };
+          return {
+            migration_id: migrationId,
+            elastic_rule: elasticRule,
+          };
+        };
+
+        const migrationRuleDocuments = getMigrationRuleDocuments(10, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch installed migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { installed: true },
+        });
+        expect(response.body.total).toEqual(2);
+
+        // fetch non-installed migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { installed: false },
+        });
+        expect(response.body.total).toEqual(8);
+      });
+
+      it('should fetch rules filtered by `failed`', async () => {
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const status = index < 4 ? SiemMigrationStatus.FAILED : SiemMigrationStatus.COMPLETED;
+          return {
+            migration_id: migrationId,
+            status,
+          };
+        };
+
+        const migrationRuleDocuments = getMigrationRuleDocuments(10, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch failed migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { failed: true },
+        });
+        expect(response.body.total).toEqual(4);
+
+        // fetch non-failed migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { failed: false },
+        });
+        expect(response.body.total).toEqual(6);
+      });
+
+      it('should fetch rules filtered by `fullyTranslated`', async () => {
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const translationResult =
+            index < 6
+              ? RuleTranslationResult.FULL
+              : index < 8
+              ? RuleTranslationResult.PARTIAL
+              : RuleTranslationResult.UNTRANSLATABLE;
+          return {
+            migration_id: migrationId,
+            translation_result: translationResult,
+          };
+        };
+
+        const migrationRuleDocuments = getMigrationRuleDocuments(10, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch failed migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { fullyTranslated: true },
+        });
+        expect(response.body.total).toEqual(6);
+
+        // fetch non-failed migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { fullyTranslated: false },
+        });
+        expect(response.body.total).toEqual(4);
+      });
+
+      it('should fetch rules filtered by `partiallyTranslated`', async () => {
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const translationResult =
+            index < 4
+              ? RuleTranslationResult.FULL
+              : index < 8
+              ? RuleTranslationResult.PARTIAL
+              : RuleTranslationResult.UNTRANSLATABLE;
+          return {
+            migration_id: migrationId,
+            translation_result: translationResult,
+          };
+        };
+
+        const migrationRuleDocuments = getMigrationRuleDocuments(10, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch failed migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { partiallyTranslated: true },
+        });
+        expect(response.body.total).toEqual(4);
+
+        // fetch non-failed migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { partiallyTranslated: false },
+        });
+        expect(response.body.total).toEqual(6);
+      });
+
+      it('should fetch rules filtered by `untranslatable`', async () => {
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const translationResult =
+            index < 3
+              ? RuleTranslationResult.FULL
+              : index < 5
+              ? RuleTranslationResult.PARTIAL
+              : RuleTranslationResult.UNTRANSLATABLE;
+          return {
+            migration_id: migrationId,
+            translation_result: translationResult,
+          };
+        };
+
+        const migrationRuleDocuments = getMigrationRuleDocuments(10, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch failed migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { untranslatable: true },
+        });
+        expect(response.body.total).toEqual(5);
+
+        // fetch non-failed migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          filters: { untranslatable: false },
+        });
+        expect(response.body.total).toEqual(5);
+      });
+    });
+
+    describe('Sorting', () => {
+      it('should fetch rules sorted by `title`', async () => {
+        const titles = ['Elastic 1', 'Windows', 'Linux', 'Elastic 2'];
+
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const title = titles[index];
+          const originalRule = { ...defaultOriginalRule, title };
+          const elasticRule = { ...defaultElasticRule, title };
+          return {
+            migration_id: migrationId,
+            original_rule: originalRule,
+            elastic_rule: elasticRule,
+          };
+        };
+        const migrationRuleDocuments = getMigrationRuleDocuments(titles.length, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'elastic_rule.title',
+          sortDirection: 'asc',
+        });
+        expect(response.body.data.map((rule) => rule.elastic_rule?.title)).toEqual(titles.sort());
+
+        // fetch migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'elastic_rule.title',
+          sortDirection: 'desc',
+        });
+        expect(response.body.data.map((rule) => rule.elastic_rule?.title)).toEqual(
+          titles.sort().reverse()
+        );
+      });
+
+      it('should fetch rules sorted by `severity`', async () => {
+        const severities = ['critical', 'low', 'medium', 'low', 'critical'];
+
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const severity = severities[index];
+          const elasticRule = { ...defaultElasticRule, severity };
+          return {
+            migration_id: migrationId,
+            elastic_rule: elasticRule,
+          };
+        };
+        const migrationRuleDocuments = getMigrationRuleDocuments(
+          severities.length,
+          overrideCallback
+        );
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'elastic_rule.severity',
+          sortDirection: 'asc',
+        });
+        expect(response.body.data.map((rule) => rule.elastic_rule?.severity)).toEqual([
+          'low',
+          'low',
+          'medium',
+          'critical',
+          'critical',
+        ]);
+
+        // fetch migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'elastic_rule.severity',
+          sortDirection: 'desc',
+        });
+        expect(response.body.data.map((rule) => rule.elastic_rule?.severity)).toEqual([
+          'critical',
+          'critical',
+          'medium',
+          'low',
+          'low',
+        ]);
+      });
+
+      it('should fetch rules sorted by `risk_score`', async () => {
+        const riskScores = [55, 0, 100, 23];
+
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const riskScore = riskScores[index];
+          const elasticRule = { ...defaultElasticRule, risk_score: riskScore };
+          return {
+            migration_id: migrationId,
+            elastic_rule: elasticRule,
+          };
+        };
+        const migrationRuleDocuments = getMigrationRuleDocuments(
+          riskScores.length,
+          overrideCallback
+        );
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'elastic_rule.risk_score',
+          sortDirection: 'asc',
+        });
+        expect(response.body.data.map((rule) => rule.elastic_rule?.risk_score)).toEqual(
+          riskScores.sort((a, b) => {
+            return a - b;
+          })
+        );
+
+        // fetch migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'elastic_rule.risk_score',
+          sortDirection: 'desc',
+        });
+        expect(response.body.data.map((rule) => rule.elastic_rule?.risk_score)).toEqual(
+          riskScores
+            .sort((a, b) => {
+              return a - b;
+            })
+            .reverse()
+        );
+      });
+
+      it('should fetch rules sorted by `prebuilt_rule_id`', async () => {
+        const prebuiltRuleIds = ['rule-1', undefined, undefined, 'rule-2', undefined];
+
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const prebuiltRuleId = prebuiltRuleIds[index];
+          const elasticRule = { ...defaultElasticRule, prebuilt_rule_id: prebuiltRuleId };
+          return {
+            migration_id: migrationId,
+            elastic_rule: elasticRule,
+          };
+        };
+        const migrationRuleDocuments = getMigrationRuleDocuments(
+          prebuiltRuleIds.length,
+          overrideCallback
+        );
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'elastic_rule.prebuilt_rule_id',
+          sortDirection: 'asc',
+        });
+        expect(response.body.data.map((rule) => rule.elastic_rule?.prebuilt_rule_id)).toEqual([
+          undefined,
+          undefined,
+          undefined,
+          'rule-1',
+          'rule-2',
+        ]);
+
+        // fetch migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'elastic_rule.prebuilt_rule_id',
+          sortDirection: 'desc',
+        });
+        expect(response.body.data.map((rule) => rule.elastic_rule?.prebuilt_rule_id)).toEqual([
+          'rule-2',
+          'rule-1',
+          undefined,
+          undefined,
+          undefined,
+        ]);
+      });
+
+      it('should fetch rules sorted by `translation_result`', async () => {
+        const translationResults = [
+          RuleTranslationResult.UNTRANSLATABLE,
+          RuleTranslationResult.FULL,
+          RuleTranslationResult.PARTIAL,
+        ];
+
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          return {
+            migration_id: migrationId,
+            translation_result: translationResults[index],
+          };
+        };
+        const migrationRuleDocuments = getMigrationRuleDocuments(
+          translationResults.length,
+          overrideCallback
+        );
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'translation_result',
+          sortDirection: 'asc',
+        });
+        expect(response.body.data.map((rule) => rule.translation_result)).toEqual([
+          RuleTranslationResult.UNTRANSLATABLE,
+          RuleTranslationResult.PARTIAL,
+          RuleTranslationResult.FULL,
+        ]);
+
+        // fetch migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'translation_result',
+          sortDirection: 'desc',
+        });
+        expect(response.body.data.map((rule) => rule.translation_result)).toEqual([
+          RuleTranslationResult.FULL,
+          RuleTranslationResult.PARTIAL,
+          RuleTranslationResult.UNTRANSLATABLE,
+        ]);
+      });
+
+      it('should fetch rules sorted by `updated_at`', async () => {
+        // create a document
+        const migrationId = uuidv4();
+
+        // Creating documents separately to have different `update_at` timestamps
+        await createMigrationRules(es, [getMigrationRuleDocument({ migration_id: migrationId })]);
+        await createMigrationRules(es, [getMigrationRuleDocument({ migration_id: migrationId })]);
+        await createMigrationRules(es, [getMigrationRuleDocument({ migration_id: migrationId })]);
+        await createMigrationRules(es, [getMigrationRuleDocument({ migration_id: migrationId })]);
+        await createMigrationRules(es, [getMigrationRuleDocument({ migration_id: migrationId })]);
+
+        // fetch migration rules
+        let response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'updated_at',
+          sortDirection: 'asc',
+        });
+        const ascSorted = response.body.data.map((rule) => rule.updated_at);
+
+        // fetch migration rules
+        response = await migrationRulesRoutes.get({
+          migrationId,
+          sortField: 'updated_at',
+          sortDirection: 'desc',
+        });
+        const descSorted = response.body.data.map((rule) => rule.updated_at);
+
+        expect(ascSorted).toEqual(descSorted.reverse());
+      });
+    });
+
+    describe('Pagination', () => {
+      it('should fetch rules within specific page', async () => {
+        const titles = Array.from({ length: 50 }, (_, index) => `Migration rule - ${index}`);
+
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const title = titles[index];
+          const originalRule = { ...defaultOriginalRule, title };
+          const elasticRule = { ...defaultElasticRule, title };
+          return {
+            migration_id: migrationId,
+            original_rule: originalRule,
+            elastic_rule: elasticRule,
+          };
+        };
+        const migrationRuleDocuments = getMigrationRuleDocuments(titles.length, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch migration rules
+        const response = await migrationRulesRoutes.get({
+          migrationId,
+          page: 3,
+          perPage: 7,
+        });
+        const start = 3 * 7;
+        expect(response.body.data.map((rule) => rule.elastic_rule?.title)).toEqual(
+          titles.slice(start, start + 7)
+        );
+      });
+
+      it('should fetch rules within very first page if `perPage` is not specified', async () => {
+        const titles = Array.from({ length: 50 }, (_, index) => `Migration rule - ${index}`);
+
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const title = titles[index];
+          const originalRule = { ...defaultOriginalRule, title };
+          const elasticRule = { ...defaultElasticRule, title };
+          return {
+            migration_id: migrationId,
+            original_rule: originalRule,
+            elastic_rule: elasticRule,
+          };
+        };
+        const migrationRuleDocuments = getMigrationRuleDocuments(titles.length, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch migration rules
+        const response = await migrationRulesRoutes.get({
+          migrationId,
+          page: 3,
+        });
+        const defaultSize = 10;
+        expect(response.body.data.map((rule) => rule.elastic_rule?.title)).toEqual(
+          titles.slice(0, defaultSize)
+        );
+      });
+
+      it('should fetch rules within very first page of a specified size if `perPage` is specified', async () => {
+        const titles = Array.from({ length: 50 }, (_, index) => `Migration rule - ${index}`);
+
+        // create a document
+        const migrationId = uuidv4();
+
+        const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+          const title = titles[index];
+          const originalRule = { ...defaultOriginalRule, title };
+          const elasticRule = { ...defaultElasticRule, title };
+          return {
+            migration_id: migrationId,
+            original_rule: originalRule,
+            elastic_rule: elasticRule,
+          };
+        };
+        const migrationRuleDocuments = getMigrationRuleDocuments(titles.length, overrideCallback);
+        await createMigrationRules(es, migrationRuleDocuments);
+
+        // fetch migration rules
+        const response = await migrationRulesRoutes.get({
+          migrationId,
+          perPage: 18,
+        });
+        expect(response.body.data.map((rule) => rule.elastic_rule?.title)).toEqual(
+          titles.slice(0, 18)
+        );
+      });
     });
   });
 };


### PR DESCRIPTION
## Summary

[Internal link](https://github.com/elastic/security-team/issues/10820) to the feature details

Part of https://github.com/elastic/security-team/issues/11232

This PR covers SIEM Migrations GET API (route: `/internal/siem_migrations/rules/{migration_id}`) integration test:
* Basic calls
* Filtering
* Sorting
* Pagination


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->