### PR TITLE
[Fleet] Re-enable registry version check in Docker template

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/kibana_yml.template.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/kibana_yml.template.ts
@@ -24,11 +24,6 @@ function generator({ imageFlavor }: TemplateContext) {
   server.shutdownTimeout: "5s"
   elasticsearch.hosts: [ "http://elasticsearch:9200" ]
   monitoring.ui.container.elasticsearch.enabled: true
-
-  # Must be removed before v9 release
-  # Requires all registry packages to add v9 as a compatible semver range
-  # https://github.com/elastic/kibana/issues/192624
-  xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
   `);
 }
 


### PR DESCRIPTION
## Summary

We re-enabled registry version checks in https://github.com/elastic/kibana/pull/208169 but missed this Docker template. 

cc @jsoriano 

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->