### PR TITLE
[Fix]Removes synonyms read-only permission.

### DIFF
--- a/x-pack/solutions/search/plugins/search_synonyms/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/plugin.ts
@@ -49,22 +49,21 @@ export class SearchSynonymsPlugin
       privileges: {
         all: {
           app: ['kibana', PLUGIN_ID],
-          api: ['synonyms:manage', 'synonyms:read'],
+          api: ['manage_synonyms'],
           catalogue: [PLUGIN_ID],
           savedObject: {
             all: [],
             read: [],
           },
-          ui: ['read', 'save'],
+          ui: ['manage'],
         },
         read: {
-          app: ['kibana', PLUGIN_ID],
-          api: ['synonyms:read'],
+          disabled: true,
           savedObject: {
             all: [],
             read: [],
           },
-          ui: ['read'],
+          ui: [],
         },
       },
     });
@@ -72,7 +71,7 @@ export class SearchSynonymsPlugin
     return {};
   }
 
-  public start(core: CoreStart) {
+  public start(_: CoreStart) {
     return {};
   }
 

--- a/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
@@ -26,7 +26,6 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SETS,
       options: {
         access: 'internal',
-        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
@@ -78,7 +77,6 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID,
       options: {
         access: 'internal',
-        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
@@ -119,7 +117,6 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID,
       options: {
         access: 'internal',
-        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
@@ -177,7 +174,6 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID_RULE_ID,
       options: {
         access: 'internal',
-        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
@@ -228,7 +224,6 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID_RULE_ID,
       options: {
         access: 'internal',
-        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
@@ -279,7 +274,6 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID,
       options: {
         access: 'internal',
-        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
@@ -328,7 +322,6 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.GENERATE_SYNONYM_RULE_ID,
       options: {
         access: 'internal',
-        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
@@ -377,7 +370,6 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID_RULE_ID,
       options: {
         access: 'internal',
-        tags: ['manage_synonyms'],
       },
       security: {
         authz: {

--- a/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_synonyms/server/routes.ts
@@ -26,11 +26,11 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SETS,
       options: {
         access: 'internal',
-        tags: ['synonyms:read'],
+        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
-          requiredPrivileges: ['synonyms:read'],
+          requiredPrivileges: ['manage_synonyms'],
         },
       },
       validate: {
@@ -78,11 +78,11 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID,
       options: {
         access: 'internal',
-        tags: ['synonyms:write', 'synonyms:read'],
+        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
-          requiredPrivileges: ['synonyms:write', 'synonyms:read'],
+          requiredPrivileges: ['manage_synonyms'],
         },
       },
       validate: {
@@ -119,11 +119,11 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID,
       options: {
         access: 'internal',
-        tags: ['synonyms:read'],
+        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
-          requiredPrivileges: ['synonyms:read'],
+          requiredPrivileges: ['manage_synonyms'],
         },
       },
       validate: {
@@ -177,11 +177,11 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID_RULE_ID,
       options: {
         access: 'internal',
-        tags: ['synonyms:read'],
+        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
-          requiredPrivileges: ['synonyms:read'],
+          requiredPrivileges: ['manage_synonyms'],
         },
       },
       validate: {
@@ -228,11 +228,11 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID_RULE_ID,
       options: {
         access: 'internal',
-        tags: ['synonyms:write', 'synonyms:read'],
+        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
-          requiredPrivileges: ['synonyms:write', 'synonyms:read'],
+          requiredPrivileges: ['manage_synonyms'],
         },
       },
       validate: {
@@ -279,11 +279,11 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID,
       options: {
         access: 'internal',
-        tags: ['synonyms:write', 'synonyms:read'],
+        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
-          requiredPrivileges: ['synonyms:write', 'synonyms:read'],
+          requiredPrivileges: ['manage_synonyms'],
         },
       },
       validate: {
@@ -328,11 +328,11 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.GENERATE_SYNONYM_RULE_ID,
       options: {
         access: 'internal',
-        tags: ['synonyms:write', 'synonyms:read'],
+        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
-          requiredPrivileges: ['synonyms:write', 'synonyms:read'],
+          requiredPrivileges: ['manage_synonyms'],
         },
       },
       validate: {
@@ -377,11 +377,11 @@ export function defineRoutes({ logger, router }: { logger: Logger; router: IRout
       path: APIRoutes.SYNONYM_SET_ID_RULE_ID,
       options: {
         access: 'internal',
-        tags: ['synonyms:write', 'synonyms:read'],
+        tags: ['manage_synonyms'],
       },
       security: {
         authz: {
-          requiredPrivileges: ['synonyms:write', 'synonyms:read'],
+          requiredPrivileges: ['manage_synonyms'],
         },
       },
       validate: {

--- a/x-pack/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
+++ b/x-pack/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
@@ -62,6 +62,7 @@ export default function navLinksTests({ getService }: FtrProviderContext) {
                 'enterpriseSearchApplications',
                 'enterpriseSearchAnalytics',
                 'searchPlayground',
+                'searchSynonyms',
                 'searchInferenceEndpoints',
                 'guidedOnboardingFeature',
                 'securitySolutionAssistant',


### PR DESCRIPTION
## Summary

Kibana permission for read-only is removed. This is not a breaking change while the feature is not yet released.
Cluster requirements make it obsolete.
Also fixed warnings on permission names.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->