### PR TITLE
[EDR Workflows] OpenApi Missing Content - Endpoint Management

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -52289,7 +52289,7 @@ components:
           required:
             - parameters
     Security_Endpoint_Management_API_SortDirection:
-      description: Determines the sort order, which can be desc or asc.
+      description: Determines the sort order.
       enum:
         - asc
         - desc

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -9914,16 +9914,41 @@ paths:
       operationId: GetEndpointMetadataList
       parameters:
         - in: query
-          name: query
+          name: page
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_Page'
+        - in: query
+          name: pageSize
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_PageSize'
+        - in: query
+          name: kuery
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_Kuery'
+        - in: query
+          name: hostStatuses
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Endpoint_Management_API_ListRequestQuery'
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_HostStatuses'
+        - in: query
+          name: sortField
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_SortField'
+        - in: query
+          name: sortDirection
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_SortDirection'
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Security_Endpoint_Management_API_SuccessResponse'
+                $ref: '#/components/schemas/Security_Endpoint_Management_API_MetadataListResponse'
           description: OK
       summary: Get a metadata list
       tags:
@@ -9937,13 +9962,14 @@ paths:
           name: id
           required: true
           schema:
+            example: ed518850-681a-4d60-bb98-e22640cae2a8
             type: string
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Security_Endpoint_Management_API_SuccessResponse'
+                $ref: '#/components/schemas/Security_Endpoint_Management_API_EndpointMetadataResponse'
           description: OK
       summary: Get metadata
       tags:
@@ -51698,6 +51724,92 @@ components:
         type: string
       minItems: 1
       type: array
+    Security_Endpoint_Management_API_EndpointMetadataResponse:
+      example:
+        host_status: healthy
+        last_checkin: '2023-07-04T15:48:57.360Z'
+        metadata:
+          '@timestamp': '2023-07-04T15:48:57.3609346Z'
+          agent:
+            build:
+              original: 'version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch: 7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab'
+            id: abb8a826-6812-448c-a571-6d8269b51449
+            type: endpoint
+            version: 7.16.0
+          data_stream:
+            dataset: endpoint.metadata
+            namespace: default
+            type: metrics
+          ecs:
+            version: 1.11.0
+          elastic:
+            agent:
+              id: abb8a826-6812-448c-a571-6d8269b51449
+          Endpoint:
+            capabilities:
+              - isolation
+            configuration:
+              isolation: false
+            policy:
+              applied:
+                endpoint_policy_version: '2'
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                name: test
+                status: success
+                version: '3'
+            state:
+              isolation: false
+            status: enrolled
+          event:
+            action: endpoint_metadata
+            agent_id_status: verified
+            category:
+              - host
+            created: '2023-07-04T15:48:57.3609346Z'
+            dataset: endpoint.metadata
+            id: MNtRc++KoKHXXwlj+++++OhZ
+            ingested: '2023-07-04T15:48:58Z'
+            kind: metric
+            module: endpoint
+            sequence: 43757
+            type:
+              - info
+          host:
+            architecture: x86_64
+            hostname: WinDev2104Eval
+            id: 17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5
+            ip:
+              - 10.0.2.15
+              - fe80::21a6:63d3:d70e:e3ad
+              - 127.0.0.1
+              - '::1'
+            mac:
+              - 08:00:27:b1:1d:5a
+            name: WinDev2104Eval
+            os:
+              Ext:
+                variant: Windows 10 Enterprise Evaluation
+              family: windows
+              full: Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)
+              kernel: 20H2 (10.0.19042.906)
+              name: Windows
+              platform: windows
+              type: windows
+              version: 20H2 (10.0.19042.906)
+          message: Endpoint metadata
+          policy_info:
+            agent:
+              applied:
+                id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                revision: 3
+              configured:
+                id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                revision: 3
+            endpoint:
+              id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+              revision: 2
+      type: object
+      properties: {}
     Security_Endpoint_Management_API_EntityId:
       type: object
       properties:
@@ -51825,6 +51937,20 @@ components:
           type: integer
       required:
         - hostPath
+    Security_Endpoint_Management_API_HostStatuses:
+      description: A set of agent health statuses to filter by.
+      example:
+        - healthy
+        - updating
+      items:
+        enum:
+          - healthy
+          - offline
+          - updating
+          - inactive
+          - unenrolled
+        type: string
+      type: array
     Security_Endpoint_Management_API_IsolateRouteRequestBody:
       type: object
       properties:
@@ -51874,56 +52000,195 @@ components:
                       type: string
           required:
             - parameters
-    Security_Endpoint_Management_API_ListRequestQuery:
+    Security_Endpoint_Management_API_Kuery:
+      description: A KQL string.
+      example: 'united.endpoint.host.os.name : ''Windows'''
+      type: string
+    Security_Endpoint_Management_API_MetadataListResponse:
+      example:
+        data:
+          - host_status: healthy
+            last_checkin: '2023-07-04T15:47:57.432Z'
+            metadata:
+              '@timestamp': '2023-07-04T15:47:57.432173535Z'
+              agent:
+                build:
+                  original: 'version: 7.16.0, compiled: Tue Nov 16 16:00:00 2021, branch: 7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab'
+                id: 285297c6-3bff-4b83-9a07-f3e749801123
+                type: endpoint
+                version: 7.16.0
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: 1.11.0
+              elastic:
+                agent:
+                  id: 285297c6-3bff-4b83-9a07-f3e749801123
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: '2'
+                    id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                    name: test
+                    status: success
+                    version: '3'
+                state:
+                  isolation: false
+                status: enrolled
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: '2023-07-04T15:47:57.432173535Z'
+                dataset: endpoint.metadata
+                id: MNtSXK/SkhEBnmgt++++++7S
+                ingested: '2023-07-04T15:47:58Z'
+                kind: metric
+                module: endpoint
+                sequence: 400
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: david-Xubuntu
+                id: 0cfead88e2024bd8a27476352b5ab264
+                ip:
+                  - 127.0.0.1
+                  - '::1'
+                  - 10.0.2.15
+                  - fe80::2ac7:8e15:b957:2fa1
+                mac:
+                  - 08:00:27:e6:78:8b
+                name: david-Xubuntu
+                os:
+                  Ext:
+                    variant: Ubuntu
+                  family: ubuntu
+                  full: Ubuntu 20.04.2
+                  kernel: '5.8.0-59-generic #66~20.04.1-Ubuntu SMP Thu Jun 17 11:14:10 UTC 2021'
+                  name: Linux
+                  platform: ubuntu
+                  type: linux
+                  version: 20.04.2
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 0
+                configured:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 3
+              endpoint:
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                revision: 2
+          - host_status: healthy
+            last_checkin: '2023-07-04T15:44:31.491Z'
+            metadata:
+              '@timestamp': '2023-07-04T15:44:31.4917849Z'
+              agent:
+                build:
+                  original: 'version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch: 7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab'
+                id: abb8a826-6812-448c-a571-6d8269b51449
+                type: endpoint
+                version: 7.16.0
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: 1.11.0
+              elastic:
+                agent:
+                  id: abb8a826-6812-448c-a571-6d8269b51449
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: '2'
+                    id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                    name: test
+                    status: success
+                    version: '3'
+                state:
+                  isolation: false
+                status: enrolled
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: '2023-07-04T15:44:31.4917849Z'
+                dataset: endpoint.metadata
+                id: MNtRc++KoKHXXwlj+++++/N9
+                ingested: '2023-07-04T15:44:33Z'
+                kind: metric
+                module: endpoint
+                sequence: 5159
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: WinDev2104Eval
+                id: 17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5
+                ip:
+                  - 10.0.2.15
+                  - fe80::21a6:63d3:d70e:e3ad
+                  - 127.0.0.1
+                  - '::1'
+                mac:
+                  - 08:00:27:b1:1d:5a
+                name: WinDev2104Eval
+                os:
+                  Ext:
+                    variant: Windows 10 Enterprise Evaluation
+                  family: windows
+                  full: Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)
+                  kernel: 20H2 (10.0.19042.906)
+                  name: Windows
+                  platform: windows
+                  type: windows
+                  version: 20H2 (10.0.19042.906)
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 0
+                configured:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 3
+              endpoint:
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                revision: 2
+        page: 0
+        pageSize: 10
+        sortDirection: desc
+        sortField: enrolled_at
+        total: 2
       type: object
