### PR TITLE
[DO NOT MERGE] - Combined performance changes

### DIFF
--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_items/field_items.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_items/field_items.tsx
@@ -17,7 +17,6 @@ import {
   EuiBadge,
   EuiScreenReaderOnly,
 } from '@elastic/eui';
-import { uniqBy } from 'lodash/fp';
 import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
 import { EcsFlat } from '@elastic/ecs';
 import { EcsMetadata } from '@kbn/alerts-as-data-utils/src/field_maps/types';
@@ -67,29 +66,35 @@ export const getFieldItemsData = ({
     selectedCategoryIds.length > 0 ? selectedCategoryIds : Object.keys(browserFields);
   const selectedFieldIds = new Set(columnIds);
 
-  const fieldItems = uniqBy(
-    'name',
-    categoryIds.reduce<BrowserFieldItem[]>((fieldItemsAcc, categoryId) => {
+  const getFieldItems = () => {
+    const fieldItemsAcc: BrowserFieldItem[] = [];
+    const fieldSeen: Map<string, boolean> = new Map();
+
+    for (let i = 0; i < categoryIds.length; i += 1) {
+      const categoryId = categoryIds[i];
       const categoryBrowserFields = Object.values(browserFields[categoryId]?.fields ?? {});
       if (categoryBrowserFields.length > 0) {
-        fieldItemsAcc.push(
-          ...categoryBrowserFields.map(({ name = '', ...field }) => {
-            return {
-              name,
-              type: field.type,
-              description: getDescription(name, EcsFlat as Record<string, EcsMetadata>),
-              example: field.example?.toString(),
-              category: getCategory(name),
-              selected: selectedFieldIds.has(name),
-              isRuntime: !!field.runtimeField,
-            };
-          })
-        );
+        for (let j = 0; j < categoryBrowserFields.length; j += 1) {
+          const { name = '', ...field } = categoryBrowserFields[j];
+          if (fieldSeen.has(name)) continue;
+          fieldSeen.set(name, true);
+          const categoryFieldItem = {
+            name,
+            type: field.type,
+            description: getDescription(name, EcsFlat as Record<string, EcsMetadata>),
+            example: field.example?.toString(),
+            category: getCategory(name),
+            selected: selectedFieldIds.has(name),
+            isRuntime: !!field.runtimeField,
+          };
+          fieldItemsAcc.push(categoryFieldItem);
+        }
       }
-      return fieldItemsAcc;
-    }, [])
-  );
-  return { fieldItems };
+    }
+    return fieldItemsAcc;
+  };
+
+  return { fieldItems: getFieldItems() };
 };
 
 const getDefaultFieldTableColumns = ({ highlight }: { highlight: string }): FieldTableColumns => {

--- a/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/home/index.tsx
@@ -13,7 +13,6 @@ import { SecuritySolutionAppWrapper } from '../../common/components/page';
 
 import { HelpMenu } from '../../common/components/help_menu';
 import { getScopeFromPath } from '../../sourcerer/containers/sourcerer_paths';
-import { useSourcererDataView } from '../../sourcerer/containers';
 import { GlobalHeader } from './global_header';
 import { ConsoleManager } from '../../management/components/console/components/console_manager';
 
@@ -34,12 +33,10 @@ interface HomePageProps {
 
 const HomePageComponent: React.FC<HomePageProps> = ({ children }) => {
   const { pathname } = useLocation();
-  useInitSourcerer(getScopeFromPath(pathname));
+  const { browserFields } = useInitSourcerer(getScopeFromPath(pathname));
   useUrlState();
   useUpdateBrowserTitle();
   useUpdateExecutionContext();
-
-  const { browserFields } = useSourcererDataView(getScopeFromPath(pathname));
 
   // side effect: this will attempt to upgrade the endpoint package if it is not up to date
   // this will run when a user navigates to the Security Solution app and when they navigate between

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/drag_and_drop/cell_actions_wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/drag_and_drop/cell_actions_wrapper.tsx
@@ -16,7 +16,7 @@ import {
   SecurityCellActionType,
 } from '../cell_actions';
 import { getSourcererScopeId } from '../../../helpers';
-import { TimelineContext } from '../../../timelines/components/timeline';
+import { TimelineContext } from '../../../timelines/components/timeline/context';
 
 import { TableContext } from '../events_viewer/shared';
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/plugin_template_wrapper/plugin_template_wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/plugin_template_wrapper/plugin_template_wrapper.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { FC } from 'react';
 import type { KibanaPageTemplateProps } from '@kbn/shared-ux-page-kibana-template';
 import { useKibana } from '../../lib/kibana';
@@ -15,14 +15,18 @@ import { useKibana } from '../../lib/kibana';
  *
  * The `template` prop can be used to alter the page layout for a given plugin route / all routes within a plugin - depending on the nesting.
  */
-export const PluginTemplateWrapper: FC<KibanaPageTemplateProps> = ({ children, ...rest }) => {
-  const {
-    services: {
-      securityLayout: { getPluginWrapper },
-    },
-  } = useKibana();
+export const PluginTemplateWrapper: FC<KibanaPageTemplateProps> = React.memo(
+  ({ children, ...rest }) => {
+    const {
+      services: {
+        securityLayout: { getPluginWrapper },
+      },
+    } = useKibana();
 
-  const Wrapper = getPluginWrapper();
+    const Wrapper = useMemo(() => getPluginWrapper(), [getPluginWrapper]);
 
-  return <Wrapper {...rest}>{children}</Wrapper>;
-};
+    return <Wrapper {...rest}>{children}</Wrapper>;
+  }
+);
+
+PluginTemplateWrapper.displayName = 'PluginTemplateWrapper';

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/index.test.tsx
@@ -5,151 +5,19 @@
  * 2.0.
  */
 
-import type { IndexFieldSearch } from './use_data_view';
-import { useDataView } from './use_data_view';
-import { mocksSource } from './mock';
-import { mockGlobalState, TestProviders } from '../../mock';
-import { act, renderHook } from '@testing-library/react';
-import { useKibana } from '../../lib/kibana';
-
-const mockDispatch = jest.fn();
-jest.mock('react-redux', () => {
-  const original = jest.requireActual('react-redux');
-
-  return {
-    ...original,
-    useDispatch: () => mockDispatch,
-  };
-});
-jest.mock('../../lib/kibana');
-jest.mock('../../lib/apm/use_track_http_request');
+import { mockBrowserFields, mockIndexFields, mockIndexFieldsByName } from './mock';
+import * as indexUtils from '.';
 
 describe('source/index.tsx', () => {
-  describe('useDataView hook', () => {
-    const mockSearchResponse = {
-      ...mocksSource,
-      indicesExist: ['auditbeat-*', mockGlobalState.sourcerer.signalIndexName],
-      isRestore: false,
-      rawResponse: {},
-      runtimeMappings: {},
-    };
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      const mock = {
-        subscribe: ({ next }: { next: Function }) => next(mockSearchResponse),
-        unsubscribe: jest.fn(),
-      };
-
-      (useKibana as jest.Mock).mockReturnValue({
-        services: {
-          data: {
-            dataViews: {
-              ...useKibana().services.data.dataViews,
-              get: async (dataViewId: string, displayErrors?: boolean, refreshFields = false) => {
-                const dataViewMock = {
-                  id: dataViewId,
-                  matchedIndices: refreshFields
-                    ? ['hello', 'world', 'refreshed']
-                    : ['hello', 'world'],
-                  fields: mocksSource.indexFields,
-                  getIndexPattern: () =>
-                    refreshFields ? 'hello*,world*,refreshed*' : 'hello*,world*',
-                  getRuntimeMappings: () => ({
-                    myfield: {
-                      type: 'keyword',
-                    },
-                  }),
-                };
-                return Promise.resolve({
-                  toSpec: () => dataViewMock,
-                  ...dataViewMock,
-                });
-              },
-              getFieldsForWildcard: async () => Promise.resolve(),
-              getExistingIndices: async (indices: string[]) => Promise.resolve(indices),
-            },
-            search: {
-              search: jest.fn().mockReturnValue({
-                subscribe: ({ next }: { next: Function }) => {
-                  next(mockSearchResponse);
-                  return mock;
-                },
-                unsubscribe: jest.fn(),
-              }),
-            },
-          },
-        },
-      });
+  describe('getAllBrowserFields', () => {
+    it('should return the expected browser fields list', () => {
+      expect(indexUtils.getAllBrowserFields(mockBrowserFields)).toEqual(mockIndexFields);
     });
-    it('sets field data for data view', async () => {
-      const { result } = renderHook(() => useDataView(), {
-        wrapper: TestProviders,
-      });
+  });
 
-      await act(async () => {
-        await result.current.indexFieldsSearch({ dataViewId: 'neato' });
-      });
-      expect(mockDispatch.mock.calls[0][0]).toEqual({
-        type: 'x-pack/security_solution/local/sourcerer/SET_DATA_VIEW_LOADING',
-        payload: { id: 'neato', loading: true },
-      });
-      const { type: sourceType, payload } = mockDispatch.mock.calls[1][0];
-      expect(sourceType).toEqual('x-pack/security_solution/local/sourcerer/SET_DATA_VIEW');
-      expect(payload.id).toEqual('neato');
-    });
-
-    it('should reuse the result for dataView info when cleanCache not passed', async () => {
-      let indexFieldsSearch: IndexFieldSearch;
-
-      const { result } = renderHook(() => useDataView(), {
-        wrapper: TestProviders,
-      });
-
-      await act(async () => {
-        indexFieldsSearch = result.current.indexFieldsSearch;
-      });
-
-      await indexFieldsSearch!({ dataViewId: 'neato' });
-      const {
-        payload: { browserFields, indexFields },
-      } = mockDispatch.mock.calls[1][0];
-
-      mockDispatch.mockClear();
-
-      await indexFieldsSearch!({ dataViewId: 'neato' });
-      const {
-        payload: { browserFields: newBrowserFields, indexFields: newIndexFields },
-      } = mockDispatch.mock.calls[1][0];
-
-      expect(browserFields).toBe(newBrowserFields);
-      expect(indexFields).toBe(newIndexFields);
-    });
-
-    it('should not reuse the result for dataView info when cleanCache passed', async () => {
-      let indexFieldsSearch: IndexFieldSearch;
-      const { result } = renderHook(() => useDataView(), {
-        wrapper: TestProviders,
-      });
-
-      await act(async () => {
-        indexFieldsSearch = result.current.indexFieldsSearch;
-      });
-
-      await indexFieldsSearch!({ dataViewId: 'neato' });
-      const {
-        payload: { patternList },
-      } = mockDispatch.mock.calls[1][0];
-
-      mockDispatch.mockClear();
-
-      await indexFieldsSearch!({ dataViewId: 'neato', cleanCache: true });
-      const {
-        payload: { patternList: newPatternList },
-      } = mockDispatch.mock.calls[1][0];
-      expect(patternList).not.toBe(newPatternList);
-      expect(patternList).not.toContain('refreshed*');
-      expect(newPatternList).toContain('refreshed*');
+  describe('getAllFieldsByName', () => {
+    it('should return the expected browser fields list', () => {
+      expect(indexUtils.getAllFieldsByName(mockBrowserFields)).toEqual(mockIndexFieldsByName);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/index.tsx
@@ -22,10 +22,11 @@ import type { ENDPOINT_FIELDS_SEARCH_STRATEGY } from '../../../../common/endpoin
 export type { BrowserFields };
 
 export function getAllBrowserFields(browserFields: BrowserFields): Array<Partial<FieldSpec>> {
-  const result: Array<Partial<FieldSpec>> = [];
+  let result: Array<Partial<FieldSpec>> = [];
   for (const namespace of Object.values(browserFields)) {
     if (namespace.fields) {
-      result.push(...Object.values(namespace.fields));
+      const namespaceFields = Object.values(namespace.fields);
+      result = result.concat(namespaceFields);
     }
   }
   return result;
@@ -36,9 +37,11 @@ export function getAllBrowserFields(browserFields: BrowserFields): Array<Partial
  * @param browserFields
  * @returns
  */
-export const getAllFieldsByName = (
-  browserFields: BrowserFields
-): { [fieldName: string]: Partial<FieldSpec> } => keyBy('name', getAllBrowserFields(browserFields));
+export const getAllFieldsByName = memoizeOne(
+  (browserFields: BrowserFields): { [fieldName: string]: Partial<FieldSpec> } =>
+    keyBy('name', getAllBrowserFields(browserFields)),
+  (newArgs, lastArgs) => newArgs[0] === lastArgs[0]
+);
 
 export const getIndexFields = memoizeOne(
   (title: string, fields: IIndexPatternFieldList): DataViewBase =>

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/mock.ts
@@ -7,6 +7,7 @@
 
 import type { MappingRuntimeFieldType } from '@elastic/elasticsearch/lib/api/types';
 import { flatten } from 'lodash';
+import type { FieldSpec } from '@kbn/data-views-plugin/common';
 import type { BrowserFields } from '../../../../common/search_strategy/index_fields';
 
 export const mocksSource = {
@@ -386,6 +387,13 @@ export const mockBrowserFields: BrowserFields = {
 export const mockIndexFields = flatten(
   Object.values(mockBrowserFields).map((fieldItem) => Object.values(fieldItem.fields ?? {}))
 );
+
+export const mockIndexFieldsByName = mockIndexFields.reduce((acc, indexFieldObj) => {
+  if (indexFieldObj.name) {
+    acc[indexFieldObj.name] = indexFieldObj;
+  }
+  return acc;
+}, {} as { [fieldName: string]: Partial<FieldSpec> });
 
 const runTimeType: MappingRuntimeFieldType = 'keyword' as const;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/use_data_view.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/containers/source/use_data_view.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IndexFieldSearch } from './use_data_view';
+import { useDataView } from './use_data_view';
+import { mocksSource } from './mock';
+import { mockGlobalState, TestProviders } from '../../mock';
+import { act, renderHook } from '@testing-library/react';
+import { useKibana } from '../../lib/kibana';
+
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => {
+  const original = jest.requireActual('react-redux');
+
+  return {
+    ...original,
+    useDispatch: () => mockDispatch,
+  };
+});
+jest.mock('../../lib/kibana');
+jest.mock('../../lib/apm/use_track_http_request');
+
+describe('useDataView', () => {
+  const mockSearchResponse = {
+    ...mocksSource,
+    indicesExist: ['auditbeat-*', mockGlobalState.sourcerer.signalIndexName],
+    isRestore: false,
+    rawResponse: {},
+    runtimeMappings: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const mock = {
+      subscribe: ({ next }: { next: Function }) => next(mockSearchResponse),
+      unsubscribe: jest.fn(),
+    };
+
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        data: {
+          dataViews: {
+            ...useKibana().services.data.dataViews,
+            get: async (dataViewId: string, displayErrors?: boolean, refreshFields = false) => {
+              const dataViewMock = {
+                id: dataViewId,
+                matchedIndices: refreshFields
+                  ? ['hello', 'world', 'refreshed']
+                  : ['hello', 'world'],
+                fields: mocksSource.indexFields,
+                getIndexPattern: () =>
+                  refreshFields ? 'hello*,world*,refreshed*' : 'hello*,world*',
+                getRuntimeMappings: () => ({
+                  myfield: {
+                    type: 'keyword',
+                  },
+                }),
+              };
+              return Promise.resolve({
+                toSpec: () => dataViewMock,
+                ...dataViewMock,
+              });
+            },
+            getFieldsForWildcard: async () => Promise.resolve(),
+            getExistingIndices: async (indices: string[]) => Promise.resolve(indices),
+          },
+          search: {
+            search: jest.fn().mockReturnValue({
+              subscribe: ({ next }: { next: Function }) => {
+                next(mockSearchResponse);
+                return mock;
+              },
+              unsubscribe: jest.fn(),
+            }),
+          },
+        },
+      },
+    });
+  });
+  it('sets field data for data view', async () => {
+    const { result } = renderHook(() => useDataView(), {
+      wrapper: TestProviders,
+    });
+
+    await act(async () => {
+      await result.current.indexFieldsSearch({ dataViewId: 'neato' });
+    });
+    expect(mockDispatch.mock.calls[0][0]).toEqual({
+      type: 'x-pack/security_solution/local/sourcerer/SET_DATA_VIEW_LOADING',
+      payload: { id: 'neato', loading: true },
+    });
+    const { type: sourceType, payload } = mockDispatch.mock.calls[1][0];
+    expect(sourceType).toEqual('x-pack/security_solution/local/sourcerer/SET_DATA_VIEW');
+    expect(payload.id).toEqual('neato');
+  });
+
+  it('should reuse the result for dataView info when cleanCache not passed', async () => {
+    let indexFieldsSearch: IndexFieldSearch;
+
+    const { result } = renderHook(() => useDataView(), {
+      wrapper: TestProviders,
+    });
+
+    await act(async () => {
+      indexFieldsSearch = result.current.indexFieldsSearch;
+    });
+
+    await indexFieldsSearch!({ dataViewId: 'neato' });
+    const {
+      payload: { browserFields, indexFields },
+    } = mockDispatch.mock.calls[1][0];
+
+    mockDispatch.mockClear();
+
+    await indexFieldsSearch!({ dataViewId: 'neato' });
+    const {
+      payload: { browserFields: newBrowserFields, indexFields: newIndexFields },
+    } = mockDispatch.mock.calls[1][0];
+
+    expect(browserFields).toBe(newBrowserFields);
+    expect(indexFields).toBe(newIndexFields);
+  });
+
+  it('should not reuse the result for dataView info when cleanCache passed', async () => {
+    let indexFieldsSearch: IndexFieldSearch;
+    const { result } = renderHook(() => useDataView(), {
+      wrapper: TestProviders,
+    });
+
+    await act(async () => {
+      indexFieldsSearch = result.current.indexFieldsSearch;
+    });
+
+    await indexFieldsSearch!({ dataViewId: 'neato' });
+    const {
+      payload: { patternList },
+    } = mockDispatch.mock.calls[1][0];
+
+    mockDispatch.mockClear();
+
+    await indexFieldsSearch!({ dataViewId: 'neato', cleanCache: true });
+    const {
+      payload: { patternList: newPatternList },
+    } = mockDispatch.mock.calls[1][0];
+    expect(patternList).not.toBe(newPatternList);
+    expect(patternList).not.toContain('refreshed*');
+    expect(newPatternList).toContain('refreshed*');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_histogram.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_histogram.tsx
@@ -14,6 +14,7 @@ import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { DataViewBase } from '@kbn/es-query';
 import { buildEsQuery } from '@kbn/es-query';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { AlertTableCellContextProvider } from '../../../../detections/configurations/security_solution_detections/cell_value_context';
 import { StatefulEventsViewer } from '../../../../common/components/events_viewer';
 import { defaultRowRenderers } from '../../../../timelines/components/timeline/body/renderers';
 import * as i18n from './translations';
@@ -142,7 +143,7 @@ const PreviewHistogramComponent = ({
   }, [config, indexPattern, previewId]);
 
   return (
-    <>
+    <AlertTableCellContextProvider sourcererScope={SourcererScopeName.detections}>
       <Panel height={DEFAULT_HISTOGRAM_HEIGHT} data-test-subj={'preview-histogram-panel'}>
         <EuiFlexGroup gutterSize="none" direction="column">
           <EuiFlexItem grow={1}>
@@ -199,7 +200,7 @@ const PreviewHistogramComponent = ({
           bulkActions={false}
         />
       </FullScreenContainer>
-    </>
+    </AlertTableCellContextProvider>
   );
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_table_cell_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_table_cell_renderer.tsx
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { LegacyField } from '@kbn/alerting-types';
 import type { CellValueElementProps } from '../../../../../common/types';
 import { SourcererScopeName } from '../../../../sourcerer/store/model';
 import { CellValue } from '../../../../detections/configurations/security_solution_detections';
+
+const emptyUserProfiles = { profiles: [], isLoading: false };
 
 export const PreviewRenderCellValue: React.FC<
   EuiDataGridCellValueElementProps & CellValueElementProps
@@ -28,11 +30,12 @@ export const PreviewRenderCellValue: React.FC<
   rowRenderers,
   truncate,
 }) => {
+  const legacyAlert = useMemo(() => (data ?? []) as LegacyField[], [data]);
   return (
     <CellValue
       tableType={TableId.rulePreview}
       sourcererScope={SourcererScopeName.detections}
-      legacyAlert={(data ?? []) as LegacyField[]}
+      legacyAlert={legacyAlert}
       ecsAlert={ecsData}
       asPlainText={true}
       setCellProps={setCellProps}
@@ -44,7 +47,7 @@ export const PreviewRenderCellValue: React.FC<
       columnId={columnId}
       rowRenderers={rowRenderers}
       truncate={truncate}
-      userProfiles={{ profiles: [], isLoading: false }}
+      userProfiles={emptyUserProfiles}
     />
   );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -73,6 +73,7 @@ import { AdditionalToolbarControls } from './additional_toolbar_controls';
 import { useFetchUserProfilesFromAlerts } from '../../configurations/security_solution_detections/fetch_page_context';
 import { useCellActionsOptions } from '../../hooks/trigger_actions_alert_table/use_cell_actions';
 import { useAlertsTableFieldsBrowserOptions } from '../../hooks/trigger_actions_alert_table/use_trigger_actions_browser_fields_options';
+import { AlertTableCellContextProvider } from '../../configurations/security_solution_detections/cell_value_context';
 
 const { updateIsLoading, updateTotalCount } = dataTableActions;
 
@@ -172,9 +173,10 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
 
   const dispatch = useDispatch();
 
+  const timelineID = tableType;
   // Store context in state rather than creating object in provider value={} to prevent re-renders caused by a new object being created
   const [activeStatefulEventContext] = useState({
-    timelineID: tableType,
+    timelineID,
     tabType: 'query',
     enableHostDetailsFlyout: true,
     enableIpDetailsFlyout: true,
@@ -444,6 +446,11 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
     [count, isEventRenderedView]
   );
 
+  const alertTableId = useMemo(
+    () => id ?? `detection-engine-alert-table-${tableType}-${tableView}`,
+    [id, tableType, tableView]
+  );
+
   if (isLoading) {
     return null;
   }
@@ -454,44 +461,49 @@ const DetectionEngineAlertsTableComponent: FC<Omit<DetectionEngineAlertTableProp
       <FullWidthFlexGroupTable $visible={!graphEventId && graphOverlay == null} gutterSize="none">
         <StatefulEventContext.Provider value={activeStatefulEventContext}>
           <EuiDataGridContainer hideLastPage={false}>
-            <AlertsTable<SecurityAlertsTableContext>
-              ref={alertsTableRef}
-              // Stores separate configuration based on the view of the table
-              id={id ?? `detection-engine-alert-table-${tableType}-${tableView}`}
-              ruleTypeIds={SECURITY_SOLUTION_RULE_TYPE_IDS}
-              consumers={ALERT_TABLE_CONSUMERS}
-              query={finalBoolQuery}
-              initialSort={initialSort}
-              casesConfiguration={casesConfiguration}
-              gridStyle={gridStyle}
-              shouldHighlightRow={shouldHighlightRow}
-              rowHeightsOptions={rowHeightsOptions}
-              columns={finalColumns}
-              browserFields={finalBrowserFields}
-              onUpdate={onUpdate}
-              additionalContext={additionalContext}
-              height={alertTableHeight}
-              initialPageSize={50}
-              runtimeMappings={sourcererDataView?.runtimeFieldMap as RunTimeMappings}
-              toolbarVisibility={toolbarVisibility}
-              renderCellValue={CellValue}
-              renderActionsCell={ActionsCell}
-              renderAdditionalToolbarControls={
-                tableType !== TableId.alertsOnCasePage ? AdditionalToolbarControls : undefined
-              }
-              actionsColumnWidth={leadingControlColumn.width}
-              getBulkActions={getBulkActions}
-              fieldsBrowserOptions={
-                tableType === TableId.alertsOnAlertsPage ||
-                tableType === TableId.alertsOnRuleDetailsPage
-                  ? fieldsBrowserOptions
-                  : undefined
-              }
-              cellActionsOptions={cellActionsOptions}
-              showInspectButton
-              services={services}
-              {...tablePropsOverrides}
-            />
+            <AlertTableCellContextProvider
+              tableId={alertTableId}
+              sourcererScope={SourcererScopeName.detections}
+            >
+              <AlertsTable<SecurityAlertsTableContext>
+                ref={alertsTableRef}
+                // Stores separate configuration based on the view of the table
+                id={alertTableId}
+                ruleTypeIds={SECURITY_SOLUTION_RULE_TYPE_IDS}
+                consumers={ALERT_TABLE_CONSUMERS}
+                query={finalBoolQuery}
+                initialSort={initialSort}
+                casesConfiguration={casesConfiguration}
+                gridStyle={gridStyle}
+                shouldHighlightRow={shouldHighlightRow}
+                rowHeightsOptions={rowHeightsOptions}
+                columns={finalColumns}
+                browserFields={finalBrowserFields}
+                onUpdate={onUpdate}
+                additionalContext={additionalContext}
+                height={alertTableHeight}
+                initialPageSize={50}
+                runtimeMappings={sourcererDataView?.runtimeFieldMap as RunTimeMappings}
+                toolbarVisibility={toolbarVisibility}
+                renderCellValue={CellValue}
+                renderActionsCell={ActionsCell}
+                renderAdditionalToolbarControls={
+                  tableType !== TableId.alertsOnCasePage ? AdditionalToolbarControls : undefined
+                }
+                actionsColumnWidth={leadingControlColumn.width}
+                getBulkActions={getBulkActions}
+                fieldsBrowserOptions={
+                  tableType === TableId.alertsOnAlertsPage ||
+                  tableType === TableId.alertsOnRuleDetailsPage
+                    ? fieldsBrowserOptions
+                    : undefined
+                }
+                cellActionsOptions={cellActionsOptions}
+                showInspectButton
+                services={services}
+                {...tablePropsOverrides}
+              />
+            </AlertTableCellContextProvider>
           </EuiDataGridContainer>
         </StatefulEventContext.Provider>
       </FullWidthFlexGroupTable>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/user_info/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/user_info/index.tsx
@@ -7,7 +7,7 @@
 
 import { noop } from 'lodash/fp';
 import type { Dispatch } from 'react';
-import React, { useEffect, useReducer, createContext, useContext } from 'react';
+import React, { useEffect, useReducer, createContext, useContext, useMemo } from 'react';
 
 import { useAlertsPrivileges } from '../../containers/detection_engine/alerts/use_alerts_privileges';
 import { useSignalIndex } from '../../containers/detection_engine/alerts/use_signal_index';
@@ -353,19 +353,38 @@ export const useUserInfo = (): State => {
     signalIndexMappingOutdated,
   ]);
 
-  return {
-    loading,
-    isSignalIndexExists,
-    isAuthenticated,
-    hasEncryptionKey,
-    canUserCRUD,
-    canUserREAD,
-    hasIndexManage,
-    hasIndexMaintenance,
-    hasIndexWrite,
-    hasIndexRead,
-    hasIndexUpdateDelete,
-    signalIndexName,
-    signalIndexMappingOutdated,
-  };
+  const userInfo = useMemo(
+    () => ({
+      loading,
+      isSignalIndexExists,
+      isAuthenticated,
+      hasEncryptionKey,
+      canUserCRUD,
+      canUserREAD,
+      hasIndexManage,
+      hasIndexMaintenance,
+      hasIndexWrite,
+      hasIndexRead,
+      hasIndexUpdateDelete,
+      signalIndexName,
+      signalIndexMappingOutdated,
+    }),
+    [
+      canUserCRUD,
+      canUserREAD,
+      hasEncryptionKey,
+      hasIndexMaintenance,
+      hasIndexManage,
+      hasIndexRead,
+      hasIndexUpdateDelete,
+      hasIndexWrite,
+      isAuthenticated,
+      isSignalIndexExists,
+      loading,
+      signalIndexMappingOutdated,
+      signalIndexName,
+    ]
+  );
+
+  return userInfo;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/cell_value_context.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/cell_value_context.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { createContext, useMemo, useState } from 'react';
+import type { FieldSpec } from '@kbn/data-views-plugin/common';
+import { tableDefaults, dataTableSelectors } from '@kbn/securitysolution-data-table';
+import type { BrowserFields } from '@kbn/timelines-plugin/common';
+import type { SourcererScopeName } from '../../../sourcerer/store/model';
+import { useLicense } from '../../../common/hooks/use_license';
+import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
+import { useSourcererDataView } from '../../../sourcerer/containers';
+import { VIEW_SELECTION } from '../../../../common/constants';
+import { getAllFieldsByName } from '../../../common/containers/source';
+import { eventRenderedViewColumns, getColumns } from './columns';
+import type { AlertColumnHeaders } from './columns';
+
+interface AlertTableCellContextProps {
+  browserFields: BrowserFields;
+  browserFieldsByName: Record<string, Partial<FieldSpec>>;
+  columnHeaders: AlertColumnHeaders;
+}
+
+export const AlertTableCellContext = createContext<AlertTableCellContextProps | null>(null);
+
+export const AlertTableCellContextProvider = ({
+  tableId = '',
+  sourcererScope,
+  children,
+}: {
+  tableId?: string;
+  sourcererScope: SourcererScopeName;
+  children: React.ReactNode;
+}) => {
+  const { browserFields } = useSourcererDataView(sourcererScope);
+  const browserFieldsByName = useMemo(() => getAllFieldsByName(browserFields), [browserFields]);
+  const license = useLicense();
+  const gridColumns = useMemo(() => {
+    return getColumns(license);
+  }, [license]);
+  const getTable = useMemo(() => dataTableSelectors.getTableByIdSelector(), []);
+  const viewMode =
+    useDeepEqualSelector((state) => (getTable(state, tableId ?? '') ?? tableDefaults).viewMode) ??
+    tableDefaults.viewMode;
+  const columnHeaders = useMemo(() => {
+    return viewMode === VIEW_SELECTION.gridView ? gridColumns : eventRenderedViewColumns;
+  }, [gridColumns, viewMode]);
+
+  const [commonCellValueContext] = useState<AlertTableCellContextProps>({
+    browserFields,
+    browserFieldsByName,
+    columnHeaders,
+  });
+
+  return (
+    <AlertTableCellContext.Provider value={commonCellValueContext}>
+      {children}
+    </AlertTableCellContext.Provider>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/columns.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/columns.ts
@@ -137,11 +137,10 @@ const getBaseColumns = (
  * columns implements a subset of `EuiDataGrid`'s `EuiDataGridColumn` interface,
  * plus additional TGrid column properties
  */
-export const getColumns = (
-  license?: LicenseService
-): Array<
+export type AlertColumnHeaders = Array<
   Pick<EuiDataGridColumn, 'display' | 'displayAsText' | 'id' | 'initialWidth'> & ColumnHeaderOptions
-> => [
+>;
+export const getColumns = (license?: LicenseService): AlertColumnHeaders => [
   {
     columnHeaderType: defaultColumnHeaderType,
     id: '@timestamp',

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { cloneDeep } from 'lodash/fp';
 import type { ComponentProps } from 'react';
 import React from 'react';
@@ -16,9 +16,10 @@ import { DragDropContextWrapper } from '../../../common/components/drag_and_drop
 import { defaultHeaders, mockTimelineData, TestProviders } from '../../../common/mock';
 import { defaultRowRenderers } from '../../../timelines/components/timeline/body/renderers';
 import type { TimelineNonEcsData } from '../../../../common/search_strategy/timeline';
-import { DefaultCellRenderer } from '../../../timelines/components/timeline/cell_rendering/default_cell_renderer';
+import type { RenderCellValueProps } from './render_cell_value';
 import { CellValue } from './render_cell_value';
 import { SourcererScopeName } from '../../../sourcerer/store/model';
+import { AlertTableCellContextProvider } from './cell_value_context';
 
 jest.mock('../../../common/lib/kibana');
 jest.mock('../../../sourcerer/containers', () => ({
@@ -41,12 +42,12 @@ describe('RenderCellValue', () => {
 
   let data: TimelineNonEcsData[];
   let header: ColumnHeaderOptions;
-  let props: ComponentProps<typeof CellValue>;
+  let defaultProps: RenderCellValueProps;
 
   beforeEach(() => {
     data = cloneDeep(mockTimelineData[0].data);
     header = cloneDeep(defaultHeaders[0]);
-    props = {
+    defaultProps = {
       columnId,
       legacyAlert: data,
       eventId,
@@ -68,37 +69,54 @@ describe('RenderCellValue', () => {
     } as unknown as ComponentProps<typeof CellValue>;
   });
 
-  test('it forwards the `CellValueElementProps` to the `DefaultCellRenderer`', () => {
-    const wrapper = mount(
+  const RenderCellValueComponent = (props: RenderCellValueProps) => {
+    return (
       <TestProviders>
         <DragDropContextWrapper browserFields={mockBrowserFields}>
-          <CellValue
-            {...props}
-            sourcererScope={SourcererScopeName.default}
-            tableType={TableId.test}
-          />
+          <AlertTableCellContextProvider
+            tableId={TableId.test}
+            sourcererScope={SourcererScopeName.detections}
+          >
+            <CellValue
+              {...defaultProps}
+              {...props}
+              sourcererScope={SourcererScopeName.detections}
+              tableType={TableId.test}
+            />
+          </AlertTableCellContextProvider>
         </DragDropContextWrapper>
       </TestProviders>
     );
+  };
 
-    const { legacyAlert, ...defaultCellRendererProps } = props;
+  it('should throw an error if not wrapped by the AlertTableCellContextProvider', () => {
+    const renderWithError = () =>
+      render(
+        <TestProviders>
+          <DragDropContextWrapper browserFields={mockBrowserFields}>
+            <CellValue
+              {...defaultProps}
+              sourcererScope={SourcererScopeName.detections}
+              tableType={TableId.test}
+            />
+          </DragDropContextWrapper>
+        </TestProviders>
+      );
 
-    expect(wrapper.find(DefaultCellRenderer).props()).toEqual({
-      ...defaultCellRendererProps,
-      data: legacyAlert,
-      scopeId: SourcererScopeName.default,
-    });
+    expect(renderWithError).toThrow(
+      'render_cell_value.tsx: CellValue must be used within AlertTableCellContextProvider'
+    );
   });
 
-  test('it renders a GuidedOnboardingTourStep', () => {
-    const wrapper = mount(
-      <TestProviders>
-        <DragDropContextWrapper browserFields={mockBrowserFields}>
-          <CellValue {...props} scopeId={SourcererScopeName.default} tableType={TableId.test} />
-        </DragDropContextWrapper>
-      </TestProviders>
-    );
+  it('should fully render the cell value', () => {
+    const { getByText } = render(<RenderCellValueComponent {...defaultProps} />);
 
-    expect(wrapper.find('[data-test-subj="GuidedOnboardingTourStep"]').exists()).toEqual(true);
+    expect(getByText('Nov 5, 2018 @ 19:03:25.937')).toBeInTheDocument();
+  });
+
+  it('should render the guided onboarding step', () => {
+    const { getByTestId } = render(<RenderCellValueComponent {...defaultProps} />);
+
+    expect(getByTestId('GuidedOnboardingTourStep')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
@@ -5,13 +5,11 @@
  * 2.0.
  */
 
-import React, { useMemo, memo, type ComponentProps } from 'react';
+import React, { useMemo, memo, type ComponentProps, useContext } from 'react';
 import { EuiIcon, EuiToolTip, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { find, getOr } from 'lodash/fp';
 import type { TimelineNonEcsData } from '@kbn/timelines-plugin/common';
-import { tableDefaults, dataTableSelectors } from '@kbn/securitysolution-data-table';
-import { useLicense } from '../../../common/hooks/use_license';
-import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
+import { useKibana } from '../../../common/lib/kibana';
 import { defaultRowRenderers } from '../../../timelines/components/timeline/body/renderers';
 import { GuidedOnboardingTourStep } from '../../../common/components/guided_onboarding_tour/tour_step';
 import { isDetectionsAlertsTable } from '../../../common/components/top_n/helpers';
@@ -20,15 +18,12 @@ import {
   SecurityStepId,
 } from '../../../common/components/guided_onboarding_tour/tour_config';
 import { SIGNAL_RULE_NAME_FIELD_NAME } from '../../../timelines/components/timeline/body/renderers/constants';
-import { useSourcererDataView } from '../../../sourcerer/containers';
 import { DefaultCellRenderer } from '../../../timelines/components/timeline/cell_rendering/default_cell_renderer';
 
 import { SUPPRESSED_ALERT_TOOLTIP } from './translations';
-import { VIEW_SELECTION } from '../../../../common/constants';
-import { getAllFieldsByName } from '../../../common/containers/source';
-import { eventRenderedViewColumns, getColumns } from './columns';
 import type { GetSecurityAlertsTableProp } from '../../components/alerts_table/types';
 import type { CellValueElementProps, ColumnHeaderOptions } from '../../../../common/types';
+import { AlertTableCellContext } from './cell_value_context';
 
 /**
  * This implementation of `EuiDataGrid`'s `renderCellValue`
@@ -36,7 +31,7 @@ import type { CellValueElementProps, ColumnHeaderOptions } from '../../../../com
  * from the TGrid
  */
 
-type RenderCellValueProps = Pick<
+export type RenderCellValueProps = Pick<
   ComponentProps<GetSecurityAlertsTableProp<'renderCellValue'>>,
   | 'columnId'
   | 'rowIndex'
@@ -76,6 +71,7 @@ export const CellValue = memo(function RenderCellValue({
   truncate,
   userProfiles,
 }: RenderCellValueProps) {
+  const { notifications } = useKibana().services;
   const isTourAnchor = useMemo(
     () =>
       columnId === SIGNAL_RULE_NAME_FIELD_NAME &&
@@ -84,22 +80,21 @@ export const CellValue = memo(function RenderCellValue({
       !isDetails,
     [columnId, isDetails, rowIndex, tableType]
   );
-  const { browserFields } = useSourcererDataView(sourcererScope);
-  const browserFieldsByName = useMemo(() => getAllFieldsByName(browserFields), [browserFields]);
-  const getTable = useMemo(() => dataTableSelectors.getTableByIdSelector(), []);
-  const license = useLicense();
-  const viewMode =
-    useDeepEqualSelector((state) => (getTable(state, tableId ?? '') ?? tableDefaults).viewMode) ??
-    tableDefaults.viewMode;
+  const cellValueContext = useContext(AlertTableCellContext);
 
-  const gridColumns = useMemo(() => {
-    return getColumns(license);
-  }, [license]);
+  if (!cellValueContext) {
+    const contextMissingError = new Error(
+      'render_cell_value.tsx: CellValue must be used within AlertTableCellContextProvider'
+    );
 
-  const columnHeaders = useMemo(() => {
-    return viewMode === VIEW_SELECTION.gridView ? gridColumns : eventRenderedViewColumns;
-  }, [gridColumns, viewMode]);
+    notifications.toasts.addError(contextMissingError, {
+      title: 'AlertTableCellContextProvider is missing',
+      toastMessage: 'CellValue must be used within AlertTableCellContextProvider',
+    });
+    throw new Error(contextMissingError.message);
+  }
 
+  const { browserFields, browserFieldsByName, columnHeaders } = cellValueContext;
   /**
    * There is difference between how `triggers actions` fetched data v/s
    * how security solution fetches data via timelineSearchStrategy
@@ -111,17 +106,24 @@ export const CellValue = memo(function RenderCellValue({
    */
 
   const finalData = useMemo(() => {
-    return (legacyAlert as TimelineNonEcsData[]).map((field) => {
-      if (['_id', '_index'].includes(field.field)) {
-        const newValue = field.value ?? '';
-        return {
-          field: field.field,
-          value: Array.isArray(newValue) ? newValue : [newValue],
-        };
-      } else {
-        return field;
-      }
-    });
+    const idPosition = legacyAlert.findIndex((field) => field.field === '_id');
+    const indexPosition = legacyAlert.findIndex((field) => field.field === '_index');
+
+    const clonedLegacyAlert = structuredClone(legacyAlert);
+
+    if (idPosition !== -1) {
+      const idValue = clonedLegacyAlert[idPosition].value;
+      clonedLegacyAlert[idPosition].value = Array.isArray(idValue) ? idValue : [idValue];
+    }
+
+    if (indexPosition !== -1) {
+      const indexValue = clonedLegacyAlert[indexPosition].value;
+      clonedLegacyAlert[indexPosition].value = Array.isArray(indexValue)
+        ? indexValue
+        : [indexValue];
+    }
+
+    return clonedLegacyAlert as TimelineNonEcsData[];
   }, [legacyAlert]);
 
   const actualSuppressionCount = useMemo(() => {
@@ -134,11 +136,21 @@ export const CellValue = memo(function RenderCellValue({
     return ecsSuppressionCount ? parseInt(ecsSuppressionCount, 10) : dataSuppressionCount;
   }, [ecsAlert, legacyAlert]);
 
-  const Renderer = useMemo(() => {
-    const myHeader =
-      header ?? ({ id: columnId, ...browserFieldsByName[columnId] } as ColumnHeaderOptions);
-    const colHeader = columnHeaders.find((col) => col.id === columnId);
-    const localLinkValues = getOr([], colHeader?.linkField ?? '', ecsAlert);
+  const myHeader = useMemo(
+    () => header ?? ({ id: columnId, ...browserFieldsByName[columnId] } as ColumnHeaderOptions),
+    [browserFieldsByName, columnId, header]
+  );
+
+  const colHeader = useMemo(
+    () => columnHeaders.find((col) => col.id === columnId),
+    [columnHeaders, columnId]
+  );
+  const localLinkValues = useMemo(
+    () => getOr([], colHeader?.linkField ?? '', ecsAlert),
+    [colHeader?.linkField, ecsAlert]
+  );
+
+  const CellRenderer = useMemo(() => {
     return (
       <GuidedOnboardingTourStep
         isTourAnchor={isTourAnchor}
@@ -168,20 +180,18 @@ export const CellValue = memo(function RenderCellValue({
       </GuidedOnboardingTourStep>
     );
   }, [
-    header,
-    columnId,
-    browserFieldsByName,
-    columnHeaders,
-    ecsAlert,
     isTourAnchor,
     browserFields,
+    columnId,
     finalData,
+    ecsAlert,
     eventId,
+    myHeader,
     isDetails,
-
     isExpandable,
     isExpanded,
     linkValues,
+    localLinkValues,
     rowIndex,
     colIndex,
     rowRenderers,
@@ -198,9 +208,9 @@ export const CellValue = memo(function RenderCellValue({
           <EuiIcon type="layers" />
         </EuiToolTip>
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>{Renderer}</EuiFlexItem>
+      <EuiFlexItem grow={false}>{CellRenderer}</EuiFlexItem>
     </EuiFlexGroup>
   ) : (
-    <>{Renderer}</>
+    <>{CellRenderer}</>
   );
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -23,7 +23,7 @@ import type { ConnectedProps } from 'react-redux';
 import { connect, useDispatch } from 'react-redux';
 import type { Dispatch } from 'redux';
 import { isTab } from '@kbn/timelines-plugin/public';
-import type { Filter } from '@kbn/es-query';
+import type { Filter, TimeRange } from '@kbn/es-query';
 import type { DocLinks } from '@kbn/doc-links';
 import {
   dataTableActions,
@@ -299,22 +299,13 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
     [isLoadingIndexPattern, areDetectionPageFiltersLoading]
   );
 
-  const AlertPageFilters = useMemo(
-    () => (
-      <DetectionEngineFilters
-        filters={topLevelFilters}
-        onFiltersChange={onFilterControlsChange}
-        query={query}
-        timeRange={{
-          from,
-          to,
-          mode: 'absolute',
-        }}
-        onInit={setDetectionPageFilterHandler}
-        dataViewSpec={sourcererDataView}
-      />
-    ),
-    [from, sourcererDataView, onFilterControlsChange, query, to, topLevelFilters]
+  const pageFiltersTimerange = useMemo<TimeRange>(
+    () => ({
+      from,
+      to,
+      mode: 'absolute',
+    }),
+    [from, to]
   );
 
   const renderAlertTable = useCallback(
@@ -408,7 +399,14 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
               </HeaderPage>
               <EuiHorizontalRule margin="none" />
               <EuiSpacer size="l" />
-              {AlertPageFilters}
+              <DetectionEngineFilters
+                filters={topLevelFilters}
+                onFiltersChange={onFilterControlsChange}
+                query={query}
+                timeRange={pageFiltersTimerange}
+                onInit={setDetectionPageFilterHandler}
+                dataViewSpec={sourcererDataView}
+              />
               <EuiSpacer size="l" />
               <ChartPanels
                 addFilter={addFilter}

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/hooks.test.tsx
@@ -70,6 +70,11 @@ const mockCreateSourcererDataView = jest.fn(() => {
   throw errToReturn;
 });
 
+jest.mock('../../common/hooks/use_selector', () => ({
+  // Mock timeline so_id return
+  useDeepEqualSelector: jest.fn().mockReturnValue({ savedObjectId: null }),
+}));
+
 jest.mock('../../common/lib/kibana', () => ({
   useToasts: () => ({
     addError: mockAddError,

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/index.tsx
@@ -67,10 +67,11 @@ export const useSourcererDataView = (
     if (selectedDataView == null || missingPatterns.length > 0) {
       // old way of fetching indices, legacy timeline
       setLegacyPatterns(selectedPatterns);
-    } else {
+    } else if (legacyPatterns.length > 0) {
+      // Only create a new array reference if legacyPatterns is not empty
       setLegacyPatterns([]);
     }
-  }, [missingPatterns, selectedDataView, selectedPatterns]);
+  }, [legacyPatterns.length, missingPatterns, selectedDataView, selectedPatterns]);
 
   const sourcererDataView = useMemo(() => {
     const _dv =

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/containers/use_init_sourcerer.tsx
@@ -57,7 +57,7 @@ export const useInitSourcerer = (
   }, [addWarning, defaultDataView.error]);
 
   const getTimelineSelector = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
-  const activeTimeline = useDeepEqualSelector((state) =>
+  const { savedObjectId: timelineSavedObjectId } = useDeepEqualSelector((state) =>
     getTimelineSelector(state, TimelineId.active)
   );
 
@@ -178,7 +178,7 @@ export const useInitSourcerer = (
       !loadingSignalIndex &&
       signalIndexName != null &&
       signalIndexNameSourcerer == null &&
-      (activeTimeline == null || activeTimeline.savedObjectId == null) &&
+      timelineSavedObjectId == null &&
       initialTimelineSourcerer.current &&
       defaultDataView.id.length > 0
     ) {
@@ -209,7 +209,7 @@ export const useInitSourcerer = (
       );
     } else if (
       signalIndexNameSourcerer != null &&
-      (activeTimeline == null || activeTimeline.savedObjectId == null) &&
+      timelineSavedObjectId == null &&
       initialTimelineSourcerer.current &&
       defaultDataView.id.length > 0
     ) {
@@ -240,14 +240,14 @@ export const useInitSourcerer = (
       );
     }
   }, [
-    activeTimeline,
+    timelineSavedObjectId,
     defaultDataView,
     dispatch,
     loadingSignalIndex,
     signalIndexName,
     signalIndexNameSourcerer,
   ]);
-  const { dataViewId } = useSourcererDataView(scopeId);
+  const { dataViewId, browserFields } = useSourcererDataView(scopeId);
 
   const updateSourcererDataView = useCallback(
     (newSignalsIndex: string) => {
@@ -370,4 +370,11 @@ export const useInitSourcerer = (
     signalIndexName,
     signalIndexNameSourcerer,
   ]);
+
+  return useMemo(
+    () => ({
+      browserFields,
+    }),
+    [browserFields]
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/more_container/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/field_renderers/more_container/index.tsx
@@ -9,7 +9,7 @@ import React, { useContext, useMemo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/css';
 import classNames from 'classnames';
-import { TimelineContext } from '../../timeline';
+import { TimelineContext } from '../../timeline/context';
 import { getSourcererScopeId } from '../../../../helpers';
 import { escapeDataProviderId } from '../../../../common/components/drag_and_drop/helpers';
 import { defaultToEmptyTag } from '../../../../common/components/empty_value';

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.test.tsx
@@ -14,12 +14,27 @@ import type { UnifiedTimelineBodyProps } from './unified_timeline_body';
 import { UnifiedTimelineBody } from './unified_timeline_body';
 import { render } from '@testing-library/react';
 import { defaultHeaders, mockTimelineData, TestProviders } from '../../../../common/mock';
+import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
+import { mockSourcererScope } from '../../../../sourcerer/containers/mocks';
+import { DataView } from '@kbn/data-views-plugin/common';
 
 jest.mock('../unified_components', () => {
   return {
     UnifiedTimeline: jest.fn(),
   };
 });
+
+const mockDataView = new DataView({
+  spec: mockSourcererScope.sourcererDataView,
+  fieldFormats: fieldFormatsMock,
+});
+
+// Not returning an actual dataView here, just an object as a non-null value;
+const mockUseGetScopedSourcererDataView = jest.fn().mockImplementation(() => mockDataView);
+
+jest.mock('../../../../sourcerer/components/use_get_sourcerer_data_view', () => ({
+  useGetScopedSourcererDataView: () => mockUseGetScopedSourcererDataView(),
+}));
 
 const mockEventsData = structuredClone(mockTimelineData);
 
@@ -76,5 +91,12 @@ describe('UnifiedTimelineBody', () => {
       }),
       {}
     );
+  });
+
+  it('should render the dataview error component when no dataView is provided', () => {
+    mockUseGetScopedSourcererDataView.mockImplementationOnce(() => undefined);
+    const { queryByTestId } = renderTestComponents();
+
+    expect(queryByTestId('dataViewErrorComponent')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/body/unified_timeline_body.tsx
@@ -8,11 +8,15 @@
 import type { ComponentProps, ReactElement } from 'react';
 import React, { useMemo } from 'react';
 import { RootDragDropProvider } from '@kbn/dom-drag-drop';
+import { useGetScopedSourcererDataView } from '../../../../sourcerer/components/use_get_sourcerer_data_view';
+import { DataViewErrorComponent } from '../../../../common/components/with_data_view/data_view_error';
 import { StyledTableFlexGroup, StyledUnifiedTableFlexItem } from '../unified_components/styles';
 import { UnifiedTimeline } from '../unified_components';
 import { defaultUdtHeaders } from './column_headers/default_headers';
+import { SourcererScopeName } from '../../../../sourcerer/store/model';
 
-export interface UnifiedTimelineBodyProps extends ComponentProps<typeof UnifiedTimeline> {
+export interface UnifiedTimelineBodyProps
+  extends Omit<ComponentProps<typeof UnifiedTimeline>, 'dataView'> {
   header: ReactElement;
 }
 
@@ -37,7 +41,9 @@ export const UnifiedTimelineBody = (props: UnifiedTimelineBodyProps) => {
     leadingControlColumns,
     onUpdatePageIndex,
   } = props;
-
+  const dataView = useGetScopedSourcererDataView({
+    sourcererScope: SourcererScopeName.timeline,
+  });
   const columnsHeader = useMemo(() => columns ?? defaultUdtHeaders, [columns]);
 
   return (
@@ -48,26 +54,31 @@ export const UnifiedTimelineBody = (props: UnifiedTimelineBodyProps) => {
         data-test-subj="unifiedTimelineBody"
       >
         <RootDragDropProvider>
-          <UnifiedTimeline
-            columns={columnsHeader}
-            rowRenderers={rowRenderers}
-            isSortEnabled={isSortEnabled}
-            timelineId={timelineId}
-            itemsPerPage={itemsPerPage}
-            itemsPerPageOptions={itemsPerPageOptions}
-            sort={sort}
-            events={events}
-            refetch={refetch}
-            dataLoadingState={dataLoadingState}
-            totalCount={totalCount}
-            onFetchMoreRecords={onFetchMoreRecords}
-            activeTab={activeTab}
-            updatedAt={updatedAt}
-            isTextBasedQuery={false}
-            trailingControlColumns={trailingControlColumns}
-            leadingControlColumns={leadingControlColumns}
-            onUpdatePageIndex={onUpdatePageIndex}
-          />
+          {dataView ? (
+            <UnifiedTimeline
+              columns={columnsHeader}
+              dataView={dataView}
+              rowRenderers={rowRenderers}
+              isSortEnabled={isSortEnabled}
+              timelineId={timelineId}
+              itemsPerPage={itemsPerPage}
+              itemsPerPageOptions={itemsPerPageOptions}
+              sort={sort}
+              events={events}
+              refetch={refetch}
+              dataLoadingState={dataLoadingState}
+              totalCount={totalCount}
+              onFetchMoreRecords={onFetchMoreRecords}
+              activeTab={activeTab}
+              updatedAt={updatedAt}
+              isTextBasedQuery={false}
+              trailingControlColumns={trailingControlColumns}
+              leadingControlColumns={leadingControlColumns}
+              onUpdatePageIndex={onUpdatePageIndex}
+            />
+          ) : (
+            <DataViewErrorComponent />
+          )}
         </RootDragDropProvider>
       </StyledUnifiedTableFlexItem>
     </StyledTableFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/context.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createContext } from 'react';
+
+export const TimelineContext = createContext<{
+  timelineId: string | null;
+}>({ timelineId: null });

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -7,7 +7,7 @@
 
 import { pick } from 'lodash/fp';
 import { EuiPanel, EuiProgress, EuiText } from '@elastic/eui';
-import React, { useCallback, useEffect, useMemo, useRef, createContext } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 
@@ -30,6 +30,7 @@ import { EXIT_FULL_SCREEN_CLASS_NAME } from '../../../common/components/exit_ful
 import { useResolveConflict } from '../../../common/hooks/use_resolve_conflict';
 import { sourcererSelectors } from '../../../common/store';
 import { defaultUdtHeaders } from './body/column_headers/default_headers';
+import { TimelineContext } from './context';
 
 const TimelineBody = styled.div`
   height: 100%;
@@ -37,7 +38,6 @@ const TimelineBody = styled.div`
   flex-direction: column;
 `;
 
-export const TimelineContext = createContext<{ timelineId: string | null }>({ timelineId: null });
 export interface Props {
   renderCellValue: (props: CellValueElementProps) => React.ReactNode;
   rowRenderers: RowRenderer[];

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/index.tsx
@@ -45,17 +45,7 @@ import { selectTimelineById, selectTimelineESQLSavedSearchId } from '../../../st
 import { fetchNotesBySavedObjectIds, selectSortedNotesBySavedObjectId } from '../../../../notes';
 import { ENABLE_VISUALIZATIONS_IN_FLYOUT_SETTING } from '../../../../../common/constants';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
-
-const HideShowContainer = styled.div.attrs<{ $isVisible: boolean; isOverflowYScroll: boolean }>(
-  ({ $isVisible = false, isOverflowYScroll = false }) => ({
-    style: {
-      display: $isVisible ? 'flex' : 'none',
-      overflow: isOverflowYScroll ? 'hidden scroll' : 'hidden',
-    },
-  })
-)<{ $isVisible: boolean; isOverflowYScroll?: boolean }>`
-  flex: 1;
-`;
+import { OnDemandRenderer, OnDemandSuspenseFallback } from './on_demand_renderer';
 
 /**
  * A HOC which supplies React.Suspense with a fallback component
@@ -76,13 +66,35 @@ const tabWithSuspense = <P extends {}, R = {}>(
   return Comp;
 };
 
-const QueryTab = tabWithSuspense(lazy(() => import('./query')));
-const EqlTab = tabWithSuspense(lazy(() => import('./eql')));
-const GraphTab = tabWithSuspense(lazy(() => import('./graph')));
-const NotesTab = tabWithSuspense(lazy(() => import('./notes')));
-const PinnedTab = tabWithSuspense(lazy(() => import('./pinned')));
-const SessionTab = tabWithSuspense(lazy(() => import('./session')));
-const EsqlTab = tabWithSuspense(lazy(() => import('./esql')));
+const QueryTab = tabWithSuspense(
+  lazy(() => import('./query')),
+  <OnDemandSuspenseFallback />
+);
+const EqlTab = tabWithSuspense(
+  lazy(() => import('./eql')),
+  <OnDemandSuspenseFallback />
+);
+const GraphTab = tabWithSuspense(
+  lazy(() => import('./graph')),
+  <OnDemandSuspenseFallback />
+);
+const NotesTab = tabWithSuspense(
+  lazy(() => import('./notes')),
+  <OnDemandSuspenseFallback />
+);
+const PinnedTab = tabWithSuspense(
+  lazy(() => import('./pinned')),
+  <OnDemandSuspenseFallback />
+);
+const SessionTab = tabWithSuspense(
+  lazy(() => import('./session')),
+  <OnDemandSuspenseFallback />
+);
+const EsqlTab = tabWithSuspense(
+  lazy(() => import('./esql')),
+  <OnDemandSuspenseFallback />
+);
+
 interface BasicTimelineTab {
   renderCellValue: (props: CellValueElementProps) => React.ReactNode;
   rowRenderers: RowRenderer[];
@@ -145,53 +157,58 @@ const ActiveTimelineTab = memo<ActiveTimelineTabProps>(
      */
     return (
       <>
-        <HideShowContainer
-          $isVisible={TimelineTabs.query === activeTimelineTab}
-          data-test-subj={`timeline-tab-content-${TimelineTabs.query}`}
+        <OnDemandRenderer
+          timelineId={timelineId}
+          shouldShowTab={TimelineTabs.query === activeTimelineTab}
+          dataTestSubj={`timeline-tab-content-${TimelineTabs.query}`}
         >
           <QueryTab
             renderCellValue={renderCellValue}
             rowRenderers={rowRenderers}
             timelineId={timelineId}
           />
-        </HideShowContainer>
+        </OnDemandRenderer>
         {showTimeline && shouldShowESQLTab && activeTimelineTab === TimelineTabs.esql && (
-          <HideShowContainer
-            $isVisible={true}
-            data-test-subj={`timeline-tab-content-${TimelineTabs.esql}`}
+          <OnDemandRenderer
+            timelineId={timelineId}
+            shouldShowTab={true}
+            dataTestSubj={`timeline-tab-content-${TimelineTabs.esql}`}
           >
             <EsqlTab timelineId={timelineId} />
-          </HideShowContainer>
+          </OnDemandRenderer>
         )}
-        <HideShowContainer
-          $isVisible={TimelineTabs.pinned === activeTimelineTab}
-          data-test-subj={`timeline-tab-content-${TimelineTabs.pinned}`}
+        <OnDemandRenderer
+          timelineId={timelineId}
+          shouldShowTab={TimelineTabs.pinned === activeTimelineTab}
+          dataTestSubj={`timeline-tab-content-${TimelineTabs.pinned}`}
         >
           <PinnedTab
             renderCellValue={renderCellValue}
             rowRenderers={rowRenderers}
             timelineId={timelineId}
           />
-        </HideShowContainer>
+        </OnDemandRenderer>
         {timelineType === TimelineTypeEnum.default && (
-          <HideShowContainer
-            $isVisible={TimelineTabs.eql === activeTimelineTab}
-            data-test-subj={`timeline-tab-content-${TimelineTabs.eql}`}
+          <OnDemandRenderer
+            timelineId={timelineId}
+            shouldShowTab={TimelineTabs.eql === activeTimelineTab}
+            dataTestSubj={`timeline-tab-content-${TimelineTabs.eql}`}
           >
             <EqlTab
               renderCellValue={renderCellValue}
               rowRenderers={rowRenderers}
               timelineId={timelineId}
             />
-          </HideShowContainer>
+          </OnDemandRenderer>
         )}
-        <HideShowContainer
-          $isVisible={isGraphOrNotesTabs}
+        <OnDemandRenderer
+          timelineId={timelineId}
+          shouldShowTab={isGraphOrNotesTabs}
           isOverflowYScroll={activeTimelineTab === TimelineTabs.session}
-          data-test-subj={`timeline-tab-content-${TimelineTabs.graph}-${TimelineTabs.notes}`}
+          dataTestSubj={`timeline-tab-content-${TimelineTabs.graph}-${TimelineTabs.notes}`}
         >
-          {isGraphOrNotesTabs && getTab(activeTimelineTab)}
-        </HideShowContainer>
+          {isGraphOrNotesTabs ? getTab(activeTimelineTab) : null}
+        </OnDemandRenderer>
       </>
     );
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/on_demand_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/on_demand_renderer.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+import { render } from '@testing-library/react';
+import type { OnDemandRendererProps } from './on_demand_renderer';
+import { OnDemandRenderer } from './on_demand_renderer';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { TimelineId } from '../../../../../common/types';
+
+jest.mock('../../../../common/hooks/use_selector');
+
+describe('OnDemandRenderer', () => {
+  const mockUseDeepEqualSelector = useDeepEqualSelector as jest.Mock;
+  const defaultProps = {
+    dataTestSubj: 'test',
+    shouldShowTab: true,
+    isOverflowYScroll: false,
+    timelineId: TimelineId.test,
+  };
+
+  const TestComponent = ({ children, ...restProps }: Partial<OnDemandRendererProps>) => (
+    <OnDemandRenderer {...defaultProps} {...restProps}>
+      <div>{children ?? 'test component'}</div>
+    </OnDemandRenderer>
+  );
+  const renderTestComponents = (props?: Partial<OnDemandRendererProps>) => {
+    const { children, ...restProps } = props ?? {};
+    return render(<TestComponent {...restProps}>{children}</TestComponent>);
+  };
+
+  beforeEach(() => {
+    mockUseDeepEqualSelector.mockClear();
+  });
+
+  describe('timeline visibility', () => {
+    it('should NOT render children when the timeline show status is false', () => {
+      mockUseDeepEqualSelector.mockReturnValue({ show: false });
+      const { queryByText } = renderTestComponents();
+      expect(queryByText('test component')).not.toBeInTheDocument();
+    });
+
+    it('should render children when the timeline show status is true', () => {
+      mockUseDeepEqualSelector.mockReturnValue({ show: true });
+
+      const { getByText } = renderTestComponents();
+
+      expect(getByText('test component')).toBeInTheDocument();
+    });
+  });
+
+  describe('tab visibility', () => {
+    it('should not render children when show tab is false', () => {
+      const { queryByText } = renderTestComponents({ shouldShowTab: false });
+
+      expect(queryByText('test component')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('re-rendering', () => {
+    const testChildString = 'new content';
+    const mockFnShouldThatShouldOnlyRunOnce = jest.fn();
+
+    const TestChild = () => {
+      useEffect(() => {
+        mockFnShouldThatShouldOnlyRunOnce();
+      }, []);
+      return <div>{testChildString}</div>;
+    };
+
+    const RerenderTestComponent = (props?: Partial<OnDemandRendererProps>) => (
+      <TestComponent {...props}>
+        <TestChild />
+      </TestComponent>
+    );
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      mockUseDeepEqualSelector.mockReturnValue({ show: true });
+    });
+
+    it('should NOT re-render children after the first render', () => {
+      const { rerender, queryByText } = render(<RerenderTestComponent />);
+      rerender(<RerenderTestComponent />);
+      expect(queryByText(testChildString)).toBeInTheDocument();
+      expect(mockFnShouldThatShouldOnlyRunOnce).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT re-render children even if timeline show status changes', () => {
+      const { rerender, queryByText } = render(<RerenderTestComponent />);
+      mockUseDeepEqualSelector.mockReturnValue({ show: false });
+      rerender(<RerenderTestComponent />);
+      expect(queryByText(testChildString)).toBeInTheDocument();
+      expect(mockFnShouldThatShouldOnlyRunOnce).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT re-render children even if tab visibility status changes', () => {
+      const { rerender, queryByText } = render(<RerenderTestComponent />);
+      rerender(<RerenderTestComponent shouldShowTab={false} />);
+      rerender(<RerenderTestComponent shouldShowTab={true} />);
+      expect(queryByText(testChildString)).toBeInTheDocument();
+      expect(mockFnShouldThatShouldOnlyRunOnce).toHaveBeenCalledTimes(1);
+    });
+
+    it('should re-render if the component is unmounted and remounted', () => {
+      const { rerender, queryByText, unmount } = render(<RerenderTestComponent />);
+      unmount();
+      rerender(<RerenderTestComponent shouldShowTab={true} />);
+      expect(queryByText(testChildString)).toBeInTheDocument();
+      expect(mockFnShouldThatShouldOnlyRunOnce).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/on_demand_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/on_demand_renderer.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo, useState, useEffect } from 'react';
+import { css } from '@emotion/react';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingElastic } from '@elastic/eui';
+import type { TimelineId } from '../../../../../common/types';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { getTimelineShowStatusByIdSelector } from '../../../store/selectors';
+
+/**
+ * We check for the timeline open status to request the fields for the fields browser as the fields request
+ * is often a much longer running request for customers with a significant number of indices and fields in those indices.
+ * This request should only be made after the user has decided to interact with a specific tab in the timeline to prevent any performance impacts
+ * to the underlying security solution views, as this query will always run when the timeline exists on the page.
+ *
+ * `hasTimelineTabBeenOpenedOnce` - We want to keep timeline loading times as fast as possible after the user
+ * has chosen to interact with timeline at least once, so we use this flag to prevent re-requesting of this fields data
+ * every time timeline is closed and re-opened after the first interaction.
+ */
+
+export interface OnDemandRendererProps {
+  children: React.ReactElement | null;
+  dataTestSubj: string;
+  isOverflowYScroll?: boolean;
+  shouldShowTab: boolean;
+  timelineId: TimelineId;
+}
+
+export const OnDemandRenderer = React.memo(
+  ({
+    children,
+    dataTestSubj,
+    shouldShowTab,
+    isOverflowYScroll,
+    timelineId,
+  }: OnDemandRendererProps) => {
+    const getTimelineShowStatus = useMemo(() => getTimelineShowStatusByIdSelector(), []);
+    const { show } = useDeepEqualSelector((state) => getTimelineShowStatus(state, timelineId));
+
+    const [hasTimelineTabBeenOpenedOnce, setHasTimelineTabBeenOpenedOnce] = useState(false);
+
+    useEffect(() => {
+      if (!hasTimelineTabBeenOpenedOnce && show && shouldShowTab) {
+        setHasTimelineTabBeenOpenedOnce(true);
+      }
+    }, [hasTimelineTabBeenOpenedOnce, shouldShowTab, show]);
+
+    return (
+      <div
+        // The shouldShowTab check here is necessary for the flex container to accurately size to the modal window when it's opened
+        css={css`
+          display: ${shouldShowTab ? 'flex' : 'none'};
+          overflow: ${isOverflowYScroll ? 'hidden scroll' : 'hidden'};
+          flex: 1;
+        `}
+        data-test-subj={dataTestSubj}
+      >
+        {hasTimelineTabBeenOpenedOnce ? children : <EuiLoadingElastic size="xl" />}
+      </div>
+    );
+  }
+);
+
+OnDemandRenderer.displayName = 'OnDemandRenderer';
+
+export const OnDemandSuspenseFallback = () => (
+  <EuiFlexGroup direction="row" justifyContent="spaceAround">
+    <EuiFlexItem
+      grow={false}
+      css={css`
+        justify-content: center;
+      `}
+    >
+      <EuiLoadingElastic size="xxl" />
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.test.tsx
@@ -10,14 +10,16 @@ import React from 'react';
 import { TimelineDataTable } from '.';
 import { TimelineId, TimelineTabs } from '../../../../../../common/types';
 import { DataLoadingState } from '@kbn/unified-data-table';
+import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
+import { DataView } from '@kbn/data-views-plugin/common';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
 import type { ComponentProps } from 'react';
 import { getColumnHeaders } from '../../body/column_headers/helpers';
 import { mockSourcererScope } from '../../../../../sourcerer/containers/mocks';
 import * as timelineActions from '../../../../store/actions';
-import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { defaultUdtHeaders } from '../../body/column_headers/default_headers';
+import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 
 jest.mock('../../../../../sourcerer/containers');
 
@@ -54,6 +56,11 @@ type TestComponentProps = Partial<ComponentProps<typeof TimelineDataTable>> & {
 // that is why we are setting it to 10s
 const SPECIAL_TEST_TIMEOUT = 50000;
 
+const mockDataView = new DataView({
+  spec: mockSourcererScope.sourcererDataView,
+  fieldFormats: fieldFormatsMock,
+});
+
 const TestComponent = (props: TestComponentProps) => {
   const { store = createMockStore(), ...restProps } = props;
   useSourcererDataView();
@@ -62,6 +69,7 @@ const TestComponent = (props: TestComponentProps) => {
       <TimelineDataTable
         columns={initialEnrichedColumns}
         columnIds={initialEnrichedColumnsIds}
+        dataView={mockDataView}
         activeTab={TimelineTabs.query}
         timelineId={TimelineId.test}
         itemsPerPage={50}

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -24,7 +24,6 @@ import { DocumentDetailsRightPanelKey } from '../../../../../flyout/document_det
 import { selectTimelineById } from '../../../../store/selectors';
 import { RowRendererCount } from '../../../../../../common/api/timeline';
 import { EmptyComponent } from '../../../../../common/lib/cell_actions/helpers';
-import { withDataView } from '../../../../../common/components/with_data_view';
 import { StatefulEventContext } from '../../../../../common/components/events_viewer/stateful_event_context';
 import type { TimelineItem } from '../../../../../../common/search_strategy';
 import { useKibana } from '../../../../../common/lib/kibana';
@@ -432,7 +431,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
   }
 );
 
-export const TimelineDataTable = withDataView<DataTableProps>(TimelineDataTableComponent);
+export const TimelineDataTable = React.memo(TimelineDataTableComponent);
 
 // eslint-disable-next-line import/no-default-export
 export { TimelineDataTable as default };

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.test.tsx
@@ -34,6 +34,8 @@ import { DataLoadingState } from '@kbn/unified-data-table';
 import { getColumnHeaders } from '../body/column_headers/helpers';
 import { defaultUdtHeaders } from '../body/column_headers/default_headers';
 import type { ColumnHeaderType } from '../../../../../common/types';
+import { DataView } from '@kbn/data-views-plugin/common';
+import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 
 jest.mock('../../../containers', () => ({
   useTimelineEvents: jest.fn(),
@@ -85,6 +87,11 @@ const SPECIAL_TEST_TIMEOUT = 50000;
 
 const localMockedTimelineData = structuredClone(mockTimelineData);
 
+const mockDataView = new DataView({
+  spec: mockSourcererScope.sourcererDataView,
+  fieldFormats: fieldFormatsMock,
+});
+
 const TestComponent = (
   props: Partial<ComponentProps<typeof UnifiedTimeline>> & { show?: boolean }
 ) => {
@@ -92,6 +99,7 @@ const TestComponent = (
   const testComponentDefaultProps: ComponentProps<typeof QueryTabContent> = {
     columns: getColumnHeaders(columnsToDisplay, mockSourcererScope.browserFields),
     activeTab: TimelineTabs.query,
+    dataView: mockDataView,
     rowRenderers: [],
     timelineId: TimelineId.test,
     itemsPerPage: 10,
@@ -513,50 +521,14 @@ describe('unified timeline', () => {
   });
 
   describe('unified field list', () => {
-    describe('render', () => {
-      let TestProviderWithNewStore: FC<PropsWithChildren<unknown>>;
-      beforeEach(() => {
-        const freshStore = createMockStore();
-        // eslint-disable-next-line react/display-name
-        TestProviderWithNewStore = ({ children }) => {
-          return <TestProviders store={freshStore}>{children}</TestProviders>;
-        };
-      });
-      it(
-        'should not render when timeline has never been opened',
-        async () => {
-          render(<TestComponent show={false} />, {
-            wrapper: TestProviderWithNewStore,
-          });
-          expect(await screen.queryByTestId('timeline-sidebar')).not.toBeInTheDocument();
-        },
-        SPECIAL_TEST_TIMEOUT
-      );
-
-      it(
-        'should render when timeline has been opened',
-        async () => {
-          render(<TestComponent />, {
-            wrapper: TestProviderWithNewStore,
-          });
-          expect(await screen.queryByTestId('timeline-sidebar')).toBeInTheDocument();
-        },
-        SPECIAL_TEST_TIMEOUT
-      );
-
-      it(
-        'should not re-render when timeline has been opened at least once',
-        async () => {
-          const { rerender } = render(<TestComponent />, {
-            wrapper: TestProviderWithNewStore,
-          });
-          rerender(<TestComponent show={false} />);
-          // Even after timeline is closed, it should still exist in the background
-          expect(await screen.queryByTestId('timeline-sidebar')).toBeInTheDocument();
-        },
-        SPECIAL_TEST_TIMEOUT
-      );
-    });
+    it(
+      'should render',
+      async () => {
+        renderTestComponents();
+        expect(await screen.queryByTestId('timeline-sidebar')).toBeInTheDocument();
+      },
+      SPECIAL_TEST_TIMEOUT
+    );
 
     it(
       'should be able to add filters',

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/index.tsx
@@ -6,7 +6,7 @@
  */
 import type { EuiDataGridProps } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiHideFor, useEuiTheme } from '@elastic/eui';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { generateFilters } from '@kbn/data-plugin/public';
 import type { DataView, DataViewField } from '@kbn/data-plugin/common';
@@ -26,8 +26,6 @@ import { UnifiedFieldListSidebarContainer } from '@kbn/unified-field-list';
 import type { EuiTheme } from '@kbn/react-kibana-context-styled';
 import type { CoreStart } from '@kbn/core-lifecycle-browser';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
-import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
-import { withDataView } from '../../../../common/components/with_data_view';
 import { EventDetailsWidthProvider } from '../../../../common/components/events_viewer/event_details_width_context';
 import type { TimelineItem } from '../../../../../common/search_strategy';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -47,7 +45,6 @@ import TimelineDataTable from './data_table';
 import { timelineActions } from '../../../store';
 import { getFieldsListCreationOptions } from './get_fields_list_creation_options';
 import { defaultUdtHeaders } from '../body/column_headers/default_headers';
-import { getTimelineShowStatusByIdSelector } from '../../../store/selectors';
 
 const TimelineBodyContainer = styled.div.attrs(({ className = '' }) => ({
   className: `${className}`,
@@ -347,31 +344,6 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
     onFieldEdited();
   }, [onFieldEdited]);
 
-  // PERFORMANCE ONLY CODE BLOCK
-  /**
-   * We check for the timeline open status to request the fields for the fields browser as the fields request
-   * is often a much longer running request for customers with a significant number of indices and fields in those indices.
-   * This request should only be made after the user has decided to interact with timeline to prevent any performance impacts
-   * to the underlying security solution views, as this query will always run when the timeline exists on the page.
-   *
-   * `hasTimelineBeenOpenedOnce` - We want to keep timeline loading times as fast as possible after the user
-   * has chosen to interact with timeline at least once, so we use this flag to prevent re-requesting of this fields data
-   * every time timeline is closed and re-opened after the first interaction.
-   */
-
-  const getTimelineShowStatus = useMemo(() => getTimelineShowStatusByIdSelector(), []);
-  const { show } = useDeepEqualSelector((state) => getTimelineShowStatus(state, timelineId));
-
-  const [hasTimelineBeenOpenedOnce, setHasTimelineBeenOpenedOnce] = useState(false);
-
-  useEffect(() => {
-    if (!hasTimelineBeenOpenedOnce && show) {
-      setHasTimelineBeenOpenedOnce(true);
-    }
-  }, [hasTimelineBeenOpenedOnce, show]);
-
-  // END PERFORMANCE ONLY CODE BLOCK
-
   return (
     <TimelineBodyContainer className="timelineBodyContainer" ref={setSidebarContainer}>
       <TimelineResizableLayout
@@ -380,7 +352,7 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
         sidebarPanel={
           <SidebarPanelFlexGroup gutterSize="none">
             <EuiFlexItem className="sidebarContainer">
-              {dataView && hasTimelineBeenOpenedOnce ? (
+              {dataView && (
                 <UnifiedFieldListSidebarContainer
                   ref={unifiedFieldListContainerRef}
                   showFieldList
@@ -396,7 +368,7 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
                   onAddFilter={onAddFilter}
                   onFieldEdited={wrappedOnFieldEdited}
                 />
-              ) : null}
+              )}
             </EuiFlexItem>
             <EuiHideFor sizes={HIDE_FOR_SIZES}>
               <EuiFlexItem
@@ -430,6 +402,7 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
                     <DataGridMemoized
                       columns={columns}
                       columnIds={currentColumnIds}
+                      dataView={dataView}
                       rowRenderers={rowRenderers}
                       timelineId={timelineId}
                       isSortEnabled={isSortEnabled}
@@ -463,6 +436,6 @@ const UnifiedTimelineComponent: React.FC<Props> = ({
   );
 };
 
-export const UnifiedTimeline = React.memo(withDataView<Props>(UnifiedTimelineComponent));
+export const UnifiedTimeline = React.memo(UnifiedTimelineComponent);
 // eslint-disable-next-line import/no-default-export
 export { UnifiedTimeline as default };


### PR DESCRIPTION
_NOTE: This PR should NOT be merged, but merely serves as a way to test a combination of changes that were made throughout the application to improve the performance at scale._

## Summary

In an effort to improve the performance of the security solution application, the following changes were made and broken out into the separate PRs below. Details about each of the issues in decreasing severity can be found in the relevant PRs below

1. Improving the performance of computing browser fields. https://github.com/elastic/kibana/pull/212469.
2. Loading timeline tabs on demand and preventing multiple calls to `dataView.create` https://github.com/elastic/kibana/pull/212478
3. Limiting re-renders caused by reference changes in sourcerer https://github.com/elastic/kibana/pull/212482
4. Limiting re-renders in the application caused by the `PluginTemplateWrapper` https://github.com/elastic/kibana/pull/212488

[Bonus] - https://github.com/elastic/kibana/pull/212982

## Testing

_Note_:

1. Run ES with enough memory to handle the request sizes. With 500k fields I saw on average 6 gigs used, but opted for 10g to be safe.
`export ES_JAVA_OPTS="-Xms10g -Xmx10g" && yarn es snapshot [...whatever your typical args are here]`

2. Set your max payload in your `kibana.dev.yml` file to a sufficient enough max. I opted for 100mb
` server.maxPayload: 104857600 `. The largest request I generated was about 30mb

3. Generate the dev tools requests to create an index `test-large-index` with 500k mapped fields and a document with all 500k fields populated via [this util](https://gist.github.com/michaelolo24/2cbb0622f7e62009fb355b52bed3b2ef) you can run locally: 

_Note: the browser may crash if you try and paste the entire thing into the kibana dev tools, so run the 'mapping' and 'doc' calls seprately in dev tools_

4. Add the newly generated index pattern `test-large-index` to the `securitySolution:defaultIndex` setting in the kibana advanced settings page. Make sure to reload after updating

6. Now visit the security solution application. Another reload might be needed as in testing I saw that the new index wasn't always picked up immediately.

7. Generate alerts that look at the new index. Simply creating a rule that looks at the new default security indices with `test-large-index` and querying against `host.name:*` should generate alerts.

8. Now test by clicking through various views such as the Alerts Page, Host Events Page, Cases, opening the field browser component, and lastly opening and navigating the timeline tabs.

