### PR TITLE
[Automatic Import] Fix generated name for integration title

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/data_stream_step/data_stream_step.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/data_stream_step/data_stream_step.tsx
@@ -132,7 +132,7 @@ export const DataStreamStep = React.memo<DataStreamStepProps>(
       // Only executed once when the packageNames are loaded
       if (packageNames != null && integrationSettings?.name == null && integrationSettings?.title) {
         const generatedName = getNameFromTitle(integrationSettings.title);
-        if (!packageNames.has(generatedName)) {
+        if (!packageNames.has(generatedName) && isValidName(generatedName)) {
           setName(generatedName);
           setIntegrationValues({ name: generatedName });
         }
@@ -195,7 +195,7 @@ export const DataStreamStep = React.memo<DataStreamStepProps>(
                   <EuiFieldText
                     name="name"
                     data-test-subj="nameInput"
-                    value={isValidName(name) ? name : ''}
+                    value={name}
                     onChange={onChange.name}
                     isInvalid={invalidFields.name}
                     isLoading={isLoadingPackageNames}

--- a/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/data_stream_step/data_stream_step.tsx
+++ b/x-pack/platform/plugins/shared/automatic_import/public/components/create_integration/create_automatic_import/steps/data_stream_step/data_stream_step.tsx
@@ -55,7 +55,8 @@ export const InputTypeOptions: Array<EuiComboBoxOptionOption<InputType>> = [
 
 const isValidName = (name: string) => NAME_REGEX_PATTERN.test(name);
 const isValidDatastreamName = (name: string) => DATASTREAM_NAME_REGEX_PATTERN.test(name);
-const getNameFromTitle = (title: string) => title.toLowerCase().replaceAll(/[^a-z0-9]/g, '_');
+export const getNameFromTitle = (title: string) =>
+  title.toLowerCase().replaceAll(/[^a-z0-9]/g, '_');
 
 interface DataStreamStepProps {
   integrationSettings: State['integrationSettings'];


### PR DESCRIPTION
## Summary

A bug was introduced with #210770 and this PR fixes that. The Package name generated is validated.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->