### PR TITLE
[8.16] Backport rowHeightOption: auto EuiDataGrid fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@elastic/ecs": "^8.11.1",
     "@elastic/elasticsearch": "^8.15.0",
     "@elastic/ems-client": "8.5.3",
-    "@elastic/eui": "97.0.0-backport.2",
+    "@elastic/eui": "97.0.0-backport.3",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "^1.2.3",
     "@elastic/numeral": "^2.5.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -87,7 +87,7 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.5.3': ['Elastic License 2.0'],
-  '@elastic/eui@97.0.0-backport.2': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
+  '@elastic/eui@97.0.0-backport.3': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
   'buffers@0.1.1': ['MIT'], // license in importing module https://www.npmjs.com/package/binary
   '@bufbuild/protobuf@1.2.1': ['Apache-2.0'], // license (Apache-2.0 AND BSD-3-Clause)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,10 +1775,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui@97.0.0-backport.2":
-  version "97.0.0-backport.2"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-97.0.0-backport.2.tgz#d373ff74eb766ef25c02f5a42a62b0d05255a3cd"
-  integrity sha512-5gDXIJBSLUsWHj0I7Yn7R3bnP5g4d2GNC8MF8mBG7LKLiEXoRMpppfe6G/J5qBfu+h1kZ0PJLLXFKtzaZGfZcQ==
+"@elastic/eui@97.0.0-backport.3":
+  version "97.0.0-backport.3"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-97.0.0-backport.3.tgz#12ec31ea14512fbbd553f1ef85bc34074cd9511f"
+  integrity sha512-r72EXWZF0jSIR26kw1CWGR0C5mbC/wpgtd5RjOnbEp0etCfBKEJxnYLT2IXmsoMRuoFy2pxvcc9N7+YrZFF2bg==
   dependencies:
     "@hello-pangea/dnd" "^16.6.0"
     "@types/lodash" "^4.14.202"


### PR DESCRIPTION
## Summary

Fix for https://github.com/elastic/eui/issues/8245

Backporting [af189da](https://github.com/elastic/eui/commit/af189da870404bb050bc421c3499499cc3659c72) to `8.16` Kibana version. It was introduced on https://github.com/elastic/eui/pull/8251.

The npm backport release: https://www.npmjs.com/package/@elastic/eui/v/97.0.0-backport.3

### Checklist

The issue being backported, https://github.com/elastic/eui/issues/8245, is intermittent. You cannot consistently reproduce it on OSX, apparently it's reproducible on Windows. I'd appreciate a manual test from the reviewers 🙏🏻 

**The steps to reproduce in `8.16` are:**
1. Go to Security > Alerts.
2. In the data grid, set the view from "Grid view" to "Event rendered view".
3. Choose the settings icon, in the picker choose "Auto fit" in Row height.

The data grid's height changes to 0. It's reproducible on first load.