### PR TITLE
[Logs UI] Fix log view loading states

### DIFF
--- a/x-pack/platform/plugins/shared/logs_shared/public/hooks/use_log_view.ts
+++ b/x-pack/platform/plugins/shared/logs_shared/public/hooks/use_log_view.ts
@@ -117,8 +117,9 @@ export const useLogView = ({
   const isLoading =
     isLoadingLogView || isResolvingLogView || isLoadingLogViewStatus || isUpdatingLogView;
 
-  const isUninitialized = useSelector(logViewStateService, (state) =>
-    state.matches('uninitialized')
+  const isUninitialized = useSelector(
+    logViewStateService,
+    (state) => state.matches('uninitialized') || state.matches('initializingFromUrl')
   );
 
   const hasFailedLoadingLogView = useSelector(logViewStateService, (state) =>

--- a/x-pack/platform/plugins/shared/logs_shared/public/observability_logs/log_view_state/src/types.ts
+++ b/x-pack/platform/plugins/shared/logs_shared/public/observability_logs/log_view_state/src/types.ts
@@ -46,6 +46,10 @@ export type LogViewTypestate =
       context: LogViewContextWithReference;
     }
   | {
+      value: 'initializingFromUrl';
+      context: LogViewContextWithReference;
+    }
+  | {
       value: 'resolving';
       context: LogViewContextWithReference & LogViewContextWithLogView;
     }


### PR DESCRIPTION
## :memo: Summary

This fixes a problem with the log view resolution when entering the log settings page under certain conditions.

fixes: https://github.com/elastic/kibana/issues/212004

## :female_detective: Review notes

There was a mismatch between the selectors in the `useLogView` hook and the state machine it consumes.That caused it to not correctly recognize a loading state when the Kibana url state storage was in a specific state. The reproduction steps in the bug report can be used to bring it into that state.