-      properties:
-        hostStatuses:
-          items:
-            enum:
-              - healthy
-              - offline
-              - updating
-              - inactive
-              - unenrolled
-            type: string
-          type: array
-        kuery:
-          nullable: true
-          type: string
-        page:
-          default: 0
-          description: Page number
-          minimum: 0
-          type: integer
-        pageSize:
-          default: 10
-          description: Number of items per page
-          maximum: 10000
-          minimum: 1
-          type: integer
-        sortDirection:
-          enum:
-            - asc
-            - desc
-          nullable: true
-          type: string
-        sortField:
-          enum:
-            - enrolled_at
-            - metadata.host.hostname
-            - host_status
-            - metadata.Endpoint.policy.applied.name
-            - metadata.Endpoint.policy.applied.status
-            - metadata.host.os.name
-            - metadata.host.ip
-            - metadata.agent.version
-            - last_checkin
-          type: string
-      required:
-        - hostStatuses
+      properties: {}
     Security_Endpoint_Management_API_Page:
       default: 1
       description: Page number
+      example: 1
+      minimum: 1
+      type: integer
+    Security_Endpoint_Management_API_PageSize:
+      default: 10
+      description: Number of items per page
+      example: 10
+      maximum: 100
       minimum: 1
       type: integer
     Security_Endpoint_Management_API_Parameters:
@@ -52023,6 +52288,27 @@ components:
                 - path
           required:
             - parameters
+    Security_Endpoint_Management_API_SortDirection:
+      description: Determines the sort order, which can be desc or asc.
+      enum:
+        - asc
+        - desc
+      example: desc
+      type: string
+    Security_Endpoint_Management_API_SortField:
+      description: Determines which field is used to sort the results.
+      enum:
+        - enrolled_at
+        - metadata.host.hostname
+        - host_status
+        - metadata.Endpoint.policy.applied.name
+        - metadata.Endpoint.policy.applied.status
+        - metadata.host.os.name
+        - metadata.host.ip
+        - metadata.agent.version
+        - last_checkin
+      example: enrolled_at
+      type: string
     Security_Endpoint_Management_API_StartDate:
       description: Start date
       type: string

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -12083,16 +12083,41 @@ paths:
       operationId: GetEndpointMetadataList
       parameters:
         - in: query
-          name: query
+          name: page
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_Page'
+        - in: query
+          name: pageSize
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_PageSize'
+        - in: query
+          name: kuery
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_Kuery'
+        - in: query
+          name: hostStatuses
           required: true
           schema:
-            $ref: '#/components/schemas/Security_Endpoint_Management_API_ListRequestQuery'
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_HostStatuses'
+        - in: query
+          name: sortField
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_SortField'
+        - in: query
+          name: sortDirection
+          required: false
+          schema:
+            $ref: '#/components/schemas/Security_Endpoint_Management_API_SortDirection'
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Security_Endpoint_Management_API_SuccessResponse'
+                $ref: '#/components/schemas/Security_Endpoint_Management_API_MetadataListResponse'
           description: OK
       summary: Get a metadata list
       tags:
@@ -12105,13 +12130,14 @@ paths:
           name: id
           required: true
           schema:
+            example: ed518850-681a-4d60-bb98-e22640cae2a8
             type: string
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Security_Endpoint_Management_API_SuccessResponse'
+                $ref: '#/components/schemas/Security_Endpoint_Management_API_EndpointMetadataResponse'
           description: OK
       summary: Get metadata
       tags:
@@ -58465,6 +58491,92 @@ components:
         type: string
       minItems: 1
       type: array
+    Security_Endpoint_Management_API_EndpointMetadataResponse:
+      example:
+        host_status: healthy
+        last_checkin: '2023-07-04T15:48:57.360Z'
+        metadata:
+          '@timestamp': '2023-07-04T15:48:57.3609346Z'
+          agent:
+            build:
+              original: 'version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch: 7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab'
+            id: abb8a826-6812-448c-a571-6d8269b51449
+            type: endpoint
+            version: 7.16.0
+          data_stream:
+            dataset: endpoint.metadata
+            namespace: default
+            type: metrics
+          ecs:
+            version: 1.11.0
+          elastic:
+            agent:
+              id: abb8a826-6812-448c-a571-6d8269b51449
+          Endpoint:
+            capabilities:
+              - isolation
+            configuration:
+              isolation: false
+            policy:
+              applied:
+                endpoint_policy_version: '2'
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                name: test
+                status: success
+                version: '3'
+            state:
+              isolation: false
+            status: enrolled
+          event:
+            action: endpoint_metadata
+            agent_id_status: verified
+            category:
+              - host
+            created: '2023-07-04T15:48:57.3609346Z'
+            dataset: endpoint.metadata
+            id: MNtRc++KoKHXXwlj+++++OhZ
+            ingested: '2023-07-04T15:48:58Z'
+            kind: metric
+            module: endpoint
+            sequence: 43757
+            type:
+              - info
+          host:
+            architecture: x86_64
+            hostname: WinDev2104Eval
+            id: 17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5
+            ip:
+              - 10.0.2.15
+              - fe80::21a6:63d3:d70e:e3ad
+              - 127.0.0.1
+              - '::1'
+            mac:
+              - 08:00:27:b1:1d:5a
+            name: WinDev2104Eval
+            os:
+              Ext:
+                variant: Windows 10 Enterprise Evaluation
+              family: windows
+              full: Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)
+              kernel: 20H2 (10.0.19042.906)
+              name: Windows
+              platform: windows
+              type: windows
+              version: 20H2 (10.0.19042.906)
+          message: Endpoint metadata
+          policy_info:
+            agent:
+              applied:
+                id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                revision: 3
+              configured:
+                id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                revision: 3
+            endpoint:
+              id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+              revision: 2
+      type: object
+      properties: {}
     Security_Endpoint_Management_API_EntityId:
       type: object
       properties:
@@ -58592,6 +58704,20 @@ components:
           type: integer
       required:
         - hostPath
+    Security_Endpoint_Management_API_HostStatuses:
+      description: A set of agent health statuses to filter by.
+      example:
+        - healthy
+        - updating
+      items:
+        enum:
+          - healthy
+          - offline
+          - updating
+          - inactive
+          - unenrolled
+        type: string
+      type: array
     Security_Endpoint_Management_API_IsolateRouteRequestBody:
       type: object
       properties:
@@ -58641,56 +58767,195 @@ components:
                       type: string
           required:
             - parameters
