### PR TITLE
[8.16] [dashboard] fix legacy embeddables do not render in print mode (#211072)

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -239,6 +239,11 @@ export class DashboardContainer
     const controlGroupApi$ = new BehaviorSubject<ControlGroupApi | undefined>(undefined);
     async function untilContainerInitialized(): Promise<void> {
       return new Promise((resolve) => {
+        if (initialInput.viewMode === ViewMode.PRINT) {
+          // control group is not created in print mode
+          resolve();
+          return;
+        }
         controlGroupApi$
           .pipe(
             skipWhile((controlGroupApi) => !controlGroupApi),


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.17` to `8.16`:
 - [[dashboard] fix legacy embeddables do not render in print mode (#211072)](https://github.com/elastic/kibana/pull/211072)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2025-02-18T16:09:44Z","message":"[dashboard] fix legacy embeddables do not render in print mode (#211072)\n\nCloses https://github.com/elastic/kibana/issues/211070\r\n\r\nImmediately resolve `DashboardContainer.untilContainerInitialized` when\r\nin print mode since controlGroupApi will never become available.\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1829e15687e04ac00011695bcbcfecd1d3cbb7a5","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","release_note:skip","project:embeddableRebuild","backport:version","v8.17.3","v8.16.5"],"title":"[dashboard] fix legacy embeddables do not render in print mode","number":211072,"url":"https://github.com/elastic/kibana/pull/211072","mergeCommit":{"message":"[dashboard] fix legacy embeddables do not render in print mode (#211072)\n\nCloses https://github.com/elastic/kibana/issues/211070\r\n\r\nImmediately resolve `DashboardContainer.untilContainerInitialized` when\r\nin print mode since controlGroupApi will never become available.\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1829e15687e04ac00011695bcbcfecd1d3cbb7a5"}},"sourceBranch":"8.17","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"8.17","label":"v8.17.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211072","number":211072,"mergeCommit":{"message":"[dashboard] fix legacy embeddables do not render in print mode (#211072)\n\nCloses https://github.com/elastic/kibana/issues/211070\r\n\r\nImmediately resolve `DashboardContainer.untilContainerInitialized` when\r\nin print mode since controlGroupApi will never become available.\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1829e15687e04ac00011695bcbcfecd1d3cbb7a5"}},{"branch":"8.16","label":"v8.16.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->