### PR TITLE
Fix `SolutionNav` padding in pages that use overridden EUI breakpoints

### DIFF
--- a/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.tsx
+++ b/src/platform/packages/shared/shared-ux/page/solution_nav/src/solution_nav.tsx
@@ -29,7 +29,7 @@ import {
   useEuiThemeCSSVariables,
   EuiPageSidebar,
   useEuiOverflowScroll,
-  useEuiBreakpoint,
+  useEuiMinBreakpoint,
   euiCanAnimate,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -222,7 +222,7 @@ export const SolutionNav: FC<SolutionNavProps> = ({
 
       ${useEuiOverflowScroll('y')};
 
-      ${useEuiBreakpoint(['m', 'l', 'xl'])} {
+      ${useEuiMinBreakpoint('m')} {
         width: ${FLYOUT_SIZE_CSS};
         padding: ${euiTheme.size.l};
       }


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/211474

This PR fixes a bug introduced in #207008 that caused the `<SolutionNav />` component to not have the `padding` style defined when rendered on certain Observability pages.

The underlying issue was caused by `useEuiBreakpoint(['m', 'l', 'xl'])` hook to define breakpoints while the APM, Synthetics, and User Experience apps modify the default EUI breakpoints to add custom `xxl` (>=1600px) and `xxxl` (>=2000px) levels. This breakpoint modification resulted in not all breakpoint levels being recognized as matching and the `padding` style not applied.

| Before | After |
|--------|--------|
| <img width="1728" alt="Screenshot 2025-02-18 at 00 33 08" src="https://github.com/user-attachments/assets/49ce4f8e-343e-4d04-99fc-5fd1163f1b3f" /> | <img width="1728" alt="Screenshot 2025-02-18 at 00 30 23" src="https://github.com/user-attachments/assets/ba7ffa63-cbd0-41ce-8b36-01931dda4167" /> |

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->