### PR TITLE
[8.18] SKA: Categorise platform devOnly packages under `/packages` (#211560)

### DIFF
--- a/packages/kbn-ambient-common-types/kibana.jsonc
+++ b/packages/kbn-ambient-common-types/kibana.jsonc
@@ -2,5 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/ambient-common-types",
   "owner": "@elastic/kibana-operations",
+  "group": "platform",
+  "visibility": "private",
   "devOnly": true
 }

--- a/packages/kbn-ambient-ftr-types/kibana.jsonc
+++ b/packages/kbn-ambient-ftr-types/kibana.jsonc
@@ -2,5 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/ambient-ftr-types",
   "owner": ["@elastic/kibana-operations", "@elastic/appex-qa"],
+  "group": "platform",
+  "visibility": "private",
   "devOnly": true
 }

--- a/packages/kbn-ambient-storybook-types/kibana.jsonc
+++ b/packages/kbn-ambient-storybook-types/kibana.jsonc
@@ -1,6 +1,8 @@
 {
   "type": "shared-common",
   "id": "@kbn/ambient-storybook-types",
-  "devOnly": true,
-  "owner": "@elastic/kibana-operations"
+  "owner": "@elastic/kibana-operations",
+  "group": "platform",
+  "visibility": "shared",
+  "devOnly": true
 }

--- a/packages/kbn-ambient-ui-types/kibana.jsonc
+++ b/packages/kbn-ambient-ui-types/kibana.jsonc
@@ -1,6 +1,8 @@
 {
   "type": "shared-common",
   "id": "@kbn/ambient-ui-types",
-  "devOnly": true,
-  "owner": "@elastic/kibana-operations"
+  "owner": "@elastic/kibana-operations",
+  "group": "platform",
+  "visibility": "shared",
+  "devOnly": true
 }

--- a/packages/kbn-axe-config/kibana.jsonc
+++ b/packages/kbn-axe-config/kibana.jsonc
@@ -1,6 +1,10 @@
 {
   "type": "shared-common",
   "id": "@kbn/axe-config",
-  "devOnly": true,
-  "owner": "@elastic/kibana-qa"
+  "owner": [
+    "@elastic/kibana-qa"
+  ],
+  "group": "platform",
+  "visibility": "shared",
+  "devOnly": true
 }

--- a/packages/kbn-gen-ai-functional-testing/kibana.jsonc
+++ b/packages/kbn-gen-ai-functional-testing/kibana.jsonc
@@ -1,6 +1,10 @@
 {
   "type": "shared-common",
   "id": "@kbn/gen-ai-functional-testing",
-  "owner": "@elastic/appex-ai-infra",
+  "owner": [
+    "@elastic/appex-ai-infra"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "devOnly": true
 }

--- a/packages/kbn-node-libs-browser-webpack-plugin/kibana.jsonc
+++ b/packages/kbn-node-libs-browser-webpack-plugin/kibana.jsonc
@@ -1,5 +1,7 @@
 {
   "type": "shared-common",
   "id": "@kbn/node-libs-browser-webpack-plugin",
-  "owner": "@elastic/kibana-operations"
+  "owner": "@elastic/kibana-operations",
+  "group": "platform",
+  "visibility": "private"
 }

--- a/packages/kbn-openapi-bundler/kibana.jsonc
+++ b/packages/kbn-openapi-bundler/kibana.jsonc
@@ -1,6 +1,10 @@
 {
-  "devOnly": true,
+  "type": "shared-common",
   "id": "@kbn/openapi-bundler",
-  "owner": "@elastic/security-detection-rule-management",
-  "type": "shared-common"
+  "owner": [
+    "@elastic/security-detection-rule-management"
+  ],
+  "group": "platform",
+  "visibility": "shared",
+  "devOnly": true
 }

--- a/packages/kbn-openapi-generator/kibana.jsonc
+++ b/packages/kbn-openapi-generator/kibana.jsonc
@@ -1,6 +1,10 @@
 {
-  "devOnly": true,
+  "type": "shared-common",
   "id": "@kbn/openapi-generator",
-  "owner": "@elastic/security-detection-rule-management",
-  "type": "shared-common"
+  "owner": [
+    "@elastic/security-detection-rule-management"
+  ],
+  "group": "platform",
+  "visibility": "shared",
+  "devOnly": true
 }

--- a/packages/kbn-scout-info/kibana.jsonc
+++ b/packages/kbn-scout-info/kibana.jsonc
@@ -1,6 +1,10 @@
 {
   "type": "shared-common",
   "id": "@kbn/scout-info",
-  "owner": "@elastic/appex-qa",
+  "owner": [
+    "@elastic/appex-qa"
+  ],
+  "group": "platform",
+  "visibility": "private",
   "devOnly": true
 }

--- a/packages/kbn-scout-reporting/kibana.jsonc
+++ b/packages/kbn-scout-reporting/kibana.jsonc
@@ -2,5 +2,7 @@
   "type": "shared-common",
   "id": "@kbn/scout-reporting",
   "owner": "@elastic/appex-qa",
+  "group": "platform",
+  "visibility": "private",
   "devOnly": true
 }

