### PR TITLE
[Security Solution][PoC] AI 4 SOC navigation

### DIFF
--- a/x-pack/solutions/security/packages/features/src/notes/kibana_features.ts
+++ b/x-pack/solutions/security/packages/features/src/notes/kibana_features.ts
@@ -36,8 +36,8 @@ export const getNotesBaseKibanaFeature = (
         all: params.savedObjects,
         read: params.savedObjects,
       },
-      ui: ['read', 'crud'],
-      api: ['notes_read', 'notes_write'],
+      ui: [],
+      api: [],
     },
     read: {
       app: [NOTES_FEATURE_ID, 'kibana'],
@@ -46,8 +46,8 @@ export const getNotesBaseKibanaFeature = (
         all: [],
         read: params.savedObjects,
       },
-      ui: ['read'],
-      api: ['notes_read'],
+      ui: [],
+      api: [],
     },
   },
 });

--- a/x-pack/solutions/security/packages/features/src/product_features_keys.ts
+++ b/x-pack/solutions/security/packages/features/src/product_features_keys.ts
@@ -6,6 +6,10 @@
  */
 
 export enum ProductFeatureSecurityKey {
+  /** Enables Detections workflows, with rules and alerts management */
+  detections = 'detections',
+  /** Enables Security dashboards */
+  dashboards = 'dashboards',
   /** Enables Advanced Insights (Entity Risk, GenAI) */
   advancedInsights = 'advanced_insights',
   /**

--- a/x-pack/solutions/security/packages/features/src/security/product_feature_config.ts
+++ b/x-pack/solutions/security/packages/features/src/security/product_feature_config.ts
@@ -20,6 +20,24 @@ import type { DefaultSecurityProductFeaturesConfig } from './types';
  * - `subFeaturesPrivileges`: the privileges that will be added into the existing Security subFeature with the privilege `id` specified.
  */
 export const securityDefaultProductFeaturesConfig: DefaultSecurityProductFeaturesConfig = {
+  [ProductFeatureSecurityKey.dashboards]: {
+    privileges: {
+      all: { ui: ['dashboards'] },
+      read: { ui: ['dashboards'] },
+    },
+  },
+  [ProductFeatureSecurityKey.detections]: {
+    privileges: {
+      all: {
+        ui: ['rules', 'alerts', 'explore'],
+        api: [`${APP_ID}-detections`], // TODO: add detections API action `authz`
+      },
+      read: {
+        ui: ['rules', 'alerts', 'explore'],
+        api: [`${APP_ID}-detections`], // TODO: add detections API action `authz`
+      },
+    },
+  },
   [ProductFeatureSecurityKey.advancedInsights]: {
     privileges: {
       all: {

--- a/x-pack/solutions/security/packages/features/src/timeline/kibana_features.ts
+++ b/x-pack/solutions/security/packages/features/src/timeline/kibana_features.ts
@@ -36,8 +36,8 @@ export const getTimelineBaseKibanaFeature = (
         all: params.savedObjects,
         read: params.savedObjects,
       },
-      ui: ['read', 'crud'],
-      api: ['timeline_read', 'timeline_write'],
+      ui: [],
+      api: [],
     },
     read: {
       app: [TIMELINE_FEATURE_ID, 'kibana'],
@@ -46,8 +46,8 @@ export const getTimelineBaseKibanaFeature = (
         all: [],
         read: params.savedObjects,
       },
-      ui: ['read'],
-      api: ['timeline_read'],
+      ui: [],
+      api: [],
     },
   },
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/links/sections/investigations_links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/links/sections/investigations_links.ts
@@ -6,8 +6,11 @@
  */
 
 import { ExternalPageName, SecurityPageName } from '@kbn/security-solution-navigation';
-import { INVESTIGATIONS_PATH } from '../../../../../common/constants';
-import { SECURITY_FEATURE_ID } from '../../../../../common';
+import {
+  INVESTIGATIONS_PATH,
+  NOTES_FEATURE_ID,
+  TIMELINE_FEATURE_ID,
+} from '../../../../../common/constants';
 import type { LinkItem } from '../../../../common/links/types';
 import type { SolutionNavLink } from '../../../../common/links';
 import { IconOsqueryLazy, IconTimelineLazy } from './lazy_icons';
@@ -18,7 +21,7 @@ const investigationsAppLink: LinkItem = {
   id: SecurityPageName.investigations,
   title: i18n.INVESTIGATIONS_TITLE,
   path: INVESTIGATIONS_PATH,
-  capabilities: [`${SECURITY_FEATURE_ID}.show`],
+  capabilities: [`${TIMELINE_FEATURE_ID}.read`, `${NOTES_FEATURE_ID}.read`],
   hideTimeline: true,
   skipUrlState: true,
   links: [], // timeline and note links are added via the methods below

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/links.ts
@@ -31,7 +31,7 @@ export const dashboardsLinks: LinkItem = {
   title: DASHBOARDS,
   path: DASHBOARDS_PATH,
   globalNavPosition: 1,
-  capabilities: [`${SECURITY_FEATURE_ID}.show`],
+  capabilities: [[`${SECURITY_FEATURE_ID}.show`, `${SECURITY_FEATURE_ID}.dashboards`]],
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.dashboards', {
       defaultMessage: 'Dashboards',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/links.ts
@@ -13,7 +13,7 @@ export const links: LinkItem = {
   id: SecurityPageName.alerts,
   title: ALERTS,
   path: ALERTS_PATH,
-  capabilities: [`${SECURITY_FEATURE_ID}.show`],
+  capabilities: [[`${SECURITY_FEATURE_ID}.show`, `${SECURITY_FEATURE_ID}.alerts`]],
   globalNavPosition: 3,
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.alerts', {

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/links.ts
@@ -209,7 +209,7 @@ export const exploreLinks: LinkItem = {
   title: EXPLORE,
   path: EXPLORE_PATH,
   globalNavPosition: 9,
-  capabilities: [`${SECURITY_FEATURE_ID}.show`],
+  capabilities: [[`${SECURITY_FEATURE_ID}.show`, `${SECURITY_FEATURE_ID}.explore`]],
   globalSearchKeywords: [
     i18n.translate('xpack.securitySolution.appLinks.explore', {
       defaultMessage: 'Explore',

--- a/x-pack/solutions/security/plugins/security_solution/public/rules/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/rules/links.ts
@@ -38,7 +38,7 @@ export const links: LinkItem = {
   hideTimeline: true,
   skipUrlState: true,
   globalNavPosition: 2,
-  capabilities: [`${SECURITY_FEATURE_ID}.show`],
+  capabilities: [[`${SECURITY_FEATURE_ID}.show`, `${SECURITY_FEATURE_ID}.rules`]],
   links: [
     {
       id: SecurityPageName.rules,

--- a/x-pack/solutions/security/plugins/security_solution_serverless/common/config.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/common/config.ts
@@ -10,6 +10,7 @@ import { ProductLine, ProductTier } from './product';
 
 export const productLine = schema.oneOf([
   schema.literal(ProductLine.security),
+  schema.literal(ProductLine.ai),
   schema.literal(ProductLine.endpoint),
   schema.literal(ProductLine.cloud),
 ]);

--- a/x-pack/solutions/security/plugins/security_solution_serverless/common/pli/pli_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/common/pli/pli_config.ts
@@ -16,6 +16,10 @@ type PliProductFeatures = Readonly<
 export const PLI_PRODUCT_FEATURES: PliProductFeatures = {
   security: {
     essentials: [
+      ProductFeatureKey.dashboards,
+      ProductFeatureKey.detections,
+      ProductFeatureKey.timeline,
+      ProductFeatureKey.notes,
       ProductFeatureKey.endpointHostManagement,
       ProductFeatureKey.endpointPolicyManagement,
     ],
@@ -51,6 +55,16 @@ export const PLI_PRODUCT_FEATURES: PliProductFeatures = {
   },
   cloud: {
     essentials: [ProductFeatureKey.cloudSecurityPosture],
+    complete: [],
+  },
+  ai: {
+    // Not split into essentials and complete, using essentials for now
+    essentials: [
+      // I am guessing here
+      ProductFeatureKey.attackDiscovery,
+      ProductFeatureKey.assistant,
+      ProductFeatureKey.threatIntelligence,
+    ],
     complete: [],
   },
 } as const;

--- a/x-pack/solutions/security/plugins/security_solution_serverless/common/product.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/common/product.ts
@@ -7,6 +7,7 @@
 
 export enum ProductLine {
   security = 'security',
+  ai = 'ai',
   endpoint = 'endpoint',
   cloud = 'cloud',
 }

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_soc_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_soc_navigation.ts
@@ -27,7 +27,7 @@ export const shouldUseAINavigation = (productTypes: SecurityProductTypes) => {
 // The navigation tree received by parameter is generated at: x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/navigation_tree.ts
 // An example of static navigation tree: x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
 // This is a temporary solution until the "classic" navigation is deprecated and the "generated" navigationTree is replaced by a static navigationTree (probably multiple of them).
-export const applySocNavigation = (
+export const applyAiSocNavigation = (
   draft: WritableDraft<NavigationTreeDefinition<AppDeepLinkId>>
 ): void => {
   const group = draft.body[0] as WritableDraft<GroupDefinition<AppDeepLinkId, string, string>>;
@@ -57,6 +57,6 @@ export const applySocNavigation = (
       defaultIsCollapsed: false,
       isCollapsible: false,
     };
-    draft.body.push(aiGroup);
+    draft.body = [aiGroup];
   }
 };

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_soc_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_soc_navigation.ts
@@ -57,6 +57,6 @@ export const applyAiSocNavigation = (
       defaultIsCollapsed: false,
       isCollapsible: false,
     };
-    draft.body = [aiGroup];
+    draft.body.push(aiGroup);
   }
 };

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/index.ts
@@ -6,15 +6,16 @@
  */
 
 import { APP_PATH } from '@kbn/security-solution-plugin/common';
+import type { SecurityProductTypes } from '../../common/config';
 import type { Services } from '../common/services';
 import { subscribeBreadcrumbs } from './breadcrumbs';
 import { initSideNavigation } from './side_navigation';
 import { enableManagementCardsLanding } from './management_cards';
 
-export const startNavigation = (services: Services) => {
+export const startNavigation = (services: Services, productTypes: SecurityProductTypes) => {
   services.serverless.setProjectHome(APP_PATH);
 
-  initSideNavigation(services);
+  initSideNavigation(services, productTypes);
   enableManagementCardsLanding(services);
   subscribeBreadcrumbs(services);
 };

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/side_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/side_navigation.ts
@@ -11,7 +11,7 @@ import produce from 'immer';
 import { map } from 'rxjs';
 import type { SecurityProductTypes } from '../../common/config';
 import { type Services } from '../common/services';
-import { applySocNavigation, shouldUseAINavigation } from './soc_navigation';
+import { applyAiSocNavigation, shouldUseAINavigation } from './ai_soc_navigation';
 
 const PROJECT_SETTINGS_TITLE = i18n.translate(
   'xpack.securitySolutionServerless.navLinks.projectSettings.title',
@@ -49,7 +49,7 @@ export const initSideNavigation = async (
         }
 
         if (showAINavigation) {
-          applySocNavigation(draft);
+          applyAiSocNavigation(draft);
         }
       })
     )

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/side_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/side_navigation.ts
@@ -9,15 +9,21 @@ import { i18n } from '@kbn/i18n';
 import type { AppDeepLinkId, GroupDefinition, NodeDefinition } from '@kbn/core-chrome-browser';
 import produce from 'immer';
 import { map } from 'rxjs';
+import type { SecurityProductTypes } from '../../common/config';
 import { type Services } from '../common/services';
+import { applySocNavigation, shouldUseAINavigation } from './soc_navigation';
 
 const PROJECT_SETTINGS_TITLE = i18n.translate(
   'xpack.securitySolutionServerless.navLinks.projectSettings.title',
   { defaultMessage: 'Project Settings' }
 );
 
-export const initSideNavigation = async (services: Services) => {
+export const initSideNavigation = async (
+  services: Services,
+  productTypes: SecurityProductTypes
+) => {
   services.securitySolution.setIsSolutionNavigationEnabled(true);
+  const showAINavigation = shouldUseAINavigation(productTypes);
 
   const { navigationTree$, panelContentProvider } =
     await services.securitySolution.getSolutionNavigation();
@@ -40,6 +46,10 @@ export const initSideNavigation = async (services: Services) => {
         if (footerGroup) {
           footerGroup.title = PROJECT_SETTINGS_TITLE;
           footerGroup.children.push({ cloudLink: 'billingAndSub', openInNewTab: true });
+        }
+
+        if (showAINavigation) {
+          applySocNavigation(draft);
         }
       })
     )

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/soc_navigation.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/soc_navigation.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  AppDeepLinkId,
+  GroupDefinition,
+  NavigationTreeDefinition,
+  NodeDefinition,
+} from '@kbn/core-chrome-browser';
+
+import type { WritableDraft } from 'immer/dist/internal';
+import { AssistantIcon } from '@kbn/ai-assistant-icon';
+import { remove } from 'lodash';
+import { SecurityPageName } from '@kbn/deeplinks-security';
+import { ProductLine } from '../../common/product';
+import type { SecurityProductTypes } from '../../common/config';
+
+export const shouldUseAINavigation = (productTypes: SecurityProductTypes) => {
+  return productTypes.some((productType) => productType.product_line === ProductLine.ai);
+};
+
+// Apply AI for SOC navigation tree changes.
+// The navigation tree received by parameter is generated at: x-pack/solutions/security/plugins/security_solution/public/app/solution_navigation/navigation_tree.ts
+// An example of static navigation tree: x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
+// This is a temporary solution until the "classic" navigation is deprecated and the "generated" navigationTree is replaced by a static navigationTree (probably multiple of them).
+export const applySocNavigation = (
+  draft: WritableDraft<NavigationTreeDefinition<AppDeepLinkId>>
+): void => {
+  const group = draft.body[0] as WritableDraft<GroupDefinition<AppDeepLinkId, string, string>>;
+  const [attachDiscovery] = group.children.reduce<Array<NodeDefinition<AppDeepLinkId>>>(
+    (nodes, category) => {
+      const [attachDiscoveryNode] = remove(category.children ?? [], {
+        id: SecurityPageName.attackDiscovery,
+      });
+      if (attachDiscoveryNode) {
+        nodes.push(attachDiscoveryNode);
+      }
+      return nodes;
+    },
+    []
+  );
+
+  if (attachDiscovery) {
+    group.appendHorizontalRule = true; // does not seem to work :( talk with sharedUx team
+
+    const aiGroup: GroupDefinition<AppDeepLinkId, string, string> = {
+      type: 'navGroup',
+      id: 'security_solution_ai_nav',
+      title: 'AI for SOC',
+      icon: AssistantIcon,
+      children: [attachDiscovery],
+      breadcrumbStatus: 'hidden',
+      defaultIsCollapsed: false,
+      isCollapsible: false,
+    };
+    draft.body.push(aiGroup);
+  }
+};

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/plugin.ts
@@ -72,7 +72,7 @@ export class SecuritySolutionServerlessPlugin
     });
 
     setOnboardingSettings(services);
-    startNavigation(services);
+    startNavigation(services, productTypes);
 
     return {};
   }


### PR DESCRIPTION
## Summary

This is an example of navigation changes to implement the AI 4 SOC. 

It's built on top of existing functionalities (navigationTree, ProductFeatures, AppLinks configs, capabilities...). It does not require any modification of existing frameworks.

![Screenshot](https://github.com/user-attachments/assets/fb563a87-bd83-4d4c-9c4d-1c25a55d5dec)

> [!NOTE]  
> When the _classic_ navigation is deprecated we won't need to support both config formats, so we'll be able to clean and simplify the navigation links infrastructure. For now, we need to stay compatible, this is a simple way to accomplish the goal without major changes. When we do the refactor we will be able to create a static nav tree for "AI 4 SOC".

### Test:

in your `config/serverless.security.dev.yml`:
```yml
xpack.securitySolutionServerless.productTypes:
  [
    # { product_line: 'security', product_tier: 'complete' },
    { product_line: 'ai', product_tier: 'essentials' },
    # { product_line: 'endpoint', product_tier: 'complete' },
    # { product_line: 'cloud', product_tier: 'complete' },
  ]
```

### Important parts:

#### Left nav links

The `applyAiSocNavigation` is where we update the `navigationTree` only when the `productLevel.ai` is enabled. Here we can make any modifications to the tree:

https://github.com/elastic/kibana/blob/ea0fcacdb950bbad563b332fb95439a528454855/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_soc_navigation.ts#L30-L62

#### Disable links

With the current approach, the easiest way to make links inaccessible (left nav, global search, direct URL access...) it to use the `capabilities` property of the links, and add the capabilities conditionally for the ProductFeature, creating new if necessary.

I implemented the example for `rules`, `alerts`, `explore`, `dashboards`, `timeline`, and `notes`. 
