### PR TITLE
[8.17] Entity Flyout flickers when loading risk score panel (#211568)

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
@@ -58,7 +58,7 @@ export const HostPanelContent = ({
               queryId={HOST_PANEL_RISK_SCORE_QUERY_ID}
               openDetailsPanel={openDetailsPanel}
               isPreviewMode={isPreviewMode}
-              />
+            />
             <EuiHorizontalRule />
           </>
         )}

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/host_right/content.tsx
@@ -48,18 +48,20 @@ export const HostPanelContent = ({
 
   return (
     <FlyoutBody>
-      {riskScoreState.isModuleEnabled && riskScoreState.data?.length !== 0 && (
-        <>
-          <FlyoutRiskSummary
-            riskScoreData={riskScoreState}
-            recalculatingScore={recalculatingScore}
-            queryId={HOST_PANEL_RISK_SCORE_QUERY_ID}
-            openDetailsPanel={openDetailsPanel}
-            isPreviewMode={isPreviewMode}
-          />
-          <EuiHorizontalRule />
-        </>
-      )}
+      {Array.isArray(riskScoreState.data) &&
+        riskScoreState.isModuleEnabled &&
+        riskScoreState.data.length > 0 && (
+          <>
+            <FlyoutRiskSummary
+              riskScoreData={riskScoreState}
+              recalculatingScore={recalculatingScore}
+              queryId={HOST_PANEL_RISK_SCORE_QUERY_ID}
+              openDetailsPanel={openDetailsPanel}
+              isPreviewMode={isPreviewMode}
+              />
+            <EuiHorizontalRule />
+          </>
+        )}
       <AssetCriticalityAccordion
         entity={{ name: hostName, type: 'host' }}
         onChange={onAssetCriticalityChange}

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
@@ -57,7 +57,9 @@ export const UserPanelContent = ({
 
   return (
     <FlyoutBody>
-      {riskScoreState.isModuleEnabled && riskScoreState.data?.length !== 0 && (
+      {Array.isArray(riskScoreState.data) &&
+        riskScoreState.isModuleEnabled &&
+        riskScoreState.data.length > 0 && (
         <>
           <FlyoutRiskSummary
             riskScoreData={riskScoreState}

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/content.tsx
@@ -60,17 +60,17 @@ export const UserPanelContent = ({
       {Array.isArray(riskScoreState.data) &&
         riskScoreState.isModuleEnabled &&
         riskScoreState.data.length > 0 && (
-        <>
-          <FlyoutRiskSummary
-            riskScoreData={riskScoreState}
-            recalculatingScore={recalculatingScore}
-            queryId={USER_PANEL_RISK_SCORE_QUERY_ID}
-            openDetailsPanel={openDetailsPanel}
-            isPreviewMode={isPreviewMode}
-          />
-          <EuiHorizontalRule />
-        </>
-      )}
+          <>
+            <FlyoutRiskSummary
+              riskScoreData={riskScoreState}
+              recalculatingScore={recalculatingScore}
+              queryId={USER_PANEL_RISK_SCORE_QUERY_ID}
+              openDetailsPanel={openDetailsPanel}
+              isPreviewMode={isPreviewMode}
+            />
+            <EuiHorizontalRule />
+          </>
+        )}
       <AssetCriticalityAccordion
         entity={{ name: userName, type: 'user' }}
         onChange={onAssetCriticalityChange}


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.17`:
 - [Entity Flyout flickers when loading risk score panel (#211568)](https://github.com/elastic/kibana/pull/211568)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Charlotte Alexandra Wilson","email":"CAWilson94@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-18T15:09:12Z","message":"Entity Flyout flickers when loading risk score panel (#211568)\n\n## Summary\r\nThis PR fixes the issue where the Risk Score Panel flickers into view\r\nwhen no risk score is available yet. This occurs in two cases:\r\n1. Opening the flyout for a user or host.\r\n2. Updating Asset Criticality from the flyout.\r\n\r\n### Steps to Reproduce (Before Fix)\r\n[@abhishekbhatia1710](https://github.com/abhishekbhatia1710) [provided\r\nsteps as below in original\r\nticket](https://github.com/elastic/security-team/issues/11590#issuecomment-2643056694):\r\n\r\n1. Ensure you are using version 8.18\r\n2. Enable the Risk Engine.\r\n3. Enable the Entity Store.\r\n4. Upload the asset criticality file.\r\n5. Do not run the risk score on the newly added entities yet.\r\n6. Navigate to the EA Dashboard.\r\n7. Scroll down to the Entities section.\r\n8. Search for the user/host uploaded in the asset criticality file.\r\n9. Click on the entity to open the flyout.\r\n10. Assign asset criticality within the flyout.\r\n11. Before fix: Risk Score panel briefly appears (flickers) despite no\r\nrisk score being available.\r\n\r\n###  Expected Behaviour (After Fix)\r\nFollowing the same steps, the Risk Score Panel no longer flickers when\r\nopening the flyout or updating asset criticality - for both user and\r\nhost entity types.\r\n\r\n### Video (After Fix)\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/7ef28ee1-7e5d-43ae-b6d3-7075b63229be","sha":"f486939e0aa00163f4c41cdfaae96110ca508dc4","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","fixed","Team: SecuritySolution","ci:project-deploy-security","ci:project-persist-deployment","Team:Entity Analytics","backport:version","v8.17.0","v8.18.0"],"title":"Entity Flyout flickers when loading risk score panel","number":211568,"url":"https://github.com/elastic/kibana/pull/211568","mergeCommit":{"message":"Entity Flyout flickers when loading risk score panel (#211568)\n\n## Summary\r\nThis PR fixes the issue where the Risk Score Panel flickers into view\r\nwhen no risk score is available yet. This occurs in two cases:\r\n1. Opening the flyout for a user or host.\r\n2. Updating Asset Criticality from the flyout.\r\n\r\n### Steps to Reproduce (Before Fix)\r\n[@abhishekbhatia1710](https://github.com/abhishekbhatia1710) [provided\r\nsteps as below in original\r\nticket](https://github.com/elastic/security-team/issues/11590#issuecomment-2643056694):\r\n\r\n1. Ensure you are using version 8.18\r\n2. Enable the Risk Engine.\r\n3. Enable the Entity Store.\r\n4. Upload the asset criticality file.\r\n5. Do not run the risk score on the newly added entities yet.\r\n6. Navigate to the EA Dashboard.\r\n7. Scroll down to the Entities section.\r\n8. Search for the user/host uploaded in the asset criticality file.\r\n9. Click on the entity to open the flyout.\r\n10. Assign asset criticality within the flyout.\r\n11. Before fix: Risk Score panel briefly appears (flickers) despite no\r\nrisk score being available.\r\n\r\n###  Expected Behaviour (After Fix)\r\nFollowing the same steps, the Risk Score Panel no longer flickers when\r\nopening the flyout or updating asset criticality - for both user and\r\nhost entity types.\r\n\r\n### Video (After Fix)\r\n\r\n\r\n\r\nhttps://github.com/user-attachments/assets/7ef28ee1-7e5d-43ae-b6d3-7075b63229be","sha":"f486939e0aa00163f4c41cdfaae96110ca508dc4"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.17","8.18"],"targetPullRequestStates":[{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->