### PR TITLE
[8.x] [Obs AI Assistant] Fix connector test in MKI (#211235)

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/connectors/connectors.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/connectors/connectors.spec.ts
@@ -10,6 +10,7 @@ import type { DeploymentAgnosticFtrProviderContext } from '../../../../ftr_provi
 
 export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
+
   describe('List connectors', () => {
     before(async () => {
       await observabilityAIAssistantAPIClient.deleteAllActionConnectors();
@@ -32,7 +33,10 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         endpoint: 'GET /internal/observability_ai_assistant/connectors',
       });
 
-      expect(res.body.length).to.be(0);
+      const connectorsExcludingPreconfiguredInference = res.body.filter(
+        (c) => c.actionTypeId !== '.inference'
+      );
+      expect(connectorsExcludingPreconfiguredInference.length).to.be(0);
     });
 
     it("returns the gen ai connector if it's been created", async () => {
@@ -44,7 +48,10 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         endpoint: 'GET /internal/observability_ai_assistant/connectors',
       });
 
-      expect(res.body.length).to.be(1);
+      const connectorsExcludingPreconfiguredInference = res.body.filter(
+        (c) => c.actionTypeId !== '.inference'
+      );
+      expect(connectorsExcludingPreconfiguredInference.length).to.be(1);
 
       await observabilityAIAssistantAPIClient.deleteActionConnector({ actionId: connectorId });
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Obs AI Assistant] Fix connector test in MKI (#211235)](https://github.com/elastic/kibana/pull/211235)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-02-14T16:35:42Z","message":"[Obs AI Assistant] Fix connector test in MKI (#211235)\n\nCloses https://github.com/elastic/kibana/issues/211175\n\n## Problem\n\nThe connectors test is failing Serverless because we now have a\npre-configured inference connector\n\n## Solution\n\nFilter out the pre-configured inference connector in tests\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"c1d055973877bc66eec5e2cbf6b3b1a53396fdf5","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:Obs AI Assistant","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Obs AI Assistant] Fix connector test in MKI","number":211235,"url":"https://github.com/elastic/kibana/pull/211235","mergeCommit":{"message":"[Obs AI Assistant] Fix connector test in MKI (#211235)\n\nCloses https://github.com/elastic/kibana/issues/211175\n\n## Problem\n\nThe connectors test is failing Serverless because we now have a\npre-configured inference connector\n\n## Solution\n\nFilter out the pre-configured inference connector in tests\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"c1d055973877bc66eec5e2cbf6b3b1a53396fdf5"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211235","number":211235,"mergeCommit":{"message":"[Obs AI Assistant] Fix connector test in MKI (#211235)\n\nCloses https://github.com/elastic/kibana/issues/211175\n\n## Problem\n\nThe connectors test is failing Serverless because we now have a\npre-configured inference connector\n\n## Solution\n\nFilter out the pre-configured inference connector in tests\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"c1d055973877bc66eec5e2cbf6b3b1a53396fdf5"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->