### PR TITLE
🌊 Fix "stream" field conflicting with stream.name

### DIFF
--- a/x-pack/solutions/observability/plugins/streams/server/lib/streams/ingest_pipelines/generate_ingest_pipeline.ts
+++ b/x-pack/solutions/observability/plugins/streams/server/lib/streams/ingest_pipelines/generate_ingest_pipeline.ts
@@ -45,9 +45,12 @@ export function generateIngestPipeline(
           ]
         : []),
       {
-        set: {
-          field: 'stream.name',
-          value: definition.name,
+        script: {
+          source: 'ctx["stream.name"] = params.field',
+          lang: 'painless',
+          params: {
+            field: definition.name,
+          },
         },
       },
       ...((isWiredStream && formatToIngestProcessors(definition.ingest.processing)) || []),

--- a/x-pack/solutions/observability/plugins/streams/server/lib/streams/ingest_pipelines/generate_ingest_pipeline.ts
+++ b/x-pack/solutions/observability/plugins/streams/server/lib/streams/ingest_pipelines/generate_ingest_pipeline.ts
@@ -32,7 +32,7 @@ export function generateIngestPipeline(
             {
               script: {
                 source: `
-                  if (ctx.stream?.name != params.parentName) {
+                  if (ctx["stream.name"] != params.parentName) {
                     throw new IllegalArgumentException('stream.name is not set properly - did you send the document directly to a child stream instead of the main logs stream?');
                   }
                 `,


### PR DESCRIPTION
Currently, streams logs with a `stream` field fail ingest because the set processor tries to set a
```
"stream": {
  "name": "<name field>"
}
```

which doesn't work if `"stream": "abc"` is already in the document (some shippers do this, e.g. docker or kubernetes)

Using a painless processor this problem can be avoided and you can have `"stream"` and `"stream.name"`

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->