### PR TITLE
[8.x] [Security Solution] [AI Assistant] Update copy of the citations tour. (#210398)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/api/index.tsx
@@ -6,7 +6,12 @@
  */
 
 import { HttpSetup } from '@kbn/core/public';
-import { API_VERSIONS, ApiConfig, Replacements } from '@kbn/elastic-assistant-common';
+import {
+  API_VERSIONS,
+  ApiConfig,
+  MessageMetadata,
+  Replacements,
+} from '@kbn/elastic-assistant-common';
 import { API_ERROR } from '../translations';
 import { getOptionalRequestParams } from '../helpers';
 import { TraceOptions } from '../types';
@@ -34,6 +39,7 @@ export interface FetchConnectorExecuteResponse {
     transactionId: string;
     traceId: string;
   };
+  metadata?: MessageMetadata;
 }
 
 export const fetchConnectorExecuteAction = async ({
@@ -110,6 +116,7 @@ export const fetchConnectorExecuteAction = async ({
         transaction_id: string;
         trace_id: string;
       };
+      metadata?: MessageMetadata;
     }>(`/internal/elastic_assistant/actions/connector/${apiConfig?.connectorId}/_execute`, {
       method: 'POST',
       body: JSON.stringify(requestBody),
@@ -144,6 +151,7 @@ export const fetchConnectorExecuteAction = async ({
 
     return {
       response: response.data,
+      metadata: response.metadata,
       isError: false,
       isStream: false,
       traceData,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_header/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_header/index.tsx
@@ -166,7 +166,11 @@ export const AssistantHeader: React.FC<Props> = ({
                 />
               </EuiFlexItem>
               <EuiFlexItem id={AI_ASSISTANT_SETTINGS_MENU_CONTAINER_ID}>
-                <SettingsContextMenu isDisabled={isDisabled} onChatCleared={onChatCleared} />
+                <SettingsContextMenu
+                  isDisabled={isDisabled}
+                  onChatCleared={onChatCleared}
+                  selectedConversation={selectedConversation}
+                />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_header/translations.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/assistant_header/translations.ts
@@ -84,25 +84,6 @@ export const CHAT_OPTIONS = i18n.translate(
   }
 );
 
-const isMac = navigator.platform.toLowerCase().indexOf('mac') >= 0;
-
-export const ANONYMIZE_VALUES_TOOLTIP = i18n.translate(
-  'xpack.elasticAssistant.assistant.settings.anonymizeValues.tooltip',
-  {
-    values: { keyboardShortcut: isMac ? '⌥ + a' : 'Alt + a' },
-    defaultMessage:
-      'Toggle to reveal or hide field values in your chat stream. The data sent to the LLM is still anonymized based on settings in the Anonymization panel. Keyboard shortcut: {keyboardShortcut}',
-  }
-);
-
-export const SHOW_CITATIONS_TOOLTIP = i18n.translate(
-  'xpack.elasticAssistant.assistant.settings.showCitationsLabel.tooltip',
-  {
-    values: { keyboardShortcut: isMac ? '⌥ + c' : 'Alt + c' },
-    defaultMessage: 'Keyboard shortcut: {keyboardShortcut}',
-  }
-);
-
 export const CANCEL_BUTTON_TEXT = i18n.translate(
   'xpack.elasticAssistant.assistant.resetConversationModal.cancelButtonText',
   {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/conversations/utils/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/conversations/utils/index.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { alertConvo, conversationWithContentReferences } from '../../../mock/conversation';
+import { Conversation } from '../../../..';
+import { conversationContainsContentReferences, conversationContainsAnonymizedValues } from '.';
+
+describe('conversation utils', () => {
+  it.each([
+    [undefined, false],
+    [conversationWithContentReferences, true],
+    [alertConvo, false],
+  ])(
+    'conversationContainsContentReferences',
+    (conversation: Conversation | undefined, expected: boolean) => {
+      expect(conversationContainsContentReferences(conversation)).toBe(expected);
+    }
+  );
+
+  it.each([
+    [undefined, false],
+    [conversationWithContentReferences, false],
+    [alertConvo, true],
+  ])(
+    'conversationContainsAnonymizedValues',
+    (conversation: Conversation | undefined, expected: boolean) => {
+      expect(conversationContainsAnonymizedValues(conversation)).toBe(expected);
+    }
+  );
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/conversations/utils/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/conversations/utils/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isEmpty } from 'lodash';
+import { Conversation } from '../../../..';
+
+export const conversationContainsContentReferences = (conversation?: Conversation): boolean => {
+  return (
+    conversation?.messages.some((message) => !isEmpty(message.metadata?.contentReferences)) ?? false
+  );
+};
+
+/** Checks if the conversations has replacements, not if the replacements are actually used */
+export const conversationContainsAnonymizedValues = (conversation?: Conversation): boolean => {
+  return !isEmpty(conversation?.replacements);
+};

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/helpers.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/helpers.ts
@@ -25,6 +25,7 @@ export const getMessageFromRawResponse = (
       timestamp: dateTimeString,
       isError,
       traceData: rawResponse.traceData,
+      metadata: rawResponse.metadata,
     };
   } else {
     return {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -51,6 +51,10 @@ import { ConversationSidePanel } from './conversations/conversation_sidepanel';
 import { SelectedPromptContexts } from './prompt_editor/selected_prompt_contexts';
 import { AssistantHeader } from './assistant_header';
 import { AnonymizedValuesAndCitationsTour } from '../tour/anonymized_values_and_citations_tour';
+import {
+  conversationContainsAnonymizedValues,
+  conversationContainsContentReferences,
+} from './conversations/utils';
 
 export const CONVERSATION_SIDE_PANEL_WIDTH = 220;
 
@@ -226,10 +230,12 @@ const AssistantComponent: React.FC<Props> = ({
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.altKey && event.code === 'KeyC') {
+        if (!conversationContainsContentReferences(currentConversation)) return;
         event.preventDefault();
         setContentReferencesVisible(!contentReferencesVisible);
       }
       if (event.altKey && event.code === 'KeyA') {
+        if (!conversationContainsAnonymizedValues(currentConversation)) return;
         event.preventDefault();
         setShowAnonymizedValues(!showAnonymizedValues);
       }
@@ -239,6 +245,7 @@ const AssistantComponent: React.FC<Props> = ({
       contentReferencesVisible,
       setShowAnonymizedValues,
       showAnonymizedValues,
+      currentConversation,
     ]
   );
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/settings/settings_context_menu/settings_context_menu.tsx
@@ -21,24 +21,43 @@ import {
   EuiHorizontalRule,
   EuiToolTip,
   EuiSwitchEvent,
+  EuiIcon,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { euiThemeVars } from '@kbn/ui-theme';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { KnowledgeBaseTour } from '../../../tour/knowledge_base';
 import { AnonymizationSettingsManagement } from '../../../data_anonymization/settings/anonymization_settings_management';
-import { useAssistantContext } from '../../../..';
+import { Conversation, useAssistantContext } from '../../../..';
 import * as i18n from '../../assistant_header/translations';
 import { AlertsSettingsModal } from '../alerts_settings/alerts_settings_modal';
 import { KNOWLEDGE_BASE_TAB } from '../const';
 import { AI_ASSISTANT_MENU } from './translations';
+import {
+  conversationContainsAnonymizedValues,
+  conversationContainsContentReferences,
+} from '../../conversations/utils';
 
 interface Params {
   isDisabled?: boolean;
   onChatCleared?: () => void;
+  selectedConversation?: Conversation;
 }
 
+const isMac = navigator.platform.toLowerCase().indexOf('mac') >= 0;
+
+const ConditionalWrap = ({
+  condition,
+  wrap,
+  children,
+}: {
+  condition: boolean;
+  wrap: (children: React.ReactElement) => React.ReactElement;
+  children: React.ReactElement;
+}) => (condition ? wrap(children) : children);
+
 export const SettingsContextMenu: React.FC<Params> = React.memo(
-  ({ isDisabled = false, onChatCleared }: Params) => {
+  ({ isDisabled = false, onChatCleared, selectedConversation }: Params) => {
     const {
       navigateToApp,
       knowledgeBase,
@@ -116,6 +135,16 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
       [setShowAnonymizedValues]
     );
 
+    const selectedConversationHasCitations = useMemo(
+      () => conversationContainsContentReferences(selectedConversation),
+      [selectedConversation]
+    );
+
+    const selectedConversationHasAnonymizedValues = useMemo(
+      () => conversationContainsAnonymizedValues(selectedConversation),
+      [selectedConversation]
+    );
+
     const items = useMemo(
       () => [
         <EuiContextMenuItem
@@ -173,43 +202,114 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
             <h3>{i18n.CHAT_OPTIONS}</h3>
           </EuiTitle>
           <EuiHorizontalRule margin="none" />
-          <EuiToolTip
-            position="left"
-            key={'anonymize-values-tooltip'}
-            content={i18n.ANONYMIZE_VALUES_TOOLTIP}
+          <EuiContextMenuItem
+            aria-label={'anonymize-values'}
+            key={'anonymize-values'}
+            data-test-subj={'anonymize-values'}
           >
-            <EuiContextMenuItem
-              aria-label={'anonymize-values'}
-              key={'anonymize-values'}
-              data-test-subj={'anonymize-values'}
-            >
-              <EuiSwitch
-                label={i18n.ANONYMIZE_VALUES}
-                checked={showAnonymizedValues}
-                onChange={onChangeShowAnonymizedValues}
-                compressed
-              />
-            </EuiContextMenuItem>
-          </EuiToolTip>
+            <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <ConditionalWrap
+                  condition={!selectedConversationHasAnonymizedValues}
+                  wrap={(children) => (
+                    <EuiToolTip
+                      position="top"
+                      key={'disabled-anonymize-values-tooltip'}
+                      content={
+                        <FormattedMessage
+                          id="xpack.elasticAssistant.assistant.settings.anonymizeValues.disabled.tooltip"
+                          defaultMessage="This conversation does not contain anonymized fields."
+                        />
+                      }
+                    >
+                      {children}
+                    </EuiToolTip>
+                  )}
+                >
+                  <EuiSwitch
+                    label={i18n.ANONYMIZE_VALUES}
+                    checked={showAnonymizedValues}
+                    onChange={onChangeShowAnonymizedValues}
+                    compressed
+                    disabled={!selectedConversationHasAnonymizedValues}
+                  />
+                </ConditionalWrap>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiToolTip
+                  position="top"
+                  key={'anonymize-values-tooltip'}
+                  content={
+                    <FormattedMessage
+                      id="xpack.elasticAssistant.assistant.settings.anonymizeValues.tooltip"
+                      defaultMessage="Toggle to reveal or obfuscate field values in your chat stream. The data sent to the LLM is still anonymized based on settings in the Anonymization panel. Keyboard shortcut: <bold>{keyboardShortcut}</bold>"
+                      values={{
+                        keyboardShortcut: isMac ? '⌥ + a' : 'Alt + a',
+                        bold: (str) => <strong>{str}</strong>,
+                      }}
+                    />
+                  }
+                >
+                  <EuiIcon tabIndex={0} type="iInCircle" />
+                </EuiToolTip>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiContextMenuItem>
+
           {contentReferencesEnabled && (
-            <EuiToolTip
-              position="left"
-              key={'show-citations-tooltip'}
-              content={i18n.SHOW_CITATIONS_TOOLTIP}
+            <EuiContextMenuItem
+              aria-label={'show-citations'}
+              key={'show-citations'}
+              data-test-subj={'show-citations'}
             >
-              <EuiContextMenuItem
-                aria-label={'show-citations'}
-                key={'show-citations'}
-                data-test-subj={'show-citations'}
-              >
-                <EuiSwitch
-                  label={i18n.SHOW_CITATIONS}
-                  checked={contentReferencesVisible}
-                  onChange={onChangeContentReferencesVisible}
-                  compressed
-                />
-              </EuiContextMenuItem>
-            </EuiToolTip>
+              <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+                <EuiFlexItem grow={false}>
+                  <ConditionalWrap
+                    condition={!selectedConversationHasCitations}
+                    wrap={(children) => (
+                      <EuiToolTip
+                        position="top"
+                        key={'disabled-anonymize-values-tooltip'}
+                        content={
+                          <FormattedMessage
+                            id="xpack.elasticAssistant.assistant.settings.showCitationsLabel.disabled.tooltip"
+                            defaultMessage="This conversation does not contain citations."
+                          />
+                        }
+                      >
+                        {children}
+                      </EuiToolTip>
+                    )}
+                  >
+                    <EuiSwitch
+                      label={i18n.SHOW_CITATIONS}
+                      checked={contentReferencesVisible}
+                      onChange={onChangeContentReferencesVisible}
+                      compressed
+                      disabled={!selectedConversationHasCitations}
+                    />
+                  </ConditionalWrap>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiToolTip
+                    position="top"
+                    key={'show-citations-tooltip'}
+                    content={
+                      <FormattedMessage
+                        id="xpack.elasticAssistant.assistant.settings.showCitationsLabel.tooltip"
+                        defaultMessage="Keyboard shortcut: <bold>{keyboardShortcut}</bold>"
+                        values={{
+                          keyboardShortcut: isMac ? '⌥ + c' : 'Alt + c',
+                          bold: (str) => <strong>{str}</strong>,
+                        }}
+                      />
+                    }
+                  >
+                    <EuiIcon tabIndex={0} type="iInCircle" />
+                  </EuiToolTip>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiContextMenuItem>
           )}
           <EuiHorizontalRule margin="none" />
           <EuiContextMenuItem
@@ -238,6 +338,8 @@ export const SettingsContextMenu: React.FC<Params> = React.memo(
         knowledgeBase.latestAlerts,
         showDestroyModal,
         contentReferencesEnabled,
+        selectedConversationHasCitations,
+        selectedConversationHasAnonymizedValues,
       ]
     );
 

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/tour/anonymized_values_and_citations_tour/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/tour/anonymized_values_and_citations_tour/index.tsx
@@ -7,12 +7,16 @@
 
 import { EuiTourStep } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
-import { isEmpty, throttle } from 'lodash';
+import { throttle } from 'lodash';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { Conversation } from '../../assistant_context/types';
 import { NEW_FEATURES_TOUR_STORAGE_KEYS } from '../const';
 import { anonymizedValuesAndCitationsTourStep1 } from './step_config';
 import { TourState } from '../knowledge_base';
+import {
+  conversationContainsAnonymizedValues,
+  conversationContainsContentReferences,
+} from '../../assistant/conversations/utils';
 
 interface Props {
   conversation: Conversation | undefined;
@@ -49,12 +53,10 @@ export const AnonymizedValuesAndCitationsTour: React.FC<Props> = ({ conversation
       return;
     }
 
-    const containsContentReferences = conversation.messages.some(
-      (message) => !isEmpty(message.metadata?.contentReferences)
-    );
-    const containsReplacements = !isEmpty(conversation.replacements);
+    const containsContentReferences = conversationContainsContentReferences(conversation);
+    const containsAnonymizedValues = conversationContainsAnonymizedValues(conversation);
 
-    if (containsContentReferences || containsReplacements) {
+    if (containsContentReferences || containsAnonymizedValues) {
       const timer = setTimeout(() => {
         setShowTour(true);
       }, 1000);

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/tour/anonymized_values_and_citations_tour/step_config.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/tour/anonymized_values_and_citations_tour/step_config.tsx
@@ -30,18 +30,18 @@ export const anonymizedValuesAndCitationsTourStep1 = {
     <EuiText size="s">
       <FormattedMessage
         id="xpack.elasticAssistant.anonymizedValuesAndCitations.tour.content.citedKnowledgeBaseEntries"
-        defaultMessage="<bold>Cited</bold> Knowledge base entries show in the chat stream. Toggle on or off in the menu or with the shortcut: {keyboardShortcut}."
+        defaultMessage="AI Assistant can now cite sources in its responses. Toggle citations by using this menu or <bold>{keyboardShortcut}</bold>"
         values={{
-          keyboardShortcut: isMac ? '⌥ c' : 'Alt c',
+          keyboardShortcut: isMac ? '⌥ + c' : 'Alt + c',
           bold: (str) => <strong>{str}</strong>,
         }}
       />
       <EuiSpacer size="s" />
       <FormattedMessage
         id="xpack.elasticAssistant.anonymizedValuesAndCitations.tour.content.anonymizedValues"
-        defaultMessage="The toggle to show or hide <bold>Anonymized values</bold> in the chat stream, has moved to the menu. Use the shortcut: {keyboardShortcut}. Your data is still sent anonymized to the LLM based on the settings in the Anonymization panel."
+        defaultMessage="Quickly toggle the obfuscation of anonymized values in your conversation by using this menu, or <bold>{keyboardShortcut}</bold>. This does not affect the anonymization of data sent to the LLM"
         values={{
-          keyboardShortcut: isMac ? '⌥ a' : 'Alt a',
+          keyboardShortcut: isMac ? '⌥ + a' : 'Alt + a',
           bold: (str) => <strong>{str}</strong>,
         }}
       />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution] [AI Assistant] Update copy of the citations tour. (#210398)](https://github.com/elastic/kibana/pull/210398)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kenneth Kreindler","email":"42113355+KDKHD@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-21T09:03:53Z","message":"[Security Solution] [AI Assistant] Update copy of the citations tour. (#210398)\n\n## Summary\n\nAddresses\nhttps://github.com/elastic/security-docs/issues/6485#issuecomment-2639562221\n\nThis PR updates the copy in the Citations and Anonymized values tour\naccording to the figma linked in the issue. Furthermore, the PR includes\nthe logic that disables the \"Show anonymized values\" and \"Show\ncitations\" buttons in the assistant settings menu when the conversation\ndoes not contain anonymized values or citations respectivly.\n\n### How to test new copy is correct\n<img width=\"864\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/22bd2671-6d06-4e68-85f5-3c10d9974a4a\"\n/>\n\n\n- Enable feature flag\n```yaml\n# kibana.dev.yml\nxpack.securitySolution.enableExperimental: ['contentReferencesEnabled']\n```\n- Clear the key\n`elasticAssistant.anonymizedValuesAndCitationsTourCompleted.v8.18` from\nyour local storage if it exists.\n- Open Security assistant\n- Ask the assistant a question about your alerts or a KB document, the\nresponse should contain anonymized values or a citation.\n- The tour with the new copy should appear (copy in screenshot above).\n*the Anonymized values and citations will not appear if the knowledge\nbase tour is currently open.\n\n### How to test assistant settings menu changes:\n<img width=\"349\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/58e445d7-79c0-46ca-a245-bc2ab90eeb5d\"\n/>\n\n- Enable feature flag\n```yaml\n# kibana.dev.yml\nxpack.securitySolution.enableExperimental: ['contentReferencesEnabled']\n```\n- Open Security assistant\n- In a new conversation, inside the settings menu, the \"Show anonymized\nvalues\" and \"Show citations\" menu items should be disabled because the\nconversation is empty and does not contain citations or anonymized\nvalues.\n- Ask the assistant a question about a KB document or Alert. The \"Show\ncitations\" menu item should become available if the response contains\ncitations. The \"Show anonymized values\" menu item will become available\nif the conversation contains replacements. Hovering over the disabled\nmenu item will make a tooltip appear explaining why it is disabled.\n*Sometimes the conversation will contain replacements but the\nreplacements are not used in the messages. In that case, the anonymized\nvalues menu item will not be disabled. This is a known\n[issue](https://github.com/elastic/kibana/issues/208517).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b59712fa8cc5709cb36da6914c61823411b6c1fe","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Security Generative AI","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Security Solution] [AI Assistant] Update copy of the citations tour.","number":210398,"url":"https://github.com/elastic/kibana/pull/210398","mergeCommit":{"message":"[Security Solution] [AI Assistant] Update copy of the citations tour. (#210398)\n\n## Summary\n\nAddresses\nhttps://github.com/elastic/security-docs/issues/6485#issuecomment-2639562221\n\nThis PR updates the copy in the Citations and Anonymized values tour\naccording to the figma linked in the issue. Furthermore, the PR includes\nthe logic that disables the \"Show anonymized values\" and \"Show\ncitations\" buttons in the assistant settings menu when the conversation\ndoes not contain anonymized values or citations respectivly.\n\n### How to test new copy is correct\n<img width=\"864\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/22bd2671-6d06-4e68-85f5-3c10d9974a4a\"\n/>\n\n\n- Enable feature flag\n```yaml\n# kibana.dev.yml\nxpack.securitySolution.enableExperimental: ['contentReferencesEnabled']\n```\n- Clear the key\n`elasticAssistant.anonymizedValuesAndCitationsTourCompleted.v8.18` from\nyour local storage if it exists.\n- Open Security assistant\n- Ask the assistant a question about your alerts or a KB document, the\nresponse should contain anonymized values or a citation.\n- The tour with the new copy should appear (copy in screenshot above).\n*the Anonymized values and citations will not appear if the knowledge\nbase tour is currently open.\n\n### How to test assistant settings menu changes:\n<img width=\"349\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/58e445d7-79c0-46ca-a245-bc2ab90eeb5d\"\n/>\n\n- Enable feature flag\n```yaml\n# kibana.dev.yml\nxpack.securitySolution.enableExperimental: ['contentReferencesEnabled']\n```\n- Open Security assistant\n- In a new conversation, inside the settings menu, the \"Show anonymized\nvalues\" and \"Show citations\" menu items should be disabled because the\nconversation is empty and does not contain citations or anonymized\nvalues.\n- Ask the assistant a question about a KB document or Alert. The \"Show\ncitations\" menu item should become available if the response contains\ncitations. The \"Show anonymized values\" menu item will become available\nif the conversation contains replacements. Hovering over the disabled\nmenu item will make a tooltip appear explaining why it is disabled.\n*Sometimes the conversation will contain replacements but the\nreplacements are not used in the messages. In that case, the anonymized\nvalues menu item will not be disabled. This is a known\n[issue](https://github.com/elastic/kibana/issues/208517).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b59712fa8cc5709cb36da6914c61823411b6c1fe"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212018","number":212018,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210398","number":210398,"mergeCommit":{"message":"[Security Solution] [AI Assistant] Update copy of the citations tour. (#210398)\n\n## Summary\n\nAddresses\nhttps://github.com/elastic/security-docs/issues/6485#issuecomment-2639562221\n\nThis PR updates the copy in the Citations and Anonymized values tour\naccording to the figma linked in the issue. Furthermore, the PR includes\nthe logic that disables the \"Show anonymized values\" and \"Show\ncitations\" buttons in the assistant settings menu when the conversation\ndoes not contain anonymized values or citations respectivly.\n\n### How to test new copy is correct\n<img width=\"864\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/22bd2671-6d06-4e68-85f5-3c10d9974a4a\"\n/>\n\n\n- Enable feature flag\n```yaml\n# kibana.dev.yml\nxpack.securitySolution.enableExperimental: ['contentReferencesEnabled']\n```\n- Clear the key\n`elasticAssistant.anonymizedValuesAndCitationsTourCompleted.v8.18` from\nyour local storage if it exists.\n- Open Security assistant\n- Ask the assistant a question about your alerts or a KB document, the\nresponse should contain anonymized values or a citation.\n- The tour with the new copy should appear (copy in screenshot above).\n*the Anonymized values and citations will not appear if the knowledge\nbase tour is currently open.\n\n### How to test assistant settings menu changes:\n<img width=\"349\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/58e445d7-79c0-46ca-a245-bc2ab90eeb5d\"\n/>\n\n- Enable feature flag\n```yaml\n# kibana.dev.yml\nxpack.securitySolution.enableExperimental: ['contentReferencesEnabled']\n```\n- Open Security assistant\n- In a new conversation, inside the settings menu, the \"Show anonymized\nvalues\" and \"Show citations\" menu items should be disabled because the\nconversation is empty and does not contain citations or anonymized\nvalues.\n- Ask the assistant a question about a KB document or Alert. The \"Show\ncitations\" menu item should become available if the response contains\ncitations. The \"Show anonymized values\" menu item will become available\nif the conversation contains replacements. Hovering over the disabled\nmenu item will make a tooltip appear explaining why it is disabled.\n*Sometimes the conversation will contain replacements but the\nreplacements are not used in the messages. In that case, the anonymized\nvalues menu item will not be disabled. This is a known\n[issue](https://github.com/elastic/kibana/issues/208517).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [X] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [X]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [X] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [X] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [X] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [X] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [X] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"b59712fa8cc5709cb36da6914c61823411b6c1fe"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->