### PR TITLE
[8.x] [Navigation] Add stack monitoring to Security sidebar (#210203)

### DIFF
--- a/x-pack/solutions/security/packages/navigation/src/constants.ts
+++ b/x-pack/solutions/security/packages/navigation/src/constants.ts
@@ -94,6 +94,7 @@ export enum ExternalPageName {
   managementFiles = 'management:filesManagement',
   managementSpaces = 'management:spaces',
   managementSettings = 'management:settings',
+  managementMonitoring = 'monitoring:',
   // Cloud UI
   // These are links to Cloud UI outside Kibana
   // Special Format: <cloud>:<cloudUrlKey>

--- a/x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/categories.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/categories.ts
@@ -66,6 +66,10 @@ export const FOOTER_CATEGORIES: Array<LinkCategory<SolutionPageName>> = [
       defaultMessage: 'Management',
     }),
     iconType: 'gear',
-    linkIds: [ExternalPageName.management, ExternalPageName.integrationsSecurity],
+    linkIds: [
+      ExternalPageName.management,
+      ExternalPageName.managementMonitoring,
+      ExternalPageName.integrationsSecurity,
+    ],
   },
 ];

--- a/x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/links/sections/settings_links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/links/sections/settings_links.ts
@@ -32,6 +32,11 @@ export const settingsNavLinks: SolutionNavLink[] = [
     isFooterLink: true,
   },
   {
+    id: ExternalPageName.managementMonitoring,
+    title: i18n.MONITORING_TITLE,
+    isFooterLink: true,
+  },
+  {
     id: ExternalPageName.integrationsSecurity,
     title: i18n.INTEGRATIONS_TITLE,
     isFooterLink: true,

--- a/x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/links/sections/settings_translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/links/sections/settings_translations.ts
@@ -41,3 +41,6 @@ export const VISUALIZE_DESCRIPTION = i18n.translate(
     defaultMessage: 'Manage visualization library. Create, edit, and share visualizations.',
   }
 );
+export const MONITORING_TITLE = i18n.translate('xpack.securitySolution.navLinks.monitoring.title', {
+  defaultMessage: 'Stack Monitoring',
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Navigation] Add stack monitoring to Security sidebar (#210203)](https://github.com/elastic/kibana/pull/210203)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Krzysztof Kowalczyk","email":"krzysztof.kowalczyk@elastic.co"},"sourceCommit":{"committedDate":"2025-02-10T14:28:17Z","message":"[Navigation] Add stack monitoring to Security sidebar (#210203)\n\n## Summary\r\nThis PR adds Stack Monitoring to the side navigation.\r\nAddresses: https://github.com/elastic/kibana-team/issues/1312\r\n\r\n![Screenshot 2025-02-07 at 17 24\r\n28](https://github.com/user-attachments/assets/1a11d9cd-6f66-49f2-b7d0-8b60f224781c)","sha":"96381335e41d177f9851cc66eb9c5f7ec7d19d99","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["enhancement","release_note:skip","v9.0.0","Team:Threat Hunting","Team: SecuritySolution","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Navigation] Add stack monitoring to Security sidebar","number":210203,"url":"https://github.com/elastic/kibana/pull/210203","mergeCommit":{"message":"[Navigation] Add stack monitoring to Security sidebar (#210203)\n\n## Summary\r\nThis PR adds Stack Monitoring to the side navigation.\r\nAddresses: https://github.com/elastic/kibana-team/issues/1312\r\n\r\n![Screenshot 2025-02-07 at 17 24\r\n28](https://github.com/user-attachments/assets/1a11d9cd-6f66-49f2-b7d0-8b60f224781c)","sha":"96381335e41d177f9851cc66eb9c5f7ec7d19d99"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210203","number":210203,"mergeCommit":{"message":"[Navigation] Add stack monitoring to Security sidebar (#210203)\n\n## Summary\r\nThis PR adds Stack Monitoring to the side navigation.\r\nAddresses: https://github.com/elastic/kibana-team/issues/1312\r\n\r\n![Screenshot 2025-02-07 at 17 24\r\n28](https://github.com/user-attachments/assets/1a11d9cd-6f66-49f2-b7d0-8b60f224781c)","sha":"96381335e41d177f9851cc66eb9c5f7ec7d19d99"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->