### PR TITLE
[Upgrade Assistant] Adapt upgrade assistant to migrate all native connectors to self-managed

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/enterprise_search/kibana.jsonc
@@ -12,7 +12,9 @@
     "id": "enterpriseSearch",
     "server": true,
     "browser": true,
-    "configPath": ["enterpriseSearch"],
+    "configPath": [
+      "enterpriseSearch"
+    ],
     "requiredPlugins": [
       "data",
       "features",
@@ -42,9 +44,10 @@
       "charts",
       "cloud",
       "lens",
-      "share",
-      "fleet"
+      "share"
     ],
-    "requiredBundles": ["kibanaReact"]
+    "requiredBundles": [
+      "kibanaReact"
+    ]
   }
 }

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.test.ts
@@ -103,129 +103,24 @@ describe('Native connector deprecations', () => {
       is_native: false,
     } as Connector;
     mockedFetchConnectors = jest.fn().mockResolvedValue([connectorClient]);
-    const deprecations = await getNativeConnectorDeprecations(ctx, true, true, cloud, docsUrl);
+    const deprecations = await getNativeConnectorDeprecations(ctx, docsUrl);
     expect(deprecations).toHaveLength(0);
   });
 
-  it('Has a deprecation if there are native connectors with illegal service types', async () => {
+  it('Has a deprecation if there are native connectors present', async () => {
     const nativeConnector = {
       id: 'foo',
       is_native: true,
       service_type: 'fake',
     } as Connector;
     mockedFetchConnectors = jest.fn().mockResolvedValue([nativeConnector]);
-    const deprecations = await getNativeConnectorDeprecations(ctx, true, true, cloud, docsUrl);
+    const deprecations = await getNativeConnectorDeprecations(ctx, docsUrl);
     expect(deprecations).toHaveLength(1);
     expect(deprecations[0].correctiveActions.api?.path).toStrictEqual(
       '/internal/enterprise_search/deprecations/convert_connectors_to_client'
     );
     expect(deprecations[0].correctiveActions.api?.body).toStrictEqual({ ids: ['foo'] });
-    expect(deprecations[0].title).toMatch('must be of supported service types');
-  });
-
-  it('Does not allow "native" connectors in non-agentless environments', async () => {
-    const nativeConnector = {
-      id: 'foo',
-      is_native: true,
-      service_type: 'github',
-    } as Connector;
-    const hasAgentless = false;
-    mockedFetchConnectors = jest.fn().mockResolvedValue([nativeConnector]);
-    const deprecations = await getNativeConnectorDeprecations(
-      ctx,
-      hasAgentless,
-      true,
-      notCloud,
-      docsUrl
-    );
-    expect(deprecations).toHaveLength(1);
-    expect(deprecations[0].correctiveActions.api?.path).toStrictEqual(
-      '/internal/enterprise_search/deprecations/convert_connectors_to_client'
-    );
-    expect(deprecations[0].correctiveActions.api?.body).toStrictEqual({ ids: ['foo'] });
-    expect(deprecations[0].title).toMatch('not supported in self-managed environments');
-  });
-
-  it('Does not allow native connector upgrades without fleet server', async () => {
-    const nativeConnector = {
-      id: 'foo',
-      is_native: true,
-      service_type: 'github',
-    } as Connector;
-    const hasFleetServer = false;
-    mockedFetchConnectors = jest.fn().mockResolvedValue([nativeConnector]);
-    const deprecations = await getNativeConnectorDeprecations(
-      ctx,
-      true,
-      hasFleetServer,
-      cloud,
-      docsUrl
-    );
-    expect(deprecations).toHaveLength(1);
-    expect(deprecations[0].title).toMatch('Integration Server must be provisioned');
-  });
-
-  it('Gives precedence to your env being ineligible for agentless', async () => {
-    const connectors = [
-      {
-        id: 'foo',
-        is_native: true,
-        service_type: 'github',
-      },
-      {
-        id: 'bar',
-        is_native: true,
-        service_type: 'fake',
-      },
-    ] as Connector[];
-    const hasAgentless = false;
-    const hasFleetServer = false;
-    mockedFetchConnectors = jest.fn().mockResolvedValue(connectors);
-    const deprecations = await getNativeConnectorDeprecations(
-      ctx,
-      hasAgentless,
-      hasFleetServer,
-      notCloud,
-      docsUrl
-    );
-    expect(deprecations).toHaveLength(1);
-    expect(deprecations[0].correctiveActions.api?.path).toStrictEqual(
-      '/internal/enterprise_search/deprecations/convert_connectors_to_client'
-    );
-    expect(deprecations[0].correctiveActions.api?.body).toStrictEqual({ ids: ['foo', 'bar'] });
-    expect(deprecations[0].title).toMatch('not supported in self-managed environments');
-  });
-
-  it('can register both fleet server missing and bad service types together', async () => {
-    const connectors = [
-      {
-        id: 'foo',
-        is_native: true,
-        service_type: 'github',
-      },
-      {
-        id: 'bar',
-        is_native: true,
-        service_type: 'fake',
-      },
-    ] as Connector[];
-    const hasAgentless = true;
-    const hasFleetServer = false;
-    mockedFetchConnectors = jest.fn().mockResolvedValue(connectors);
-    const deprecations = await getNativeConnectorDeprecations(
-      ctx,
-      hasAgentless,
-      hasFleetServer,
-      cloud,
-      docsUrl
-    );
-    expect(deprecations).toHaveLength(2);
-    expect(deprecations[0].correctiveActions.api?.path).toStrictEqual(
-      '/internal/enterprise_search/deprecations/convert_connectors_to_client'
-    );
-    expect(deprecations[0].correctiveActions.api?.body).toStrictEqual({ ids: ['bar'] });
-    expect(deprecations[0].title).toMatch('must be of supported service types');
-    expect(deprecations[1].title).toMatch('Integration Server must be provisioned');
+    expect(deprecations[0].title).toMatch('Elastic-managed connectors are no longer supported');
   });
 });
 

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
@@ -9,43 +9,12 @@ import { CloudSetup } from '@kbn/cloud-plugin/server';
 import { DeprecationsDetails } from '@kbn/core-deprecations-common';
 import { GetDeprecationsContext, RegisterDeprecationsConfig } from '@kbn/core-deprecations-server';
 
