### PR TITLE
[8.18] [Cloud Security] skip flaky tests (#186438)

### DIFF
--- a/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_aws.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_aws.ts
@@ -69,8 +69,10 @@ export default function (providerContext: FtrProviderContext) {
           )?.includes('https://console.aws.amazon.com/cloudformation/')
         ).to.be(true);
       });
-      it('Clicking on Launch CloudFormation on post intall modal should lead user to Cloud Formation page', async () => {
+      // SKIP https://github.com/elastic/kibana/issues/186438 in 8.18
+      it.skip('Clicking on Launch CloudFormation on post intall modal should lead user to Cloud Formation page', async () => {
         await cisIntegration.clickOptionButton(CIS_AWS_OPTION_TEST_ID);
+        await cisIntegration.inputUniqueIntegrationName();
         await cisIntegration.clickSaveButton();
         await pageObjects.header.waitUntilLoadingHasFinished();
         expect(


### PR DESCRIPTION
# Backport

This will skip the following tests in version `8.18`:
 - https://github.com/elastic/kibana/issues/186438

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)