--- a/packages/kbn-scout/kibana.jsonc
+++ b/packages/kbn-scout/kibana.jsonc
@@ -1,6 +1,10 @@
 {
   "type": "test-helper",
   "id": "@kbn/scout",
-  "owner": "@elastic/appex-qa",
+  "owner": [
+    "@elastic/appex-qa"
+  ],
+  "group": "platform",
+  "visibility": "shared",
   "devOnly": true
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [SKA: Categorise platform devOnly packages under `/packages` (#211560)](https://github.com/elastic/kibana/pull/211560)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gerard Soldevila","email":"gerard.soldevila@elastic.co"},"sourceCommit":{"committedDate":"2025-02-19T09:38:42Z","message":"SKA: Categorise platform devOnly packages under `/packages` (#211560)\n\n## Summary\r\n\r\nMost of the packages under `/packages` have been relocated in the\r\ncontext of _Sustainable Kibana Architecture_.\r\n\r\nThe remaining packages are `devOnly: true`, and they can be grouped as\r\nfollows:\r\n\r\n1. Packages that are ONLY used from /scripts/\r\n2. Packages that are used from platform and solutions modules (they are\r\nused from tests, cypress tests, storybook configs, ./scripts/ folders\r\ninside some modules, or other non-prod-time logic).\r\n\r\nThis PR categorises the packages in (2) as `platform/(private|shared)`\r\nto reflect that they are being used from platform and solutions modules\r\n(even though they're used from non-production code).\r\n\r\nNext, we're gonna have to decide whether we want to relocate some of\r\nthem (1, 2 or both) under a different path.","sha":"a1fde9776552bae822f380195951f34996665c12","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","v9.0.0","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"SKA: Categorise platform devOnly packages under `/packages`","number":211560,"url":"https://github.com/elastic/kibana/pull/211560","mergeCommit":{"message":"SKA: Categorise platform devOnly packages under `/packages` (#211560)\n\n## Summary\r\n\r\nMost of the packages under `/packages` have been relocated in the\r\ncontext of _Sustainable Kibana Architecture_.\r\n\r\nThe remaining packages are `devOnly: true`, and they can be grouped as\r\nfollows:\r\n\r\n1. Packages that are ONLY used from /scripts/\r\n2. Packages that are used from platform and solutions modules (they are\r\nused from tests, cypress tests, storybook configs, ./scripts/ folders\r\ninside some modules, or other non-prod-time logic).\r\n\r\nThis PR categorises the packages in (2) as `platform/(private|shared)`\r\nto reflect that they are being used from platform and solutions modules\r\n(even though they're used from non-production code).\r\n\r\nNext, we're gonna have to decide whether we want to relocate some of\r\nthem (1, 2 or both) under a different path.","sha":"a1fde9776552bae822f380195951f34996665c12"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211560","number":211560,"mergeCommit":{"message":"SKA: Categorise platform devOnly packages under `/packages` (#211560)\n\n## Summary\r\n\r\nMost of the packages under `/packages` have been relocated in the\r\ncontext of _Sustainable Kibana Architecture_.\r\n\r\nThe remaining packages are `devOnly: true`, and they can be grouped as\r\nfollows:\r\n\r\n1. Packages that are ONLY used from /scripts/\r\n2. Packages that are used from platform and solutions modules (they are\r\nused from tests, cypress tests, storybook configs, ./scripts/ folders\r\ninside some modules, or other non-prod-time logic).\r\n\r\nThis PR categorises the packages in (2) as `platform/(private|shared)`\r\nto reflect that they are being used from platform and solutions modules\r\n(even though they're used from non-production code).\r\n\r\nNext, we're gonna have to decide whether we want to relocate some of\r\nthem (1, 2 or both) under a different path.","sha":"a1fde9776552bae822f380195951f34996665c12"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/211702","number":211702,"state":"OPEN"}]}] BACKPORT-->