### PR TITLE
[8.18] [UA] Exclude critical, reindex enterprise search data stream deprecations (#211881)

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/__fixtures__/fake_deprecations.json
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/__fixtures__/fake_deprecations.json
@@ -232,21 +232,63 @@
         "details": "This data stream has backing indices that were created before Elasticsearch 8.0.0",
         "resolve_during_rolling_upgrade": false,
         "_meta": {
-          "backing_indices": {
-            "count": 52,
-            "need_upgrading": {
-              "count": 37,
-              "searchable_snapshot": {
-                "count": 23,
-                "fully_mounted": {
-                  "count": 7
-                },
-                "partially_mounted": {
-                  "count": 16
-                }
-              }
-            }
-          }
+          "indices_requiring_upgrade": [
+            ".ds-some-backing-index-5-2024.11.07-000001"
+          ],
+          "indices_requiring_upgrade_count": 1,
+          "total_backing_indices": 2,
+          "reindex_required": true
+        }
+      }
+    ],
+    "logs-enterprise_search.default": [
+      {
+        "level": "critical",
+        "message": "Old data stream with a compatibility version < 8.0",
+        "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
+        "details": "This data stream has backing indices that were created before Elasticsearch 8.0.0",
+        "resolve_during_rolling_upgrade": false,
+        "_meta": {
+          "indices_requiring_upgrade": [
+            ".ds-some-backing-index-5-2024.11.07-000001"
+          ],
+          "indices_requiring_upgrade_count": 1,
+          "total_backing_indices": 2,
+          "reindex_required": true
+        }
+      }
+    ],
+    "logs-app_search.default": [
+      {
+        "level": "critical",
+        "message": "Old data stream with a compatibility version < 8.0",
+        "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
+        "details": "This data stream has backing indices that were created before Elasticsearch 8.0.0",
+        "resolve_during_rolling_upgrade": false,
+        "_meta": {
+          "indices_requiring_upgrade": [
+            ".ds-some-backing-index-5-2024.11.07-000001"
+          ],
+          "indices_requiring_upgrade_count": 1,
+          "total_backing_indices": 2,
+          "reindex_required": true
+        }
+      }
+    ],
+    "logs-workplace_search.default": [
+      {
+        "level": "critical",
+        "message": "Old data stream with a compatibility version < 8.0",
+        "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
+        "details": "This data stream has backing indices that were created before Elasticsearch 8.0.0",
+        "resolve_during_rolling_upgrade": false,
+        "_meta": {
+          "indices_requiring_upgrade": [
+            ".ds-some-backing-index-5-2024.11.07-000001"
+          ],
+          "indices_requiring_upgrade_count": 1,
+          "total_backing_indices": 2,
+          "reindex_required": true
         }
       }
     ]

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations_routes.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/enterprise_search_deprecations_routes.ts
@@ -9,13 +9,7 @@ import { setPreEightEnterpriseSearchIndicesReadOnly } from './pre_eight_index_de
 import { versionCheckHandlerWrapper } from '../es_version_precheck';
 import { RouteDependencies } from '../../types';
 
-export function registerEnterpriseSearchDeprecationRoutes({
-  config: { featureSet },
-  router,
-  lib: { handleEsError },
-  licensing,
-  log,
-}: RouteDependencies) {
+export function registerEnterpriseSearchDeprecationRoutes({ router }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/deprecations/set_enterprise_search_indices_read_only',

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/index.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/enterprise_search/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export {
+  ENT_SEARCH_DATASTREAM_PATTERN,
+  ENT_SEARCH_DATASTREAM_PREFIXES,
+  ENT_SEARCH_INDEX_PREFIX,
+} from './pre_eight_index_deprecator';

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/__snapshots__/index.test.ts.snap
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/__snapshots__/index.test.ts.snap
@@ -202,7 +202,19 @@ Object {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
     },
     Object {
-      "correctiveAction": undefined,
+      "correctiveAction": Object {
+        "metadata": Object {
+          "ignoredIndicesRequiringUpgrade": Array [],
+          "ignoredIndicesRequiringUpgradeCount": 0,
+          "indicesRequiringUpgrade": Array [
+            ".ds-some-backing-index-5-2024.11.07-000001",
+          ],
+          "indicesRequiringUpgradeCount": 1,
+          "reindexRequired": true,
+          "totalBackingIndices": 2,
+        },
+        "type": "dataStream",
+      },
       "details": "This data stream has backing indices that were created before Elasticsearch 8.0.0",
       "index": "my-v7-data-stream",
       "isCritical": true,


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[UA] Exclude critical, reindex enterprise search data stream deprecations (#211881)](https://github.com/elastic/kibana/pull/211881)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jean-Louis Leysens","email":"jeanlouis.leysens@elastic.co"},"sourceCommit":{"committedDate":"2025-02-25T11:54:59Z","message":"[UA] Exclude critical, reindex enterprise search data stream deprecations (#211881)\n\n## Summary\n\nClose https://github.com/elastic/kibana/issues/211712\n\nRelated https://github.com/elastic/kibana/pull/211847","sha":"4c42363a7ab5ef049273fb6f39b6fafb4d0015d8","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","Feature:Upgrade Assistant","backport:version","v8.18.0","v8.19.0"],"title":"[UA] Exclude critical, reindex enterprise search data stream deprecations","number":211881,"url":"https://github.com/elastic/kibana/pull/211881","mergeCommit":{"message":"[UA] Exclude critical, reindex enterprise search data stream deprecations (#211881)\n\n## Summary\n\nClose https://github.com/elastic/kibana/issues/211712\n\nRelated https://github.com/elastic/kibana/pull/211847","sha":"4c42363a7ab5ef049273fb6f39b6fafb4d0015d8"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->