### PR TITLE
fix(NA): use filesystem apis on kbn/optimizer populate_bundle_cache plugin

### DIFF
--- a/packages/kbn-optimizer/src/worker/populate_bundle_cache_plugin.ts
+++ b/packages/kbn-optimizer/src/worker/populate_bundle_cache_plugin.ts
@@ -37,6 +37,9 @@ interface InputFileSystem {
     encoding: null | undefined,
     callback: (err: Error | null, stats: Buffer) => void
   ) => void;
+  statSync: (
+    path: string,
+  ) => any;
 }
 
 /**
@@ -47,6 +50,22 @@ interface InputFileSystem {
  * across mulitple workers on machines with lots of cores.
  */
 const EXTRA_SCSS_WORK_UNITS = 100;
+
+const fileCheckCache = new Map();
+function isFile(inputFileSystem: InputFileSystem, path: string) {
+  if (fileCheckCache.has(path)) {
+    return fileCheckCache.get(path);
+  }
+  
+  try {
+    const result = inputFileSystem.statSync(path).isFile();
+    fileCheckCache.set(path, result);
+    return result;
+  } catch (err) {
+    fileCheckCache.set(path, false);
+    return false; // Path does not exist or is not a file
+  }
+}
 
 export class PopulateBundleCachePlugin {
   constructor(
@@ -78,7 +97,7 @@ export class PopulateBundleCachePlugin {
             // in webpack v5 there a lot of paths collected that are not real files
             // but instead folders or partial paths.
             // Here we're verifying if what we have as indeed a filepath
-            if (Path.extname(path).length > 0) {
+            if (isFile(inputFs, path)) {
               realFileDeps.push(path);
               allFileDepsPathSet.add(path);
             }
@@ -127,7 +146,7 @@ export class PopulateBundleCachePlugin {
           for (const module of compilation.modules) {
             if (isNormalModule(module)) {
               const path = getModulePath(module);
-              if (Path.extname(path).length === 0) {
+              if (!isFile(inputFs, path)) {
                 continue;
               }
 

--- a/packages/kbn-optimizer/src/worker/populate_bundle_cache_plugin.ts
+++ b/packages/kbn-optimizer/src/worker/populate_bundle_cache_plugin.ts
@@ -37,9 +37,7 @@ interface InputFileSystem {
     encoding: null | undefined,
     callback: (err: Error | null, stats: Buffer) => void
   ) => void;
-  statSync: (
-    path: string,
-  ) => any;
+  statSync: (path: string) => any;
 }
 
 /**
@@ -56,7 +54,7 @@ function isFile(inputFileSystem: InputFileSystem, path: string) {
   if (fileCheckCache.has(path)) {
     return fileCheckCache.get(path);
   }
-  
+
   try {
     const result = inputFileSystem.statSync(path).isFile();
     fileCheckCache.set(path, result);


### PR DESCRIPTION
This PR solves an issue detected in the populate bundle cache plugin after the webpack v5 migration. On the new version webpack v5 returns a lot of incomplete paths when we walk over file dependencies or internal modules. The heuristic logic used previously was faulty so the fixes turns to use a cached filesystem api instead.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->