### PR TITLE
[8.18] [Search] Fix error page for workplace search

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/workplace_search/views/error_state/error_state.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/workplace_search/views/error_state/error_state.tsx
@@ -9,11 +9,9 @@ import React from 'react';
 
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 
-import { WORKPLACE_SEARCH_PLUGIN } from '../../../../../common/constants';
 import { ErrorStatePrompt } from '../../../shared/error_state';
 import { SetWorkplaceSearchChrome as SetPageChrome } from '../../../shared/kibana_chrome';
 import { SendWorkplaceSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
-import { ViewContentHeader } from '../../components/shared/view_content_header';
 
 export const ErrorState: React.FC = () => {
   return (
@@ -22,7 +20,6 @@ export const ErrorState: React.FC = () => {
       <SendTelemetry action="error" metric="cannot_connect" />
 
       <KibanaPageTemplate isEmptyState>
-        <ViewContentHeader title={WORKPLACE_SEARCH_PLUGIN.NAME} />
         <ErrorStatePrompt />
       </KibanaPageTemplate>
     </>


### PR DESCRIPTION
## Summary

Fix error page for workplace search
**Before:**
<img width="817" alt="image" src="https://github.com/user-attachments/assets/123e2fa2-0bc8-457f-9b00-43bb9686389d" />
**After:**
<img width="2553" alt="image" src="https://github.com/user-attachments/assets/032d6198-feb6-43e4-a646-683c5e80603f" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

