### PR TITLE
[ES|QL] Removes deprecated setImmediate

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -241,9 +241,9 @@ export const ESQLEditor = memo(function ESQLEditor({
 
   const showSuggestionsIfEmptyQuery = useCallback(() => {
     if (editorModel.current?.getValueLength() === 0) {
-      setImmediate(() => {
+      setTimeout(() => {
         editor1.current?.trigger(undefined, 'editor.action.triggerSuggest', {});
-      });
+      }, 0);
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Apparently they decided against setImmediate https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate so I am removing this from our codebase




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->