### PR TITLE
Rollup upgrade assistant

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
@@ -122,8 +122,20 @@ const normalizeEsResponse = (migrationsResponse: EsDeprecations) => {
 export const getEnrichedDeprecations = async (
   dataClient: IScopedClusterClient
 ): Promise<EnrichedDeprecationInfo[]> => {
-  const deprecations = (await dataClient.asCurrentUser.migration.deprecations()) as EsDeprecations;
-  const systemIndices = await getESSystemIndicesMigrationStatus(dataClient.asCurrentUser);
+  const asCurrentUser = dataClient.asCurrentUser;
+  const deprecationsPromise =
+    dataClient.asCurrentUser.migration.deprecations() as Promise<EsDeprecations>;
+  const systemIndicesPromise = getESSystemIndicesMigrationStatus(asCurrentUser);
+  const rollupCapsPromise = asCurrentUser.rollup.getRollupCaps();
+
+  const [deprecations, systemIndices, rollupCaps] = await Promise.all([
+    deprecationsPromise,
+    systemIndicesPromise,
+    rollupCapsPromise,
+  ]);
+
+  // todo
+  rollupCaps;
 
   const systemIndicesList = convertFeaturesToIndicesArray(systemIndices.features);
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
@@ -127,6 +127,7 @@ export const getEnrichedDeprecations = async (
 
   const systemIndicesList = convertFeaturesToIndicesArray(systemIndices.features);
 
+  // this is the list of indices that have deprecations
   const indexSettingsIndexNames = Object.keys(deprecations.index_settings);
   const indexSettingsIndexStates = indexSettingsIndexNames.length
     ? await esIndicesStateCheck(dataClient.asCurrentUser, indexSettingsIndexNames)


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



