### PR TITLE
Bump backport to v9.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1708,7 +1708,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-plugin-transform-require-default": "^0.1.7",
     "babel-plugin-transform-typescript-metadata": "^0.3.2",
-    "backport": "^9.6.5",
+    "backport": "^9.6.6",
     "blob-polyfill": "^7.0.20220408",
     "buildkite-test-collector": "^1.7.0",
     "callsites": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1708,7 +1708,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-plugin-transform-require-default": "^0.1.7",
     "babel-plugin-transform-typescript-metadata": "^0.3.2",
-    "backport": "^9.6.4",
+    "backport": "^9.6.5",
     "blob-polyfill": "^7.0.20220408",
     "buildkite-test-collector": "^1.7.0",
     "callsites": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14456,10 +14456,10 @@ babel-runtime@6.x:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-backport@^9.6.4:
-  version "9.6.4"
-  resolved "https://registry.yarnpkg.com/backport/-/backport-9.6.4.tgz#ea45ab97f32ebca1564269f92a6fc56eda703cdc"
-  integrity sha512-cTaItWSGoO33vOD/br/Di2KFesgHyE6UWuc0GN0IiFk13UqEadeURq3UOQptARyQC3Nz56Us5QYNJ3E5L61zYg==
+backport@^9.6.5:
+  version "9.6.5"
+  resolved "https://registry.yarnpkg.com/backport/-/backport-9.6.5.tgz#9565c38359379bc19c4b5e06dd15976be2df091f"
+  integrity sha512-Gk9NemFWt694TUUh6RsU7z4R+v+oFoZhPYzEUsEjMxGJPotxI2dcVDYGkJh0jYjzJBP0eUS/fvAPS3X/EokCwA==
   dependencies:
     "@octokit/rest" "^19.0.7"
     axios "^1.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14456,10 +14456,10 @@ babel-runtime@6.x:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-backport@^9.6.5:
-  version "9.6.5"
-  resolved "https://registry.yarnpkg.com/backport/-/backport-9.6.5.tgz#9565c38359379bc19c4b5e06dd15976be2df091f"
-  integrity sha512-Gk9NemFWt694TUUh6RsU7z4R+v+oFoZhPYzEUsEjMxGJPotxI2dcVDYGkJh0jYjzJBP0eUS/fvAPS3X/EokCwA==
+backport@^9.6.6:
+  version "9.6.6"
+  resolved "https://registry.yarnpkg.com/backport/-/backport-9.6.6.tgz#ab7d0a1720eb5cd3ccef51cd79f1872bb9ed409c"
+  integrity sha512-X/2vWZNZP5wvbfWaxtLsXSbnOxANgoCh84IZavTS2X2/6X/si3cpUL0ky1fh+70bK5O8PI+3Fopp5srmeqHB1g==
   dependencies:
     "@octokit/rest" "^19.0.7"
     axios "^1.6.2"


### PR DESCRIPTION
This bumps backport to 9.6.6. Most notably fixes an issue with Handlebars templates and stripping markdown comments:
https://github.com/sorenlouv/backport/compare/v9.6.4...v9.6.6

Also bumped here: https://github.com/elastic/kibana-github-actions/pull/55

<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->