### PR TITLE
[ES|QL] Use async uiActions

### DIFF
--- a/src/platform/plugins/shared/esql/public/plugin.ts
+++ b/src/platform/plugins/shared/esql/public/plugin.ts
@@ -18,11 +18,11 @@ import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import {
   updateESQLQueryTrigger,
-  UpdateESQLQueryAction,
+  ACTION_UPDATE_ESQL_QUERY,
   UPDATE_ESQL_QUERY_TRIGGER,
   esqlControlTrigger,
-  CreateESQLControlAction,
   ESQL_CONTROL_TRIGGER,
+  ACTION_CREATE_ESQL_CONTROL,
 } from './triggers';
 import { setKibanaServices } from './kibana_services';
 import { JoinIndicesAutocompleteResult } from '../common';
@@ -74,11 +74,21 @@ export class EsqlPlugin implements Plugin<{}, EsqlPluginStart> {
     const storage = new Storage(localStorage);
 
     // Register triggers
-    const appendESQLAction = new UpdateESQLQueryAction(data);
+    uiActions.addTriggerActionAsync(
+      UPDATE_ESQL_QUERY_TRIGGER,
+      ACTION_UPDATE_ESQL_QUERY,
+      async () => {
+        const { UpdateESQLQueryAction } = await import('./triggers');
+        const appendESQLAction = new UpdateESQLQueryAction(data);
+        return appendESQLAction;
+      }
+    );
 
-    uiActions.addTriggerAction(UPDATE_ESQL_QUERY_TRIGGER, appendESQLAction);
-    const createESQLControlAction = new CreateESQLControlAction(core, data.search.search);
-    uiActions.addTriggerAction(ESQL_CONTROL_TRIGGER, createESQLControlAction);
+    uiActions.addTriggerActionAsync(ESQL_CONTROL_TRIGGER, ACTION_CREATE_ESQL_CONTROL, async () => {
+      const { CreateESQLControlAction } = await import('./triggers');
+      const createESQLControlAction = new CreateESQLControlAction(core, data.search.search);
+      return createESQLControlAction;
+    });
 
     const variablesService = new EsqlVariablesService();
 

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
@@ -15,7 +15,7 @@ import type { ESQLVariableType, ESQLControlVariable } from '@kbn/esql-validation
 import { monaco } from '@kbn/monaco';
 import type { ESQLControlState } from './types';
 
-const ACTION_CREATE_ESQL_CONTROL = 'ACTION_CREATE_ESQL_CONTROL';
+export const ACTION_CREATE_ESQL_CONTROL = 'ACTION_CREATE_ESQL_CONTROL';
 
 interface Context {
   queryString: string;

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/esql_control_action.ts
@@ -14,6 +14,7 @@ import type { ISearchGeneric } from '@kbn/search-types';
 import type { ESQLVariableType, ESQLControlVariable } from '@kbn/esql-validation-autocomplete';
 import { monaco } from '@kbn/monaco';
 import type { ESQLControlState } from './types';
+import { isActionCompatible, executeAction } from './esql_control_helpers';
 
 export const ACTION_CREATE_ESQL_CONTROL = 'ACTION_CREATE_ESQL_CONTROL';
 
@@ -26,8 +27,6 @@ interface Context {
   cursorPosition?: monaco.Position;
   initialState?: ESQLControlState;
 }
-
-export const getHelpersAsync = async () => await import('./esql_control_helpers');
 
 export class CreateESQLControlAction implements Action<Context> {
   public type = ACTION_CREATE_ESQL_CONTROL;
@@ -47,7 +46,6 @@ export class CreateESQLControlAction implements Action<Context> {
   }
 
   public async isCompatible({ queryString }: Context) {
-    const { isActionCompatible } = await getHelpersAsync();
     return isActionCompatible(queryString);
   }
 
@@ -60,7 +58,6 @@ export class CreateESQLControlAction implements Action<Context> {
     cursorPosition,
     initialState,
   }: Context) {
-    const { executeAction } = await getHelpersAsync();
     return executeAction({
       queryString,
       core: this.core,

--- a/src/platform/plugins/shared/esql/public/triggers/index.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/index.ts
@@ -11,7 +11,13 @@ export {
   updateESQLQueryTrigger,
   UPDATE_ESQL_QUERY_TRIGGER,
 } from './update_esql_query/update_esql_query_trigger';
-export { UpdateESQLQueryAction } from './update_esql_query/update_esql_query_actions';
+export {
+  UpdateESQLQueryAction,
+  ACTION_UPDATE_ESQL_QUERY,
+} from './update_esql_query/update_esql_query_actions';
 
 export { esqlControlTrigger, ESQL_CONTROL_TRIGGER } from './esql_controls/esql_control_trigger';
-export { CreateESQLControlAction } from './esql_controls/esql_control_action';
+export {
+  CreateESQLControlAction,
+  ACTION_CREATE_ESQL_CONTROL,
+} from './esql_controls/esql_control_action';

--- a/src/platform/plugins/shared/esql/public/triggers/update_esql_query/update_esql_query_actions.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/update_esql_query/update_esql_query_actions.ts
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 
-const ACTION_UPDATE_ESQL_QUERY = 'ACTION_UPDATE_ESQL_QUERY';
+export const ACTION_UPDATE_ESQL_QUERY = 'ACTION_UPDATE_ESQL_QUERY';
 
 interface Context {
   queryString: string;

--- a/src/platform/plugins/shared/esql/public/triggers/update_esql_query/update_esql_query_actions.ts
+++ b/src/platform/plugins/shared/esql/public/triggers/update_esql_query/update_esql_query_actions.ts
@@ -10,14 +10,13 @@
 import { i18n } from '@kbn/i18n';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import { isActionCompatible, executeAction } from './update_esql_query_helpers';
 
 export const ACTION_UPDATE_ESQL_QUERY = 'ACTION_UPDATE_ESQL_QUERY';
 
 interface Context {
   queryString: string;
 }
-
-export const getHelpersAsync = async () => await import('./update_esql_query_helpers');
 
 export class UpdateESQLQueryAction implements Action<Context> {
   public type = ACTION_UPDATE_ESQL_QUERY;
@@ -37,12 +36,10 @@ export class UpdateESQLQueryAction implements Action<Context> {
   }
 
   public async isCompatible() {
-    const { isActionCompatible } = await getHelpersAsync();
     return isActionCompatible(this.data);
   }
 
   public async execute({ queryString }: Context) {
-    const { executeAction } = await getHelpersAsync();
     return executeAction({
       queryString,
       data: this.data,


### PR DESCRIPTION
## Summary

Uses the `addTriggerActionAsync` from uiActions to register the ES|QL ui actions





