### PR TITLE
[Entity Analytics][Flaky Test] Allow task status to be running when risk engine is enabled

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 import { riskEngineConfigurationTypeName } from '@kbn/security-solution-plugin/server/lib/entity_analytics/risk_engine/saved_object';
 
 import { riskEngineRouteHelpersFactory } from '../../utils';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 
-const expectTaskIsNotRunning = (taskStatus?: string) => {
-  expect(['idle', 'claiming']).contain(taskStatus);
+const expectTaskIsHealthy = (taskStatus?: string) => {
+  expect(['idle', 'claiming', 'running']).contain(taskStatus);
 };
 
 export default ({ getService }: FtrProviderContext) => {
@@ -762,7 +762,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(status2.body.risk_engine_status).to.be('ENABLED');
 
         expect(status2.body.risk_engine_task_status?.runAt).to.be.a('string');
-        expectTaskIsNotRunning(status2.body.risk_engine_task_status?.status);
+        expectTaskIsHealthy(status2.body.risk_engine_task_status?.status);
         expect(status2.body.risk_engine_task_status?.startedAt).to.be(undefined);
 
         await riskEngineRoutes.disable();
@@ -778,7 +778,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(status4.body.risk_engine_status).to.be('ENABLED');
 
         expect(status4.body.risk_engine_task_status?.runAt).to.be.a('string');
-        expectTaskIsNotRunning(status4.body.risk_engine_task_status?.status);
+        expectTaskIsHealthy(status4.body.risk_engine_task_status?.status);
         expect(status4.body.risk_engine_task_status?.startedAt).to.be(undefined);
       });
     });

--- a/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/entity_analytics/risk_engine/trial_license_complete_tier/init_and_status_apis.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import { riskEngineConfigurationTypeName } from '@kbn/security-solution-plugin/server/lib/entity_analytics/risk_engine/saved_object';
 
 import { riskEngineRouteHelpersFactory } from '../../utils';


### PR DESCRIPTION
## Summary

closes #196319 

I think I got the intention of the test wrong in https://github.com/elastic/kibana/pull/196172.

Looking at the test we enable the risk engine and check everything is happy. When the risk engine is enabled, the task should be healthy, so I believe that `running` is a valid status here.

Latest flaky failure: 

```

└- ✖ fail: Entity Analytics - Risk Engine @ess @serverless @serverlessQA init_and_status_apis status api should disable / enable risk engine
--
  | │      Error: expected [ 'idle', 'claiming' ] to contain 'running'
  | │       at Assertion.assert (expect.js:100:11)
  | │       at Assertion.contain (expect.js:447:10)
  | │       at expectTaskIsNotRunning (init_and_status_apis.ts:15:32)
  | │       at Context.<anonymous> (init_and_status_apis.ts:781:9)
  | │       at processTicksAndRejections (node:internal/process/task_queues:95:5)
  | │       at Object.apply (wrap_function.js:74:16)
```