### PR TITLE
[Integration] Hide elastic_connectors package

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/filtered_packages.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/filtered_packages.ts
@@ -10,7 +10,7 @@ import { FLEET_SERVER_PACKAGE } from '../../../common/constants';
 
 export function getFilteredSearchPackages() {
   const shouldFilterFleetServer = appContextService.getConfig()?.internal?.fleetServerStandalone;
-  const filtered: string[] = ['profiler_collector', 'profiler_symbolizer'];
+  const filtered: string[] = ['profiler_collector', 'profiler_symbolizer', 'elastic_connectors'];
   // Do not allow to search for Fleet server integration if configured to use  standalone fleet server
   if (shouldFilterFleetServer) {
     filtered.push(FLEET_SERVER_PACKAGE);
@@ -22,7 +22,7 @@ export function getFilteredSearchPackages() {
 }
 
 export function getFilteredInstallPackages() {
-  const filtered: string[] = [];
+  const filtered: string[] = ['elastic_connectors'];
 
   const excludePackages = appContextService.getConfig()?.internal?.registry?.excludePackages ?? [];
 


### PR DESCRIPTION
## Summary

Hide `elastic_conenctors` package by default. This excludes the package from:
- integration page
- search results

#### Verification

Without the change package shows up as the integration, and search results. With the change it's correctly excluded.




<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->