### PR TITLE
[Obs AI Assistant] Pass system message to inferenceCliente.chatComplete

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.test.ts
@@ -346,6 +346,7 @@ describe('Observability AI Assistant client', () => {
           {
             connectorId: 'foo',
             stream: true,
+            system: EXPECTED_STORED_SYSTEM_MESSAGE,
             messages: expect.arrayContaining([
               { role: 'user', content: 'How many alerts do I have?' },
             ]),
@@ -916,6 +917,7 @@ describe('Observability AI Assistant client', () => {
           {
             connectorId: 'foo',
             stream: true,
+            system: EXPECTED_STORED_SYSTEM_MESSAGE,
             messages: expect.arrayContaining([
               { role: 'user', content: 'How many alerts do I have?' },
             ]),
@@ -1077,6 +1079,7 @@ describe('Observability AI Assistant client', () => {
           {
             connectorId: 'foo',
             stream: true,
+            system: EXPECTED_STORED_SYSTEM_MESSAGE,
             messages: expect.arrayContaining([
               { role: 'user', content: 'How many alerts do I have?' },
             ]),

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -508,6 +508,8 @@ export class ObservabilityAIAssistantClient {
 
     const options = {
       connectorId,
+      system: messages.find((message) => message.message.role === MessageRole.System)?.message
+        .content,
       messages: convertMessagesForInference(
         messages.filter((message) => message.message.role !== MessageRole.System)
       ),


### PR DESCRIPTION
Closes #211257 

## Summary

Regression introduced in 8.18 (https://github.com/elastic/kibana/pull/199286)

We no longer pass the `system` message to the inference plugin, and thereby the LLM. This means that we are only passing user messages to the LLM. The system message is important in steering the conversation, and providing guardrails to the LLM.

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->