### PR TITLE
[Feature Flags] Remove `apm.captureError` on slow setup

### DIFF
--- a/src/core/packages/feature-flags/browser-internal/src/feature_flags_service.test.ts
+++ b/src/core/packages/feature-flags/browser-internal/src/feature_flags_service.test.ts
@@ -83,7 +83,11 @@ describe('FeatureFlagsService Browser', () => {
       const spy = jest.spyOn(OpenFeature, 'setProviderAndWait').mockImplementationOnce(async () => {
         await new Promise(() => {}); // never resolves
       });
-      const apmCaptureErrorSpy = jest.spyOn(apm, 'captureError');
+      const addLabelsMock = jest.fn();
+      jest
+        .spyOn(apm, 'getCurrentTransaction')
+        // @ts-expect-error incomplete signature, but we don't care at this point
+        .mockImplementationOnce(() => ({ addLabels: addLabelsMock }));
       const fakeProvider = {} as Provider;
       setProvider(fakeProvider);
       expect(spy).toHaveBeenCalledWith(fakeProvider);
@@ -91,9 +95,7 @@ describe('FeatureFlagsService Browser', () => {
       await expect(isSettledPromise(startPromise)).resolves.toBe(false);
       await new Promise((resolve) => setTimeout(resolve, 2100)); // A bit longer than 2 seconds
       await expect(isSettledPromise(startPromise)).resolves.toBe(true);
-      expect(apmCaptureErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('The feature flags provider took too long to initialize.')
-      );
+      expect(addLabelsMock).toHaveBeenCalledWith({ slow_setup: true });
     });
 
     describe('APM instrumentation', () => {

--- a/src/core/packages/feature-flags/browser-internal/src/feature_flags_service.ts
+++ b/src/core/packages/feature-flags/browser-internal/src/feature_flags_service.ts
@@ -173,7 +173,8 @@ export class FeatureFlagsService {
         Won't hold the page load any longer.
         Feature flags will return the provided fallbacks until the provider is eventually initialized.`;
         this.logger.warn(msg);
-        apm.captureError(msg);
+        // Flag the transaction as slow so that we can quantify how often it happens
+        apm.getCurrentTransaction()?.addLabels({ slow_setup: true });
       }),
     ]);
     clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary

The current `apm.captureError` is causing noise in our monitoring systems when it's not actually an error.

Since the setup is traced in a transaction, we already have the visibility by looking at the traces
<img width="2104" alt="image" src="https://github.com/user-attachments/assets/1c19a0d7-dec2-475f-af22-868781aa062f" />

On top of that, we're adding a label to make it easier to filter in case it's needed.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->