### PR TITLE
[ML] Trained models: Update the start model allocation response type

### DIFF
--- a/x-pack/platform/plugins/shared/ml/common/types/trained_models.ts
+++ b/x-pack/platform/plugins/shared/ml/common/types/trained_models.ts
@@ -168,6 +168,17 @@ export type TrainedModelDeploymentStatsResponse = estypes.MlTrainedModelDeployme
   };
 };
 
+export interface StartTrainedModelDeploymentResponse {
+  // TODO update types in elasticsearch-specification
+  assignment: estypes.MlStartTrainedModelDeploymentResponse['assignment'] & {
+    adaptive_allocations?: {
+      enabled: boolean;
+      min_number_of_allocations?: number;
+      max_number_of_allocations?: number;
+    };
+  };
+}
+
 export interface AllocatedModel {
   key: string;
   deployment_id: string;

--- a/x-pack/platform/plugins/shared/ml/public/application/services/ml_api_service/trained_models.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/services/ml_api_service/trained_models.ts
@@ -27,6 +27,7 @@ import type {
   ModelDownloadState,
   TrainedModelUIItem,
   TrainedModelConfigResponse,
+  StartTrainedModelDeploymentResponse,
 } from '../../../../common/types/trained_models';
 
 export interface InferenceQueryParams {
@@ -238,7 +239,7 @@ export function trainedModelsApiProvider(httpService: HttpService) {
       deploymentParams,
       adaptiveAllocationsParams,
     }: StartAllocationParams) {
-      return httpService.http$<{ acknowledge: boolean }>({
+      return httpService.http$<StartTrainedModelDeploymentResponse>({
         path: `${ML_INTERNAL_BASE_PATH}/trained_models/${modelId}/deployment/_start`,
         method: 'POST',
         query: deploymentParams,


### PR DESCRIPTION
Updates the type correctly, as it is currently set to `{acknowledge: boolean}`, which is the wrong type.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->