### PR TITLE
[Streams 🌊] Revert route change that breaks navigation on refresh

### DIFF
--- a/x-pack/solutions/observability/plugins/streams_app/public/routes/config.tsx
+++ b/x-pack/solutions/observability/plugins/streams_app/public/routes/config.tsx
@@ -34,17 +34,16 @@ const streamsAppRoutes = {
     ),
     children: {
       '/{key}': {
-        element: (
-          <RedirectTo path="/{key}/{tab}" params={{ path: { tab: 'overview' } }}>
-            <Outlet />
-          </RedirectTo>
-        ),
+        element: <Outlet />,
         params: t.type({
           path: t.type({
             key: t.string,
           }),
         }),
         children: {
+          '/{key}': {
+            element: <RedirectTo path="/{key}/{tab}" params={{ path: { tab: 'overview' } }} />,
+          },
           '/{key}/management': {
             element: (
               <RedirectTo


### PR DESCRIPTION
## 📓 Summary

Revert a route config change introduced in [[Streams 🌊] Enrichment simulation behaviour improvements](https://github.com/elastic/kibana/pull/209985) that bring always to the overview page on refresh.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->