### PR TITLE
[8.18] [8.x] Ensure Enterprise Search pre 8.x Datastream Deprecations (#211847)

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DeprecationDetailsMessage, DeprecationsDetails } from '@kbn/core-deprecations-common';
+import { GetDeprecationsContext } from '@kbn/core-deprecations-server';
+
+import { getEnterpriseSearchPre8IndexDeprecations } from './enterprise_search_deprecations';
+import indexDeprecatorFxns = require('./pre_eight_index_deprecator');
+
+const ctx = {
+  esClient: {
+    asInternalUser: {},
+  },
+} as GetDeprecationsContext;
+
+function getMessageFromDeprecation(details: DeprecationsDetails): string {
+  const message = details.message as DeprecationDetailsMessage;
+  return message.content;
+}
+
+describe('getEnterpriseSearchPre8IndexDeprecations', () => {
+  it('can register index and data stream deprecations that need to be set to read only', async () => {
+    const getIndicesMock = jest.fn(() =>
+      Promise.resolve([
+        {
+          name: '.ent-search-index_without_datastream',
+          hasDatastream: false,
+          datastreams: [],
+        },
+        {
+          name: '.ent-search-with_data_stream',
+          hasDatastream: true,
+          datastreams: ['datastream-testing'],
+        },
+      ])
+    );
+
+    jest
+      .spyOn(indexDeprecatorFxns, 'getPreEightEnterpriseSearchIndices')
+      .mockImplementation(getIndicesMock);
+
+    const deprecations = await getEnterpriseSearchPre8IndexDeprecations(ctx, 'docsurl');
+    expect(deprecations).toHaveLength(1);
+    expect(deprecations[0].correctiveActions.api?.path).toStrictEqual(
+      '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only'
+    );
+    expect(deprecations[0].title).toMatch('Pre 8.x Enterprise Search indices compatibility');
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      'The following indices are found to be incompatible for upgrade'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      '.ent-search-index_without_datastream'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      'The following data streams are found to be incompatible for upgrade'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).toContain('.ent-search-with_data_stream');
+  });
+
+  it('can register an index without data stream deprecations that need to be set to read only', async () => {
+    const getIndicesMock = jest.fn(() =>
+      Promise.resolve([
+        {
+          name: '.ent-search-index_without_datastream',
+          hasDatastream: false,
+          datastreams: [''],
+        },
+      ])
+    );
+
+    jest
+      .spyOn(indexDeprecatorFxns, 'getPreEightEnterpriseSearchIndices')
+      .mockImplementation(getIndicesMock);
+
+    const deprecations = await getEnterpriseSearchPre8IndexDeprecations(ctx, 'docsurl');
+    expect(deprecations).toHaveLength(1);
+    expect(deprecations[0].correctiveActions.api?.path).toStrictEqual(
+      '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only'
+    );
+    expect(deprecations[0].title).toMatch('Pre 8.x Enterprise Search indices compatibility');
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      'The following indices are found to be incompatible for upgrade'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).toContain(
+      '.ent-search-index_without_datastream'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).not.toContain(
+      'The following data streams are found to be incompatible for upgrade'
+    );
+    expect(getMessageFromDeprecation(deprecations[0])).not.toContain(
+      '.ent-search-with_data_stream'
+    );
+  });
+});

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DeprecationsDetails } from '@kbn/core-deprecations-common';
+import { GetDeprecationsContext, RegisterDeprecationsConfig } from '@kbn/core-deprecations-server';
+
+import { i18n } from '@kbn/i18n';
+import { getPreEightEnterpriseSearchIndices } from './pre_eight_index_deprecator';
+
+export const getEntepriseSearchRegisteredDeprecations = (
+  docsUrl: string
+): RegisterDeprecationsConfig => {
+  return {
+    getDeprecations: async (ctx: GetDeprecationsContext) => {
+      const [entSearchIndexIncompatibility] = await Promise.all([
+        getEnterpriseSearchPre8IndexDeprecations(ctx, docsUrl),
+      ]);
+      return [...entSearchIndexIncompatibility];
+    },
+  };
+};
+
+/**
+ * If there are any Enterprise Search indices that were created with Elasticsearch 7.x, they must be removed
+ * or set to read-only
+ */
+export async function getEnterpriseSearchPre8IndexDeprecations(
+  ctx: GetDeprecationsContext,
+  docsUrl: string
+): Promise<DeprecationsDetails[]> {
+  const deprecations: DeprecationsDetails[] = [];
+
+  const entSearchIndices = await getPreEightEnterpriseSearchIndices(ctx.esClient.asInternalUser);
+  if (!entSearchIndices || entSearchIndices.length === 0) {
+    return deprecations;
+  }
+
+  let indicesList = '';
+  let datastreamsList = '';
+  for (const index of entSearchIndices) {
+    if (index.hasDatastream) {
+      indicesList += `${index.name}\n`;
+      for (const datastream of index.datastreams) {
+        if (datastream === '') continue;
+        datastreamsList += `${datastream}\n`;
+      }
+    } else {
+      indicesList += `${index.name}\n`;
+    }
+  }
+
+  let message = `There are ${entSearchIndices.length} incompatible Enterprise Search indices.\n\n`;
+
+  if (indicesList.length > 0) {
+    message +=
+      'The following indices are found to be incompatible for upgrade:\n\n' +
+      '```\n' +
+      `${indicesList}` +
+      '\n```\n' +
+      'These indices must be either set to read-only or deleted before upgrading.\n';
+  }
+
+  if (datastreamsList.length > 0) {
+    message +=
+      '\nThe following data streams are found to be incompatible for upgrade:\n\n' +
+      '```\n' +
+      `${datastreamsList}` +
+      '\n```\n' +
+      'Using the "quick resolve" button below will roll over any datastreams and set all incompatible indices to read-only.\n\n' +
+      'Alternatively, manually deleting these indices and data streams will also unblock your upgrade.';
+  } else {
+    message +=
+      'Setting these indices to read-only can be attempted with the "quick resolve" button below.\n\n' +
+      'Alternatively, manually deleting these indices will also unblock your upgrade.';
+  }
+
+  deprecations.push({
+    level: 'critical',
+    deprecationType: 'feature',
+    title: i18n.translate(
+      'xpack.upgradeAssistant.deprecations.incompatibleEnterpriseSearchIndexes.title',
+      {
+        defaultMessage: 'Pre 8.x Enterprise Search indices compatibility',
+      }
+    ),
+    message: {
+      type: 'markdown',
+      content: i18n.translate(
+        'xpack.upgradeAssistant.deprecations.incompatibleEnterpriseSearchIndexes.message',
+        {
+          defaultMessage: message,
+        }
+      ),
+    },
+    documentationUrl: docsUrl,
+    correctiveActions: {
+      manualSteps: [
+        i18n.translate(
+          'xpack.upgradeAssistant.deprecations.incompatibleEnterpriseSearchIndexes.deleteIndices',
+          {
+            defaultMessage: 'Set all incompatible indices and data streams to read only, or',
+          }
+        ),
+        i18n.translate(
+          'xpack.upgradeAssistant.deprecations.incompatibleEnterpriseSearchIndexes.deleteIndices',
+          {
+            defaultMessage: 'Delete all incompatible indices and data streams',
+          }
+        ),
+      ],
+      api: {
+        method: 'POST',
+        path: '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',
+        body: {
+          deprecationDetails: { domainId: 'enterpriseSearch' },
+        },
+      },
+    },
+  });
+
+  return deprecations;
+}

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations_routes.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations_routes.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kibanaResponseFactory } from '@kbn/core/server';
+
+import { handleEsError } from '../../shared_imports';
+import {
+  createMockRouter,
+  MockRouter,
+  routeHandlerContextMock,
+} from '../../routes/__mocks__/routes.mock';
+import { createRequestMock } from '../../routes/__mocks__/request.mock';
+
+jest.mock('../es_version_precheck', () => ({
+  versionCheckHandlerWrapper: (a: any) => a,
+}));
+
+import indexDeprecatorFxns = require('./pre_eight_index_deprecator');
+
+import { registerEnterpriseSearchDeprecationRoutes } from './enterprise_search_deprecations_routes';
+
+describe('deprecation routes', () => {
+  let routeDependencies: any;
+
+  describe('POST /internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only', () => {
+    let mockRouter: MockRouter;
+
+    function registerMockRouter({ mlSnapshots } = { mlSnapshots: true }) {
+      mockRouter = createMockRouter();
+      routeDependencies = {
+        config: {
+          featureSet: { mlSnapshots, migrateSystemIndices: true, reindexCorrectiveActions: true },
+        },
+        router: mockRouter,
+        lib: { handleEsError },
+      };
+      registerEnterpriseSearchDeprecationRoutes(routeDependencies);
+    }
+
+    beforeEach(() => {
+      registerMockRouter();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('sets read-only and 200s correctly in happy path', async () => {
+      const setIndicesReadOnlyMock = jest.spyOn(
+        indexDeprecatorFxns,
+        'setPreEightEnterpriseSearchIndicesReadOnly'
+      );
+
+      setIndicesReadOnlyMock.mockResolvedValue('');
+
+      const resp = await routeDependencies.router.getHandler({
+        method: 'post',
+        pathPattern:
+          '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',
+      })(
+        routeHandlerContextMock,
+        createRequestMock({
+          body: { deprecationDetails: { domainId: 'enterpriseSearch' } },
+        }),
+        kibanaResponseFactory
+      );
+
+      expect(resp.status).toEqual(200);
+      expect(resp.payload).toEqual({
+        acknowedged: true,
+      });
+
+      expect(setIndicesReadOnlyMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations_routes.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations_routes.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { setPreEightEnterpriseSearchIndicesReadOnly } from './pre_eight_index_deprecator';
+import { versionCheckHandlerWrapper } from '../es_version_precheck';
+import { RouteDependencies } from '../../types';
+
+export function registerEnterpriseSearchDeprecationRoutes({
+  config: { featureSet },
+  router,
+  lib: { handleEsError },
+  licensing,
+  log,
+}: RouteDependencies) {
+  router.post(
+    {
+      path: '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',
+      validate: {},
+    },
+    versionCheckHandlerWrapper(async ({ core }, request, response) => {
+      const { client } = (await core).elasticsearch;
+      const setResponse = await setPreEightEnterpriseSearchIndicesReadOnly(client.asCurrentUser);
+      if (setResponse.length > 0) {
+        return response.badRequest({
+          body: { message: setResponse },
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return response.ok({
+        body: { acknowedged: true },
+        headers: { 'content-type': 'application/json' },
+      });
+    })
+  );
+}

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/plugin.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/plugin.ts
@@ -38,6 +38,7 @@ import { handleEsError } from './shared_imports';
 import { RouteDependencies } from './types';
 import type { UpgradeAssistantConfig } from './config';
 import type { FeatureSet } from '../common/types';
+import { getEntepriseSearchRegisteredDeprecations } from './lib/enterprise_search/enterprise_search_deprecations';
 
 interface PluginsSetup {
   usageCollection: UsageCollectionSetup;
@@ -82,7 +83,7 @@ export class UpgradeAssistantServerPlugin implements Plugin {
   }
 
   setup(
-    { http, getStartServices, savedObjects }: CoreSetup,
+    { http, deprecations, getStartServices, savedObjects, docLinks }: CoreSetup,
     { usageCollection, features, licensing, logsShared, security }: PluginsSetup
   ) {
     this.licensing = licensing;
@@ -146,6 +147,11 @@ export class UpgradeAssistantServerPlugin implements Plugin {
     };
 
     registerRoutes(dependencies, this.getWorker.bind(this));
+
+    // Register deprecations for Enterprise Search pre-8 indices
+    deprecations.registerDeprecations({
+      ...getEntepriseSearchRegisteredDeprecations(docLinks.links.enterpriseSearch.upgrade9x),
+    });
 
     if (usageCollection) {
       void getStartServices().then(([{ elasticsearch }]) => {

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/register_routes.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/register_routes.ts
@@ -23,6 +23,7 @@ import { registerNodeDiskSpaceRoute } from './node_disk_space';
 import { registerClusterSettingsRoute } from './cluster_settings';
 import { registerMigrateDataStreamRoutes } from './migrate_data_streams';
 import { registerUpdateIndexRoute } from './update_index';
+import { registerEnterpriseSearchDeprecationRoutes } from '../lib/enterprise_search/enterprise_search_deprecations_routes';
 
 export function registerRoutes(dependencies: RouteDependencies, getWorker: () => ReindexWorker) {
   registerAppRoutes(dependencies);
@@ -47,4 +48,7 @@ export function registerRoutes(dependencies: RouteDependencies, getWorker: () =>
 
   // Mark index as read-only and unfreeze it
   registerUpdateIndexRoute(dependencies);
+
+  // Enterprise Search deprecations
+  registerEnterpriseSearchDeprecationRoutes(dependencies);
 }

--- a/x-pack/platform/plugins/private/upgrade_assistant/tsconfig.json
+++ b/x-pack/platform/plugins/private/upgrade_assistant/tsconfig.json
@@ -43,7 +43,9 @@
     "@kbn/core-logging-server-mocks",
     "@kbn/core-http-server-mocks",
     "@kbn/core-http-server-utils",
-    "@kbn/core-elasticsearch-server"
+    "@kbn/core-elasticsearch-server",
+    "@kbn/core-deprecations-common",
+    "@kbn/core-deprecations-server"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
@@ -14,8 +14,6 @@ import { Connector, fetchConnectors } from '@kbn/search-connectors';
 
 import { ConfigType } from '..';
 
-import { getPreEightEnterpriseSearchIndices } from './pre_eight_index_deprecator';
-
 export const getRegisteredDeprecations = (
   config: ConfigType,
   cloud: CloudSetup,
@@ -24,18 +22,11 @@ export const getRegisteredDeprecations = (
   return {
     getDeprecations: async (ctx: GetDeprecationsContext) => {
       const entSearchDetails = getEnterpriseSearchNodeDeprecation(config, cloud, docsUrl);
-      const [crawlerDetails, nativeConnectorsDetails, entSearchIndexIncompatibility] =
-        await Promise.all([
-          getCrawlerDeprecations(ctx, docsUrl),
-          getNativeConnectorDeprecations(ctx, docsUrl),
-          getEnterpriseSearchPre8IndexDeprecations(ctx, docsUrl, config.host),
-        ]);
-      return [
-        ...entSearchDetails,
-        ...crawlerDetails,
-        ...nativeConnectorsDetails,
-        ...entSearchIndexIncompatibility,
-      ];
+      const [crawlerDetails, nativeConnectorsDetails] = await Promise.all([
+        getCrawlerDeprecations(ctx, docsUrl),
+        getNativeConnectorDeprecations(ctx, docsUrl),
+      ]);
+      return [...entSearchDetails, ...crawlerDetails, ...nativeConnectorsDetails];
     },
   };
 };
@@ -49,7 +40,7 @@ export function getEnterpriseSearchNodeDeprecation(
   cloud: CloudSetup,
   docsUrl: string
 ): DeprecationsDetails[] {
-  if (config.host) {
+  if (config.host || config.customHeaders) {
     const steps = [];
     let addendum: string = '';
     const isCloud = !!cloud?.cloudId;
@@ -96,6 +87,10 @@ export function getEnterpriseSearchNodeDeprecation(
           i18n.translate('xpack.enterpriseSearch.deprecations.entsearchhost.removeconfig', {
             defaultMessage: "Edit 'kibana.yml' to remove 'enterpriseSearch.host'",
           }),
+          i18n.translate('xpack.enterpriseSearch.deprecations.entsearchhost.removecustomconfig', {
+            defaultMessage:
+              "Edit 'kibana.yml' to remove 'enterpriseSearch.customHeaders' if it exists",
+          }),
           i18n.translate('xpack.enterpriseSearch.deprecations.entsearchhost.restart', {
             defaultMessage: 'Restart Kibana',
           }),
@@ -107,7 +102,7 @@ export function getEnterpriseSearchNodeDeprecation(
         level: 'critical',
         deprecationType: 'feature',
         title: i18n.translate('xpack.enterpriseSearch.deprecations.entsearchhost.title', {
-          defaultMessage: 'Enterprise Search host(s) must be removed',
+          defaultMessage: 'Enterprise Search host(s) and configuration must be removed',
         }),
         message: {
           type: 'markdown',
@@ -120,6 +115,7 @@ export function getEnterpriseSearchNodeDeprecation(
               'Enterprise Search is not supported in versions >= 9.x.\n\n' +
               'Please note the following:\n' +
               '- You must remove any Enterprise Search nodes from your deployment to proceed with the upgrade.\n' +
+              '- You must also remove any Enterprise Search configuration elements in your Kibana config.\n' +
               '- If you are currently using App Search, Workplace Search, or the Elastic Web Crawler, these features will ' +
               'cease to function if you remove Enterprise Search from your deployment. Therefore, it is critical to ' +
               'first [migrate your Enterprise Search use cases]({migration_link}) before decommissioning your ' +
@@ -266,106 +262,4 @@ export async function getNativeConnectorDeprecations(
 
     return deprecations;
   }
-}
-
-/**
- * If there are any Enterprise Search indices that were created with Elasticsearch 7.x, they must be removed
- * or set to read-only
- */
-export async function getEnterpriseSearchPre8IndexDeprecations(
-  ctx: GetDeprecationsContext,
-  docsUrl: string,
-  configHost?: string
-): Promise<DeprecationsDetails[]> {
-  const deprecations: DeprecationsDetails[] = [];
-
-  if (!configHost) {
-    return deprecations;
-  }
-
-  const entSearchIndices = await getPreEightEnterpriseSearchIndices(ctx.esClient.asInternalUser);
-  if (!entSearchIndices || entSearchIndices.length === 0) {
-    return deprecations;
-  }
-
-  let indicesList = '';
-  let datastreamsList = '';
-  for (const index of entSearchIndices) {
-    if (index.isDatastream) {
-      datastreamsList += `${index.name}\n`;
-    } else {
-      indicesList += `${index.name}\n`;
-    }
-  }
-
-  let message = `There are ${entSearchIndices.length} incompatible Enterprise Search indices.\n\n`;
-
-  if (indicesList.length > 0) {
-    message +=
-      'The following indices are found to be incompatible for upgrade:\n\n' +
-      '```\n' +
-      `${indicesList}` +
-      '\n```\n\n' +
-      'These indices must be either set to read-only or deleted before upgrading. ';
-  }
-
-  if (datastreamsList.length > 0) {
-    message +=
-      '\nThe following data streams are found to be incompatible for upgrade:\n\n' +
-      '```\n' +
-      `${datastreamsList}` +
-      '\n```\n\n' +
-      'Using the "quick resolve" button below will roll over any datastreams and set all incompatible indices to read-only.\n\n' +
-      'Alternatively, manually deleting these indices and data streams will also unblock your upgrade.';
-  } else {
-    message +=
-      'Setting these indices to read-only can be attempted with the "quick resolve" button below.\n\n' +
-      'Alternatively, manually deleting these indices will also unblock your upgrade.';
-  }
-
-  deprecations.push({
-    level: 'critical',
-    deprecationType: 'feature',
-    title: i18n.translate(
-      'xpack.enterpriseSearch.deprecations.incompatibleEnterpriseSearchIndexes.title',
-      {
-        defaultMessage: 'Pre 8.x Enterprise Search indices compatibility',
-      }
-    ),
-    message: {
-      type: 'markdown',
-      content: i18n.translate(
-        'xpack.enterpriseSearch.deprecations.incompatibleEnterpriseSearchIndexes.message',
-        {
-          defaultMessage: message,
-        }
-      ),
-    },
-    documentationUrl: docsUrl,
-    correctiveActions: {
-      manualSteps: [
-        i18n.translate(
-          'xpack.enterpriseSearch.deprecations.incompatibleEnterpriseSearchIndexes.deleteIndices',
-          {
-            defaultMessage: 'Set all incompatible indices to read only, or',
-          }
-        ),
-        i18n.translate(
-          'xpack.enterpriseSearch.deprecations.incompatibleEnterpriseSearchIndexes.deleteIndices',
-          {
-            defaultMessage: 'Delete all incompatible indices',
-          }
-        ),
-      ],
-      api: {
-        method: 'POST',
-        path: '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',
-        body: {
-          deprecationDetails: { domainId: 'enterpriseSearch' },
-        },
-      },
-    },
-  });
-
-  return deprecations;
 }

--- a/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
@@ -64,11 +64,6 @@ export const config: PluginConfigDescriptor<ConfigType> = {
           level: 'critical',
           title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
         }),
-        deprecate('customHeaders', '9.0.0', {
-          documentationUrl: context.docLinks.enterpriseSearch.upgrade9x,
-          level: 'critical',
-          title: ENT_SEARCH_NODE_DEPRECATION_TITLE,
-        }),
         deprecate('isCloud', '9.0.0', {
           level: 'critical',
         }),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
@@ -15,8 +15,6 @@ import { mockDependencies, MockRouter } from '../../__mocks__';
 import { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 import { deleteConnectorById, putUpdateNative } from '@kbn/search-connectors';
 
-import indexDeprecatorFxns = require('../../deprecations/pre_eight_index_deprecator');
-
 import { registerDeprecationRoutes } from './deprecations';
 
 describe('deprecation routes', () => {
@@ -178,51 +176,6 @@ describe('deprecation routes', () => {
       expect(updateNativeMock).toHaveBeenCalledWith(mockClient, 'foo', false);
       expect(updateNativeMock).toHaveBeenCalledWith(mockClient, 'bar', false);
       expect(updateNativeMock).toHaveBeenCalledWith(mockClient, 'baz', false);
-    });
-  });
-
-  describe('POST /internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only', () => {
-    const mockClient = {};
-    let mockRouter: MockRouter;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      const context = {
-        core: Promise.resolve({ elasticsearch: { client: { asCurrentUser: mockClient } } }),
-      } as jest.Mocked<RequestHandlerContext>;
-      mockRouter = new MockRouter({
-        context,
-        method: 'post',
-        path: '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',
-      });
-
-      registerDeprecationRoutes({
-        ...mockDependencies,
-        router: mockRouter.router,
-      });
-    });
-
-    it('sets read-only and 200s correctly in happy path', async () => {
-      const setIndicesReadOnlyMock = jest.spyOn(
-        indexDeprecatorFxns,
-        'setPreEightEnterpriseSearchIndicesReadOnly'
-      );
-
-      const request = {
-        body: { deprecationDetails: { domainId: 'enterpriseSearch' } },
-      };
-      mockRouter.shouldValidate(request);
-
-      setIndicesReadOnlyMock.mockResolvedValue('');
-
-      await mockRouter.callRoute(request);
-      expect(setIndicesReadOnlyMock).toHaveBeenCalledTimes(1);
-      expect(mockRouter.response.ok).toHaveBeenCalledTimes(1);
-    });
-
-    it('fails validation without deprecation context', () => {
-      const request = { body: {} };
-      mockRouter.shouldThrow(request);
     });
   });
 });

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.ts
@@ -9,7 +9,6 @@ import { schema } from '@kbn/config-schema';
 
 import { deleteConnectorById, putUpdateNative } from '@kbn/search-connectors';
 
-import { setPreEightEnterpriseSearchIndicesReadOnly } from '../../deprecations/pre_eight_index_deprecator';
 import { RouteDependencies } from '../../plugin';
 
 import { elasticsearchErrorHandler } from '../../utils/elasticsearch_error_handler';
@@ -58,31 +57,6 @@ export function registerDeprecationRoutes({ router, log }: RouteDependencies) {
       );
       return response.ok({
         body: { converted_to_client: request.body.ids },
-        headers: { 'content-type': 'application/json' },
-      });
-    })
-  );
-
-  router.post(
-    {
-      path: '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',
-      validate: {
-        body: schema.object({
-          deprecationDetails: schema.object({ domainId: schema.literal('enterpriseSearch') }),
-        }),
-      },
-    },
-    elasticsearchErrorHandler(log, async (context, request, response) => {
-      const { client } = (await context.core).elasticsearch;
-      const setResponse = await setPreEightEnterpriseSearchIndicesReadOnly(client.asCurrentUser);
-      if (setResponse.length > 0) {
-        return response.badRequest({
-          body: { message: setResponse },
-          headers: { 'content-type': 'application/json' },
-        });
-      }
-      return response.ok({
-        body: { acknowedged: true },
         headers: { 'content-type': 'application/json' },
       });
     })


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[8.x] Ensure Enterprise Search pre 8.x Datastream Deprecations (#211847)](https://github.com/elastic/kibana/pull/211847)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mark J. Hoy","email":"mark.hoy@elastic.co"},"sourceCommit":{"committedDate":"2025-02-24T16:32:44Z","message":"[8.x] Ensure Enterprise Search pre 8.x Datastream Deprecations (#211847)\n\n## Summary\n\nThe [previous PR](https://github.com/elastic/kibana/pull/210688) for\ndeprecating Enterprise Search indices before 8.x did not handle all of\nthe necessary datastreams to be rolled over. This adds those. Also, the\nconfiguration check for `enterpriseSearch.customHeaders` has now been\nrolled into the Enterprise Search node removal and configuration check.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bf8cfca07c76ac27aed41560bf4a6f6a9db1dadb","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Upgrade Assistant","Team:EnterpriseSearch","v8.18.0","v8.19.0","backport:8.18"],"title":"[8.x] Ensure Enterprise Search pre 8.x Datastream Deprecations","number":211847,"url":"https://github.com/elastic/kibana/pull/211847","mergeCommit":{"message":"[8.x] Ensure Enterprise Search pre 8.x Datastream Deprecations (#211847)\n\n## Summary\n\nThe [previous PR](https://github.com/elastic/kibana/pull/210688) for\ndeprecating Enterprise Search indices before 8.x did not handle all of\nthe necessary datastreams to be rolled over. This adds those. Also, the\nconfiguration check for `enterpriseSearch.customHeaders` has now been\nrolled into the Enterprise Search node removal and configuration check.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bf8cfca07c76ac27aed41560bf4a6f6a9db1dadb"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->