### PR TITLE
[Cloud Security] replace sleep usage with retry.tryForTime in add_cis_integration FTR

### DIFF
--- a/x-pack/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
+++ b/x-pack/test/cloud_security_posture_functional/page_objects/add_cis_integration_form_page.ts
@@ -6,7 +6,6 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { setTimeout as sleep } from 'node:timers/promises';
 import expect from '@kbn/expect';
 import { testSubjectIds } from '../constants/test_subject_ids';
 import type { FtrProviderContext } from '../ftr_provider_context';
@@ -19,6 +18,7 @@ export function AddCisIntegrationFormPageProvider({
   const PageObjects = getPageObjects(['common', 'header']);
   const browser = getService('browser');
   const logger = getService('log');
+  const retry = getService('retry');
 
   const AWS_CREDENTIAL_SELECTOR = 'aws-credentials-type-selector';
 
@@ -256,8 +256,9 @@ export function AddCisIntegrationFormPageProvider({
     const button = await testSubjects.find(buttonId);
     await button.click();
     // Wait a bit to allow the new tab to load the URL
-    await sleep(3000);
-    await browser.switchTab(1);
+    await retry.tryForTime(3000, async () => {
+      await browser.switchTab(1);
+    });
     const currentUrl = await browser.getCurrentUrl();
     await browser.closeCurrentWindow();
     await browser.switchTab(0);


### PR DESCRIPTION
## Summary

This PR replace the usage of sleep method to use retry.tryForTime instead.


### Checklist
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
