### PR TITLE
[8.x] [ML] AIOps Hiding saved query controls (#210556)

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu.tsx
@@ -75,6 +75,7 @@ export interface QueryBarMenuProps extends WithCloseFilterEditorConfirmModalProp
   showQueryInput?: boolean;
   showFilterBar?: boolean;
   showSaveQuery?: boolean;
+  showSavedQueryControls?: boolean;
   timeRangeForSuggestionsOverride?: boolean;
   filtersForSuggestions?: Filter[];
   indexPatterns?: Array<DataView | string>;
@@ -110,6 +111,7 @@ function QueryBarMenuComponent({
   showQueryInput,
   showFilterBar,
   showSaveQuery,
+  showSavedQueryControls,
   indexPatterns,
   timeRangeForSuggestionsOverride,
   filtersForSuggestions,
@@ -176,6 +178,7 @@ function QueryBarMenuComponent({
     timeFilter,
     query,
     showSaveQuery,
+    showSavedQueryControls,
     showFilterBar,
     showQueryInput,
     savedQueryService,

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu_panels.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu_panels.tsx
@@ -171,6 +171,7 @@ export interface QueryBarMenuPanelsProps {
   timeFilter?: SavedQueryTimeFilter;
   query?: Query;
   showSaveQuery?: boolean;
+  showSavedQueryControls?: boolean;
   showQueryInput?: boolean;
   showFilterBar?: boolean;
   savedQueryService: SavedQueryService;
@@ -199,6 +200,7 @@ export function useQueryBarMenuPanels({
   timeFilter,
   query,
   showSaveQuery,
+  showSavedQueryControls = true,
   showFilterBar,
   showQueryInput,
   savedQueryService,
@@ -430,7 +432,7 @@ export function useQueryBarMenuPanels({
   }
 
   // saved queries actions are only shown when the showQueryInput and showFilterBar is true
-  if (showQueryInput && showFilterBar) {
+  if (showQueryInput && showFilterBar && showSavedQueryControls) {
     items.push(...queryAndFiltersRelatedPanels);
   }
 

--- a/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/search_bar.tsx
@@ -87,6 +87,8 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
   query?: QT | Query;
   // Show when user has privileges to save. See `canShowSavedQuery(...)` lib.
   showSaveQuery?: boolean;
+  // Show the controls to save and load saved queries
+  showSavedQueryControls?: boolean;
   savedQuery?: SavedQuery;
   onQueryChange?: (payload: { dateRange: TimeRange; query?: QT | Query }) => void;
   onQuerySubmit?: (
@@ -556,6 +558,7 @@ class SearchBarUI<QT extends (Query | AggregateQuery) | Query = Query> extends C
         showQueryInput={this.props.showQueryInput}
         showFilterBar={this.props.showFilterBar}
         showSaveQuery={this.props.showSaveQuery}
+        showSavedQueryControls={this.props.showSavedQueryControls}
         isDisabled={this.props.isDisabled}
         buttonProps={{ size: this.shouldShowDatePickerAsBadge() ? 's' : 'm' }}
         indexPatterns={this.props.indexPatterns}

--- a/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/search_panel/search_bar.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/application/index_data_visualizer/components/search_panel/search_bar.tsx
@@ -117,6 +117,7 @@ export const SearchPanelContent = ({
       showFilterBar={true}
       showDatePicker={false}
       showQueryInput={true}
+      showSavedQueryControls={false}
       query={searchInput}
       onQuerySubmit={(params: { dateRange: TimeRange; query?: Query | undefined }) =>
         searchHandler({ query: params.query })

--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/search_bar.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/search_bar.tsx
@@ -80,6 +80,7 @@ export const SearchBarWrapper: FC<SearchBarProps> = ({
         showDatePicker={false}
         showQueryInput
         query={resultQuery}
+        showSavedQueryControls={false}
         filters={filters ?? []}
         onQuerySubmit={onQuerySubmit}
         indexPatterns={[dataView]}

--- a/x-pack/platform/plugins/shared/aiops/public/components/search_panel/search_panel.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/search_panel/search_panel.tsx
@@ -98,6 +98,7 @@ export const SearchPanel: FC<Props> = ({ searchString, searchQueryLanguage, setS
           showFilterBar={true}
           showDatePicker={false}
           showQueryInput={true}
+          showSavedQueryControls={false}
           query={searchInput}
           onQuerySubmit={(params: { dateRange: TimeRange; query?: Query | undefined }) =>
             searchHandler({ query: params.query })


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ML] AIOps Hiding saved query controls (#210556)](https://github.com/elastic/kibana/pull/210556)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"James Gowdy","email":"jgowdy@elastic.co"},"sourceCommit":{"committedDate":"2025-02-12T19:52:30Z","message":"[ML] AIOps Hiding saved query controls (#210556)\n\nThe AIOps pages in ML make use of the shared query bar component, but do\r\nnot support saved queries.\r\nBy having the load and save query options in the menu, it can give the\r\nimpression that these options are generally available but for some\r\nreason cannot be used.\r\nThis PR adds a new optional flag which allows the load and save options\r\nto be hidden from the menu.\r\nThe flag defaults to always showing the options.\r\n\r\nFixes https://github.com/elastic/kibana/issues/209152\r\n\r\n**Before**\r\n\r\n![image](https://github.com/user-attachments/assets/a26a73d0-63b4-47c1-bfa2-8579b08dfe24)\r\n\r\n**After**\r\n\r\n![image](https://github.com/user-attachments/assets/4fe6937e-3c7d-4d15-98da-fdf472fc21ee)","sha":"36c764ebf722455a412416d48d48c737feb30e71","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","Feature:ML/AIOps","backport:version","v9.1.0","v8.19.0"],"title":"[ML] AIOps Hiding saved query controls","number":210556,"url":"https://github.com/elastic/kibana/pull/210556","mergeCommit":{"message":"[ML] AIOps Hiding saved query controls (#210556)\n\nThe AIOps pages in ML make use of the shared query bar component, but do\r\nnot support saved queries.\r\nBy having the load and save query options in the menu, it can give the\r\nimpression that these options are generally available but for some\r\nreason cannot be used.\r\nThis PR adds a new optional flag which allows the load and save options\r\nto be hidden from the menu.\r\nThe flag defaults to always showing the options.\r\n\r\nFixes https://github.com/elastic/kibana/issues/209152\r\n\r\n**Before**\r\n\r\n![image](https://github.com/user-attachments/assets/a26a73d0-63b4-47c1-bfa2-8579b08dfe24)\r\n\r\n**After**\r\n\r\n![image](https://github.com/user-attachments/assets/4fe6937e-3c7d-4d15-98da-fdf472fc21ee)","sha":"36c764ebf722455a412416d48d48c737feb30e71"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210556","number":210556,"mergeCommit":{"message":"[ML] AIOps Hiding saved query controls (#210556)\n\nThe AIOps pages in ML make use of the shared query bar component, but do\r\nnot support saved queries.\r\nBy having the load and save query options in the menu, it can give the\r\nimpression that these options are generally available but for some\r\nreason cannot be used.\r\nThis PR adds a new optional flag which allows the load and save options\r\nto be hidden from the menu.\r\nThe flag defaults to always showing the options.\r\n\r\nFixes https://github.com/elastic/kibana/issues/209152\r\n\r\n**Before**\r\n\r\n![image](https://github.com/user-attachments/assets/a26a73d0-63b4-47c1-bfa2-8579b08dfe24)\r\n\r\n**After**\r\n\r\n![image](https://github.com/user-attachments/assets/4fe6937e-3c7d-4d15-98da-fdf472fc21ee)","sha":"36c764ebf722455a412416d48d48c737feb30e71"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->