### PR TITLE
[kbn-grid-layout] Fix mobile styles

### DIFF
--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_layout.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_layout.tsx
@@ -181,7 +181,7 @@ const styles = {
   singleColumn: css({
     '&.kbnGrid--mobileView': {
       '.kbnGridRow': {
-        gridTemplateAreas: '100%',
+        gridTemplateColumns: '100%',
         gridTemplateRows: 'auto',
         gridAutoFlow: 'row',
         gridAutoRows: 'auto',


### PR DESCRIPTION
## Summary

This PR fixes a broken style introduced in https://github.com/elastic/kibana/pull/210285 where, when rewriting the single column styles from strings to objects, I accidentally set the property `gridTemplateAreas` instead of `gridTemplateColumns` - this resulted in the single column / mobile view being broken:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e0541cc7-66dd-41a0-8e21-6931c491cea4) | ![image](https://github.com/user-attachments/assets/12bc1453-1da4-4784-9242-b1cccdf9e24e) | 


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->