-    Security_Endpoint_Management_API_ListRequestQuery:
+    Security_Endpoint_Management_API_Kuery:
+      description: A KQL string.
+      example: 'united.endpoint.host.os.name : ''Windows'''
+      type: string
+    Security_Endpoint_Management_API_MetadataListResponse:
+      example:
+        data:
+          - host_status: healthy
+            last_checkin: '2023-07-04T15:47:57.432Z'
+            metadata:
+              '@timestamp': '2023-07-04T15:47:57.432173535Z'
+              agent:
+                build:
+                  original: 'version: 7.16.0, compiled: Tue Nov 16 16:00:00 2021, branch: 7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab'
+                id: 285297c6-3bff-4b83-9a07-f3e749801123
+                type: endpoint
+                version: 7.16.0
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: 1.11.0
+              elastic:
+                agent:
+                  id: 285297c6-3bff-4b83-9a07-f3e749801123
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: '2'
+                    id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                    name: test
+                    status: success
+                    version: '3'
+                state:
+                  isolation: false
+                status: enrolled
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: '2023-07-04T15:47:57.432173535Z'
+                dataset: endpoint.metadata
+                id: MNtSXK/SkhEBnmgt++++++7S
+                ingested: '2023-07-04T15:47:58Z'
+                kind: metric
+                module: endpoint
+                sequence: 400
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: david-Xubuntu
+                id: 0cfead88e2024bd8a27476352b5ab264
+                ip:
+                  - 127.0.0.1
+                  - '::1'
+                  - 10.0.2.15
+                  - fe80::2ac7:8e15:b957:2fa1
+                mac:
+                  - 08:00:27:e6:78:8b
+                name: david-Xubuntu
+                os:
+                  Ext:
+                    variant: Ubuntu
+                  family: ubuntu
+                  full: Ubuntu 20.04.2
+                  kernel: '5.8.0-59-generic #66~20.04.1-Ubuntu SMP Thu Jun 17 11:14:10 UTC 2021'
+                  name: Linux
+                  platform: ubuntu
+                  type: linux
+                  version: 20.04.2
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 0
+                configured:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 3
+              endpoint:
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                revision: 2
+          - host_status: healthy
+            last_checkin: '2023-07-04T15:44:31.491Z'
+            metadata:
+              '@timestamp': '2023-07-04T15:44:31.4917849Z'
+              agent:
+                build:
+                  original: 'version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch: 7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab'
+                id: abb8a826-6812-448c-a571-6d8269b51449
+                type: endpoint
+                version: 7.16.0
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: 1.11.0
+              elastic:
+                agent:
+                  id: abb8a826-6812-448c-a571-6d8269b51449
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: '2'
+                    id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                    name: test
+                    status: success
+                    version: '3'
+                state:
+                  isolation: false
+                status: enrolled
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: '2023-07-04T15:44:31.4917849Z'
+                dataset: endpoint.metadata
+                id: MNtRc++KoKHXXwlj+++++/N9
+                ingested: '2023-07-04T15:44:33Z'
+                kind: metric
+                module: endpoint
+                sequence: 5159
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: WinDev2104Eval
+                id: 17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5
+                ip:
+                  - 10.0.2.15
+                  - fe80::21a6:63d3:d70e:e3ad
+                  - 127.0.0.1
+                  - '::1'
+                mac:
+                  - 08:00:27:b1:1d:5a
+                name: WinDev2104Eval
+                os:
+                  Ext:
+                    variant: Windows 10 Enterprise Evaluation
+                  family: windows
+                  full: Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)
+                  kernel: 20H2 (10.0.19042.906)
+                  name: Windows
+                  platform: windows
+                  type: windows
+                  version: 20H2 (10.0.19042.906)
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 0
+                configured:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 3
+              endpoint:
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                revision: 2
+        page: 0
+        pageSize: 10
+        sortDirection: desc
+        sortField: enrolled_at
+        total: 2
       type: object
-      properties:
-        hostStatuses:
-          items:
-            enum:
-              - healthy
-              - offline
-              - updating
-              - inactive
-              - unenrolled
-            type: string
-          type: array
-        kuery:
-          nullable: true
-          type: string
-        page:
-          default: 0
-          description: Page number
-          minimum: 0
-          type: integer
-        pageSize:
-          default: 10
-          description: Number of items per page
-          maximum: 10000
-          minimum: 1
-          type: integer
-        sortDirection:
-          enum:
-            - asc
-            - desc
-          nullable: true
-          type: string
-        sortField:
-          enum:
-            - enrolled_at
-            - metadata.host.hostname
-            - host_status
-            - metadata.Endpoint.policy.applied.name
-            - metadata.Endpoint.policy.applied.status
-            - metadata.host.os.name
-            - metadata.host.ip
-            - metadata.agent.version
-            - last_checkin
-          type: string
-      required:
-        - hostStatuses
+      properties: {}
     Security_Endpoint_Management_API_Page:
       default: 1
       description: Page number
+      example: 1
+      minimum: 1
+      type: integer
+    Security_Endpoint_Management_API_PageSize:
+      default: 10
+      description: Number of items per page
+      example: 10
+      maximum: 100
       minimum: 1
       type: integer
     Security_Endpoint_Management_API_Parameters:
@@ -58790,6 +59055,27 @@ components:
                 - path
           required:
             - parameters
+    Security_Endpoint_Management_API_SortDirection:
+      description: Determines the sort order, which can be desc or asc.
+      enum:
+        - asc
+        - desc
+      example: desc
+      type: string
+    Security_Endpoint_Management_API_SortField:
+      description: Determines which field is used to sort the results.
+      enum:
+        - enrolled_at
+        - metadata.host.hostname
+        - host_status
+        - metadata.Endpoint.policy.applied.name
+        - metadata.Endpoint.policy.applied.status
+        - metadata.host.os.name
+        - metadata.host.ip
+        - metadata.agent.version
+        - last_checkin
+      example: enrolled_at
+      type: string
     Security_Endpoint_Management_API_StartDate:
       description: Start date
       type: string

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -59056,7 +59056,7 @@ components:
           required:
             - parameters
     Security_Endpoint_Management_API_SortDirection:
-      description: Determines the sort order, which can be desc or asc.
+      description: Determines the sort order.
       enum:
         - asc
         - desc

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/get_metadata.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/get_metadata.gen.ts
@@ -16,18 +16,30 @@
 
 import { z } from '@kbn/zod';
 
-import { ListRequestQuery } from './list_metadata.gen';
-import { SuccessResponse } from '../model/schema/common.gen';
+import {
+  Page,
+  PageSize,
+  Kuery,
+  HostStatuses,
+  SortField,
+  SortDirection,
+} from '../model/schema/common.gen';
+import { MetadataListResponse } from './list_metadata.gen';
 
 export type GetEndpointMetadataListRequestQuery = z.infer<
   typeof GetEndpointMetadataListRequestQuery
 >;
 export const GetEndpointMetadataListRequestQuery = z.object({
-  query: ListRequestQuery,
+  page: Page.optional(),
+  pageSize: PageSize.optional(),
+  kuery: Kuery.optional(),
+  hostStatuses: HostStatuses,
+  sortField: SortField.optional(),
+  sortDirection: SortDirection.optional(),
 });
 export type GetEndpointMetadataListRequestQueryInput = z.input<
   typeof GetEndpointMetadataListRequestQuery
 >;
 
 export type GetEndpointMetadataListResponse = z.infer<typeof GetEndpointMetadataListResponse>;
