### PR TITLE
[8.x] [kbn-test] error message if MFA is enabled for test account (#196906)

### DIFF
--- a/packages/kbn-test/src/auth/saml_auth.test.ts
+++ b/packages/kbn-test/src/auth/saml_auth.test.ts
@@ -168,6 +168,36 @@ describe('saml_auth', () => {
         'Failed to create the new cloud session, check retry arguments: {"attemptsCount":0,"attemptDelay":100}'
       );
     });
+
+    test(`should fail without retry when response has 'mfa_required: true'`, async () => {
+      axiosRequestMock.mockImplementation((config: AxiosRequestConfig) => {
+        if (config.url?.endsWith('/api/v1/saas/auth/_login')) {
+          return Promise.resolve({
+            data: { user_id: 12345, authenticated: false, mfa_required: true },
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${config.url}`));
+      });
+
+      await expect(
+        createCloudSession(
+          {
+            hostname: 'cloud',
+            email: 'viewer@elastic.co',
+            password: 'changeme',
+            log,
+          },
+          {
+            attemptsCount: 3,
+            attemptDelay: 100,
+          }
+        )
+      ).rejects.toThrow(
+        'Failed to create the new cloud session: MFA must be disabled for the test account'
+      );
+      expect(axiosRequestMock).toBeCalledTimes(1);
+    });
   });
 
   describe('createSAMLRequest', () => {

--- a/packages/kbn-test/src/auth/saml_auth.ts
+++ b/packages/kbn-test/src/auth/saml_auth.ts
@@ -137,7 +137,17 @@ export const createCloudSession = async (
                 data[key] = 'REDACTED';
               }
             });
+
+            // MFA must be disabled for test accounts
+            if (data.mfa_required === true) {
+              // Changing MFA configuration requires manual action, skip retry
+              attemptsLeft = 0;
+              throw new Error(
+                `Failed to create the new cloud session: MFA must be disabled for the test account`
+              );
+            }
           }
+
           throw new Error(
             `Failed to create the new cloud session: token is missing in response data\n${JSON.stringify(
               data


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[kbn-test] error message if MFA is enabled for test account (#196906)](https://github.com/elastic/kibana/pull/196906)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2024-10-21T11:41:00Z","message":"[kbn-test] error message if MFA is enabled for test account (#196906)\n\n## Summary\r\n\r\nRecently few engineers reported issues when running FTR **locally**\r\nagainst MKI project on QA env. It turned out MFA was enabled for the\r\ntest cloud accounts, that breaks automatic login to the Cloud.\r\n\r\nThis PR checks response for `mfa_required: true` and fails without\r\nretrying asking to disable MFA for test account.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"63ebd41c6c88cedc39a70079a70580027836eabd","branchLabelMapping":{"^v9.0.0$":"main","^v8.17.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0"],"title":"[kbn-test] error message if MFA is enabled for test account","number":196906,"url":"https://github.com/elastic/kibana/pull/196906","mergeCommit":{"message":"[kbn-test] error message if MFA is enabled for test account (#196906)\n\n## Summary\r\n\r\nRecently few engineers reported issues when running FTR **locally**\r\nagainst MKI project on QA env. It turned out MFA was enabled for the\r\ntest cloud accounts, that breaks automatic login to the Cloud.\r\n\r\nThis PR checks response for `mfa_required: true` and fails without\r\nretrying asking to disable MFA for test account.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"63ebd41c6c88cedc39a70079a70580027836eabd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/196906","number":196906,"mergeCommit":{"message":"[kbn-test] error message if MFA is enabled for test account (#196906)\n\n## Summary\r\n\r\nRecently few engineers reported issues when running FTR **locally**\r\nagainst MKI project on QA env. It turned out MFA was enabled for the\r\ntest cloud accounts, that breaks automatic login to the Cloud.\r\n\r\nThis PR checks response for `mfa_required: true` and fails without\r\nretrying asking to disable MFA for test account.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"63ebd41c6c88cedc39a70079a70580027836eabd"}}]}] BACKPORT-->