### PR TITLE
[Obs AI Assistant] add system message in copy conversation JSON payload

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
@@ -255,7 +255,8 @@ export function ChatBody({
     const deserializedMessages = (conversation.value?.messages ?? messages).map(deserializeMessage);
 
     const content = JSON.stringify({
-      title: initialTitle,
+      title: conversation.value?.conversation.title || initialTitle,
+      systemMessage: conversation.value?.systemMessage,
       messages: deserializedMessages,
     });
 


### PR DESCRIPTION
Closes #212006
## Problem
Due to https://github.com/elastic/kibana/pull/209773 we no longer add the system message to the output from the "Copy conversation" button.





<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->