-export const GetEndpointMetadataListResponse = SuccessResponse;
+export const GetEndpointMetadataListResponse = MetadataListResponse;

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/get_metadata.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/get_metadata.schema.yaml
@@ -10,18 +10,43 @@ paths:
       x-codegen-enabled: true
       x-labels: [ess, serverless]
       parameters:
-        - name: query
+        - name: page
+          in: query
+          required: false
+          schema:
+            $ref: '../model/schema/common.schema.yaml#/components/schemas/Page'
+        - name: pageSize
+          in: query
+          required: false
+          schema:
+            $ref: '../model/schema/common.schema.yaml#/components/schemas/PageSize'
+        - name: kuery
+          in: query
+          required: false
+          schema:
+            $ref: '../model/schema/common.schema.yaml#/components/schemas/Kuery'
+        - name: hostStatuses
           in: query
           required: true
           schema:
-            $ref: './list_metadata.schema.yaml#/components/schemas/ListRequestQuery'
+            $ref: '../model/schema/common.schema.yaml#/components/schemas/HostStatuses'
+        - name: sortField
+          in: query
+          required: false
+          schema:
+            $ref: '../model/schema/common.schema.yaml#/components/schemas/SortField'
+        - name: sortDirection
+          in: query
+          required: false
+          schema:
+            $ref: '../model/schema/common.schema.yaml#/components/schemas/SortDirection'
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: '../model/schema/common.schema.yaml#/components/schemas/SuccessResponse'
+                $ref: './list_metadata.schema.yaml#/components/schemas/MetadataListResponse'
 
   /internal/api/endpoint/metadata/transforms:
     get:
@@ -50,10 +75,11 @@ paths:
           required: true
           schema:
             type: string
+            example: 'ed518850-681a-4d60-bb98-e22640cae2a8'
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: '../model/schema/common.schema.yaml#/components/schemas/SuccessResponse'
+                $ref: './list_metadata.schema.yaml#/components/schemas/EndpointMetadataResponse'

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/list_metadata.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/list_metadata.gen.ts
@@ -16,30 +16,8 @@
 
 import { z } from '@kbn/zod';
 
-export type ListRequestQuery = z.infer<typeof ListRequestQuery>;
-export const ListRequestQuery = z.object({
-  /**
-   * Page number
-   */
-  page: z.number().int().min(0).optional().default(0),
-  /**
-   * Number of items per page
-   */
-  pageSize: z.number().int().min(1).max(10000).optional().default(10),
-  kuery: z.string().nullable().optional(),
-  sortField: z
-    .enum([
-      'enrolled_at',
-      'metadata.host.hostname',
-      'host_status',
-      'metadata.Endpoint.policy.applied.name',
-      'metadata.Endpoint.policy.applied.status',
-      'metadata.host.os.name',
-      'metadata.host.ip',
-      'metadata.agent.version',
-      'last_checkin',
-    ])
-    .optional(),
-  sortDirection: z.enum(['asc', 'desc']).nullable().optional(),
-  hostStatuses: z.array(z.enum(['healthy', 'offline', 'updating', 'inactive', 'unenrolled'])),
-});
+export type EndpointMetadataResponse = z.infer<typeof EndpointMetadataResponse>;
+export const EndpointMetadataResponse = z.object({});
+
+export type MetadataListResponse = z.infer<typeof MetadataListResponse>;
+export const MetadataListResponse = z.object({});

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/list_metadata.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/metadata/list_metadata.schema.yaml
@@ -5,50 +5,265 @@ info:
 paths: { }
 components:
   schemas:
-    ListRequestQuery:
+    EndpointMetadataResponse:
       type: object
