### PR TITLE
[ResponseOps][Rules] Move the params of tracking containment rule type to @kbn/response-ops-rule-params package

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_params/geo_containment/index.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/geo_containment/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { trackingContainmentRuleParamsSchema } from './latest';
+export { trackingContainmentRuleParamsSchema as trackingContainmentRuleParamsSchemaV1 } from './latest';
+
+export type { TrackingContainmentRuleParams } from './latest';
+export type { TrackingContainmentRuleParams as TrackingContainmentRuleParamsV1 } from './latest';

--- a/src/platform/packages/shared/response-ops/rule_params/geo_containment/latest.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/geo_containment/latest.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export * from './v1';

--- a/src/platform/packages/shared/response-ops/rule_params/geo_containment/v1.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/geo_containment/v1.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { schema, TypeOf } from '@kbn/config-schema';
+
+export const trackingContainmentRuleParamsSchema = schema.object({
+  index: schema.string({ minLength: 1 }),
+  indexId: schema.string({ minLength: 1 }),
+  geoField: schema.string({ minLength: 1 }),
+  entity: schema.string({ minLength: 1 }),
+  dateField: schema.string({ minLength: 1 }),
+  boundaryType: schema.string({ minLength: 1 }),
+  boundaryIndexTitle: schema.string({ minLength: 1 }),
+  boundaryIndexId: schema.string({ minLength: 1 }),
+  boundaryGeoField: schema.string({ minLength: 1 }),
+  boundaryNameField: schema.maybe(schema.string({ minLength: 1 })),
+  indexQuery: schema.maybe(schema.any({})),
+  boundaryIndexQuery: schema.maybe(schema.any({})),
+});
+
+export type TrackingContainmentRuleParams = TypeOf<typeof trackingContainmentRuleParamsSchema>;

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/geo_containment/rule_type.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/geo_containment/rule_type.ts
@@ -6,10 +6,10 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { schema } from '@kbn/config-schema';
 import { SavedObjectReference, DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
 import { RuleParamsAndRefs } from '@kbn/alerting-plugin/server';
 import { STACK_ALERTS_FEATURE_ID } from '@kbn/rule-data-utils';
+import { trackingContainmentRuleParamsSchema } from '@kbn/response-ops-rule-params/geo_containment';
 import type {
   GeoContainmentRuleType,
   GeoContainmentExtractedRuleParams,
@@ -90,21 +90,6 @@ const actionVariables = {
   ],
 };
 
-export const ParamsSchema = schema.object({
-  index: schema.string({ minLength: 1 }),
-  indexId: schema.string({ minLength: 1 }),
-  geoField: schema.string({ minLength: 1 }),
-  entity: schema.string({ minLength: 1 }),
-  dateField: schema.string({ minLength: 1 }),
-  boundaryType: schema.string({ minLength: 1 }),
-  boundaryIndexTitle: schema.string({ minLength: 1 }),
-  boundaryIndexId: schema.string({ minLength: 1 }),
-  boundaryGeoField: schema.string({ minLength: 1 }),
-  boundaryNameField: schema.maybe(schema.string({ minLength: 1 })),
-  indexQuery: schema.maybe(schema.any({})),
-  boundaryIndexQuery: schema.maybe(schema.any({})),
-});
-
 export function extractEntityAndBoundaryReferences(params: GeoContainmentRuleParams): {
   params: GeoContainmentExtractedRuleParams;
   references: SavedObjectReference[];
@@ -183,12 +168,12 @@ export function getRuleType(): GeoContainmentRuleType {
     category: DEFAULT_APP_CATEGORIES.management.id,
     producer: STACK_ALERTS_FEATURE_ID,
     validate: {
-      params: ParamsSchema,
+      params: trackingContainmentRuleParamsSchema,
     },
     schemas: {
       params: {
         type: 'config-schema',
-        schema: ParamsSchema,
+        schema: trackingContainmentRuleParamsSchema,
       },
     },
     actionVariables,

--- a/x-pack/platform/plugins/shared/stack_alerts/tsconfig.json
+++ b/x-pack/platform/plugins/shared/stack_alerts/tsconfig.json
@@ -55,7 +55,8 @@
     "@kbn/task-manager-plugin",
     "@kbn/core-logging-server-mocks",
     "@kbn/core-saved-objects-server",
-    "@kbn/alerting-rule-utils"
+    "@kbn/alerting-rule-utils",
+    "@kbn/response-ops-rule-params"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
Connected with https://github.com/elastic/kibana/issues/195188

## Summary

- Moved the params of tracking containment rule type to `@kbn/response-ops-rule-params/geo_containment` package



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->