### PR TITLE
[Docs] 7.17.28 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -13,6 +13,7 @@ Review important information about the {kib} 7.17.x releases.
 // Best practices:
 // * When there are changes to kibana.yml settings, include the links to the new settings.
 
+* <<release-notes-7.17.28>>
 * <<release-notes-7.17.27>>
 * <<release-notes-7.17.26>>
 * <<release-notes-7.17.25>>
@@ -97,6 +98,11 @@ Review important information about the {kib} 7.17.x releases.
 //* <<release-notes-7.0.0-alpha1>>
 
 --
+
+[[release-notes-7.17.28]]
+== {kib} 7.17.28
+
+There are no user-facing changes in the 7.17.28 release.
 
 [[release-notes-7.17.27]]
 == {kib} 7.17.27


### PR DESCRIPTION
## Summary

Adding 7.17.28 release notes. There were no user-facing changes.

Rel: [3024](https://github.com/elastic/dev/issues/3024)
Closes: [644](https://github.com/elastic/platform-docs-team/issues/644)