### PR TITLE
[8.x] [Security Solution][Siem migrations] Implement rate limit backoff (#211469)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/__mocks__/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/__mocks__/mocks.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import { mockRuleMigrationsDataClient } from '../data/__mocks__/mocks';
-import { mockRuleMigrationsTaskClient } from '../task/__mocks__/mocks';
+import { createRuleMigrationsDataClientMock } from '../data/__mocks__/mocks';
+import { createRuleMigrationsTaskClientMock } from '../task/__mocks__/mocks';
 
 export const createRuleMigrationDataClient = jest
   .fn()
-  .mockImplementation(() => mockRuleMigrationsDataClient);
+  .mockImplementation(() => createRuleMigrationsDataClientMock());
 
 export const createRuleMigrationTaskClient = jest
   .fn()
-  .mockImplementation(() => mockRuleMigrationsTaskClient);
+  .mockImplementation(() => createRuleMigrationsTaskClientMock());
 
 export const createRuleMigrationClient = () => ({
   data: createRuleMigrationDataClient(),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/__mocks__/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/__mocks__/mocks.ts
@@ -5,24 +5,28 @@
  * 2.0.
  */
 
+import type { RuleMigrationsDataIntegrationsClient } from '../rule_migrations_data_integrations_client';
+import type { RuleMigrationsDataLookupsClient } from '../rule_migrations_data_lookups_client';
+import type { RuleMigrationsDataPrebuiltRulesClient } from '../rule_migrations_data_prebuilt_rules_client';
+import type { RuleMigrationsDataResourcesClient } from '../rule_migrations_data_resources_client';
 import type { RuleMigrationsDataRulesClient } from '../rule_migrations_data_rules_client';
 
 // Rule migrations data rules client
 export const mockRuleMigrationsDataRulesClient = {
   create: jest.fn().mockResolvedValue(undefined),
-  get: jest.fn().mockResolvedValue([]),
+  get: jest.fn().mockResolvedValue({ data: [], total: 0 }),
   searchBatches: jest.fn().mockReturnValue({
     next: jest.fn().mockResolvedValue([]),
     all: jest.fn().mockResolvedValue([]),
   }),
-  takePending: jest.fn().mockResolvedValue([]),
+  saveProcessing: jest.fn().mockResolvedValue(undefined),
   saveCompleted: jest.fn().mockResolvedValue(undefined),
   saveError: jest.fn().mockResolvedValue(undefined),
   releaseProcessing: jest.fn().mockResolvedValue(undefined),
   updateStatus: jest.fn().mockResolvedValue(undefined),
   getStats: jest.fn().mockResolvedValue(undefined),
   getAllStats: jest.fn().mockResolvedValue([]),
-} as unknown as RuleMigrationsDataRulesClient;
+} as unknown as jest.Mocked<RuleMigrationsDataRulesClient>;
 export const MockRuleMigrationsDataRulesClient = jest
   .fn()
   .mockImplementation(() => mockRuleMigrationsDataRulesClient);
@@ -35,30 +39,42 @@ export const mockRuleMigrationsDataResourcesClient = {
     next: jest.fn().mockResolvedValue([]),
     all: jest.fn().mockResolvedValue([]),
   }),
-};
+} as unknown as jest.Mocked<RuleMigrationsDataResourcesClient>;
 export const MockRuleMigrationsDataResourcesClient = jest
   .fn()
   .mockImplementation(() => mockRuleMigrationsDataResourcesClient);
 
 export const mockRuleMigrationsDataIntegrationsClient = {
+  populate: jest.fn().mockResolvedValue(undefined),
   retrieveIntegrations: jest.fn().mockResolvedValue([]),
-};
+} as unknown as jest.Mocked<RuleMigrationsDataIntegrationsClient>;
+
+export const mockRuleMigrationsDataPrebuiltRulesClient = {
+  populate: jest.fn().mockResolvedValue(undefined),
+  search: jest.fn().mockResolvedValue([]),
+} as unknown as jest.Mocked<RuleMigrationsDataPrebuiltRulesClient>;
+export const mockRuleMigrationsDataLookupsClient = {
+  create: jest.fn().mockResolvedValue(undefined),
+  indexData: jest.fn().mockResolvedValue(undefined),
+} as unknown as jest.Mocked<RuleMigrationsDataLookupsClient>;
 
 // Rule migrations data client
-export const mockRuleMigrationsDataClient = {
+export const createRuleMigrationsDataClientMock = () => ({
   rules: mockRuleMigrationsDataRulesClient,
   resources: mockRuleMigrationsDataResourcesClient,
   integrations: mockRuleMigrationsDataIntegrationsClient,
-};
+  prebuiltRules: mockRuleMigrationsDataPrebuiltRulesClient,
+  lookups: mockRuleMigrationsDataLookupsClient,
+});
 
 export const MockRuleMigrationsDataClient = jest
   .fn()
-  .mockImplementation(() => mockRuleMigrationsDataClient);
+  .mockImplementation(() => createRuleMigrationsDataClientMock());
 
 // Rule migrations data service
 export const mockIndexName = 'mocked_siem_rule_migrations_index_name';
 export const mockInstall = jest.fn().mockResolvedValue(undefined);
