### PR TITLE
[Search] Remove coming soon pages

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/self_managed_web_crawler_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/self_managed_web_crawler_empty_prompt.tsx
@@ -7,7 +7,6 @@
 import React from 'react';
 
 import {
-  EuiBadge,
   EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
@@ -20,10 +19,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { SearchEmptyPrompt, DecorativeHorizontalStepper, EuiIconWeb } from '@kbn/search-shared-ui';
 
-import { COMING_SOON_LABEL } from '../../../shared/constants';
 import { GithubIcon } from '../../../shared/icons/github_icon';
-import { KibanaLogic } from '../../../shared/kibana';
-import { CRAWLERS_ELASTIC_MANAGED_PATH } from '../../routes';
 
 export const SelfManagedWebCrawlerEmptyPrompt: React.FC = () => {
   return (
@@ -196,23 +192,6 @@ export const SelfManagedWebCrawlerEmptyPrompt: React.FC = () => {
                 defaultMessage: 'Self-managed web crawler',
               })}
             </EuiButton>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiFlexGroup direction="column" gutterSize="s" alignItems="center">
-              <EuiFlexItem>
-                <EuiButton
-                  data-test-subj="enterpriseSearchEmptyConnectorsPromptCreateElasticManagedConnectorButton"
-                  onClick={() => KibanaLogic.values.navigateToUrl(CRAWLERS_ELASTIC_MANAGED_PATH)}
-                >
-                  {i18n.translate('xpack.enterpriseSearch.webCrawlersEmpty.elasticManagedButton', {
-                    defaultMessage: 'Elastic managed web crawler',
-                  })}
-                </EuiButton>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiBadge color="accent">{COMING_SOON_LABEL}</EuiBadge>
-              </EuiFlexItem>
-            </EuiFlexGroup>
           </EuiFlexItem>
         </>
       }

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/self_managed_connectors_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/self_managed_connectors_empty_prompt.tsx
@@ -24,7 +24,6 @@ import {
   EuiIconPlugs,
 } from '@kbn/search-shared-ui';
 import { docLinks } from '../../../../common/doc_links';
-import { useKibanaServices } from '../../hooks/use_kibana';
 import { useConnectorTypes } from '../../hooks/api/use_connector_types';
 import { useCreateConnector } from '../../hooks/api/use_create_connector';
 import { useConnectors } from '../../hooks/api/use_connectors';
@@ -36,9 +35,6 @@ export const SelfManagedConnectorsEmptyPrompt: React.FC = () => {
   );
   const { createConnector, isLoading } = useCreateConnector();
   const { data } = useConnectors();
-  const {
-    application: { navigateToUrl },
-  } = useKibanaServices();
 
   return (
     <SearchEmptyPrompt

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/self_managed_connectors_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/connectors/self_managed_connectors_empty_prompt.tsx
@@ -12,7 +12,6 @@ import {
   EuiIcon,
   EuiLink,
   EuiButton,
-  EuiBadge,
   EuiText,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -29,8 +28,6 @@ import { useKibanaServices } from '../../hooks/use_kibana';
 import { useConnectorTypes } from '../../hooks/api/use_connector_types';
 import { useCreateConnector } from '../../hooks/api/use_create_connector';
 import { useConnectors } from '../../hooks/api/use_connectors';
-import { ELASTIC_MANAGED_CONNECTOR_PATH, BASE_CONNECTORS_PATH } from '../../constants';
-import { BACK_LABEL } from '../../../../common/i18n_string';
 
 export const SelfManagedConnectorsEmptyPrompt: React.FC = () => {
   const connectorTypes = useConnectorTypes();
@@ -229,26 +226,6 @@ export const SelfManagedConnectorsEmptyPrompt: React.FC = () => {
                 defaultMessage: 'Self-managed connector',
               })}
             </EuiButton>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiFlexGroup direction="column" gutterSize="s" alignItems="center">
-              <EuiFlexItem>
-                <EuiButton
-                  data-test-subj="serverlessSearchEmptyConnectorsPromptCreateElasticManagedConnectorButton"
-                  isLoading={isLoading}
-                  onClick={() =>
-                    navigateToUrl(`${BASE_CONNECTORS_PATH}/${ELASTIC_MANAGED_CONNECTOR_PATH}`)
-                  }
-                >
-                  {i18n.translate('xpack.serverlessSearch.connectorsEmpty.elasticManagedButton', {
-                    defaultMessage: 'Elastic managed connector',
-                  })}
-                </EuiButton>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiBadge color="accent">{BACK_LABEL}</EuiBadge>
-              </EuiFlexItem>
-            </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
       }

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/self_managed_web_crawlers_empty_prompt.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/web_crawlers/self_managed_web_crawlers_empty_prompt.tsx
@@ -6,7 +6,6 @@
  */
 import React from 'react';
 import {
-  EuiBadge,
   EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,16 +17,9 @@ import {
 import { i18n } from '@kbn/i18n';
 import { SearchEmptyPrompt, DecorativeHorizontalStepper, EuiIconWeb } from '@kbn/search-shared-ui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { ELASTIC_MANAGED_WEB_CRAWLERS_PATH, BASE_WEB_CRAWLERS_PATH } from '../../constants';
-import { COMING_SOON_LABEL } from '../../../../common/i18n_string';
-import { useKibanaServices } from '../../hooks/use_kibana';
 import { useAssetBasePath } from '../../hooks/use_asset_base_path';
 
 export const SelfManagedWebCrawlersEmptyPrompt = () => {
-  const {
-    application: { navigateToUrl },
-  } = useKibanaServices();
-
   const assetBasePath = useAssetBasePath();
   const githubIcon = assetBasePath + '/github_white.svg';
 
@@ -201,25 +193,6 @@ export const SelfManagedWebCrawlersEmptyPrompt = () => {
                 defaultMessage: 'Self-managed web crawler',
               })}
             </EuiButton>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiFlexGroup direction="column" gutterSize="s" alignItems="center">
-              <EuiFlexItem>
-                <EuiButton
-                  data-test-subj="serverlessSearchEmptyConnectorsPromptCreateElasticManagedConnectorButton"
-                  onClick={() =>
-                    navigateToUrl(`${BASE_WEB_CRAWLERS_PATH}/${ELASTIC_MANAGED_WEB_CRAWLERS_PATH}`)
-                  }
-                >
-                  {i18n.translate('xpack.serverlessSearch.webCrawlersEmpty.elasticManagedButton', {
-                    defaultMessage: 'Elastic managed web crawler',
-                  })}
-                </EuiButton>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiBadge color="accent">{COMING_SOON_LABEL}</EuiBadge>
-              </EuiFlexItem>
-            </EuiFlexGroup>
           </EuiFlexItem>
         </>
       }


### PR DESCRIPTION
## Summary

Removing CTA buttons prompting users to read that Elastic managed connectors and web crawlers will be available coming soon. Self-managed flavour will be the only possibility from 9.0

[Serverless] Empty page for Connectors:

![CleanShot 2025-02-14 at 10 05 43@2x](https://github.com/user-attachments/assets/7ad0e96a-1d08-4c18-a92a-62137ff7b49f)

[Serverless] Empty page for Web Crawlers:

![CleanShot 2025-02-14 at 10 06 07@2x](https://github.com/user-attachments/assets/e213e6ce-e01f-419b-ad04-7c11b8c7a853)

[ECH] Empty page for Web Crawlers: 

![CleanShot 2025-02-14 at 11 08 18@2x](https://github.com/user-attachments/assets/896ae9db-cc5f-4e19-9c96-d427387fcc7f)



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->