-      required:
-        - hostStatuses
-      properties:
-        page:
-          type: integer
-          default: 0
-          minimum: 0
-          description: Page number
-        pageSize:
-          type: integer
-          default: 10
-          minimum: 1
-          maximum: 10000
-          description: Number of items per page
-        kuery:
-            type: string
-            nullable: true
-        sortField:
-          type: string
-          enum:
-            - enrolled_at
-            - metadata.host.hostname
-            - host_status
-            - metadata.Endpoint.policy.applied.name
-            - metadata.Endpoint.policy.applied.status
-            - metadata.host.os.name
-            - metadata.host.ip
-            - metadata.agent.version
-            - last_checkin
-        sortDirection:
-          type: string
-          enum:
-            - 'asc'
-            - 'desc'
-          nullable: true
-        hostStatuses:
-          type: array
-          items:
-            type: string
-            enum:
-              - healthy
-              - offline
-              - updating
-              - inactive
-              - unenrolled
+      properties: { }
+      example:
+        host_status: "healthy"
+        last_checkin: "2023-07-04T15:48:57.360Z"
+        metadata:
+          "@timestamp": "2023-07-04T15:48:57.3609346Z"
+          Endpoint:
+            capabilities:
+              - "isolation"
+            configuration:
+              isolation: false
+            policy:
+              applied:
+                endpoint_policy_version: "2"
+                id: "d5371dcd-93b7-4627-af88-4084f7d6aa3e"
+                name: "test"
+                status: "success"
+                version: "3"
+            state:
+              isolation: false
+            status: "enrolled"
+          agent:
+            build:
+              original: "version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch: 7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab"
+            id: "abb8a826-6812-448c-a571-6d8269b51449"
+            type: "endpoint"
+            version: "7.16.0"
+          data_stream:
+            dataset: "endpoint.metadata"
+            namespace: "default"
+            type: "metrics"
+          ecs:
+            version: "1.11.0"
+          elastic:
+            agent:
+              id: "abb8a826-6812-448c-a571-6d8269b51449"
+          event:
+            action: "endpoint_metadata"
+            agent_id_status: "verified"
+            category:
+              - "host"
+            created: "2023-07-04T15:48:57.3609346Z"
+            dataset: "endpoint.metadata"
+            id: "MNtRc++KoKHXXwlj+++++OhZ"
+            ingested: "2023-07-04T15:48:58Z"
+            kind: "metric"
+            module: "endpoint"
+            sequence: 43757
+            type:
+              - "info"
+          host:
+            architecture: "x86_64"
+            hostname: "WinDev2104Eval"
+            id: "17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5"
+            ip:
+              - "10.0.2.15"
+              - "fe80::21a6:63d3:d70e:e3ad"
+              - "127.0.0.1"
+              - "::1"
+            mac:
+              - "08:00:27:b1:1d:5a"
+            name: "WinDev2104Eval"
+            os:
+              Ext:
+                variant: "Windows 10 Enterprise Evaluation"
+              family: "windows"
+              full: "Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)"
+              kernel: "20H2 (10.0.19042.906)"
+              name: "Windows"
+              platform: "windows"
+              type: "windows"
+              version: "20H2 (10.0.19042.906)"
+          message: "Endpoint metadata"
+          policy_info:
+            agent:
+              applied:
+                id: "ed7e3720-4bad-11ec-a2a8-fb22e62a5753"
+                revision: 3
+              configured:
+                id: "ed7e3720-4bad-11ec-a2a8-fb22e62a5753"
+                revision: 3
+            endpoint:
+              id: "d5371dcd-93b7-4627-af88-4084f7d6aa3e"
+              revision: 2
+    MetadataListResponse:
+      type: object
+      properties: {}
+      example:
+        data:
+          - host_status: healthy
+            last_checkin: "2023-07-04T15:47:57.432Z"
+            metadata:
+              "@timestamp": "2023-07-04T15:47:57.432173535Z"
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: "2"
+                    id: "d5371dcd-93b7-4627-af88-4084f7d6aa3e"
+                    name: test
+                    status: success
+                    version: "3"
+                state:
+                  isolation: false
+                status: enrolled
+              agent:
+                build:
+                  original: "version: 7.16.0, compiled: Tue Nov 16 16:00:00 2021, branch: 7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab"
+                id: "285297c6-3bff-4b83-9a07-f3e749801123"
+                type: endpoint
+                version: "7.16.0"
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: "1.11.0"
+              elastic:
+                agent:
+                  id: "285297c6-3bff-4b83-9a07-f3e749801123"
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: "2023-07-04T15:47:57.432173535Z"
+                dataset: endpoint.metadata
+                id: "MNtSXK/SkhEBnmgt++++++7S"
+                ingested: "2023-07-04T15:47:58Z"
+                kind: metric
+                module: endpoint
+                sequence: 400
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: david-Xubuntu
+                id: "0cfead88e2024bd8a27476352b5ab264"
+                ip:
+                  - "127.0.0.1"
+                  - "::1"
+                  - "10.0.2.15"
+                  - "fe80::2ac7:8e15:b957:2fa1"
+                mac:
+                  - "08:00:27:e6:78:8b"
+                name: david-Xubuntu
+                os:
+                  Ext:
+                    variant: Ubuntu
+                  family: ubuntu
+                  full: Ubuntu 20.04.2
+                  kernel: "5.8.0-59-generic #66~20.04.1-Ubuntu SMP Thu Jun 17 11:14:10 UTC 2021"
+                  name: Linux
+                  platform: ubuntu
+                  type: linux
+                  version: "20.04.2"
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: "ed7e3720-4bad-11ec-a2a8-fb22e62a5753"
+                  revision: 0
+                configured:
+                  id: "ed7e3720-4bad-11ec-a2a8-fb22e62a5753"
+                  revision: 3
+              endpoint:
+                id: "d5371dcd-93b7-4627-af88-4084f7d6aa3e"
+                revision: 2
+          - host_status: healthy
+            last_checkin: "2023-07-04T15:44:31.491Z"
+            metadata:
+              "@timestamp": "2023-07-04T15:44:31.4917849Z"
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: "2"
+                    id: "d5371dcd-93b7-4627-af88-4084f7d6aa3e"
+                    name: test
+                    status: success
+                    version: "3"
+                state:
+                  isolation: false
+                status: enrolled
+              agent:
+                build:
+                  original: "version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch: 7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab"
+                id: "abb8a826-6812-448c-a571-6d8269b51449"
+                type: endpoint
+                version: "7.16.0"
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: "1.11.0"
+              elastic:
+                agent:
+                  id: "abb8a826-6812-448c-a571-6d8269b51449"
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: "2023-07-04T15:44:31.4917849Z"
+                dataset: endpoint.metadata
+                id: "MNtRc++KoKHXXwlj+++++/N9"
+                ingested: "2023-07-04T15:44:33Z"
+                kind: metric
+                module: endpoint
+                sequence: 5159
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: WinDev2104Eval
+                id: "17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5"
+                ip:
+                  - "10.0.2.15"
+                  - "fe80::21a6:63d3:d70e:e3ad"
+                  - "127.0.0.1"
+                  - "::1"
+                mac:
+                  - "08:00:27:b1:1d:5a"
+                name: WinDev2104Eval
+                os:
+                  Ext:
+                    variant: Windows 10 Enterprise Evaluation
+                  family: windows
+                  full: Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)
+                  kernel: "20H2 (10.0.19042.906)"
+                  name: Windows
+                  platform: windows
+                  type: windows
+                  version: "20H2 (10.0.19042.906)"
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: "ed7e3720-4bad-11ec-a2a8-fb22e62a5753"
+                  revision: 0
+                configured:
+                  id: "ed7e3720-4bad-11ec-a2a8-fb22e62a5753"
+                  revision: 3
+              endpoint:
+                id: "d5371dcd-93b7-4627-af88-4084f7d6aa3e"
+                revision: 2
+        total: 2
+        page: 0
+        pageSize: 10
+        sortField: enrolled_at
+        sortDirection: desc
+
+

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.gen.ts
@@ -54,6 +54,46 @@ export const EndDate = z.string();
 export type AgentId = z.infer<typeof AgentId>;
 export const AgentId = z.string();
 
+/**
+ * A KQL string.
+ */
+export type Kuery = z.infer<typeof Kuery>;
+export const Kuery = z.string();
+
+/**
+ * A set of agent health statuses to filter by.
+ */
+export type HostStatuses = z.infer<typeof HostStatuses>;
+export const HostStatuses = z.array(
+  z.enum(['healthy', 'offline', 'updating', 'inactive', 'unenrolled'])
+);
+
+/**
+ * Determines the sort order, which can be desc or asc.
+ */
+export type SortDirection = z.infer<typeof SortDirection>;
+export const SortDirection = z.enum(['asc', 'desc']);
+export type SortDirectionEnum = typeof SortDirection.enum;
+export const SortDirectionEnum = SortDirection.enum;
+
+/**
+ * Determines which field is used to sort the results.
+ */
+export type SortField = z.infer<typeof SortField>;
+export const SortField = z.enum([
+  'enrolled_at',
+  'metadata.host.hostname',
+  'host_status',
+  'metadata.Endpoint.policy.applied.name',
+  'metadata.Endpoint.policy.applied.status',
+  'metadata.host.os.name',
+  'metadata.host.ip',
+  'metadata.agent.version',
+  'last_checkin',
+]);
+export type SortFieldEnum = typeof SortField.enum;
+export const SortFieldEnum = SortField.enum;
+
 export type AgentIds = z.infer<typeof AgentIds>;
 export const AgentIds = z.union([z.array(z.string().min(1)).min(1).max(50), z.string().min(1)]);
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.gen.ts
@@ -69,7 +69,7 @@ export const HostStatuses = z.array(
 );
 
 /**
- * Determines the sort order, which can be desc or asc.
+ * Determines the sort order.
  */
 export type SortDirection = z.infer<typeof SortDirection>;
 export const SortDirection = z.enum(['asc', 'desc']);

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.schema.yaml
@@ -50,7 +50,7 @@ components:
           - unenrolled
     SortDirection:
       type: string
-      description: Determines the sort order, which can be desc or asc.
+      description: Determines the sort order.
       example: desc
       enum:
         - asc

--- a/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/endpoint/model/schema/common.schema.yaml
@@ -15,12 +15,14 @@ components:
       default: 1
       minimum: 1
       description: Page number
+      example: 1
     PageSize:
       type: integer
       default: 10
       minimum: 1
       maximum: 100
       description: Number of items per page
+      example: 10
     StartDate:
       type: string
       description: Start date
@@ -30,6 +32,43 @@ components:
     AgentId:
       type: string
       description: Agent ID
+    Kuery:
+      type: string
+      description: A KQL string.
+      example: "united.endpoint.host.os.name : 'Windows'"
+    HostStatuses:
+      type: array
+      description: A set of agent health statuses to filter by.
+      example: [ "healthy", "updating" ]
+      items:
+        type: string
+        enum:
+          - healthy
+          - offline
+          - updating
+          - inactive
+          - unenrolled
+    SortDirection:
+      type: string
+      description: Determines the sort order, which can be desc or asc.
+      example: desc
+      enum:
+        - asc
+        - desc
+    SortField:
+      type: string
+      description: Determines which field is used to sort the results.
+      example: enrolled_at
+      enum:
+        - enrolled_at
+        - metadata.host.hostname
+        - host_status
+        - metadata.Endpoint.policy.applied.name
+        - metadata.Endpoint.policy.applied.status
+        - metadata.host.os.name
+        - metadata.host.ip
+        - metadata.agent.version
+        - last_checkin
 
     AgentIds:
       oneOf:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -347,16 +347,41 @@ paths:
       operationId: GetEndpointMetadataList
       parameters:
         - in: query
