### PR TITLE
[Fleet] Do not allow alpha, beta, rc suffixes in agent versions

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.test.ts
@@ -221,7 +221,7 @@ describe('getAvailableVersions', () => {
     expect(res).toEqual(['8.10.0', '8.9.2', '8.1.0', '8.0.0', '7.17.0']);
   });
 
-  it('should filter out rc and beta versions', async () => {
+  it('should not filter out rc and beta versions', async () => {
     mockKibanaVersion = '300.0.0';
     mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);
     mockedFetch.mockResolvedValueOnce({
@@ -231,11 +231,19 @@ describe('getAvailableVersions', () => {
           [
             {
               title: 'Elastic Agent 8.0.0',
-              version_number: '8.0.0-rc1',
+              version_number: '8.0.0-rc2',
             },
             {
               title: 'Elastic Agent 8.0.0',
               version_number: '8.0.0-beta1',
+            },
+            {
+              title: 'Elastic Agent 8.0.0',
+              version_number: '8.0.0-alpha1',
+            },
+            {
+              title: 'Elastic Agent 8.0.0',
+              version_number: '8.0.0-unkown',
             },
           ],
         ])
@@ -245,7 +253,7 @@ describe('getAvailableVersions', () => {
     const res = await getAvailableVersions({ ignoreCache: true });
 
     // Should sort, uniquify and filter out versions < 7.17
-    expect(res).toEqual(['8.1.0', '8.0.0', '7.17.0']);
+    expect(res).toEqual(['8.1.0', '8.0.0', '8.0.0-rc2', '8.0.0-beta1', '8.0.0-alpha1', '7.17.0']);
   });
 
   it('should include build version', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.test.ts
@@ -221,7 +221,7 @@ describe('getAvailableVersions', () => {
     expect(res).toEqual(['8.10.0', '8.9.2', '8.1.0', '8.0.0', '7.17.0']);
   });
 
-  it('should not filter out rc and beta versions', async () => {
+  it('should filter out rc and beta versions', async () => {
     mockKibanaVersion = '300.0.0';
     mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);
     mockedFetch.mockResolvedValueOnce({
@@ -229,6 +229,10 @@ describe('getAvailableVersions', () => {
       text: jest.fn().mockResolvedValue(
         JSON.stringify([
           [
+            {
+              title: 'Elastic Agent 9.0.0',
+              version_number: '9.0.0-rc1',
+            },
             {
               title: 'Elastic Agent 8.0.0',
               version_number: '8.0.0-rc2',
@@ -253,7 +257,7 @@ describe('getAvailableVersions', () => {
     const res = await getAvailableVersions({ ignoreCache: true });
 
     // Should sort, uniquify and filter out versions < 7.17
-    expect(res).toEqual(['8.1.0', '8.0.0', '8.0.0-rc2', '8.0.0-beta1', '8.0.0-alpha1', '7.17.0']);
+    expect(res).toEqual(['8.1.0', '8.0.0', '7.17.0']);
   });
 
   it('should include build version', async () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.ts
@@ -110,11 +110,17 @@ export const getAvailableVersions = async ({
   // fetch from the live API more than `TIME_BETWEEN_FETCHES` milliseconds.
   const apiVersions = await fetchAgentVersionsFromApi();
 
+  const allowedSuffixes = ['-rc', '-beta', '-alpha', '+build'];
+
   // Take each version and compare to our `MINIMUM_SUPPORTED_VERSION` - we
   // only want support versions in the final result. We'll also sort by newest version first.
   availableVersions = uniq(
     [...availableVersions, ...apiVersions]
-      .map((item: any) => (item.includes('+build') ? item : semverCoerce(item)?.version || ''))
+      .map((item: any) =>
+        allowedSuffixes.some((suffix) => item.includes(suffix))
+          ? item
+          : semverCoerce(item)?.version || ''
+      )
       .filter((v: any) => semverGte(v, MINIMUM_SUPPORTED_VERSION))
       .sort((a: any, b: any) => (semverGt(a, b) ? -1 : 1))
   );

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.ts
@@ -15,7 +15,6 @@ import semverGte from 'semver/functions/gte';
 import semverGt from 'semver/functions/gt';
 import semverRcompare from 'semver/functions/rcompare';
 import semverLt from 'semver/functions/lt';
-import semverCoerce from 'semver/functions/coerce';
 import semverParse from 'semver/functions/parse';
 
 import { REPO_ROOT } from '@kbn/repo-info';


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/211777

Add agent flyout should not show `9.0.0` or `9.0.0-beta1` now as currently only 9.0.0-rc1 is available:
<img width="743" alt="Screenshot 2025-02-19 at 1 21 26 PM" src="https://github.com/user-attachments/assets/b6a7f37d-341a-4a9c-b5b2-15a622207a51" />

```
GET kbn:/api/fleet/agents/available_versions
{
  "items": [
    "8.17.2",
    "8.17.1",
    "8.17.0",
    "8.16.4",
    "8.16.3",
    "8.16.2",
    "8.16.1",
    "8.16.0",
    "8.15.5",
    "8.15.4",
    "8.15.3+build202411051926",
    "8.15.3",
    "8.15.2",
    "8.15.1",
    "8.15.0",
    "8.14.3+build202407291657",
    "8.14.3+build202408141002",
    "8.14.3",
    "8.14.2",
    "8.14.1",
    "8.14.0",
    "8.13.4",
    "8.13.3",
    "8.13.2",
    "8.13.1",
    "8.13.0",
    "8.12.2",
    "8.12.1",
    "8.12.0",
    "8.11.4",
    "8.11.3",
    "8.11.2",
    "8.11.1",
    "8.11.0",
    "8.10.4",
    "8.10.3",
    "8.10.2",
    "8.10.1",
    "8.10.0",
    "8.9.2",
    "8.9.1",
    "8.9.0",
    "8.8.2",
    "8.8.1",
    "8.8.0",
    "8.7.1",
    "8.7.0",
    "8.6.2",
    "8.6.1",
    "8.6.0",
    "8.5.3",
    "8.5.2",
    "8.5.1",
    "8.5.0",
    "8.4.3",
    "8.4.2",
    "8.4.1",
    "8.4.0",
    "8.3.3",
    "8.3.2",
    "8.3.1",
    "8.3.0",
    "8.2.3",
    "8.2.2",
    "8.2.1",
    "8.2.0",
    "8.1.3",
    "8.1.2",
    "8.1.1",
    "8.1.0",
    "8.0.1",
    "8.0.0",
    "7.17.27",
    "7.17.26",
    "7.17.25",
    "7.17.24",
    "7.17.23",
    "7.17.22",
    "7.17.21",
    "7.17.20",
    "7.17.19",
    "7.17.18",
    "7.17.17",
    "7.17.16",
    "7.17.15",
    "7.17.14",
    "7.17.13",
    "7.17.12",
    "7.17.11",
    "7.17.10",
    "7.17.9",
    "7.17.8",
    "7.17.7",
    "7.17.6",
    "7.17.5",
    "7.17.4",
    "7.17.3",
    "7.17.2",
    "7.17.1",
    "7.17.0"
  ]
}
```




### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->