### PR TITLE
[OnWeek][Discover Session] Sync charts cursor with the currently expanded record

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -51,6 +51,7 @@ import { getDefaultRowsPerPage } from '../../../../../common/constants';
 import { useInternalStateSelector } from '../../state_management/discover_internal_state_container';
 import { useAppStateSelector } from '../../state_management/discover_app_state_container';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
+import { useRecordCursorInCharts } from '../../../../hooks/use_record_cursor_in_charts';
 import { FetchStatus } from '../../../types';
 import { DiscoverStateContainer } from '../../state_management/discover_state';
 import { useDataState } from '../../hooks/use_data_state';
@@ -202,11 +203,13 @@ function DiscoverDocumentsComponent({
     [onRemoveColumn, ebtManager, fieldsMetadata]
   );
 
+  const updateRecordCursorInCharts = useRecordCursorInCharts(dataView);
   const setExpandedDoc = useCallback(
     (doc: DataTableRecord | undefined) => {
       stateContainer.internalState.transitions.setExpandedDoc(doc);
+      updateRecordCursorInCharts(doc);
     },
-    [stateContainer]
+    [stateContainer, updateRecordCursorInCharts]
   );
 
   const onResizeDataGrid = useCallback<NonNullable<UnifiedDataTableProps['onResize']>>(

--- a/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
@@ -26,6 +26,7 @@ import { DiscoverGridFlyout } from '../../components/discover_grid_flyout';
 import { SavedSearchEmbeddableBase } from './saved_search_embeddable_base';
 import { TotalDocuments } from '../../application/main/components/total_documents/total_documents';
 import { useProfileAccessor } from '../../context_awareness';
+import { useRecordCursorInCharts } from '../../hooks/use_record_cursor_in_charts';
 
 interface DiscoverGridEmbeddableProps extends Omit<UnifiedDataTableProps, 'sampleSizeState'> {
   sampleSizeState: number; // a required prop
@@ -43,8 +44,17 @@ export const DiscoverGridMemoized = React.memo(DiscoverGrid);
 
 export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
   const { interceptedWarnings, enableDocumentViewer, ...gridProps } = props;
+  const updateRecordCursorInCharts = useRecordCursorInCharts(props.dataView);
 
   const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>(undefined);
+
+  const changeExpandedDoc = useCallback(
+    (doc: DataTableRecord | undefined) => {
+      setExpandedDoc(doc);
+      updateRecordCursorInCharts(doc);
+    },
+    [setExpandedDoc, updateRecordCursorInCharts]
+  );
 
   const renderDocumentView = useCallback(
     (
@@ -64,8 +74,8 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
         onFilter={props.onFilter}
         onRemoveColumn={props.onRemoveColumn}
         onAddColumn={props.onAddColumn}
-        onClose={() => setExpandedDoc(undefined)}
-        setExpandedDoc={setExpandedDoc}
+        onClose={() => changeExpandedDoc(undefined)}
+        setExpandedDoc={changeExpandedDoc}
         query={props.query}
         filters={props.filters}
       />
@@ -78,6 +88,7 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
       props.query,
       props.filters,
       props.savedSearchId,
+      changeExpandedDoc,
     ]
   );
 
@@ -128,7 +139,7 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
         {...gridProps}
         isPaginationEnabled={!gridProps.isPlainRecord}
         totalHits={props.totalHitCount}
-        setExpandedDoc={setExpandedDoc}
+        setExpandedDoc={changeExpandedDoc}
         expandedDoc={expandedDoc}
         showMultiFields={props.services.uiSettings.get(SHOW_MULTIFIELDS)}
         maxDocFieldsDisplayed={props.services.uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}

--- a/src/platform/plugins/shared/discover/public/hooks/use_record_cursor_in_charts.ts
+++ b/src/platform/plugins/shared/discover/public/hooks/use_record_cursor_in_charts.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback } from 'react';
+import type { DataView } from '@kbn/data-views-plugin/public';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
+import { useDiscoverServices } from './use_discover_services';
+
+const DISCOVER_CHART_ID = 'discover_session';
+
+export type UseRecordCursorReturn = (record: DataTableRecord | undefined) => void;
+
+export const useRecordCursorInCharts = (dataView: DataView): UseRecordCursorReturn => {
+  const { charts } = useDiscoverServices();
+
+  return useCallback(
+    (record) => {
+      const commonProps = {
+        accessors: [`${dataView.getIndexPattern()}:${dataView.timeFieldName}`],
+        isDateHistogram: true,
+      };
+
+      if (!record) {
+        charts.activeCursor.activeCursor$?.next({
+          ...commonProps,
+          cursor: {
+            chartId: DISCOVER_CHART_ID,
+            type: 'Out',
+          },
+        });
+        return;
+      }
+
+      const timestampValue = dataView.timeFieldName
+        ? record?.flattened[dataView.timeFieldName]
+        : undefined;
+      const timestamp = Array.isArray(timestampValue) ? timestampValue[0] : timestampValue;
+      const x = timestamp ? new Date(timestamp).getTime() : undefined;
+
+      if (x) {
+        charts.activeCursor.activeCursor$?.next({
+          ...commonProps,
+          cursor: {
+            chartId: DISCOVER_CHART_ID,
+            type: 'Over',
+            scale: 'time',
+            x,
+            y: [{ value: 0, groupId: 'left' }],
+            smVerticalValue: null,
+            smHorizontalValue: null,
+          },
+        });
+      }
+    },
+    [dataView, charts]
+  );
+};


### PR DESCRIPTION
## Summary

Charts support cursor syncing between them which is very handy when several charts are added to a Dashboard. This PR makes the Discover Session embeddable act as one of the charts which triggers cursor synchronisation. 

When user expands a data grid row, the charts start showing a grey-bar indicating the record position on the chart. It works on Dashboard and Discover pages. The highlight is quite light though.

![Feb-24-2025 20-06-28](https://github.com/user-attachments/assets/d0b22e8c-6e2c-41ec-98cd-aa8cbef17bb2)

<img width="1599" alt="Screenshot 2025-02-24 at 20 11 37" src="https://github.com/user-attachments/assets/1a67b9c3-d149-4ba8-a2d1-cc60f61dfee5" />