-          name: query
+          name: page
+          required: false
+          schema:
+            $ref: '#/components/schemas/Page'
+        - in: query
+          name: pageSize
+          required: false
+          schema:
+            $ref: '#/components/schemas/PageSize'
+        - in: query
+          name: kuery
+          required: false
+          schema:
+            $ref: '#/components/schemas/Kuery'
+        - in: query
+          name: hostStatuses
           required: true
           schema:
-            $ref: '#/components/schemas/ListRequestQuery'
+            $ref: '#/components/schemas/HostStatuses'
+        - in: query
+          name: sortField
+          required: false
+          schema:
+            $ref: '#/components/schemas/SortField'
+        - in: query
+          name: sortDirection
+          required: false
+          schema:
+            $ref: '#/components/schemas/SortDirection'
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                $ref: '#/components/schemas/MetadataListResponse'
           description: OK
       summary: Get a metadata list
       tags:
@@ -369,13 +394,14 @@ paths:
           name: id
           required: true
           schema:
+            example: ed518850-681a-4d60-bb98-e22640cae2a8
             type: string
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                $ref: '#/components/schemas/EndpointMetadataResponse'
           description: OK
       summary: Get metadata
       tags:
@@ -570,6 +596,94 @@ components:
         type: string
       minItems: 1
       type: array
+    EndpointMetadataResponse:
+      example:
+        host_status: healthy
+        last_checkin: '2023-07-04T15:48:57.360Z'
+        metadata:
+          '@timestamp': '2023-07-04T15:48:57.3609346Z'
+          agent:
+            build:
+              original: >-
+                version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch:
+                7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab
+            id: abb8a826-6812-448c-a571-6d8269b51449
+            type: endpoint
+            version: 7.16.0
+          data_stream:
+            dataset: endpoint.metadata
+            namespace: default
+            type: metrics
+          ecs:
+            version: 1.11.0
+          elastic:
+            agent:
+              id: abb8a826-6812-448c-a571-6d8269b51449
+          Endpoint:
+            capabilities:
+              - isolation
+            configuration:
+              isolation: false
+            policy:
+              applied:
+                endpoint_policy_version: '2'
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                name: test
+                status: success
+                version: '3'
+            state:
+              isolation: false
+            status: enrolled
+          event:
+            action: endpoint_metadata
+            agent_id_status: verified
+            category:
+              - host
+            created: '2023-07-04T15:48:57.3609346Z'
+            dataset: endpoint.metadata
+            id: MNtRc++KoKHXXwlj+++++OhZ
+            ingested: '2023-07-04T15:48:58Z'
+            kind: metric
+            module: endpoint
+            sequence: 43757
+            type:
+              - info
+          host:
+            architecture: x86_64
+            hostname: WinDev2104Eval
+            id: 17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5
+            ip:
+              - 10.0.2.15
+              - fe80::21a6:63d3:d70e:e3ad
+              - 127.0.0.1
+              - '::1'
+            mac:
+              - 08:00:27:b1:1d:5a
+            name: WinDev2104Eval
+            os:
+              Ext:
+                variant: Windows 10 Enterprise Evaluation
+              family: windows
+              full: Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)
+              kernel: 20H2 (10.0.19042.906)
+              name: Windows
+              platform: windows
+              type: windows
+              version: 20H2 (10.0.19042.906)
+          message: Endpoint metadata
+          policy_info:
+            agent:
+              applied:
+                id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                revision: 3
+              configured:
+                id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                revision: 3
+            endpoint:
+              id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+              revision: 2
+      type: object
+      properties: {}
     EntityId:
       type: object
       properties:
@@ -697,6 +811,20 @@ components:
           type: integer
       required:
         - hostPath
+    HostStatuses:
+      description: A set of agent health statuses to filter by.
+      example:
+        - healthy
+        - updating
+      items:
+        enum:
+          - healthy
+          - offline
+          - updating
+          - inactive
+          - unenrolled
+        type: string
+      type: array
     IsolateRouteRequestBody:
       type: object
       properties:
@@ -746,56 +874,201 @@ components:
                       type: string
           required:
             - parameters
-    ListRequestQuery:
+    Kuery:
+      description: A KQL string.
+      example: 'united.endpoint.host.os.name : ''Windows'''
+      type: string
+    MetadataListResponse:
+      example:
+        data:
+          - host_status: healthy
+            last_checkin: '2023-07-04T15:47:57.432Z'
+            metadata:
+              '@timestamp': '2023-07-04T15:47:57.432173535Z'
+              agent:
+                build:
+                  original: >-
+                    version: 7.16.0, compiled: Tue Nov 16 16:00:00 2021, branch:
+                    7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab
+                id: 285297c6-3bff-4b83-9a07-f3e749801123
+                type: endpoint
+                version: 7.16.0
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: 1.11.0
+              elastic:
+                agent:
+                  id: 285297c6-3bff-4b83-9a07-f3e749801123
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: '2'
+                    id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                    name: test
+                    status: success
+                    version: '3'
+                state:
+                  isolation: false
+                status: enrolled
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: '2023-07-04T15:47:57.432173535Z'
+                dataset: endpoint.metadata
+                id: MNtSXK/SkhEBnmgt++++++7S
+                ingested: '2023-07-04T15:47:58Z'
+                kind: metric
+                module: endpoint
+                sequence: 400
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: david-Xubuntu
+                id: 0cfead88e2024bd8a27476352b5ab264
+                ip:
+                  - 127.0.0.1
+                  - '::1'
+                  - 10.0.2.15
+                  - fe80::2ac7:8e15:b957:2fa1
+                mac:
+                  - 08:00:27:e6:78:8b
+                name: david-Xubuntu
+                os:
+                  Ext:
+                    variant: Ubuntu
+                  family: ubuntu
+                  full: Ubuntu 20.04.2
+                  kernel: >-
+                    5.8.0-59-generic #66~20.04.1-Ubuntu SMP Thu Jun 17 11:14:10
+                    UTC 2021
+                  name: Linux
+                  platform: ubuntu
+                  type: linux
+                  version: 20.04.2
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 0
+                configured:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 3
+              endpoint:
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                revision: 2
+          - host_status: healthy
+            last_checkin: '2023-07-04T15:44:31.491Z'
+            metadata:
+              '@timestamp': '2023-07-04T15:44:31.4917849Z'
+              agent:
+                build:
+                  original: >-
+                    version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch:
+                    7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab
+                id: abb8a826-6812-448c-a571-6d8269b51449
+                type: endpoint
+                version: 7.16.0
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: 1.11.0
+              elastic:
+                agent:
+                  id: abb8a826-6812-448c-a571-6d8269b51449
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: '2'
+                    id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                    name: test
+                    status: success
+                    version: '3'
+                state:
+                  isolation: false
+                status: enrolled
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: '2023-07-04T15:44:31.4917849Z'
+                dataset: endpoint.metadata
+                id: MNtRc++KoKHXXwlj+++++/N9
+                ingested: '2023-07-04T15:44:33Z'
+                kind: metric
+                module: endpoint
+                sequence: 5159
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: WinDev2104Eval
+                id: 17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5
+                ip:
+                  - 10.0.2.15
+                  - fe80::21a6:63d3:d70e:e3ad
+                  - 127.0.0.1
+                  - '::1'
+                mac:
+                  - 08:00:27:b1:1d:5a
+                name: WinDev2104Eval
+                os:
+                  Ext:
+                    variant: Windows 10 Enterprise Evaluation
+                  family: windows
+                  full: Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)
+                  kernel: 20H2 (10.0.19042.906)
+                  name: Windows
+                  platform: windows
+                  type: windows
+                  version: 20H2 (10.0.19042.906)
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 0
+                configured:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 3
+              endpoint:
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                revision: 2
+        page: 0
+        pageSize: 10
+        sortDirection: desc
+        sortField: enrolled_at
+        total: 2
       type: object
