### PR TITLE
[8.x] [ES|QL][Lens] Keeps the chart configuration when possible (#210780)

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -115,6 +115,10 @@ export const ESQLEditor = memo(function ESQLEditor({
   esqlVariables,
 }: ESQLEditorProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
+  const editorModel = useRef<monaco.editor.ITextModel>();
+  const editor1 = useRef<monaco.editor.IStandaloneCodeEditor>();
+  const containerRef = useRef<HTMLElement>(null);
+
   const datePickerOpenStatusRef = useRef<boolean>(false);
   const theme = useEuiTheme();
   const kibana = useKibana<ESQLEditorDeps>();
@@ -338,6 +342,12 @@ export const ESQLEditor = memo(function ESQLEditor({
     );
   });
 
+  editor1.current?.addCommand(
+    // eslint-disable-next-line no-bitwise
+    monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+    onQuerySubmit
+  );
+
   const styles = esqlEditorStyles(
     theme.euiTheme,
     editorHeight,
@@ -347,9 +357,6 @@ export const ESQLEditor = memo(function ESQLEditor({
     Boolean(editorIsInline),
     Boolean(hasOutline)
   );
-  const editorModel = useRef<monaco.editor.ITextModel>();
-  const editor1 = useRef<monaco.editor.IStandaloneCodeEditor>();
-  const containerRef = useRef<HTMLElement>(null);
 
   const onMouseDownResize = useCallback<typeof onMouseDownResizeHandler>(
     (
@@ -664,47 +671,50 @@ export const ESQLEditor = memo(function ESQLEditor({
 
   onLayoutChangeRef.current = onLayoutChange;
 
-  const codeEditorOptions: CodeEditorProps['options'] = {
-    hover: {
-      above: false,
-    },
-    accessibilitySupport: 'off',
-    autoIndent: 'none',
-    automaticLayout: true,
-    fixedOverflowWidgets: true,
-    folding: false,
-    fontSize: 14,
-    hideCursorInOverviewRuler: true,
-    // this becomes confusing with multiple markers, so quick fixes
-    // will be proposed only within the tooltip
-    lightbulb: {
-      enabled: false,
-    },
-    lineDecorationsWidth: 20,
-    lineNumbers: 'on',
-    lineNumbersMinChars: 3,
-    minimap: { enabled: false },
-    overviewRulerLanes: 0,
-    overviewRulerBorder: false,
-    padding: {
-      top: 8,
-      bottom: 8,
-    },
-    quickSuggestions: true,
-    readOnly: isDisabled,
-    renderLineHighlight: 'line',
-    renderLineHighlightOnlyWhenFocus: true,
-    scrollbar: {
-      horizontal: 'hidden',
-      horizontalScrollbarSize: 6,
-      vertical: 'auto',
-      verticalScrollbarSize: 6,
-    },
-    scrollBeyondLastLine: false,
-    theme: darkMode ? ESQL_DARK_THEME_ID : ESQL_LIGHT_THEME_ID,
-    wordWrap: 'on',
-    wrappingIndent: 'none',
-  };
+  const codeEditorOptions: CodeEditorProps['options'] = useMemo(
+    () => ({
+      hover: {
+        above: false,
+      },
+      accessibilitySupport: 'off',
+      autoIndent: 'none',
+      automaticLayout: true,
+      fixedOverflowWidgets: true,
+      folding: false,
+      fontSize: 14,
+      hideCursorInOverviewRuler: true,
+      // this becomes confusing with multiple markers, so quick fixes
+      // will be proposed only within the tooltip
+      lightbulb: {
+        enabled: false,
+      },
+      lineDecorationsWidth: 20,
+      lineNumbers: 'on',
+      lineNumbersMinChars: 3,
+      minimap: { enabled: false },
+      overviewRulerLanes: 0,
+      overviewRulerBorder: false,
+      padding: {
+        top: 8,
+        bottom: 8,
+      },
+      quickSuggestions: true,
+      readOnly: isDisabled,
+      renderLineHighlight: 'line',
+      renderLineHighlightOnlyWhenFocus: true,
+      scrollbar: {
+        horizontal: 'hidden',
+        horizontalScrollbarSize: 6,
+        vertical: 'auto',
+        verticalScrollbarSize: 6,
+      },
+      scrollBeyondLastLine: false,
+      theme: darkMode ? ESQL_DARK_THEME_ID : ESQL_LIGHT_THEME_ID,
+      wordWrap: 'on',
+      wrappingIndent: 'none',
+    }),
+    [isDisabled]
+  );
 
   const editorPanel = (
     <>
@@ -800,13 +810,6 @@ export const ESQLEditor = memo(function ESQLEditor({
                     editor.onKeyDown(() => {
                       onEditorFocus();
                     });
-
-                    // on CMD/CTRL + Enter submit the query
-                    editor.addCommand(
-                      // eslint-disable-next-line no-bitwise
-                      monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-                      onQuerySubmit
-                    );
 
                     // on CMD/CTRL + / comment out the entire line
                     editor.addCommand(

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -713,7 +713,7 @@ export const ESQLEditor = memo(function ESQLEditor({
       wordWrap: 'on',
       wrappingIndent: 'none',
     }),
-    [isDisabled]
+    [isDisabled, darkMode]
   );
 
   const editorPanel = (

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.test.ts
@@ -7,6 +7,7 @@
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { getESQLResults } from '@kbn/esql-utils';
 import type { LensPluginStartDependencies } from '../../../plugin';
+import type { TypedLensSerializedState } from '../../../react_embeddable/types';
 import { createMockStartDependencies } from '../../../editor_frame_service/mocks';
 import {
   mockVisualizationMap,
@@ -15,7 +16,7 @@ import {
   mockAllSuggestions,
 } from '../../../mocks';
 import { suggestionsApi } from '../../../lens_suggestions_api';
-import { getSuggestions } from './helpers';
+import { getSuggestions, injectESQLQueryIntoLensLayers } from './helpers';
 
 const mockSuggestionApi = suggestionsApi as jest.Mock;
 const mockFetchData = getESQLResults as jest.Mock;
@@ -82,74 +83,146 @@ jest.mock('@kbn/esql-utils', () => {
   };
 });
 
-describe('getSuggestions', () => {
-  const query = {
-    esql: 'from index1 | limit 10 | stats average = avg(bytes)',
-  };
-  const mockStartDependencies =
-    createMockStartDependencies() as unknown as LensPluginStartDependencies;
-  const dataViews = dataViewPluginMocks.createStartContract();
-  dataViews.create.mockResolvedValue(mockDataViewWithTimefield);
-  const dataviewSpecArr = [
-    {
-      id: 'd2588ae7-9ea0-4439-9f5b-f808754a3b97',
-      title: 'index1',
-      timeFieldName: '@timestamp',
-      sourceFilters: [],
-      fieldFormats: {},
-      runtimeFieldMap: {},
-      fieldAttrs: {},
-      allowNoIndex: false,
-      name: 'index1',
-    },
-  ];
-  const startDependencies = {
-    ...mockStartDependencies,
-    dataViews,
-  };
+describe('Lens inline editing helpers', () => {
+  describe('getSuggestions', () => {
+    const query = {
+      esql: 'from index1 | limit 10 | stats average = avg(bytes)',
+    };
+    const mockStartDependencies =
+      createMockStartDependencies() as unknown as LensPluginStartDependencies;
+    const dataViews = dataViewPluginMocks.createStartContract();
+    dataViews.create.mockResolvedValue(mockDataViewWithTimefield);
+    const dataviewSpecArr = [
+      {
+        id: 'd2588ae7-9ea0-4439-9f5b-f808754a3b97',
+        title: 'index1',
+        timeFieldName: '@timestamp',
+        sourceFilters: [],
+        fieldFormats: {},
+        runtimeFieldMap: {},
+        fieldAttrs: {},
+        allowNoIndex: false,
+        name: 'index1',
+      },
+    ];
+    const startDependencies = {
+      ...mockStartDependencies,
+      dataViews,
+    };
 
-  it('returns the suggestions attributes correctly', async () => {
-    const suggestionsAttributes = await getSuggestions(
-      query,
-      startDependencies,
-      mockDatasourceMap(),
-      mockVisualizationMap(),
-      dataviewSpecArr,
-      jest.fn()
-    );
-    expect(suggestionsAttributes?.visualizationType).toBe(mockAllSuggestions[0].visualizationId);
-    expect(suggestionsAttributes?.state.visualization).toStrictEqual(
-      mockAllSuggestions[0].visualizationState
-    );
-  });
-
-  it('returns undefined if no suggestions are computed', async () => {
-    mockSuggestionApi.mockResolvedValueOnce([]);
-    const suggestionsAttributes = await getSuggestions(
-      query,
-      startDependencies,
-      mockDatasourceMap(),
-      mockVisualizationMap(),
-      dataviewSpecArr,
-      jest.fn()
-    );
-    expect(suggestionsAttributes).toBeUndefined();
-  });
-
-  it('returns an error if fetching the data fails', async () => {
-    mockFetchData.mockImplementation(() => {
-      throw new Error('sorry!');
+    it('returns the suggestions attributes correctly', async () => {
+      const suggestionsAttributes = await getSuggestions(
+        query,
+        startDependencies,
+        mockDatasourceMap(),
+        mockVisualizationMap(),
+        dataviewSpecArr,
+        jest.fn()
+      );
+      expect(suggestionsAttributes?.visualizationType).toBe(mockAllSuggestions[0].visualizationId);
+      expect(suggestionsAttributes?.state.visualization).toStrictEqual(
+        mockAllSuggestions[0].visualizationState
+      );
     });
-    const setErrorsSpy = jest.fn();
-    const suggestionsAttributes = await getSuggestions(
-      query,
-      startDependencies,
-      mockDatasourceMap(),
-      mockVisualizationMap(),
-      dataviewSpecArr,
-      setErrorsSpy
-    );
-    expect(suggestionsAttributes).toBeUndefined();
-    expect(setErrorsSpy).toHaveBeenCalled();
+
+    it('returns undefined if no suggestions are computed', async () => {
+      mockSuggestionApi.mockResolvedValueOnce([]);
+      const suggestionsAttributes = await getSuggestions(
+        query,
+        startDependencies,
+        mockDatasourceMap(),
+        mockVisualizationMap(),
+        dataviewSpecArr,
+        jest.fn()
+      );
+      expect(suggestionsAttributes).toBeUndefined();
+    });
+
+    it('returns an error if fetching the data fails', async () => {
+      mockFetchData.mockImplementation(() => {
+        throw new Error('sorry!');
+      });
+      const setErrorsSpy = jest.fn();
+      const suggestionsAttributes = await getSuggestions(
+        query,
+        startDependencies,
+        mockDatasourceMap(),
+        mockVisualizationMap(),
+        dataviewSpecArr,
+        setErrorsSpy
+      );
+      expect(suggestionsAttributes).toBeUndefined();
+      expect(setErrorsSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('injectESQLQueryIntoLensLayers', () => {
+    const query = {
+      esql: 'from index1 | limit 10 | stats average = avg(bytes)',
+    };
+
+    it('should inject the query correctly for ES|QL charts', async () => {
+      const lensAttributes = {
+        title: 'test',
+        visualizationType: 'testVis',
+        state: {
+          datasourceStates: {
+            textBased: { layers: { layer1: { query: { esql: 'from index1 | limit 10' } } } },
+          },
+          visualization: { preferredSeriesType: 'line' },
+        },
+        filters: [],
+        query: {
+          esql: 'from index1 | limit 10',
+        },
+        references: [],
+      } as unknown as TypedLensSerializedState['attributes'];
+
+      const expectedLensAttributes = {
+        ...lensAttributes,
+        state: {
+          ...lensAttributes.state,
+          datasourceStates: {
+            ...lensAttributes.state.datasourceStates,
+            textBased: {
+              ...lensAttributes.state.datasourceStates.textBased,
+              layers: {
+                layer1: {
+                  query: { esql: 'from index1 | limit 10 | stats average = avg(bytes)' },
+                },
+              },
+            },
+          },
+        },
+      };
+      const newAttributes = injectESQLQueryIntoLensLayers(lensAttributes, query);
+      expect(newAttributes).toStrictEqual(expectedLensAttributes);
+    });
+
+    it('should return the Lens attributes as they are for unknown datasourceId', async () => {
+      const attributes = {
+        visualizationType: 'lnsXY',
+        state: {
+          visualization: { preferredSeriesType: 'line' },
+          datasourceStates: { unknownId: { layers: {} } },
+        },
+      } as unknown as TypedLensSerializedState['attributes'];
+      expect(injectESQLQueryIntoLensLayers(attributes, { esql: 'from foo' })).toStrictEqual(
+        attributes
+      );
+    });
+
+    it('should return the Lens attributes as they are for form based charts', async () => {
+      const attributes = {
+        visualizationType: 'lnsXY',
+        state: {
+          visualization: { preferredSeriesType: 'line' },
+          datasourceStates: { formBased: { layers: {} } },
+        },
+      } as TypedLensSerializedState['attributes'];
+      expect(injectESQLQueryIntoLensLayers(attributes, { esql: 'from foo' })).toStrictEqual(
+        attributes
+      );
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -11,10 +11,15 @@ import {
   formatESQLColumns,
   mapVariableToColumn,
 } from '@kbn/esql-utils';
+import { isEqual, cloneDeep } from 'lodash';
 import { type AggregateQuery, buildEsQuery } from '@kbn/es-query';
 import type { ESQLControlVariable } from '@kbn/esql-validation-autocomplete';
 import type { ESQLRow } from '@kbn/es-types';
-import { getLensAttributesFromSuggestion } from '@kbn/visualization-utils';
+import {
+  getLensAttributesFromSuggestion,
+  mapVisToChartType,
+  getDatasourceId,
+} from '@kbn/visualization-utils';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { DatatableColumn } from '@kbn/expressions-plugin/common';
@@ -93,7 +98,8 @@ export const getSuggestions = async (
   abortController?: AbortController,
   setDataGridAttrs?: (attrs: ESQLDataGridAttrs) => void,
   esqlVariables: ESQLControlVariable[] = [],
-  shouldUpdateAttrs = true
+  shouldUpdateAttrs = true,
+  preferredVisAttributes?: TypedLensSerializedState['attributes']
 ) => {
   try {
     const { dataView, columns, rows } = await getGridAttrs(
@@ -117,6 +123,10 @@ export const getSuggestions = async (
       return;
     }
 
+    const preferredChartType = preferredVisAttributes
+      ? mapVisToChartType(preferredVisAttributes.visualizationType)
+      : undefined;
+
     const context = {
       dataViewSpec: dataView?.toSpec(false),
       fieldName: '',
@@ -125,7 +135,16 @@ export const getSuggestions = async (
     };
 
     const allSuggestions =
-      suggestionsApi({ context, dataView, datasourceMap, visualizationMap }) ?? [];
+      suggestionsApi({
+        context,
+        dataView,
+        datasourceMap,
+        visualizationMap,
+        preferredChartType,
+        preferredVisAttributes: preferredVisAttributes
+          ? injectESQLQueryIntoLensLayers(preferredVisAttributes, query)
+          : undefined,
+      }) ?? [];
 
     // Lens might not return suggestions for some cases, i.e. in case of errors
     if (!allSuggestions.length) return undefined;
@@ -149,4 +168,46 @@ export const getSuggestions = async (
     setErrors?.([e]);
   }
   return undefined;
+};
+
+/**
+ * Injects the ESQL query into the lens layers. This is used to keep the query in sync with the lens layers.
+ * @param attributes, the current lens attributes
+ * @param query, the new query to inject
+ * @returns the new lens attributes with the query injected
+ */
+export const injectESQLQueryIntoLensLayers = (
+  attributes: TypedLensSerializedState['attributes'],
+  query: AggregateQuery
+) => {
+  const datasourceId = getDatasourceId(attributes.state.datasourceStates);
+
+  // if the datasource is formBased, we should not fix the query
+  if (!datasourceId || datasourceId === 'formBased') {
+    return attributes;
+  }
+
+  if (!attributes.state.datasourceStates[datasourceId]) {
+    return attributes;
+  }
+
+  const datasourceState = cloneDeep(attributes.state.datasourceStates[datasourceId]);
+
+  if (datasourceState && datasourceState.layers) {
+    Object.values(datasourceState.layers).forEach((layer) => {
+      if (!isEqual(layer.query, query)) {
+        layer.query = query;
+      }
+    });
+  }
+  return {
+    ...attributes,
+    state: {
+      ...attributes.state,
+      datasourceStates: {
+        ...attributes.state.datasourceStates,
+        [datasourceId]: datasourceState,
+      },
+    },
+  };
 };

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/use_current_attributes.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/use_current_attributes.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useEffect, useState } from 'react';
+import { isEqual } from 'lodash';
+import type { TypedLensSerializedState } from '../../../react_embeddable/types';
+import { useLensSelector } from '../../../state_management';
+import { extractReferencesFromState } from '../../../utils';
+import type { DatasourceMap, VisualizationMap } from '../../../types';
+
+export const useCurrentAttributes = ({
+  textBasedMode,
+  initialAttributes,
+  datasourceMap,
+  visualizationMap,
+}: {
+  initialAttributes: TypedLensSerializedState['attributes'];
+  datasourceMap: DatasourceMap;
+  visualizationMap: VisualizationMap;
+  textBasedMode?: string;
+}) => {
+  const { datasourceStates, visualization } = useLensSelector((state) => state.lens);
+  // use the latest activeId, but fallback to attributes
+  const activeVisualization =
+    visualizationMap[visualization.activeId ?? initialAttributes.visualizationType];
+
+  const [currentAttributes, setCurrentAttributes] =
+    useState<TypedLensSerializedState['attributes']>(initialAttributes);
+
+  useEffect(() => {
+    const dsStates = Object.fromEntries(
+      Object.entries(datasourceStates).map(([id, ds]) => {
+        const dsState = ds.state;
+        return [id, dsState];
+      })
+    );
+    // as ES|QL queries are using adHoc dataviews, we don't want to pass references
+    const references =
+      !textBasedMode && visualization.state
+        ? extractReferencesFromState({
+            activeDatasources: Object.keys(datasourceStates).reduce(
+              (acc, id) => ({
+                ...acc,
+                [id]: datasourceMap[id],
+              }),
+              {}
+            ),
+            datasourceStates,
+            visualizationState: visualization.state,
+            activeVisualization,
+          })
+        : [];
+    const attrs: TypedLensSerializedState['attributes'] = {
+      ...initialAttributes,
+      state: {
+        ...initialAttributes.state,
+        visualization: visualization.state,
+        datasourceStates: dsStates,
+      },
+      references,
+      visualizationType: visualization.activeId ?? initialAttributes.visualizationType,
+    };
+    if (!isEqual(attrs, currentAttributes)) {
+      setCurrentAttributes(attrs);
+    }
+  }, [
+    activeVisualization,
+    initialAttributes,
+    datasourceMap,
+    datasourceStates,
+    currentAttributes,
+    textBasedMode,
+    visualization.activeId,
+    visualization.state,
+  ]);
+
+  return currentAttributes;
+};

--- a/x-pack/test/functional/apps/lens/group7/esql.ts
+++ b/x-pack/test/functional/apps/lens/group7/esql.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+export default function ({ getService, getPageObjects }: FtrProviderContext) {
+  const { dashboard, header, common, timePicker } = getPageObjects([
+    'dashboard',
+    'header',
+    'common',
+    'timePicker',
+  ]);
+  const monacoEditor = getService('monacoEditor');
+  const esArchiver = getService('esArchiver');
+  const kibanaServer = getService('kibanaServer');
+  const dashboardPanelActions = getService('dashboardPanelActions');
+  const testSubjects = getService('testSubjects');
+  const security = getService('security');
+
+  const defaultSettings = {
+    defaultIndex: 'logstash-*',
+  };
+
+  describe('lens ES|QL tests', () => {
+    before(async () => {
+      await kibanaServer.savedObjects.cleanStandardList();
+      await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
+      await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
+      await kibanaServer.uiSettings.replace(defaultSettings);
+      await timePicker.setDefaultAbsoluteRangeViaUiSettings();
+    });
+
+    after(async () => {
+      await timePicker.resetDefaultAbsoluteRangeViaUiSettings();
+      await esArchiver.unload('test/functional/fixtures/es_archiver/logstash_functional');
+    });
+    it('should add a limit without changing the chart type or the color', async () => {
+      await dashboard.navigateToApp();
+      // no dataviews page
+      await testSubjects.click('tryESQLLink');
+      await dashboard.switchToEditMode();
+      // edit the existing panel that is being added when the Try ES|QL CTA is clicked
+      const [panel] = await dashboard.getDashboardPanels();
+      await dashboardPanelActions.clickInlineEdit(panel);
+      await dashboard.waitForRenderComplete();
+
+      await monacoEditor.setCodeEditorValue(
+        'from logstash-* | stats maxB = max(bytes) by geo.dest'
+      );
+      await testSubjects.click('ESQLEditor-run-query-button');
+      await header.waitUntilLoadingHasFinished();
+
+      // change to line chart
+      await testSubjects.click('lnsChartSwitchPopover');
+      await testSubjects.click('lnsChartSwitchPopover_line');
+      await header.waitUntilLoadingHasFinished();
+
+      // change the color to red
+      await testSubjects.click('lnsXY_yDimensionPanel');
+      const colorPickerInput = await testSubjects.find('~indexPattern-dimension-colorPicker');
+      await colorPickerInput.clearValueWithKeyboard();
+      await colorPickerInput.type('#ff0000');
+      await common.sleep(1000); // give time for debounced components to rerender
+
+      await header.waitUntilLoadingHasFinished();
+      await testSubjects.click('lns-indexPattern-dimensionContainerClose');
+      await testSubjects.click('applyFlyoutButton');
+      expect(await testSubjects.exists('xyVisChart')).to.be(true);
+
+      await dashboardPanelActions.clickInlineEdit(panel);
+
+      await header.waitUntilLoadingHasFinished();
+      await monacoEditor.setCodeEditorValue(
+        'from logstash-* | stats maxB = max(bytes) by geo.dest | limit 10'
+      );
+      await testSubjects.click('ESQLEditor-run-query-button');
+      await header.waitUntilLoadingHasFinished();
+
+      // check that the type is still line
+      const chartSwitcher = await testSubjects.find('lnsChartSwitchPopover');
+      const type = await chartSwitcher.getVisibleText();
+      expect(type).to.be('Line');
+
+      // check that the color is still red
+      await testSubjects.click('lnsXY_yDimensionPanel');
+      const colorPickerInputAfterFilter = await testSubjects.find(
+        '~indexPattern-dimension-colorPicker'
+      );
+      expect(await colorPickerInputAfterFilter.getAttribute('value')).to.be('#FF0000');
+    });
+  });
+}

--- a/x-pack/test/functional/apps/lens/group7/index.ts
+++ b/x-pack/test/functional/apps/lens/group7/index.ts
@@ -73,5 +73,6 @@ export default ({ getService, loadTestFile, getPageObjects }: FtrProviderContext
 
     // total run time ~30m
     loadTestFile(require.resolve('./logsdb')); // 30m
+    loadTestFile(require.resolve('./esql'));
   });
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ES|QL][Lens] Keeps the chart configuration when possible (#210780)](https://github.com/elastic/kibana/pull/210780)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2025-02-21T08:24:00Z","message":"[ES|QL][Lens] Keeps the chart configuration when possible (#210780)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/186366\n\n\n![meow](https://github.com/user-attachments/assets/6e5bd59a-2dcb-4b0e-a0a3-1ed15a64306f)\n\nIt keeps the chart configuration when the user is doing actions\ncompatible with the current query such as:\n\n- Adding a where filter\n- Changing to a compatible chart type (from example from bar to line or\npie to treemap)\n- In general changing the query that doesnt affect the generated columns\nmapped to a chart.\n\n### Release notes\n\nKeeps the chart configuration changes done by the user when changing the\nquery whenever it is possible.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"cb77b978877443cdce12f00a42e54609c0b36dbc","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:Visualizations","Feature:Lens","Feature:ES|QL","backport:version","v9.1.0","v8.19.0"],"title":"[ES|QL][Lens] Keeps the chart configuration when possible","number":210780,"url":"https://github.com/elastic/kibana/pull/210780","mergeCommit":{"message":"[ES|QL][Lens] Keeps the chart configuration when possible (#210780)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/186366\n\n\n![meow](https://github.com/user-attachments/assets/6e5bd59a-2dcb-4b0e-a0a3-1ed15a64306f)\n\nIt keeps the chart configuration when the user is doing actions\ncompatible with the current query such as:\n\n- Adding a where filter\n- Changing to a compatible chart type (from example from bar to line or\npie to treemap)\n- In general changing the query that doesnt affect the generated columns\nmapped to a chart.\n\n### Release notes\n\nKeeps the chart configuration changes done by the user when changing the\nquery whenever it is possible.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"cb77b978877443cdce12f00a42e54609c0b36dbc"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210780","number":210780,"mergeCommit":{"message":"[ES|QL][Lens] Keeps the chart configuration when possible (#210780)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/186366\n\n\n![meow](https://github.com/user-attachments/assets/6e5bd59a-2dcb-4b0e-a0a3-1ed15a64306f)\n\nIt keeps the chart configuration when the user is doing actions\ncompatible with the current query such as:\n\n- Adding a where filter\n- Changing to a compatible chart type (from example from bar to line or\npie to treemap)\n- In general changing the query that doesnt affect the generated columns\nmapped to a chart.\n\n### Release notes\n\nKeeps the chart configuration changes done by the user when changing the\nquery whenever it is possible.\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"cb77b978877443cdce12f00a42e54609c0b36dbc"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->