### PR TITLE
Fixes console warning when the resizable flyout is being used

### DIFF
--- a/src/core/packages/overlays/browser-internal/src/flyout/flyout_service.tsx
+++ b/src/core/packages/overlays/browser-internal/src/flyout/flyout_service.tsx
@@ -87,6 +87,7 @@ export class FlyoutService {
 
     return {
       open: (mount: MountPoint, options: OverlayFlyoutOpenOptions = {}): OverlayRef => {
+        const { isResizable, ...restOptions } = options;
         // If there is an active flyout session close it before opening a new one.
         if (this.activeFlyout) {
           this.activeFlyout.close();
@@ -113,9 +114,9 @@ export class FlyoutService {
         };
 
         const getWrapper = (children: JSX.Element) => {
-          return options?.isResizable ? (
+          return isResizable ? (
             <EuiFlyoutResizable
-              {...options}
+              {...restOptions}
               onClose={onCloseFlyout}
               ref={React.createRef()}
               maxWidth={Number(options?.maxWidth)}
@@ -123,7 +124,7 @@ export class FlyoutService {
               {children}
             </EuiFlyoutResizable>
           ) : (
-            <EuiFlyout {...options} onClose={onCloseFlyout}>
+            <EuiFlyout {...restOptions} onClose={onCloseFlyout}>
               {children}
             </EuiFlyout>
           );


### PR DESCRIPTION
## Summary

Fixes this warning that appears when a user opens the inline editing flyout


![image (82)](https://github.com/user-attachments/assets/4016f784-ad9e-4ab5-9db8-0c5e92a36886)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->