-      properties:
-        hostStatuses:
-          items:
-            enum:
-              - healthy
-              - offline
-              - updating
-              - inactive
-              - unenrolled
-            type: string
-          type: array
-        kuery:
-          nullable: true
-          type: string
-        page:
-          default: 0
-          description: Page number
-          minimum: 0
-          type: integer
-        pageSize:
-          default: 10
-          description: Number of items per page
-          maximum: 10000
-          minimum: 1
-          type: integer
-        sortDirection:
-          enum:
-            - asc
-            - desc
-          nullable: true
-          type: string
-        sortField:
-          enum:
-            - enrolled_at
-            - metadata.host.hostname
-            - host_status
-            - metadata.Endpoint.policy.applied.name
-            - metadata.Endpoint.policy.applied.status
-            - metadata.host.os.name
-            - metadata.host.ip
-            - metadata.agent.version
-            - last_checkin
-          type: string
-      required:
-        - hostStatuses
+      properties: {}
     Page:
       default: 1
       description: Page number
+      example: 1
+      minimum: 1
+      type: integer
+    PageSize:
+      default: 10
+      description: Number of items per page
+      example: 10
+      maximum: 100
       minimum: 1
       type: integer
     Parameters:
@@ -897,6 +1170,27 @@ components:
                 - path
           required:
             - parameters
+    SortDirection:
+      description: Determines the sort order, which can be desc or asc.
+      enum:
+        - asc
+        - desc
+      example: desc
+      type: string
+    SortField:
+      description: Determines which field is used to sort the results.
+      enum:
+        - enrolled_at
+        - metadata.host.hostname
+        - host_status
+        - metadata.Endpoint.policy.applied.name
+        - metadata.Endpoint.policy.applied.status
+        - metadata.host.os.name
+        - metadata.host.ip
+        - metadata.agent.version
+        - last_checkin
+      example: enrolled_at
+      type: string
     StartDate:
       description: Start date
       type: string

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -1171,7 +1171,7 @@ components:
           required:
             - parameters
     SortDirection:
-      description: Determines the sort order, which can be desc or asc.
+      description: Determines the sort order.
       enum:
         - asc
         - desc

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -347,16 +347,41 @@ paths:
       operationId: GetEndpointMetadataList
       parameters:
         - in: query
-          name: query
+          name: page
+          required: false
+          schema:
+            $ref: '#/components/schemas/Page'
+        - in: query
+          name: pageSize
+          required: false
+          schema:
+            $ref: '#/components/schemas/PageSize'
+        - in: query
+          name: kuery
+          required: false
+          schema:
+            $ref: '#/components/schemas/Kuery'
+        - in: query
+          name: hostStatuses
           required: true
           schema:
-            $ref: '#/components/schemas/ListRequestQuery'
+            $ref: '#/components/schemas/HostStatuses'
+        - in: query
+          name: sortField
+          required: false
+          schema:
+            $ref: '#/components/schemas/SortField'
+        - in: query
+          name: sortDirection
+          required: false
+          schema:
+            $ref: '#/components/schemas/SortDirection'
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                $ref: '#/components/schemas/MetadataListResponse'
           description: OK
       summary: Get a metadata list
       tags:
@@ -369,13 +394,14 @@ paths:
           name: id
           required: true
           schema:
+            example: ed518850-681a-4d60-bb98-e22640cae2a8
             type: string
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                $ref: '#/components/schemas/EndpointMetadataResponse'
           description: OK
       summary: Get metadata
       tags:
@@ -570,6 +596,94 @@ components:
         type: string
       minItems: 1
       type: array
+    EndpointMetadataResponse:
+      example:
+        host_status: healthy
+        last_checkin: '2023-07-04T15:48:57.360Z'
+        metadata:
+          '@timestamp': '2023-07-04T15:48:57.3609346Z'
+          agent:
+            build:
+              original: >-
+                version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch:
+                7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab
+            id: abb8a826-6812-448c-a571-6d8269b51449
+            type: endpoint
+            version: 7.16.0
+          data_stream:
+            dataset: endpoint.metadata
+            namespace: default
+            type: metrics
+          ecs:
+            version: 1.11.0
+          elastic:
+            agent:
+              id: abb8a826-6812-448c-a571-6d8269b51449
+          Endpoint:
+            capabilities:
+              - isolation
+            configuration:
+              isolation: false
+            policy:
+              applied:
+                endpoint_policy_version: '2'
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                name: test
+                status: success
+                version: '3'
+            state:
+              isolation: false
+            status: enrolled
+          event:
+            action: endpoint_metadata
+            agent_id_status: verified
+            category:
+              - host
+            created: '2023-07-04T15:48:57.3609346Z'
+            dataset: endpoint.metadata
+            id: MNtRc++KoKHXXwlj+++++OhZ
+            ingested: '2023-07-04T15:48:58Z'
+            kind: metric
+            module: endpoint
+            sequence: 43757
+            type:
+              - info
+          host:
+            architecture: x86_64
+            hostname: WinDev2104Eval
+            id: 17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5
+            ip:
+              - 10.0.2.15
+              - fe80::21a6:63d3:d70e:e3ad
+              - 127.0.0.1
+              - '::1'
+            mac:
+              - 08:00:27:b1:1d:5a
+            name: WinDev2104Eval
+            os:
+              Ext:
+                variant: Windows 10 Enterprise Evaluation
+              family: windows
+              full: Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)
+              kernel: 20H2 (10.0.19042.906)
+              name: Windows
+              platform: windows
+              type: windows
+              version: 20H2 (10.0.19042.906)
+          message: Endpoint metadata
+          policy_info:
+            agent:
+              applied:
+                id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                revision: 3
+              configured:
+                id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                revision: 3
+            endpoint:
+              id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+              revision: 2
+      type: object
+      properties: {}
     EntityId:
       type: object
       properties:
@@ -697,6 +811,20 @@ components:
           type: integer
       required:
         - hostPath
+    HostStatuses:
+      description: A set of agent health statuses to filter by.
+      example:
+        - healthy
+        - updating
+      items:
+        enum:
+          - healthy
+          - offline
+          - updating
+          - inactive
+          - unenrolled
+        type: string
+      type: array
     IsolateRouteRequestBody:
       type: object
       properties:
@@ -746,56 +874,201 @@ components:
                       type: string
           required:
             - parameters