-import { hasFleetServers } from '@kbn/fleet-plugin/server';
-import { isAgentlessEnabled } from '@kbn/fleet-plugin/server';
 import { i18n } from '@kbn/i18n';
 import { Connector, fetchConnectors } from '@kbn/search-connectors';
 
 import { ConfigType } from '..';
 
 import { getPreEightEnterpriseSearchIndices } from './pre_eight_index_deprecator';
-
-const NATIVE_SERVICE_TYPES = [
-  'azure_blob_storage',
-  'box',
-  'confluence',
-  'dropbox',
-  'github',
-  'gmail',
-  'google_cloud_storage',
-  'google_drive',
-  'jira',
-  'mssql',
-  'mongodb',
-  'mysql',
-  'network_drive',
-  'notion',
-  'onedrive',
-  'oracle',
-  'outlook',
-  'postgresql',
-  's3',
-  'salesforce',
-  'servicenow',
-  'sharepoint_online',
-  'sharepoint_server',
-  'slack',
-  'microsoft_teams',
-  'zoom',
-];
 
 export const getRegisteredDeprecations = (
   config: ConfigType,
@@ -54,17 +23,11 @@ export const getRegisteredDeprecations = (
 ): RegisterDeprecationsConfig => {
   return {
     getDeprecations: async (ctx: GetDeprecationsContext) => {
-      const hasAgentless = isAgentlessEnabled();
-      const hasFleetServer = await hasFleetServers(
-        ctx.esClient.asInternalUser,
-        ctx.savedObjectsClient,
-        true // only counts if the Fleet Server is active
-      );
       const entSearchDetails = getEnterpriseSearchNodeDeprecation(config, cloud, docsUrl);
       const [crawlerDetails, nativeConnectorsDetails, entSearchIndexIncompatibility] =
         await Promise.all([
           getCrawlerDeprecations(ctx, docsUrl),
-          getNativeConnectorDeprecations(ctx, hasAgentless, hasFleetServer, cloud, docsUrl),
+          getNativeConnectorDeprecations(ctx, docsUrl),
           getEnterpriseSearchPre8IndexDeprecations(ctx, docsUrl, config.host),
         ]);
       return [
@@ -232,15 +195,10 @@ export async function getCrawlerDeprecations(
 }
 
 /**
- * if the customer is using Native Connectors, agentless is available, but the integration server is missing, they are told that Integrations Server must be added
- * if the customer is using Native Connectors, and agentless is unavailable, they are told that they must convert their connectors to Connector Clients
- * if the customer was using "native" connectors that don't match our connector service types, they must delete them or convert them to connector clients.
+ * If the customer is using Native Connectors, and agentless is unavailable, they are told that they must convert their connectors to Connector Clients
  */
 export async function getNativeConnectorDeprecations(
   ctx: GetDeprecationsContext,
-  hasAgentless: boolean,
-  hasFleetServer: boolean,
-  cloud: CloudSetup,
   docsUrl: string
 ): Promise<DeprecationsDetails[]> {
   const client = ctx.esClient.asInternalUser;
@@ -251,173 +209,58 @@ export async function getNativeConnectorDeprecations(
   } else {
     const deprecations: DeprecationsDetails[] = [];
 
-    if (nativeConnectors.length > 0 && !hasAgentless) {
-      // you can't have elastic-managed connectors in an environment that Elastic doesn't manage
-      // ... and agentless is available in every Elastic-managed environment
-
+    if (nativeConnectors.length > 0) {
+      // There are some illegal service_types in their native connectors
       deprecations.push({
         level: 'critical',
         deprecationType: 'feature',
-        title: i18n.translate('xpack.enterpriseSearch.deprecations.notManaged.title', {
-          defaultMessage:
-            'Connectors with `is_native: true` are not supported in self-managed environments',
+        title: i18n.translate('xpack.enterpriseSearch.deprecations.fauxNativeConnector.title', {
+          defaultMessage: 'Elastic-managed connectors are no longer supported',
         }),
         message: {
           type: 'markdown',
-          content: i18n.translate('xpack.enterpriseSearch.deprecations.notManaged.message', {
-            defaultMessage:
-              '"Native Connectors" are managed services in Elastic-managed environments such as Elastic Cloud Hosted and ' +
-              'Elastic Cloud Serverless. Any connectors with `is_native: true` must be converted to connector clients or deleted ' +
-              'before this upgrade can proceed.',
-          }),
+          content: i18n.translate(
+            'xpack.enterpriseSearch.deprecations.fauxNativeConnector.message',
+            {
+              values: {
+                connectorIds:
+                  nativeConnectors.map((connector) => `- \`${connector.id}\``).join('\n') + '\n',
+              },
+              defaultMessage:
+                'Elastic-managed connectors are no longer supported.\n\n' +
+                'The following connectors need to be converted to self-managed connectors to continue using them:\n' +
+                '{connectorIds}' +
+                'This conversion is a lossless process and can be performed using "quick resolve".\n\n' +
+                'Alternatively, deleting these connectors will also unblock your upgrade.',
+            }
+          ),
         },
         documentationUrl: docsUrl,
         correctiveActions: {
           manualSteps: [
-            i18n.translate('xpack.enterpriseSearch.deprecations.notManaged.listConnectors', {
-              defaultMessage: 'Enumerate all connector records',
-            }),
-            i18n.translate('xpack.enterpriseSearch.deprecations.notManaged.convertPretenders', {
-              defaultMessage:
-                'On the connector Overview tab, select "Convert Connector" for any Native Connectors.',
-            }),
+            i18n.translate(
+              'xpack.enterpriseSearch.deprecations.fauxNativeConnector.listConnectors',
+              {
+                defaultMessage: 'Enumerate all connector records',
+              }
+            ),
+            i18n.translate(
+              'xpack.enterpriseSearch.deprecations.fauxNativeConnector.convertPretenders',
+              {
+                defaultMessage:
+                  'Select "Convert to Client" for any connectors where `is_native: true`.',
+              }
+            ),
           ],
           api: {
             method: 'POST',
             path: '/internal/enterprise_search/deprecations/convert_connectors_to_client',
             body: {
-              ids: nativeConnectors.map((it) => it.id),
+              ids: nativeConnectors.map((connector) => connector.id),
             },
           },
         },
       });
-    } else {
-      const nativeTypesStr = '- `' + NATIVE_SERVICE_TYPES.join('`\n- `') + '`\n\n';
-      const fauxNativeConnectors = nativeConnectors.filter(
-        (hit) => !NATIVE_SERVICE_TYPES.includes(hit.service_type!)
-      );
-
-      if (fauxNativeConnectors.length > 0) {
-        // There are some illegal service_types in their native connectors
-        deprecations.push({
-          level: 'critical',
-          deprecationType: 'feature',
-          title: i18n.translate('xpack.enterpriseSearch.deprecations.fauxNativeConnector.title', {
-            defaultMessage: 'Native connectors must be of supported service types',
-          }),
-          message: {
-            type: 'markdown',
-            content: i18n.translate(
-              'xpack.enterpriseSearch.deprecations.fauxNativeConnector.message',
-              {
-                values: { serviceTypes: nativeTypesStr },
-                defaultMessage:
-                  'Not all service types are supported by Elastic-managed connectors.\n\n' +
-                  'The following service types are supported for Elastic-managed connectors:\n' +
-                  '{serviceTypes}' +
-                  'Unsupported service types must be converted to Connector Clients before upgrading. ' +
-                  'This is a lossless operation, and can be attempted with "quick resolve".\n\n' +
-                  'Alternatively, deleting these connectors with mismatched service types will also unblock your upgrade.',
-              }
-            ),
-          },
-          documentationUrl: docsUrl,
-          correctiveActions: {
-            manualSteps: [
-              i18n.translate(
-                'xpack.enterpriseSearch.deprecations.fauxNativeConnector.listConnectors',
-                {
-                  defaultMessage: 'Enumerate all connector records',
-                }
-              ),
-              i18n.translate(
-                'xpack.enterpriseSearch.deprecations.fauxNativeConnector.convertPretenders',
-                {
-                  defaultMessage:
-                    'Select "Convert to Client" for any connectors where `is_native: true` but the `service_type` is NOT supported, per the list above.',
-                }
-              ),
-            ],
-            api: {
-              method: 'POST',
-              path: '/internal/enterprise_search/deprecations/convert_connectors_to_client',
-              body: {
-                ids: fauxNativeConnectors.map((it) => it.id),
-              },
-            },
-          },
-        });
-      }
-
-      if (hasAgentless && nativeConnectors.length > 0 && !hasFleetServer) {
-        // the Integration Server is a required component in your deployment, for Agentless
-        deprecations.push({
-          level: 'critical',
-          deprecationType: 'feature',
-          title: i18n.translate(
-            'xpack.enterpriseSearch.deprecations.missingIntegrationServer.title',
-            {
-              defaultMessage: 'Integration Server must be provisioned',
-            }
-          ),
-          message: {
-            type: 'markdown',
-            content: i18n.translate(
-              'xpack.enterpriseSearch.deprecations.missingIntegrationServer.message',
-              {
-                defaultMessage:
-                  'In versions >= 9.x, Elastic-managed connectors are run through the Elastic Integrations ecosystem. ' +
-                  'This requires the Integration Server to be present in your deployment.\n\n' +
-                  'Unless you are running more than 1000 connectors, a single instance of the smallest Integration Server' +
-                  'should be sufficient.\n\n' +
-                  'For full details, see the documentation.' +
-                  `\n\n[Click here to manage your deployment](${
-                    cloud.baseUrl + '/deployments/' + cloud.deploymentId
-                  }).`,
-              }
-            ),
-          },
-          documentationUrl: docsUrl,
-          correctiveActions: {
-            manualSteps: [
-              i18n.translate(
-                'xpack.enterpriseSearch.deprecations.missingIntegrationServer.gotocloud',
-                {
-                  values: { baseUrl: cloud.baseUrl },
-                  defaultMessage:
-                    'Go to {baseUrl} and select this deployment. Or click the link above to go straight there.',
-                }
-              ),
-              i18n.translate(
-                'xpack.enterpriseSearch.deprecations.missingIntegrationServer.clickedit',
-                {
-                  defaultMessage: "Click the 'Edit' tab",
-                }
-              ),
-              i18n.translate(
-                'xpack.enterpriseSearch.deprecations.missingIntegrationServer.scrolldown',
-                {
-                  defaultMessage: "Scroll down to the 'Integration Server' section",
-                }
-              ),
-              i18n.translate(
-                'xpack.enterpriseSearch.deprecations.missingIntegrationServer.addCapacity',
-                {
-                  defaultMessage:
-                    "Click the button to '+ Add capacity' and choose a size/count. For most customers," +
-                    'the smallest option in a single zone is sufficient.',
-                }
-              ),
-              i18n.translate(
-                'xpack.enterpriseSearch.deprecations.missingIntegrationServer.clicksave',
-                {
-                  defaultMessage: "Click 'Save' and confirm",
-                }
-              ),
-            ],
-          },
-        });
-      }
     }
 
     return deprecations;

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
@@ -223,13 +223,14 @@ export async function getNativeConnectorDeprecations(
             'xpack.enterpriseSearch.deprecations.fauxNativeConnector.message',
             {
               values: {
-                connectorIds:
-                  nativeConnectors.map((connector) => `- \`${connector.id}\``).join('\n') + '\n',
+                connectorIds: nativeConnectors
+                  .map((connector) => `- \`${connector.id}\``)
+                  .join('\n'),
               },
               defaultMessage:
                 'Elastic-managed connectors are no longer supported.\n\n' +
                 'The following connectors need to be converted to self-managed connectors to continue using them:\n' +
-                '{connectorIds}' +
+                '{connectorIds}\n\n' +
                 'This conversion is a lossless process and can be performed using "quick resolve".\n\n' +
                 'Alternatively, deleting these connectors will also unblock your upgrade.',
             }
@@ -241,14 +242,14 @@ export async function getNativeConnectorDeprecations(
             i18n.translate(
               'xpack.enterpriseSearch.deprecations.fauxNativeConnector.listConnectors',
               {
-                defaultMessage: 'Enumerate all connector records',
+                defaultMessage: 'Go through the Elastic-managed connectors in the Connectors UI.',
               }
             ),
             i18n.translate(
               'xpack.enterpriseSearch.deprecations.fauxNativeConnector.convertPretenders',
               {
                 defaultMessage:
-                  'Select "Convert to Client" for any connectors where `is_native: true`.',
+                  'Click on "Convert to self-managed" in the Connector Configuration tab for any connector with the "Elastic-managed connector" badge.',
               }
             ),
           ],

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
@@ -195,7 +195,7 @@ export async function getCrawlerDeprecations(
 }
 
 /**
- * If the customer is using Native Connectors, and agentless is unavailable, they are told that they must convert their connectors to Connector Clients
+ * If the customer is using Native Connectors, they are told that they must convert their connectors to Connector Clients
  */
 export async function getNativeConnectorDeprecations(
   ctx: GetDeprecationsContext,
@@ -210,7 +210,7 @@ export async function getNativeConnectorDeprecations(
     const deprecations: DeprecationsDetails[] = [];
 
     if (nativeConnectors.length > 0) {
-      // There are some illegal service_types in their native connectors
+      // There are some native connectors
       deprecations.push({
         level: 'critical',
         deprecationType: 'feature',

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
@@ -242,7 +242,7 @@ export async function getNativeConnectorDeprecations(
             i18n.translate(
               'xpack.enterpriseSearch.deprecations.fauxNativeConnector.listConnectors',
               {
-                defaultMessage: 'Go through the Elastic-managed connectors in the Connectors UI.',
+                defaultMessage: 'Identify all Elastic-managed connectors in the Connectors UI.',
               }
             ),
             i18n.translate(

--- a/x-pack/solutions/search/plugins/enterprise_search/tsconfig.json
+++ b/x-pack/solutions/search/plugins/enterprise_search/tsconfig.json
@@ -88,7 +88,6 @@
     "@kbn/ui-actions-plugin",
     "@kbn/core-deprecations-server",
     "@kbn/core-deprecations-common",
-    "@kbn/fleet-plugin",
     "@kbn/core-http-request-handler-context-server",
     "@kbn/ui-actions-enhanced-plugin",
     "@kbn/file-upload-common",


### PR DESCRIPTION
## Summary

Follow-up on https://github.com/elastic/kibana/pull/205500 , this changes the logic around connectors upgrade:
- now user need to either convert all native connectors to self-managed or remove them

#### Screenshot

<img width="300" alt="Screenshot 2025-02-18 at 09 07 19" src="https://github.com/user-attachments/assets/16267451-6c18-4ec3-93b9-d9b7419bf91f" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




