### PR TITLE
[8.18] [8.x] chore(NA): remove ununsed EUI imports into ui-shared-deps (#211656)

### DIFF
--- a/src/platform/packages/private/kbn-ui-shared-deps-npm/webpack.config.js
+++ b/src/platform/packages/private/kbn-ui-shared-deps-npm/webpack.config.js
@@ -61,7 +61,6 @@ module.exports = (_, argv) => {
         '@elastic/charts',
         '@elastic/eui',
         '@elastic/eui/optimize/es/components/provider/nested',
-        '@elastic/eui/optimize/es/services/theme/warning',
         '@elastic/eui/dist/eui_theme_amsterdam_light.json',
         '@elastic/eui/dist/eui_theme_amsterdam_dark.json',
         '@elastic/numeral',

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/src/definitions.js
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/src/definitions.js
@@ -75,7 +75,6 @@ const externals = {
   '@elastic/eui': '__kbnSharedDeps__.ElasticEui',
   '@elastic/eui/lib/components/provider/nested':
     '__kbnSharedDeps__.ElasticEuiLibComponentsUseIsNestedEuiProvider',
-  '@elastic/eui/lib/services/theme/warning': '__kbnSharedDeps__.ElasticEuiLibServicesThemeWarning',
 
   // transient dep of eui
   '@hello-pangea/dnd': '__kbnSharedDeps__.HelloPangeaDnd',

--- a/src/platform/packages/private/kbn-ui-shared-deps-src/src/entry.js
+++ b/src/platform/packages/private/kbn-ui-shared-deps-src/src/entry.js
@@ -52,7 +52,6 @@ export const ElasticNumeral = require('@elastic/numeral');
 export const ElasticCharts = require('@elastic/charts');
 export const ElasticEui = require('@elastic/eui');
 export const ElasticEuiLibComponentsUseIsNestedEuiProvider = require('@elastic/eui/optimize/es/components/provider/nested');
-export const ElasticEuiLibServicesThemeWarning = require('@elastic/eui/optimize/es/services/theme/warning');
 export const KbnDatemath = require('@kbn/datemath');
 export const HelloPangeaDnd = require('@hello-pangea/dnd/dist/dnd');
 export const ReduxjsToolkit = require('@reduxjs/toolkit');


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[8.x] chore(NA): remove ununsed EUI imports into ui-shared-deps (#211656)](https://github.com/elastic/kibana/pull/211656)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2025-02-19T03:43:29Z","message":"[8.x] chore(NA): remove ununsed EUI imports into ui-shared-deps (#211656)\n\nThis PR removes from the UI shared deps EUI import exposures that\ndoesn't seem like to be used across the codebase.","sha":"356da9e152ea4e407c656b92fd8d970f8b3a936c","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:version","v8.18.0","v8.19.0"],"title":"[8.x] chore(NA): remove ununsed EUI imports into ui-shared-deps","number":211656,"url":"https://github.com/elastic/kibana/pull/211656","mergeCommit":{"message":"[8.x] chore(NA): remove ununsed EUI imports into ui-shared-deps (#211656)\n\nThis PR removes from the UI shared deps EUI import exposures that\ndoesn't seem like to be used across the codebase.","sha":"356da9e152ea4e407c656b92fd8d970f8b3a936c"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->