### PR TITLE
[8.x] [scout] adding test helper `@kbn/scout-oblt` package and uptate onboarding tests (#209761)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -794,6 +794,7 @@ src/platform/packages/shared/kbn-saved-search-component @elastic/obs-ux-logs-tea
 src/platform/plugins/shared/saved_search @elastic/kibana-data-discovery
 packages/kbn-scout @elastic/appex-qa
 packages/kbn-scout-info @elastic/appex-qa
+x-pack/solutions/observability/packages/kbn-scout-oblt @elastic/appex-qa
 packages/kbn-scout-reporting @elastic/appex-qa
 examples/screenshot_mode_example @elastic/appex-sharedux
 src/platform/plugins/shared/screenshot_mode @elastic/appex-sharedux
@@ -958,7 +959,6 @@ packages/kbn-stdio-dev-helpers @elastic/kibana-operations
 packages/kbn-storybook @elastic/kibana-operations
 x-pack/solutions/observability/plugins/streams_app @simianhacker @flash1293 @dgieselaar
 x-pack/solutions/observability/plugins/streams @simianhacker @flash1293 @dgieselaar
-x-pack/solutions/observability/packages/kbn-scout-oblt @elastic/appex-qa
 x-pack/solutions/observability/packages/kbn-streams-schema @elastic/streams-program-team
 packages/kbn-styled-components-mapping-cli @elastic/kibana-operations @elastic/eui-team
 x-pack/solutions/observability/plugins/synthetics/e2e @elastic/obs-ux-management-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -958,6 +958,7 @@ packages/kbn-stdio-dev-helpers @elastic/kibana-operations
 packages/kbn-storybook @elastic/kibana-operations
 x-pack/solutions/observability/plugins/streams_app @simianhacker @flash1293 @dgieselaar
 x-pack/solutions/observability/plugins/streams @simianhacker @flash1293 @dgieselaar
+x-pack/solutions/observability/packages/kbn-scout-oblt @elastic/appex-qa
 x-pack/solutions/observability/packages/kbn-streams-schema @elastic/streams-program-team
 packages/kbn-styled-components-mapping-cli @elastic/kibana-operations @elastic/eui-team
 x-pack/solutions/observability/plugins/synthetics/e2e @elastic/obs-ux-management-team

--- a/package.json
+++ b/package.json
@@ -1496,6 +1496,7 @@
     "@kbn/reporting-mocks-server": "link:src/platform/packages/private/kbn-reporting/mocks_server",
     "@kbn/scout": "link:packages/kbn-scout",
     "@kbn/scout-info": "link:packages/kbn-scout-info",
+    "@kbn/scout-oblt": "link:x-pack/solutions/observability/packages/kbn-scout-oblt",
     "@kbn/scout-reporting": "link:packages/kbn-scout-reporting",
     "@kbn/security-api-integration-helpers": "link:x-pack/test/security_api_integration/packages/helpers",
     "@kbn/serverless-storybook-config": "link:packages/serverless/storybook/config",

--- a/packages/kbn-scout/index.ts
+++ b/packages/kbn-scout/index.ts
@@ -36,3 +36,8 @@ export type {
   ScoutServerConfig,
   ScoutTestConfig,
 } from './src/types';
+
+// re-export from Playwright
+export type { Locator } from 'playwright/test';
+
+export { measurePerformance, measurePerformanceAsync } from './src/common';

--- a/packages/kbn-scout/src/playwright/fixtures/parallel_run_fixtures.ts
+++ b/packages/kbn-scout/src/playwright/fixtures/parallel_run_fixtures.ts
@@ -8,8 +8,9 @@
  */
 
 import { mergeTests } from 'playwright/test';
-import { coreWorkerFixtures, scoutSpaceParallelFixture } from './worker';
+import { apiFixtures, coreWorkerFixtures, scoutSpaceParallelFixture } from './worker';
 import type {
+  ApiParallelWorkerFixtures,
   EsClient,
   KbnClient,
   KibanaUrl,
@@ -29,6 +30,7 @@ export const scoutParallelFixtures = mergeTests(
   // worker scope fixtures
   coreWorkerFixtures,
   scoutSpaceParallelFixture,
+  apiFixtures,
   // test scope fixtures
   browserAuthFixture,
   scoutPageParallelFixture,
@@ -42,7 +44,7 @@ export interface ScoutParallelTestFixtures {
   pageObjects: PageObjects;
 }
 
-export interface ScoutParallelWorkerFixtures {
+export interface ScoutParallelWorkerFixtures extends ApiParallelWorkerFixtures {
   log: ScoutLogger;
   config: ScoutTestConfig;
   kbnUrl: KibanaUrl;

--- a/packages/kbn-scout/src/playwright/fixtures/single_thread_fixtures.ts
+++ b/packages/kbn-scout/src/playwright/fixtures/single_thread_fixtures.ts
@@ -8,7 +8,13 @@
  */
 
 import { mergeTests } from 'playwright/test';
-import { coreWorkerFixtures, esArchiverFixture, uiSettingsFixture } from './worker';
+import {
+  ApiFixtures,
+  apiFixtures,
+  coreWorkerFixtures,
+  esArchiverFixture,
+  uiSettingsFixture,
+} from './worker';
 import type {
   EsArchiverFixture,
   EsClient,
@@ -34,6 +40,8 @@ export const scoutFixtures = mergeTests(
   coreWorkerFixtures,
   esArchiverFixture,
   uiSettingsFixture,
+  // api fixtures
+  apiFixtures,
   // test scope fixtures
   browserAuthFixture,
   scoutPageFixture,
@@ -47,7 +55,7 @@ export interface ScoutTestFixtures {
   pageObjects: PageObjects;
 }
 
-export interface ScoutWorkerFixtures {
+export interface ScoutWorkerFixtures extends ApiFixtures {
   log: ScoutLogger;
   config: ScoutTestConfig;
   kbnUrl: KibanaUrl;

--- a/packages/kbn-scout/src/playwright/fixtures/test/scout_page/index.ts
+++ b/packages/kbn-scout/src/playwright/fixtures/test/scout_page/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { Page } from '@playwright/test';
+import { PathOptions } from '../../../../common/services/kibana_url';
 
 /**
  * Extends the Playwright 'Page' interface with methods specific to Kibana.
@@ -24,7 +25,7 @@ export type ScoutPage = Page & {
    * @param options - Additional navigation options, passed directly to Playwright's `goto` method.
    * @returns A Promise resolving to a Playwright `Response` or `null`.
    */
-  gotoApp: (appName: string, options?: Parameters<Page['goto']>[1]) => ReturnType<Page['goto']>;
+  gotoApp: (appName: string, pathOptions?: PathOptions) => ReturnType<Page['goto']>;
   /**
    * Waits for the Kibana loading spinner indicator to disappear.
    * @returns A Promise resolving when the indicator is hidden.

--- a/packages/kbn-scout/src/playwright/fixtures/test/scout_page/parallel.ts
+++ b/packages/kbn-scout/src/playwright/fixtures/test/scout_page/parallel.ts
@@ -8,6 +8,7 @@
  */
 
 import { Page, test as base } from '@playwright/test';
+import { PathOptions } from '../../../../common/services/kibana_url';
 import { ScoutPage } from '.';
 import { KibanaUrl, ScoutLogger } from '../../worker';
 import { ScoutSpaceParallelFixture } from '../../worker/scout_space';
@@ -29,8 +30,8 @@ export const scoutPageParallelFixture = base.extend<
     const extendedPage = extendPlaywrightPage({ page, kbnUrl });
 
     // Overriding navigation to specific Kibana apps: url should respect the Kibana Space id
-    extendedPage.gotoApp = (appName: string) =>
-      page.goto(kbnUrl.app(appName, { space: scoutSpace.id }));
+    extendedPage.gotoApp = (appName: string, pathOptions?: PathOptions) =>
+      page.goto(kbnUrl.app(appName, { space: scoutSpace.id, pathOptions }));
 
     log.serviceLoaded(`scoutPage:${scoutSpace.id}`);
     await use(extendedPage);

--- a/packages/kbn-scout/src/playwright/fixtures/test/scout_page/single_thread.ts
+++ b/packages/kbn-scout/src/playwright/fixtures/test/scout_page/single_thread.ts
@@ -9,6 +9,7 @@
 
 import { Page } from '@playwright/test';
 import { subj } from '@kbn/test-subj-selector';
+import { PathOptions } from '../../../../common/services/kibana_url';
 import { KibanaUrl, ScoutLogger, coreWorkerFixtures } from '../../worker';
 import { ScoutPage } from '.';
 
@@ -81,7 +82,8 @@ export function extendPlaywrightPage({
   // Extend page with '@kbn/test-subj-selector' support
   extendedPage.testSubj = extendPageWithTestSubject(page);
   // Method to navigate to specific Kibana apps
-  extendedPage.gotoApp = (appName: string) => page.goto(kbnUrl.app(appName));
+  extendedPage.gotoApp = (appName: string, pathOptions?: PathOptions) =>
+    page.goto(kbnUrl.app(appName, { pathOptions }));
   // Method to wait for global loading indicator to be hidden
   extendedPage.waitForLoadingIndicatorHidden = () =>
     extendedPage.testSubj.waitForSelector('globalLoadingIndicator-hidden', {

--- a/packages/kbn-scout/src/playwright/fixtures/worker/apis/fleet/index.ts
+++ b/packages/kbn-scout/src/playwright/fixtures/worker/apis/fleet/index.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { measurePerformanceAsync } from '../../../../../common';
+import { coreWorkerFixtures } from '../../core_fixtures';
+
+export interface FleetApiFixture {
+  integration: {
+    install: (name: string) => Promise<void>;
+    delete: (name: string) => Promise<void>;
+  };
+}
+
+/**
+ * This fixture provides a helper to interact with the Fleet API.
+ */
+export const fleetApiFixture = coreWorkerFixtures.extend<{}, { fleetApi: FleetApiFixture }>({
+  fleetApi: [
+    async ({ kbnClient, log }, use) => {
+      const fleetApiHelper = {
+        integration: {
+          install: async (name: string) => {
+            await measurePerformanceAsync(
+              log,
+              `fleetApi.integration.install [${name}]`,
+              async () => {
+                await kbnClient.request({
+                  method: 'POST',
+                  path: `/api/fleet/epm/custom_integrations`,
+                  body: {
+                    force: true,
+                    integrationName: name,
+                    datasets: [
+                      { name: `${name}.access`, type: 'logs' },
+                      { name: `${name}.error`, type: 'metrics' },
+                      { name: `${name}.warning`, type: 'logs' },
+                    ],
+                  },
+                });
+              }
+            );
+          },
+
+          delete: async (name: string) => {
+            await measurePerformanceAsync(
+              log,
+              `fleetApi.integration.delete [${name}]`,
+              async () => {
+                await kbnClient.request({
+                  method: 'DELETE',
+                  path: `/api/fleet/epm/packages/${name}`,
+                  ignoreErrors: [400],
+                });
+              }
+            );
+          },
+        },
+      };
+
+      log.serviceLoaded('fleetApi');
+      await use(fleetApiHelper);
+    },
+    { scope: 'worker' },
+  ],
+});

--- a/packages/kbn-scout/src/playwright/fixtures/worker/apis/index.ts
+++ b/packages/kbn-scout/src/playwright/fixtures/worker/apis/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { mergeTests } from 'playwright/test';
+import { FleetApiFixture, fleetApiFixture } from './fleet';
+
+export const apiFixtures = mergeTests(fleetApiFixture);
+
+export interface ApiFixtures {
+  fleetApi: FleetApiFixture;
+}
+
+export interface ApiParallelWorkerFixtures {
+  fleetApi: FleetApiFixture;
+}

--- a/packages/kbn-scout/src/playwright/fixtures/worker/index.ts
+++ b/packages/kbn-scout/src/playwright/fixtures/worker/index.ts
@@ -25,3 +25,6 @@ export type { UiSettingsFixture } from './ui_settings';
 
 export { scoutSpaceParallelFixture } from './scout_space';
 export type { ScoutSpaceParallelFixture } from './scout_space';
+
+export { apiFixtures } from './apis';
+export type { ApiFixtures, ApiParallelWorkerFixtures } from './apis';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1582,6 +1582,8 @@
       "@kbn/scout/*": ["packages/kbn-scout/*"],
       "@kbn/scout-info": ["packages/kbn-scout-info"],
       "@kbn/scout-info/*": ["packages/kbn-scout-info/*"],
+      "@kbn/scout-oblt": ["x-pack/solutions/observability/packages/kbn-scout-oblt"],
+      "@kbn/scout-oblt/*": ["x-pack/solutions/observability/packages/kbn-scout-oblt/*"],
       "@kbn/scout-reporting": ["packages/kbn-scout-reporting"],
       "@kbn/scout-reporting/*": ["packages/kbn-scout-reporting/*"],
       "@kbn/screenshot-mode-example-plugin": ["examples/screenshot_mode_example"],

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/README.md
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/README.md
@@ -1,0 +1,45 @@
+# @kbn/scout-oblt
+
+`@kbn/scout-oblt` is a test library that extends `@kbn/scout` with test helpers specifically designed for `Observability` products in Kibana.
+
+Its primary goal is to simplify the test development experience for teams working on `Observability` plugins by providing custom Playwright fixtures, page objects, and utilities tailored for Observability-related testing scenarios.
+
+### Table of Contents
+
+1. Folder Structure
+2. How to Use
+3. Contributing
+
+### Folder Structure
+
+The `@kbn/scout-oblt` structure includes the following key directories and files:
+
+```
+x-pack/solutions/observability/packages/kbn-scout-oblt/
+├── src/
+│   ├── playwright/
+│   │   └── fixtures
+│   │   │   └── test/
+│   │   │   │   └── // Observability test-scope fixtures
+│   │   │   └── worker/
+│   │   │   │   └── // Observability worker-scope fixtures
+│   │   │   └── single_thread_fixtures.ts
+│   │   │   └── parallel_run_fixtures.ts
+│   │   │   └── index.ts
+│   │   └── page_objects/
+│   │   │   └── // Observability pages
+│   └── index.ts
+├── package.json
+├── tsconfig.json
+```
+
+### How to use
+
+```
+import { test } from '@kbn/scout-oblt';
+
+test('verifies Observability Home loads', async ({ page, pageObjects }) => {
+  await pageObjects.onboardingHome.goto();
+  expect(await page.title()).toContain('Observability');
+});
+```

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/index.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { test, spaceTest } from './src/playwright';
+export type {
+  ObltPageObjects,
+  ObltTestFixtures,
+  ObltWorkerFixtures,
+  ObltParallelTestFixtures,
+  ObltParallelWorkerFixtures,
+} from './src/playwright';
+
+// re-export from @kbn/scout
+export {
+  expect,
+  tags,
+  createPlaywrightConfig,
+  createLazyPageObject,
+  ingestTestDataHook,
+} from '@kbn/scout';
+
+export type {
+  EsClient,
+  KbnClient,
+  KibanaUrl,
+  ScoutLogger,
+  ScoutPage,
+  PageObjects,
+  ScoutServerConfig,
+  ScoutTestConfig,
+  ScoutPlaywrightOptions,
+  ScoutTestOptions,
+  Locator,
+} from '@kbn/scout';

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/jest.config.js
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/jest.config.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/x-pack/solutions/observability/packages/kbn-scout-oblt'],
+};

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/kibana.jsonc
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/kibana.jsonc
@@ -1,0 +1,6 @@
+{
+  "type": "test-helper",
+  "id": "@kbn/scout-oblt",
+  "owner": "@elastic/appex-qa",
+  "devOnly": true
+}

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/package.json
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/scout-oblt",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0"
+}

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { test } from './single_thread_fixtures';
+export { spaceTest } from './parallel_run_fixtures';
+export * from './types';

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/parallel_run_fixtures.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/parallel_run_fixtures.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { spaceTest as spaceBase } from '@kbn/scout';
+
+import { extendPageObjects } from '../page_objects';
+import { ObltParallelTestFixtures, ObltParallelWorkerFixtures } from './types';
+
+/**
+ * Should be used test spec files, running in parallel in isolated spaces agaist the same Kibana instance.
+ */
+export const spaceTest = spaceBase.extend<ObltParallelTestFixtures, ObltParallelWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: ObltParallelTestFixtures['pageObjects'];
+      page: ObltParallelTestFixtures['page'];
+    },
+    use: (pageObjects: ObltParallelTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    const extendedPageObjects = extendPageObjects(pageObjects, page);
+    await use(extendedPageObjects);
+  },
+});

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/single_thread_fixtures.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/single_thread_fixtures.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { test as base } from '@kbn/scout';
+
+import { extendPageObjects } from '../page_objects';
+import { ObltTestFixtures, ObltWorkerFixtures } from './types';
+
+/**
+ * Should be used for the test spec files executed seqentially.
+ */
+export const test = base.extend<ObltTestFixtures, ObltWorkerFixtures>({
+  pageObjects: async (
+    {
+      pageObjects,
+      page,
+    }: {
+      pageObjects: ObltTestFixtures['pageObjects'];
+      page: ObltTestFixtures['page'];
+    },
+    use: (pageObjects: ObltTestFixtures['pageObjects']) => Promise<void>
+  ) => {
+    const extendedPageObjects = extendPageObjects(pageObjects, page);
+    await use(extendedPageObjects);
+  },
+});

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/types.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/fixtures/types.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ScoutParallelTestFixtures,
+  ScoutParallelWorkerFixtures,
+  ScoutTestFixtures,
+  ScoutWorkerFixtures,
+} from '@kbn/scout';
+import { ObltPageObjects } from '../page_objects';
+
+export interface ObltTestFixtures extends ScoutTestFixtures {
+  pageObjects: ObltPageObjects;
+}
+
+export type ObltWorkerFixtures = ScoutWorkerFixtures;
+
+export interface ObltParallelTestFixtures extends ScoutParallelTestFixtures {
+  pageObjects: ObltPageObjects;
+}
+
+export type ObltParallelWorkerFixtures = ScoutParallelWorkerFixtures;

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+<<<<<<<< HEAD:x-pack/platform/plugins/shared/logs_shared/public/containers/logs/log_highlights/index.ts
+export * from './log_highlights';
+========
+export * from './fixtures';
+export type { ObltPageObjects } from './page_objects';
+>>>>>>>> bd13e829498 ([scout] adding test helper `@kbn/scout-oblt` package and uptate onboarding tests (#209761)):x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/index.ts

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/index.ts
@@ -5,9 +5,5 @@
  * 2.0.
  */
 
-<<<<<<<< HEAD:x-pack/platform/plugins/shared/logs_shared/public/containers/logs/log_highlights/index.ts
-export * from './log_highlights';
-========
 export * from './fixtures';
 export type { ObltPageObjects } from './page_objects';
->>>>>>>> bd13e829498 ([scout] adding test helper `@kbn/scout-oblt` package and uptate onboarding tests (#209761)):x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/index.ts

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/custom_logs.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/custom_logs.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ScoutPage, Locator } from '@kbn/scout';
+
+export class CustomLogsPage {
+  public advancedSettingsContent: Locator;
+  public logFilePathList: Locator;
+  public addLogFilePathButton: Locator;
+  public integrationNameInput: Locator;
+  public datasetNameInput: Locator;
+  public serviceNameInput: Locator;
+  public namespaceInput: Locator;
+  public customConfigInput: Locator;
+  public customIntegrationInstalledCallout: Locator;
+  public customIntegrationErrorCallout: Locator;
+  public apiKeyCreatedCallout: Locator;
+  public apiKeyPrivilegesErrorCallout: Locator;
+  public apiKeyCreateErrorCallout: Locator;
+  public autoDownloadConfigurationToggle: Locator;
+  public autoDownloadConfigurationCallout: Locator;
+  public installCodeSnippet: Locator;
+  public windowsInstallElasticAgentDocLink: Locator;
+  public configureElasticAgentStep: Locator;
+  public downloadConfigurationButton: Locator;
+  public continueButton: Locator;
+  public exploreLogsButton: Locator;
+  public checkLogsStepMessage: Locator;
+
+  constructor(private readonly page: ScoutPage) {
+    this.advancedSettingsContent = this.page.testSubj
+      .locator('obltOnboardingCustomLogsAdvancedSettings')
+      .getByRole('group');
+    this.logFilePathList = this.page.locator(`[data-test-subj^=obltOnboardingLogFilePath-]`);
+    this.addLogFilePathButton = this.page.testSubj.locator('obltOnboardingCustomLogsAddFilePath');
+    this.integrationNameInput = this.page.testSubj.locator(
+      'obltOnboardingCustomLogsIntegrationsName'
+    );
+    this.datasetNameInput = this.page.testSubj.locator('obltOnboardingCustomLogsDatasetName');
+    this.serviceNameInput = this.page.testSubj.locator('obltOnboardingCustomLogsServiceName');
+    this.namespaceInput = this.page.testSubj.locator('obltOnboardingCustomLogsNamespace');
+
+    this.continueButton = page.testSubj.locator('obltOnboardingCustomLogsContinue');
+
+    this.customConfigInput = this.page.testSubj.locator('obltOnboardingCustomLogsCustomConfig');
+    this.customIntegrationInstalledCallout = this.page.testSubj.locator(
+      'obltOnboardingCustomIntegrationInstalled'
+    );
+    this.customIntegrationErrorCallout = this.page.testSubj.locator(
+      'obltOnboardingCustomIntegrationErrorCallout'
+    );
+    this.apiKeyCreatedCallout = this.page.testSubj.locator('obltOnboardingLogsApiKeyCreated');
+    this.apiKeyPrivilegesErrorCallout = this.page.testSubj.locator(
+      'obltOnboardingLogsApiKeyCreationNoPrivileges'
+    );
+    this.apiKeyCreateErrorCallout = this.page.testSubj.locator(
+      'obltOnboardingLogsApiKeyCreationFailed'
+    );
+    this.autoDownloadConfigurationToggle = this.page.testSubj.locator(
+      'obltOnboardingInstallElasticAgentAutoDownloadConfig'
+    );
+    this.autoDownloadConfigurationCallout = this.page.testSubj.locator(
+      'obltOnboardingInstallElasticAgentAutoDownloadConfigCallout'
+    );
+    this.installCodeSnippet = this.page.testSubj
+      .locator('obltOnboardingInstallElasticAgentStep')
+      .getByRole('code');
+    this.windowsInstallElasticAgentDocLink = this.page.testSubj.locator(
+      'obltOnboardingInstallElasticAgentWindowsDocsLink'
+    );
+    this.configureElasticAgentStep = this.page.testSubj.locator(
+      'obltOnboardingConfigureElasticAgentStep'
+    );
+    this.downloadConfigurationButton = this.page.testSubj.locator(
+      'obltOnboardingConfigureElasticAgentStepDownloadConfig'
+    );
+
+    this.exploreLogsButton = this.page.testSubj.locator('obltOnboardingExploreLogs');
+    this.checkLogsStepMessage = this.page.testSubj
+      .locator('obltOnboardingCheckLogsStep')
+      .locator(`.euiStep__title`);
+  }
+
+  async goto() {
+    return this.page.gotoApp('observabilityOnboarding/customLogs');
+  }
+
+  async clickBackButton() {
+    return this.page.testSubj.click('observabilityOnboardingFlowBackToSelectionButton');
+  }
+
+  getLogFilePathInputField(index: number) {
+    return this.page.testSubj.locator(`obltOnboardingLogFilePath-${index}`).getByRole('textbox');
+  }
+
+  logFilePathDeleteButton(index: number) {
+    return this.page.testSubj.locator(`obltOnboardingLogFilePathDelete-${index}`);
+  }
+
+  async clickAdvancedSettingsButton() {
+    return this.page.testSubj
+      .locator('obltOnboardingCustomLogsAdvancedSettings')
+      .getByRole('button')
+      .first()
+      .click();
+  }
+
+  getStepStatusLocator(status: 'loading' | 'complete' | 'danger' | 'warning') {
+    return this.page.testSubj.locator(`obltOnboardingStepStatus-${status}`);
+  }
+
+  async selectPlatform(name: 'linux' | 'macos' | 'windows') {
+    return this.page.testSubj.click(name);
+  }
+
+  getCheckLogsStepLocator(status: 'loading' | 'incomplete' | 'complete') {
+    return this.page.testSubj
+      .locator('obltOnboardingCheckLogsStep')
+      .locator(`.euiStep__titleWrapper [class$="euiStepNumber-s-${status}"]`);
+  }
+}

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/index.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PageObjects, ScoutPage, createLazyPageObject } from '@kbn/scout';
+import { OnboardingHomePage } from './onboarding_home';
+import { CustomLogsPage } from './custom_logs';
+
+export interface ObltPageObjects extends PageObjects {
+  onboardingHome: OnboardingHomePage;
+  customLogs: CustomLogsPage;
+}
+
+export function extendPageObjects(pageObjects: PageObjects, page: ScoutPage): ObltPageObjects {
+  return {
+    ...pageObjects,
+    onboardingHome: createLazyPageObject(OnboardingHomePage, page),
+    customLogs: createLazyPageObject(CustomLogsPage, page),
+  };
+}

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/onboarding_home.ts
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/src/playwright/page_objects/onboarding_home.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const QUERY_TESTER_TITLE = i18n.translate(
+  'xpack.enterpriseSearch.appSearch.engine.queryTesterTitle',
+  {
+    defaultMessage: 'Query tester',
+  }
+);

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/tsconfig.json
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": [
+    "@kbn/scout",
+  ]
+}

--- a/x-pack/solutions/observability/packages/kbn-scout-oblt/tsconfig.json
+++ b/x-pack/solutions/observability/packages/kbn-scout-oblt/tsconfig.json
@@ -15,5 +15,6 @@
   ],
   "kbn_references": [
     "@kbn/scout",
+    "@kbn/i18n",
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7014,6 +7014,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/scout-oblt@link:x-pack/solutions/observability/packages/kbn-scout-oblt":
+  version "0.0.0"
+  uid ""
+
 "@kbn/scout-reporting@link:packages/kbn-scout-reporting":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[scout] adding test helper &#x60;@kbn/scout-oblt&#x60; package and uptate onboarding tests (#209761)](https://github.com/elastic/kibana/pull/209761)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-02-11T17:38:41Z","message":"[scout] adding test helper `@kbn/scout-oblt` package and uptate onboarding tests (#209761)\n\n## Summary\r\n\r\n`@kbn/scout-oblt` is a test library that extends `@kbn/scout` with test\r\nhelpers specifically designed to test `Observability` applications in\r\nKibana. All Oblt plugins should only import from `@kbn/scout-oblt`\r\n\r\nIts primary goal is to simplify the test development experience for\r\nteams working on `Observability` plugins by providing custom Playwright\r\nfixtures, page objects, and utilities tailored for Observability-related\r\ntesting scenarios.\r\n\r\nContributing:\r\n- when Fixture/Page Object is sharable across all Solutions and Platform\r\n(`fleetApi` fixture), it should be added in `@kbn/scout`\r\n- when Fixture/Page Object is Oblt-specific but is shared across tests\r\nunder the multiple plugins (`OnboardingHome` page), it should be added\r\nin `@kbn/scout-oblt`\r\n- when Fixture/Page Object is only used in a single plugin (`onboarding`\r\ninternal APIs ?), it should be added in this plugin.\r\n\r\nI also re-worked existing tests with few ideas in mind:\r\n- Scout is **e2e testing tool** and should target primary e2e test\r\nscenarios; We have _API integration tests_ to test multiple short\r\nscenarios for APIs behavior (response, status code) and _jest/React\r\ntesting library_ to test components in isolation (elements rendering,\r\nfields validation). Doing all the testing with e2e tool like Playwright\r\nwill dramatically affect cost efficiency and stability of tests, but\r\nalso slows overall CI execution and PRs delivery. The goal is to follow\r\ntesting pyramid and keep in mind its principles.\r\n- We on purpose spin up new browser context for each `test` block to\r\nmake sure our **tests are independent**. Having too many short `test`\r\nblocks in the file significantly slows down the execution: every block\r\ntriggers browser context, saml authentication, adding/removing Fleet\r\nintegrations (each call up to 2 seconds) and other beforeEach/afterEach\r\nhooks. Real browser-based testing is expensive. It is not about putting\r\nevery step into 1 `test` block, but also not a Jest unit-test-style\r\ndesign. When it is possible to group similar actions on the same page\r\nand if it is a part of the same user flow - we should do it. It also\r\ndoesn't bring the testing value repeating the same UI steps multiple\r\ntimes in different scenarios. _Our CI costs are critical to cut when it\r\nis possible_\r\n- Avoid **nesting describe** blocks: it complicates test readability and\r\nalso complicates for CI bot to properly skip the failing block (it will\r\nskip the top level one). We encourage **Scout parallel test execution**\r\nbased on running test spec files in multiple workers, not the `test`\r\nblocks within the same file. Having too many `test` blocks in the same\r\nfile will be slowly run in the single thread and in case of flakiness,\r\nit means Team lose more test coverage than they probably expect.\r\n\r\nBefore (**59** test blocks - **8-8.5 min** per distro):\r\n<img width=\"1709\" alt=\"Screenshot 2025-02-08 at 18 01 40\"\r\nsrc=\"https://github.com/user-attachments/assets/5fd65a1c-85f9-4594-9dae-3f8e99a005ab\"\r\n/>\r\n\r\nAfter (**15** test blocks - **3.5-4 min** per distro):\r\n<img width=\"1578\" alt=\"Screenshot 2025-02-10 at 18 14 42\"\r\nsrc=\"https://github.com/user-attachments/assets/6846898f-7dd2-4f6b-8bc5-d06741b0b120\"\r\n/>\r\n\r\nFor reviewers: updated tests are possible to run in 2 parallel workers\r\nagainst the same Kibana/ES instance and run time is dropping to **2.5-3\r\nmin** 🚀 . It is up to UX-Logs team to decide if you want to keep\r\nparallel run (new tests can be added either to parallel or sequential\r\nrun)\r\n<img width=\"1578\" alt=\"Screenshot 2025-02-11 at 12 14 30\"\r\nsrc=\"https://github.com/user-attachments/assets/e94113f2-d7f1-470e-a6d5-cb5154d99c41\"\r\n/>\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bd13e829498032c07bf8490f770a563f34e9f856","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:version","test:scout","v9.1.0","v8.19.0"],"title":"[scout] adding test helper `@kbn/scout-oblt` package and uptate onboarding tests","number":209761,"url":"https://github.com/elastic/kibana/pull/209761","mergeCommit":{"message":"[scout] adding test helper `@kbn/scout-oblt` package and uptate onboarding tests (#209761)\n\n## Summary\r\n\r\n`@kbn/scout-oblt` is a test library that extends `@kbn/scout` with test\r\nhelpers specifically designed to test `Observability` applications in\r\nKibana. All Oblt plugins should only import from `@kbn/scout-oblt`\r\n\r\nIts primary goal is to simplify the test development experience for\r\nteams working on `Observability` plugins by providing custom Playwright\r\nfixtures, page objects, and utilities tailored for Observability-related\r\ntesting scenarios.\r\n\r\nContributing:\r\n- when Fixture/Page Object is sharable across all Solutions and Platform\r\n(`fleetApi` fixture), it should be added in `@kbn/scout`\r\n- when Fixture/Page Object is Oblt-specific but is shared across tests\r\nunder the multiple plugins (`OnboardingHome` page), it should be added\r\nin `@kbn/scout-oblt`\r\n- when Fixture/Page Object is only used in a single plugin (`onboarding`\r\ninternal APIs ?), it should be added in this plugin.\r\n\r\nI also re-worked existing tests with few ideas in mind:\r\n- Scout is **e2e testing tool** and should target primary e2e test\r\nscenarios; We have _API integration tests_ to test multiple short\r\nscenarios for APIs behavior (response, status code) and _jest/React\r\ntesting library_ to test components in isolation (elements rendering,\r\nfields validation). Doing all the testing with e2e tool like Playwright\r\nwill dramatically affect cost efficiency and stability of tests, but\r\nalso slows overall CI execution and PRs delivery. The goal is to follow\r\ntesting pyramid and keep in mind its principles.\r\n- We on purpose spin up new browser context for each `test` block to\r\nmake sure our **tests are independent**. Having too many short `test`\r\nblocks in the file significantly slows down the execution: every block\r\ntriggers browser context, saml authentication, adding/removing Fleet\r\nintegrations (each call up to 2 seconds) and other beforeEach/afterEach\r\nhooks. Real browser-based testing is expensive. It is not about putting\r\nevery step into 1 `test` block, but also not a Jest unit-test-style\r\ndesign. When it is possible to group similar actions on the same page\r\nand if it is a part of the same user flow - we should do it. It also\r\ndoesn't bring the testing value repeating the same UI steps multiple\r\ntimes in different scenarios. _Our CI costs are critical to cut when it\r\nis possible_\r\n- Avoid **nesting describe** blocks: it complicates test readability and\r\nalso complicates for CI bot to properly skip the failing block (it will\r\nskip the top level one). We encourage **Scout parallel test execution**\r\nbased on running test spec files in multiple workers, not the `test`\r\nblocks within the same file. Having too many `test` blocks in the same\r\nfile will be slowly run in the single thread and in case of flakiness,\r\nit means Team lose more test coverage than they probably expect.\r\n\r\nBefore (**59** test blocks - **8-8.5 min** per distro):\r\n<img width=\"1709\" alt=\"Screenshot 2025-02-08 at 18 01 40\"\r\nsrc=\"https://github.com/user-attachments/assets/5fd65a1c-85f9-4594-9dae-3f8e99a005ab\"\r\n/>\r\n\r\nAfter (**15** test blocks - **3.5-4 min** per distro):\r\n<img width=\"1578\" alt=\"Screenshot 2025-02-10 at 18 14 42\"\r\nsrc=\"https://github.com/user-attachments/assets/6846898f-7dd2-4f6b-8bc5-d06741b0b120\"\r\n/>\r\n\r\nFor reviewers: updated tests are possible to run in 2 parallel workers\r\nagainst the same Kibana/ES instance and run time is dropping to **2.5-3\r\nmin** 🚀 . It is up to UX-Logs team to decide if you want to keep\r\nparallel run (new tests can be added either to parallel or sequential\r\nrun)\r\n<img width=\"1578\" alt=\"Screenshot 2025-02-11 at 12 14 30\"\r\nsrc=\"https://github.com/user-attachments/assets/e94113f2-d7f1-470e-a6d5-cb5154d99c41\"\r\n/>\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bd13e829498032c07bf8490f770a563f34e9f856"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210675","number":210675,"state":"MERGED","mergeCommit":{"sha":"187b2307220a1f54776b0b3b05d131b0e75b6e03","message":"[9.0] [scout] adding test helper &#x60;@kbn/scout-oblt&#x60; package and uptate onboarding tests (#209761) (#210675)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[scout] adding test helper &#x60;@kbn/scout-oblt&#x60; package and\nuptate onboarding tests\n(#209761)](https://github.com/elastic/kibana/pull/209761)\n\n<!--- Backport version: 9.4.3 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Dzmitry\nLemechko\",\"email\":\"dzmitry.lemechko@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-02-11T17:38:41Z\",\"message\":\"[scout]\nadding test helper `@kbn/scout-oblt` package and uptate onboarding tests\n(#209761)\\n\\n## Summary\\r\\n\\r\\n`@kbn/scout-oblt` is a test library that\nextends `@kbn/scout` with test\\r\\nhelpers specifically designed to test\n`Observability` applications in\\r\\nKibana. All Oblt plugins should only\nimport from `@kbn/scout-oblt`\\r\\n\\r\\nIts primary goal is to simplify the\ntest development experience for\\r\\nteams working on `Observability`\nplugins by providing custom Playwright\\r\\nfixtures, page objects, and\nutilities tailored for Observability-related\\r\\ntesting\nscenarios.\\r\\n\\r\\nContributing:\\r\\n- when Fixture/Page Object is\nsharable across all Solutions and Platform\\r\\n(`fleetApi` fixture), it\nshould be added in `@kbn/scout`\\r\\n- when Fixture/Page Object is\nOblt-specific but is shared across tests\\r\\nunder the multiple plugins\n(`OnboardingHome` page), it should be added\\r\\nin `@kbn/scout-oblt`\\r\\n-\nwhen Fixture/Page Object is only used in a single plugin\n(`onboarding`\\r\\ninternal APIs ?), it should be added in this\nplugin.\\r\\n\\r\\nI also re-worked existing tests with few ideas in\nmind:\\r\\n- Scout is **e2e testing tool** and should target primary e2e\ntest\\r\\nscenarios; We have _API integration tests_ to test multiple\nshort\\r\\nscenarios for APIs behavior (response, status code) and\n_jest/React\\r\\ntesting library_ to test components in isolation\n(elements rendering,\\r\\nfields validation). Doing all the testing with\ne2e tool like Playwright\\r\\nwill dramatically affect cost efficiency and\nstability of tests, but\\r\\nalso slows overall CI execution and PRs\ndelivery. The goal is to follow\\r\\ntesting pyramid and keep in mind its\nprinciples.\\r\\n- We on purpose spin up new browser context for each\n`test` block to\\r\\nmake sure our **tests are independent**. Having too\nmany short `test`\\r\\nblocks in the file significantly slows down the\nexecution: every block\\r\\ntriggers browser context, saml authentication,\nadding/removing Fleet\\r\\nintegrations (each call up to 2 seconds) and\nother beforeEach/afterEach\\r\\nhooks. Real browser-based testing is\nexpensive. It is not about putting\\r\\nevery step into 1 `test` block,\nbut also not a Jest unit-test-style\\r\\ndesign. When it is possible to\ngroup similar actions on the same page\\r\\nand if it is a part of the\nsame user flow - we should do it. It also\\r\\ndoesn't bring the testing\nvalue repeating the same UI steps multiple\\r\\ntimes in different\nscenarios. _Our CI costs are critical to cut when it\\r\\nis\npossible_\\r\\n- Avoid **nesting describe** blocks: it complicates test\nreadability and\\r\\nalso complicates for CI bot to properly skip the\nfailing block (it will\\r\\nskip the top level one). We encourage **Scout\nparallel test execution**\\r\\nbased on running test spec files in\nmultiple workers, not the `test`\\r\\nblocks within the same file. Having\ntoo many `test` blocks in the same\\r\\nfile will be slowly run in the\nsingle thread and in case of flakiness,\\r\\nit means Team lose more test\ncoverage than they probably expect.\\r\\n\\r\\nBefore (**59** test blocks -\n**8-8.5 min** per distro):\\r\\n<img width=\\\"1709\\\" alt=\\\"Screenshot\n2025-02-08 at 18 01\n40\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/5fd65a1c-85f9-4594-9dae-3f8e99a005ab\\\"\\r\\n/>\\r\\n\\r\\nAfter\n(**15** test blocks - **3.5-4 min** per distro):\\r\\n<img width=\\\"1578\\\"\nalt=\\\"Screenshot 2025-02-10 at 18 14\n42\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/6846898f-7dd2-4f6b-8bc5-d06741b0b120\\\"\\r\\n/>\\r\\n\\r\\nFor\nreviewers: updated tests are possible to run in 2 parallel\nworkers\\r\\nagainst the same Kibana/ES instance and run time is dropping\nto **2.5-3\\r\\nmin** 🚀 . It is up to UX-Logs team to decide if you want\nto keep\\r\\nparallel run (new tests can be added either to parallel or\nsequential\\r\\nrun)\\r\\n<img width=\\\"1578\\\" alt=\\\"Screenshot 2025-02-11 at\n12 14\n30\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/e94113f2-d7f1-470e-a6d5-cb5154d99c41\\\"\\r\\n/>\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"bd13e829498032c07bf8490f770a563f34e9f856\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"v9.0.0\",\"backport:version\",\"test:scout\",\"v9.1.0\",\"v8.19.0\"],\"title\":\"[scout]\nadding test helper `@kbn/scout-oblt` package and uptate onboarding\ntests\",\"number\":209761,\"url\":\"https://github.com/elastic/kibana/pull/209761\",\"mergeCommit\":{\"message\":\"[scout]\nadding test helper `@kbn/scout-oblt` package and uptate onboarding tests\n(#209761)\\n\\n## Summary\\r\\n\\r\\n`@kbn/scout-oblt` is a test library that\nextends `@kbn/scout` with test\\r\\nhelpers specifically designed to test\n`Observability` applications in\\r\\nKibana. All Oblt plugins should only\nimport from `@kbn/scout-oblt`\\r\\n\\r\\nIts primary goal is to simplify the\ntest development experience for\\r\\nteams working on `Observability`\nplugins by providing custom Playwright\\r\\nfixtures, page objects, and\nutilities tailored for Observability-related\\r\\ntesting\nscenarios.\\r\\n\\r\\nContributing:\\r\\n- when Fixture/Page Object is\nsharable across all Solutions and Platform\\r\\n(`fleetApi` fixture), it\nshould be added in `@kbn/scout`\\r\\n- when Fixture/Page Object is\nOblt-specific but is shared across tests\\r\\nunder the multiple plugins\n(`OnboardingHome` page), it should be added\\r\\nin `@kbn/scout-oblt`\\r\\n-\nwhen Fixture/Page Object is only used in a single plugin\n(`onboarding`\\r\\ninternal APIs ?), it should be added in this\nplugin.\\r\\n\\r\\nI also re-worked existing tests with few ideas in\nmind:\\r\\n- Scout is **e2e testing tool** and should target primary e2e\ntest\\r\\nscenarios; We have _API integration tests_ to test multiple\nshort\\r\\nscenarios for APIs behavior (response, status code) and\n_jest/React\\r\\ntesting library_ to test components in isolation\n(elements rendering,\\r\\nfields validation). Doing all the testing with\ne2e tool like Playwright\\r\\nwill dramatically affect cost efficiency and\nstability of tests, but\\r\\nalso slows overall CI execution and PRs\ndelivery. The goal is to follow\\r\\ntesting pyramid and keep in mind its\nprinciples.\\r\\n- We on purpose spin up new browser context for each\n`test` block to\\r\\nmake sure our **tests are independent**. Having too\nmany short `test`\\r\\nblocks in the file significantly slows down the\nexecution: every block\\r\\ntriggers browser context, saml authentication,\nadding/removing Fleet\\r\\nintegrations (each call up to 2 seconds) and\nother beforeEach/afterEach\\r\\nhooks. Real browser-based testing is\nexpensive. It is not about putting\\r\\nevery step into 1 `test` block,\nbut also not a Jest unit-test-style\\r\\ndesign. When it is possible to\ngroup similar actions on the same page\\r\\nand if it is a part of the\nsame user flow - we should do it. It also\\r\\ndoesn't bring the testing\nvalue repeating the same UI steps multiple\\r\\ntimes in different\nscenarios. _Our CI costs are critical to cut when it\\r\\nis\npossible_\\r\\n- Avoid **nesting describe** blocks: it complicates test\nreadability and\\r\\nalso complicates for CI bot to properly skip the\nfailing block (it will\\r\\nskip the top level one). We encourage **Scout\nparallel test execution**\\r\\nbased on running test spec files in\nmultiple workers, not the `test`\\r\\nblocks within the same file. Having\ntoo many `test` blocks in the same\\r\\nfile will be slowly run in the\nsingle thread and in case of flakiness,\\r\\nit means Team lose more test\ncoverage than they probably expect.\\r\\n\\r\\nBefore (**59** test blocks -\n**8-8.5 min** per distro):\\r\\n<img width=\\\"1709\\\" alt=\\\"Screenshot\n2025-02-08 at 18 01\n40\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/5fd65a1c-85f9-4594-9dae-3f8e99a005ab\\\"\\r\\n/>\\r\\n\\r\\nAfter\n(**15** test blocks - **3.5-4 min** per distro):\\r\\n<img width=\\\"1578\\\"\nalt=\\\"Screenshot 2025-02-10 at 18 14\n42\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/6846898f-7dd2-4f6b-8bc5-d06741b0b120\\\"\\r\\n/>\\r\\n\\r\\nFor\nreviewers: updated tests are possible to run in 2 parallel\nworkers\\r\\nagainst the same Kibana/ES instance and run time is dropping\nto **2.5-3\\r\\nmin** 🚀 . It is up to UX-Logs team to decide if you want\nto keep\\r\\nparallel run (new tests can be added either to parallel or\nsequential\\r\\nrun)\\r\\n<img width=\\\"1578\\\" alt=\\\"Screenshot 2025-02-11 at\n12 14\n30\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/e94113f2-d7f1-470e-a6d5-cb5154d99c41\\\"\\r\\n/>\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"bd13e829498032c07bf8490f770a563f34e9f856\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"9.0\",\"8.x\"],\"targetPullRequestStates\":[{\"branch\":\"9.0\",\"label\":\"v9.0.0\",\"branchLabelMappingKey\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/209761\",\"number\":209761,\"mergeCommit\":{\"message\":\"[scout]\nadding test helper `@kbn/scout-oblt` package and uptate onboarding tests\n(#209761)\\n\\n## Summary\\r\\n\\r\\n`@kbn/scout-oblt` is a test library that\nextends `@kbn/scout` with test\\r\\nhelpers specifically designed to test\n`Observability` applications in\\r\\nKibana. All Oblt plugins should only\nimport from `@kbn/scout-oblt`\\r\\n\\r\\nIts primary goal is to simplify the\ntest development experience for\\r\\nteams working on `Observability`\nplugins by providing custom Playwright\\r\\nfixtures, page objects, and\nutilities tailored for Observability-related\\r\\ntesting\nscenarios.\\r\\n\\r\\nContributing:\\r\\n- when Fixture/Page Object is\nsharable across all Solutions and Platform\\r\\n(`fleetApi` fixture), it\nshould be added in `@kbn/scout`\\r\\n- when Fixture/Page Object is\nOblt-specific but is shared across tests\\r\\nunder the multiple plugins\n(`OnboardingHome` page), it should be added\\r\\nin `@kbn/scout-oblt`\\r\\n-\nwhen Fixture/Page Object is only used in a single plugin\n(`onboarding`\\r\\ninternal APIs ?), it should be added in this\nplugin.\\r\\n\\r\\nI also re-worked existing tests with few ideas in\nmind:\\r\\n- Scout is **e2e testing tool** and should target primary e2e\ntest\\r\\nscenarios; We have _API integration tests_ to test multiple\nshort\\r\\nscenarios for APIs behavior (response, status code) and\n_jest/React\\r\\ntesting library_ to test components in isolation\n(elements rendering,\\r\\nfields validation). Doing all the testing with\ne2e tool like Playwright\\r\\nwill dramatically affect cost efficiency and\nstability of tests, but\\r\\nalso slows overall CI execution and PRs\ndelivery. The goal is to follow\\r\\ntesting pyramid and keep in mind its\nprinciples.\\r\\n- We on purpose spin up new browser context for each\n`test` block to\\r\\nmake sure our **tests are independent**. Having too\nmany short `test`\\r\\nblocks in the file significantly slows down the\nexecution: every block\\r\\ntriggers browser context, saml authentication,\nadding/removing Fleet\\r\\nintegrations (each call up to 2 seconds) and\nother beforeEach/afterEach\\r\\nhooks. Real browser-based testing is\nexpensive. It is not about putting\\r\\nevery step into 1 `test` block,\nbut also not a Jest unit-test-style\\r\\ndesign. When it is possible to\ngroup similar actions on the same page\\r\\nand if it is a part of the\nsame user flow - we should do it. It also\\r\\ndoesn't bring the testing\nvalue repeating the same UI steps multiple\\r\\ntimes in different\nscenarios. _Our CI costs are critical to cut when it\\r\\nis\npossible_\\r\\n- Avoid **nesting describe** blocks: it complicates test\nreadability and\\r\\nalso complicates for CI bot to properly skip the\nfailing block (it will\\r\\nskip the top level one). We encourage **Scout\nparallel test execution**\\r\\nbased on running test spec files in\nmultiple workers, not the `test`\\r\\nblocks within the same file. Having\ntoo many `test` blocks in the same\\r\\nfile will be slowly run in the\nsingle thread and in case of flakiness,\\r\\nit means Team lose more test\ncoverage than they probably expect.\\r\\n\\r\\nBefore (**59** test blocks -\n**8-8.5 min** per distro):\\r\\n<img width=\\\"1709\\\" alt=\\\"Screenshot\n2025-02-08 at 18 01\n40\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/5fd65a1c-85f9-4594-9dae-3f8e99a005ab\\\"\\r\\n/>\\r\\n\\r\\nAfter\n(**15** test blocks - **3.5-4 min** per distro):\\r\\n<img width=\\\"1578\\\"\nalt=\\\"Screenshot 2025-02-10 at 18 14\n42\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/6846898f-7dd2-4f6b-8bc5-d06741b0b120\\\"\\r\\n/>\\r\\n\\r\\nFor\nreviewers: updated tests are possible to run in 2 parallel\nworkers\\r\\nagainst the same Kibana/ES instance and run time is dropping\nto **2.5-3\\r\\nmin** 🚀 . It is up to UX-Logs team to decide if you want\nto keep\\r\\nparallel run (new tests can be added either to parallel or\nsequential\\r\\nrun)\\r\\n<img width=\\\"1578\\\" alt=\\\"Screenshot 2025-02-11 at\n12 14\n30\\\"\\r\\nsrc=\\\"https://github.com/user-attachments/assets/e94113f2-d7f1-470e-a6d5-cb5154d99c41\\\"\\r\\n/>\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"bd13e829498032c07bf8490f770a563f34e9f856\"}},{\"branch\":\"8.x\",\"label\":\"v8.19.0\",\"branchLabelMappingKey\":\"^v8.19.0$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209761","number":209761,"mergeCommit":{"message":"[scout] adding test helper `@kbn/scout-oblt` package and uptate onboarding tests (#209761)\n\n## Summary\r\n\r\n`@kbn/scout-oblt` is a test library that extends `@kbn/scout` with test\r\nhelpers specifically designed to test `Observability` applications in\r\nKibana. All Oblt plugins should only import from `@kbn/scout-oblt`\r\n\r\nIts primary goal is to simplify the test development experience for\r\nteams working on `Observability` plugins by providing custom Playwright\r\nfixtures, page objects, and utilities tailored for Observability-related\r\ntesting scenarios.\r\n\r\nContributing:\r\n- when Fixture/Page Object is sharable across all Solutions and Platform\r\n(`fleetApi` fixture), it should be added in `@kbn/scout`\r\n- when Fixture/Page Object is Oblt-specific but is shared across tests\r\nunder the multiple plugins (`OnboardingHome` page), it should be added\r\nin `@kbn/scout-oblt`\r\n- when Fixture/Page Object is only used in a single plugin (`onboarding`\r\ninternal APIs ?), it should be added in this plugin.\r\n\r\nI also re-worked existing tests with few ideas in mind:\r\n- Scout is **e2e testing tool** and should target primary e2e test\r\nscenarios; We have _API integration tests_ to test multiple short\r\nscenarios for APIs behavior (response, status code) and _jest/React\r\ntesting library_ to test components in isolation (elements rendering,\r\nfields validation). Doing all the testing with e2e tool like Playwright\r\nwill dramatically affect cost efficiency and stability of tests, but\r\nalso slows overall CI execution and PRs delivery. The goal is to follow\r\ntesting pyramid and keep in mind its principles.\r\n- We on purpose spin up new browser context for each `test` block to\r\nmake sure our **tests are independent**. Having too many short `test`\r\nblocks in the file significantly slows down the execution: every block\r\ntriggers browser context, saml authentication, adding/removing Fleet\r\nintegrations (each call up to 2 seconds) and other beforeEach/afterEach\r\nhooks. Real browser-based testing is expensive. It is not about putting\r\nevery step into 1 `test` block, but also not a Jest unit-test-style\r\ndesign. When it is possible to group similar actions on the same page\r\nand if it is a part of the same user flow - we should do it. It also\r\ndoesn't bring the testing value repeating the same UI steps multiple\r\ntimes in different scenarios. _Our CI costs are critical to cut when it\r\nis possible_\r\n- Avoid **nesting describe** blocks: it complicates test readability and\r\nalso complicates for CI bot to properly skip the failing block (it will\r\nskip the top level one). We encourage **Scout parallel test execution**\r\nbased on running test spec files in multiple workers, not the `test`\r\nblocks within the same file. Having too many `test` blocks in the same\r\nfile will be slowly run in the single thread and in case of flakiness,\r\nit means Team lose more test coverage than they probably expect.\r\n\r\nBefore (**59** test blocks - **8-8.5 min** per distro):\r\n<img width=\"1709\" alt=\"Screenshot 2025-02-08 at 18 01 40\"\r\nsrc=\"https://github.com/user-attachments/assets/5fd65a1c-85f9-4594-9dae-3f8e99a005ab\"\r\n/>\r\n\r\nAfter (**15** test blocks - **3.5-4 min** per distro):\r\n<img width=\"1578\" alt=\"Screenshot 2025-02-10 at 18 14 42\"\r\nsrc=\"https://github.com/user-attachments/assets/6846898f-7dd2-4f6b-8bc5-d06741b0b120\"\r\n/>\r\n\r\nFor reviewers: updated tests are possible to run in 2 parallel workers\r\nagainst the same Kibana/ES instance and run time is dropping to **2.5-3\r\nmin** 🚀 . It is up to UX-Logs team to decide if you want to keep\r\nparallel run (new tests can be added either to parallel or sequential\r\nrun)\r\n<img width=\"1578\" alt=\"Screenshot 2025-02-11 at 12 14 30\"\r\nsrc=\"https://github.com/user-attachments/assets/e94113f2-d7f1-470e-a6d5-cb5154d99c41\"\r\n/>\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bd13e829498032c07bf8490f770a563f34e9f856"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->