### PR TITLE
[scout] Don't mix `await` with promise callbacks

### DIFF
--- a/packages/kbn-scout-reporting/src/helpers/elasticsearch.ts
+++ b/packages/kbn-scout-reporting/src/helpers/elasticsearch.ts
@@ -30,17 +30,15 @@ export async function getValidatedESClient(
   const { log, cli = false } = helperSettings;
   const es = new ESClient(esClientOptions);
 
-  await es.info().then(
-    (esInfo) => {
-      if (log !== undefined) {
-        log.info(`Connected to Elasticsearch node '${esInfo.name}'`);
-      }
-    },
-    (err) => {
-      const msg = `Failed to connect to Elasticsearch\n${err}`;
-      throw cli ? createFailError(msg) : Error(msg);
+  try {
+    const esInfo = await es.info();
+    if (log !== undefined) {
+      log.info(`Connected to Elasticsearch node '${esInfo.name}'`);
     }
-  );
+  } catch (err) {
+    const msg = `Failed to connect to Elasticsearch\n${err}`;
+    throw cli ? createFailError(msg) : Error(msg);
+  }
 
   return es;
 }


### PR DESCRIPTION
## Summary

There's a high likelihood that this causes some unwanted behavior where the promise is not resolved and the `node` process just exists without any error.




<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->