### PR TITLE
Fix cloud UI sanity tests

### DIFF
--- a/x-pack/test/cloud_security_posture_functional/cloud_tests/findings_sanity.ts
+++ b/x-pack/test/cloud_security_posture_functional/cloud_tests/findings_sanity.ts
@@ -93,7 +93,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
             expect(rowsCount).to.be(expectedRowsCount);
             const groupSelector = await findings.groupSelector();
             await groupSelector.openDropDown();
-            await groupSelector.setValue('Cloud account');
+            await groupSelector.setValue('Cloud account ID');
             const grouping = await findings.findingsGrouping();
             // Check that the group count and unit count matches the expected values
             const groupCount = await grouping.getGroupCount();


### PR DESCRIPTION
## Summary

This PR fixes the `Querying provider data` tests executed on the `Findings` page.

Sanity UI tests successfully [run](https://github.com/elastic/cloudbeat/actions/runs/13538801407/job/37835192467).

![Screenshot 2025-02-26 at 10 27 31](https://github.com/user-attachments/assets/f2447f62-fafa-4e58-a98c-5abbf7f08c42)






<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->