### PR TITLE
[8.18] [8.x] Add Pre-8.x Enterprise Search Index Incompatibility Deprecations (#210688)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.test.ts
@@ -15,15 +15,19 @@ jest.mock('@kbn/search-connectors', () => {
     fetchConnectors: () => mockedFetchConnectors(),
   };
 });
+import { DeprecationDetailsMessage, DeprecationsDetails } from '@kbn/core-deprecations-common';
 import { GetDeprecationsContext } from '@kbn/core-deprecations-server';
 
 import { Connector } from '@kbn/search-connectors';
 
 import { ConfigType } from '..';
 
+import indexDeprecatorFxns = require('./pre_eight_index_deprecator');
+
 import {
   getCrawlerDeprecations,
   getEnterpriseSearchNodeDeprecation,
+  getEnterpriseSearchPre8IndexDeprecations,
   getNativeConnectorDeprecations,
 } from '.';
 
@@ -35,6 +39,12 @@ const ctx = {
 const cloud = { baseUrl: 'cloud.elastic.co', deploymentId: '123', cloudId: 'abc' } as CloudSetup;
 const notCloud = {} as CloudSetup;
 const docsUrl = 'example.com';
+
+function getMessageFromDeprecation(details: DeprecationsDetails): string {
+  const message = details.message as DeprecationDetailsMessage;
+  return message.content;
+}
+
 describe('Enterprise Search node deprecation', () => {
   it('Tells you to remove capacity if running on cloud', () => {
     const config = { host: 'example.com' } as ConfigType;
@@ -216,5 +226,80 @@ describe('Native connector deprecations', () => {
     expect(deprecations[0].correctiveActions.api?.body).toStrictEqual({ ids: ['bar'] });
     expect(deprecations[0].title).toMatch('must be of supported service types');
     expect(deprecations[1].title).toMatch('Integration Server must be provisioned');
+  });
+});
+
+describe('getEnterpriseSearchPre8IndexDeprecations', () => {
+  it('can register index and data stream deprecations that need to be set to read only', async () => {
+    const getIndicesMock = jest.fn(() =>
+      Promise.resolve([
+        {
+          name: '.ent-search-index_without_datastream',
+          isDatastream: false,
+          datastreamName: '',
+        },
+        {
+          name: '.ent-search-with_data_stream',
+          isDatastream: true,
+          datastreamName: 'datastream-testing',
+        },
+      ])
+    );
+
+    jest
+      .spyOn(indexDeprecatorFxns, 'getPreEightEnterpriseSearchIndices')
+      .mockImplementation(getIndicesMock);
+
+    const deprecations = await getEnterpriseSearchPre8IndexDeprecations(ctx, 'docsurl', 'mockhost');
+    expect(deprecations).toHaveLength(1);
+    expect(deprecations[0].correctiveActions.api?.path).toStrictEqual(
+      '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only'
+    );
+    expect(deprecations[0].title).toMatch('Pre 8.x Enterprise Search indices compatibility');
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      'The following indices are found to be incompatible for upgrade'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      '.ent-search-index_without_datastream'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      'The following data streams are found to be incompatible for upgrade'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).toContain('.ent-search-with_data_stream');
+  });
+
+  it('can register an index without data stream deprecations that need to be set to read only', async () => {
+    const getIndicesMock = jest.fn(() =>
+      Promise.resolve([
+        {
+          name: '.ent-search-index_without_datastream',
+          isDatastream: false,
+          datastreamName: '',
+        },
+      ])
+    );
+
+    jest
+      .spyOn(indexDeprecatorFxns, 'getPreEightEnterpriseSearchIndices')
+      .mockImplementation(getIndicesMock);
+
+    const deprecations = await getEnterpriseSearchPre8IndexDeprecations(ctx, 'docsurl', 'mockhost');
+    expect(deprecations).toHaveLength(1);
+    expect(deprecations[0].correctiveActions.api?.path).toStrictEqual(
+      '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only'
+    );
+    expect(deprecations[0].title).toMatch('Pre 8.x Enterprise Search indices compatibility');
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      'The following indices are found to be incompatible for upgrade'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      '.ent-search-index_without_datastream'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).not.toContain(
+      'The following data streams are found to be incompatible for upgrade'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).not.toContain(
+      '.ent-search-with_data_stream'
+    );
   });
 });

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
@@ -16,6 +16,8 @@ import { Connector, fetchConnectors } from '@kbn/search-connectors';
 
 import { ConfigType } from '..';
 
+import { getPreEightEnterpriseSearchIndices } from './pre_eight_index_deprecator';
+
 const NATIVE_SERVICE_TYPES = [
   'azure_blob_storage',
   'box',
@@ -59,11 +61,18 @@ export const getRegisteredDeprecations = (
         true // only counts if the Fleet Server is active
       );
       const entSearchDetails = getEnterpriseSearchNodeDeprecation(config, cloud, docsUrl);
-      const [crawlerDetails, nativeConnectorsDetails] = await Promise.all([
-        await getCrawlerDeprecations(ctx, docsUrl),
-        await getNativeConnectorDeprecations(ctx, hasAgentless, hasFleetServer, cloud, docsUrl),
-      ]);
-      return [...entSearchDetails, ...crawlerDetails, ...nativeConnectorsDetails];
+      const [crawlerDetails, nativeConnectorsDetails, entSearchIndexIncompatibility] =
+        await Promise.all([
+          getCrawlerDeprecations(ctx, docsUrl),
+          getNativeConnectorDeprecations(ctx, hasAgentless, hasFleetServer, cloud, docsUrl),
+          getEnterpriseSearchPre8IndexDeprecations(ctx, docsUrl, config.host),
+        ]);
+      return [
+        ...entSearchDetails,
+        ...crawlerDetails,
+        ...nativeConnectorsDetails,
+        ...entSearchIndexIncompatibility,
+      ];
     },
   };
 };
