### PR TITLE
[9.0] [Index Management] Verify if isLoading before showing warning in add lifecycle confirm modal (#209108)

### DIFF
--- a/x-pack/platform/plugins/private/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.tsx
+++ b/x-pack/platform/plugins/private/index_lifecycle_management/public/extend_index_management/components/add_lifecycle_confirm_modal.tsx
@@ -44,6 +44,7 @@ interface State {
   selectedAlias: string;
   policies: PolicyFromES[];
   policyErrorMessage?: string;
+  isLoading: boolean;
 }
 
 export class AddLifecyclePolicyConfirmModal extends Component<Props, State> {
@@ -53,6 +54,7 @@ export class AddLifecyclePolicyConfirmModal extends Component<Props, State> {
       policies: [],
       selectedPolicyName: '',
       selectedAlias: '',
+      isLoading: true,
     };
   }
   addPolicy = async () => {
@@ -218,7 +220,7 @@ export class AddLifecyclePolicyConfirmModal extends Component<Props, State> {
   async componentDidMount() {
     try {
       const policies = await loadPolicies();
-      this.setState({ policies });
+      this.setState({ policies, isLoading: false });
     } catch (err) {
       showApiError(
         err,
@@ -233,7 +235,7 @@ export class AddLifecyclePolicyConfirmModal extends Component<Props, State> {
     }
   }
   render() {
-    const { policies } = this.state;
+    const { policies, isLoading } = this.state;
     const { indexName, closeModal, getUrlForApp } = this.props;
     const title = (
       <FormattedMessage
@@ -244,7 +246,7 @@ export class AddLifecyclePolicyConfirmModal extends Component<Props, State> {
         }}
       />
     );
-    if (!policies.length) {
+    if (!isLoading && !policies.length) {
       return (
         <EuiModal onClose={closeModal}>
           <EuiModalHeader>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Index Management] Verify if isLoading before showing warning in add lifecycle confirm modal (#209108)](https://github.com/elastic/kibana/pull/209108)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
