### PR TITLE
[canvas] remove usage of EmbeddableInput type

### DIFF
--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/expression_types/embeddable.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/expression_types/embeddable.ts
@@ -6,14 +6,12 @@
  */
 
 import { ExpressionTypeDefinition } from '@kbn/expressions-plugin/common';
-import { EmbeddableInput } from '../../types';
 import { EmbeddableTypes } from './embeddable_types';
 
 export const EmbeddableExpressionType = 'embeddable';
-export type { EmbeddableInput };
 export { EmbeddableTypes };
 
-export interface EmbeddableExpression<Input extends EmbeddableInput> {
+export interface EmbeddableExpression {
   /**
    * The type of the expression result
    */
@@ -21,7 +19,7 @@ export interface EmbeddableExpression<Input extends EmbeddableInput> {
   /**
    * The input to be passed to the embeddable
    */
-  input: Input;
+  input: Record<string, unknown>;
   /**
    * The type of embeddable
    */
@@ -35,11 +33,11 @@ export interface EmbeddableExpression<Input extends EmbeddableInput> {
 
 export const embeddableType = (): ExpressionTypeDefinition<
   typeof EmbeddableExpressionType,
-  EmbeddableExpression<any>
+  EmbeddableExpression
 > => ({
   name: EmbeddableExpressionType,
   to: {
-    render: (embeddableExpression: EmbeddableExpression<any>) => {
+    render: (embeddableExpression: EmbeddableExpression) => {
       return {
         type: 'render',
         as: EmbeddableExpressionType,

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/embeddable.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/embeddable.ts
@@ -13,7 +13,7 @@ import {
 } from '@kbn/expressions-plugin/common';
 import { MigrateFunction, MigrateFunctionsObject } from '@kbn/kibana-utils-plugin/common';
 import { SavedObjectReference } from '@kbn/core/types';
-import { ExpressionValueFilter, EmbeddableInput } from '../../../types';
+import { ExpressionValueFilter } from '../../../types';
 import { EmbeddableExpressionType, EmbeddableExpression } from '../../expression_types';
 import { getFunctionHelp } from '../../../i18n';
 import { getQueryFilters } from '../../../common/lib/build_embeddable_filters';
@@ -36,13 +36,11 @@ const baseEmbeddableInput = {
   renderMode: 'noInteractivity',
 };
 
-type Return = EmbeddableExpression<EmbeddableInput>;
-
 type EmbeddableFunction = ExpressionFunctionDefinition<
   'embeddable',
   ExpressionValueFilter | null,
   Arguments,
-  Return
+  EmbeddableExpression
 >;
 
 export function embeddableFunctionFactory({
@@ -56,7 +54,7 @@ export function embeddableFunctionFactory({
         migrateFn: MigrateFunction<EmbeddableStateWithType, EmbeddableStateWithType>
       ): MigrateFunction<ExpressionAstFunction, ExpressionAstFunction> =>
       (state: ExpressionAstFunction): ExpressionAstFunction => {
-        const embeddableInput = decode(state.arguments.config[0] as string) as EmbeddableInput;
+        const embeddableInput = decode(state.arguments.config[0] as string);
 
         const embeddableType = state.arguments.type[0];
 
@@ -92,7 +90,7 @@ export function embeddableFunctionFactory({
       fn: (input, args) => {
         const filters = input ? input.and : [];
 
-        const embeddableInput = decode(args.config) as EmbeddableInput;
+        const embeddableInput = decode(args.config);
 
         return {
           type: EmbeddableExpressionType,

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_lens.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_lens.ts
@@ -25,13 +25,13 @@ interface Arguments {
   palette?: PaletteOutput;
 }
 
-export type SavedLensInput = {
+export interface SavedLensInput {
   title?: string;
   savedObjectId: string;
   timeRange?: TimeRange;
   filters: DataFilter[];
   palette?: PaletteOutput;
-};
+}
 
 const defaultTimeRange = {
   from: 'now-15m',

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_lens.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_lens.ts
@@ -11,7 +11,7 @@ import { Filter as DataFilter } from '@kbn/es-query';
 import type { TimeRange } from '@kbn/es-query';
 import { SavedObjectReference } from '@kbn/core/types';
 import { getQueryFilters } from '../../../common/lib/build_embeddable_filters';
-import { ExpressionValueFilter, EmbeddableInput, TimeRange as TimeRangeArg } from '../../../types';
+import { ExpressionValueFilter, TimeRange as TimeRangeArg } from '../../../types';
 import {
   EmbeddableTypes,
   EmbeddableExpressionType,
@@ -25,7 +25,8 @@ interface Arguments {
   palette?: PaletteOutput;
 }
 
-export type SavedLensInput = EmbeddableInput & {
+export type SavedLensInput = {
+  title?: string;
   savedObjectId: string;
   timeRange?: TimeRange;
   filters: DataFilter[];
@@ -37,13 +38,11 @@ const defaultTimeRange = {
   to: 'now',
 };
 
-type Return = EmbeddableExpression<SavedLensInput>;
-
 export function savedLens(): ExpressionFunctionDefinition<
   'savedLens',
   ExpressionValueFilter | null,
   Arguments,
-  Return
+  EmbeddableExpression
 > {
   const { help, args: argHelp } = getFunctionHelp().savedLens;
   return {

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_map.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_map.ts
@@ -6,7 +6,6 @@
  */
 
 import { ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
-import type { MapSerializedState } from '@kbn/maps-plugin/public';
 import { SavedObjectReference } from '@kbn/core/types';
 import { ExpressionValueFilter, MapCenter, TimeRange as TimeRangeArg } from '../../../types';
 import {
@@ -29,13 +28,11 @@ const defaultTimeRange = {
   to: 'now',
 };
 
-type Output = EmbeddableExpression<MapSerializedState & { id: string }>;
-
 export function savedMap(): ExpressionFunctionDefinition<
   'savedMap',
   ExpressionValueFilter | null,
   Arguments,
-  Output
+  EmbeddableExpression
 > {
   const { help, args: argHelp } = getFunctionHelp().savedMap;
   return {

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_search.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_search.ts
@@ -6,10 +6,7 @@
  */
 
 import type { ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
-import type { SearchEmbeddableSerializedState } from '@kbn/discover-plugin/public';
 import type { SavedObjectReference } from '@kbn/core/types';
-import type { Filter } from '@kbn/es-query';
-import type { ViewMode } from '@kbn/presentation-publishing';
 import {
   EmbeddableTypes,
   EmbeddableExpressionType,
@@ -24,19 +21,11 @@ interface Arguments {
   id: string;
 }
 
-type Output = EmbeddableExpression<
-  Partial<SearchEmbeddableSerializedState> & {
-    id: string;
-    filters?: Filter[];
-    viewMode?: ViewMode;
-  }
->;
-
 export function savedSearch(): ExpressionFunctionDefinition<
   'savedSearch',
   ExpressionValueFilter | null,
   Arguments,
-  Output
+  EmbeddableExpression
 > {
   const { help, args: argHelp } = getFunctionHelp().savedSearch;
   return {

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_visualization.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/functions/external/saved_visualization.ts
@@ -26,8 +26,6 @@ interface Arguments {
   title: string | null;
 }
 
-type Output = EmbeddableExpression<VisualizeInput & { savedObjectId: string }>;
-
 const defaultTimeRange = {
   from: 'now-15m',
   to: 'now',
@@ -37,7 +35,7 @@ export function savedVisualization(): ExpressionFunctionDefinition<
   'savedVisualization',
   ExpressionValueFilter | null,
   Arguments,
-  Output
+  EmbeddableExpression
 > {
   const { help, args: argHelp } = getFunctionHelp().savedVisualization;
   return {

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
@@ -24,7 +24,6 @@ import { CANVAS_EMBEDDABLE_CLASSNAME } from '../../../common/lib';
 import { RendererStrings } from '../../../i18n';
 import {
   CanvasContainerApi,
-  EmbeddableInput,
   RendererFactory,
   RendererHandlers,
 } from '../../../types';
@@ -46,7 +45,7 @@ const renderReactEmbeddable = ({
 }: {
   type: string;
   uuid: string;
-  input: EmbeddableInput;
+  input: { filters?: Filter[] };
   container: CanvasContainerApi;
   handlers: RendererHandlers;
   core: CoreStart;
@@ -75,7 +74,7 @@ const renderReactEmbeddable = ({
         key={`${type}_${uuid}`}
         onAnyStateChange={(newState) => {
           const newExpression = embeddableInputToExpression(
-            newState.rawState as unknown as EmbeddableInput,
+            newState.rawState,
             type,
             undefined,
             true
@@ -117,7 +116,7 @@ const renderReactEmbeddable = ({
 export const embeddableRendererFactory = (
   core: CoreStart,
   plugins: StartDeps
-): RendererFactory<EmbeddableExpression<EmbeddableInput> & { canvasApi: CanvasContainerApi }> => {
+): RendererFactory<EmbeddableExpression & { canvasApi: CanvasContainerApi }> => {
   return () => ({
     name: 'embeddable',
     displayName: strings.getDisplayName(),
@@ -146,7 +145,7 @@ export const embeddableRendererFactory = (
           return ReactDOM.unmountComponentAtNode(domNode);
         });
       } else {
-        api.setFilters(input.filters);
+        api.setFilters((input as { filters?: Filter[] }).filters);
       }
     },
   });

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable.tsx
@@ -22,11 +22,7 @@ import {
 import { BehaviorSubject } from 'rxjs';
 import { CANVAS_EMBEDDABLE_CLASSNAME } from '../../../common/lib';
 import { RendererStrings } from '../../../i18n';
-import {
-  CanvasContainerApi,
-  RendererFactory,
-  RendererHandlers,
-} from '../../../types';
+import { CanvasContainerApi, RendererFactory, RendererHandlers } from '../../../types';
 import { EmbeddableExpression } from '../../expression_types/embeddable';
 import { StartDeps } from '../../plugin';
 import { embeddableInputToExpression } from './embeddable_input_to_expression';

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PaletteRegistry } from '@kbn/coloring';
-import { EmbeddableTypes, EmbeddableInput } from '../../expression_types';
+import { EmbeddableTypes } from '../../expression_types';
 import { toExpression as mapToExpression } from './input_type_to_expression/map';
 import { toExpression as visualizationToExpression } from './input_type_to_expression/visualization';
 import { toExpression as lensToExpression } from './input_type_to_expression/lens';
@@ -25,7 +25,7 @@ export function embeddableInputToExpression<
   UseGenericEmbeddable extends boolean,
   ConditionalReturnType = UseGenericEmbeddable extends true ? string : string | undefined
 >(
-  input: Omit<EmbeddableInput, 'id'>,
+  input: object,
   embeddableType: string,
   palettes?: PaletteRegistry,
   useGenericEmbeddable?: UseGenericEmbeddable

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.test.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { toExpression } from './embeddable';
-import { EmbeddableInput } from '../../../../types';
 import { decode } from '../../../../common/lib/embeddable_dataurl';
 import { fromExpression } from '@kbn/interpreter';
 
@@ -19,7 +18,7 @@ describe('toExpression', () => {
     };
 
     it('converts to an embeddable expression', () => {
-      const input: EmbeddableInput = baseEmbeddableInput;
+      const input = baseEmbeddableInput;
 
       const expression = toExpression(input, 'visualization');
       const ast = fromExpression(expression);
@@ -34,7 +33,7 @@ describe('toExpression', () => {
     });
 
     it('includes optional input values', () => {
-      const input: EmbeddableInput = {
+      const input = {
         ...baseEmbeddableInput,
         title: 'title',
         timeRange: {
@@ -55,7 +54,7 @@ describe('toExpression', () => {
     });
 
     it('includes empty panel title', () => {
-      const input: EmbeddableInput = {
+      const input = {
         ...baseEmbeddableInput,
         title: '',
       };
@@ -76,7 +75,7 @@ describe('toExpression', () => {
       filters: [],
     };
     it('converts to an embeddable expression', () => {
-      const input: EmbeddableInput = baseEmbeddableInput;
+      const input = baseEmbeddableInput;
 
       const expression = toExpression(input, 'visualization');
       const ast = fromExpression(expression);
@@ -91,7 +90,7 @@ describe('toExpression', () => {
     });
 
     it('includes optional input values', () => {
-      const input: EmbeddableInput = {
+      const input = {
         ...baseEmbeddableInput,
         title: 'title',
         timeRange: {
@@ -112,7 +111,7 @@ describe('toExpression', () => {
     });
 
     it('includes empty panel title', () => {
-      const input: EmbeddableInput = {
+      const input = {
         ...baseEmbeddableInput,
         title: '',
       };

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/input_type_to_expression/embeddable.ts
@@ -6,8 +6,7 @@
  */
 
 import { encode } from '../../../../common/lib/embeddable_dataurl';
-import { EmbeddableInput } from '../../../expression_types';
 
-export function toExpression(input: Omit<EmbeddableInput, 'id'>, embeddableType: string): string {
+export function toExpression(input: object, embeddableType: string): string {
   return `embeddable config="${encode(input)}" type="${embeddableType}" | render`;
 }

--- a/x-pack/platform/plugins/private/canvas/public/components/hooks/use_canvas_api.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/hooks/use_canvas_api.tsx
@@ -9,7 +9,6 @@ import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { BehaviorSubject, Subject } from 'rxjs';
 
-import { EmbeddableInput } from '@kbn/embeddable-plugin/common';
 import { ViewMode } from '@kbn/presentation-publishing';
 
 import { embeddableInputToExpression } from '../../../canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression';
@@ -28,7 +27,7 @@ export const useCanvasApi: () => CanvasContainerApi = () => {
   const dispatch = useDispatch();
 
   const createNewEmbeddable = useCallback(
-    (type: string, embeddableInput: EmbeddableInput) => {
+    (type: string, embeddableInput: object) => {
       if (trackCanvasUiMetric) {
         trackCanvasUiMetric(METRIC_TYPE.CLICK, type);
       }
@@ -60,7 +59,7 @@ export const useCanvasApi: () => CanvasContainerApi = () => {
         initialState,
       }: {
         panelType: string;
-        initialState: EmbeddableInput;
+        initialState: object;
       }) => {
         createNewEmbeddable(panelType, initialState);
       },

--- a/x-pack/platform/plugins/private/canvas/tsconfig.json
+++ b/x-pack/platform/plugins/private/canvas/tsconfig.json
@@ -31,7 +31,6 @@
     "@kbn/charts-plugin",
     "@kbn/data-plugin",
     "@kbn/share-plugin",
-    "@kbn/discover-plugin",
     "@kbn/embeddable-plugin",
     "@kbn/expressions-plugin",
     "@kbn/expression-error-plugin",

--- a/x-pack/platform/plugins/private/canvas/types/embeddables.ts
+++ b/x-pack/platform/plugins/private/canvas/types/embeddables.ts
@@ -5,9 +5,6 @@
  * 2.0.
  */
 
-import type { TimeRange } from '@kbn/es-query';
-import { Filter } from '@kbn/es-query';
-import { EmbeddableInput as Input } from '@kbn/embeddable-plugin/common';
 import type {
   HasAppContext,
   HasDisableTriggers,
@@ -17,12 +14,6 @@ import type {
   PublishesUnifiedSearch,
 } from '@kbn/presentation-publishing';
 import type { CanAddNewPanel, HasSerializedChildState } from '@kbn/presentation-containers';
-
-export type EmbeddableInput = Input & {
-  timeRange?: TimeRange;
-  filters?: Filter[];
-  savedObjectId?: string;
-};
 
 export type CanvasContainerApi = PublishesViewMode &
   CanAddNewPanel &


### PR DESCRIPTION
Part of effort to remove legacy EmbeddableInput type.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->