### PR TITLE
[scout] disable reporter for config validation command

### DIFF
--- a/packages/kbn-scout/src/playwright/runner/run_tests.ts
+++ b/packages/kbn-scout/src/playwright/runner/run_tests.ts
@@ -38,7 +38,10 @@ export async function runTests(log: ToolingLog, options: RunTestsOptions) {
     log.info(`scout: Validate Playwright config has tests`);
     try {
       // '--list' flag tells Playwright to collect all the tests, but do not run it
-      const result = await execPromise(`${cmd} ${cmdArgs.join(' ')} --list`);
+      // We disable scout reporter explicitly to avoid creating directories and collecting stats
+      const result = await execPromise(
+        `SCOUT_REPORTER_ENABLED=false ${cmd} ${cmdArgs.join(' ')} --list`
+      );
       const lastLine = result.stdout.trim().split('\n').pop();
       log.info(`scout: ${lastLine}`);
     } catch (err) {


### PR DESCRIPTION
## Summary

In #211918 I added config validation check to skip run if there are no tests in playwright config.

It turned out that Playwright init reporters even when `--list` command is passed and no tests are executed, that lead to Scout reports being loaded and then causing reporter error when the other command runs the tests:

```
 proc [playwright]  info Calling save with destination: /Users/dmle/github/kibana/.scout/reports/scout-playwright-9518363d47816953
 proc [playwright] ERROR Error: Save destination path '/Users/dmle/github/kibana/.scout/reports/scout-playwright-9518363d47816953' already exists
 proc [playwright]           at ScoutEventsReport.save (/Users/dmle/github/kibana/packages/kbn-scout-reporting/src/reporting/report/events/report.ts:56:13)
 proc [playwright]           at ScoutPlaywrightReporter.onEnd (/Users/dmle/github/kibana/packages/kbn-scout-reporting/src/reporting/playwright/events/playwright_reporter.ts:277:19)
 proc [playwright]           at ReporterV2Wrapper.onEnd (/Users/dmle/github/kibana/node_modules/playwright/lib/reporters/reporterV2.js:91:165)
 proc [playwright]           at /Users/dmle/github/kibana/node_modules/playwright/lib/reporters/multiplexer.js:71:117
 proc [playwright]           at wrapAsync (/Users/dmle/github/kibana/node_modules/playwright/lib/reporters/multiplexer.js:112:18)
 proc [playwright]           at Multiplexer.onEnd (/Users/dmle/github/kibana/node_modules/playwright/lib/reporters/multiplexer.js:69:31)
 proc [playwright]           at InternalReporter.onEnd (/Users/dmle/github/kibana/node_modules/playwright/lib/reporters/internalReporter.js:77:12)
 proc [playwright]           at finishTaskRun (/Users/dmle/github/kibana/node_modules/playwright/lib/runner/tasks.js:90:26)
 proc [playwright]           at runTasks (/Users/dmle/github/kibana/node_modules/playwright/lib/runner/tasks.js:73:10)
 proc [playwright]           at Runner.runAllTests (/Users/dmle/github/kibana/node_modules/playwright/lib/runner/runner.js:72:20)
 proc [playwright]           at runTests (/Users/dmle/github/kibana/node_modules/playwright/lib/program.js:211:18)
 proc [playwright]           at t.<anonymous> (/Users/dmle/github/kibana/node_modules/playwright/lib/program.js:54:7)
```

The simplest solution is to explicitly disable Scout reporter for config validation command.

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->