### PR TITLE
[8.x] [ObsUX][APM][Profiling] Update documentation links to use doc link service instead of hardcoded URLs  (#212051)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/fleet_integration/apm_policy_form/settings_definition/tail_sampling_settings.test.tsx
@@ -4,12 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { docLinksServiceMock } from '@kbn/core/public/mocks';
 import { getTailSamplingSettings, isTailBasedSamplingValid } from './tail_sampling_settings';
 
-const DOCS_LINK =
-  'https://www.elastic.co/guide/en/apm/guide/master/configure-tail-based-sampling.html';
-
 describe('tail_sampling_settings - isTailBasedSamplingFormValid', () => {
+  const docLinks = docLinksServiceMock.createStartContract();
+  const DOCS_LINK = docLinks.links.apm.tailSamplingPolicies;
+
   it('return true when tail_sampling_interval is greater than 1s', () => {
     const settings = getTailSamplingSettings(DOCS_LINK);
     const isValid = isTailBasedSamplingValid(

--- a/x-pack/solutions/observability/plugins/profiling/public/views/add_data_view/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/add_data_view/index.tsx
@@ -68,6 +68,7 @@ export function AddDataView() {
     services: { setupDataCollectionInstructions },
     start: { core },
   } = useProfilingDependencies();
+  const { docLinks } = core;
 
   const { data, status } = useAsync(
     ({ http }) => {
@@ -410,7 +411,7 @@ EOF`}
                     <EuiLink
                       data-test-subj="profilingAddDataViewInstructionsHereLink"
                       target="_blank"
-                      href={`https://www.elastic.co/guide/en/kibana/master/api-keys.html`}
+                      href={docLinks.links.management.apiKeys}
                     >
                       {i18n.translate('xpack.profiling.tabs.symbols.step2.instructions', {
                         defaultMessage: 'Instructions here',
@@ -455,7 +456,7 @@ EOF`}
                             <EuiLink
                               data-test-subj="profilingAddDataViewTheCorrespondingDocumentationPageLink"
                               target="_blank"
-                              href={`${core.docLinks.ELASTIC_WEBSITE_URL}/guide/en/observability/${core.docLinks.DOC_LINK_VERSION}/profiling-add-symbols.html`}
+                              href={`${docLinks.ELASTIC_WEBSITE_URL}/guide/en/observability/${docLinks.DOC_LINK_VERSION}/profiling-add-symbols.html`}
                             >
                               {i18n.translate('xpack.profiling.tabs.symbols.step3.doc-ref.link', {
                                 defaultMessage: 'the corresponding documentation page',
@@ -475,8 +476,9 @@ EOF`}
     ],
     [
       collectionAgentHost,
-      core.docLinks.DOC_LINK_VERSION,
-      core.docLinks.ELASTIC_WEBSITE_URL,
+      docLinks.DOC_LINK_VERSION,
+      docLinks.ELASTIC_WEBSITE_URL,
+      docLinks.links.management.apiKeys,
       core.http.basePath,
       data?.profilerAgent.version,
       majorVersion,
@@ -593,7 +595,7 @@ EOF`}
                     <EuiLink
                       data-test-subj="profilingAddDataViewAdvancedConfigurationLink"
                       target="_blank"
-                      href={`${core.docLinks.ELASTIC_WEBSITE_URL}/guide/en/observability/${core.docLinks.DOC_LINK_VERSION}/profiling-advanced-configuration.html`}
+                      href={`${docLinks.ELASTIC_WEBSITE_URL}/guide/en/observability/${docLinks.DOC_LINK_VERSION}/profiling-advanced-configuration.html`}
                     >
                       {i18n.translate('xpack.profiling.tabs.debWarning.advancedLink', {
                         defaultMessage: 'Advanced configuration',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ObsUX][APM][Profiling] Update documentation links to use doc link service instead of hardcoded URLs  (#212051)](https://github.com/elastic/kibana/pull/212051)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-02-21T14:52:40Z","message":"[ObsUX][APM][Profiling] Update documentation links to use doc link service instead of hardcoded URLs  (#212051)\n\n## Summary\n\nCloses #208895\n\nThis PR updates documentation links to use the doc link service, to\navoid hardcoding URLs","sha":"6a6f0e70b3e91162d30e2ad190d8dea5eb36c263","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","apm","backport:prev-minor","Team:obs-ux-infra_services","Feature:UniversalProfiling","v9.1.0"],"title":"[ObsUX][APM][Profiling] Update documentation links to use doc link service instead of hardcoded URLs ","number":212051,"url":"https://github.com/elastic/kibana/pull/212051","mergeCommit":{"message":"[ObsUX][APM][Profiling] Update documentation links to use doc link service instead of hardcoded URLs  (#212051)\n\n## Summary\n\nCloses #208895\n\nThis PR updates documentation links to use the doc link service, to\navoid hardcoding URLs","sha":"6a6f0e70b3e91162d30e2ad190d8dea5eb36c263"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212051","number":212051,"mergeCommit":{"message":"[ObsUX][APM][Profiling] Update documentation links to use doc link service instead of hardcoded URLs  (#212051)\n\n## Summary\n\nCloses #208895\n\nThis PR updates documentation links to use the doc link service, to\navoid hardcoding URLs","sha":"6a6f0e70b3e91162d30e2ad190d8dea5eb36c263"}}]}] BACKPORT-->