### PR TITLE
[8.17] [Security Solution] Fix Incorrect Enable Button Behavior in Entity Store Modal (#212078)

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.test.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.test.tsx
@@ -146,6 +146,24 @@ describe('EntityStoreEnablementModal', () => {
       expect(enableButton).toBeDisabled();
     });
 
+    it('should show proceed warning when riskScore is enabled but entityStore is disabled and unchecked', () => {
+      renderComponent({
+        ...defaultProps,
+        riskScore: { disabled: false, checked: false }, // Enabled & Checked
+        entityStore: { disabled: true, checked: false }, // Disabled & Unchecked
+      });
+      expect(screen.getByText('Please enable at least one option to proceed.')).toBeInTheDocument();
+    });
+
+    it('should show proceed warning when entityStore is enabled but riskScore is disabled and unchecked', () => {
+      renderComponent({
+        ...defaultProps,
+        entityStore: { disabled: false, checked: false }, // Enabled & Checked
+        riskScore: { disabled: true, checked: false }, // Disabled & Unchecked
+      });
+      expect(screen.getByText('Please enable at least one option to proceed.')).toBeInTheDocument();
+    });
+
     it('should not show entity engine missing privileges warning when no missing privileges', () => {
       renderComponent();
       expect(

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
@@ -57,6 +57,20 @@ interface EntityStoreEnablementModalProps {
   };
 }
 
+const shouldAllowEnablement = (
+  riskScoreEnabled: boolean,
+  entityStoreEnabled: boolean,
+  enablements: Enablements
+) => {
+  if (riskScoreEnabled) {
+    return enablements.entityStore;
+  }
+  if (entityStoreEnabled) {
+    return enablements.riskScore;
+  }
+  return enablements.riskScore || enablements.entityStore;
+};
+
 export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProps> = ({
   visible,
   toggle,
@@ -72,7 +86,12 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
   const { data: entityEnginePrivileges, isLoading: isLoadingEntityEnginePrivileges } =
     useEntityEnginePrivileges();
   const riskEnginePrivileges = useMissingRiskEnginePrivileges();
-  const enablementOptions = enablements.riskScore || enablements.entityStore;
+
+  const enablementOptions = shouldAllowEnablement(
+    !!riskScore.disabled,
+    !!entityStore.disabled,
+    enablements
+  );
   const { EnablementModalCallout } = useContractComponents();
 
   if (!visible) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Security Solution] Fix Incorrect Enable Button Behavior in Entity Store Modal (#212078)](https://github.com/elastic/kibana/pull/212078)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Charlotte Alexandra Wilson","email":"CAWilson94@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-24T14:35:30Z","message":"[Security Solution] Fix Incorrect Enable Button Behavior in Entity Store Modal (#212078)\n\n## Summary\n\nEnsure Enable Button Considers Disabled State of Risk Score & Entity\nStore. Previously only used the checked state of the toggle.\n\n### Reproduce the Issue\nSteps, as [per bug\nticket:](https://github.com/elastic/kibana/issues/209242#issue-2826951496)\n\n1. Kibana version 8.16.0 or above should exist\n2. Navigate to the Dashboards tab under Security\n3. Select Entity Analytics dashboard\n4. Click on the enable button and enable risk score\n5. Disable the options for Entity store\n6. Then again select the enable button for Entity store\n7. Disable the enable button\n8. Observe the Enable button is still enabled\n\n### After Issue Solved\n\nSame steps as above, but should show the warning and disable the button.\n\n#### Videos\n\nVideos show when either riskScore or entityStore is enabled, and the\nother is unchecked, the warning should show and the button should be\ndisabled.\n\n\nhttps://github.com/user-attachments/assets/236f9e69-f810-4116-9948-38fd27d4d945\n\n\n\nhttps://github.com/user-attachments/assets/2971e845-5d46-4eac-997a-79b3b17922c0\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ba9210c2594c5d2d1a4915943e5c73911f1acbf8","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team: SecuritySolution","Theme: entity_analytics","Feature:Entity Analytics","ci:project-deploy-security","ci:project-persist-deployment","Team:Entity Analytics","v8.16.0","backport:version","v8.17.0","v8.18.0","v9.1.0","v8.19.0"],"title":"[Security Solution] Fix Incorrect Enable Button Behavior in Entity Store Modal","number":212078,"url":"https://github.com/elastic/kibana/pull/212078","mergeCommit":{"message":"[Security Solution] Fix Incorrect Enable Button Behavior in Entity Store Modal (#212078)\n\n## Summary\n\nEnsure Enable Button Considers Disabled State of Risk Score & Entity\nStore. Previously only used the checked state of the toggle.\n\n### Reproduce the Issue\nSteps, as [per bug\nticket:](https://github.com/elastic/kibana/issues/209242#issue-2826951496)\n\n1. Kibana version 8.16.0 or above should exist\n2. Navigate to the Dashboards tab under Security\n3. Select Entity Analytics dashboard\n4. Click on the enable button and enable risk score\n5. Disable the options for Entity store\n6. Then again select the enable button for Entity store\n7. Disable the enable button\n8. Observe the Enable button is still enabled\n\n### After Issue Solved\n\nSame steps as above, but should show the warning and disable the button.\n\n#### Videos\n\nVideos show when either riskScore or entityStore is enabled, and the\nother is unchecked, the warning should show and the button should be\ndisabled.\n\n\nhttps://github.com/user-attachments/assets/236f9e69-f810-4116-9948-38fd27d4d945\n\n\n\nhttps://github.com/user-attachments/assets/2971e845-5d46-4eac-997a-79b3b17922c0\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ba9210c2594c5d2d1a4915943e5c73911f1acbf8"}},"sourceBranch":"main","suggestedTargetBranches":["8.16","8.17"],"targetPullRequestStates":[{"branch":"8.16","label":"v8.16.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212250","number":212250,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212078","number":212078,"mergeCommit":{"message":"[Security Solution] Fix Incorrect Enable Button Behavior in Entity Store Modal (#212078)\n\n## Summary\n\nEnsure Enable Button Considers Disabled State of Risk Score & Entity\nStore. Previously only used the checked state of the toggle.\n\n### Reproduce the Issue\nSteps, as [per bug\nticket:](https://github.com/elastic/kibana/issues/209242#issue-2826951496)\n\n1. Kibana version 8.16.0 or above should exist\n2. Navigate to the Dashboards tab under Security\n3. Select Entity Analytics dashboard\n4. Click on the enable button and enable risk score\n5. Disable the options for Entity store\n6. Then again select the enable button for Entity store\n7. Disable the enable button\n8. Observe the Enable button is still enabled\n\n### After Issue Solved\n\nSame steps as above, but should show the warning and disable the button.\n\n#### Videos\n\nVideos show when either riskScore or entityStore is enabled, and the\nother is unchecked, the warning should show and the button should be\ndisabled.\n\n\nhttps://github.com/user-attachments/assets/236f9e69-f810-4116-9948-38fd27d4d945\n\n\n\nhttps://github.com/user-attachments/assets/2971e845-5d46-4eac-997a-79b3b17922c0\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ba9210c2594c5d2d1a4915943e5c73911f1acbf8"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212251","number":212251,"state":"OPEN"}]}] BACKPORT-->