### PR TITLE
[8.x] [Security Solution][Network details] add ability to show full network flyout from preview (#211065)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/footer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/footer.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { PreviewPanelFooter } from './footer';
+import { PREVIEW_FOOTER_LINK_TEST_ID, PREVIEW_FOOTER_TEST_ID } from './test_ids';
+import { NetworkPanelKey } from '.';
+import { FlowTargetSourceDest } from '../../../common/search_strategy';
+import { mockFlyoutApi } from '../document_details/shared/mocks/mock_flyout_context';
+
+jest.mock('@kbn/expandable-flyout');
+
+const ip = 'ip';
+const flowTarget = FlowTargetSourceDest.destination;
+const scopeId = 'scopeId';
+
+describe('<PreviewPanelFooter />', () => {
+  beforeEach(() => {
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
+  });
+
+  it('should open network details flyout when clicked', () => {
+    const { getByTestId } = render(
+      <PreviewPanelFooter ip={ip} flowTarget={flowTarget} scopeId={scopeId} />
+    );
+
+    expect(getByTestId(PREVIEW_FOOTER_TEST_ID)).toBeInTheDocument();
+
+    getByTestId(PREVIEW_FOOTER_LINK_TEST_ID).click();
+    expect(mockFlyoutApi.openFlyout).toHaveBeenCalledWith({
+      right: {
+        id: NetworkPanelKey,
+        params: {
+          ip,
+          flowTarget,
+          scopeId,
+        },
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/footer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/footer.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FC } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiFlyoutFooter, EuiLink, EuiPanel } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { PREVIEW_FOOTER_LINK_TEST_ID, PREVIEW_FOOTER_TEST_ID } from './test_ids';
+import type { FlowTargetSourceDest } from '../../../common/search_strategy';
+import { NetworkPanelKey } from '.';
+
+export interface PreviewPanelFooterProps {
+  /**
+   * IP value
+   */
+  ip: string;
+  /**
+   * Destination or source information
+   */
+  flowTarget: FlowTargetSourceDest;
+  /**
+   * Scope ID
+   */
+  scopeId: string;
+}
+
+/**
+ * Footer at the bottom of preview panel with a link to open network details flyout
+ */
+export const PreviewPanelFooter: FC<PreviewPanelFooterProps> = ({ ip, flowTarget, scopeId }) => {
+  const { openFlyout } = useExpandableFlyoutApi();
+
+  const openNetworkFlyout = useCallback(() => {
+    openFlyout({
+      right: {
+        id: NetworkPanelKey,
+        params: {
+          ip,
+          flowTarget,
+          scopeId,
+        },
+      },
+    });
+  }, [openFlyout, flowTarget, ip, scopeId]);
+
+  const fullDetailsLink = useMemo(
+    () => (
+      <EuiLink
+        onClick={openNetworkFlyout}
+        target="_blank"
+        data-test-subj={PREVIEW_FOOTER_LINK_TEST_ID}
+      >
+        <>
+          {i18n.translate('xpack.securitySolution.flyout.network.preview.openFlyoutLabel', {
+            defaultMessage: 'Show full network details',
+          })}
+        </>
+      </EuiLink>
+    ),
+    [openNetworkFlyout]
+  );
+
+  return (
+    <EuiFlyoutFooter data-test-subj={PREVIEW_FOOTER_TEST_ID}>
+      <EuiPanel color="transparent">
+        <EuiFlexGroup justifyContent="center">
+          <EuiFlexItem grow={false}>{fullDetailsLink}</EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </EuiFlyoutFooter>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/index.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  useExpandableFlyoutApi,
+  useExpandableFlyoutHistory,
+  useExpandableFlyoutState,
+} from '@kbn/expandable-flyout';
+import { PREVIEW_FOOTER_TEST_ID } from './test_ids';
+import { NetworkPanel } from '.';
+import { FlowTargetSourceDest } from '../../../common/search_strategy';
+import { mockFlyoutApi } from '../document_details/shared/mocks/mock_flyout_context';
+import { TestProviders } from '../../common/mock';
+
+jest.mock('@kbn/expandable-flyout');
+jest.mock('../../common/hooks/use_experimental_features');
+
+const ip = 'ip';
+const flowTarget = FlowTargetSourceDest.destination;
+const scopeId = 'scopeId';
+
+describe('<NetworkPanel />', () => {
+  beforeEach(() => {
+    jest.mocked(useExpandableFlyoutApi).mockReturnValue(mockFlyoutApi);
+    jest.mocked(useExpandableFlyoutHistory).mockReturnValue([]);
+    (useExpandableFlyoutState as jest.Mock).mockReturnValue({});
+  });
+
+  it('should not show footer if non-preview mode', () => {
+    const { queryByTestId } = render(
+      <TestProviders>
+        <NetworkPanel ip={ip} flowTarget={flowTarget} scopeId={scopeId} isPreviewMode={false} />
+      </TestProviders>
+    );
+
+    expect(queryByTestId(PREVIEW_FOOTER_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('should show footer if preview mode', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <NetworkPanel ip={ip} flowTarget={flowTarget} scopeId={scopeId} isPreviewMode={true} />
+      </TestProviders>
+    );
+
+    expect(getByTestId(PREVIEW_FOOTER_TEST_ID)).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/index.tsx
@@ -10,6 +10,7 @@ import React, { memo } from 'react';
 import type { FlyoutPanelProps } from '@kbn/expandable-flyout';
 import { i18n } from '@kbn/i18n';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { PreviewPanelFooter } from './footer';
 import type { FlowTargetSourceDest } from '../../../common/search_strategy';
 import { PanelHeader } from './header';
 import { PanelContent } from './content';
@@ -64,6 +65,7 @@ export const NetworkPanel: FC<NetworkPanelProps> = memo(
         />
         <PanelHeader ip={ip} flowTarget={flowTarget} />
         <PanelContent ip={ip} flowTarget={flowTarget} />
+        {isPreviewMode && <PreviewPanelFooter ip={ip} flowTarget={flowTarget} scopeId={scopeId} />}
       </>
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/test_ids.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/network_details/test_ids.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PREFIX } from '../shared/test_ids';
+
+export const PREVIEW_FOOTER_TEST_ID = `${PREFIX}NetworkPreviewFooter` as const;
+export const PREVIEW_FOOTER_LINK_TEST_ID = `${PREVIEW_FOOTER_TEST_ID}Link` as const;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Network details] add ability to show full network flyout from preview (#211065)](https://github.com/elastic/kibana/pull/211065)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-02-13T20:54:34Z","message":"[Security Solution][Network details] add ability to show full network flyout from preview (#211065)\n\n## Summary\r\n\r\nThis PR is a follow up of [this\r\nPR](https://github.com/elastic/kibana/pull/187870) that replaced the old\r\nnetwork/ip flyout with a new panel for the expandable flyout. Since then\r\nwe improved the UI or preview and added the ability to jump to a full\r\nflyout from its preview.\r\n\r\nThis PR fixes the issues where users could not navigate to the full\r\ndetails network/ip flyout from a preview. This functionality already\r\nexists for the alert, event, host and user flyouts. The PR adds a new\r\nfooter to the network/ip flyout - only shown in preview mode - that\r\nallows users to navigate to the full detail network/ip flyout.\r\n\r\n| Old behavior  | New behavior |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-02-13 at 11 53\r\n22 AM](https://github.com/user-attachments/assets/8ecc5ad4-1038-4fd4-9f56-3e7d0e497b06)\r\n| ![Screenshot 2025-02-13 at 11 34\r\n19 AM](https://github.com/user-attachments/assets/bfb909f0-5be8-4f97-af66-4ed3292e6bc3)\r\n|\r\n\r\nThe user has the ability to navigate to the full detail flyout:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/4c809e5d-0b59-4498-9966-0133d139233b\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"96b4f8442e29f3e2aca919e9552c479ea0811393","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Threat Hunting:Investigations","backport:version","v8.18.0","v9.1.0"],"title":"[Security Solution][Network details] add ability to show full network flyout from preview","number":211065,"url":"https://github.com/elastic/kibana/pull/211065","mergeCommit":{"message":"[Security Solution][Network details] add ability to show full network flyout from preview (#211065)\n\n## Summary\r\n\r\nThis PR is a follow up of [this\r\nPR](https://github.com/elastic/kibana/pull/187870) that replaced the old\r\nnetwork/ip flyout with a new panel for the expandable flyout. Since then\r\nwe improved the UI or preview and added the ability to jump to a full\r\nflyout from its preview.\r\n\r\nThis PR fixes the issues where users could not navigate to the full\r\ndetails network/ip flyout from a preview. This functionality already\r\nexists for the alert, event, host and user flyouts. The PR adds a new\r\nfooter to the network/ip flyout - only shown in preview mode - that\r\nallows users to navigate to the full detail network/ip flyout.\r\n\r\n| Old behavior  | New behavior |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-02-13 at 11 53\r\n22 AM](https://github.com/user-attachments/assets/8ecc5ad4-1038-4fd4-9f56-3e7d0e497b06)\r\n| ![Screenshot 2025-02-13 at 11 34\r\n19 AM](https://github.com/user-attachments/assets/bfb909f0-5be8-4f97-af66-4ed3292e6bc3)\r\n|\r\n\r\nThe user has the ability to navigate to the full detail flyout:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/4c809e5d-0b59-4498-9966-0133d139233b\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"96b4f8442e29f3e2aca919e9552c479ea0811393"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/211100","number":211100,"state":"MERGED","mergeCommit":{"sha":"0619ae535e5c6045c350f6e5f355bda8da69a01c","message":"[9.0] [Security Solution][Network details] add ability to show full network flyout from preview (#211065) (#211100)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution][Network details] add ability to show full network\nflyout from preview\n(#211065)](https://github.com/elastic/kibana/pull/211065)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Philippe\nOberti\",\"email\":\"philippe.oberti@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-13T20:54:34Z\",\"message\":\"[Security\nSolution][Network details] add ability to show full network flyout from\npreview (#211065)\\n\\n## Summary\\r\\n\\r\\nThis PR is a follow up of\n[this\\r\\nPR](https://github.com/elastic/kibana/pull/187870) that\nreplaced the old\\r\\nnetwork/ip flyout with a new panel for the\nexpandable flyout. Since then\\r\\nwe improved the UI or preview and added\nthe ability to jump to a full\\r\\nflyout from its preview.\\r\\n\\r\\nThis PR\nfixes the issues where users could not navigate to the full\\r\\ndetails\nnetwork/ip flyout from a preview. This functionality already\\r\\nexists\nfor the alert, event, host and user flyouts. The PR adds a new\\r\\nfooter\nto the network/ip flyout - only shown in preview mode - that\\r\\nallows\nusers to navigate to the full detail network/ip flyout.\\r\\n\\r\\n| Old\nbehavior | New behavior |\\r\\n| ------------- | ------------- |\\r\\n|\n![Screenshot 2025-02-13 at 11\n53\\r\\n22 AM](https://github.com/user-attachments/assets/8ecc5ad4-1038-4fd4-9f56-3e7d0e497b06)\\r\\n|\n![Screenshot 2025-02-13 at 11\n34\\r\\n19 AM](https://github.com/user-attachments/assets/bfb909f0-5be8-4f97-af66-4ed3292e6bc3)\\r\\n|\\r\\n\\r\\nThe\nuser has the ability to navigate to the full detail\nflyout:\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/4c809e5d-0b59-4498-9966-0133d139233b\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\n- [x] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\\r\\n-\n[x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"96b4f8442e29f3e2aca919e9552c479ea0811393\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Team:Threat\nHunting:Investigations\",\"backport:version\",\"v8.18.0\",\"v9.1.0\"],\"title\":\"[Security\nSolution][Network details] add ability to show full network flyout from\npreview\",\"number\":211065,\"url\":\"https://github.com/elastic/kibana/pull/211065\",\"mergeCommit\":{\"message\":\"[Security\nSolution][Network details] add ability to show full network flyout from\npreview (#211065)\\n\\n## Summary\\r\\n\\r\\nThis PR is a follow up of\n[this\\r\\nPR](https://github.com/elastic/kibana/pull/187870) that\nreplaced the old\\r\\nnetwork/ip flyout with a new panel for the\nexpandable flyout. Since then\\r\\nwe improved the UI or preview and added\nthe ability to jump to a full\\r\\nflyout from its preview.\\r\\n\\r\\nThis PR\nfixes the issues where users could not navigate to the full\\r\\ndetails\nnetwork/ip flyout from a preview. This functionality already\\r\\nexists\nfor the alert, event, host and user flyouts. The PR adds a new\\r\\nfooter\nto the network/ip flyout - only shown in preview mode - that\\r\\nallows\nusers to navigate to the full detail network/ip flyout.\\r\\n\\r\\n| Old\nbehavior | New behavior |\\r\\n| ------------- | ------------- |\\r\\n|\n![Screenshot 2025-02-13 at 11\n53\\r\\n22 AM](https://github.com/user-attachments/assets/8ecc5ad4-1038-4fd4-9f56-3e7d0e497b06)\\r\\n|\n![Screenshot 2025-02-13 at 11\n34\\r\\n19 AM](https://github.com/user-attachments/assets/bfb909f0-5be8-4f97-af66-4ed3292e6bc3)\\r\\n|\\r\\n\\r\\nThe\nuser has the ability to navigate to the full detail\nflyout:\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/4c809e5d-0b59-4498-9966-0133d139233b\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\n- [x] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\\r\\n-\n[x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"96b4f8442e29f3e2aca919e9552c479ea0811393\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"9.0\",\"8.18\"],\"targetPullRequestStates\":[{\"branch\":\"9.0\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.18\",\"label\":\"v8.18.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/211065\",\"number\":211065,\"mergeCommit\":{\"message\":\"[Security\nSolution][Network details] add ability to show full network flyout from\npreview (#211065)\\n\\n## Summary\\r\\n\\r\\nThis PR is a follow up of\n[this\\r\\nPR](https://github.com/elastic/kibana/pull/187870) that\nreplaced the old\\r\\nnetwork/ip flyout with a new panel for the\nexpandable flyout. Since then\\r\\nwe improved the UI or preview and added\nthe ability to jump to a full\\r\\nflyout from its preview.\\r\\n\\r\\nThis PR\nfixes the issues where users could not navigate to the full\\r\\ndetails\nnetwork/ip flyout from a preview. This functionality already\\r\\nexists\nfor the alert, event, host and user flyouts. The PR adds a new\\r\\nfooter\nto the network/ip flyout - only shown in preview mode - that\\r\\nallows\nusers to navigate to the full detail network/ip flyout.\\r\\n\\r\\n| Old\nbehavior | New behavior |\\r\\n| ------------- | ------------- |\\r\\n|\n![Screenshot 2025-02-13 at 11\n53\\r\\n22 AM](https://github.com/user-attachments/assets/8ecc5ad4-1038-4fd4-9f56-3e7d0e497b06)\\r\\n|\n![Screenshot 2025-02-13 at 11\n34\\r\\n19 AM](https://github.com/user-attachments/assets/bfb909f0-5be8-4f97-af66-4ed3292e6bc3)\\r\\n|\\r\\n\\r\\nThe\nuser has the ability to navigate to the full detail\nflyout:\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/4c809e5d-0b59-4498-9966-0133d139233b\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\n- [x] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\\r\\n-\n[x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"96b4f8442e29f3e2aca919e9552c479ea0811393\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/211099","number":211099,"state":"MERGED","mergeCommit":{"sha":"51b5251f7bbe5d8c4dec5a153d630b4e882e4cdf","message":"[8.18] [Security Solution][Network details] add ability to show full network flyout from preview (#211065) (#211099)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Security Solution][Network details] add ability to show full network\nflyout from preview\n(#211065)](https://github.com/elastic/kibana/pull/211065)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Philippe\nOberti\",\"email\":\"philippe.oberti@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-13T20:54:34Z\",\"message\":\"[Security\nSolution][Network details] add ability to show full network flyout from\npreview (#211065)\\n\\n## Summary\\r\\n\\r\\nThis PR is a follow up of\n[this\\r\\nPR](https://github.com/elastic/kibana/pull/187870) that\nreplaced the old\\r\\nnetwork/ip flyout with a new panel for the\nexpandable flyout. Since then\\r\\nwe improved the UI or preview and added\nthe ability to jump to a full\\r\\nflyout from its preview.\\r\\n\\r\\nThis PR\nfixes the issues where users could not navigate to the full\\r\\ndetails\nnetwork/ip flyout from a preview. This functionality already\\r\\nexists\nfor the alert, event, host and user flyouts. The PR adds a new\\r\\nfooter\nto the network/ip flyout - only shown in preview mode - that\\r\\nallows\nusers to navigate to the full detail network/ip flyout.\\r\\n\\r\\n| Old\nbehavior | New behavior |\\r\\n| ------------- | ------------- |\\r\\n|\n![Screenshot 2025-02-13 at 11\n53\\r\\n22 AM](https://github.com/user-attachments/assets/8ecc5ad4-1038-4fd4-9f56-3e7d0e497b06)\\r\\n|\n![Screenshot 2025-02-13 at 11\n34\\r\\n19 AM](https://github.com/user-attachments/assets/bfb909f0-5be8-4f97-af66-4ed3292e6bc3)\\r\\n|\\r\\n\\r\\nThe\nuser has the ability to navigate to the full detail\nflyout:\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/4c809e5d-0b59-4498-9966-0133d139233b\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\n- [x] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\\r\\n-\n[x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"96b4f8442e29f3e2aca919e9552c479ea0811393\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"Team:Threat\nHunting:Investigations\",\"backport:version\",\"v8.18.0\",\"v9.1.0\"],\"title\":\"[Security\nSolution][Network details] add ability to show full network flyout from\npreview\",\"number\":211065,\"url\":\"https://github.com/elastic/kibana/pull/211065\",\"mergeCommit\":{\"message\":\"[Security\nSolution][Network details] add ability to show full network flyout from\npreview (#211065)\\n\\n## Summary\\r\\n\\r\\nThis PR is a follow up of\n[this\\r\\nPR](https://github.com/elastic/kibana/pull/187870) that\nreplaced the old\\r\\nnetwork/ip flyout with a new panel for the\nexpandable flyout. Since then\\r\\nwe improved the UI or preview and added\nthe ability to jump to a full\\r\\nflyout from its preview.\\r\\n\\r\\nThis PR\nfixes the issues where users could not navigate to the full\\r\\ndetails\nnetwork/ip flyout from a preview. This functionality already\\r\\nexists\nfor the alert, event, host and user flyouts. The PR adds a new\\r\\nfooter\nto the network/ip flyout - only shown in preview mode - that\\r\\nallows\nusers to navigate to the full detail network/ip flyout.\\r\\n\\r\\n| Old\nbehavior | New behavior |\\r\\n| ------------- | ------------- |\\r\\n|\n![Screenshot 2025-02-13 at 11\n53\\r\\n22 AM](https://github.com/user-attachments/assets/8ecc5ad4-1038-4fd4-9f56-3e7d0e497b06)\\r\\n|\n![Screenshot 2025-02-13 at 11\n34\\r\\n19 AM](https://github.com/user-attachments/assets/bfb909f0-5be8-4f97-af66-4ed3292e6bc3)\\r\\n|\\r\\n\\r\\nThe\nuser has the ability to navigate to the full detail\nflyout:\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/4c809e5d-0b59-4498-9966-0133d139233b\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\n- [x] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\\r\\n-\n[x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"96b4f8442e29f3e2aca919e9552c479ea0811393\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"9.0\",\"8.18\"],\"targetPullRequestStates\":[{\"branch\":\"9.0\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.18\",\"label\":\"v8.18.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/211065\",\"number\":211065,\"mergeCommit\":{\"message\":\"[Security\nSolution][Network details] add ability to show full network flyout from\npreview (#211065)\\n\\n## Summary\\r\\n\\r\\nThis PR is a follow up of\n[this\\r\\nPR](https://github.com/elastic/kibana/pull/187870) that\nreplaced the old\\r\\nnetwork/ip flyout with a new panel for the\nexpandable flyout. Since then\\r\\nwe improved the UI or preview and added\nthe ability to jump to a full\\r\\nflyout from its preview.\\r\\n\\r\\nThis PR\nfixes the issues where users could not navigate to the full\\r\\ndetails\nnetwork/ip flyout from a preview. This functionality already\\r\\nexists\nfor the alert, event, host and user flyouts. The PR adds a new\\r\\nfooter\nto the network/ip flyout - only shown in preview mode - that\\r\\nallows\nusers to navigate to the full detail network/ip flyout.\\r\\n\\r\\n| Old\nbehavior | New behavior |\\r\\n| ------------- | ------------- |\\r\\n|\n![Screenshot 2025-02-13 at 11\n53\\r\\n22 AM](https://github.com/user-attachments/assets/8ecc5ad4-1038-4fd4-9f56-3e7d0e497b06)\\r\\n|\n![Screenshot 2025-02-13 at 11\n34\\r\\n19 AM](https://github.com/user-attachments/assets/bfb909f0-5be8-4f97-af66-4ed3292e6bc3)\\r\\n|\\r\\n\\r\\nThe\nuser has the ability to navigate to the full detail\nflyout:\\r\\n\\r\\n\\r\\nhttps://github.com/user-attachments/assets/4c809e5d-0b59-4498-9966-0133d139233b\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\n- [x] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\\r\\n-\n[x] [Unit or\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common\nscenarios\",\"sha\":\"96b4f8442e29f3e2aca919e9552c479ea0811393\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211065","number":211065,"mergeCommit":{"message":"[Security Solution][Network details] add ability to show full network flyout from preview (#211065)\n\n## Summary\r\n\r\nThis PR is a follow up of [this\r\nPR](https://github.com/elastic/kibana/pull/187870) that replaced the old\r\nnetwork/ip flyout with a new panel for the expandable flyout. Since then\r\nwe improved the UI or preview and added the ability to jump to a full\r\nflyout from its preview.\r\n\r\nThis PR fixes the issues where users could not navigate to the full\r\ndetails network/ip flyout from a preview. This functionality already\r\nexists for the alert, event, host and user flyouts. The PR adds a new\r\nfooter to the network/ip flyout - only shown in preview mode - that\r\nallows users to navigate to the full detail network/ip flyout.\r\n\r\n| Old behavior  | New behavior |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-02-13 at 11 53\r\n22 AM](https://github.com/user-attachments/assets/8ecc5ad4-1038-4fd4-9f56-3e7d0e497b06)\r\n| ![Screenshot 2025-02-13 at 11 34\r\n19 AM](https://github.com/user-attachments/assets/bfb909f0-5be8-4f97-af66-4ed3292e6bc3)\r\n|\r\n\r\nThe user has the ability to navigate to the full detail flyout:\r\n\r\n\r\nhttps://github.com/user-attachments/assets/4c809e5d-0b59-4498-9966-0133d139233b\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"96b4f8442e29f3e2aca919e9552c479ea0811393"}}]}] BACKPORT-->