### PR TITLE
[8.18] [Security Solution][Expandable flyout] add ability for user to resize the flyout and the left/right section even if preview is rendered (#211938)

### DIFF
--- a/x-pack/solutions/security/packages/expandable-flyout/src/components/container.tsx
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/components/container.tsx
@@ -215,7 +215,6 @@ export const Container: React.FC<ContainerProps> = memo(
           leftComponent={leftComponent as React.ReactElement}
           rightComponent={rightComponent as React.ReactElement}
           showLeft={showExpanded}
-          showPreview={showPreview}
         />
 
         {showPreview && (

--- a/x-pack/solutions/security/packages/expandable-flyout/src/components/preview_section.tsx
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/components/preview_section.tsx
@@ -92,7 +92,8 @@ export const PreviewSection: React.FC<PreviewSectionProps> = memo(
     // - if both the right and left sections are visible, we use the width of the right section (minus the same padding)
     const width = useMemo(() => {
       const percentage = rightPercentage ? rightPercentage : defaultPercentages.rightPercentage;
-      return showExpanded ? `calc(${percentage}% - 8px)` : `calc(100% - 8px)`;
+      // we need to keep 1px here to make sure users can click on the EuiResizableButton and resize the flyout with preview opened
+      return showExpanded ? `calc(${percentage}% - 1px)` : `calc(100% - 1px)`;
     }, [defaultPercentages.rightPercentage, rightPercentage, showExpanded]);
 
     const closeButton = (

--- a/x-pack/solutions/security/packages/expandable-flyout/src/components/resizable_container.test.tsx
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/components/resizable_container.test.tsx
@@ -38,7 +38,6 @@ describe('ResizableContainer', () => {
           leftComponent={leftComponent}
           rightComponent={rightComponent}
           showLeft={false}
-          showPreview={false}
         />
       </TestProvider>
     );
@@ -74,7 +73,6 @@ describe('ResizableContainer', () => {
           leftComponent={leftComponent}
           rightComponent={rightComponent}
           showLeft={true}
-          showPreview={false}
         />
       </TestProvider>
     );
@@ -90,33 +88,5 @@ describe('ResizableContainer', () => {
     const leftSection = getByTestId(RESIZABLE_LEFT_SECTION_TEST_ID);
     expect(leftSection).toBeInTheDocument();
     expect(leftSection.parentElement).toHaveStyle('inline-size: 50%; block-size: auto;');
-  });
-
-  it('should disable the resize button if preview is rendered', () => {
-    const state = {
-      ...initialState,
-      ui: {
-        ...initialState.ui,
-        userSectionWidths: {
-          leftPercentage: 50,
-          rightPercentage: 50,
-        },
-      },
-    };
-
-    const { getByTestId } = render(
-      <TestProvider state={state}>
-        <ResizableContainer
-          leftComponent={leftComponent}
-          rightComponent={rightComponent}
-          showLeft={true}
-          showPreview={true}
-        />
-      </TestProvider>
-    );
-
-    const resizeButton = getByTestId(RESIZABLE_BUTTON_TEST_ID);
-    expect(resizeButton).toBeInTheDocument();
-    expect(resizeButton).toBeDisabled();
   });
 });

--- a/x-pack/solutions/security/packages/expandable-flyout/src/components/resizable_container.tsx
+++ b/x-pack/solutions/security/packages/expandable-flyout/src/components/resizable_container.tsx
@@ -40,10 +40,6 @@ interface ResizableContainerProps {
    * If the left section is not shown we disable the resize button and hide the left size of the resizable panel
    */
   showLeft: boolean;
-  /**
-   * If the preview section is shown we disable the resize button
-   */
-  showPreview: boolean;
 }
 
 /**
@@ -51,7 +47,7 @@ interface ResizableContainerProps {
  * It allows the resizing of the sections, saving the percentages in local storage.
  */
 export const ResizableContainer: React.FC<ResizableContainerProps> = memo(
-  ({ leftComponent, rightComponent, showLeft, showPreview }: ResizableContainerProps) => {
+  ({ leftComponent, rightComponent, showLeft }: ResizableContainerProps) => {
     const dispatch = useDispatch();
 
     const { leftPercentage, rightPercentage } = useSelector(selectUserSectionWidths);
@@ -95,10 +91,7 @@ export const ResizableContainer: React.FC<ResizableContainerProps> = memo(
             >
               <LeftSection component={leftComponent} />
             </EuiResizablePanel>
-            <EuiResizableButton
-              disabled={showPreview || !showLeft}
-              data-test-subj={RESIZABLE_BUTTON_TEST_ID}
-            />
+            <EuiResizableButton disabled={!showLeft} data-test-subj={RESIZABLE_BUTTON_TEST_ID} />
             <EuiResizablePanel
               id={RIGHT_PANEL_ID}
               initialSize={initialRightPercentage}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security Solution][Expandable flyout] add ability for user to resize the flyout and the left/right section even if preview is rendered (#211938)](https://github.com/elastic/kibana/pull/211938)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-02-20T19:28:57Z","message":"[Security Solution][Expandable flyout] add ability for user to resize the flyout and the left/right section even if preview is rendered (#211938)\n\n## Summary\n\nThis PR makes a couple of small changes to the expandable flyout\npackage:\n- get rid of an unwanted white space when preview are shown\n- allow the user to resize the flyout and the internal left/right\nsections when a preview is rendered\n\n#### White space removal\n\n| Before  | After |\n| ------------- | ------------- |\n| ![Screenshot 2025-02-20 at 11 17\n30 AM](https://github.com/user-attachments/assets/7c7cb817-3fd9-4cac-9f63-5b168c1df832)\n| ![Screenshot 2025-02-20 at 11 15\n20 AM](https://github.com/user-attachments/assets/6490dda1-e440-41f3-be63-71fd524e736b)\n|\n\n#### Allow resize even when previews are shown\n\n\nhttps://github.com/user-attachments/assets/034f59c2-6c4a-4efa-a817-8c23dbc11b60\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"a4c7c8b28e9a36cd412a5665bbbd97c11f9b8f3a","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Threat Hunting:Investigations","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Security Solution][Expandable flyout] add ability for user to resize the flyout and the left/right section even if preview is rendered","number":211938,"url":"https://github.com/elastic/kibana/pull/211938","mergeCommit":{"message":"[Security Solution][Expandable flyout] add ability for user to resize the flyout and the left/right section even if preview is rendered (#211938)\n\n## Summary\n\nThis PR makes a couple of small changes to the expandable flyout\npackage:\n- get rid of an unwanted white space when preview are shown\n- allow the user to resize the flyout and the internal left/right\nsections when a preview is rendered\n\n#### White space removal\n\n| Before  | After |\n| ------------- | ------------- |\n| ![Screenshot 2025-02-20 at 11 17\n30 AM](https://github.com/user-attachments/assets/7c7cb817-3fd9-4cac-9f63-5b168c1df832)\n| ![Screenshot 2025-02-20 at 11 15\n20 AM](https://github.com/user-attachments/assets/6490dda1-e440-41f3-be63-71fd524e736b)\n|\n\n#### Allow resize even when previews are shown\n\n\nhttps://github.com/user-attachments/assets/034f59c2-6c4a-4efa-a817-8c23dbc11b60\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"a4c7c8b28e9a36cd412a5665bbbd97c11f9b8f3a"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211938","number":211938,"mergeCommit":{"message":"[Security Solution][Expandable flyout] add ability for user to resize the flyout and the left/right section even if preview is rendered (#211938)\n\n## Summary\n\nThis PR makes a couple of small changes to the expandable flyout\npackage:\n- get rid of an unwanted white space when preview are shown\n- allow the user to resize the flyout and the internal left/right\nsections when a preview is rendered\n\n#### White space removal\n\n| Before  | After |\n| ------------- | ------------- |\n| ![Screenshot 2025-02-20 at 11 17\n30 AM](https://github.com/user-attachments/assets/7c7cb817-3fd9-4cac-9f63-5b168c1df832)\n| ![Screenshot 2025-02-20 at 11 15\n20 AM](https://github.com/user-attachments/assets/6490dda1-e440-41f3-be63-71fd524e736b)\n|\n\n#### Allow resize even when previews are shown\n\n\nhttps://github.com/user-attachments/assets/034f59c2-6c4a-4efa-a817-8c23dbc11b60\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"a4c7c8b28e9a36cd412a5665bbbd97c11f9b8f3a"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/211964","number":211964,"state":"OPEN"}]}] BACKPORT-->