### PR TITLE
[Rules migration][Integration test] Get Prebuilt Rules APIs (#11232)

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/get_prebuilt_rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/get_prebuilt_rules.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { v4 as uuidv4 } from 'uuid';
+import { RuleTranslationResult } from '@kbn/security-solution-plugin/common/siem_migrations/constants';
+import { deleteAllRules } from '../../../../../common/utils/security_solution';
+import {
+  RuleMigrationDocument,
+  createMigrationRules,
+  defaultElasticRule,
+  deleteAllMigrationRules,
+  getMigrationRuleDocuments,
+  migrationRulesRouteHelpersFactory,
+} from '../../utils';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+import {
+  createPrebuiltRuleAssetSavedObjects,
+  createRuleAssetSavedObject,
+  deleteAllPrebuiltRuleAssets,
+  deleteAllTimelines,
+} from '../../../detections_response/utils';
+
+export default ({ getService }: FtrProviderContext) => {
+  const es = getService('es');
+  const log = getService('log');
+  const supertest = getService('supertest');
+  const migrationRulesRoutes = migrationRulesRouteHelpersFactory(supertest);
+
+  describe('@ess @serverless @serverlessQA Get Prebuilt Rules API', () => {
+    beforeEach(async () => {
+      await deleteAllRules(supertest, log);
+      await deleteAllTimelines(es, log);
+      await deleteAllPrebuiltRuleAssets(es, log);
+      await deleteAllMigrationRules(es);
+
+      // Add some prebuilt rules
+      const ruleAssetSavedObjects = [
+        createRuleAssetSavedObject({ rule_id: 'rule-1', version: 1 }),
+        createRuleAssetSavedObject({ rule_id: 'rule-2', version: 1 }),
+        createRuleAssetSavedObject({ rule_id: 'rule-3', version: 1 }),
+        createRuleAssetSavedObject({ rule_id: 'rule-4', version: 1 }),
+        createRuleAssetSavedObject({ rule_id: 'rule-5', version: 1 }),
+      ];
+      await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
+    });
+
+    it('should return all prebuilt rules matched by migration rules', async () => {
+      const migrationId = uuidv4();
+
+      const overrideCallback = (index: number): Partial<RuleMigrationDocument> => {
+        const { query_language: queryLanguage, query, ...rest } = defaultElasticRule;
+        return {
+          migration_id: migrationId,
+          elastic_rule: index < 2 ? { ...rest, prebuilt_rule_id: `rule-${index + 1}` } : undefined,
+          translation_result: index < 2 ? RuleTranslationResult.FULL : undefined,
+        };
+      };
+      const migrationRuleDocuments = getMigrationRuleDocuments(4, overrideCallback);
+      await createMigrationRules(es, migrationRuleDocuments);
+
+      const response = await migrationRulesRoutes.getPrebuiltRules({ migrationId });
+
+      const prebuiltRulesIds = Object.keys(response.body).sort();
+      expect(prebuiltRulesIds).toEqual(['rule-1', 'rule-2']);
+    });
+
+    it('should return empty response when migration rules did not match prebuilt rules', async () => {
+      const migrationId = uuidv4();
+
+      const migrationRuleDocuments = getMigrationRuleDocuments(10, () => ({
+        migration_id: migrationId,
+      }));
+      await createMigrationRules(es, migrationRuleDocuments);
+
+      const response = await migrationRulesRoutes.getPrebuiltRules({ migrationId });
+      expect(response.body).toEqual({});
+    });
+  });
+};

--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/index.ts
@@ -9,6 +9,7 @@ import { FtrProviderContext } from '../../../../ftr_provider_context';
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('@ess SecuritySolution SIEM Migrations', () => {
     loadTestFile(require.resolve('./create'));
+    loadTestFile(require.resolve('./get_prebuilt_rules'));
     loadTestFile(require.resolve('./get'));
     loadTestFile(require.resolve('./install'));
     loadTestFile(require.resolve('./stats'));

--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/utils/rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/utils/rules.ts
@@ -15,6 +15,7 @@ import { replaceParams } from '@kbn/openapi-common/shared';
 import {
   SIEM_RULE_MIGRATIONS_ALL_STATS_PATH,
   SIEM_RULE_MIGRATIONS_PATH,
+  SIEM_RULE_MIGRATIONS_PREBUILT_RULES_PATH,
   SIEM_RULE_MIGRATION_INSTALL_PATH,
   SIEM_RULE_MIGRATION_PATH,
   SIEM_RULE_MIGRATION_STATS_PATH,
@@ -23,6 +24,7 @@ import {
 import {
   CreateRuleMigrationResponse,
   GetAllStatsRuleMigrationResponse,
+  GetRuleMigrationPrebuiltRulesResponse,
   GetRuleMigrationRequestQuery,
   GetRuleMigrationResponse,
   GetRuleMigrationStatsResponse,
@@ -175,6 +177,22 @@ export const migrationRulesRouteHelpersFactory = (supertest: SuperTest.Agent) =>
         .get(
           replaceParams(SIEM_RULE_MIGRATION_TRANSLATION_STATS_PATH, { migration_id: migrationId })
         )
+        .set('kbn-xsrf', 'true')
+        .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1)
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+        .send();
+
+      assertStatusCode(expectStatusCode, response);
+
+      return response;
+    },
+
+    getPrebuiltRules: async ({
+      migrationId,
+      expectStatusCode = 200,
+    }: MigrationRequestParams): Promise<{ body: GetRuleMigrationPrebuiltRulesResponse }> => {
+      const response = await supertest
+        .get(replaceParams(SIEM_RULE_MIGRATIONS_PREBUILT_RULES_PATH, { migration_id: migrationId }))
         .set('kbn-xsrf', 'true')
         .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1)
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')


### PR DESCRIPTION
## Summary

[Internal link](https://github.com/elastic/security-team/issues/10820) to the feature details

Part of https://github.com/elastic/security-team/issues/11232

This PR covers SIEM Migrations Get prebuilt rules API (route: `GET /internal/siem_migrations/rules/{migration_id}/prebuilt_rules`) integration test:
* get all prebuilt rules matched by migration rules
* return empty response when migration rules did not match prebuilt rules


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->