### PR TITLE
[Security Solution] [Detections] Disables sorting ip ranges in value list modal

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/value_list/components/list_item_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/value_list/components/list_item_table.tsx
@@ -39,7 +39,7 @@ export const ListItemTable = ({
       name: COLUMN_VALUE,
       render: (value, item) =>
         canWriteIndex ? <InlineEditListItemValue listItem={item} key={value} /> : value,
-      sortable: list.type !== 'text',
+      sortable: list.type !== 'text' && list.type !== 'ip_range',
     },
     {
       field: LIST_ITEM_FIELDS.updatedAt,


### PR DESCRIPTION
## Summary

Disables sorting ip range values in a value list until this bug is fixed: https://github.com/elastic/elasticsearch/issues/122358


<img width="1024" alt="disabled_ip_range_sorting_value_list" src="https://github.com/user-attachments/assets/46c9c470-4db7-4a04-af8a-6801ec4bdab9" />





<!--ONMERGE {"backportTargets":["8.17","8.18","9.0"]} ONMERGE-->