### PR TITLE
Entity Flyout flickers when loading risk score panel

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
@@ -49,20 +49,22 @@ export const HostPanelContent = ({
 
   return (
     <FlyoutBody>
-      {riskScoreState.isModuleEnabled && riskScoreState.data?.length !== 0 && (
-        <>
-          <FlyoutRiskSummary
-            entityType={EntityType.host}
-            riskScoreData={riskScoreState}
-            recalculatingScore={recalculatingScore}
-            queryId={HOST_PANEL_RISK_SCORE_QUERY_ID}
-            openDetailsPanel={openDetailsPanel}
-            isPreviewMode={isPreviewMode}
-            isLinkEnabled={isLinkEnabled}
-          />
-          <EuiHorizontalRule />
-        </>
-      )}
+      {Array.isArray(riskScoreState.data) &&
+        riskScoreState.isModuleEnabled &&
+        riskScoreState.data.length > 0 && (
+          <>
+            <FlyoutRiskSummary
+              entityType={EntityType.host}
+              riskScoreData={riskScoreState}
+              recalculatingScore={recalculatingScore}
+              queryId={HOST_PANEL_RISK_SCORE_QUERY_ID}
+              openDetailsPanel={openDetailsPanel}
+              isPreviewMode={isPreviewMode}
+              isLinkEnabled={isLinkEnabled}
+            />
+            <EuiHorizontalRule />
+          </>
+        )}
       <AssetCriticalityAccordion
         entity={{ name: hostName, type: EntityType.host }}
         onChange={onAssetCriticalityChange}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
@@ -58,20 +58,22 @@ export const UserPanelContent = ({
 
   return (
     <FlyoutBody>
-      {riskScoreState.isModuleEnabled && riskScoreState.data?.length !== 0 && (
-        <>
-          <FlyoutRiskSummary
-            riskScoreData={riskScoreState}
-            recalculatingScore={recalculatingScore}
-            queryId={USER_PANEL_RISK_SCORE_QUERY_ID}
-            openDetailsPanel={openDetailsPanel}
-            isPreviewMode={isPreviewMode}
-            isLinkEnabled={isLinkEnabled}
-            entityType={EntityType.user}
-          />
-          <EuiHorizontalRule />
-        </>
-      )}
+      {Array.isArray(riskScoreState.data) &&
+        riskScoreState.isModuleEnabled &&
+        riskScoreState.data.length > 0 && (
+          <>
+            <FlyoutRiskSummary
+              riskScoreData={riskScoreState}
+              recalculatingScore={recalculatingScore}
+              queryId={USER_PANEL_RISK_SCORE_QUERY_ID}
+              openDetailsPanel={openDetailsPanel}
+              isPreviewMode={isPreviewMode}
+              isLinkEnabled={isLinkEnabled}
+              entityType={EntityType.user}
+            />
+            <EuiHorizontalRule />
+          </>
+        )}
       <AssetCriticalityAccordion
         entity={{ name: userName, type: EntityType.user }}
         onChange={onAssetCriticalityChange}


### PR DESCRIPTION
## Summary
This PR fixes the issue where the Risk Score Panel flickers into view when no risk score is available yet. This occurs in two cases:
1. Opening the flyout for a user or host.
2. Updating Asset Criticality from the flyout.

### Steps to Reproduce (Before Fix)
[@abhishekbhatia1710](https://github.com/abhishekbhatia1710) [provided steps as below in original ticket](https://github.com/elastic/security-team/issues/11590#issuecomment-2643056694):

1. Ensure you are using version 8.18
2. Enable the Risk Engine.
3. Enable the Entity Store.
4. Upload the asset criticality file.
5. Do not run the risk score on the newly added entities yet.
6. Navigate to the EA Dashboard.
7. Scroll down to the Entities section.
8. Search for the user/host uploaded in the asset criticality file.
9. Click on the entity to open the flyout.
10. Assign asset criticality within the flyout.
11. Before fix: Risk Score panel briefly appears (flickers) despite no risk score being available.

###  Expected Behaviour (After Fix)
Following the same steps, the Risk Score Panel no longer flickers when opening the flyout or updating asset criticality - for both user and host entity types.

### Video (After Fix)


https://github.com/user-attachments/assets/7ef28ee1-7e5d-43ae-b6d3-7075b63229be










