### PR TITLE
Attempt to register the inlineCompletionsProvider

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -621,6 +621,10 @@ export const ESQLEditor = memo(function ESQLEditor({
 
   const hoverProvider = useMemo(() => ESQLLang.getHoverProvider?.(esqlCallbacks), [esqlCallbacks]);
 
+  const inlineCompletionsProvider = useMemo(() => {
+    return ESQLLang.getInlineCompletionsProvider?.(esqlCallbacks);
+  }, [esqlCallbacks]);
+
   const codeActionProvider = useMemo(
     () => ESQLLang.getCodeActionProvider?.(esqlCallbacks),
     [esqlCallbacks]
@@ -680,6 +684,9 @@ export const ESQLEditor = memo(function ESQLEditor({
       lightbulb: {
         enabled: false,
       },
+      inlineSuggest: {
+        enabled: true,
+      },
       lineDecorationsWidth: 20,
       lineNumbers: 'on',
       lineNumbersMinChars: 3,
@@ -692,8 +699,8 @@ export const ESQLEditor = memo(function ESQLEditor({
       },
       quickSuggestions: true,
       readOnly: isDisabled,
-      renderLineHighlight: 'line',
-      renderLineHighlightOnlyWhenFocus: true,
+      // renderLineHighlight: 'line',
+      // renderLineHighlightOnlyWhenFocus: true,
       scrollbar: {
         horizontal: 'hidden',
         horizontalScrollbarSize: 6,
@@ -773,6 +780,7 @@ export const ESQLEditor = memo(function ESQLEditor({
                       return hoverProvider?.provideHover(model, position, token);
                     },
                   }}
+                  inlineCompletionsProvider={inlineCompletionsProvider}
                   codeActions={codeActionProvider}
                   onChange={onQueryUpdate}
                   editorDidMount={(editor) => {

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
@@ -34,6 +34,27 @@ export const ESQLLang: CustomLangModuleType<ESQLCallbacks> = {
     workerProxyService.setup(ESQL_LANG_ID);
 
     monaco.languages.setTokensProvider(ESQL_LANG_ID, new ESQLTokensProvider());
+
+    // monaco.languages.registerInlineCompletionsProvider(ESQL_LANG_ID, {
+    //   provideInlineCompletions: async (model, position) => {
+    //     console.log('provideInlineCompletions', model, position);
+    //     const range = new monaco.Range(
+    //       position.lineNumber,
+    //       position.column,
+    //       position.lineNumber,
+    //       position.column
+    //     );
+    //     return {
+    //       items: [
+    //         {
+    //           insertText: 'FROM logs',
+    //           range,
+    //         },
+    //       ],
+    //     };
+    //   },
+    //   freeInlineCompletions: () => {},
+    // });
   },
   languageThemeResolver: buildESQLTheme,
   languageConfiguration: {
@@ -92,6 +113,24 @@ export const ESQLLang: CustomLangModuleType<ESQLCallbacks> = {
         );
         return astAdapter.getHover(model, position, token);
       },
+    };
+  },
+  getInlineCompletionsProvider: (
+    callbacks?: ESQLCallbacks
+  ): monaco.languages.InlineCompletionsProvider => {
+    return {
+      provideInlineCompletions(model, position) {
+        console.log('provideInlineCompletions');
+        return {
+          items: [
+            // {
+            //   insertText: 'provide',
+            //   range: meow,
+            // },
+          ],
+        };
+      },
+      freeInlineCompletions: () => {},
     };
   },
   getSuggestionProvider: (callbacks?: ESQLCallbacks): monaco.languages.CompletionItemProvider => {

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
@@ -34,27 +34,6 @@ export const ESQLLang: CustomLangModuleType<ESQLCallbacks> = {
     workerProxyService.setup(ESQL_LANG_ID);
 
     monaco.languages.setTokensProvider(ESQL_LANG_ID, new ESQLTokensProvider());
-
-    // monaco.languages.registerInlineCompletionsProvider(ESQL_LANG_ID, {
-    //   provideInlineCompletions: async (model, position) => {
-    //     console.log('provideInlineCompletions', model, position);
-    //     const range = new monaco.Range(
-    //       position.lineNumber,
-    //       position.column,
-    //       position.lineNumber,
-    //       position.column
-    //     );
-    //     return {
-    //       items: [
-    //         {
-    //           insertText: 'FROM logs',
-    //           range,
-    //         },
-    //       ],
-    //     };
-    //   },
-    //   freeInlineCompletions: () => {},
-    // });
   },
   languageThemeResolver: buildESQLTheme,
   languageConfiguration: {

--- a/src/platform/packages/shared/kbn-monaco/src/types.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/types.ts
@@ -37,6 +37,7 @@ export interface LanguageProvidersModule<Deps = unknown> {
   getSuggestionProvider: (callbacks?: Deps) => monaco.languages.CompletionItemProvider;
   getSignatureProvider?: (callbacks?: Deps) => monaco.languages.SignatureHelpProvider;
   getHoverProvider?: (callbacks?: Deps) => monaco.languages.HoverProvider;
+  getInlineCompletionsProvider?: (callbacks?: Deps) => monaco.languages.InlineCompletionsProvider;
   getCodeActionProvider?: (callbacks?: Deps) => monaco.languages.CodeActionProvider;
 }
 

--- a/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
+++ b/src/platform/packages/shared/shared-ux/code_editor/impl/code_editor.tsx
@@ -82,6 +82,8 @@ export interface CodeEditorProps {
    */
   hoverProvider?: monaco.languages.HoverProvider;
 
+  inlineCompletionsProvider?: monaco.languages.InlineCompletionsProvider;
+
   /**
    * Language config provider for bracket
    * Documentation for the provider can be found here:
@@ -178,6 +180,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   suggestionProvider,
   signatureProvider,
   hoverProvider,
+  inlineCompletionsProvider,
   placeholder,
   languageConfiguration,
   codeActions,
@@ -374,6 +377,10 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           monaco.languages.registerHoverProvider(languageId, hoverProvider);
         }
 
+        if (inlineCompletionsProvider) {
+          monaco.languages.registerInlineCompletionsProvider(languageId, inlineCompletionsProvider);
+        }
+
         if (languageConfiguration) {
           monaco.languages.setLanguageConfiguration(languageId, languageConfiguration);
         }
@@ -396,6 +403,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
       suggestionProvider,
       signatureProvider,
       hoverProvider,
+      inlineCompletionsProvider,
       codeActions,
       languageConfiguration,
       enableFindAction,


### PR DESCRIPTION
## Summary

This works in monaco playground with our monaco version (0.44)
```
     function createDependencyProposals(range) {
	// returning a static list of proposals, not even looking at the prefix (filtering is done by the Monaco editor),
	// here you could do a server side lookup
	return [
		{
			label: '"lodash"',
			kind: monaco.languages.CompletionItemKind.Function,
			documentation: "The Lodash library exported as Node.js modules.",
			insertText: '"lodash": "*"',
			range: range,
		},
		{
			label: '"express"',
			kind: monaco.languages.CompletionItemKind.Function,
			documentation: "Fast, unopinionated, minimalist web framework",
			insertText: '"express": "*"',
			range: range,
		},
		{
			label: '"mkdirp"',
			kind: monaco.languages.CompletionItemKind.Function,
			documentation: "Recursively mkdir, like <code>mkdir -p</code>",
			insertText: '"mkdirp": "*"',
			range: range,
		},
		{
			label: '"my-third-party-library"',
			kind: monaco.languages.CompletionItemKind.Function,
			documentation: "Describe your library here",
			insertText: '"${1:my-third-party-library}": "${2:1.2.3}"',
			insertTextRules:
				monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
			range: range,
		},
	];
}

monaco.languages.registerInlineCompletionsProvider("json", {
		provideInlineCompletions: function (model, position) {
	    console.log('provide')
		const meow = new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column + 'press'.length);
		return {
          items: [
            {
              insertText: 'provide',
              range: meow,
            },
          ],
        };
	},
	freeInlineCompletions: () => {}
});

monaco.languages.registerCompletionItemProvider("json", {
	provideCompletionItems: function (model, position) {
		// find out if we are completing a property in the 'dependencies' object.
		var textUntilPosition = model.getValueInRange({
			startLineNumber: 1,
			startColumn: 1,
			endLineNumber: position.lineNumber,
			endColumn: position.column,
		});
		var match = textUntilPosition.match(
			/"dependencies"\s*:\s*\{\s*("[^"]*"\s*:\s*"[^"]*"\s*,\s*)*([^"]*)?$/
		);
		if (!match) {
			return { suggestions: [] };
		}
		var word = model.getWordUntilPosition(position);
		var range = {
			startLineNumber: position.lineNumber,
			endLineNumber: position.lineNumber,
			startColumn: word.startColumn,
			endColumn: word.endColumn,
		};
		return {
			suggestions: createDependencyProposals(range),
		};
	},
});

monaco.editor.create(document.getElementById("container"), {
	value: '{\n\t"dependencies": {\n\t\t\n\t}\n}\n',
	language: "json",
});
```

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



