### PR TITLE
[ColorMapping] Fix palette key mapping for legacy palette ids

### DIFF
--- a/src/platform/packages/shared/kbn-palettes/classes/palettes.ts
+++ b/src/platform/packages/shared/kbn-palettes/classes/palettes.ts
@@ -37,7 +37,7 @@ export class KbnPalettes {
 function buildAliasMappings(palettes: IKbnPalette[]): Map<string, string> {
   return palettes.reduce((acc, { id, aliases }) => {
     aliases.forEach((alias) => {
-      acc.set(alias, id);
+      if (!acc.has(alias)) acc.set(alias, id);
     });
     return acc;
   }, new Map());

--- a/src/platform/packages/shared/kbn-palettes/palettes/categorical/elastic.ts
+++ b/src/platform/packages/shared/kbn-palettes/palettes/categorical/elastic.ts
@@ -20,6 +20,7 @@ export const elasticPalette = new KbnColorFnPalette({
   id: KbnPalette.Default,
   type: 'categorical',
   aliases: [
+    KbnPalette.Default, // needed when switching between new and old themes
     'elastic_borealis', // placeholder - not yet used
     KbnPalette.Amsterdam, // to assign to existing default palettes
   ],


### PR DESCRIPTION
## Summary

Currently, palettes with the legacy palette id of `eui_amsterdam_color_blind`, the old default id, gets assigned the `kibana 7` palette. The desired behavior is that this palette is assigned the new borealis default palette in `9.0`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->