### PR TITLE
[9.0] [ES|QL] Fix WHERE autocomplete with MATCH before LIMIT (#210607)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.where.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.where.test.ts
@@ -136,6 +136,24 @@ describe('WHERE <expression>', () => {
       }
     });
 
+    test('filters suggestions based on previous commands', async () => {
+      const { assertSuggestions } = await setup();
+
+      await assertSuggestions('from a | where / | limit 3', [
+        ...getFieldNamesByType('any')
+          .map((field) => `${field} `)
+          .map(attachTriggerCommand),
+        ...allEvalFns,
+      ]);
+
+      await assertSuggestions('from a | limit 3 | where / ', [
+        ...getFieldNamesByType('any')
+          .map((field) => `${field} `)
+          .map(attachTriggerCommand),
+        ...allEvalFns.filter((fn) => fn.label !== 'QSTR' && fn.label !== 'MATCH'),
+      ]);
+    });
+
     test('suggests operators after a field name', async () => {
       const { assertSuggestions } = await setup();
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -115,7 +115,7 @@ export const policies = [
 /**
  * Utility to filter down the function list for the given type
  * It is mainly driven by the return type, but it can be filtered upon with the last optional argument "paramsTypes"
- * jsut make sure to pass the arguments in the right order
+ * just make sure to pass the arguments in the right order
  * @param command current command context
  * @param expectedReturnType the expected type returned by the function
  * @param functionCategories

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -10,7 +10,6 @@
 import { uniq, uniqBy } from 'lodash';
 import type {
   AstProviderFn,
-  ESQLAst,
   ESQLAstItem,
   ESQLCommand,
   ESQLCommandOption,
@@ -163,10 +162,6 @@ export async function suggest(
   const { ast } = await astProvider(correctedQuery);
   const astContext = getAstContext(innerText, ast, offset);
 
-  // But we also need the full ast for the full query
-  const correctedFullQuery = correctQuerySyntax(fullText, context);
-  const { ast: fullAst } = await astProvider(correctedFullQuery);
-
   if (astContext.type === 'comment') {
     return [];
   }
@@ -230,7 +225,6 @@ export async function suggest(
       getPolicies,
       getPolicyMetadata,
       resourceRetriever?.getPreferences,
-      fullAst,
       resourceRetriever
     );
   }
@@ -417,7 +411,6 @@ async function getSuggestionsWithinCommandExpression(
   getPolicies: GetPoliciesFn,
   getPolicyMetadata: GetPolicyMetadataFn,
   getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
-  fullAst?: ESQLAst,
   callbacks?: ESQLCallbacks
 ) {
   const commandDef = getCommandDefinition(command.name);
@@ -438,7 +431,7 @@ async function getSuggestionsWithinCommandExpression(
       (expression: ESQLAstItem | undefined) =>
         getExpressionType(expression, references.fields, references.variables),
       getPreferences,
-      fullAst,
+      commands,
       commandDef,
       callbacks
     );

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { type ESQLAstItem, ESQLAst } from '@kbn/esql-ast';
+import { type ESQLAstItem, type ESQLCommand } from '@kbn/esql-ast';
 import { ESQLCommand } from '@kbn/esql-ast/src/types';
 import type { ESQLCallbacks } from '../../../shared/types';
 import {
@@ -45,7 +45,7 @@ export const suggest: CommandBaseDefinition<'join'>['suggest'] = async (
   getSuggestedVariableName: () => string,
   getExpressionType: (expression: ESQLAstItem | undefined) => SupportedDataType | 'unknown',
   getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
-  fullTextAst?: ESQLAst,
+  previousCommands?: ESQLCommand[],
   definition?: CommandDefinition<'join'>,
   callbacks?: ESQLCallbacks
 ): Promise<SuggestionRawDefinition[]> => {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
@@ -9,7 +9,6 @@
 
 import { i18n } from '@kbn/i18n';
 import { type ESQLAstItem, type ESQLCommand } from '@kbn/esql-ast';
-import { ESQLCommand } from '@kbn/esql-ast/src/types';
 import type { ESQLCallbacks } from '../../../shared/types';
 import {
   CommandBaseDefinition,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/where/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/where/index.ts
@@ -13,7 +13,6 @@ import {
   type ESQLCommand,
   type ESQLSingleAstItem,
   type ESQLFunction,
-  ESQLAst,
 } from '@kbn/esql-ast';
 import { logicalOperators } from '../../../definitions/builtin';
 import { isParameterType, type SupportedDataType } from '../../../definitions/types';
@@ -42,7 +41,7 @@ export async function suggest(
   _getSuggestedVariableName: () => string,
   getExpressionType: (expression: ESQLAstItem | undefined) => SupportedDataType | 'unknown',
   _getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
-  fullTextAst?: ESQLAst
+  previousCommands?: ESQLCommand[]
 ): Promise<SuggestionRawDefinition[]> {
   const suggestions: SuggestionRawDefinition[] = [];
 
@@ -163,7 +162,7 @@ export async function suggest(
 
     case 'empty_expression':
       // Don't suggest MATCH or QSTR after unsupported commands
-      const priorCommands = fullTextAst?.map((a) => a.name) ?? [];
+      const priorCommands = previousCommands?.map((a) => a.name) ?? [];
       const ignored = [];
       if (priorCommands.some((c) => UNSUPPORTED_COMMANDS_BEFORE_MATCH.has(c))) {
         ignored.push('match');
@@ -171,7 +170,7 @@ export async function suggest(
       if (priorCommands.some((c) => UNSUPPORTED_COMMANDS_BEFORE_QSTR.has(c))) {
         ignored.push('qstr');
       }
-      const last = fullTextAst?.[fullTextAst.length - 1];
+      const last = previousCommands?.[previousCommands.length - 1];
       let columnSuggestions: SuggestionRawDefinition[] = [];
       if (!last?.text?.endsWith(`:${EDITOR_MARKER}`)) {
         columnSuggestions = await getColumnsByType('any', [], {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
@@ -8,7 +8,6 @@
  */
 
 import type {
-  ESQLAst,
   ESQLAstItem,
   ESQLCommand,
   ESQLCommandOption,
@@ -210,7 +209,7 @@ export interface CommandBaseDefinition<CommandName extends string> {
     getSuggestedVariableName: () => string,
     getExpressionType: (expression: ESQLAstItem | undefined) => SupportedDataType | 'unknown',
     getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
-    fullTextAst?: ESQLAst,
+    previousCommands?: ESQLCommand[],
     definition?: CommandDefinition<CommandName>,
     callbacks?: ESQLCallbacks
   ) => Promise<SuggestionRawDefinition[]>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[ES|QL] Fix WHERE autocomplete with MATCH before LIMIT (#210607)](https://github.com/elastic/kibana/pull/210607)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dima Arnautov","email":"dmitrii.arnautov@elastic.co"},"sourceCommit":{"committedDate":"2025-02-12T17:38:45Z","message":"[ES|QL] Fix WHERE autocomplete with MATCH before LIMIT (#210607)\n\n## Summary\r\n\r\nRelated PR https://github.com/elastic/kibana/pull/199032\r\n\r\n\r\nFixes `WHERE` autocomplete with `MATCH` before `LIMIT`.\r\n\r\nThe previous check was filtering suggestions based on all present\r\ncommands, not just the previous one.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"1ccb6db350425f8cdfbacd6341a3e4defaba1bcb","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Feature:ES|QL","Team:ESQL","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[ES|QL] Fix WHERE autocomplete with MATCH before LIMIT","number":210607,"url":"https://github.com/elastic/kibana/pull/210607","mergeCommit":{"message":"[ES|QL] Fix WHERE autocomplete with MATCH before LIMIT (#210607)\n\n## Summary\r\n\r\nRelated PR https://github.com/elastic/kibana/pull/199032\r\n\r\n\r\nFixes `WHERE` autocomplete with `MATCH` before `LIMIT`.\r\n\r\nThe previous check was filtering suggestions based on all present\r\ncommands, not just the previous one.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"1ccb6db350425f8cdfbacd6341a3e4defaba1bcb"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210607","number":210607,"mergeCommit":{"message":"[ES|QL] Fix WHERE autocomplete with MATCH before LIMIT (#210607)\n\n## Summary\r\n\r\nRelated PR https://github.com/elastic/kibana/pull/199032\r\n\r\n\r\nFixes `WHERE` autocomplete with `MATCH` before `LIMIT`.\r\n\r\nThe previous check was filtering suggestions based on all present\r\ncommands, not just the previous one.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"1ccb6db350425f8cdfbacd6341a3e4defaba1bcb"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210901","number":210901,"state":"MERGED","mergeCommit":{"sha":"5eb5c66aa66fde123a14bc67368fb3259cdb3dfb","message":"[8.x] [ES|QL] Fix WHERE autocomplete with MATCH before LIMIT (#210607) (#210901)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[ES|QL] Fix WHERE autocomplete with MATCH before LIMIT\n(#210607)](https://github.com/elastic/kibana/pull/210607)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Dima\nArnautov\",\"email\":\"dmitrii.arnautov@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-12T17:38:45Z\",\"message\":\"[ES|QL]\nFix WHERE autocomplete with MATCH before LIMIT (#210607)\\n\\n##\nSummary\\r\\n\\r\\nRelated PR\nhttps://github.com/elastic/kibana/pull/199032\\r\\n\\r\\n\\r\\nFixes `WHERE`\nautocomplete with `MATCH` before `LIMIT`.\\r\\n\\r\\nThe previous check was\nfiltering suggestions based on all present\\r\\ncommands, not just the\nprevious one.\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"1ccb6db350425f8cdfbacd6341a3e4defaba1bcb\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"v9.0.0\",\"Feature:ES|QL\",\"Team:ESQL\",\"backport:version\",\"v9.1.0\",\"v8.19.0\"],\"title\":\"[ES|QL]\nFix WHERE autocomplete with MATCH before\nLIMIT\",\"number\":210607,\"url\":\"https://github.com/elastic/kibana/pull/210607\",\"mergeCommit\":{\"message\":\"[ES|QL]\nFix WHERE autocomplete with MATCH before LIMIT (#210607)\\n\\n##\nSummary\\r\\n\\r\\nRelated PR\nhttps://github.com/elastic/kibana/pull/199032\\r\\n\\r\\n\\r\\nFixes `WHERE`\nautocomplete with `MATCH` before `LIMIT`.\\r\\n\\r\\nThe previous check was\nfiltering suggestions based on all present\\r\\ncommands, not just the\nprevious one.\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"1ccb6db350425f8cdfbacd6341a3e4defaba1bcb\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"9.0\",\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"9.0\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/210607\",\"number\":210607,\"mergeCommit\":{\"message\":\"[ES|QL]\nFix WHERE autocomplete with MATCH before LIMIT (#210607)\\n\\n##\nSummary\\r\\n\\r\\nRelated PR\nhttps://github.com/elastic/kibana/pull/199032\\r\\n\\r\\n\\r\\nFixes `WHERE`\nautocomplete with `MATCH` before `LIMIT`.\\r\\n\\r\\nThe previous check was\nfiltering suggestions based on all present\\r\\ncommands, not just the\nprevious one.\\r\\n\\r\\n### Checklist\\r\\n\\r\\n- [x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"1ccb6db350425f8cdfbacd6341a3e4defaba1bcb\"}},{\"branch\":\"8.x\",\"label\":\"v8.19.0\",\"branchLabelMappingKey\":\"^v8.19.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Dima Arnautov <dmitrii.arnautov@elastic.co>"}}]}] BACKPORT-->