### PR TITLE
[9.0] [Security Solution] Standardize actions in Alerts KPI visualizations (#206340)

### DIFF
--- a/packages/kbn-babel-preset/styled_components_files.js
+++ b/packages/kbn-babel-preset/styled_components_files.js
@@ -179,6 +179,7 @@ module.exports = {
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]and_or_badge[\/\\]rounded_badge_antenna.test.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]and_or_badge[\/\\]rounded_badge_antenna.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]auto_download[\/\\]auto_download.tsx/,
+    /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]charts[\/\\]draggable_legend_item.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]conditions_table[\/\\]index.stories.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]drag_and_drop[\/\\]draggable_wrapper.tsx/,
     /x-pack[\/\\]solutions[\/\\]security[\/\\]plugins[\/\\]security_solution[\/\\]public[\/\\]common[\/\\]components[\/\\]drag_and_drop[\/\\]droppable_wrapper.tsx/,

--- a/src/platform/packages/shared/kbn-cell-actions/src/__stories__/cell_actions.stories.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/__stories__/cell_actions.stories.tsx
@@ -94,6 +94,23 @@ export const CellActionInline = () => (
   </CellActions>
 );
 
+export const CellActionInlineCustomStyle = () => (
+  <CellActions
+    mode={CellActionsMode.INLINE}
+    triggerId={TRIGGER_ID}
+    data={[
+      {
+        field: FIELD,
+        value: VALUE,
+      },
+    ]}
+    extraActionsIconType="boxesVertical"
+    extraActionsColor="text"
+  >
+    {'Field value'}
+  </CellActions>
+);
+
 export const CellActionHoverPopoverDown = () => (
   <CellActions
     mode={CellActionsMode.HOVER_DOWN}

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/cell_actions.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/cell_actions.tsx
@@ -25,6 +25,8 @@ export const CellActions: React.FC<CellActionsProps> = ({
   disabledActionTypes = [],
   metadata,
   className,
+  extraActionsIconType,
+  extraActionsColor,
 }) => {
   const nodeRef = useRef<HTMLDivElement | null>(null);
 
@@ -83,6 +85,8 @@ export const CellActions: React.FC<CellActionsProps> = ({
           showActionTooltips={showActionTooltips}
           visibleCellActions={visibleCellActions}
           disabledActionTypes={disabledActionTypes}
+          extraActionsIconType={extraActionsIconType}
+          extraActionsColor={extraActionsColor}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_button.test.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_button.test.tsx
@@ -13,9 +13,12 @@ import { ExtraActionsButton } from './extra_actions_button';
 
 describe('ExtraActionsButton', () => {
   it('renders', () => {
-    const { queryByTestId } = render(<ExtraActionsButton onClick={() => {}} showTooltip={false} />);
+    const { queryByTestId, container } = render(
+      <ExtraActionsButton onClick={() => {}} showTooltip={false} />
+    );
 
     expect(queryByTestId('showExtraActionsButton')).toBeInTheDocument();
+    expect(container.querySelector('[data-euiicon-type="boxesHorizontal"]')).toBeInTheDocument();
   });
 
   it('renders tooltip when showTooltip=true is received', () => {
@@ -29,5 +32,19 @@ describe('ExtraActionsButton', () => {
 
     fireEvent.click(getByTestId('showExtraActionsButton'));
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders with correct icon when it is specified in the actionContext', () => {
+    const { queryByTestId, container } = render(
+      <ExtraActionsButton
+        onClick={() => {}}
+        showTooltip={false}
+        extraActionsIconType="boxesVertical"
+        extraActionsColor="text"
+      />
+    );
+
+    expect(queryByTestId('showExtraActionsButton')).toBeInTheDocument();
+    expect(container.querySelector('[data-euiicon-type="boxesVertical"]')).toBeInTheDocument();
   });
 });

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_button.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_button.tsx
@@ -7,22 +7,30 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+import { EuiButtonIcon, EuiToolTip, type EuiButtonIconProps } from '@elastic/eui';
 import React from 'react';
 import { SHOW_MORE_ACTIONS } from './translations';
 
 interface ExtraActionsButtonProps {
   onClick: () => void;
   showTooltip: boolean;
+  extraActionsIconType?: EuiButtonIconProps['iconType'];
+  extraActionsColor?: EuiButtonIconProps['color'];
 }
 
-export const ExtraActionsButton: React.FC<ExtraActionsButtonProps> = ({ onClick, showTooltip }) =>
-  showTooltip ? (
+export const ExtraActionsButton: React.FC<ExtraActionsButtonProps> = ({
+  onClick,
+  showTooltip,
+  extraActionsIconType,
+  extraActionsColor,
+}) => {
+  return showTooltip ? (
     <EuiToolTip content={SHOW_MORE_ACTIONS}>
       <EuiButtonIcon
         data-test-subj="showExtraActionsButton"
         aria-label={SHOW_MORE_ACTIONS}
-        iconType="boxesHorizontal"
+        iconType={extraActionsIconType ?? 'boxesHorizontal'}
+        color={extraActionsColor}
         onClick={onClick}
       />
     </EuiToolTip>
@@ -30,7 +38,9 @@ export const ExtraActionsButton: React.FC<ExtraActionsButtonProps> = ({ onClick,
     <EuiButtonIcon
       data-test-subj="showExtraActionsButton"
       aria-label={SHOW_MORE_ACTIONS}
-      iconType="boxesHorizontal"
+      iconType={extraActionsIconType ?? 'boxesHorizontal'}
+      color={extraActionsColor}
       onClick={onClick}
     />
   );
+};

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/extra_actions_popover.tsx
@@ -13,6 +13,7 @@ import {
   EuiPopover,
   EuiScreenReaderOnly,
   EuiWrappingPopover,
+  type EuiButtonIconProps,
 } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
@@ -20,9 +21,14 @@ import { css } from '@emotion/react';
 import { EXTRA_ACTIONS_ARIA_LABEL, YOU_ARE_IN_A_DIALOG_CONTAINING_OPTIONS } from './translations';
 import type { CellAction, CellActionExecutionContext } from '../types';
 
-const euiContextMenuItemCSS = css`
-  color: ${euiThemeVars.euiColorPrimaryText};
-`;
+const getEuiContextMenuItemCSS = (extraActionsColor?: EuiButtonIconProps['color']) => {
+  if (extraActionsColor && extraActionsColor === 'text') {
+    return undefined;
+  }
+  return css`
+    color: ${euiThemeVars.euiColorPrimaryText};
+  `;
+};
 
 interface ActionsPopOverProps {
   anchorPosition: 'rightCenter' | 'downCenter';
@@ -31,6 +37,7 @@ interface ActionsPopOverProps {
   closePopOver: () => void;
   actions: CellAction[];
   button: JSX.Element;
+  extraActionsColor?: EuiButtonIconProps['color'];
 }
 
 export const ExtraActionsPopOver: React.FC<ActionsPopOverProps> = ({
@@ -40,6 +47,7 @@ export const ExtraActionsPopOver: React.FC<ActionsPopOverProps> = ({
   isOpen,
   closePopOver,
   button,
+  extraActionsColor,
 }) => (
   <EuiPopover
     button={button}
@@ -57,6 +65,7 @@ export const ExtraActionsPopOver: React.FC<ActionsPopOverProps> = ({
       actions={actions}
       actionContext={actionContext}
       closePopOver={closePopOver}
+      extraActionsColor={extraActionsColor}
     />
   </EuiPopover>
 );
@@ -64,7 +73,7 @@ export const ExtraActionsPopOver: React.FC<ActionsPopOverProps> = ({
 interface ExtraActionsPopOverWithAnchorProps
   extends Pick<
     ActionsPopOverProps,
-    'anchorPosition' | 'actionContext' | 'closePopOver' | 'isOpen' | 'actions'
+    'anchorPosition' | 'actionContext' | 'closePopOver' | 'isOpen' | 'actions' | 'extraActionsColor'
   > {
   anchorRef: React.RefObject<HTMLElement>;
 }
@@ -76,6 +85,7 @@ export const ExtraActionsPopOverWithAnchor = ({
   isOpen,
   closePopOver,
   actions,
+  extraActionsColor,
 }: ExtraActionsPopOverWithAnchorProps) => {
   return anchorRef.current ? (
     <EuiWrappingPopover
@@ -95,6 +105,7 @@ export const ExtraActionsPopOverWithAnchor = ({
         actions={actions}
         actionContext={actionContext}
         closePopOver={closePopOver}
+        extraActionsColor={extraActionsColor}
       />
     </EuiWrappingPopover>
   ) : null;
@@ -102,19 +113,20 @@ export const ExtraActionsPopOverWithAnchor = ({
 
 type ExtraActionsPopOverContentProps = Pick<
   ActionsPopOverProps,
-  'actionContext' | 'closePopOver' | 'actions'
+  'actionContext' | 'closePopOver' | 'actions' | 'extraActionsColor'
 >;
 
 const ExtraActionsPopOverContent: React.FC<ExtraActionsPopOverContentProps> = ({
   actionContext,
   actions,
   closePopOver,
+  extraActionsColor,
 }) => {
   const items = useMemo(
     () =>
       actions.map((action) => (
         <EuiContextMenuItem
-          css={euiContextMenuItemCSS}
+          css={getEuiContextMenuItemCSS(extraActionsColor)}
           key={action.id}
           icon={action.getIconType(actionContext)}
           aria-label={action.getDisplayName(actionContext)}
@@ -127,7 +139,7 @@ const ExtraActionsPopOverContent: React.FC<ExtraActionsPopOverContentProps> = ({
           {action.getDisplayName(actionContext)}
         </EuiContextMenuItem>
       )),
-    [actionContext, actions, closePopOver]
+    [actionContext, actions, closePopOver, extraActionsColor]
   );
 
   return (

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/hover_actions_popover.tsx
@@ -7,8 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiPopover, EuiScreenReaderOnly } from '@elastic/eui';
-
+import { EuiPopover, EuiScreenReaderOnly, type EuiButtonIconProps } from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
@@ -43,6 +42,8 @@ interface Props {
   actionContext: CellActionExecutionContext;
   showActionTooltips: boolean;
   disabledActionTypes: string[];
+  extraActionsIconType?: EuiButtonIconProps['iconType'];
+  extraActionsColor?: EuiButtonIconProps['color'];
 }
 
 export const HoverActionsPopover: React.FC<Props> = ({
@@ -52,6 +53,8 @@ export const HoverActionsPopover: React.FC<Props> = ({
   actionContext,
   showActionTooltips,
   disabledActionTypes,
+  extraActionsIconType,
+  extraActionsColor,
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const [isExtraActionsPopoverOpen, setIsExtraActionsPopoverOpen] = useState(false);
@@ -161,6 +164,8 @@ export const HoverActionsPopover: React.FC<Props> = ({
                 <ExtraActionsButton
                   onClick={onShowExtraActionsClick}
                   showTooltip={showActionTooltips}
+                  extraActionsIconType={extraActionsIconType}
+                  extraActionsColor={extraActionsColor}
                 />
               )}
             </div>

--- a/src/platform/packages/shared/kbn-cell-actions/src/components/inline_actions.tsx
+++ b/src/platform/packages/shared/kbn-cell-actions/src/components/inline_actions.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, type EuiButtonIconProps } from '@elastic/eui';
 import { ActionItem } from './cell_action_item';
 import { usePartitionActions } from '../hooks/actions';
 import { ExtraActionsPopOver } from './extra_actions_popover';
@@ -22,6 +22,8 @@ interface InlineActionsProps {
   showActionTooltips: boolean;
   visibleCellActions: number;
   disabledActionTypes: string[];
+  extraActionsIconType?: EuiButtonIconProps['iconType'];
+  extraActionsColor?: EuiButtonIconProps['color'];
 }
 
 export const InlineActions: React.FC<InlineActionsProps> = ({
@@ -30,6 +32,8 @@ export const InlineActions: React.FC<InlineActionsProps> = ({
   showActionTooltips,
   visibleCellActions,
   disabledActionTypes,
+  extraActionsIconType,
+  extraActionsColor,
 }) => {
   const { value: actions } = useLoadActions(actionContext, { disabledActionTypes });
   const { extraActions, visibleActions } = usePartitionActions(actions ?? [], visibleCellActions);
@@ -38,8 +42,15 @@ export const InlineActions: React.FC<InlineActionsProps> = ({
   const togglePopOver = useCallback(() => setIsPopoverOpen((isOpen) => !isOpen), []);
   const closePopOver = useCallback(() => setIsPopoverOpen(false), []);
   const button = useMemo(
-    () => <ExtraActionsButton onClick={togglePopOver} showTooltip={showActionTooltips} />,
-    [togglePopOver, showActionTooltips]
+    () => (
+      <ExtraActionsButton
+        onClick={togglePopOver}
+        showTooltip={showActionTooltips}
+        extraActionsIconType={extraActionsIconType}
+        extraActionsColor={extraActionsColor}
+      />
+    ),
+    [togglePopOver, showActionTooltips, extraActionsIconType, extraActionsColor]
   );
 
   return (
@@ -68,6 +79,7 @@ export const InlineActions: React.FC<InlineActionsProps> = ({
             button={button}
             closePopOver={closePopOver}
             isOpen={isPopoverOpen}
+            extraActionsColor={extraActionsColor}
           />
         </EuiFlexItem>
       ) : null}

--- a/src/platform/packages/shared/kbn-cell-actions/src/types.ts
+++ b/src/platform/packages/shared/kbn-cell-actions/src/types.ts
@@ -15,6 +15,7 @@ import type {
 } from '@kbn/ui-actions-plugin/public';
 import type { FieldSpec } from '@kbn/data-views-plugin/common';
 import type { Serializable } from '@kbn/utility-types';
+import type { EuiButtonIconProps } from '@elastic/eui';
 import type { CellActionsMode } from './constants';
 
 export * from './actions/types';
@@ -85,8 +86,18 @@ export type CellActionsProps = PropsWithChildren<{
    * This data is sent directly to actions.
    */
   metadata?: Metadata;
-
+  /**
+   * The class name for the cell actions.
+   */
   className?: string;
+  /**
+   * The icon type for the extra actions button.
+   */
+  extraActionsIconType?: EuiButtonIconProps['iconType'];
+  /**
+   * The color for the extra actions button.
+   */
+  extraActionsColor?: EuiButtonIconProps['color'];
 }>;
 
 export interface CellActionExecutionContext extends ActionExecutionContext {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/cell_actions/index.tsx
@@ -13,6 +13,7 @@ import type {
 } from '@kbn/cell-actions';
 import React, { useMemo } from 'react';
 import type { CellActionFieldValue, CellActionsData } from '@kbn/cell-actions/src/types';
+import type { EuiButtonIconProps } from '@elastic/eui';
 import type { SecurityCellActionMetadata } from '../../../app/actions/types';
 import { SecurityCellActionsTrigger, SecurityCellActionType } from '../../../app/actions/constants';
 import { SourcererScopeName } from '../../../sourcerer/store/model';
@@ -42,6 +43,8 @@ export interface SecurityCellActionsProps
   triggerId: SecurityCellActionsTrigger;
   disabledActionTypes?: SecurityCellActionType[];
   metadata?: SecurityCellActionMetadata;
+  extraActionsIconType?: EuiButtonIconProps['iconType'];
+  extraActionsColor?: EuiButtonIconProps['color'];
 }
 
 export interface UseDataGridColumnsSecurityCellActionsProps

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/chart_settings_popover/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/chart_settings_popover/index.tsx
@@ -37,7 +37,7 @@ const ChartSettingsPopoverComponent: React.FC<Props> = ({
       <EuiButtonIcon
         aria-label={i18n.CHART_SETTINGS_POPOVER_ARIA_LABEL}
         color="text"
-        iconType="boxesHorizontal"
+        iconType="boxesVertical"
         onClick={onButtonClick}
         size="xs"
       />

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/charts/draggable_legend.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/charts/draggable_legend.test.tsx
@@ -33,6 +33,7 @@ const legendItems: LegendItem[] = [
     dataProviderId: 'draggable-legend-item-3207fda7-d008-402a-86a0-8ad632081bad-event_dataset-flow',
     field: 'event.dataset',
     value: 'flow',
+    scopeId: 'test',
   },
   {
     color: '#2B70F7',
@@ -40,6 +41,7 @@ const legendItems: LegendItem[] = [
       'draggable-legend-item-83f6c824-811d-4ec8-b373-eba2b0de6398-event_dataset-suricata_eve',
     field: 'event.dataset',
     value: 'suricata.eve',
+    scopeId: 'test',
   },
   {
     color: '#CE0060',
@@ -47,6 +49,7 @@ const legendItems: LegendItem[] = [
       'draggable-legend-item-ec57bb8f-82cd-4e07-bd38-1d11b3f0ee5f-event_dataset-traefik_access',
     field: 'event.dataset',
     value: 'traefik.access',
+    scopeId: 'test',
   },
   {
     color: '#38007E',
@@ -54,6 +57,7 @@ const legendItems: LegendItem[] = [
       'draggable-legend-item-25d5fcd6-87ba-46b5-893e-c655d7d504e3-event_dataset-esensor',
     field: 'event.dataset',
     value: 'esensor',
+    scopeId: 'test',
   },
 ];
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/charts/draggable_legend.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/charts/draggable_legend.tsx
@@ -56,9 +56,14 @@ const DraggableLegendComponent: React.FC<{
   height: number | undefined;
   legendItems: LegendItem[];
   minWidth?: number;
-}> = ({ className, height = 0, legendItems, minWidth = DEFAULT_WIDTH }) => {
-  const styles = useStyles(height === 0 ? MIN_LEGEND_HEIGHT : height, minWidth);
-
+  isInlineActions?: boolean;
+}> = ({
+  className,
+  height = 0,
+  legendItems,
+  minWidth = DEFAULT_WIDTH,
+  isInlineActions = false,
+}) => {
   if (legendItems.length === 0) {
     return null;
   }
@@ -73,7 +78,7 @@ const DraggableLegendComponent: React.FC<{
         <EuiFlexGroup direction="column" gutterSize="none">
           {legendItems.map((item) => (
             <EuiFlexItem key={item.dataProviderId} grow={false}>
-              <DraggableLegendItem legendItem={item} />
+              <DraggableLegendItem legendItem={item} isInlineActions={isInlineActions} />
               <EuiSpacer data-test-subj="draggable-legend-spacer" size="s" />
             </EuiFlexItem>
           ))}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/charts/draggable_legend_item.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/charts/draggable_legend_item.test.tsx
@@ -8,6 +8,7 @@
 import type { ReactWrapper } from 'enzyme';
 import { mount } from 'enzyme';
 import React from 'react';
+import { render } from '@testing-library/react';
 
 import '../../mock/react_beautiful_dnd';
 import { TestProviders } from '../../mock';
@@ -31,6 +32,7 @@ describe('DraggableLegendItem', () => {
     dataProviderId: 'draggable-legend-item-3207fda7-d008-402a-86a0-8ad632081bad-event_dataset-flow',
     field: 'event.dataset',
     value: 'flow',
+    scopeId: 'test',
   };
 
   let wrapper: ReactWrapper;
@@ -56,11 +58,11 @@ describe('DraggableLegendItem', () => {
   });
 
   it('renders a custom legend item via the `render` prop when provided', () => {
-    const render = (fieldValuePair?: { field: string; value: string | number }) => (
+    const renderContent = (fieldValuePair?: { field: string; value: string | number }) => (
       <div data-test-subj="custom">{`${fieldValuePair?.field} - ${fieldValuePair?.value}`}</div>
     );
 
-    const customLegendItem = { ...legendItem, render };
+    const customLegendItem = { ...legendItem, render: renderContent };
 
     wrapper = mount(
       <TestProviders>
@@ -107,5 +109,18 @@ describe('DraggableLegendItem', () => {
       </TestProviders>
     );
     expect(wrapper.find('[data-test-subj="value-wrapper-empty"]').first().exists()).toBeFalsy();
+  });
+
+  describe('when actions are inline', () => {
+    it('renders the legend item content', () => {
+      const { getByTestId, queryByTestId } = render(
+        <TestProviders>
+          <DraggableLegendItem legendItem={legendItem} isInlineActions />
+        </TestProviders>
+      );
+
+      expect(queryByTestId(`legend-item-${legendItem.dataProviderId}`)).not.toBeInTheDocument();
+      expect(getByTestId('legendItemInlineActions')).toBeInTheDocument();
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/charts/draggable_legend_item.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/charts/draggable_legend_item.tsx
@@ -7,14 +7,21 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiHealth, EuiText } from '@elastic/eui';
 import numeral from '@elastic/numeral';
-import React from 'react';
-import styled from '@emotion/styled';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
 
 import { DEFAULT_NUMBER_FORMAT } from '../../../../common/constants';
 import { DefaultDraggable } from '../draggables';
 import { useUiSetting$ } from '../../lib/kibana';
 import { EMPTY_VALUE_LABEL } from './translation';
 import { hasValueToDisplay } from '../../utils/validators';
+import {
+  SecurityCellActions,
+  SecurityCellActionType,
+  SecurityCellActionsTrigger,
+  CellActionsMode,
+} from '../cell_actions';
+import { getSourcererScopeId } from '../../../helpers';
 
 const CountFlexItem = styled(EuiFlexItem)`
   ${({ theme }) => `margin-right: ${theme.euiTheme.size.s};`}
@@ -45,9 +52,19 @@ ValueWrapper.displayName = 'ValueWrapper';
 
 const DraggableLegendItemComponent: React.FC<{
   legendItem: LegendItem;
-}> = ({ legendItem }) => {
+  isInlineActions?: boolean;
+}> = ({ legendItem, isInlineActions = false }) => {
   const [defaultNumberFormat] = useUiSetting$<string>(DEFAULT_NUMBER_FORMAT);
   const { color, count, dataProviderId, field, scopeId, value } = legendItem;
+
+  const sourcererScopeId = getSourcererScopeId(scopeId ?? '');
+  const content = useMemo(() => {
+    return legendItem.render == null ? (
+      <ValueWrapper value={value} />
+    ) : (
+      legendItem.render({ field, value })
+    );
+  }, [field, value, legendItem]);
 
   return (
     <EuiText size="xs">
@@ -66,21 +83,20 @@ const DraggableLegendItemComponent: React.FC<{
             responsive={false}
           >
             <EuiFlexItem grow={false}>
-              <DefaultDraggable
-                data-test-subj={`legend-item-${dataProviderId}`}
-                field={field}
-                hideTopN={true}
-                id={dataProviderId}
-                isDraggable={false}
-                scopeId={scopeId}
-                value={value}
-              >
-                {legendItem.render == null ? (
-                  <ValueWrapper value={value} />
-                ) : (
-                  legendItem.render({ field, value })
-                )}
-              </DefaultDraggable>
+              {isInlineActions ? (
+                content
+              ) : (
+                <DefaultDraggable
+                  data-test-subj={`legend-item-${dataProviderId}`}
+                  field={field}
+                  hideTopN={true}
+                  id={dataProviderId}
+                  scopeId={scopeId}
+                  value={value}
+                >
+                  {content}
+                </DefaultDraggable>
+              )}
             </EuiFlexItem>
 
             {count != null && (
@@ -90,6 +106,22 @@ const DraggableLegendItemComponent: React.FC<{
             )}
           </EuiFlexGroup>
         </EuiFlexItem>
+
+        {isInlineActions && (
+          <EuiFlexItem grow={false} data-test-subj="legendItemInlineActions">
+            <SecurityCellActions
+              mode={CellActionsMode.INLINE}
+              visibleCellActions={0}
+              triggerId={SecurityCellActionsTrigger.DEFAULT}
+              data={{ field, value }}
+              sourcererScopeId={sourcererScopeId}
+              metadata={{ scopeId }}
+              disabledActionTypes={[SecurityCellActionType.SHOW_TOP_N]}
+              extraActionsIconType="boxesVertical"
+              extraActionsColor="text"
+            />
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
     </EuiText>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.test.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { AlertsByRule } from './alerts_by_rule';
@@ -28,35 +28,26 @@ describe('Alert by rule chart', () => {
   });
 
   test('renders table correctly without data', () => {
-    act(() => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsByRule {...defaultProps} />
-        </TestProviders>
-      );
-      expect(
-        container.querySelector('[data-test-subj="alerts-by-rule-table"]')
-      ).toBeInTheDocument();
-      expect(
-        container.querySelector('[data-test-subj="alerts-by-rule-table"] tbody')?.textContent
-      ).toEqual('No items found');
-    });
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsByRule {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('alerts-by-rule-table')).toBeInTheDocument();
+    expect(getByTestId('alerts-by-rule-table')).toHaveTextContent('No items found');
   });
 
   test('renders table correctly with data', () => {
-    act(() => {
-      const { queryAllByRole } = render(
-        <TestProviders>
-          <AlertsByRule data={parsedAlerts} isLoading={false} />
-        </TestProviders>
-      );
+    const { queryAllByRole } = render(
+      <TestProviders>
+        <AlertsByRule data={parsedAlerts} isLoading={false} />
+      </TestProviders>
+    );
 
-      parsedAlerts.forEach((_, i) => {
-        expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].rule);
-        expect(queryAllByRole('row')[i + 1].textContent).toContain(
-          parsedAlerts[i].value.toString()
-        );
-      });
+    parsedAlerts.forEach((_, i) => {
+      expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].rule);
+      expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].value.toString());
+      expect(queryAllByRole('row')[i + 1].children).toHaveLength(3);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.tsx
@@ -14,15 +14,21 @@ import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { AlertsByRuleData } from './types';
 import { FormattedCount } from '../../../../common/components/formatted_number';
-import { DefaultDraggable } from '../../../../common/components/draggables';
 import { ALERTS_HEADERS_RULE_NAME } from '../../alerts_table/translations';
 import { COUNT_TABLE_TITLE } from '../alerts_count_panel/translations';
+import {
+  CellActionsMode,
+  SecurityCellActionsTrigger,
+  SecurityCellActions,
+  SecurityCellActionType,
+} from '../../../../common/components/cell_actions';
+import { getSourcererScopeId } from '../../../../helpers';
 
 const Wrapper = styled.div`
   margin-top: -${({ theme }) => theme.eui.euiSizeM};
 `;
 const TableWrapper = styled.div`
-  height: 178px;
+  height: 210px;
 `;
 
 export interface AlertsByRuleProps {
@@ -38,17 +44,7 @@ const COLUMNS: Array<EuiBasicTableColumn<AlertsByRuleData>> = [
     truncateText: true,
     render: (rule: string) => (
       <EuiText size="xs" className="eui-textTruncate">
-        <DefaultDraggable
-          isDraggable={false}
-          field={ALERT_RULE_NAME}
-          hideTopN={true}
-          id={`alert-detection-draggable-${rule}`}
-          value={rule}
-          queryValue={rule}
-          tooltipContent={null}
-          truncate={true}
-          scopeId={TableId.alertsOnAlertsPage}
-        />
+        {rule}
       </EuiText>
     ),
   },
@@ -64,6 +60,25 @@ const COLUMNS: Array<EuiBasicTableColumn<AlertsByRuleData>> = [
       </EuiText>
     ),
     width: '22%',
+  },
+  {
+    field: 'rule',
+    name: '',
+    'data-test-subj': 'alert-by-rule-table-actions',
+    width: '10%',
+    render: (rule: string) => (
+      <SecurityCellActions
+        mode={CellActionsMode.INLINE}
+        visibleCellActions={0}
+        triggerId={SecurityCellActionsTrigger.DEFAULT}
+        data={{ field: ALERT_RULE_NAME, value: rule }}
+        sourcererScopeId={getSourcererScopeId(TableId.alertsOnAlertsPage)}
+        disabledActionTypes={[SecurityCellActionType.SHOW_TOP_N]}
+        metadata={{ scopeId: TableId.alertsOnAlertsPage }}
+        extraActionsIconType="boxesVertical"
+        extraActionsColor="text"
+      />
+    ),
   },
 ];
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.test.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { AlertsProgressBar } from './alerts_progress_bar';
@@ -30,51 +30,41 @@ describe('Alert by grouping', () => {
   });
 
   test('progress bars renders correctly', () => {
-    act(() => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsProgressBar {...defaultProps} />
-        </TestProviders>
-      );
-      expect(
-        container.querySelector(`[data-test-subj="alerts-progress-bar-title"]`)?.textContent
-      ).toEqual(defaultProps.groupBySelection);
-      expect(container.querySelector(`[data-test-subj="empty-proress-bar"]`)).toBeInTheDocument();
-      expect(container.querySelector(`[data-test-subj="empty-proress-bar"]`)?.textContent).toEqual(
-        'No items found'
-      );
-    });
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsProgressBar {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('alerts-progress-bar-title').textContent).toEqual(
+      defaultProps.groupBySelection
+    );
+    expect(getByTestId('empty-proress-bar')).toBeInTheDocument();
+    expect(getByTestId('empty-proress-bar').textContent).toEqual('No items found');
   });
 
   test('progress bars renders correctly with data', () => {
-    act(() => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsProgressBar data={parsedAlerts} isLoading={false} groupBySelection={'host.name'} />
-        </TestProviders>
-      );
-      expect(
-        container.querySelector(`[data-test-subj="alerts-progress-bar-title"]`)?.textContent
-      ).toEqual('host.name');
-      expect(container.querySelector(`[data-test-subj="progress-bar"]`)).toBeInTheDocument();
+    const { getByTestId, queryByTestId } = render(
+      <TestProviders>
+        <AlertsProgressBar data={parsedAlerts} isLoading={false} groupBySelection={'host.name'} />
+      </TestProviders>
+    );
+    expect(getByTestId('alerts-progress-bar-title').textContent).toEqual('host.name');
+    expect(getByTestId('progress-bar')).toBeInTheDocument();
+    expect(queryByTestId('empty-proress-bar')).not.toBeInTheDocument();
 
-      expect(
-        container.querySelector(`[data-test-subj="empty-proress-bar"]`)
-      ).not.toBeInTheDocument();
-
-      parsedAlerts.forEach((alert, i) => {
-        if (alert.key !== '-') {
-          expect(
-            container.querySelector(`[data-test-subj="progress-bar-${alert.key}"]`)
-          ).toBeInTheDocument();
-          expect(
-            container.querySelector(`[data-test-subj="progress-bar-${alert.key}"]`)?.textContent
-          ).toContain(parsedAlerts[i].label);
-          expect(
-            container.querySelector(`[data-test-subj="progress-bar-${alert.key}"]`)?.textContent
-          ).toContain(parsedAlerts[i].percentageLabel);
-        }
-      });
+    parsedAlerts.forEach((alert, i) => {
+      if (alert.key !== '-') {
+        expect(getByTestId(`progress-bar-${alert.key}`)).toBeInTheDocument();
+        expect(getByTestId(`progress-bar-${alert.key}`).textContent).toContain(
+          parsedAlerts[i].label
+        );
+        expect(getByTestId(`progress-bar-${alert.key}`).textContent).toContain(
+          parsedAlerts[i].percentageLabel
+        );
+      }
+      if (alert.key !== 'Other' && alert.key !== '-') {
+        expect(getByTestId(`progress-bar-${alert.key}-actions`)).toBeInTheDocument();
+      }
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
@@ -23,8 +23,14 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import type { AlertsProgressBarData, GroupBySelection } from './types';
 import type { AddFilterProps } from '../common/types';
 import { getAggregateData } from './helpers';
-import { DefaultDraggable } from '../../../../common/components/draggables';
 import * as i18n from './translations';
+import {
+  SecurityCellActionType,
+  CellActionsMode,
+  SecurityCellActionsTrigger,
+  SecurityCellActions,
+} from '../../../../common/components/cell_actions';
+import { getSourcererScopeId } from '../../../../helpers';
 
 const ProgressWrapper = styled.div`
   height: 160px;
@@ -47,6 +53,47 @@ const DataStatsWrapper = styled.div`
   width: 250px;
 `;
 
+const EmptyAction = styled.div`
+  padding-left: ${({ theme }) => theme.eui.euiSizeL};
+`;
+
+/**
+ * Individual progress bar per row
+ */
+const ProgressBarRow: React.FC<{ item: AlertsProgressBarData }> = ({ item }) => {
+  const { euiTheme } = useEuiTheme();
+  const color = useMemo(
+    () =>
+      euiTheme.themeName === 'EUI_THEME_BOREALIS'
+        ? euiTheme.colors.vis.euiColorVis6
+        : euiTheme.colors.vis.euiColorVis9,
+    [euiTheme]
+  );
+
+  return (
+    <EuiProgress
+      valueText={
+        <EuiText size="xs" color="default">
+          <strong>{item.percentageLabel}</strong>
+        </EuiText>
+      }
+      max={1}
+      color={color}
+      size="s"
+      value={item.percentage}
+      label={
+        item.key === 'Other' ? (
+          item.label
+        ) : (
+          <EuiText size="xs" className="eui-textTruncate">
+            {item.key}
+          </EuiText>
+        )
+      }
+    />
+  );
+};
+
 export interface AlertsProcessBarProps {
   data: AlertsProgressBarData[];
   isLoading: boolean;
@@ -60,12 +107,12 @@ export const AlertsProgressBar: React.FC<AlertsProcessBarProps> = ({
   addFilter,
   groupBySelection,
 }) => {
-  const { euiTheme } = useEuiTheme();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const onButtonClick = () => setIsPopoverOpen(!isPopoverOpen);
   const closePopover = () => setIsPopoverOpen(false);
 
-  const [nonEmpty, formattedNonEmptyPercent] = getAggregateData(data);
+  const [nonEmpty, formattedNonEmptyPercent] = useMemo(() => getAggregateData(data), [data]);
+  const sourcererScopeId = useMemo(() => getSourcererScopeId(TableId.alertsOnAlertsPage), []);
 
   const dataStatsButton = (
     <EuiButtonIcon
@@ -95,33 +142,6 @@ export const AlertsProgressBar: React.FC<AlertsProcessBarProps> = ({
         </EuiLink>
       </EuiText>
     </DataStatsWrapper>
-  );
-
-  const labelWithHoverActions = (key: string) => {
-    return (
-      <DefaultDraggable
-        isDraggable={false}
-        field={groupBySelection}
-        hideTopN={true}
-        id={`top-alerts-${key}`}
-        value={key}
-        queryValue={key}
-        tooltipContent={null}
-        scopeId={TableId.alertsOnAlertsPage}
-      >
-        <EuiText size="xs" className="eui-textTruncate">
-          {key}
-        </EuiText>
-      </DefaultDraggable>
-    );
-  };
-
-  const color = useMemo(
-    () =>
-      euiTheme.themeName === 'EUI_THEME_BOREALIS'
-        ? euiTheme.colors.vis.euiColorVis6
-        : euiTheme.colors.vis.euiColorVis9,
-    [euiTheme]
   );
 
   return (
@@ -159,28 +179,38 @@ export const AlertsProgressBar: React.FC<AlertsProcessBarProps> = ({
               </>
             ) : (
               <>
-                {data.map(
-                  (item) =>
-                    item.key !== '-' && (
-                      <div key={`${item.key}`} data-test-subj={`progress-bar-${item.key}`}>
-                        <EuiProgress
-                          valueText={
-                            <EuiText size="xs" color="default">
-                              <strong>{item.percentageLabel}</strong>
-                            </EuiText>
-                          }
-                          max={1}
-                          color={color}
-                          size="s"
-                          value={item.percentage}
-                          label={
-                            item.key === 'Other' ? item.label : labelWithHoverActions(item.key)
-                          }
-                        />
-                        <EuiSpacer size="s" />
-                      </div>
-                    )
-                )}
+                {data
+                  .filter((item) => item.key !== '-')
+                  .map((item) => (
+                    <div key={`${item.key}`} data-test-subj={`progress-bar-${item.key}`}>
+                      <EuiFlexGroup alignItems="center" gutterSize="xs">
+                        <EuiFlexItem>
+                          <ProgressBarRow item={item} />
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                          data-test-subj={`progress-bar-${item.key}-actions`}
+                        >
+                          {item.key !== 'Other' ? (
+                            <SecurityCellActions
+                              mode={CellActionsMode.INLINE}
+                              visibleCellActions={0}
+                              triggerId={SecurityCellActionsTrigger.DEFAULT}
+                              data={{ field: groupBySelection, value: item.key }}
+                              sourcererScopeId={sourcererScopeId}
+                              metadata={{ scopeId: TableId.alertsOnAlertsPage }}
+                              disabledActionTypes={[SecurityCellActionType.SHOW_TOP_N]}
+                              extraActionsIconType="boxesVertical"
+                              extraActionsColor="text"
+                            />
+                          ) : (
+                            <EmptyAction />
+                          )}
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                      <EuiSpacer size="s" />
+                    </div>
+                  ))}
               </>
             )}
             <EuiSpacer size="s" />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/alerts_treemap/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/alerts_treemap/index.tsx
@@ -201,6 +201,7 @@ const AlertsTreemapComponent: React.FC<Props> = ({
                 height={minChartHeight}
                 legendItems={legendItems}
                 minWidth={DEFAULT_LEGEND_WIDTH}
+                isInlineActions
               />
             )}
           </LegendContainer>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/columns.tsx
@@ -12,11 +12,17 @@ import type { EuiBasicTableColumn } from '@elastic/eui';
 import type { Severity } from '@kbn/securitysolution-io-ts-alerting-types';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { SeverityBuckets as SeverityData } from '../../../../overview/components/detection_response/alerts_by_status/types';
-import { DefaultDraggable } from '../../../../common/components/draggables';
 import { FormattedCount } from '../../../../common/components/formatted_number';
 import { COUNT_TABLE_TITLE } from '../alerts_count_panel/translations';
 import * as i18n from './translations';
 import { useRiskSeverityColors } from '../../../../common/utils/risk_color_palette';
+import {
+  CellActionsMode,
+  SecurityCellActionsTrigger,
+  SecurityCellActions,
+  SecurityCellActionType,
+} from '../../../../common/components/cell_actions';
+import { getSourcererScopeId } from '../../../../helpers';
 
 export const useGetSeverityTableColumns = (): Array<EuiBasicTableColumn<SeverityData>> => {
   const severityColors = useRiskSeverityColors();
@@ -28,16 +34,7 @@ export const useGetSeverityTableColumns = (): Array<EuiBasicTableColumn<Severity
         'data-test-subj': 'severityTable-severity',
         render: (severity: Severity) => (
           <EuiHealth color={severityColors[severity]} textSize="xs">
-            <DefaultDraggable
-              isDraggable={false}
-              field={ALERT_SEVERITY}
-              hideTopN
-              id={`alert-severity-draggable-${severity}`}
-              value={capitalize(severity)}
-              queryValue={severity}
-              tooltipContent={null}
-              scopeId={TableId.alertsOnAlertsPage}
-            />
+            {capitalize(severity)}
           </EuiHealth>
         ),
       },
@@ -46,11 +43,30 @@ export const useGetSeverityTableColumns = (): Array<EuiBasicTableColumn<Severity
         name: COUNT_TABLE_TITLE,
         dataType: 'number',
         'data-test-subj': 'severityTable-alertCount',
-        width: '45%',
+        width: '34%',
         render: (alertCount: number) => (
           <EuiText grow={false} size="xs">
             <FormattedCount count={alertCount} />
           </EuiText>
+        ),
+      },
+      {
+        field: 'key',
+        name: '',
+        'data-test-subj': 'severityTable-actions',
+        width: '16%',
+        render: (severity: Severity) => (
+          <SecurityCellActions
+            mode={CellActionsMode.INLINE}
+            visibleCellActions={0}
+            triggerId={SecurityCellActionsTrigger.DEFAULT}
+            data={{ field: ALERT_SEVERITY, value: severity }}
+            sourcererScopeId={getSourcererScopeId(TableId.alertsOnAlertsPage)}
+            disabledActionTypes={[SecurityCellActionType.SHOW_TOP_N]}
+            metadata={{ scopeId: TableId.alertsOnAlertsPage }}
+            extraActionsIconType="boxesVertical"
+            extraActionsColor="text"
+          />
         ),
       },
     ],

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.test.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { SeverityLevelChart } from './severity_level_chart';
@@ -28,46 +28,35 @@ describe('Severity level chart', () => {
   });
 
   test('renders severity table correctly', () => {
-    act(() => {
-      const { container } = render(
-        <TestProviders>
-          <SeverityLevelChart {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector('[data-test-subj="severity-level-table"')).toBeInTheDocument();
-      expect(
-        container.querySelector('[data-test-subj="severity-level-table"] tbody')?.textContent
-      ).toEqual('No items found');
-    });
+    const { getByTestId } = render(
+      <TestProviders>
+        <SeverityLevelChart {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('severity-level-table')).toBeInTheDocument();
+    expect(getByTestId('severity-level-table')).toHaveTextContent('No items found');
   });
 
   test('renders severity donut correctly', () => {
-    act(() => {
-      const { container } = render(
-        <TestProviders>
-          <SeverityLevelChart {...defaultProps} />
-        </TestProviders>
-      );
-      expect(
-        container.querySelector('[data-test-subj="severity-level-donut"]')
-      ).toBeInTheDocument();
-    });
+    const { getByTestId } = render(
+      <TestProviders>
+        <SeverityLevelChart {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('severity-level-donut')).toBeInTheDocument();
   });
 
   test('renders table correctly with data', () => {
-    act(() => {
-      const { queryAllByRole, container } = render(
-        <TestProviders>
-          <SeverityLevelChart data={parsedAlerts} isLoading={false} />
-        </TestProviders>
-      );
-      expect(container.querySelector('[data-test-subj="severity-level-table"')).toBeInTheDocument();
-      parsedAlerts.forEach((_, i) => {
-        expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].label);
-        expect(queryAllByRole('row')[i + 1].textContent).toContain(
-          parsedAlerts[i].value.toString()
-        );
-      });
+    const { queryAllByRole, getByTestId } = render(
+      <TestProviders>
+        <SeverityLevelChart data={parsedAlerts} isLoading={false} />
+      </TestProviders>
+    );
+    expect(getByTestId('severity-level-table')).toBeInTheDocument();
+    parsedAlerts.forEach((_, i) => {
+      expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].label);
+      expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].value.toString());
+      expect(queryAllByRole('row')[i + 1].children).toHaveLength(3);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.tsx
@@ -64,7 +64,7 @@ export const SeverityLevelChart: React.FC<SeverityLevelProps> = ({
   );
 
   return (
-    <EuiFlexGroup gutterSize="s" data-test-subj="severity-level-chart">
+    <EuiFlexGroup gutterSize="none" data-test-subj="severity-level-chart">
       <EuiFlexItem>
         <EuiInMemoryTable
           data-test-subj="severity-level-table"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Standardize actions in Alerts KPI visualizations (#206340)](https://github.com/elastic/kibana/pull/206340)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-11T00:30:23Z","message":"[Security Solution] Standardize actions in Alerts KPI visualizations (#206340)\n\n### Background\r\n\r\nThe initial intent of the PR was to address customer feedback regarding\r\nhover actions in the kpi charts. Because the hover actions wrap around\r\nthe label, some users find the trigger sensitive, especially when screen\r\nresolution is high and the text labels are small.\r\n\r\nUpon exploring options and reviewing with UIUX team, it was decided that\r\nwe should follow the take action format in Lens charts (inline actions\r\ninline, vertical 3 dots icon, and black color), to ensure that we have a\r\nstandard experience in charts.\r\n\r\n### Before ###\r\n**Non-Lens charts: overview charts, treemap**\r\n- Popover actions upon hover\r\n- Popover content is blue (default color)\r\n\r\n![image](https://github.com/user-attachments/assets/20091b16-4408-4f55-ace8-95cbac25ff2e)\r\n\r\n![image](https://github.com/user-attachments/assets/06b97ad8-fe41-4508-95ff-cc0ee5a73338)\r\n\r\n\r\n**Lens charts: Trend graph, Count table**\r\n- Actions are inline, with the vertical 3 dots icon\r\n- Icon and menu item are in black color\r\n\r\n![image](https://github.com/user-attachments/assets/df0dd709-ec02-4549-bf35-60ca5fe57179)\r\n\r\n\r\n### After \r\n\r\nAll the non-Lens charts have inline actions in black\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/29c4e9e9-f458-4520-b90f-e4b16a5e1318)\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/ba904202-338c-4154-b645-128729010d1d)\r\n\r\n### Changes to `CellActions` package\r\n\r\nThis PR focuses on making the inline option flexible, by taking\r\nadditional styling options in metadata\r\n\r\n```\r\nmetadata={{\r\n          extraActionsIconType: 'boxesVertical',\r\n          extraActionsColor: 'text',\r\n        }}\r\n```\r\nThe styling does not impact hover options \r\n\r\n![image](https://github.com/user-attachments/assets/07e59cd1-0d0b-472f-9ef1-a8a185d8dd3c)\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"fc6e1d6ae97b790129f02c2a8a5adb8522639a19","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Threat Hunting","Team:Threat Hunting:Investigations","backport:version","v9.1.0","v8.19.0"],"title":"[Security Solution] Standardize actions in Alerts KPI visualizations","number":206340,"url":"https://github.com/elastic/kibana/pull/206340","mergeCommit":{"message":"[Security Solution] Standardize actions in Alerts KPI visualizations (#206340)\n\n### Background\r\n\r\nThe initial intent of the PR was to address customer feedback regarding\r\nhover actions in the kpi charts. Because the hover actions wrap around\r\nthe label, some users find the trigger sensitive, especially when screen\r\nresolution is high and the text labels are small.\r\n\r\nUpon exploring options and reviewing with UIUX team, it was decided that\r\nwe should follow the take action format in Lens charts (inline actions\r\ninline, vertical 3 dots icon, and black color), to ensure that we have a\r\nstandard experience in charts.\r\n\r\n### Before ###\r\n**Non-Lens charts: overview charts, treemap**\r\n- Popover actions upon hover\r\n- Popover content is blue (default color)\r\n\r\n![image](https://github.com/user-attachments/assets/20091b16-4408-4f55-ace8-95cbac25ff2e)\r\n\r\n![image](https://github.com/user-attachments/assets/06b97ad8-fe41-4508-95ff-cc0ee5a73338)\r\n\r\n\r\n**Lens charts: Trend graph, Count table**\r\n- Actions are inline, with the vertical 3 dots icon\r\n- Icon and menu item are in black color\r\n\r\n![image](https://github.com/user-attachments/assets/df0dd709-ec02-4549-bf35-60ca5fe57179)\r\n\r\n\r\n### After \r\n\r\nAll the non-Lens charts have inline actions in black\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/29c4e9e9-f458-4520-b90f-e4b16a5e1318)\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/ba904202-338c-4154-b645-128729010d1d)\r\n\r\n### Changes to `CellActions` package\r\n\r\nThis PR focuses on making the inline option flexible, by taking\r\nadditional styling options in metadata\r\n\r\n```\r\nmetadata={{\r\n          extraActionsIconType: 'boxesVertical',\r\n          extraActionsColor: 'text',\r\n        }}\r\n```\r\nThe styling does not impact hover options \r\n\r\n![image](https://github.com/user-attachments/assets/07e59cd1-0d0b-472f-9ef1-a8a185d8dd3c)\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"fc6e1d6ae97b790129f02c2a8a5adb8522639a19"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/206340","number":206340,"mergeCommit":{"message":"[Security Solution] Standardize actions in Alerts KPI visualizations (#206340)\n\n### Background\r\n\r\nThe initial intent of the PR was to address customer feedback regarding\r\nhover actions in the kpi charts. Because the hover actions wrap around\r\nthe label, some users find the trigger sensitive, especially when screen\r\nresolution is high and the text labels are small.\r\n\r\nUpon exploring options and reviewing with UIUX team, it was decided that\r\nwe should follow the take action format in Lens charts (inline actions\r\ninline, vertical 3 dots icon, and black color), to ensure that we have a\r\nstandard experience in charts.\r\n\r\n### Before ###\r\n**Non-Lens charts: overview charts, treemap**\r\n- Popover actions upon hover\r\n- Popover content is blue (default color)\r\n\r\n![image](https://github.com/user-attachments/assets/20091b16-4408-4f55-ace8-95cbac25ff2e)\r\n\r\n![image](https://github.com/user-attachments/assets/06b97ad8-fe41-4508-95ff-cc0ee5a73338)\r\n\r\n\r\n**Lens charts: Trend graph, Count table**\r\n- Actions are inline, with the vertical 3 dots icon\r\n- Icon and menu item are in black color\r\n\r\n![image](https://github.com/user-attachments/assets/df0dd709-ec02-4549-bf35-60ca5fe57179)\r\n\r\n\r\n### After \r\n\r\nAll the non-Lens charts have inline actions in black\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/29c4e9e9-f458-4520-b90f-e4b16a5e1318)\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/ba904202-338c-4154-b645-128729010d1d)\r\n\r\n### Changes to `CellActions` package\r\n\r\nThis PR focuses on making the inline option flexible, by taking\r\nadditional styling options in metadata\r\n\r\n```\r\nmetadata={{\r\n          extraActionsIconType: 'boxesVertical',\r\n          extraActionsColor: 'text',\r\n        }}\r\n```\r\nThe styling does not impact hover options \r\n\r\n![image](https://github.com/user-attachments/assets/07e59cd1-0d0b-472f-9ef1-a8a185d8dd3c)\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"fc6e1d6ae97b790129f02c2a8a5adb8522639a19"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210486","number":210486,"state":"MERGED","mergeCommit":{"sha":"98f18df5121207f6ea286a158a0aa0a8851b46c5","message":"[8.x][Security Solution] Standardize actions in Alerts KPI visualizations … (#210486)\n\n# Backport\r\n\r\nThis will backport the following commits from `main` to `8.x`:\r\n- [[Security Solution] Standardize actions in Alerts KPI visualizations\r\n(#206340)](https://github.com/elastic/kibana/pull/206340)\r\n\r\n\r\n\r\n…(#206340)\r\n\r\n### Background\r\n\r\nThe initial intent of the PR was to address customer feedback regarding\r\nhover actions in the kpi charts. Because the hover actions wrap around\r\nthe label, some users find the trigger sensitive, especially when screen\r\nresolution is high and the text labels are small.\r\n\r\nUpon exploring options and reviewing with UIUX team, it was decided that\r\nwe should follow the take action format in Lens charts (inline actions\r\ninline, vertical 3 dots icon, and black color), to ensure that we have a\r\nstandard experience in charts.\r\n\r\n### Before ###\r\n**Non-Lens charts: overview charts, treemap**\r\n- Popover actions upon hover\r\n- Popover content is blue (default color)\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/20091b16-4408-4f55-ace8-95cbac25ff2e)\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/06b97ad8-fe41-4508-95ff-cc0ee5a73338)\r\n\r\n**Lens charts: Trend graph, Count table**\r\n- Actions are inline, with the vertical 3 dots icon\r\n- Icon and menu item are in black color\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/df0dd709-ec02-4549-bf35-60ca5fe57179)\r\n\r\n### After\r\n\r\nAll the non-Lens charts have inline actions in black\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/29c4e9e9-f458-4520-b90f-e4b16a5e1318)\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/ba904202-338c-4154-b645-128729010d1d)\r\n\r\n### Changes to `CellActions` package\r\n\r\nThis PR focuses on making the inline option flexible, by taking\r\nadditional styling options in metadata\r\n\r\n```\r\nextraActionsIconType: 'boxesVertical',\r\nextraActionsColor: 'text',\r\n```\r\nThe styling does not impact hover options\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/07e59cd1-0d0b-472f-9ef1-a8a185d8dd3c)\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n(cherry picked from commit fc6e1d6ae97b790129f02c2a8a5adb8522639a19)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>"}}]}] BACKPORT-->