### PR TITLE
[ML] File upload: Adding link to full file upload tool

### DIFF
--- a/x-pack/platform/plugins/private/data_visualizer/public/lite/file_upload_lite_view.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/lite/file_upload_lite_view.tsx
@@ -13,6 +13,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiLink,
   EuiLoadingSpinner,
   EuiSpacer,
   EuiText,
@@ -38,6 +39,7 @@ import { IndexInput } from './index_input';
 import { OverallUploadStatus } from './overall_upload_status';
 import { ImportErrors } from './import_errors';
 import { DataViewIllustration } from './data_view_illustration';
+import { useDataVisualizerKibana } from '../application/kibana_context';
 
 interface Props {
   dataStart: DataPublicPluginStart;
@@ -63,6 +65,12 @@ export const FileUploadLiteView: FC<Props> = ({
   indexSettings,
   onClose,
 }) => {
+  const {
+    services: {
+      application: { navigateToApp },
+    },
+  } = useDataVisualizerKibana();
+
   const [indexName, setIndexName] = useState<string>('');
   const [indexValidationStatus, setIndexValidationStatus] = useState<STATUS>(STATUS.NOT_STARTED);
 
@@ -86,6 +94,11 @@ export const FileUploadLiteView: FC<Props> = ({
   const fileClashes = useMemo(
     () => uploadStatus.fileClashes.some((f) => f.clash),
     [uploadStatus.fileClashes]
+  );
+
+  const fullFileUpload = useCallback(
+    () => navigateToApp('home', { path: '#/tutorial_directory/fileDataViz' }),
+    [navigateToApp]
   );
 
   useEffect(() => {
@@ -130,6 +143,23 @@ export const FileUploadLiteView: FC<Props> = ({
                     <FormattedMessage
                       id="xpack.dataVisualizer.file.uploadView.uploadFileDescription"
                       defaultMessage="Upload your file, analyze its data, and import the data into an Elasticsearch index. The data can also be automatically vectorized using semantic text."
+                    />
+
+                    <br />
+
+                    <FormattedMessage
+                      id="xpack.dataVisualizer.file.uploadView.uploadFileDescriptionLink"
+                      defaultMessage="If you need to customize the file upload process, the full version is available {fullToolLink}."
+                      values={{
+                        fullToolLink: (
+                          <EuiLink onClick={fullFileUpload}>
+                            <FormattedMessage
+                              id="xpack.dataVisualizer.file.uploadView.uploadFileDescriptionLinkText"
+                              defaultMessage="here"
+                            />
+                          </EuiLink>
+                        ),
+                      }}
                     />
                   </p>
                 </EuiText>


### PR DESCRIPTION
Adds a link to the original file upload page from file upload lite help text.

![image](https://github.com/user-attachments/assets/12c9799f-95e6-4fa4-81f3-d997a689677a)


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->