### PR TITLE
[Search] test(search-classic-nav): improve errors & unskip

### DIFF
--- a/x-pack/test/functional/page_objects/search_classic_navigation.ts
+++ b/x-pack/test/functional/page_objects/search_classic_navigation.ts
@@ -44,7 +44,10 @@ export function SearchClassicNavigationProvider({ getService }: FtrProviderConte
         expect(itemLabel).to.equal(navItem.label);
       }
       const allSideNavItems = await testSubjects.findAll('*searchSideNav-');
-      expect(allSideNavItems.length).to.equal(items.length);
+      expect(allSideNavItems.length).to.equal(
+        items.length,
+        'Actual number of side nav items did not match the expected number'
+      );
     },
 
     async expectNavItemExists(id: string) {
@@ -63,7 +66,10 @@ export function SearchClassicNavigationProvider({ getService }: FtrProviderConte
     async expectNavItemActive(id: string) {
       await testSubjects.existOrFail(sideNavTestSubj(id));
       const item = await testSubjects.find(sideNavTestSubj(id));
-      expect(await item.elementHasClass('euiSideNavItemButton-isSelected')).to.be(true);
+      expect(await item.elementHasClass('euiSideNavItemButton-isSelected')).to.be.eql(
+        true,
+        `Expected ${id} sidenav item to be active`
+      );
     },
 
     breadcrumbs: {

--- a/x-pack/test/functional_search/tests/classic_navigation.ts
+++ b/x-pack/test/functional_search/tests/classic_navigation.ts
@@ -19,8 +19,7 @@ export default function searchSolutionNavigation({
   const spaces = getService('spaces');
   const browser = getService('browser');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/203607
-  describe.skip('Search Classic Navigation', () => {
+  describe('Search Classic Navigation', () => {
     let cleanUp: () => Promise<unknown>;
     let spaceCreated: { id: string } = { id: '' };
 


### PR DESCRIPTION
## Summary

Updating some of the error messages and testing the classic nav FTR suite unskipped. This was skipped back in Dec, but seems to be green now. 🤞  issue has already been resolved.

Closes https://github.com/elastic/kibana/issues/203607

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
