### PR TITLE
Updating preconfigured connector name

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -271,9 +271,6 @@ xpack.dataUsage.enabled: true
 # This feature is disabled in Serverless until fully tested within a Serverless environment
 xpack.dataUsage.enableExperimental: ['dataUsageDisabled']
 
-# This feature is disabled in Serverless until Inference Endpoint become enabled within a Serverless environment
-xpack.stack_connectors.enableExperimental: ['inferenceConnectorOff']
-
 # This is the definition introducing pre-configured Kibana Connector for Elastic default LLM
 xpack.actions.preconfigured:
   Elastic-LLM:

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -16,17 +16,17 @@ xpack.features.overrides:
     privileges:
       ### Dashboard's `All` feature privilege should implicitly grant `All` access to Maps and Visualize features.
       all.composedOf:
-        - feature: "maps"
-          privileges: [ "all" ]
-        - feature: "visualize"
-          privileges: [ "all" ]
+        - feature: 'maps'
+          privileges: ['all']
+        - feature: 'visualize'
+          privileges: ['all']
       ### Dashboard's `Read` feature privilege should implicitly grant `Read` access to Maps and Visualize features.
       ### Additionally, it should implicitly grant privilege to create short URLs in Visualize app.
       read.composedOf:
-        - feature: "maps"
-          privileges: [ "read" ]
-        - feature: "visualize"
-          privileges: [ "read" ]
+        - feature: 'maps'
+          privileges: ['read']
+        - feature: 'visualize'
+          privileges: ['read']
     ### All Dashboard sub-feature privileges should be hidden: reporting capabilities will be granted via dedicated
     ### Reporting feature and short URL sub-feature privilege should be granted for both `All` and `Read`.
     subFeatures.privileges:
@@ -35,22 +35,22 @@ xpack.features.overrides:
       store_search_session.disabled: true
       url_create:
         disabled: true
-        includeIn: "read"
+        includeIn: 'read'
   dashboard_v2:
     privileges:
       ### Dashboard's `All` feature privilege should implicitly grant `All` access to Maps and Visualize features.
       all.composedOf:
-        - feature: "maps_v2"
-          privileges: [ "all" ]
-        - feature: "visualize_v2"
-          privileges: [ "all" ]
+        - feature: 'maps_v2'
+          privileges: ['all']
+        - feature: 'visualize_v2'
+          privileges: ['all']
       ### Dashboard's `Read` feature privilege should implicitly grant `Read` access to Maps and Visualize features.
       ### Additionally, it should implicitly grant privilege to create short URLs in Visualize app.
       read.composedOf:
-        - feature: "maps_v2"
-          privileges: [ "read" ]
-        - feature: "visualize_v2"
-          privileges: [ "read" ]
+        - feature: 'maps_v2'
+          privileges: ['read']
+        - feature: 'visualize_v2'
+          privileges: ['read']
     ### All Dashboard sub-feature privileges should be hidden: reporting capabilities will be granted via dedicated
     ### Reporting feature and short URL sub-feature privilege should be granted for both `All` and `Read`.
     subFeatures.privileges:
@@ -59,7 +59,7 @@ xpack.features.overrides:
       store_search_session.disabled: true
       url_create:
         disabled: true
-        includeIn: "read"
+        includeIn: 'read'
   discover:
     ### All Discover sub-feature privileges should be hidden: reporting capabilities will be granted via dedicated
     ### Reporting feature and short URL sub-feature privilege should be granted for both `All` and `Read`.
@@ -68,7 +68,7 @@ xpack.features.overrides:
       store_search_session.disabled: true
       url_create:
         disabled: true
-        includeIn: "read"
+        includeIn: 'read'
   discover_v2:
     ### All Discover sub-feature privileges should be hidden: reporting capabilities will be granted via dedicated
     ### Reporting feature and short URL sub-feature privilege should be granted for both `All` and `Read`.
@@ -77,7 +77,7 @@ xpack.features.overrides:
       store_search_session.disabled: true
       url_create:
         disabled: true
-        includeIn: "read"
+        includeIn: 'read'
   ### Shared images feature is hidden in Role management since it's not needed.
   filesSharedImage.hidden: true
   ### Maps feature is hidden in Role management since it's automatically granted by Dashboard feature.
@@ -86,18 +86,18 @@ xpack.features.overrides:
   reporting:
     privileges:
       all.composedOf:
-        - feature: "dashboard_v2"
-          privileges: [ "download_csv_report" ]
-        - feature: "discover_v2"
-          privileges: [ "generate_report" ]
+        - feature: 'dashboard_v2'
+          privileges: ['download_csv_report']
+        - feature: 'discover_v2'
+          privileges: ['generate_report']
   ### Visualize feature is hidden in Role management since it's automatically granted by Dashboard feature.
   visualize:
     ### The short URL sub-feature privilege should be always granted.