@@ -413,4 +422,106 @@ export async function getNativeConnectorDeprecations(
 
     return deprecations;
   }
+}
+
+/**
+ * If there are any Enterprise Search indices that were created with Elasticsearch 7.x, they must be removed
+ * or set to read-only
+ */
+export async function getEnterpriseSearchPre8IndexDeprecations(
+  ctx: GetDeprecationsContext,
+  docsUrl: string,
+  configHost?: string
+): Promise<DeprecationsDetails[]> {
+  const deprecations: DeprecationsDetails[] = [];
+
+  if (!configHost) {
+    return deprecations;
+  }
+
+  const entSearchIndices = await getPreEightEnterpriseSearchIndices(ctx.esClient.asInternalUser);
+  if (!entSearchIndices || entSearchIndices.length === 0) {
+    return deprecations;
+  }
+
+  let indicesList = '';
+  let datastreamsList = '';
+  for (const index of entSearchIndices) {
+    if (index.isDatastream) {
+      datastreamsList += `${index.name}\n`;
+    } else {
+      indicesList += `${index.name}\n`;
+    }
+  }
+
+  let message = `There are ${entSearchIndices.length} incompatible Enterprise Search indices.\n\n`;
+
+  if (indicesList.length > 0) {
+    message +=
+      'The following indices are found to be incompatible for upgrade:\n\n' +
+      '```\n' +
+      `${indicesList}` +
+      '\n```\n\n' +
+      'These indices must be either set to read-only or deleted before upgrading. ';
+  }
+
+  if (datastreamsList.length > 0) {
+    message +=
+      '\nThe following data streams are found to be incompatible for upgrade:\n\n' +
+      '```\n' +
+      `${datastreamsList}` +
+      '\n```\n\n' +
+      'Using the "quick resolve" button below will roll over any datastreams and set all incompatible indices to read-only.\n\n' +
+      'Alternatively, manually deleting these indices and data streams will also unblock your upgrade.';
+  } else {
+    message +=
+      'Setting these indices to read-only can be attempted with the "quick resolve" button below.\n\n' +
+      'Alternatively, manually deleting these indices will also unblock your upgrade.';
+  }
+
+  deprecations.push({
+    level: 'critical',
+    deprecationType: 'feature',
+    title: i18n.translate(
+      'xpack.enterpriseSearch.deprecations.incompatibleEnterpriseSearchIndexes.title',
+      {
+        defaultMessage: 'Pre 8.x Enterprise Search indices compatibility',
+      }
+    ),
+    message: {
+      type: 'markdown',
+      content: i18n.translate(
+        'xpack.enterpriseSearch.deprecations.incompatibleEnterpriseSearchIndexes.message',
+        {
+          defaultMessage: message,
+        }
+      ),
+    },
+    documentationUrl: docsUrl,
+    correctiveActions: {
+      manualSteps: [
+        i18n.translate(
+          'xpack.enterpriseSearch.deprecations.incompatibleEnterpriseSearchIndexes.deleteIndices',
+          {
+            defaultMessage: 'Set all incompatible indices to read only, or',
+          }
+        ),
+        i18n.translate(
+          'xpack.enterpriseSearch.deprecations.incompatibleEnterpriseSearchIndexes.deleteIndices',
+          {
+            defaultMessage: 'Delete all incompatible indices',
+          }
+        ),
+      ],
+      api: {
+        method: 'POST',
+        path: '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',
+        body: {
+          deprecationDetails: { domainId: 'enterpriseSearch' },
+        },
+      },
+    },
+  });
+
+  return deprecations;
 }

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/pre_eight_index_deprecator.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/pre_eight_index_deprecator.test.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClient } from '@kbn/core/server';
+
+import {
+  getPreEightEnterpriseSearchIndices,
+  setPreEightEnterpriseSearchIndicesReadOnly,
+} from './pre_eight_index_deprecator';
+
+// settings?.index?.version?.created?.startsWith('7') && indexData.settings?.index?.blocks?.write !== 'true'
+const testIndices = {
+  'non-ent-search-index': {
+    settings: {
+      index: {
+        version: {
+          created: '7.0.0',
+        },
+      },
+    },
+  },
+  '.ent-search-already_read_only': {
+    settings: {
+      index: {
+        version: {
+          created: '7.0.0',
+        },
+        blocks: {
+          write: 'true',
+        },
+      },
+    },
+    data_stream: 'datastream-123',
+  },
+  '.ent-search-post_7_index': {
+    settings: {
+      index: {
+        version: {
+          created: '8.0.0',
+        },
+      },
+    },
+  },
+  '.ent-search-index_without_datastream': {
+    settings: {
+      index: {
+        version: {
+          created: '7.0.0',
+        },
+      },
+    },
+  },
+  '.ent-search-with_data_stream': {
+    settings: {
+      index: {
+        version: {
+          created: '7.0.0',
+        },
+      },
+    },
+    data_stream: 'datastream-testing',
+  },
+  '.ent-search-with_another_data_stream': {
+    settings: {
+      index: {
+        version: {
+          created: '7.0.0',
+        },
+      },
+    },
+    data_stream: 'datastream-testing-another',
+  },
+  '.ent-search-with_same_data_stream': {
+    settings: {
+      index: {
+        version: {
+          created: '7.0.0',
+        },
+      },
+    },
+    data_stream: 'datastream-testing',
+  },
+};
+
+const testIndicesWithoutDatastream = {
+  '.ent-search-already_read_only': {
+    settings: {
+      index: {
+        version: {
+          created: '7.0.0',
+        },
+        blocks: {
+          write: 'true',
+        },
+      },
+    },
+  },
+  '.ent-search-post_7_index': {
+    settings: {
+      index: {
+        version: {
+          created: '8.0.0',
+        },
+      },
+    },
+  },
+  '.ent-search-index_without_datastream': {
+    settings: {
+      index: {
+        version: {
+          created: '7.0.0',
+        },
+      },
+    },
+  },
+};
+
+function getMockIndicesFxn(values: any) {
+  return jest.fn((params) => {
+    let prefix = params.index;
+    let isWildcard = false;
+    if (params.index.endsWith('*')) {
+      prefix = params.index.slice(0, -1);
+      isWildcard = true;
+    }
+    const ret: any = {};
+    for (const [index, indexData] of Object.entries(values)) {
+      if (index === prefix || (isWildcard && index.startsWith(prefix))) {
+        ret[index] = indexData;
+      }
+    }
+    return Promise.resolve(ret);
+  });
+}
+
+describe('getPreEightEnterpriseSearchIndices', () => {
+  const getIndicesMock = getMockIndicesFxn(testIndices);
+  const esClientMock = {
+    indices: {
+      get: getIndicesMock,
+    },
+  } as unknown as ElasticsearchClient;
+
+  it('returns the correct indices', async () => {
+    const indices = await getPreEightEnterpriseSearchIndices(esClientMock);
+    expect(indices).toEqual([
+      {
+        name: '.ent-search-index_without_datastream',
+        isDatastream: false,
+        datastreamName: '',
+      },
+      {
+        name: '.ent-search-with_data_stream',
+        isDatastream: true,
+        datastreamName: 'datastream-testing',
+      },
+      {
+        name: '.ent-search-with_another_data_stream',
+        isDatastream: true,
+        datastreamName: 'datastream-testing-another',
+      },
+      {
+        name: '.ent-search-with_same_data_stream',
+        isDatastream: true,
+        datastreamName: 'datastream-testing',
+      },
+    ]);
+  });
+});
+
+describe('setPreEightEnterpriseSearchIndicesReadOnly', () => {
+  it('does not rollover datastreams if there are none', async () => {
+    const getIndicesMock = getMockIndicesFxn(testIndicesWithoutDatastream);
+    const rolloverMock = jest.fn(() => Promise.resolve(true));
+    const addBlockMock = jest.fn(() => Promise.resolve({ acknowledged: true }));
+    const esClientMock = {
+      indices: {
+        get: getIndicesMock,
+        rollover: rolloverMock,
+        addBlock: addBlockMock,
+      },
+    } as unknown as ElasticsearchClient;
+
+    const result = await setPreEightEnterpriseSearchIndicesReadOnly(esClientMock);
+    expect(result).toEqual('');
+    expect(getIndicesMock).toHaveBeenCalledTimes(1);
+    expect(rolloverMock).not.toHaveBeenCalled();
+    expect(addBlockMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does rollover datastreams if there are any', async () => {
+    const getIndicesMock = getMockIndicesFxn(testIndices);
+    const rolloverMock = jest.fn(() => Promise.resolve(true));
+    const addBlockMock = jest.fn(() => Promise.resolve({ acknowledged: true }));
+    const esClientMock = {
+      indices: {
+        get: getIndicesMock,
+        rollover: rolloverMock,
+        addBlock: addBlockMock,
+      },
+    } as unknown as ElasticsearchClient;
+
+    const result = await setPreEightEnterpriseSearchIndicesReadOnly(esClientMock);
+    expect(result).toEqual('');
+    expect(getIndicesMock).toHaveBeenCalledTimes(2);
+    expect(rolloverMock).toHaveBeenCalledTimes(2);
+    expect(addBlockMock).toHaveBeenCalledTimes(4);
+  });
+});

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/pre_eight_index_deprecator.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/pre_eight_index_deprecator.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ElasticsearchClient } from '@kbn/core/server';
+
+const ENT_SEARCH_INDEX_PREFIX = '.ent-search-';
+
+export interface EnterpriseSearchIndexMapping {
+  name: string;
+  isDatastream: boolean;
+  datastreamName: string;
+}
+
+export async function getPreEightEnterpriseSearchIndices(
+  esClient: ElasticsearchClient
+): Promise<EnterpriseSearchIndexMapping[]> {
+  const entSearchIndices = await esClient.indices.get({
+    index: `${ENT_SEARCH_INDEX_PREFIX}*`,
+    ignore_unavailable: true,
+    expand_wildcards: ['all'],
+  });
+
+  if (!entSearchIndices) {
+    return [];
+  }
+
+  const returnIndices: EnterpriseSearchIndexMapping[] = [];
+  for (const [index, indexData] of Object.entries(entSearchIndices)) {
+    if (
+      indexData.settings?.index?.version?.created?.startsWith('7') &&
+      indexData.settings?.index?.blocks?.write !== 'true'
+    ) {
+      const dataStreamName = indexData.data_stream;
+      returnIndices.push({
+        name: index,
+        isDatastream: dataStreamName ? true : false,
+        datastreamName: dataStreamName ?? '',
+      });
+    }
+  }
+
+  return returnIndices;
+}
+
+export async function setPreEightEnterpriseSearchIndicesReadOnly(
+  esClient: ElasticsearchClient
+): Promise<string> {
+  // get the indices again to ensure nothing's changed since the last check
+  let indices = await getPreEightEnterpriseSearchIndices(esClient);
+
+  // rollover any datastreams first
+  const rolledOverDatastreams: { [id: string]: boolean } = {};
+  for (const index of indices) {
+    if (index.isDatastream && !rolledOverDatastreams[index.datastreamName]) {
+      const indexResponse = await esClient.indices.rollover({ alias: index.datastreamName });
+
+      if (!indexResponse) {
+        return `Could not roll over datastream: ${index.name}`;
+      }
+
+      rolledOverDatastreams[index.datastreamName] = true;
+    }
+  }
+
+  if (Object.keys(rolledOverDatastreams).length > 0) {
+    // we rolled over at least one datastream,
+    // get the indices again
+    indices = await getPreEightEnterpriseSearchIndices(esClient);
+  }
+
+  for (const index of indices) {
+    const indexName = index.name;
+    const indexResponse = await esClient.indices.addBlock({ index: indexName, block: 'write' });
+
+    if (!indexResponse || indexResponse.acknowledged !== true) {
+      return `Could not set index read-only: ${indexName}`;
+    }
+  }
+
+  return '';
+}

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
@@ -15,6 +15,8 @@ import { mockDependencies, MockRouter } from '../../__mocks__';
 import { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 import { deleteConnectorById, putUpdateNative } from '@kbn/search-connectors';
 
+import indexDeprecatorFxns = require('../../deprecations/pre_eight_index_deprecator');
+
 import { registerDeprecationRoutes } from './deprecations';
 
 describe('deprecation routes', () => {
@@ -176,6 +178,51 @@ describe('deprecation routes', () => {
       expect(updateNativeMock).toHaveBeenCalledWith(mockClient, 'foo', false);
       expect(updateNativeMock).toHaveBeenCalledWith(mockClient, 'bar', false);
       expect(updateNativeMock).toHaveBeenCalledWith(mockClient, 'baz', false);
+    });
+  });
+
+  describe('POST /internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only', () => {
+    const mockClient = {};
+    let mockRouter: MockRouter;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      const context = {
+        core: Promise.resolve({ elasticsearch: { client: { asCurrentUser: mockClient } } }),
+      } as jest.Mocked<RequestHandlerContext>;
+      mockRouter = new MockRouter({
+        context,
+        method: 'post',
+        path: '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',
+      });
+
+      registerDeprecationRoutes({
+        ...mockDependencies,
+        router: mockRouter.router,
+      });
+    });
+
+    it('sets read-only and 200s correctly in happy path', async () => {
+      const setIndicesReadOnlyMock = jest.spyOn(
+        indexDeprecatorFxns,
+        'setPreEightEnterpriseSearchIndicesReadOnly'
+      );
+
+      const request = {
+        body: { deprecationDetails: { domainId: 'enterpriseSearch' } },
+      };
+      mockRouter.shouldValidate(request);
+
+      setIndicesReadOnlyMock.mockResolvedValue('');
+
+      await mockRouter.callRoute(request);
+      expect(setIndicesReadOnlyMock).toHaveBeenCalledTimes(1);
+      expect(mockRouter.response.ok).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails validation without deprecation context', () => {
+      const request = { body: {} };
+      mockRouter.shouldThrow(request);
     });
   });
 });

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.ts
@@ -9,6 +9,7 @@ import { schema } from '@kbn/config-schema';
 
 import { deleteConnectorById, putUpdateNative } from '@kbn/search-connectors';
 
