### PR TITLE
[Rule Migrations] Add Prerelease flag for integrations

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_integrations_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/siem_migrations/rules/data/rule_migrations_data_integrations_client.ts
@@ -19,13 +19,17 @@ const RETURNED_INTEGRATIONS = 5 as const;
  */
 export class RuleMigrationsDataIntegrationsClient extends RuleMigrationsDataBaseClient {
   async getIntegrationPackages(): Promise<PackageList | undefined> {
-    return this.dependencies.packageService?.asInternalUser.getPackages();
+    return this.dependencies.packageService?.asInternalUser.getPackages({
+      prerelease: true,
+    });
   }
 
   /** Indexes an array of integrations to be used with ELSER semantic search queries */
   async populate(): Promise<void> {
     const index = await this.getIndexName();
-    const packages = await this.dependencies.packageService?.asInternalUser.getPackages();
+    const packages = await this.dependencies.packageService?.asInternalUser.getPackages({
+      prerelease: true,
+    });
     if (packages) {
       const ragIntegrations = packages.map<RuleMigrationIntegration>((pkg) => ({
         title: pkg.title,


### PR DESCRIPTION
## Summary

This adds the flag to include prerelease integrations in the packageClient used to fetch integrations for the Rule Migration RAG





<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->