### PR TITLE
[EDR Workflows] Osquery docker image in tests

### DIFF
--- a/x-pack/test/osquery_cypress/agent.ts
+++ b/x-pack/test/osquery_cypress/agent.ts
@@ -41,7 +41,7 @@ export class AgentManager extends Manager {
   public async setup() {
     this.log.info(chalk.bold('Setting up Agent'));
 
-    const artifact = `docker.elastic.co/elastic-agent/elastic-agent:${await getLatestVersion()}`;
+    const artifact = `docker.elastic.co/beats/elastic-agent:${await getLatestVersion()}`;
     this.log.indent(4, () => this.log.info(`Image: ${artifact}`));
     const containerName = generateRandomString(12);
     const fleetServerUrl =


### PR DESCRIPTION
This PR aims to revert a recent change in the docker-image for elastic-agent. Let's see if this stops our on-merge CI tests to fail. 🤞 