### PR TITLE
[Streams] Small type changes for advanced mapping parameters

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/core.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/core.ts
@@ -18,31 +18,3 @@ export const streamDefinitionSchema: z.Schema<StreamDefinition> = z.union([
 ]);
 
 export const isStreamDefinition = createIsNarrowSchema(z.unknown(), streamDefinitionSchema);
-
-export type Primitive = string | number | boolean | null | undefined;
-
-export const primitive: z.ZodType<Primitive> = z.union([
-  z.string(),
-  z.number(),
-  z.boolean(),
-  z.null(),
-  z.undefined(),
-]);
-
-export interface RecursiveRecord {
-  [key: PropertyKey]: Primitive | Primitive[] | RecursiveRecord;
-}
-
-export const recursiveRecord: z.ZodType<RecursiveRecord> = z.lazy(() =>
-  z.record(z.union([primitive, z.array(primitive), recursiveRecord]))
-);
-
-export type FlattenRecord = Record<PropertyKey, Primitive | Primitive[]>;
-
-export const flattenRecord: z.ZodType<FlattenRecord> = z.record(
-  z.union([primitive, z.array(primitive)])
-);
-
-export const sampleDocument = recursiveRecord;
-
-export type SampleDocument = RecursiveRecord;

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/index.ts
@@ -11,3 +11,4 @@ export * from './api';
 export * from './core';
 export * from './helpers';
 export * from './group';
+export * from './record_types';

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/fields/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/fields/index.ts
@@ -8,6 +8,7 @@
 import { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
 import { z } from '@kbn/zod';
 import { NonEmptyString } from '@kbn/zod-helpers';
+import { recursiveRecord } from '../../record_types';
 
 export const FIELD_DEFINITION_TYPES = [
   'keyword',
@@ -34,7 +35,7 @@ export type FieldDefinitionConfigAdvancedParameters = Omit<
 >;
 
 export const fieldDefinitionConfigSchema: z.Schema<FieldDefinitionConfig> = z.intersection(
-  z.record(z.string(), z.unknown()),
+  recursiveRecord,
   z.object({
     type: z.enum(FIELD_DEFINITION_TYPES),
     format: z.optional(NonEmptyString),

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/record_types.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/record_types.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { z } from '@kbn/zod';
+
+export type Primitive = string | number | boolean | null | undefined;
+
+export const primitive: z.ZodType<Primitive> = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.undefined(),
+]);
+
+export interface RecursiveRecord {
+  [key: PropertyKey]: Primitive | Primitive[] | RecursiveRecord;
+}
+
+export const recursiveRecord: z.ZodType<RecursiveRecord> = z.lazy(() =>
+  z.record(z.union([primitive, z.array(primitive), recursiveRecord]))
+);
+
+export type FlattenRecord = Record<PropertyKey, Primitive | Primitive[]>;
+
+export const flattenRecord: z.ZodType<FlattenRecord> = z.record(
+  z.union([primitive, z.array(primitive)])
+);
+
+export const sampleDocument = recursiveRecord;
+
+export type SampleDocument = RecursiveRecord;


### PR DESCRIPTION
## Summary

Switches to the `recursiveRecord` schema so we don't get these in console:

```
[2025-02-19T15:47:07.556+01:00][WARN ][plugins.streams] Warning for PUT /api/streams/{name}: schema ZodUnknown at body.stream.ingest.wired.fields is not inspectable and could lead to runtime exceptions, convert it to a supported schema
[2025-02-19T15:47:07.557+01:00][WARN ][plugins.streams] Warning for POST /api/streams/{name}/schema/fields_simulation: schema ZodUnknown at body.field_definitions is not inspectable and could lead to runtime exceptions, convert it to a supported schema
[2025-02-19T15:47:07.557+01:00][WARN ][plugins.streams] Warning for POST /api/streams/{name}/processing/_simulate: schema ZodUnknown at body.detected_fields is not inspectable and could lead to runtime exceptions, convert it to a supported schema
```

I had to move the schema definition / types into another file otherwise a circular dependency was introduced with the `fields/index.ts` file, causing a `Cannot read properties of undefined (reading '_parse')` error.

As far as I can see the `recursiveRecord` schema should handle / cover the ES `MappingProperty` type fine.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->