### PR TITLE
[Discover] Fix resource badge text rendering

### DIFF
--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/utils.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/utils.tsx
@@ -175,7 +175,7 @@ export const createResourceFields = ({
       fieldFormats,
       dataView,
       dataView.getFieldByName(name),
-      'html'
+      'text'
     );
 
     return {

--- a/src/platform/plugins/shared/discover/public/components/data_types/logs/service_name_cell.tsx
+++ b/src/platform/plugins/shared/discover/public/components/data_types/logs/service_name_cell.tsx
@@ -50,7 +50,7 @@ export const getServiceNameCell =
       props.fieldFormats,
       props.dataView,
       field,
-      'html'
+      'text'
     );
 
     return (


### PR DESCRIPTION
## Summary

Fixes the resource badge rendering so that the formatting does not output html when the page has a filter applied to it. Badges will no longer have `<mark>` applied to the text.

<img alt="Resource badge fix 2025-02-20 114954" src="https://github.com/user-attachments/assets/f92c3c5d-152f-42c5-8159-ba34f6cd174e" />

## How to test

- Setup an edge-oblt cluster to point to in `kibana.dev.yml`, or create a data view with an id that contains `apm_static_data_view_id`, so for example `apm_static_data_view_id_default`. Then, add the following as well to the `kibana.dev.yaml`:
```yaml
discover.experimental.enabledProfiles:
  - traces-data-source-profile
```
- Go to Discover page with the data view enabled
- Add a filter for one of the resource badge fields: service.name, event.outcome
- The formatting on the badge should not show `<mark>` around the text label, and instead only on the flyout, will the filtered fields show the marked formatting.