-    subFeatures.privileges.url_create.includeIn: "read"
+    subFeatures.privileges.url_create.includeIn: 'read'
   visualize_v2:
     hidden: true
     ### The short URL sub-feature privilege should be always granted.
-    subFeatures.privileges.url_create.includeIn: "read"
+    subFeatures.privileges.url_create.includeIn: 'read'
 
 # Cloud links
 xpack.cloud.base_url: 'https://cloud.elastic.co'
@@ -109,7 +109,7 @@ core.lifecycle.disablePreboot: true
 migrations.algorithm: zdt
 
 # Enable elasticsearch response size circuit breaker
-elasticsearch.maxResponseSize: "100mb"
+elasticsearch.maxResponseSize: '100mb'
 
 # Limit batch size to reduce possibility of failures.
 # A longer migration time is acceptable due to the ZDT algorithm.
@@ -276,8 +276,8 @@ xpack.stack_connectors.enableExperimental: ['inferenceConnectorOff']
 
 # This is the definition introducing pre-configured Kibana Connector for Elastic default LLM
 xpack.actions.preconfigured:
-  Elastic-Inference-Rainbow-Sprinkles:
-    name: Elastic-Inference-Rainbow-Sprinkles
+  Elastic-LLM:
+    name: Elastic LLM
     actionTypeId: .inference
     exposeConfig: true
     config:

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -16,17 +16,17 @@ xpack.features.overrides:
     privileges:
       ### Dashboard's `All` feature privilege should implicitly grant `All` access to Maps and Visualize features.
       all.composedOf:
-        - feature: 'maps'
-          privileges: ['all']
-        - feature: 'visualize'
-          privileges: ['all']
+        - feature: "maps"
+          privileges: [ "all" ]
+        - feature: "visualize"
+          privileges: [ "all" ]
       ### Dashboard's `Read` feature privilege should implicitly grant `Read` access to Maps and Visualize features.
       ### Additionally, it should implicitly grant privilege to create short URLs in Visualize app.
       read.composedOf:
-        - feature: 'maps'
-          privileges: ['read']
-        - feature: 'visualize'
-          privileges: ['read']
+        - feature: "maps"
+          privileges: [ "read" ]
+        - feature: "visualize"
+          privileges: [ "read" ]
     ### All Dashboard sub-feature privileges should be hidden: reporting capabilities will be granted via dedicated
     ### Reporting feature and short URL sub-feature privilege should be granted for both `All` and `Read`.
     subFeatures.privileges:
@@ -35,22 +35,22 @@ xpack.features.overrides:
       store_search_session.disabled: true
       url_create:
         disabled: true
-        includeIn: 'read'
+        includeIn: "read"
   dashboard_v2:
     privileges:
       ### Dashboard's `All` feature privilege should implicitly grant `All` access to Maps and Visualize features.
       all.composedOf:
-        - feature: 'maps_v2'
-          privileges: ['all']
-        - feature: 'visualize_v2'
-          privileges: ['all']
+        - feature: "maps_v2"
+          privileges: [ "all" ]
+        - feature: "visualize_v2"
+          privileges: [ "all" ]
       ### Dashboard's `Read` feature privilege should implicitly grant `Read` access to Maps and Visualize features.
       ### Additionally, it should implicitly grant privilege to create short URLs in Visualize app.
       read.composedOf:
-        - feature: 'maps_v2'
-          privileges: ['read']
-        - feature: 'visualize_v2'
-          privileges: ['read']
+        - feature: "maps_v2"
+          privileges: [ "read" ]
+        - feature: "visualize_v2"
+          privileges: [ "read" ]
     ### All Dashboard sub-feature privileges should be hidden: reporting capabilities will be granted via dedicated
     ### Reporting feature and short URL sub-feature privilege should be granted for both `All` and `Read`.
     subFeatures.privileges:
@@ -59,7 +59,7 @@ xpack.features.overrides:
       store_search_session.disabled: true
       url_create:
         disabled: true
-        includeIn: 'read'
+        includeIn: "read"
   discover:
     ### All Discover sub-feature privileges should be hidden: reporting capabilities will be granted via dedicated
     ### Reporting feature and short URL sub-feature privilege should be granted for both `All` and `Read`.
@@ -68,7 +68,7 @@ xpack.features.overrides:
       store_search_session.disabled: true
       url_create:
         disabled: true
-        includeIn: 'read'
+        includeIn: "read"
   discover_v2:
     ### All Discover sub-feature privileges should be hidden: reporting capabilities will be granted via dedicated
     ### Reporting feature and short URL sub-feature privilege should be granted for both `All` and `Read`.
