### PR TITLE
[8.18] [Discover] [Embeddable] Fix Discover session embeddable drilldown (#211678)

### DIFF
--- a/src/platform/plugins/shared/discover/kibana.jsonc
+++ b/src/platform/plugins/shared/discover/kibana.jsonc
@@ -47,7 +47,8 @@
       "observabilityAIAssistant",
       "aiops",
       "fieldsMetadata",
-      "logsDataAccess"
+      "logsDataAccess",
+      "embeddableEnhanced"
     ],
     "requiredBundles": [
       "kibanaUtils",

--- a/src/platform/plugins/shared/discover/public/build_services.ts
+++ b/src/platform/plugins/shared/discover/public/build_services.ts
@@ -62,6 +62,7 @@ import type { DataVisualizerPluginStart } from '@kbn/data-visualizer-plugin/publ
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
 import { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
+import type { EmbeddableEnhancedPluginStart } from '@kbn/embeddable-enhanced-plugin/public';
 import type { DiscoverStartPlugins } from './types';
 import type { DiscoverContextAppLocator } from './application/context/services/locator';
 import type { DiscoverSingleDocLocator } from './application/doc/locator';
@@ -140,6 +141,7 @@ export interface DiscoverServices {
   ebtManager: DiscoverEBTManager;
   fieldsMetadata?: FieldsMetadataPublicStart;
   logsDataAccess?: LogsDataAccessPluginStart;
+  embeddableEnhanced?: EmbeddableEnhancedPluginStart;
 }
 
 export const buildServices = memoize(
@@ -233,6 +235,7 @@ export const buildServices = memoize(
       ebtManager,
       fieldsMetadata: plugins.fieldsMetadata,
       logsDataAccess: plugins.logsDataAccess,
+      embeddableEnhanced: plugins.embeddableEnhanced,
     };
   }
 );

--- a/src/platform/plugins/shared/discover/public/embeddable/constants.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/constants.ts
@@ -7,8 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { SavedSearchAttributes } from '@kbn/saved-search-plugin/common';
+import type { SavedSearchAttributes } from '@kbn/saved-search-plugin/common';
 import type { Trigger } from '@kbn/ui-actions-plugin/public';
+import type { SearchEmbeddableSerializedState } from './types';
 
 export { SEARCH_EMBEDDABLE_TYPE } from '@kbn/discover-utils';
 
@@ -37,9 +38,10 @@ export const EDITABLE_SAVED_SEARCH_KEYS: Readonly<Array<keyof SavedSearchAttribu
 ] as const;
 
 /** This constant refers to the dashboard panel specific state */