-export const mockCreateClient = jest.fn().mockReturnValue(mockRuleMigrationsDataClient);
+export const mockCreateClient = jest.fn(() => createRuleMigrationsDataClientMock());
 
 export const MockRuleMigrationsDataService = jest.fn().mockImplementation(() => ({
   createAdapter: jest.fn(),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/__mocks__/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/__mocks__/mocks.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export const mockRuleMigrationsTaskClient = {
+export const createRuleMigrationsTaskClientMock = () => ({
   start: jest.fn().mockResolvedValue({ started: true }),
   stop: jest.fn().mockResolvedValue({ stopped: true }),
   getStats: jest.fn().mockResolvedValue({
@@ -19,15 +19,15 @@ export const mockRuleMigrationsTaskClient = {
     },
   }),
   getAllStats: jest.fn().mockResolvedValue([]),
-};
+});
 
 export const MockRuleMigrationsTaskClient = jest
   .fn()
-  .mockImplementation(() => mockRuleMigrationsTaskClient);
+  .mockImplementation(() => createRuleMigrationsTaskClientMock());
 
 // Rule migrations task service
 export const mockStopAll = jest.fn();
-export const mockCreateClient = jest.fn().mockReturnValue(mockRuleMigrationsTaskClient);
+export const mockCreateClient = jest.fn(() => createRuleMigrationsTaskClientMock());
 
 export const MockRuleMigrationsTaskService = jest.fn().mockImplementation(() => ({
   createClient: mockCreateClient,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_migrations_retriever.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/retrievers/rule_migrations_retriever.ts
@@ -18,6 +18,11 @@ export interface RuleMigrationsRetrieverClients {
   savedObjects: SavedObjectsClientContract;
 }
 
+/**
+ * RuleMigrationsRetriever is a class that is responsible for retrieving all the necessary data during the rule migration process.
+ * It is composed of multiple retrievers that are responsible for retrieving specific types of data.
+ * Such as rule integrations, prebuilt rules, and rule resources.
+ */
 export class RuleMigrationsRetriever {
   public readonly resources: RuleResourceRetriever;
   public readonly integrations: IntegrationRetriever;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_client.ts
@@ -6,10 +6,6 @@
  */
 
 import type { AuthenticatedUser, Logger } from '@kbn/core/server';
-import { AbortError, abortSignalToPromise } from '@kbn/kibana-utils-plugin/server';
-import type { RunnableConfig } from '@langchain/core/runnables';
-import { TELEMETRY_SIEM_MIGRATION_ID } from './util/constants';
-import { EsqlKnowledgeBase } from './util/esql_knowledge_base';
 import {
   SiemMigrationStatus,
   SiemMigrationTaskStatus,
@@ -19,26 +15,14 @@ import type { RuleMigrationFilters } from '../../../../../common/siem_migrations
 import type { RuleMigrationsDataClient } from '../data/rule_migrations_data_client';
 import type { RuleMigrationDataStats } from '../data/rule_migrations_data_rules_client';
 import type { SiemRuleMigrationsClientDependencies } from '../types';
-import { getRuleMigrationAgent } from './agent';
-import type { MigrateRuleState } from './agent/types';
-import { RuleMigrationsRetriever } from './retrievers';
-import { SiemMigrationTelemetryClient } from './rule_migrations_telemetry_client';
 import type {
-  MigrationAgent,
-  RuleMigrationTaskCreateAgentParams,
-  RuleMigrationTaskRunParams,
   RuleMigrationTaskStartParams,
   RuleMigrationTaskStartResult,
   RuleMigrationTaskStopResult,
 } from './types';
-import type { ChatModel } from './util/actions_client_chat';
-import { ActionsClientChat } from './util/actions_client_chat';
-import { generateAssistantComment } from './util/comments';
+import { RuleMigrationTaskRunner } from './rule_migrations_task_runner';
 
-const ITERATION_BATCH_SIZE = 15 as const;
-const ITERATION_SLEEP_SECONDS = 10 as const;
-
-type MigrationsRunning = Map<string, { user: string; abortController: AbortController }>;
+export type MigrationsRunning = Map<string, RuleMigrationTaskRunner>;
 
 export class RuleMigrationsTaskClient {
   constructor(
@@ -51,7 +35,7 @@ export class RuleMigrationsTaskClient {
 
   /** Starts a rule migration task */
   async start(params: RuleMigrationTaskStartParams): Promise<RuleMigrationTaskStartResult> {
-    const { migrationId, connectorId } = params;
+    const { migrationId, connectorId, invocationConfig } = params;
     if (this.migrationsRunning.has(migrationId)) {
       return { exists: true, started: false };
     }
@@ -70,161 +54,40 @@ export class RuleMigrationsTaskClient {
     if (rules.pending === 0) {
       return { exists: true, started: false };
     }
-    const abortController = new AbortController();
-    const model = await this.createModel(connectorId, migrationId, abortController);
 
-    // run the migration without awaiting it to execute it in the background
-    this.run({ ...params, model, abortController }).catch((error) => {
-      this.logger.error(`Error executing migration ID:${migrationId} with error ${error}`);
-    });
+    const migrationLogger = this.logger.get(migrationId);
+    const abortController = new AbortController();
+    const migrationTaskRunner = new RuleMigrationTaskRunner(
+      migrationId,
+      this.currentUser,
+      abortController,
+      this.data,
+      migrationLogger,
+      this.dependencies
+    );
+
+    await migrationTaskRunner.setup(connectorId);
+
+    if (this.migrationsRunning.has(migrationId)) {
+      // Just to prevent a race condition in the setup
+      throw new Error('Task already running for this migration');
+    }
+    this.migrationsRunning.set(migrationId, migrationTaskRunner);
+
+    migrationLogger.info('Starting migration');
+
+    // run the migration in the background without awaiting and resolve the `start` promise
+    migrationTaskRunner
+      .run(invocationConfig)
+      .catch((error) => {
+        // no need to throw, the `start` promise is long gone. Just log the error
+        migrationLogger.error('Error executing migration', error);
+      })
+      .finally(() => {
+        this.migrationsRunning.delete(migrationId);
+      });
 
     return { exists: true, started: true };
-  }
-
-  private async run(params: RuleMigrationTaskRunParams): Promise<void> {
-    const { migrationId, invocationConfig, abortController, model } = params;
-    if (this.migrationsRunning.has(migrationId)) {
-      // This should never happen, but just in case
-      throw new Error(`Task already running for migration ID:${migrationId} `);
-    }
-    this.logger.info(`Starting migration ID:${migrationId}`);
-
-    this.migrationsRunning.set(migrationId, { user: this.currentUser.username, abortController });
-
-    const abortPromise = abortSignalToPromise(abortController.signal);
-    const withAbortRace = async <T>(task: Promise<T>) => Promise.race([task, abortPromise.promise]);
-
-    const sleep = async (seconds: number) => {
-      this.logger.debug(`Sleeping ${seconds}s for migration ID:${migrationId}`);
-      await withAbortRace(new Promise((resolve) => setTimeout(resolve, seconds * 1000)));
-    };
-
-    const stats = { completed: 0, failed: 0 };
-    const telemetryClient = new SiemMigrationTelemetryClient(
-      this.dependencies.telemetry,
-      this.logger,
-      migrationId,
-      model.model
-    );
-    const endSiemMigration = telemetryClient.startSiemMigration();
-    try {
-      this.logger.debug(`Creating agent for migration ID:${migrationId}`);
-
-      const agent = await withAbortRace(this.createAgent({ ...params, model, telemetryClient }));
-
-      const config: RunnableConfig = {
-        ...invocationConfig,
-        // signal: abortController.signal, // not working properly https://github.com/langchain-ai/langgraphjs/issues/319
-      };
-      let isDone: boolean = false;
-      do {
-        const ruleMigrations = await this.data.rules.takePending(migrationId, ITERATION_BATCH_SIZE);
-        this.logger.debug(
-          `Processing ${ruleMigrations.length} rules for migration ID:${migrationId}`
-        );
-
-        await Promise.all(
-          ruleMigrations.map(async (ruleMigration) => {
-            this.logger.debug(`Starting migration of rule "${ruleMigration.original_rule.title}"`);
-            if (ruleMigration.elastic_rule?.id) {
-              await this.data.rules.saveCompleted(ruleMigration);
-              return; // skip already installed rules
-            }
-            const endRuleTranslation = telemetryClient.startRuleTranslation();
-            try {
-              const invocationData = {
-                original_rule: ruleMigration.original_rule,
-              };
-
-              // using withAbortRace is a workaround for the issue with the langGraph signal not working properly
-              const migrationResult = await withAbortRace<MigrateRuleState>(
-                agent.invoke(invocationData, config)
-              );
-
-              this.logger.debug(
-                `Migration of rule "${ruleMigration.original_rule.title}" finished`
-              );
-              endRuleTranslation({ migrationResult });
-              await this.data.rules.saveCompleted({
-                ...ruleMigration,
-                elastic_rule: migrationResult.elastic_rule,
-                translation_result: migrationResult.translation_result,
-                comments: migrationResult.comments,
-              });
-              stats.completed++;
-            } catch (error) {
-              stats.failed++;
-              if (error instanceof AbortError) {
-                throw error;
-              }
-              endRuleTranslation({ error });
-              this.logger.error(
-                `Error migrating rule "${ruleMigration.original_rule.title} with error: ${error.message}"`
-              );
-              await this.data.rules.saveError({
-                ...ruleMigration,
-                comments: [generateAssistantComment(`Error migrating rule: ${error.message}`)],
-              });
-            }
-          })
-        );
-
-        this.logger.debug(`Batch processed successfully for migration ID:${migrationId}`);
-
-        const { rules } = await this.data.rules.getStats(migrationId);
-        isDone = rules.pending === 0;
-        if (!isDone) {
-          await sleep(ITERATION_SLEEP_SECONDS);
-        }
-      } while (!isDone);
-
-      this.logger.info(`Finished migration ID:${migrationId}`);
-
-      endSiemMigration({ stats });
-    } catch (error) {
-      await this.data.rules.releaseProcessing(migrationId);
-
-      if (error instanceof AbortError) {
-        this.logger.info(`Abort signal received, stopping migration ID:${migrationId}`);
-        return;
-      } else {
-        endSiemMigration({ error, stats });
-        this.logger.error(`Error processing migration ID:${migrationId} ${error}`);
-      }
-    } finally {
-      this.migrationsRunning.delete(migrationId);
-      abortPromise.cleanup();
-    }
-  }
-
-  private async createAgent({
-    connectorId,
-    migrationId,
-    model,
-    telemetryClient,
-  }: RuleMigrationTaskCreateAgentParams): Promise<MigrationAgent> {
-    const { inferenceClient, rulesClient, savedObjectsClient } = this.dependencies;
-    const esqlKnowledgeBase = new EsqlKnowledgeBase(
-      connectorId,
-      migrationId,
-      inferenceClient,
-      this.logger
-    );
-    const ruleMigrationsRetriever = new RuleMigrationsRetriever(migrationId, {
-      data: this.data,
-      rules: rulesClient,
-      savedObjects: savedObjectsClient,
-    });
-
-    await ruleMigrationsRetriever.initialize();
-
-    return getRuleMigrationAgent({
-      model,
-      esqlKnowledgeBase,
-      ruleMigrationsRetriever,
-      telemetryClient,
-      logger: this.logger,
-    });
   }
 
   /** Updates all the rules in a migration to be re-executed */
@@ -233,9 +96,10 @@ export class RuleMigrationsTaskClient {
     filter: RuleMigrationFilters
   ): Promise<{ updated: boolean }> {
     if (this.migrationsRunning.has(migrationId)) {
+      // not update migrations that are currently running
       return { updated: false };
     }
-
+    filter.installed = false; // only retry rules that are not installed
     await this.data.rules.updateStatus(migrationId, filter, SiemMigrationStatus.PENDING, {
       refresh: true,
     });
@@ -292,21 +156,5 @@ export class RuleMigrationsTaskClient {
       this.logger.error(`Error stopping migration ID:${migrationId}`, err);
       return { exists: true, stopped: false };
     }
-  }
-
-  private async createModel(
-    connectorId: string,
-    migrationId: string,
-    abortController: AbortController
-  ): Promise<ChatModel> {
-    const { actionsClient } = this.dependencies;
-    const actionsClientChat = new ActionsClientChat(connectorId, actionsClient, this.logger);
-    const model = await actionsClientChat.createModel({
-      telemetryMetadata: { pluginId: TELEMETRY_SIEM_MIGRATION_ID, aggregateBy: migrationId },
-      maxRetries: 10,
-      signal: abortController.signal,
-      temperature: 0.05,
-    });
-    return model;
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_runner.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_runner.test.ts
@@ -1,0 +1,383 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { RuleMigrationTaskRunner } from './rule_migrations_task_runner';
+import { SiemMigrationStatus } from '../../../../../common/siem_migrations/constants';
+import type { AuthenticatedUser } from '@kbn/core/server';
+import type { SiemRuleMigrationsClientDependencies, StoredRuleMigration } from '../types';
+import { createRuleMigrationsDataClientMock } from '../data/__mocks__/mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+
+const mockRetrieverInitialize = jest.fn().mockResolvedValue(undefined);
+jest.mock('./retrievers', () => ({
+  ...jest.requireActual('./retrievers'),
+  RuleMigrationsRetriever: jest
+    .fn()
+    .mockImplementation(() => ({ initialize: mockRetrieverInitialize })),
+}));
+
+const mockCreateModel = jest.fn(() => ({ model: 'test-model' }));
+jest.mock('./util/actions_client_chat', () => ({
+  ...jest.requireActual('./util/actions_client_chat'),
+  ActionsClientChat: jest.fn().mockImplementation(() => ({ createModel: mockCreateModel })),
+}));
+
+const mockInvoke = jest.fn().mockResolvedValue({});
+jest.mock('./agent', () => ({
+  ...jest.requireActual('./agent'),
+  getRuleMigrationAgent: () => ({ invoke: mockInvoke }),
+}));
+
+jest.mock('./rule_migrations_telemetry_client', () => ({
+  SiemMigrationTelemetryClient: jest.fn().mockImplementation(() => ({
+    startSiemMigrationTask: jest.fn(() => ({
+      startRuleTranslation: jest.fn(() => ({ success: jest.fn(), failure: jest.fn() })),
+      success: jest.fn(),
+      failure: jest.fn(),
+    })),
+  })),
+}));
+
+// Mock dependencies
+const mockLogger = loggerMock.create();
+
+const mockDependencies: jest.Mocked<SiemRuleMigrationsClientDependencies> = {
+  rulesClient: {},
+  savedObjectsClient: {},
+  inferenceClient: {},
+  actionsClient: {},
+  telemetry: {},
+} as unknown as SiemRuleMigrationsClientDependencies;
+
+const mockUser = {} as unknown as AuthenticatedUser;
+const ruleId = 'test-rule-id';
+
+jest.useFakeTimers();
+jest.spyOn(global, 'setTimeout');
+const mockTimeout = setTimeout as unknown as jest.Mock;
+mockTimeout.mockImplementation((cb) => {
+  // never actually wait, we'll check the calls manually
+  cb();
+});
+
+describe('RuleMigrationTaskRunner', () => {
+  let taskRunner: RuleMigrationTaskRunner;
+  let abortController: AbortController;
+  let mockRuleMigrationsDataClient: ReturnType<typeof createRuleMigrationsDataClientMock>;
+
+  beforeEach(() => {
+    mockRetrieverInitialize.mockResolvedValue(undefined); // Reset the mock
+    mockInvoke.mockResolvedValue({}); // Reset the mock
+    mockRuleMigrationsDataClient = createRuleMigrationsDataClientMock();
+    jest.clearAllMocks();
+
+    abortController = new AbortController();
+    taskRunner = new RuleMigrationTaskRunner(
+      'test-migration-id',
+      mockUser,
+      abortController,
+      mockRuleMigrationsDataClient,
+      mockLogger,
+      mockDependencies
+    );
+  });
+
+  describe('setup', () => {
+    it('should create the agent and tools', async () => {
+      await expect(taskRunner.setup('test-connector-id')).resolves.toBeUndefined();
+      // @ts-expect-error (checking private properties)
+      expect(taskRunner.agent).toBeDefined();
+      // @ts-expect-error (checking private properties)
+      expect(taskRunner.retriever).toBeDefined();
+      // @ts-expect-error (checking private properties)
+      expect(taskRunner.telemetry).toBeDefined();
+    });
+
+    it('should throw if an error occurs', async () => {
+      const errorMessage = 'Test error';
+      mockCreateModel.mockImplementationOnce(() => {
+        throw new Error(errorMessage);
+      });
+
+      await expect(taskRunner.setup('test-connector-id')).rejects.toThrowError(errorMessage);
+    });
+  });
+
+  describe('run', () => {
+    let runPromise: Promise<void>;
+    beforeEach(async () => {
+      await taskRunner.setup('test-connector-id');
+    });
+
+    it('should handle the migration successfully', async () => {
+      mockRuleMigrationsDataClient.rules.get.mockResolvedValue({ total: 0, data: [] });
+      mockRuleMigrationsDataClient.rules.get.mockResolvedValueOnce({
+        total: 1,
+        data: [{ id: ruleId, status: SiemMigrationStatus.PENDING }] as StoredRuleMigration[],
+      });
+
+      await taskRunner.setup('test-connector-id');
+      await expect(taskRunner.run({})).resolves.toBeUndefined();
+
+      expect(mockRuleMigrationsDataClient.rules.saveProcessing).toHaveBeenCalled();
+      expect(mockTimeout).toHaveBeenCalledTimes(1); // execution sleep
+      expect(mockInvoke).toHaveBeenCalledTimes(1);
+      expect(mockRuleMigrationsDataClient.rules.saveCompleted).toHaveBeenCalled();
+      expect(mockRuleMigrationsDataClient.rules.get).toHaveBeenCalledTimes(2); // One with data, one without
+      expect(mockLogger.info).toHaveBeenCalledWith('Migration completed successfully');
+    });
+
+    describe('when error occurs', () => {
+      const errorMessage = 'Test error message';
+
+      describe('during initialization', () => {
+        it('should handle abort error correctly', async () => {
+          runPromise = taskRunner.run({});
+          abortController.abort(); // Trigger the abort signal
+
+          await expect(runPromise).resolves.toBeUndefined(); // Ensure the function handles abort gracefully
+
+          expect(mockLogger.info).toHaveBeenCalledWith(
+            'Abort signal received, stopping initialization'
+          );
+        });
+
+        it('should handle other errors correctly', async () => {
+          mockRetrieverInitialize.mockRejectedValueOnce(new Error(errorMessage));
+
+          runPromise = taskRunner.run({});
+          await expect(runPromise).resolves.toBeUndefined(); // Ensure the function handles abort gracefully
+
+          expect(mockLogger.error).toHaveBeenCalledWith(
+            `Error initializing migration: Error: ${errorMessage}`
+          );
+        });
+      });
+
+      describe('during migration', () => {
+        beforeEach(() => {
+          mockRuleMigrationsDataClient.rules.get.mockRestore();
+          mockRuleMigrationsDataClient.rules.get
+            .mockResolvedValue({ total: 0, data: [] })
+            .mockResolvedValueOnce({
+              total: 1,
+              data: [{ id: ruleId, status: SiemMigrationStatus.PENDING }] as StoredRuleMigration[],
+            });
+        });
+
+        it('should handle abort error correctly', async () => {
+          runPromise = taskRunner.run({});
+          await Promise.resolve(); // Wait for the initialization to complete
+          abortController.abort(); // Trigger the abort signal
+
+          await expect(runPromise).resolves.toBeUndefined(); // Ensure the function handles abort gracefully
+          expect(mockLogger.info).toHaveBeenCalledWith('Abort signal received, stopping migration');
+          expect(mockRuleMigrationsDataClient.rules.releaseProcessing).toHaveBeenCalled();
+        });
+
+        it('should handle other errors correctly', async () => {
+          mockInvoke.mockRejectedValue(new Error(errorMessage));
+
+          runPromise = taskRunner.run({});
+          await expect(runPromise).resolves.toBeUndefined();
+
+          expect(mockLogger.error).toHaveBeenCalledWith(
+            `Error translating rule \"${ruleId}\" with error: ${errorMessage}`
+          );
+          expect(mockRuleMigrationsDataClient.rules.saveError).toHaveBeenCalled();
+        });
+
+        describe('during rate limit errors', () => {
+          const rule2Id = 'test-rule-id-2';
+          const error = new Error('429. You did way too many requests to this random LLM API bud');
+
+          beforeEach(async () => {
+            mockRuleMigrationsDataClient.rules.get.mockRestore();
+            mockRuleMigrationsDataClient.rules.get
+              .mockResolvedValue({ total: 0, data: [] })
+              .mockResolvedValueOnce({
+                total: 2,
+                data: [
+                  { id: ruleId, status: SiemMigrationStatus.PENDING },
+                  { id: rule2Id, status: SiemMigrationStatus.PENDING },
+                ] as StoredRuleMigration[],
+              });
+          });
+
+          it('should retry with exponential backoff', async () => {
+            mockInvoke
+              .mockResolvedValue({}) // Successful calls from here on
+              .mockRejectedValueOnce(error) // First failed call for rule 1
+              .mockRejectedValueOnce(error) // First failed call for rule 2
+              .mockRejectedValueOnce(error) // Second failed call for rule 1
+              .mockRejectedValueOnce(error); // Third failed call for rule 1
+
+            await expect(taskRunner.run({})).resolves.toBeUndefined(); // success
+
+            /**
+             * Invoke calls:
+             * rule 1 -> failure -> start backoff retries
+             * rule 2 -> failure -> await for rule 1 backoff
+             * then:
+             * rule 1 retry 1 -> failure
+             * rule 1 retry 2 -> failure
+             * rule 1 retry 3 -> success
+             * then:
+             * rule 2 -> success
+             */
+            expect(mockInvoke).toHaveBeenCalledTimes(6);
+            expect(mockTimeout).toHaveBeenCalledTimes(6); // 3 backoff sleeps + 3 execution sleeps
+            expect(mockTimeout).toHaveBeenNthCalledWith(
+              1,
+              expect.any(Function),
+              expect.any(Number)
+            );
+            expect(mockTimeout).toHaveBeenNthCalledWith(
+              2,
+              expect.any(Function),
+              expect.any(Number)
+            );
+            expect(mockTimeout).toHaveBeenNthCalledWith(3, expect.any(Function), 1000);
+            expect(mockTimeout).toHaveBeenNthCalledWith(4, expect.any(Function), 2000);
+            expect(mockTimeout).toHaveBeenNthCalledWith(5, expect.any(Function), 4000);
+            expect(mockTimeout).toHaveBeenNthCalledWith(
+              6,
+              expect.any(Function),
+              expect.any(Number)
+            );
+
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+              `Awaiting backoff task for rule "${rule2Id}"`
+            );
+            expect(mockInvoke).toHaveBeenCalledTimes(6); // 3 retries + 3 executions
+            expect(mockRuleMigrationsDataClient.rules.saveCompleted).toHaveBeenCalledTimes(2); // 2 rules
+          });
+
+          it('should fail when reached maxRetries', async () => {
+            mockInvoke.mockRejectedValue(error);
+
+            await expect(taskRunner.run({})).resolves.toBeUndefined(); // success
+
+            // maxRetries = 8
+            expect(mockInvoke).toHaveBeenCalledTimes(10); // 8 retries + 2 executions
+            expect(mockTimeout).toHaveBeenCalledTimes(10); // 8 backoff sleeps + 2 execution sleeps
+
+            expect(mockRuleMigrationsDataClient.rules.saveError).toHaveBeenCalledTimes(2); // 2 rules
+          });
+
+          it('should fail when reached max recovery attempts', async () => {
+            const rule3Id = 'test-rule-id-3';
+            const rule4Id = 'test-rule-id-4';
+            mockRuleMigrationsDataClient.rules.get.mockRestore();
+            mockRuleMigrationsDataClient.rules.get
+              .mockResolvedValue({ total: 0, data: [] })
+              .mockResolvedValueOnce({
+                total: 4,
+                data: [
+                  { id: ruleId, status: SiemMigrationStatus.PENDING },
+                  { id: rule2Id, status: SiemMigrationStatus.PENDING },
+                  { id: rule3Id, status: SiemMigrationStatus.PENDING },
+                  { id: rule4Id, status: SiemMigrationStatus.PENDING },
+                ] as StoredRuleMigration[],
+              });
+
+            // max recovery attempts = 3
+            mockInvoke
+              .mockResolvedValue({}) // should never reach this
+              .mockRejectedValueOnce(error) // 1st failed call for rule 1
+              .mockRejectedValueOnce(error) // 1st failed call for rule 2
+              .mockRejectedValueOnce(error) // 1st failed call for rule 3
+              .mockRejectedValueOnce(error) // 1st failed call for rule 4
+              .mockResolvedValueOnce({}) // Successful call for the rule 1 backoff
+              .mockRejectedValueOnce(error) // 2nd failed call for the rule 2 recover
+              .mockRejectedValueOnce(error) // 2nd failed call for the rule 3 recover
+              .mockRejectedValueOnce(error) // 2nd failed call for the rule 4 recover
+              .mockResolvedValueOnce({}) // Successful call for the rule 2 backoff
+              .mockRejectedValueOnce(error) // 3rd failed call for the rule 3 recover
+              .mockRejectedValueOnce(error) // 3rd failed call for the rule 4 recover
+              .mockResolvedValueOnce({}) // Successful call for the rule 3 backoff
+              .mockRejectedValueOnce(error); // 4th failed call for the rule 4 recover (max attempts failure)
+
+            await expect(taskRunner.run({})).resolves.toBeUndefined(); // success
+
+            expect(mockRuleMigrationsDataClient.rules.saveCompleted).toHaveBeenCalledTimes(3); // rules 1, 2 and 3
+            expect(mockRuleMigrationsDataClient.rules.saveError).toHaveBeenCalledTimes(1); // rule 4
+          });
+
+          it('should increase the executor sleep time when rate limited', async () => {
+            const getResponse = {
+              total: 1,
+              data: [{ id: ruleId, status: SiemMigrationStatus.PENDING }] as StoredRuleMigration[],
+            };
+            mockRuleMigrationsDataClient.rules.get.mockRestore();
+            mockRuleMigrationsDataClient.rules.get
+              .mockResolvedValue({ total: 0, data: [] })
+              .mockResolvedValueOnce(getResponse)
+              .mockResolvedValueOnce({ total: 0, data: [] })
+              .mockResolvedValueOnce(getResponse)
+              .mockResolvedValueOnce({ total: 0, data: [] })
+              .mockResolvedValueOnce(getResponse)
+              .mockResolvedValueOnce({ total: 0, data: [] })
+              .mockResolvedValueOnce(getResponse)
+              .mockResolvedValueOnce({ total: 0, data: [] })
+              .mockResolvedValueOnce(getResponse)
+              .mockResolvedValueOnce({ total: 0, data: [] })
+              .mockResolvedValueOnce(getResponse)
+              .mockResolvedValueOnce({ total: 0, data: [] });
+
+            /**
+             * Current EXECUTOR_SLEEP settings:
+             * initialValueSeconds: 3, multiplier: 2, limitSeconds: 96, // 1m36s (5 increases)
+             */
+
+            // @ts-expect-error (checking private properties)
+            expect(taskRunner.executorSleepMultiplier).toBe(3);
+
+            mockInvoke.mockResolvedValue({}).mockRejectedValueOnce(error); // rate limit and recovery
+            await expect(taskRunner.run({})).resolves.toBeUndefined(); // success
+
+            // @ts-expect-error (checking private properties)
+            expect(taskRunner.executorSleepMultiplier).toBe(6);
+
+            mockInvoke.mockResolvedValue({}).mockRejectedValueOnce(error); // rate limit and recovery
+            await expect(taskRunner.run({})).resolves.toBeUndefined(); // success
+
+            // @ts-expect-error (checking private properties)
+            expect(taskRunner.executorSleepMultiplier).toBe(12);
+
+            mockInvoke.mockResolvedValue({}).mockRejectedValueOnce(error); // rate limit and recovery
+            await expect(taskRunner.run({})).resolves.toBeUndefined(); // success
+
+            // @ts-expect-error (checking private properties)
+            expect(taskRunner.executorSleepMultiplier).toBe(24);
+
+            mockInvoke.mockResolvedValue({}).mockRejectedValueOnce(error); // rate limit and recovery
+            await expect(taskRunner.run({})).resolves.toBeUndefined(); // success
+
+            // @ts-expect-error (checking private properties)
+            expect(taskRunner.executorSleepMultiplier).toBe(48);
+
+            mockInvoke.mockResolvedValue({}).mockRejectedValueOnce(error); // rate limit and recovery
+            await expect(taskRunner.run({})).resolves.toBeUndefined(); // success
+
+            // @ts-expect-error (checking private properties)
+            expect(taskRunner.executorSleepMultiplier).toBe(96);
+
+            mockInvoke.mockResolvedValue({}).mockRejectedValueOnce(error); // rate limit and recovery
+            await expect(taskRunner.run({})).resolves.toBeUndefined(); // success
+
+            // @ts-expect-error (checking private properties)
+            expect(taskRunner.executorSleepMultiplier).toBe(96); // limit reached
+            expect(mockLogger.warn).toHaveBeenCalledWith(
+              'Executor sleep reached the maximum value'
+            );
+          });
+        });
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_runner.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_runner.ts
@@ -1,0 +1,351 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import assert from 'assert';
+import type { AuthenticatedUser, Logger } from '@kbn/core/server';
+import { abortSignalToPromise, AbortError } from '@kbn/kibana-utils-plugin/server';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import { SiemMigrationStatus } from '../../../../../common/siem_migrations/constants';
+import { initPromisePool } from '../../../../utils/promise_pool';
+import type { RuleMigrationsDataClient } from '../data/rule_migrations_data_client';
+import type { MigrateRuleState } from './agent/types';
+import { getRuleMigrationAgent } from './agent';
+import { RuleMigrationsRetriever } from './retrievers';
+import { SiemMigrationTelemetryClient } from './rule_migrations_telemetry_client';
+import type { MigrationAgent } from './types';
+import { generateAssistantComment } from './util/comments';
+import type { SiemRuleMigrationsClientDependencies, StoredRuleMigration } from '../types';
+import { ActionsClientChat } from './util/actions_client_chat';
+import { EsqlKnowledgeBase } from './util/esql_knowledge_base';
+
+/** Number of concurrent rule translations in the pool */
+const TASK_CONCURRENCY = 10 as const;
+/** Number of rules loaded in memory to be translated in the pool */
+const TASK_BATCH_SIZE = 100 as const;
+
+/** Exponential backoff configuration to handle rate limit errors */
+const RETRY_CONFIG = {
+  initialRetryDelaySeconds: 1,
+  backoffMultiplier: 2,
+  maxRetries: 8,
+  // max waiting time 4m15s (1*2^8 = 256s)
+} as const;
+
+/** Executor sleep configuration
+ * A sleep time applied at the beginning of each single rule translation in the execution pool,
+ * The objective of this sleep is to spread the load of concurrent translations, and prevent hitting the rate limit repeatedly.
+ * The sleep time applied is a random number between [0-value]. Every time we hit rate limit the value is increased by the multiplier, up to the limit.
+ */
+const EXECUTOR_SLEEP = {
+  initialValueSeconds: 3,
+  multiplier: 2,
+  limitSeconds: 96, // 1m36s (5 increases)
+} as const;
+
+/** This limit should never be reached, it's a safety net to prevent infinite loops.
+ * It represents the max number of consecutive rate limit recovery & failure attempts.
+ * This can only happen when the API can not process TASK_CONCURRENCY translations at a time,
+ * even after the executor sleep is increased on every attempt.
+ **/
+const EXECUTOR_RECOVER_MAX_ATTEMPTS = 3 as const;
+
+export class RuleMigrationTaskRunner {
+  private telemetry?: SiemMigrationTelemetryClient;
+  private agent?: MigrationAgent;
+  private retriever?: RuleMigrationsRetriever;
+  private actionsClientChat: ActionsClientChat;
+  private abort: ReturnType<typeof abortSignalToPromise>;
+  private executorSleepMultiplier: number = EXECUTOR_SLEEP.initialValueSeconds;
+  public isWaiting: boolean = false;
+
+  constructor(
+    public readonly migrationId: string,
+    public readonly startedBy: AuthenticatedUser,
+    public readonly abortController: AbortController,
+    private readonly data: RuleMigrationsDataClient,
+    private readonly logger: Logger,
+    private readonly dependencies: SiemRuleMigrationsClientDependencies
+  ) {
+    this.actionsClientChat = new ActionsClientChat(this.dependencies.actionsClient, this.logger);
+    this.abort = abortSignalToPromise(this.abortController.signal);
+  }
+
+  /** Retrieves the connector and creates the migration agent */
+  public async setup(connectorId: string) {
+    const { rulesClient, savedObjectsClient, inferenceClient } = this.dependencies;
+
+    const model = await this.actionsClientChat.createModel({
+      connectorId,
+      migrationId: this.migrationId,
+      abortController: this.abortController,
+    });
+
+    const esqlKnowledgeBase = new EsqlKnowledgeBase(
+      connectorId,
+      this.migrationId,
+      inferenceClient,
+      this.logger
+    );
+
+    this.retriever = new RuleMigrationsRetriever(this.migrationId, {
+      data: this.data,
+      rules: rulesClient,
+      savedObjects: savedObjectsClient,
+    });
+
+    this.telemetry = new SiemMigrationTelemetryClient(
+      this.dependencies.telemetry,
+      this.logger,
+      this.migrationId,
+      model.model
+    );
+
+    this.agent = getRuleMigrationAgent({
+      model,
+      esqlKnowledgeBase,
+      ruleMigrationsRetriever: this.retriever,
+      telemetryClient: this.telemetry,
+      logger: this.logger,
+    });
+  }
+
+  /** Initializes the retriever populating ELSER indices. It may take a few minutes */
+  private async initialize() {
+    assert(this.retriever, 'setup() must be called before initialize()');
+    await this.retriever.initialize();
+  }
+
+  public async run(invocationConfig: RunnableConfig): Promise<void> {
+    assert(this.telemetry, 'telemetry is missing please call setup() first');
+    const { telemetry, migrationId } = this;
+
+    const migrationTaskTelemetry = telemetry.startSiemMigrationTask();
+
+    try {
+      // TODO: track the duration of the initialization alone in the telemetry
+      this.logger.debug('Initializing migration');
+      await this.withAbort(this.initialize()); // long running operation
+    } catch (error) {
+      migrationTaskTelemetry.failure(error);
+      if (error instanceof AbortError) {
+        this.logger.info('Abort signal received, stopping initialization');
+        return;
+      } else {
+        this.logger.error(`Error initializing migration: ${error}`);
+        return;
+      }
+    }
+
+    const migrateRuleTask = this.createMigrateRuleTask(invocationConfig);
+    this.logger.debug(`Started rule translations. Concurrency is: ${TASK_CONCURRENCY}`);
+
+    try {
+      do {
+        const { data: ruleMigrations } = await this.data.rules.get(migrationId, {
+          filters: { status: SiemMigrationStatus.PENDING },
+          size: TASK_BATCH_SIZE, // keep these rules in memory and process them in the promise pool with concurrency limit
+        });
+        if (ruleMigrations.length === 0) {
+          break;
+        }
+
+        this.logger.debug(`Start processing batch of ${ruleMigrations.length} rules`);
+
+        const { errors } = await initPromisePool<StoredRuleMigration, void, Error>({
+          concurrency: TASK_CONCURRENCY,
+          abortSignal: this.abortController.signal,
+          items: ruleMigrations,
+          executor: async (ruleMigration) => {
+            const ruleTranslationTelemetry = migrationTaskTelemetry.startRuleTranslation();
+            try {
+              await this.saveRuleProcessing(ruleMigration);
+
+              const migrationResult = await migrateRuleTask(ruleMigration);
+
+              await this.saveRuleCompleted(ruleMigration, migrationResult);
+              ruleTranslationTelemetry.success(migrationResult);
+            } catch (error) {
+              if (error instanceof AbortError) {
+                throw error;
+              }
+              ruleTranslationTelemetry.failure(error);
+              await this.saveRuleFailed(ruleMigration, error);
+            }
+          },
+        });
+
+        if (errors.length > 0) {
+          throw errors[0].error; // Only AbortError is thrown from the pool. The task was aborted
+        }
+
+        this.logger.debug('Batch processed successfully');
+      } while (true);
+
+      migrationTaskTelemetry.success();
+      this.logger.info('Migration completed successfully');
+    } catch (error) {
+      await this.data.rules.releaseProcessing(migrationId);
+
+      migrationTaskTelemetry.failure(error);
+      if (error instanceof AbortError) {
+        this.logger.info('Abort signal received, stopping migration');
+        return;
+      } else {
+        this.logger.error(`Error processing migration: ${error}`);
+      }
+    } finally {
+      this.abort.cleanup();
+    }
+  }
+
+  private createMigrateRuleTask(invocationConfig: RunnableConfig) {
+    assert(this.agent, 'agent is missing please call setup() first');
+    const { agent } = this;
+    const config: RunnableConfig = {
+      ...invocationConfig,
+      // signal: abortController.signal, // not working properly https://github.com/langchain-ai/langgraphjs/issues/319
+    };
+
+    const invoke = async (migrationRule: StoredRuleMigration): Promise<MigrateRuleState> => {
+      // using withAbort in the agent invocation is not ideal but is a workaround for the issue with the langGraph signal not working properly
+      return this.withAbort<MigrateRuleState>(
+        agent.invoke({ original_rule: migrationRule.original_rule }, config)
+      );
+    };
+
+    // Invokes the rule translation with exponential backoff, should be called only when the rate limit has been hit
+    const invokeWithBackoff = async (
+      migrationRule: StoredRuleMigration
+    ): Promise<MigrateRuleState> => {
+      this.logger.debug(`Rate limit backoff started for rule "${migrationRule.id}"`);
+      let retriesLeft: number = RETRY_CONFIG.maxRetries;
+      while (true) {
+        try {
+          await this.sleepRetry(retriesLeft);
+          retriesLeft--;
+          const result = await invoke(migrationRule);
+          this.logger.info(
+            `Rate limit backoff completed successfully for rule "${migrationRule.id}" after ${
+              RETRY_CONFIG.maxRetries - retriesLeft
+            } retries`
+          );
+          return result;
+        } catch (error) {
+          if (!this.isRateLimitError(error) || retriesLeft === 0) {
+            this.logger.debug(
+              `Rate limit backoff completed unsuccessfully for rule "${migrationRule.id}"`
+            );
+            const logMessage =
+              retriesLeft === 0
+                ? `Rate limit backoff completed unsuccessfully for rule "${migrationRule.id}"`
+                : `Rate limit backoff interrupted for rule "${migrationRule.id}". ${error} `;
+            this.logger.debug(logMessage);
+            throw error;
+          }
+          this.logger.debug(
+            `Rate limit backoff not completed for rule "${migrationRule.id}", retries left: ${retriesLeft}`
+          );
+        }
+      }
+    };
+
+    let backoffPromise: Promise<MigrateRuleState> | undefined;
+    // Migrates one rule, this function will be called concurrently by the promise pool.
+    // Handles rate limit errors and ensures only one task is executing the backoff retries at a time, the rest of translation will await.
+    const migrateRule = async (migrationRule: StoredRuleMigration): Promise<MigrateRuleState> => {
+      let recoverAttemptsLeft: number = EXECUTOR_RECOVER_MAX_ATTEMPTS;
+      while (true) {
+        try {
+          await this.executorSleep(); // Random sleep, increased every time we hit the rate limit.
+          return await invoke(migrationRule);
+        } catch (error) {
+          if (!this.isRateLimitError(error) || recoverAttemptsLeft === 0) {
+            throw error;
+          }
+          if (!backoffPromise) {
+            // only one translation handles the rate limit backoff retries, the rest will await it and try again when it's resolved
+            backoffPromise = invokeWithBackoff(migrationRule);
+            this.isWaiting = true;
+            return backoffPromise.finally(() => {
+              backoffPromise = undefined;
+              this.increaseExecutorSleep();
+              this.isWaiting = false;
+            });
+          }
+          this.logger.debug(`Awaiting backoff task for rule "${migrationRule.id}"`);
+          await backoffPromise.catch(() => {
+            throw error; // throw the original error
+          });
+          recoverAttemptsLeft--;
+        }
+      }
+    };
+
+    return migrateRule;
+  }
+
+  private isRateLimitError(error: Error) {
+    return error.message.match(/\b429\b/); // "429" (whole word in the error message): Too Many Requests.
+  }
+
+  private async withAbort<T>(promise: Promise<T>): Promise<T> {
+    return Promise.race([promise, this.abort.promise]);
+  }
+
+  private async sleep(seconds: number) {
+    await this.withAbort(new Promise((resolve) => setTimeout(resolve, seconds * 1000)));
+  }
+
+  // Exponential backoff implementation
+  private async sleepRetry(retriesLeft: number) {
+    const seconds =
+      RETRY_CONFIG.initialRetryDelaySeconds *
+      Math.pow(RETRY_CONFIG.backoffMultiplier, RETRY_CONFIG.maxRetries - retriesLeft);
+    this.logger.debug(`Retry sleep: ${seconds}s`);
+    await this.sleep(seconds);
+  }
+
+  private executorSleep = async () => {
+    const seconds = Math.random() * this.executorSleepMultiplier;
+    this.logger.debug(`Executor sleep: ${seconds.toFixed(3)}s`);
+    await this.sleep(seconds);
+  };
+
+  private increaseExecutorSleep = () => {
+    const increasedMultiplier = this.executorSleepMultiplier * EXECUTOR_SLEEP.multiplier;
+    if (increasedMultiplier > EXECUTOR_SLEEP.limitSeconds) {
+      this.logger.warn('Executor sleep reached the maximum value');
+      return;
+    }
+    this.executorSleepMultiplier = increasedMultiplier;
+  };
+
+  private async saveRuleProcessing(ruleMigration: StoredRuleMigration) {
+    this.logger.debug(`Starting translation of rule "${ruleMigration.id}"`);
+    return this.data.rules.saveProcessing(ruleMigration.id);
+  }
+
+  private async saveRuleCompleted(
+    ruleMigration: StoredRuleMigration,
+    migrationResult: MigrateRuleState
+  ) {
+    this.logger.debug(`Translation of rule "${ruleMigration.id}" succeeded`);
+    const ruleMigrationTranslated = {
+      ...ruleMigration,
+      elastic_rule: migrationResult.elastic_rule,
+      translation_result: migrationResult.translation_result,
+      comments: migrationResult.comments,
+    };
+    return this.data.rules.saveCompleted(ruleMigrationTranslated);
+  }
+
+  private async saveRuleFailed(ruleMigration: StoredRuleMigration, error: Error) {
+    this.logger.error(`Error translating rule "${ruleMigration.id}" with error: ${error.message}`);
+    const comments = [generateAssistantComment(`Error migrating rule: ${error.message}`)];
+    return this.data.rules.saveError({ ...ruleMigration, comments });
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/rule_migrations_task_service.ts
@@ -7,12 +7,10 @@
 
 import type { Logger } from '@kbn/core/server';
 import type { RuleMigrationTaskCreateClientParams } from './types';
-import { RuleMigrationsTaskClient } from './rule_migrations_task_client';
-
-export type MigrationRunning = Map<string, { user: string; abortController: AbortController }>;
+import { RuleMigrationsTaskClient, type MigrationsRunning } from './rule_migrations_task_client';
 
 export class RuleMigrationsTaskService {
-  private migrationsRunning: MigrationRunning;
+  private migrationsRunning: MigrationsRunning;
 
   constructor(private logger: Logger) {
     this.migrationsRunning = new Map();

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/task/types.ts
@@ -12,6 +12,7 @@ import type { SiemRuleMigrationsClientDependencies } from '../types';
 import type { getRuleMigrationAgent } from './agent';
 import type { SiemMigrationTelemetryClient } from './rule_migrations_telemetry_client';
 import type { ChatModel } from './util/actions_client_chat';
+import type { RuleMigrationsRetriever } from './retrievers';
 
 export type MigrationAgent = ReturnType<typeof getRuleMigrationAgent>;
 
@@ -32,7 +33,9 @@ export interface RuleMigrationTaskRunParams extends RuleMigrationTaskStartParams
   abortController: AbortController;
 }
 
-export interface RuleMigrationTaskCreateAgentParams extends RuleMigrationTaskStartParams {
+export interface RuleMigrationTaskCreateAgentParams {
+  connectorId: string;
+  retriever: RuleMigrationsRetriever;
   telemetryClient: SiemMigrationTelemetryClient;
   model: ChatModel;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Siem migrations] Implement rate limit backoff (#211469)](https://github.com/elastic/kibana/pull/211469)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Massaneda","email":"sergi.massaneda@elastic.co"},"sourceCommit":{"committedDate":"2025-02-21T19:54:40Z","message":"[Security Solution][Siem migrations] Implement rate limit backoff (#211469)\n\n## Summary\n\nImplements an exponential backoff retry strategy when the LLM API throws\nrate limit (`429`) errors.\n\n### Backoff implementation\n\n- The `run` method from the `RuleMigrationsTaskClient` has been moved to\nthe new `RuleMigrationTaskRunner` class.\n- The settings for the backoff are defined in this class with:\n```ts\n/** Exponential backoff configuration to handle rate limit errors */\nconst RETRY_CONFIG = {\n  initialRetryDelaySeconds: 1,\n  backoffMultiplier: 2,\n  maxRetries: 8,\n  // max waiting time 4m15s (1*2^8 = 256s)\n} as const;\n```\n- Only one rule will be retried at a time, the rest of the concurrent\nrule translations blocked by the rate limit will await for the API to\nrecover before attempting the translation again.\n\n```ts\n/** Executor sleep configuration\n * A sleep time applied at the beginning of each single rule translation in the execution pool,\n * The objective of this sleep is to spread the load of concurrent translations, and prevent hitting the rate limit repeatedly.\n * The sleep time applied is a random number between [0-value]. Every time we hit rate limit the value is increased by the multiplier, up to the limit.\n */\nconst EXECUTOR_SLEEP = {\n  initialValueSeconds: 3,\n  multiplier: 2,\n  limitSeconds: 96, // 1m36s (5 increases)\n} as const;\n```\n\n### Migration batching changes\n\n```ts\n/** Number of concurrent rule translations in the pool */\nconst TASK_CONCURRENCY = 10 as const;\n/** Number of rules loaded in memory to be translated in the pool */\nconst TASK_BATCH_SIZE = 100 as const;\n```\n\n#### Before \n\n- Batches of 15 rules were retrieved and executed in a `Promise.all`,\nrequiring all of them to be completed before proceeding to the next\nbatch.\n- A \"batch sleep\" of 10s was executed at the end of each iteration.\n\n#### In this PR\n\n- Batches of 100 rules are retrieved and kept in memory. The execution\nis performed in a task pool with a concurrency of 10 rules. This ensures\nthere are always 10 rules executing at a time.\n- The \"batch sleep\" has been removed in favour of an \"execution sleep\"\nof rand[1-3]s at the start of each single rule migration. This\nindividual sleep serves two goals:\n  - Spread the load when the migration is first launched.\n- Prevent hitting the rate limit consistently: The sleep duration is\nincreased every time we hit a rate limit.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"64426b2b4d99901a01ecef66a17db01049b05f1a","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Threat Hunting","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Security Solution][Siem migrations] Implement rate limit backoff","number":211469,"url":"https://github.com/elastic/kibana/pull/211469","mergeCommit":{"message":"[Security Solution][Siem migrations] Implement rate limit backoff (#211469)\n\n## Summary\n\nImplements an exponential backoff retry strategy when the LLM API throws\nrate limit (`429`) errors.\n\n### Backoff implementation\n\n- The `run` method from the `RuleMigrationsTaskClient` has been moved to\nthe new `RuleMigrationTaskRunner` class.\n- The settings for the backoff are defined in this class with:\n```ts\n/** Exponential backoff configuration to handle rate limit errors */\nconst RETRY_CONFIG = {\n  initialRetryDelaySeconds: 1,\n  backoffMultiplier: 2,\n  maxRetries: 8,\n  // max waiting time 4m15s (1*2^8 = 256s)\n} as const;\n```\n- Only one rule will be retried at a time, the rest of the concurrent\nrule translations blocked by the rate limit will await for the API to\nrecover before attempting the translation again.\n\n```ts\n/** Executor sleep configuration\n * A sleep time applied at the beginning of each single rule translation in the execution pool,\n * The objective of this sleep is to spread the load of concurrent translations, and prevent hitting the rate limit repeatedly.\n * The sleep time applied is a random number between [0-value]. Every time we hit rate limit the value is increased by the multiplier, up to the limit.\n */\nconst EXECUTOR_SLEEP = {\n  initialValueSeconds: 3,\n  multiplier: 2,\n  limitSeconds: 96, // 1m36s (5 increases)\n} as const;\n```\n\n### Migration batching changes\n\n```ts\n/** Number of concurrent rule translations in the pool */\nconst TASK_CONCURRENCY = 10 as const;\n/** Number of rules loaded in memory to be translated in the pool */\nconst TASK_BATCH_SIZE = 100 as const;\n```\n\n#### Before \n\n- Batches of 15 rules were retrieved and executed in a `Promise.all`,\nrequiring all of them to be completed before proceeding to the next\nbatch.\n- A \"batch sleep\" of 10s was executed at the end of each iteration.\n\n#### In this PR\n\n- Batches of 100 rules are retrieved and kept in memory. The execution\nis performed in a task pool with a concurrency of 10 rules. This ensures\nthere are always 10 rules executing at a time.\n- The \"batch sleep\" has been removed in favour of an \"execution sleep\"\nof rand[1-3]s at the start of each single rule migration. This\nindividual sleep serves two goals:\n  - Spread the load when the migration is first launched.\n- Prevent hitting the rate limit consistently: The sleep duration is\nincreased every time we hit a rate limit.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"64426b2b4d99901a01ecef66a17db01049b05f1a"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212154","number":212154,"state":"MERGED","mergeCommit":{"sha":"4bf719063c6015b1a68703cbcafb56a281a4b491","message":"[8.18] [Security Solution][Siem migrations] Implement rate limit backoff (#211469) (#212154)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Security Solution][Siem migrations] Implement rate limit backoff\n(#211469)](https://github.com/elastic/kibana/pull/211469)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Massaneda <sergi.massaneda@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211469","number":211469,"mergeCommit":{"message":"[Security Solution][Siem migrations] Implement rate limit backoff (#211469)\n\n## Summary\n\nImplements an exponential backoff retry strategy when the LLM API throws\nrate limit (`429`) errors.\n\n### Backoff implementation\n\n- The `run` method from the `RuleMigrationsTaskClient` has been moved to\nthe new `RuleMigrationTaskRunner` class.\n- The settings for the backoff are defined in this class with:\n```ts\n/** Exponential backoff configuration to handle rate limit errors */\nconst RETRY_CONFIG = {\n  initialRetryDelaySeconds: 1,\n  backoffMultiplier: 2,\n  maxRetries: 8,\n  // max waiting time 4m15s (1*2^8 = 256s)\n} as const;\n```\n- Only one rule will be retried at a time, the rest of the concurrent\nrule translations blocked by the rate limit will await for the API to\nrecover before attempting the translation again.\n\n```ts\n/** Executor sleep configuration\n * A sleep time applied at the beginning of each single rule translation in the execution pool,\n * The objective of this sleep is to spread the load of concurrent translations, and prevent hitting the rate limit repeatedly.\n * The sleep time applied is a random number between [0-value]. Every time we hit rate limit the value is increased by the multiplier, up to the limit.\n */\nconst EXECUTOR_SLEEP = {\n  initialValueSeconds: 3,\n  multiplier: 2,\n  limitSeconds: 96, // 1m36s (5 increases)\n} as const;\n```\n\n### Migration batching changes\n\n```ts\n/** Number of concurrent rule translations in the pool */\nconst TASK_CONCURRENCY = 10 as const;\n/** Number of rules loaded in memory to be translated in the pool */\nconst TASK_BATCH_SIZE = 100 as const;\n```\n\n#### Before \n\n- Batches of 15 rules were retrieved and executed in a `Promise.all`,\nrequiring all of them to be completed before proceeding to the next\nbatch.\n- A \"batch sleep\" of 10s was executed at the end of each iteration.\n\n#### In this PR\n\n- Batches of 100 rules are retrieved and kept in memory. The execution\nis performed in a task pool with a concurrency of 10 rules. This ensures\nthere are always 10 rules executing at a time.\n- The \"batch sleep\" has been removed in favour of an \"execution sleep\"\nof rand[1-3]s at the start of each single rule migration. This\nindividual sleep serves two goals:\n  - Spread the load when the migration is first launched.\n- Prevent hitting the rate limit consistently: The sleep duration is\nincreased every time we hit a rate limit.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"64426b2b4d99901a01ecef66a17db01049b05f1a"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->