### PR TITLE
[ObsUX][APM][Profiling] Update documentation links to use doc link service instead of hardcoded URLs 

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.test.tsx
@@ -4,12 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { docLinksServiceMock } from '@kbn/core/public/mocks';
 import { getTailSamplingSettings, isTailBasedSamplingValid } from './tail_sampling_settings';
 
-const DOCS_LINK =
-  'https://www.elastic.co/guide/en/apm/guide/current/configure-tail-based-sampling.html';
-
 describe('tail_sampling_settings - isTailBasedSamplingFormValid', () => {
+  const docLinks = docLinksServiceMock.createStartContract();
+  const DOCS_LINK = docLinks.links.apm.tailSamplingPolicies;
+
   it('return true when tail_sampling_interval is greater than 1s', () => {
     const settings = getTailSamplingSettings(DOCS_LINK);
     const isValid = isTailBasedSamplingValid(

--- a/x-pack/solutions/observability/plugins/profiling/public/views/add_data_view/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/add_data_view/index.tsx
@@ -68,6 +68,7 @@ export function AddDataView() {
     services: { setupDataCollectionInstructions },
     start: { core },
   } = useProfilingDependencies();
+  const { docLinks } = core;
 
   const { data, status } = useAsync(
     ({ http }) => {
@@ -410,7 +411,7 @@ EOF`}
                     <EuiLink
                       data-test-subj="profilingAddDataViewInstructionsHereLink"
                       target="_blank"
-                      href={`https://www.elastic.co/guide/en/kibana/current/api-keys.html`}
+                      href={docLinks.links.management.apiKeys}
                     >
                       {i18n.translate('xpack.profiling.tabs.symbols.step2.instructions', {
                         defaultMessage: 'Instructions here',
@@ -455,7 +456,7 @@ EOF`}
                             <EuiLink
                               data-test-subj="profilingAddDataViewTheCorrespondingDocumentationPageLink"
                               target="_blank"
-                              href={`${core.docLinks.ELASTIC_WEBSITE_URL}/guide/en/observability/${core.docLinks.DOC_LINK_VERSION}/profiling-add-symbols.html`}
+                              href={`${docLinks.ELASTIC_WEBSITE_URL}/guide/en/observability/${docLinks.DOC_LINK_VERSION}/profiling-add-symbols.html`}
                             >
                               {i18n.translate('xpack.profiling.tabs.symbols.step3.doc-ref.link', {
                                 defaultMessage: 'the corresponding documentation page',
@@ -475,8 +476,9 @@ EOF`}
     ],
     [
       collectionAgentHost,
-      core.docLinks.DOC_LINK_VERSION,
-      core.docLinks.ELASTIC_WEBSITE_URL,
+      docLinks.DOC_LINK_VERSION,
+      docLinks.ELASTIC_WEBSITE_URL,
+      docLinks.links.management.apiKeys,
       core.http.basePath,
       data?.profilerAgent.version,
       majorVersion,
@@ -593,7 +595,7 @@ EOF`}
                     <EuiLink
                       data-test-subj="profilingAddDataViewAdvancedConfigurationLink"
                       target="_blank"
-                      href={`${core.docLinks.ELASTIC_WEBSITE_URL}/guide/en/observability/${core.docLinks.DOC_LINK_VERSION}/profiling-advanced-configuration.html`}
+                      href={`${docLinks.ELASTIC_WEBSITE_URL}/guide/en/observability/${docLinks.DOC_LINK_VERSION}/profiling-advanced-configuration.html`}
                     >
                       {i18n.translate('xpack.profiling.tabs.debWarning.advancedLink', {
                         defaultMessage: 'Advanced configuration',


### PR DESCRIPTION
## Summary

Closes #208895

This PR updates documentation links to use the doc link service, to avoid hardcoding URLs



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->