### PR TITLE
[Uptime] Fix: Uptime rules visible even when disabled via Advanced Settings

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/constants.ts
@@ -35,6 +35,15 @@ export const observabilityRuleCreationValidConsumers: RuleCreationValidConsumer[
 
 export const EventsAsUnit = 'events';
 
+export const LEGACY_UPTIME_MONITOR_STATUS_RULE_ID = 'xpack.uptime.alerts.monitorStatus';
+export const LEGACY_UPTIME_TLS_RULE_ID = 'xpack.uptime.alerts.tlsCertificate';
+export const LEGACY_UPTIME_DURATION_ANOMALY_RULE_ID = 'xpack.uptime.alerts.durationAnomaly';
+export const LEGACY_UPTIME_RULE_IDS = [
+  LEGACY_UPTIME_MONITOR_STATUS_RULE_ID,
+  LEGACY_UPTIME_TLS_RULE_ID,
+  LEGACY_UPTIME_DURATION_ANOMALY_RULE_ID,
+];
+
 export const OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES = [
   ...OBSERVABILITY_RULE_TYPE_IDS,
   ...STACK_RULE_TYPE_IDS_SUPPORTED_BY_OBSERVABILITY,

--- a/x-pack/solutions/observability/plugins/observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/plugin.ts
@@ -233,7 +233,6 @@ export class Plugin
     const kibanaVersion = this.initContext.env.packageInfo.version;
 
     const isLegacyUptimeEnabled = coreSetup.uiSettings.get('observability:enableLegacyUptimeApp');
-    console.log('enabled before register', isLegacyUptimeEnabled);
 
     this.observabilityRuleTypeRegistry = createObservabilityRuleTypeRegistry(
       pluginsSetup.triggersActionsUi.ruleTypeRegistry,

--- a/x-pack/solutions/observability/plugins/observability/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/plugin.ts
@@ -88,6 +88,7 @@ import {
   createObservabilityRuleTypeRegistry,
 } from './rules/create_observability_rule_type_registry';
 import { registerObservabilityRuleTypes } from './rules/register_observability_rule_types';
+import { LEGACY_UPTIME_RULE_IDS } from '../common/constants';
 
 export interface ConfigSchema {
   unsafe: {
@@ -231,8 +232,12 @@ export class Plugin
     const config = this.initContext.config.get();
     const kibanaVersion = this.initContext.env.packageInfo.version;
 
+    const isLegacyUptimeEnabled = coreSetup.uiSettings.get('observability:enableLegacyUptimeApp');
+    console.log('enabled before register', isLegacyUptimeEnabled);
+
     this.observabilityRuleTypeRegistry = createObservabilityRuleTypeRegistry(
-      pluginsSetup.triggersActionsUi.ruleTypeRegistry
+      pluginsSetup.triggersActionsUi.ruleTypeRegistry,
+      isLegacyUptimeEnabled ? undefined : LEGACY_UPTIME_RULE_IDS
     );
 
     const rulesLocator = pluginsSetup.share.url.locators.create(new RulesLocatorDefinition());

--- a/x-pack/solutions/observability/plugins/observability/public/rules/create_observability_rule_type_registry.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/rules/create_observability_rule_type_registry.ts
@@ -24,7 +24,10 @@ export interface ObservabilityRuleTypeModel<Params extends RuleTypeParams = Rule
   priority?: number;
 }
 
-export function createObservabilityRuleTypeRegistry(ruleTypeRegistry: RuleTypeRegistryContract) {
+export function createObservabilityRuleTypeRegistry(
+  ruleTypeRegistry: RuleTypeRegistryContract,
+  denyList?: string[]
+) {
   const formatters: Array<{
     typeId: string;
     priority: number;
@@ -33,6 +36,7 @@ export function createObservabilityRuleTypeRegistry(ruleTypeRegistry: RuleTypeRe
 
   return {
     register: (type: ObservabilityRuleTypeModel<any>) => {
+      if (denyList && denyList.includes(type.id)) return;
       const { format, priority, ...rest } = type;
       formatters.push({ typeId: type.id, priority: priority || 0, fn: format });
       ruleTypeRegistry.register(rest);


### PR DESCRIPTION
## Summary

Resolves #211243.

### Details

This patch will add a concept of deny list to the observability plugin's rule registry. When it receives alert IDs in this param, it will skip adding them to the plugin registry, and thus they will not be displayed.

It's reported in the linked ticket that [this](https://github.com/elastic/kibana/blob/e21c5d0e9175ffd1bea0ad78ffe26cb973cc489f/x-pack/solutions/observability/plugins/uptime/public/plugin.ts#L306) check should address the problem, but the rule registry causing the uptime rules to display is created during the bootstrapping of the Observability plugin. Because of this separate registry, the UI setting for uptime enabled is not respected.

### Additional information

I had originally written code in the Uptime server plugin to skip registering the alerts in case the app is disabled, but this doesn't respond well when the UI setting changes. I also had concerns over how this would impact existing rules of those types. Modifying the client in the reported area seemed less invasive and cleaner.

_NOTE:_ I don't interact with triggers actions that much anymore; if there's a more canonical way to filter out rule types based on UI settings feel free to suggest it and we can refactor.

## Testing

When the legacy uptime enabled flag is turned on in Advanced Settings, we should not be able to find Uptime rules on the Observability rules modal.

- Turn on Uptime:

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/506e3fb3-4744-4e6a-a98d-e34e2536cdf3" />

- Check for uptime rules:

<img width="1886" alt="image" src="https://github.com/user-attachments/assets/061727cd-7299-4270-98c6-0fae42e8813a" />

- Turn off Uptime:

<img width="1219" alt="image" src="https://github.com/user-attachments/assets/2c814241-66d7-4aaa-a4bb-176191a96758" />

- Check for uptime rules:

<img width="1853" alt="image" src="https://github.com/user-attachments/assets/8fb17540-3a99-440e-8931-c0378754cf96" />