+import { setPreEightEnterpriseSearchIndicesReadOnly } from '../../deprecations/pre_eight_index_deprecator';
 import { RouteDependencies } from '../../plugin';
 
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
@@ -57,6 +58,31 @@ export function registerDeprecationRoutes({ router, log }: RouteDependencies) {
       );
       return response.ok({
         body: { converted_to_client: request.body.ids },
+        headers: { 'content-type': 'application/json' },
+      });
+    })
+  );
+
+  router.post(
+    {
+      path: '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',
+      validate: {
+        body: schema.object({
+          deprecationDetails: schema.object({ domainId: schema.literal('enterpriseSearch') }),
+        }),
+      },
+    },
+    elasticsearchErrorHandler(log, async (context, request, response) => {
+      const { client } = (await context.core).elasticsearch;
+      const setResponse = await setPreEightEnterpriseSearchIndicesReadOnly(client.asCurrentUser);
+      if (setResponse.length > 0) {
+        return response.badRequest({
+          body: { message: setResponse },
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return response.ok({
+        body: { acknowedged: true },
         headers: { 'content-type': 'application/json' },
       });
     })


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[8.x] Add Pre-8.x Enterprise Search Index Incompatibility Deprecations (#210688)](https://github.com/elastic/kibana/pull/210688)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mark J. Hoy","email":"mark.hoy@elastic.co"},"sourceCommit":{"committedDate":"2025-02-13T18:21:48Z","message":"[8.x] Add Pre-8.x Enterprise Search Index Incompatibility Deprecations (#210688)\n\n## Summary\r\n\r\nAdds deprecations for the Kibana Upgrade Assistant if Enterprise Search\r\nindices from pre version 8.x are found. These indices are not compatible\r\nto upgrade to 9.x, so they must be set to read only or deleted.\r\n\r\nThe deprecations call out the specific indices, and offers a \"quick\r\nresolve\" button to set the affected indices to read only.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"271e40e9753417bb083748017aa7fa528fc34510","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Upgrade Assistant","Team:EnterpriseSearch","v8.18.0","v8.19.0","backport:8.18"],"title":"[8.x] Add Pre-8.x Enterprise Search Index Incompatibility Deprecations","number":210688,"url":"https://github.com/elastic/kibana/pull/210688","mergeCommit":{"message":"[8.x] Add Pre-8.x Enterprise Search Index Incompatibility Deprecations (#210688)\n\n## Summary\r\n\r\nAdds deprecations for the Kibana Upgrade Assistant if Enterprise Search\r\nindices from pre version 8.x are found. These indices are not compatible\r\nto upgrade to 9.x, so they must be set to read only or deleted.\r\n\r\nThe deprecations call out the specific indices, and offers a \"quick\r\nresolve\" button to set the affected indices to read only.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"271e40e9753417bb083748017aa7fa528fc34510"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->