### PR TITLE
[8.x] [Upgrade Assistant]  Critical Kibana API deprecations should not block upgrades (#209128)

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/kibana_status.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/kibana_status.test.ts
@@ -10,7 +10,7 @@ import type { DomainDeprecationDetails } from '@kbn/core/server';
 
 import { getKibanaUpgradeStatus } from './kibana_status';
 
-const mockKibanaDeprecations: DomainDeprecationDetails[] = [
+const mockKibanaDeprecations = (): DomainDeprecationDetails[] => [
   {
     title: 'mock-deprecation-title',
     correctiveActions: {
@@ -31,7 +31,7 @@ const mockKibanaDeprecations: DomainDeprecationDetails[] = [
 describe('getKibanaUpgradeStatus', () => {
   const deprecationsClient = deprecationsServiceMock.createClient();
 
-  deprecationsClient.getAllDeprecations.mockResolvedValue(mockKibanaDeprecations);
+  deprecationsClient.getAllDeprecations.mockResolvedValue(mockKibanaDeprecations());
 
   it('returns the correct shape of data', async () => {
     const resp = await getKibanaUpgradeStatus(deprecationsClient);
@@ -39,7 +39,7 @@ describe('getKibanaUpgradeStatus', () => {
   });
 
   it('returns totalCriticalDeprecations > 0 when critical issues found', async () => {
-    deprecationsClient.getAllDeprecations.mockResolvedValue(mockKibanaDeprecations);
+    deprecationsClient.getAllDeprecations.mockResolvedValue(mockKibanaDeprecations());
 
     await expect(getKibanaUpgradeStatus(deprecationsClient)).resolves.toHaveProperty(
       'totalCriticalDeprecations',
@@ -49,6 +49,100 @@ describe('getKibanaUpgradeStatus', () => {
 
   it('returns totalCriticalDeprecations === 0 when no critical issues found', async () => {
     deprecationsClient.getAllDeprecations.mockResolvedValue([]);
+
+    await expect(getKibanaUpgradeStatus(deprecationsClient)).resolves.toHaveProperty(
+      'totalCriticalDeprecations',
+      0
+    );
+  });
+
+  it('returns totalCriticalDeprecations > 0, but ignores API deprecations', async () => {
+    deprecationsClient.getAllDeprecations.mockResolvedValue([
+      ...mockKibanaDeprecations(),
+      ...mockKibanaDeprecations(),
+      {
+        title: 'mock-deprecation-title',
+        correctiveActions: {
+          manualSteps: [],
+        },
+        apiId: 'foo',
+        deprecationType: 'api',
+        documentationUrl: 'testDocUrl',
+        level: 'warning',
+        message: 'testMessage',
+        domainId: 'security',
+      },
+      {
+        title: 'mock-deprecation-title',
+        correctiveActions: {
+          manualSteps: [],
+        },
+        apiId: 'foo',
+        deprecationType: 'api',
+        documentationUrl: 'testDocUrl',
+        level: 'critical',
+        message: 'testMessage',
+        domainId: 'security',
+      },
+      {
+        title: 'mock-deprecation-title',
+        correctiveActions: {
+          manualSteps: [],
+        },
+        apiId: 'foo',
+        deprecationType: 'api',
+        documentationUrl: 'testDocUrl',
+        level: 'critical',
+        message: 'testMessage',
+        domainId: 'security',
+      },
+    ]);
+
+    await expect(getKibanaUpgradeStatus(deprecationsClient)).resolves.toHaveProperty(
+      'totalCriticalDeprecations',
+      2
+    );
+  });
+
+  it('returns totalCriticalDeprecations === 0 when only critical API deprecations', async () => {
+    deprecationsClient.getAllDeprecations.mockResolvedValue([
+      {
+        title: 'mock-deprecation-title',
+        correctiveActions: {
+          manualSteps: [],
+        },
+        apiId: 'foo',
+        deprecationType: 'api',
+        documentationUrl: 'testDocUrl',
+        level: 'warning',
+        message: 'testMessage',
+        domainId: 'security',
+      },
+      {
+        title: 'mock-deprecation-title',
+        correctiveActions: {
+          manualSteps: [],
+        },
+        apiId: 'foo',
+        deprecationType: 'api',
+        documentationUrl: 'testDocUrl',
+        level: 'critical',
+        message: 'testMessage',
+        domainId: 'security',
+      },
+      {
+        title: 'mock-deprecation-title',
+        correctiveActions: {
+          manualSteps: [],
+        },
+        apiId: 'foo',
+        deprecationType: 'api',
+        documentationUrl: 'testDocUrl',
+        level: 'critical',
+        message: 'testMessage',
+        domainId: 'security',
+      },
+    ]);
 
     await expect(getKibanaUpgradeStatus(deprecationsClient)).resolves.toHaveProperty(
       'totalCriticalDeprecations',

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/kibana_status.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/kibana_status.ts
@@ -11,7 +11,9 @@ export const getKibanaUpgradeStatus = async (deprecationsClient: DeprecationsCli
   const kibanaDeprecations: DomainDeprecationDetails[] =
     await deprecationsClient.getAllDeprecations();
 
-  const totalCriticalDeprecations = kibanaDeprecations.filter((d) => d.level === 'critical').length;
+  const totalCriticalDeprecations = kibanaDeprecations.filter(
+    (d) => d.deprecationType !== 'api' && d.level === 'critical'
+  ).length;
 
   return {
     totalCriticalDeprecations,

--- a/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
+++ b/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
@@ -224,9 +224,11 @@ export default function ({ getService }: FtrProviderContext) {
         2000
       );
       const { body } = await supertest.get(`/api/upgrade_assistant/status`).expect(200);
+
       // There are critical deprecations, but we expect none of them to be related to Kibana
       expect(body.readyForUpgrade).to.be(false);
-      expect(body.details).not.to.contain('Kibana deprecation');
+      expect(body.details?.length > 0).to.be(true);
+      expect(/Kibana/gi.test(body.details)).to.be(false);
     });
   });
 }

--- a/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
+++ b/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
@@ -43,13 +43,13 @@ export default function ({ getService }: FtrProviderContext) {
       // await kibanaServer.savedObjects.cleanStandardList();
       await esArchiver.emptyKibanaIndex();
     });
-    it('returns does not return api deprecations if the routes are not called', async () => {
+    it('does not return api deprecations if deprecated routes are not called', async () => {
       const { deprecations } = (await supertest.get(`/api/deprecations/`).expect(200)).body;
       const apiDeprecations = getApiDeprecations(deprecations);
       expect(apiDeprecations.length).to.equal(0);
     });
 
-    it('returns deprecated APIs when the api is called', async () => {
+    it('returns deprecated APIs when a deprecated api is called', async () => {
       await supertest
         .get(`/internal/routing_example/d/internal_versioned_route?apiVersion=1`)
         .expect(200);
@@ -206,6 +206,25 @@ export default function ({ getService }: FtrProviderContext) {
           ].sort()
         );
       });
+    });
+    it('GET /api/upgrade_assistant/status does not return { readyForUpgrade: false } if there are only critical API deprecations', async () => {
+      /** Throw in another critical deprecation... */
+      await supertest.get(`/api/routing_example/d/removed_route`).expect(200);
+      // sleep a little until the usage counter is synced into ES
+      await setTimeoutAsync(3000);
+      await retry.tryForTime(
+        15 * 1000,
+        async () => {
+          const { deprecations } = (await supertest.get(`/api/deprecations/`).expect(200)).body;
+          const apiDeprecations = getApiDeprecations(deprecations);
+          // confirm there is at least one CRITICAL deprecated API usage present
+          expect(apiDeprecations.some(({ level }) => level === 'critical')).to.be(true);
+        },
+        undefined,
+        2000
+      );
+      const { body } = await supertest.get(`/api/upgrade_assistant/status`).expect(200);
+      expect(body.readyForUpgrade).to.be(true);
     });
   });
 }

--- a/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
+++ b/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
@@ -224,7 +224,9 @@ export default function ({ getService }: FtrProviderContext) {
         2000
       );
       const { body } = await supertest.get(`/api/upgrade_assistant/status`).expect(200);
-      expect(body.readyForUpgrade).to.be(true);
+      // There are critical deprecations, but we expect none of them to be related to Kibana
+      expect(body.readyForUpgrade).to.be(false);
+      expect(body.details).not.to.contain('Kibana deprecation');
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Upgrade Assistant]  Critical Kibana API deprecations should not block upgrades (#209128)](https://github.com/elastic/kibana/pull/209128)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jean-Louis Leysens","email":"jeanlouis.leysens@elastic.co"},"sourceCommit":{"committedDate":"2025-02-03T11:29:05Z","message":"[Upgrade Assistant]  Critical Kibana API deprecations should not block upgrades (#209128)\n\n## Summary\r\n\r\nFilters out any deprecated Kibana API usages from blocking upgrade\r\nstatus.\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### Risks\r\n\r\nShould be mitigated by E2E tests","sha":"6bcdac4571ffff20e62328332d2b073f892d3b61","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","Feature:Upgrade Assistant","backport missing","v9.0.0","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Upgrade Assistant]  Critical Kibana API deprecations should not block upgrades","number":209128,"url":"https://github.com/elastic/kibana/pull/209128","mergeCommit":{"message":"[Upgrade Assistant]  Critical Kibana API deprecations should not block upgrades (#209128)\n\n## Summary\r\n\r\nFilters out any deprecated Kibana API usages from blocking upgrade\r\nstatus.\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### Risks\r\n\r\nShould be mitigated by E2E tests","sha":"6bcdac4571ffff20e62328332d2b073f892d3b61"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209128","number":209128,"mergeCommit":{"message":"[Upgrade Assistant]  Critical Kibana API deprecations should not block upgrades (#209128)\n\n## Summary\r\n\r\nFilters out any deprecated Kibana API usages from blocking upgrade\r\nstatus.\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### Risks\r\n\r\nShould be mitigated by E2E tests","sha":"6bcdac4571ffff20e62328332d2b073f892d3b61"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->