### PR TITLE
Codeql slack notification

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,6 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
-        debug: ${{ matrix.branch != '7.17' }}
 
     # TODO: Possibly required to follow all call paths, however, when enabled, the step below runs out of memory.
     # Possible workarounds: Apply for access to the GitHub beta where we can use beefier machines, or run it ourselves on Buildkite
@@ -65,6 +64,15 @@ jobs:
         category: "/language:${{matrix.language}}"
         ref: ${{ env.CHECKOUT_REF }}
         sha: ${{ env.CHECKOUT_SHA }}
+    - name: Notify to slack on failure
+      if: ${{ failure() }}
+      uses: slackapi/slack-github-action@v2.0.0
+      with:
+        method: chat.postMessage
+        token: ${{ secrets.CODE_SCANNING_SLACK_TOKEN }}
+        payload: |
+          channel: ${{ secrets.CODE_SCANNING_SLACK_CHANNEL_ID }}
+          text: "CodeQL analysis failed for ${{ github.repository }} on ${{ github.ref }}."
   alert:
     name: Alert
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,9 @@ name: "CodeQL"
 on:
   schedule:
     - cron: '27 21 * * *' # At 21:27 every day
+  push:
+    branches:
+      - codeql-slack-notification
 
 jobs:
   analyze:
@@ -18,13 +21,15 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'javascript' ]
-        branch: [ 'main', '7.17', '8.x' ]
+        branch: [ 'codeql-slack-notification' ]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ matrix.branch }}
+    - name: Force Failure
+      run: exit 1
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@883d8588e56d1753a8a58c1c86e88976f0c23449 # v3.26.3
@@ -72,12 +77,12 @@ jobs:
         token: ${{ secrets.CODE_SCANNING_SLACK_TOKEN }}
         payload: |
           channel: ${{ secrets.CODE_SCANNING_SLACK_CHANNEL_ID }}
-          text: "CodeQL analysis failed for ${{ github.repository }} on ${{ github.ref }}."
+          text: "[TEST] CodeQL analysis failed for ${{ github.repository }} on ${{ github.ref }}."
   alert:
     name: Alert
     runs-on: ubuntu-latest
     needs: analyze
-    if: github.repository == 'elastic/kibana' # Hack: Do not run on forks
+    if: github.repository == 'elastic/kibana' && success() # Hack: Do not run on forks
     steps:
     - name: Checkout kibana-operations
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



