### PR TITLE
 Siem Migrations - Fix rules upload API Error Test.

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/rules/sub_steps/rules_file_upload/rules_file_upload.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/rules/sub_steps/rules_file_upload/rules_file_upload.test.tsx
@@ -132,42 +132,16 @@ describe('RulesFileUpload', () => {
       },
     ];
 
-    it('should not be able to upload on API Error', async () => {
+    it('should display API Error correctly', async () => {
       renderTestComponent({
         apiError: mockApiError,
       });
 
-      const fileName = 'splunk_rules.test.data.json';
-      const ndJSONString = splunkTestRules.map((obj) => JSON.stringify(obj)).join('\n');
-      const testFile = createRulesFileFromRulesData(ndJSONString, getTestDir(), fileName);
-
-      const filePicker = screen.getByTestId('rulesFilePicker');
-
-      act(() => {
-        fireEvent.change(filePicker, {
-          target: {
-            files: [testFile],
-          },
-        });
-      });
-
       await waitFor(() => {
-        expect(filePicker).toHaveAttribute('data-loading', 'true');
-      });
-
-      await waitFor(() => {
-        expect(filePicker).toHaveAttribute('data-loading', 'false');
-      });
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('uploadFileButton'));
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText(mockApiError)).toBeVisible();
         expect(screen.getByTestId('uploadFileButton')).toBeDisabled();
       });
     });
+
     scenarios.forEach((scenario, _idx) => {
       it(`should not be able to upload when file has - ${scenario.subject}`, async () => {
         const fileName = 'invalid_rule_file.json';

--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/rules/sub_steps/rules_file_upload/rules_file_upload.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/rules/sub_steps/rules_file_upload/rules_file_upload.test.tsx
@@ -132,13 +132,13 @@ describe('RulesFileUpload', () => {
       },
     ];
 
-    it('should display API Error correctly', async () => {
+    it('should display API Error', async () => {
       renderTestComponent({
         apiError: mockApiError,
       });
 
       await waitFor(() => {
-        expect(screen.getByTestId('uploadFileButton')).toBeDisabled();
+        expect(screen.getByText(mockApiError)).toBeVisible();
       });
     });
 


### PR DESCRIPTION
## Summary

This PR fixes a incorrect UI test :

- Rules Upload File component should only display API Error in case it occurs, while previously the tests was check if the button is disabled or not. Disability of button is irrelevant.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->