### PR TITLE
[8.16] [UII] Drop ssl field from output if it's in an invalid format (#211848)

### DIFF
--- a/x-pack/plugins/fleet/server/services/output.ts
+++ b/x-pack/plugins/fleet/server/services/output.ts
@@ -119,13 +119,21 @@ export function outputIdToUuid(id: string) {
   return uuidv5(id, uuidv5.DNS);
 }
 
-function outputSavedObjectToOutput(so: SavedObject<OutputSOAttributes>): Output {
+export function outputSavedObjectToOutput(so: SavedObject<OutputSOAttributes>): Output {
+  const logger = appContextService.getLogger();
   const { output_id: outputId, ssl, proxy_id: proxyId, ...atributes } = so.attributes;
 
+  let parsedSsl;
+  try {
+    parsedSsl = typeof ssl === 'string' ? JSON.parse(ssl) : undefined;
+  } catch (e) {
+    logger.warn(`Unable to parse ssl for output ${so.id}: ${e.message}`);
+    logger.warn(`ssl value: ${ssl}`);
+  }
   return {
     id: outputId ?? so.id,
     ...atributes,
-    ...(ssl ? { ssl: JSON.parse(ssl as string) } : {}),
+    ...(parsedSsl ? { ssl: parsedSsl } : {}),
     ...(proxyId ? { proxy_id: proxyId } : {}),
   };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[UII] Drop ssl field from output if it's in an invalid format (#211848)](https://github.com/elastic/kibana/pull/211848)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jen Huang","email":"its.jenetic@gmail.com"},"sourceCommit":{"committedDate":"2025-02-21T08:52:17Z","message":"[UII] Drop ssl field from output if it's in an invalid format (#211848)\n\n## Summary\n\nReported in https://github.com/elastic/sdh-beats/issues/5676. When\nretrieving outputs information, drop the `ssl` field if it's in an\ninvalid format (causing `JSON.parse` to fail).\n\nThis can happen for ES output with `ssl` field set via API, and then\nsubsequently editing it from the UI (ES output `ssl` fields are\ncurrently unsupported, soon to be supported by\nhttps://github.com/elastic/kibana/issues/207326.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0c932fd4aba794767bf2298911e0f2e2ec2bffb3","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","backport:prev-major","v8.18.0","v9.1.0","v8.19.0"],"title":"[UII] Drop ssl field from output if it's in an invalid format","number":211848,"url":"https://github.com/elastic/kibana/pull/211848","mergeCommit":{"message":"[UII] Drop ssl field from output if it's in an invalid format (#211848)\n\n## Summary\n\nReported in https://github.com/elastic/sdh-beats/issues/5676. When\nretrieving outputs information, drop the `ssl` field if it's in an\ninvalid format (causing `JSON.parse` to fail).\n\nThis can happen for ES output with `ssl` field set via API, and then\nsubsequently editing it from the UI (ES output `ssl` fields are\ncurrently unsupported, soon to be supported by\nhttps://github.com/elastic/kibana/issues/207326.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0c932fd4aba794767bf2298911e0f2e2ec2bffb3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212015","number":212015,"state":"MERGED","mergeCommit":{"sha":"fc82a79ec2f0f6ad1d91c7a32f06822ebd7bf535","message":"[8.18] [UII] Drop ssl field from output if it's in an invalid format (#211848) (#212015)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[UII] Drop ssl field from output if it's in an invalid format\n(#211848)](https://github.com/elastic/kibana/pull/211848)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jen Huang <its.jenetic@gmail.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211848","number":211848,"mergeCommit":{"message":"[UII] Drop ssl field from output if it's in an invalid format (#211848)\n\n## Summary\n\nReported in https://github.com/elastic/sdh-beats/issues/5676. When\nretrieving outputs information, drop the `ssl` field if it's in an\ninvalid format (causing `JSON.parse` to fail).\n\nThis can happen for ES output with `ssl` field set via API, and then\nsubsequently editing it from the UI (ES output `ssl` fields are\ncurrently unsupported, soon to be supported by\nhttps://github.com/elastic/kibana/issues/207326.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0c932fd4aba794767bf2298911e0f2e2ec2bffb3"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212016","number":212016,"state":"MERGED","mergeCommit":{"sha":"26fe14935bc6c1be610057662c55f3b6bc0c2fde","message":"[8.x] [UII] Drop ssl field from output if it's in an invalid format (#211848) (#212016)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[UII] Drop ssl field from output if it's in an invalid format\n(#211848)](https://github.com/elastic/kibana/pull/211848)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jen Huang <its.jenetic@gmail.com>"}}]}] BACKPORT-->