### PR TITLE
[scout] enable authc debug logs for ES

### DIFF
--- a/packages/kbn-scout/src/common/services/clients.ts
+++ b/packages/kbn-scout/src/common/services/clients.ts
@@ -8,6 +8,7 @@
  */
 
 import { createEsClientForTesting, KbnClient } from '@kbn/test';
+import { ToolingLog } from '@kbn/tooling-log';
 import { ScoutLogger } from './logger';
 import { ScoutTestConfig, EsClient } from '../../types';
 
@@ -16,7 +17,7 @@ interface ClientOptions {
   url: string;
   username: string;
   password: string;
-  log: ScoutLogger;
+  log: ScoutLogger | ToolingLog;
 }
 
 function createClientUrlWithAuth({ serviceName, url, username, password, log }: ClientOptions) {
@@ -24,14 +25,17 @@ function createClientUrlWithAuth({ serviceName, url, username, password, log }: 
   clientUrl.username = username;
   clientUrl.password = password;
 
-  log.serviceLoaded(`${serviceName}Client`);
+  if (log instanceof ScoutLogger) {
+    log.serviceLoaded(`${serviceName}Client`);
+  }
+
   return clientUrl.toString();
 }
 
 let esClientInstance: EsClient | null = null;
 let kbnClientInstance: KbnClient | null = null;
 
-export function getEsClient(config: ScoutTestConfig, log: ScoutLogger) {
+export function getEsClient(config: ScoutTestConfig, log: ScoutLogger | ToolingLog) {
   if (!esClientInstance) {
     const { username, password } = config.auth;
     const elasticsearchUrl = createClientUrlWithAuth({

--- a/packages/kbn-scout/src/servers/start_servers.ts
+++ b/packages/kbn-scout/src/servers/start_servers.ts
@@ -16,7 +16,7 @@ import { runElasticsearch } from './run_elasticsearch';
 import { getExtraKbnOpts, runKibanaServer } from './run_kibana_server';
 import { StartServerOptions } from './flags';
 import { loadServersConfig } from '../config';
-import { silence } from '../common';
+import { getEsClient, silence } from '../common';
 
 export async function startServers(log: ToolingLog, options: StartServerOptions) {
   const runStartTime = Date.now();
@@ -30,6 +30,14 @@ export async function startServers(log: ToolingLog, options: StartServerOptions)
       log,
       esFrom: options.esFrom,
       logsDir: options.logsDir,
+    });
+
+    log.info('Enable authc debug logs for ES');
+    const client = getEsClient(config.getScoutTestConfig(), log);
+    await client.cluster.putSettings({
+      persistent: {
+        'logger.org.elasticsearch.xpack.security.authc': 'debug',
+      },
     });
 
     await runKibanaServer({


### PR DESCRIPTION
## Summary

Temporarily enabling ES authc debug logging to get more details for 401 SAML callback response.

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->