### PR TITLE
[Fleet] Auto upgrade improvements

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/details_page/components/header/manage_auto_upgrade_agents.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/details_page/components/header/manage_auto_upgrade_agents.tsx
@@ -31,15 +31,14 @@ export const ManageAutoUpgradeAgentsBadge: React.FC<Props> = ({
   setIsManageAutoUpgradeAgentsModalOpen,
 }: Props) => {
   const { data: autoUpgradeAgentsStatus } = useGetAutoUpgradeAgentsStatusQuery(agentPolicy.id);
+  const requiredVersions = (agentPolicy.required_versions ?? []).map(
+    (reqVersion) => reqVersion.version
+  );
   const hasErrors = useMemo(() => {
     return autoUpgradeAgentsStatus?.currentVersions
-      .filter((value) =>
-        (agentPolicy.required_versions ?? [])
-          .map((reqVersion) => reqVersion.version)
-          .includes(value.version)
-      )
+      .filter((value) => requiredVersions.includes(value.version))
       .some((value) => value.failedUpgradeAgents > 0);
-  }, [autoUpgradeAgentsStatus, agentPolicy.required_versions]);
+  }, [autoUpgradeAgentsStatus, requiredVersions]);
 
   return (
     <EuiFlexGroup

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/details_page/components/header/manage_auto_upgrade_agents.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/details_page/components/header/manage_auto_upgrade_agents.tsx
@@ -32,8 +32,14 @@ export const ManageAutoUpgradeAgentsBadge: React.FC<Props> = ({
 }: Props) => {
   const { data: autoUpgradeAgentsStatus } = useGetAutoUpgradeAgentsStatusQuery(agentPolicy.id);
   const hasErrors = useMemo(() => {
-    return autoUpgradeAgentsStatus?.currentVersions.some((value) => value.failedUpgradeAgents > 0);
-  }, [autoUpgradeAgentsStatus]);
+    return autoUpgradeAgentsStatus?.currentVersions
+      .filter((value) =>
+        (agentPolicy.required_versions ?? [])
+          .map((reqVersion) => reqVersion.version)
+          .includes(value.version)
+      )
+      .some((value) => value.failedUpgradeAgents > 0);
+  }, [autoUpgradeAgentsStatus, agentPolicy.required_versions]);
 
   return (
     <EuiFlexGroup

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.test.tsx
@@ -339,7 +339,10 @@ describe('AgentUpgradeStatus', () => {
               error_msg: 'Something went wrong',
             },
           },
+          local_metadata: { elastic: { agent: { version: '8.11.0', upgradeable: true } } },
         },
+        isAgentUpgradable: true,
+        latestAgentVersion: '8.12.0',
       });
 
       expectUpgradeStatusBadgeLabel(results, 'Upgrade failed');

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_upgrade_status.tsx
@@ -283,17 +283,6 @@ export const AgentUpgradeStatus: React.FC<{
   const minVersion = '8.12';
   const notUpgradeableMessage = getNotUpgradeableMessage(agent, latestAgentVersion);
 
-  if (isAgentUpgradable && isAgentUpgradeAvailable(agent, latestAgentVersion)) {
-    return (
-      <EuiBadge color="hollow" iconType="sortUp">
-        <FormattedMessage
-          id="xpack.fleet.agentUpgradeStatusBadge.upgradeAvailable"
-          defaultMessage="Upgrade available"
-        />
-      </EuiBadge>
-    );
-  }
-
   if (agent.upgrade_details && status) {
     return (
       <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
@@ -309,6 +298,17 @@ export const AgentUpgradeStatus: React.FC<{
           </EuiFlexItem>
         )}
       </EuiFlexGroup>
+    );
+  }
+
+  if (isAgentUpgradable && isAgentUpgradeAvailable(agent, latestAgentVersion)) {
+    return (
+      <EuiBadge color="hollow" iconType="sortUp">
+        <FormattedMessage
+          id="xpack.fleet.agentUpgradeStatusBadge.upgradeAvailable"
+          defaultMessage="Upgrade available"
+        />
+      </EuiBadge>
     );
   }
 


### PR DESCRIPTION
## Summary

Relates https://github.com/elastic/ingest-dev/issues/4731

Hiding warning icon in Agent policy details header if the failed upgrade agents is not related to a target version present in the list of required_versions.

<img width="1774" alt="image" src="https://github.com/user-attachments/assets/634bde32-8b58-45ac-9092-56af4ce0e774" />

Also fixed a small bug in Agent version badge where the Upgrade failed state was not displayed when the status is healthy and upgrade is available.

<img width="1056" alt="image" src="https://github.com/user-attachments/assets/9797cf73-eb95-4436-87af-2109514f100b" />