-    ListRequestQuery:
+    Kuery:
+      description: A KQL string.
+      example: 'united.endpoint.host.os.name : ''Windows'''
+      type: string
+    MetadataListResponse:
+      example:
+        data:
+          - host_status: healthy
+            last_checkin: '2023-07-04T15:47:57.432Z'
+            metadata:
+              '@timestamp': '2023-07-04T15:47:57.432173535Z'
+              agent:
+                build:
+                  original: >-
+                    version: 7.16.0, compiled: Tue Nov 16 16:00:00 2021, branch:
+                    7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab
+                id: 285297c6-3bff-4b83-9a07-f3e749801123
+                type: endpoint
+                version: 7.16.0
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: 1.11.0
+              elastic:
+                agent:
+                  id: 285297c6-3bff-4b83-9a07-f3e749801123
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: '2'
+                    id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                    name: test
+                    status: success
+                    version: '3'
+                state:
+                  isolation: false
+                status: enrolled
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: '2023-07-04T15:47:57.432173535Z'
+                dataset: endpoint.metadata
+                id: MNtSXK/SkhEBnmgt++++++7S
+                ingested: '2023-07-04T15:47:58Z'
+                kind: metric
+                module: endpoint
+                sequence: 400
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: david-Xubuntu
+                id: 0cfead88e2024bd8a27476352b5ab264
+                ip:
+                  - 127.0.0.1
+                  - '::1'
+                  - 10.0.2.15
+                  - fe80::2ac7:8e15:b957:2fa1
+                mac:
+                  - 08:00:27:e6:78:8b
+                name: david-Xubuntu
+                os:
+                  Ext:
+                    variant: Ubuntu
+                  family: ubuntu
+                  full: Ubuntu 20.04.2
+                  kernel: >-
+                    5.8.0-59-generic #66~20.04.1-Ubuntu SMP Thu Jun 17 11:14:10
+                    UTC 2021
+                  name: Linux
+                  platform: ubuntu
+                  type: linux
+                  version: 20.04.2
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 0
+                configured:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 3
+              endpoint:
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                revision: 2
+          - host_status: healthy
+            last_checkin: '2023-07-04T15:44:31.491Z'
+            metadata:
+              '@timestamp': '2023-07-04T15:44:31.4917849Z'
+              agent:
+                build:
+                  original: >-
+                    version: 7.16.0, compiled: Tue Nov 16 17:00:00 2021, branch:
+                    7.16, commit: 73a51033db85e0fb3be1c934697ef6a2b08979ab
+                id: abb8a826-6812-448c-a571-6d8269b51449
+                type: endpoint
+                version: 7.16.0
+              data_stream:
+                dataset: endpoint.metadata
+                namespace: default
+                type: metrics
+              ecs:
+                version: 1.11.0
+              elastic:
+                agent:
+                  id: abb8a826-6812-448c-a571-6d8269b51449
+              Endpoint:
+                capabilities:
+                  - isolation
+                configuration:
+                  isolation: false
+                policy:
+                  applied:
+                    endpoint_policy_version: '2'
+                    id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                    name: test
+                    status: success
+                    version: '3'
+                state:
+                  isolation: false
+                status: enrolled
+              event:
+                action: endpoint_metadata
+                agent_id_status: verified
+                category:
+                  - host
+                created: '2023-07-04T15:44:31.4917849Z'
+                dataset: endpoint.metadata
+                id: MNtRc++KoKHXXwlj+++++/N9
+                ingested: '2023-07-04T15:44:33Z'
+                kind: metric
+                module: endpoint
+                sequence: 5159
+                type:
+                  - info
+              host:
+                architecture: x86_64
+                hostname: WinDev2104Eval
+                id: 17d9cabc-7edd-43bc-bacb-8da5f5e6c0e5
+                ip:
+                  - 10.0.2.15
+                  - fe80::21a6:63d3:d70e:e3ad
+                  - 127.0.0.1
+                  - '::1'
+                mac:
+                  - 08:00:27:b1:1d:5a
+                name: WinDev2104Eval
+                os:
+                  Ext:
+                    variant: Windows 10 Enterprise Evaluation
+                  family: windows
+                  full: Windows 10 Enterprise Evaluation 20H2 (10.0.19042.906)
+                  kernel: 20H2 (10.0.19042.906)
+                  name: Windows
+                  platform: windows
+                  type: windows
+                  version: 20H2 (10.0.19042.906)
+              message: Endpoint metadata
+            policy_info:
+              agent:
+                applied:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 0
+                configured:
+                  id: ed7e3720-4bad-11ec-a2a8-fb22e62a5753
+                  revision: 3
+              endpoint:
+                id: d5371dcd-93b7-4627-af88-4084f7d6aa3e
+                revision: 2
+        page: 0
+        pageSize: 10
+        sortDirection: desc
+        sortField: enrolled_at
+        total: 2
       type: object
-      properties:
-        hostStatuses:
-          items:
-            enum:
-              - healthy
-              - offline
-              - updating
-              - inactive
-              - unenrolled
-            type: string
-          type: array
-        kuery:
-          nullable: true
-          type: string
-        page:
-          default: 0
-          description: Page number
-          minimum: 0
-          type: integer
-        pageSize:
-          default: 10
-          description: Number of items per page
-          maximum: 10000
-          minimum: 1
-          type: integer
-        sortDirection:
-          enum:
-            - asc
-            - desc
-          nullable: true
-          type: string
-        sortField:
-          enum:
-            - enrolled_at
-            - metadata.host.hostname
-            - host_status
-            - metadata.Endpoint.policy.applied.name
-            - metadata.Endpoint.policy.applied.status
-            - metadata.host.os.name
-            - metadata.host.ip
-            - metadata.agent.version
-            - last_checkin
-          type: string
-      required:
-        - hostStatuses
+      properties: {}
     Page:
       default: 1
       description: Page number
+      example: 1
+      minimum: 1
+      type: integer
+    PageSize:
+      default: 10
+      description: Number of items per page
+      example: 10
+      maximum: 100
       minimum: 1
       type: integer
     Parameters:
@@ -897,6 +1170,27 @@ components:
                 - path
           required:
             - parameters
+    SortDirection:
+      description: Determines the sort order, which can be desc or asc.
+      enum:
+        - asc
+        - desc
+      example: desc
+      type: string
+    SortField:
+      description: Determines which field is used to sort the results.
+      enum:
+        - enrolled_at
+        - metadata.host.hostname
+        - host_status
+        - metadata.Endpoint.policy.applied.name
+        - metadata.Endpoint.policy.applied.status
+        - metadata.host.os.name
+        - metadata.host.ip
+        - metadata.agent.version
+        - last_checkin
+      example: enrolled_at
+      type: string
     StartDate:
       description: Start date
       type: string

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_endpoint_management_api_2023_10_31.bundled.schema.yaml
@@ -1171,7 +1171,7 @@ components:
           required:
             - parameters
     SortDirection:
-      description: Determines the sort order, which can be desc or asc.
+      description: Determines the sort order.
       enum:
         - asc
         - desc


### PR DESCRIPTION
Part of DW team effort - https://github.com/elastic/security-team/issues/11804

This PR aligns the property/schema descriptions and examples in AsciiDocs with OpenAPI schemas. The primary goal of this PR was not to extend or enhance the documentation but to migrate from one system to another.

Ascii docs - https://www.elastic.co/guide/en/kibana/8.17/osquery-manager-api.html
OpenApi generated docs - https://www.elastic.co/docs/api/doc/kibana/operation/operation-endpointgetactionslist

Changes:

Copied missing property descriptions from AsciiDoc to OpenApi properties
Copied existing AsciiDoc examples for both requests and responses
Fixed falsy query object in some GET requests - in OpenApi it was defined as an object, not as path query params.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->