### PR TITLE
[Fleet] fix `prerelease:boolean` in package_service

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/package_service.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/package_service.ts
@@ -120,7 +120,7 @@ export interface PackageClient {
   ): ReturnType<typeof getPackageInfo>;
 
   getPackages(params?: {
-    excludeInstallStatus?: false;
+    excludeInstallStatus?: boolean;
     category?: CategoryId;
     prerelease?: boolean;
   }): Promise<PackageList>;
@@ -345,7 +345,7 @@ class PackageClientImpl implements PackageClient {
   }
 
   public async getPackages(params?: {
-    excludeInstallStatus?: false;
+    excludeInstallStatus?: boolean;
     category?: CategoryId;
     prerelease?: boolean;
   }) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/package_service.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/package_service.ts
@@ -122,13 +122,13 @@ export interface PackageClient {
   getPackages(params?: {
     excludeInstallStatus?: false;
     category?: CategoryId;
-    prerelease?: false;
+    prerelease?: boolean;
   }): Promise<PackageList>;
 
   getAgentPolicyConfigYAML(
     pkgName: string,
     pkgVersion?: string,
-    prerelease?: false,
+    prerelease?: boolean,
     ignoreUnverified?: boolean
   ): Promise<string>;
 
@@ -296,7 +296,7 @@ class PackageClientImpl implements PackageClient {
   public async getAgentPolicyConfigYAML(
     pkgName: string,
     pkgVersion?: string,
-    prerelease?: false,
+    prerelease?: boolean,
     ignoreUnverified?: boolean
   ) {
     await this.#runPreflight(READ_PACKAGE_INFO_AUTHZ);
@@ -347,7 +347,7 @@ class PackageClientImpl implements PackageClient {
   public async getPackages(params?: {
     excludeInstallStatus?: false;
     category?: CategoryId;
-    prerelease?: false;
+    prerelease?: boolean;
   }) {
     const { excludeInstallStatus, category, prerelease } = params || {};
     await this.#runPreflight(READ_PACKAGE_INFO_AUTHZ);


### PR DESCRIPTION
Use `boolean` instead of `false` in `getPackages` to support querying prerelease packages.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->