### PR TITLE
Fix issue with "Let Us Know" button getting hidden when Management Menu is open

### DIFF
--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/navigation.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/navigation.tsx
@@ -16,7 +16,7 @@ import type {
   NavigationTreeDefinitionUI,
 } from '@kbn/core-chrome-browser';
 import type { Observable } from 'rxjs';
-import { EuiCollapsibleNavBeta, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiCollapsibleNavBeta, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import {
   RecentlyAccessed,
   NavigationPanel,
@@ -94,14 +94,16 @@ const NavigationComp: FC<Props> = ({ navigationTree$, dataTestSubj, panelContent
         <EuiCollapsibleNavBeta.Body data-test-subj={dataTestSubj}>
           <EuiFlexGroup direction="column" justifyContent="spaceBetween" css={{ height: '100%' }}>
             <EuiFlexItem>{renderNodes(navigationTree.body)}</EuiFlexItem>
-            {isFeedbackBtnVisible && (
-              <EuiFlexItem grow={false}>
-                <FeedbackBtn solutionId={solutionId} />
-              </EuiFlexItem>
-            )}
           </EuiFlexGroup>
         </EuiCollapsibleNavBeta.Body>
-
+        {isFeedbackBtnVisible && (
+          <EuiFlexGroup>
+            <EuiFlexItem grow={false}>
+              <EuiSpacer size="s" />
+              <FeedbackBtn solutionId={solutionId} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        )}
         {/* Footer */}
         {navigationTree.footer && (
           <EuiCollapsibleNavBeta.Footer>


### PR DESCRIPTION
## Summary

Closes  #210919

## Visuals

https://github.com/user-attachments/assets/0a2f3306-5e85-42f5-a28f-b3e9ca18f1a4

<!--

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


-->


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->