-export const EDITABLE_PANEL_KEYS = [
+export const EDITABLE_PANEL_KEYS: Readonly<Array<keyof SearchEmbeddableSerializedState>> = [
   'title', // panel title
   'description', // panel description
   'timeRange', // panel custom time range
   'hidePanelTitles', // panel hidden title
+  'enhancements', // panel enhancements (e.g. drilldowns)
 ] as const;

--- a/src/platform/plugins/shared/discover/public/embeddable/types.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/types.ts
@@ -7,13 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { DataTableRecord } from '@kbn/discover-utils/types';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type { DefaultEmbeddableApi } from '@kbn/embeddable-plugin/public';
-import { HasInspectorAdapters } from '@kbn/inspector-plugin/public';
-import {
+import type { HasInspectorAdapters } from '@kbn/inspector-plugin/public';
+import type {
   EmbeddableApiContext,
   HasEditCapabilities,
   HasLibraryTransforms,
+  HasSupportedTriggers,
   PublishesBlockingError,
   PublishesDataLoading,
   PublishesSavedObjectId,
@@ -23,15 +24,17 @@ import {
   SerializedTimeRange,
   SerializedTitles,
 } from '@kbn/presentation-publishing';
-import {
+import type {
   SavedSearch,
   SavedSearchAttributes,
   SerializableSavedSearch,
 } from '@kbn/saved-search-plugin/common/types';
-import { DataTableColumnsMeta } from '@kbn/unified-data-table';
-import { BehaviorSubject } from 'rxjs';
-import { PublishesWritableDataViews } from '@kbn/presentation-publishing/interfaces/publishes_data_views';
-import { EDITABLE_SAVED_SEARCH_KEYS } from './constants';
+import type { DataTableColumnsMeta } from '@kbn/unified-data-table';
+import type { BehaviorSubject } from 'rxjs';
+import type { PublishesWritableDataViews } from '@kbn/presentation-publishing/interfaces/publishes_data_views';
+import type { DynamicActionsSerializedState } from '@kbn/embeddable-enhanced-plugin/public/plugin';
+import type { HasDynamicActions } from '@kbn/embeddable-enhanced-plugin/public';
+import type { EDITABLE_SAVED_SEARCH_KEYS } from './constants';
 
 export type SearchEmbeddableState = Pick<
   SerializableSavedSearch,
@@ -75,6 +78,7 @@ export type EditableSavedSearchAttributes = Partial<
 
 export type SearchEmbeddableSerializedState = SerializedTitles &
   SerializedTimeRange &
+  Partial<DynamicActionsSerializedState> &
   EditableSavedSearchAttributes & {
     // by value
     attributes?: SavedSearchAttributes & { references: SavedSearch['references'] };
@@ -85,7 +89,8 @@ export type SearchEmbeddableSerializedState = SerializedTitles &
 
 export type SearchEmbeddableRuntimeState = SearchEmbeddableSerializedAttributes &
   SerializedTitles &
-  SerializedTimeRange & {
+  SerializedTimeRange &
+  Partial<DynamicActionsSerializedState> & {
     rawSavedObjectAttributes?: EditableSavedSearchAttributes;
     savedObjectTitle?: string;
     savedObjectId?: string;
@@ -107,7 +112,9 @@ export type SearchEmbeddableApi = DefaultEmbeddableApi<
   HasLibraryTransforms &
   HasTimeRange &
   HasInspectorAdapters &
-  Partial<HasEditCapabilities & PublishesSavedObjectId>;
+  Partial<HasEditCapabilities & PublishesSavedObjectId> &
+  HasDynamicActions &
+  HasSupportedTriggers;
 
 export interface PublishesSavedSearch {
   savedSearch$: PublishingSubject<SavedSearch>;

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.test.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.test.ts
@@ -121,6 +121,7 @@ describe('Serialization utils', () => {
         savedSearch,
         serializeTitles: jest.fn(),
         serializeTimeRange: jest.fn(),
+        serializeDynamicActions: jest.fn(),
       });
 
       expect(serializedState).toEqual({
@@ -156,6 +157,7 @@ describe('Serialization utils', () => {
           savedSearch,
           serializeTitles: jest.fn(),
           serializeTimeRange: jest.fn(),
+          serializeDynamicActions: jest.fn(),
           savedObjectId: 'test-id',
         });
 
@@ -176,6 +178,7 @@ describe('Serialization utils', () => {
           savedSearch: { ...savedSearch, sampleSize: 500, sort: [['order_date', 'asc']] },
           serializeTitles: jest.fn(),
           serializeTimeRange: jest.fn(),
+          serializeDynamicActions: jest.fn(),
           savedObjectId: 'test-id',
         });
 

--- a/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.ts
+++ b/src/platform/plugins/shared/discover/public/embeddable/utils/serialization_utils.ts
@@ -23,6 +23,7 @@ import {
 } from '@kbn/saved-search-plugin/common';
 import { SavedSearchUnwrapResult } from '@kbn/saved-search-plugin/public';
 
+import type { DynamicActionsSerializedState } from '@kbn/embeddable-enhanced-plugin/public/plugin';
 import { extract, inject } from '../../../common/embeddable/search_inject_extract';
 import { DiscoverServices } from '../../build_services';
 import {
@@ -85,6 +86,7 @@ export const serializeState = ({
   savedSearch,
   serializeTitles,
   serializeTimeRange,
+  serializeDynamicActions,
   savedObjectId,
 }: {
   uuid: string;
@@ -92,6 +94,7 @@ export const serializeState = ({
   savedSearch: SavedSearch;
   serializeTitles: () => SerializedTitles;
   serializeTimeRange: () => SerializedTimeRange;
+  serializeDynamicActions: (() => DynamicActionsSerializedState) | undefined;
   savedObjectId?: string;
 }): SerializedPanelState<SearchEmbeddableSerializedState> => {
   const searchSource = savedSearch.searchSource;
@@ -115,6 +118,7 @@ export const serializeState = ({
         // Serialize the current dashboard state into the panel state **without** updating the saved object
         ...serializeTitles(),
         ...serializeTimeRange(),
+        ...serializeDynamicActions?.(),
         ...overwriteState,
       },
       // No references to extract for by-reference embeddable since all references are stored with by-reference saved object

--- a/src/platform/plugins/shared/discover/public/types.ts
+++ b/src/platform/plugins/shared/discover/public/types.ts
@@ -43,6 +43,7 @@ import type { DataVisualizerPluginStart } from '@kbn/data-visualizer-plugin/publ
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
 import { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
+import type { EmbeddableEnhancedPluginStart } from '@kbn/embeddable-enhanced-plugin/public';
 import { DiscoverAppLocator } from '../common';
 import { DiscoverCustomizationContext } from './customizations';
 import { type DiscoverContainerProps } from './components/discover_container';
@@ -174,4 +175,5 @@ export interface DiscoverStartPlugins {
   unifiedSearch: UnifiedSearchPublicPluginStart;
   urlForwarding: UrlForwardingStart;
   usageCollection?: UsageCollectionSetup;
+  embeddableEnhanced?: EmbeddableEnhancedPluginStart;
 }

--- a/src/platform/plugins/shared/discover/tsconfig.json
+++ b/src/platform/plugins/shared/discover/tsconfig.json
@@ -99,7 +99,8 @@
     "@kbn/discover-contextual-components",
     "@kbn/esql-ast",
     "@kbn/discover-shared-plugin",
-    "@kbn/ui-theme"
+    "@kbn/ui-theme",
+    "@kbn/embeddable-enhanced-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/test/functional/services/dashboard/drilldowns_manage.ts
+++ b/test/functional/services/dashboard/drilldowns_manage.ts
@@ -78,7 +78,11 @@ export function DashboardDrilldownsManageProvider({ getService }: FtrProviderCon
     }: {
       drilldownName: string;
       destinationURLTemplate: string;
-      trigger: 'VALUE_CLICK_TRIGGER' | 'SELECT_RANGE_TRIGGER' | 'IMAGE_CLICK_TRIGGER';
+      trigger:
+        | 'VALUE_CLICK_TRIGGER'
+        | 'SELECT_RANGE_TRIGGER'
+        | 'IMAGE_CLICK_TRIGGER'
+        | 'CONTEXT_MENU_TRIGGER';
     }) {
       await this.fillInDrilldownName(drilldownName);
       await this.selectTriggerIfNeeded(trigger);
@@ -94,7 +98,11 @@ export function DashboardDrilldownsManageProvider({ getService }: FtrProviderCon
     }
 
     async selectTriggerIfNeeded(
-      trigger: 'VALUE_CLICK_TRIGGER' | 'SELECT_RANGE_TRIGGER' | 'IMAGE_CLICK_TRIGGER'
+      trigger:
+        | 'VALUE_CLICK_TRIGGER'
+        | 'SELECT_RANGE_TRIGGER'
+        | 'IMAGE_CLICK_TRIGGER'
+        | 'CONTEXT_MENU_TRIGGER'
     ) {
       if (await testSubjects.exists(`triggerPicker`)) {
         const container = await testSubjects.find(`triggerPicker-${trigger}`);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Discover] [Embeddable] Fix Discover session embeddable drilldown (#211678)](https://github.com/elastic/kibana/pull/211678)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2025-02-21T17:26:22Z","message":"[Discover] [Embeddable] Fix Discover session embeddable drilldown (#211678)\n\n## Summary\n\nThis PR re-adds drilldown support to the Discover session embeddable\nafter it was accidentally removed during the refactoring in #180536\n(related PR where drilldowns / dynamic actions were refactored:\n#178896). A new functional test has also been added to prevent future\nregressions.\n\nFixes #211677.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Matthias Wilhelm <matthias.wilhelm@elastic.co>","sha":"257971d4c0f99c0da56b9b817cff731977f8891f","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:fix","Team:DataDiscovery","backport:prev-major","v9.1.0"],"title":"[Discover] [Embeddable] Fix Discover session embeddable drilldown","number":211678,"url":"https://github.com/elastic/kibana/pull/211678","mergeCommit":{"message":"[Discover] [Embeddable] Fix Discover session embeddable drilldown (#211678)\n\n## Summary\n\nThis PR re-adds drilldown support to the Discover session embeddable\nafter it was accidentally removed during the refactoring in #180536\n(related PR where drilldowns / dynamic actions were refactored:\n#178896). A new functional test has also been added to prevent future\nregressions.\n\nFixes #211677.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Matthias Wilhelm <matthias.wilhelm@elastic.co>","sha":"257971d4c0f99c0da56b9b817cff731977f8891f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211678","number":211678,"mergeCommit":{"message":"[Discover] [Embeddable] Fix Discover session embeddable drilldown (#211678)\n\n## Summary\n\nThis PR re-adds drilldown support to the Discover session embeddable\nafter it was accidentally removed during the refactoring in #180536\n(related PR where drilldowns / dynamic actions were refactored:\n#178896). A new functional test has also been added to prevent future\nregressions.\n\nFixes #211677.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Matthias Wilhelm <matthias.wilhelm@elastic.co>","sha":"257971d4c0f99c0da56b9b817cff731977f8891f"}},{"url":"https://github.com/elastic/kibana/pull/212142","number":212142,"branch":"8.17","state":"OPEN"}]}] BACKPORT-->