@@ -77,7 +77,7 @@ xpack.features.overrides:
       store_search_session.disabled: true
       url_create:
         disabled: true
-        includeIn: 'read'
+        includeIn: "read"
   ### Shared images feature is hidden in Role management since it's not needed.
   filesSharedImage.hidden: true
   ### Maps feature is hidden in Role management since it's automatically granted by Dashboard feature.
@@ -86,18 +86,18 @@ xpack.features.overrides:
   reporting:
     privileges:
       all.composedOf:
-        - feature: 'dashboard_v2'
-          privileges: ['download_csv_report']
-        - feature: 'discover_v2'
-          privileges: ['generate_report']
+        - feature: "dashboard_v2"
+          privileges: [ "download_csv_report" ]
+        - feature: "discover_v2"
+          privileges: [ "generate_report" ]
   ### Visualize feature is hidden in Role management since it's automatically granted by Dashboard feature.
   visualize:
     ### The short URL sub-feature privilege should be always granted.
-    subFeatures.privileges.url_create.includeIn: 'read'
+    subFeatures.privileges.url_create.includeIn: "read"
   visualize_v2:
     hidden: true
     ### The short URL sub-feature privilege should be always granted.
-    subFeatures.privileges.url_create.includeIn: 'read'
+    subFeatures.privileges.url_create.includeIn: "read"
 
 # Cloud links
 xpack.cloud.base_url: 'https://cloud.elastic.co'
@@ -109,7 +109,7 @@ core.lifecycle.disablePreboot: true
 migrations.algorithm: zdt
 
 # Enable elasticsearch response size circuit breaker
-elasticsearch.maxResponseSize: '100mb'
+elasticsearch.maxResponseSize: "100mb"
 
 # Limit batch size to reduce possibility of failures.
 # A longer migration time is acceptable due to the ZDT algorithm.

--- a/x-pack/platform/plugins/shared/fleet/cypress/tasks/api_calls/connectors.ts
+++ b/x-pack/platform/plugins/shared/fleet/cypress/tasks/api_calls/connectors.ts
@@ -25,7 +25,7 @@ export const request = <T = unknown>({
     ...options,
   });
 };
-export const INTERNAL_INFERENCE_CONNECTORS = ['Elastic-Inference-Rainbow-Sprinkles'];
+export const INTERNAL_INFERENCE_CONNECTORS = ['Elastic-LLM'];
 export const INTERNAL_CLOUD_CONNECTORS = ['Elastic-Cloud-SMTP'];
 
 export const getConnectors = () =>

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../../common/endpoint/constants';
 
 const INTERNAL_CLOUD_CONNECTORS = ['Elastic-Cloud-SMTP'];
-const INTERNAL_INFERENCE_CONNECTORS = ['Elastic-Inference-Rainbow-Sprinkles'];
+const INTERNAL_INFERENCE_CONNECTORS = ['Elastic-LLM'];
 const INTERNAL_CONNECTORS = [...INTERNAL_CLOUD_CONNECTORS, ...INTERNAL_INFERENCE_CONNECTORS];
 
 export const createBedrockAIConnector = (connectorName?: string) =>

--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/common.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/common.ts
@@ -26,7 +26,7 @@ export const API_HEADERS = Object.freeze({
 });
 
 export const INTERNAL_CLOUD_CONNECTORS = ['Elastic-Cloud-SMTP'];
-export const INTERNAL_INFERENCE_CONNECTORS = ['Elastic-Inference-Rainbow-Sprinkles'];
+export const INTERNAL_INFERENCE_CONNECTORS = ['Elastic-LLM'];
 
 export const rootRequest = <T = unknown>({
   headers: optionHeaders = {},


### PR DESCRIPTION
## Summary

Update Preconfigured connector name to `Elastic LLM`.

<img width="1504" alt="Screenshot 2025-02-20 at 11 29 02 AM" src="https://github.com/user-attachments/assets/aa0a32f7-f1b2-4496-8c2e-7773f017c153" />

### ES3 Testing instruction
No additional config needed. Once run in local machine, the changes should reflect automatically.

### ESS instructions
In `kibana.dev.yml` file, add
```
# xpack.actions.preconfigured:
   Elastic-LLM:
     name: Elastic LLM
     actionTypeId: .inference
     exposeConfig: true
     config:
       provider: 'elastic'
       taskType: 'chat_completion'
       inferenceId: '.rainbow-sprinkles-elastic'
       providerConfig:
         model_id: 'rainbow-sprinkles'
```
and the preconfigured endpoint with updated name should be visible.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->