### PR TITLE
[Alert rules visualization] a simple scafolding of adding a new action for milestone 1

### DIFF
--- a/src/platform/packages/shared/kbn-ui-actions-browser/src/triggers/alert_rule_trigger.ts
+++ b/src/platform/packages/shared/kbn-ui-actions-browser/src/triggers/alert_rule_trigger.ts
@@ -7,10 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './trigger';
-export * from './row_click_trigger';
-export * from './default_trigger';
-export * from './visualize_field_trigger';
-export * from './visualize_geo_field_trigger';
-export * from './dashboard_app_panel_trigger';
-export * from './alert_rule_trigger';
+import { Trigger } from '.';
+
+export const alertRuleTrigger: Trigger = {
+  id: 'alertRule',
+  title:'alert rule trigger',
+  description: 'alert rule trigger',
+};

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.tsx
@@ -118,6 +118,7 @@ import './xy_chart.scss';
 import { TooltipHeader } from './tooltip';
 import { LegendColorPickerWrapperContext, LegendColorPickerWrapper } from './legend_color_picker';
 import { createSplitPoint, getTooltipActions, getXSeriesPoint } from './tooltip/tooltip_actions';
+import { on } from 'events';
 
 declare global {
   interface Window {
@@ -140,6 +141,7 @@ export type XYChartRenderProps = Omit<XYChartProps, 'canNavigateToLens'> & {
   interactive?: boolean;
   onClickValue: (data: FilterEvent['data']) => void;
   onClickMultiValue: (data: MultiFilterEvent['data']) => void;
+  onCreateAlertRule: (data: MultiFilterEvent['data']) => void,
   layerCellValueActions: LayerCellValueActions;
   onSelectRange: (data: BrushEvent['data']) => void;
   renderMode: RenderMode;
@@ -203,6 +205,7 @@ export function XYChart({
   minInterval,
   onClickValue,
   onClickMultiValue,
+  onCreateAlertRule,
   layerCellValueActions,
   onSelectRange,
   setChartSize,
@@ -786,6 +789,7 @@ export function XYChart({
             actions={getTooltipActions(
               dataLayers,
               onClickMultiValue,
+              onCreateAlertRule,
               fieldFormats,
               formattedDatatables,
               xAxisFormatter,

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
@@ -222,6 +222,9 @@ export const getXyChartRenderer = ({
     const onClickMultiValue = (data: MultiFilterEvent['data']) => {
       handlers.event({ name: 'multiFilter', data });
     };
+    const onCreateAlertRule = (data: MultiFilterEvent['data']) => {
+      handlers.event({ name: 'alertRule', data });
+    };
     const setChartSize = (data: ChartSizeSpec) => {
       const event: ChartSizeEvent = { name: 'chartSize', data };
       handlers.event(event);
@@ -279,6 +282,7 @@ export const getXyChartRenderer = ({
             interactive={handlers.isInteractive()}
             onClickValue={onClickValue}
             onClickMultiValue={onClickMultiValue}
+            onCreateAlertRule={onCreateAlertRule}
             layerCellValueActions={layerCellValueActions}
             onSelectRange={onSelectRange}
             renderMode={handlers.getRenderMode()}

--- a/src/platform/plugins/shared/ui_actions/public/plugin.ts
+++ b/src/platform/plugins/shared/ui_actions/public/plugin.ts
@@ -14,6 +14,7 @@ import {
   visualizeFieldTrigger,
   visualizeGeoFieldTrigger,
   addPanelMenuTrigger,
+  alertRuleTrigger
 } from '@kbn/ui-actions-browser/src/triggers';
 import { UiActionsService } from './service';
 import { setAnalytics, setI18n, setNotifications, setTheme, setUserProfile } from './services';
@@ -54,6 +55,7 @@ export class UiActionsPlugin
   public setup(_core: CoreSetup): UiActionsPublicSetup {
     this.service.registerTrigger(addPanelMenuTrigger);
     this.service.registerTrigger(rowClickTrigger);
+    this.service.registerTrigger(alertRuleTrigger);
     this.service.registerTrigger(visualizeFieldTrigger);
     this.service.registerTrigger(visualizeGeoFieldTrigger);
     return this.service;

--- a/src/platform/plugins/shared/visualizations/public/embeddable/events.ts
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/events.ts
@@ -15,12 +15,15 @@ import {
   MULTI_VALUE_CLICK_TRIGGER,
 } from '@kbn/embeddable-plugin/public';
 
+const ALERT_RULE: "alertRule" = 'alertRule'
+
 export interface VisEventToTrigger {
   ['applyFilter']: typeof APPLY_FILTER_TRIGGER;
   ['brush']: typeof SELECT_RANGE_TRIGGER;
   ['filter']: typeof VALUE_CLICK_TRIGGER;
   ['multiFilter']: typeof MULTI_VALUE_CLICK_TRIGGER;
   ['tableRowContextMenuClick']: typeof ROW_CLICK_TRIGGER;
+  ['alertRule']: typeof ALERT_RULE;
 }
 
 export const VIS_EVENT_TO_TRIGGER: VisEventToTrigger = {
@@ -29,4 +32,5 @@ export const VIS_EVENT_TO_TRIGGER: VisEventToTrigger = {
   filter: VALUE_CLICK_TRIGGER,
   multiFilter: MULTI_VALUE_CLICK_TRIGGER,
   tableRowContextMenuClick: ROW_CLICK_TRIGGER,
+  alertRule: 'alertRule',
 };

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -671,6 +671,19 @@ export class LensPlugin {
       )(core.application)
     );
 
+
+  const alertRulesDefinition = {
+      type: 'alertRule',
+      id: 'alertRule',
+      shouldAutoExecute: async () => true,
+      execute: async (context: unknown) => {
+      console.log('open the flyout and execute the action here', context);
+      }
+  }
+
+
+    startDependencies.uiActions.addTriggerAction('alertRule', alertRulesDefinition);
+
     // Allows the Lens embeddable to easily open the inline editing flyout
     const editLensEmbeddableAction = new EditLensEmbeddableAction(core, async () => {
       const { visualizationMap, datasourceMap } = await this.initEditorFrameService();
@@ -695,6 +708,7 @@ export class LensPlugin {
       return getAddLensPanelAction(startDependencies);
     });
     startDependencies.uiActions.attachAction(ADD_PANEL_TRIGGER, 'addLensPanelAction');
+
     if (startDependencies.uiActions.hasTrigger('ADD_CANVAS_ELEMENT_TRIGGER')) {
       // Because Canvas is not enabled in Serverless, this trigger might not be registered - only attach
       // the create action if the Canvas-specific trigger does indeed exist.

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/on_event.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/on_event.ts
@@ -9,6 +9,7 @@ import { ExpressionRendererEvent } from '@kbn/expressions-plugin/public';
 import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
 import { type AggregateQuery, type Query, isOfAggregateQueryType } from '@kbn/es-query';
 import {
+  isLensAlertRule,
   isLensBrushEvent,
   isLensEditEvent,
   isLensFilterEvent,
@@ -51,6 +52,19 @@ export const prepareEventHandler =
       eventHandler = callbacks.onFilter;
     } else if (isLensTableRowContextMenuClickEvent(event)) {
       eventHandler = callbacks.onTableRowClick;
+    } else if (isLensAlertRule(event)) {
+      // TODO: here is where we run the uiActions on the embeddable for the alert rule
+      eventHandler = callbacks.onAlertRule;
+       if (shouldExecuteDefaultTriggers) {
+        // this runs the function that we define in addTriggerAction in the plugin.ts file in alertRulesDefinition
+        uiActions.getTrigger(VIS_EVENT_TO_TRIGGER[event.name]).exec(
+          {
+            data: event.data,
+            embeddable: api,
+          },
+          true
+        );
+      }
     }
     const currentState = getState();
 

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
@@ -229,6 +229,7 @@ export interface LensPublicCallbacks extends LensApiProps {
    * Let the consumer overwrite embeddable user messages
    */
   onBeforeBadgesRender?: (userMessages: UserMessage[]) => UserMessage[];
+  onAlertRule?: (data: unknown) => void;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/lens/public/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/types.ts
@@ -1402,11 +1402,19 @@ export interface LensTableRowContextMenuEvent {
   data: RowClickContext['data'];
 }
 
+export interface LensAlertRulesEvent {
+  name: 'alertRule';
+  data: unknown;
+}
+
+
+
 export type TriggerEvent =
   | BrushTriggerEvent
   | ClickTriggerEvent
   | MultiClickTriggerEvent
-  | LensTableRowContextMenuEvent;
+  | LensTableRowContextMenuEvent 
+  | LensAlertRulesEvent
 
 export function isLensFilterEvent(event: ExpressionRendererEvent): event is ClickTriggerEvent {
   return event.name === 'filter';
@@ -1432,6 +1440,12 @@ export function isLensTableRowContextMenuClickEvent(
   event: ExpressionRendererEvent
 ): event is LensTableRowContextMenuEvent {
   return event.name === 'tableRowContextMenuClick';
+}
+
+export function isLensAlertRule(
+  event: ExpressionRendererEvent
+): event is LensAlertRulesEvent {
+  return event.name === 'alertRule';
 }
 
 /**


### PR DESCRIPTION
## Summary

Scafolding for milestone 1 of this issue: https://github.com/elastic/kibana/issues/197489

1. adds a new action for uiActions (`alertRule`)
2. show the action on the tooltip menu for the xy time visualization 
3. When a user triggers the action (with a click on `Add alert rule`) the `alertRulesDefinition.execute` action is being run.

<img width="517" alt="Screenshot 2025-02-21 at 15 21 15" src="https://github.com/user-attachments/assets/5da87160-95b0-4c36-bcd5-6a8a4fae76c9" />

Let me know if anything else is needed. I believe this is enough as a brief POC to achieve milestone 1 - creating an alert rule from visualization but without modifying the visualization state (no thresholds or anything shown)