### PR TITLE
[8.18] Remove setup_access from gcp package policy (#209126)

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
@@ -338,17 +338,16 @@ export const getInputVarsFields = (input: NewPackagePolicyInput, fields: GcpFiel
     });
 
 const getSetupFormatFromInput = (
-  input: Extract<
-    NewPackagePolicyPostureInput,
-    { type: 'cloudbeat/cis_aws' | 'cloudbeat/cis_eks' | 'cloudbeat/cis_gcp' }
-  >
+  input: Extract<NewPackagePolicyPostureInput, { type: 'cloudbeat/cis_gcp' }>
 ): SetupFormatGCP => {
-  const credentialsType = input.streams[0].vars?.setup_access?.value;
+  const credentialsType = getGcpCredentialsType(input);
+
   // Google Cloud shell is the default value
   if (!credentialsType) {
     return GCP_SETUP_ACCESS.CLOUD_SHELL;
   }
-  if (credentialsType !== GCP_SETUP_ACCESS.CLOUD_SHELL) {
+
+  if (credentialsType !== GCP_CREDENTIALS_TYPE.CREDENTIALS_NONE) {
     return GCP_SETUP_ACCESS.MANUAL;
   }
 
@@ -474,10 +473,6 @@ export const GcpCredentialsForm = ({
 
       updatePolicy(
         getPosturePolicy(newPolicy, input.type, {
-          setup_access: {
-            value: GCP_SETUP_ACCESS.CLOUD_SHELL,
-            type: 'text',
-          },
           'gcp.credentials.type': {
             value: GCP_CREDENTIALS_TYPE.CREDENTIALS_NONE,
             type: 'text',
@@ -490,10 +485,6 @@ export const GcpCredentialsForm = ({
     } else {
       updatePolicy(
         getPosturePolicy(newPolicy, input.type, {
-          setup_access: {
-            value: GCP_SETUP_ACCESS.MANUAL,
-            type: 'text',
-          },
           'gcp.credentials.type': {
             // Restoring last manual credentials type
             value: lastCredentialsType.current || GCP_CREDENTIALS_TYPE.CREDENTIALS_FILE,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
@@ -1169,7 +1169,6 @@ describe('<CspPolicyTemplateForm />', () => {
       let policy = getMockPolicyGCP();
       policy = getPosturePolicy(policy, CLOUDBEAT_GCP, {
         credentials_type: { value: 'credentials-file' },
-        setup_access: { value: 'manual' },
       });
 
       const { getByText } = render(
@@ -1191,7 +1190,6 @@ describe('<CspPolicyTemplateForm />', () => {
       let policy = getMockPolicyGCP();
       policy = getPosturePolicy(policy, CLOUDBEAT_GCP, {
         credentials_type: { value: 'credentials-file' },
-        setup_access: { value: 'manual' },
       });
 
       const { getByText } = render(
@@ -1208,7 +1206,6 @@ describe('<CspPolicyTemplateForm />', () => {
       let policy = getMockPolicyGCP();
       policy = getPosturePolicy(policy, CLOUDBEAT_GCP, {
         'gcp.account_type': { value: GCP_ORGANIZATION_ACCOUNT },
-        setup_access: { value: 'google_cloud_shell' },
       });
 
       const { getByTestId } = render(
@@ -1228,7 +1225,6 @@ describe('<CspPolicyTemplateForm />', () => {
       let policy = getMockPolicyGCP();
       policy = getPosturePolicy(policy, CLOUDBEAT_GCP, {
         'gcp.credentials.type': { value: 'credentials-file' },
-        setup_access: { value: 'manual' },
       });
 
       const { getByLabelText, getByRole } = render(
@@ -1247,7 +1243,6 @@ describe('<CspPolicyTemplateForm />', () => {
       policy = getPosturePolicy(policy, CLOUDBEAT_GCP, {
         'gcp.project_id': { value: 'a' },
         'gcp.credentials.type': { value: 'credentials-file' },
-        setup_access: { value: 'manual' },
       });
 
       const { getByTestId } = render(
@@ -1289,7 +1284,6 @@ describe('<CspPolicyTemplateForm />', () => {
       let policy = getMockPolicyGCP();
       policy = getPosturePolicy(policy, CLOUDBEAT_GCP, {
         'gcp.account_type': { value: GCP_ORGANIZATION_ACCOUNT },
-        setup_access: { value: 'google_cloud_shell' },
       });
 
       const { getByLabelText, getByTestId } = render(
@@ -1305,7 +1299,6 @@ describe('<CspPolicyTemplateForm />', () => {
       let policy = getMockPolicyGCP();
       policy = getPosturePolicy(policy, CLOUDBEAT_GCP, {
         'gcp.account_type': { value: GCP_ORGANIZATION_ACCOUNT },
-        setup_access: { value: 'manual' },
       });
 
       const { getByLabelText, getByTestId } = render(
@@ -1321,7 +1314,6 @@ describe('<CspPolicyTemplateForm />', () => {
       let policy = getMockPolicyGCP();
       policy = getPosturePolicy(policy, CLOUDBEAT_GCP, {
         'gcp.account_type': { value: GCP_SINGLE_ACCOUNT },
-        setup_access: { value: 'google_cloud_shell' },
       });
 
       const { queryByLabelText, queryByTestId } = render(
@@ -1337,7 +1329,6 @@ describe('<CspPolicyTemplateForm />', () => {
       let policy = getMockPolicyGCP();
       policy = getPosturePolicy(policy, CLOUDBEAT_GCP, {
         'gcp.account_type': { value: GCP_ORGANIZATION_ACCOUNT },
-        setup_access: { value: 'manual' },
       });
 
       const { getByTestId } = render(

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.test.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.test.ts
@@ -446,7 +446,6 @@ describe('getDefaultGcpHiddenVars', () => {
 
     expect(result).toMatchObject({
       'gcp.credentials.type': { value: 'credentials-json', type: 'text' },
-      setup_access: { value: 'manual', type: 'text' },
     });
   });
 
@@ -456,7 +455,6 @@ describe('getDefaultGcpHiddenVars', () => {
 
     expect(result).toMatchObject({
       'gcp.credentials.type': { value: 'credentials-none', type: 'text' },
-      setup_access: { value: 'google_cloud_shell', type: 'text' },
     });
   });
 
@@ -483,7 +481,6 @@ describe('getDefaultGcpHiddenVars', () => {
 
     expect(result).toMatchObject({
       'gcp.credentials.type': { value: 'credentials-file', type: 'text' },
-      setup_access: { value: 'manual', type: 'text' },
     });
   });
 });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/utils.ts
@@ -43,7 +43,7 @@ import {
   DEFAULT_AWS_CREDENTIALS_TYPE,
   DEFAULT_MANUAL_AWS_CREDENTIALS_TYPE,
 } from './aws_credentials_form/get_aws_credentials_form_options';
-import { GCP_CREDENTIALS_TYPE, GCP_SETUP_ACCESS } from './gcp_credentials_form/gcp_credential_form';
+import { GCP_CREDENTIALS_TYPE } from './gcp_credentials_form/gcp_credential_form';
 import { AZURE_CREDENTIALS_TYPE } from './azure_credentials_form/azure_credentials_form';
 
 // Posture policies only support the default namespace
@@ -257,10 +257,6 @@ export const getDefaultGcpHiddenVars = (
         value: GCP_CREDENTIALS_TYPE.CREDENTIALS_JSON,
         type: 'text',
       },
-      setup_access: {
-        value: GCP_SETUP_ACCESS.MANUAL,
-        type: 'text',
-      },
     };
   }
 
@@ -271,20 +267,12 @@ export const getDefaultGcpHiddenVars = (
         value: GCP_CREDENTIALS_TYPE.CREDENTIALS_NONE,
         type: 'text',
       },
-      setup_access: {
-        value: GCP_SETUP_ACCESS.CLOUD_SHELL,
-        type: 'text',
-      },
     };
   }
 
   return {
     'gcp.credentials.type': {
       value: GCP_CREDENTIALS_TYPE.CREDENTIALS_FILE,
-      type: 'text',
-    },
-    setup_access: {
-      value: GCP_SETUP_ACCESS.MANUAL,
       type: 'text',
     },
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Remove setup_access from gcp package policy (#209126)](https://github.com/elastic/kibana/pull/209126)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maxim Kholod","email":"maxim.kholod@elastic.co"},"sourceCommit":{"committedDate":"2025-02-03T12:22:44Z","message":"Remove setup_access from gcp package policy (#209126)\n\n## Summary\r\n\r\n`setup_access` doesn't exist on GCP input type manifest [on CSPM\r\nintegration\r\n](https://github.com/elastic/integrations/blob/main/packages/cloud_security_posture/data_stream/findings/manifest.yml#L200)\r\nbut being added by the client-side code. This works atm in the UI but\r\ngenerates incorrect Preview API request which is used by automation. In\r\ngeneral we shouldn't pass variables that don't exist on the input\r\nmanifest as it can break in any future version of the stack. AWS and\r\nAzure already don't have this logic, bringing GCP on par with them\r\n\r\nRelates to:\r\n- https://github.com/elastic/kibana/issues/172687 \r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"778f70cf5f097aa23056d16feaa8bcb2b944fa8e","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.1.0"],"title":"Remove setup_access from gcp package policy","number":209126,"url":"https://github.com/elastic/kibana/pull/209126","mergeCommit":{"message":"Remove setup_access from gcp package policy (#209126)\n\n## Summary\r\n\r\n`setup_access` doesn't exist on GCP input type manifest [on CSPM\r\nintegration\r\n](https://github.com/elastic/integrations/blob/main/packages/cloud_security_posture/data_stream/findings/manifest.yml#L200)\r\nbut being added by the client-side code. This works atm in the UI but\r\ngenerates incorrect Preview API request which is used by automation. In\r\ngeneral we shouldn't pass variables that don't exist on the input\r\nmanifest as it can break in any future version of the stack. AWS and\r\nAzure already don't have this logic, bringing GCP on par with them\r\n\r\nRelates to:\r\n- https://github.com/elastic/kibana/issues/172687 \r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"778f70cf5f097aa23056d16feaa8bcb2b944fa8e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209126","number":209126,"mergeCommit":{"message":"Remove setup_access from gcp package policy (#209126)\n\n## Summary\r\n\r\n`setup_access` doesn't exist on GCP input type manifest [on CSPM\r\nintegration\r\n](https://github.com/elastic/integrations/blob/main/packages/cloud_security_posture/data_stream/findings/manifest.yml#L200)\r\nbut being added by the client-side code. This works atm in the UI but\r\ngenerates incorrect Preview API request which is used by automation. In\r\ngeneral we shouldn't pass variables that don't exist on the input\r\nmanifest as it can break in any future version of the stack. AWS and\r\nAzure already don't have this logic, bringing GCP on par with them\r\n\r\nRelates to:\r\n- https://github.com/elastic/kibana/issues/172687 \r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [x]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [x] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"778f70cf5f097aa23056d16feaa8bcb2b944fa8e"}}]}] BACKPORT-->