### PR TITLE
Enhance the hover experience in the ES|QL editor

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -409,7 +409,16 @@ export const ESQLEditor = memo(function ESQLEditor({
   const { cache: esqlFieldsCache, memoizedFieldsFromESQL } = useMemo(() => {
     // need to store the timing of the first request so we can atomically clear the cache per query
     const fn = memoize(
-      (...args: [{ esql: string }, ExpressionsStart, TimeRange, AbortController?]) => ({
+      (
+        ...args: [
+          { esql: string },
+          ExpressionsStart,
+          TimeRange,
+          AbortController?,
+          string?,
+          ESQLControlVariable[]?
+        ]
+      ) => ({
         timestamp: Date.now(),
         result: fetchFieldsFromESQL(...args),
       }),
@@ -449,7 +458,9 @@ export const ESQLEditor = memo(function ESQLEditor({
               esqlQuery,
               expressions,
               timeRange,
-              abortController
+              abortController,
+              undefined,
+              esqlVariables
             ).result;
             const columns: ESQLRealField[] =
               table?.columns.map((c) => {
@@ -466,6 +477,29 @@ export const ESQLEditor = memo(function ESQLEditor({
         }
         return [];
       },
+      getHoverData: async ({ query: queryToExecute }: { query?: string } | undefined = {}) => {
+        if (queryToExecute) {
+          const esqlQuery = {
+            esql: `${queryToExecute} | limit 5`,
+          };
+          const timeRange = data.query.timefilter.timefilter.getTime();
+          try {
+            const table = await memoizedFieldsFromESQL(
+              esqlQuery,
+              expressions,
+              timeRange,
+              abortController,
+              undefined,
+              esqlVariables
+            ).result;
+
+            return table;
+          } catch (e) {
+            // no action yet
+          }
+        }
+        return undefined;
+      },
       getPolicies: async () => {
         const { data: policies, error } =
           (await indexManagementApiService?.getAllEnrichPolicies()) || {};
@@ -481,8 +515,8 @@ export const ESQLEditor = memo(function ESQLEditor({
       },
       // @ts-expect-error To prevent circular type import, type defined here is partial of full client
       getFieldsMetadata: fieldsMetadata?.getClient(),
-      getVariablesByType: (type: ESQLVariableType) => {
-        return variablesService?.esqlVariables.filter((variable) => variable.type === type);
+      getESQLVariables: () => {
+        return variablesService?.esqlVariables;
       },
       canSuggestVariables: () => {
         return variablesService?.areSuggestionsEnabled ?? false;
@@ -492,6 +526,7 @@ export const ESQLEditor = memo(function ESQLEditor({
     return callbacks;
   }, [
     fieldsMetadata,
+    esqlVariables,
     kibana.services?.esql?.getJoinIndicesAutocomplete,
     dataSourcesCache,
     query.esql,

--- a/src/platform/packages/private/kbn-esql-editor/src/fetch_fields_from_esql.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/fetch_fields_from_esql.ts
@@ -11,6 +11,7 @@ import { pluck } from 'rxjs';
 import { lastValueFrom } from 'rxjs';
 import { Query, AggregateQuery, TimeRange } from '@kbn/es-query';
 import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
+import { type ESQLControlVariable } from '@kbn/esql-validation-autocomplete';
 import type { Datatable } from '@kbn/expressions-plugin/public';
 import { textBasedQueryStateToAstWithValidation } from '@kbn/data-plugin/common';
 
@@ -26,7 +27,8 @@ export function fetchFieldsFromESQL(
   expressions: ExpressionsStart,
   time?: TimeRange,
   abortController?: AbortController,
-  timeFieldName?: string
+  timeFieldName?: string,
+  esqlVariables?: ESQLControlVariable[]
 ) {
   return textBasedQueryStateToAstWithValidation({
     query,
@@ -38,6 +40,7 @@ export function fetchFieldsFromESQL(
         const executionContract = expressions.execute(ast, null, {
           searchContext: {
             timeRange: time,
+            esqlVariables,
           },
         });
 

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -341,5 +341,15 @@ export const getEditorOverwrites = (theme: UseEuiTheme<{}>) => {
     .monaco-list .monaco-scrollable-element .monaco-list-row.focused {
       border-radius: ${theme.euiTheme.border.radius.medium};
     }
+
+    .hover-contents th {
+      padding: 2px 2px;
+      border: 1px solid ${theme.euiTheme.colors.backgroundBasePlain};
+      color: ${theme.euiTheme.colors.textAccent};
+    }
+    .hover-contents td {
+      padding: 2px 2px;
+      border: 1px solid ${theme.euiTheme.colors.backgroundBasePlain};
+    }
   `;
 };

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -342,14 +342,18 @@ export const getEditorOverwrites = (theme: UseEuiTheme<{}>) => {
       border-radius: ${theme.euiTheme.border.radius.medium};
     }
 
-    .hover-contents th {
-      padding: 2px 2px;
-      border: 1px solid ${theme.euiTheme.colors.backgroundBasePlain};
-      color: ${theme.euiTheme.colors.textAccent};
-    }
+    .hover-contents th,
     .hover-contents td {
       padding: 2px 2px;
       border: 1px solid ${theme.euiTheme.colors.backgroundBasePlain};
+      text-align: left;
+      font-weight: normal;
     }
+    .hover-contents strong {
+      color: ${theme.euiTheme.colors.textAccentSecondary};
+    }
+
+    .hover-contents h3 {
+      color: ${theme.euiTheme.colors.textAccent};
   `;
 };

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.stats.test.ts
@@ -379,7 +379,7 @@ describe('autocomplete.suggest', () => {
           const suggestions = await suggest('FROM a | STATS /', {
             callbacks: {
               canSuggestVariables: () => true,
-              getVariablesByType: () => [],
+              getESQLVariables: () => [],
               getColumnsFor: () => Promise.resolve([{ name: 'clientip', type: 'ip' }]),
             },
           });
@@ -400,7 +400,7 @@ describe('autocomplete.suggest', () => {
           const suggestions = await suggest('FROM a | STATS var0 = /', {
             callbacks: {
               canSuggestVariables: () => true,
-              getVariablesByType: () => [
+              getESQLVariables: () => [
                 {
                   key: 'function',
                   value: 'avg',
@@ -427,7 +427,7 @@ describe('autocomplete.suggest', () => {
           const suggestions = await suggest('FROM a | STATS BY /', {
             callbacks: {
               canSuggestVariables: () => true,
-              getVariablesByType: () => [],
+              getESQLVariables: () => [],
               getColumnsFor: () => Promise.resolve([{ name: 'clientip', type: 'ip' }]),
             },
           });
@@ -448,7 +448,7 @@ describe('autocomplete.suggest', () => {
           const suggestions = await suggest('FROM a | STATS BY /', {
             callbacks: {
               canSuggestVariables: () => true,
-              getVariablesByType: () => [
+              getESQLVariables: () => [
                 {
                   key: 'field',
                   value: 'clientip',
@@ -475,7 +475,7 @@ describe('autocomplete.suggest', () => {
           const suggestions = await suggest('FROM a | STATS BY BUCKET(@timestamp, /)', {
             callbacks: {
               canSuggestVariables: () => true,
-              getVariablesByType: () => [
+              getESQLVariables: () => [
                 {
                   key: 'interval',
                   value: '1 hour',

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.where.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.where.test.ts
@@ -400,7 +400,7 @@ describe('WHERE <expression>', () => {
         const suggestions = await suggest('FROM a | WHERE agent.name == /', {
           callbacks: {
             canSuggestVariables: () => true,
-            getVariablesByType: () => [],
+            getESQLVariables: () => [],
             getColumnsFor: () => Promise.resolve([{ name: 'agent.name', type: 'keyword' }]),
           },
         });
@@ -422,7 +422,7 @@ describe('WHERE <expression>', () => {
         const suggestions = await suggest('FROM a | WHERE agent.name == /', {
           callbacks: {
             canSuggestVariables: () => true,
-            getVariablesByType: () => [
+            getESQLVariables: () => [
               {
                 key: 'value',
                 value: 'java',

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -84,12 +84,7 @@ import {
   getPolicyHelper,
   getSourcesHelper,
 } from '../shared/resources_helpers';
-import type {
-  ESQLCallbacks,
-  ESQLSourceResult,
-  ESQLControlVariable,
-  ESQLVariableType,
-} from '../shared/types';
+import type { ESQLCallbacks, ESQLSourceResult, ESQLControlVariable } from '../shared/types';
 import {
   getFunctionsToIgnoreForStats,
   getQueryForFields,
@@ -171,7 +166,7 @@ export async function suggest(
     resourceRetriever
   );
   const supportsControls = resourceRetriever?.canSuggestVariables?.() ?? false;
-  const getVariablesByType = resourceRetriever?.getVariablesByType;
+  const getESQLVariables = resourceRetriever?.getESQLVariables;
   const getSources = getSourcesHelper(resourceRetriever);
   const { getPolicies, getPolicyMetadata } = getPolicyRetriever(resourceRetriever);
 
@@ -219,7 +214,7 @@ export async function suggest(
       getFieldsByType,
       getFieldsMap,
       getPolicies,
-      getVariablesByType,
+      getESQLVariables,
       resourceRetriever?.getPreferences,
       resourceRetriever,
       supportsControls
@@ -258,7 +253,7 @@ export async function suggest(
       getFieldsMap,
       fullText,
       offset,
-      getVariablesByType,
+      getESQLVariables,
       supportsControls
     );
   }
@@ -280,7 +275,7 @@ export function getFieldsByTypeRetriever(
   resourceRetriever?: ESQLCallbacks
 ): { getFieldsByType: GetColumnsByTypeFn; getFieldsMap: GetFieldsMapFn } {
   const helpers = getFieldsByTypeHelper(queryString, resourceRetriever);
-  const getVariablesByType = resourceRetriever?.getVariablesByType;
+  const getESQLVariables = resourceRetriever?.getESQLVariables;
   const supportsControls = resourceRetriever?.canSuggestVariables?.() ?? false;
   return {
     getFieldsByType: async (
@@ -293,7 +288,7 @@ export function getFieldsByTypeRetriever(
         supportsControls,
       };
       const fields = await helpers.getFieldsByType(expectedType, ignored);
-      return buildFieldsDefinitionsWithMetadata(fields, updatedOptions, getVariablesByType);
+      return buildFieldsDefinitionsWithMetadata(fields, updatedOptions, getESQLVariables);
     },
     getFieldsMap: helpers.getFieldsMap,
   };
@@ -395,7 +390,7 @@ async function getSuggestionsWithinCommandExpression(
   getColumnsByType: GetColumnsByTypeFn,
   getFieldsMap: GetFieldsMapFn,
   getPolicies: GetPoliciesFn,
-  getVariablesByType?: (type: ESQLVariableType) => ESQLControlVariable[] | undefined,
+  getESQLVariables?: () => ESQLControlVariable[] | undefined,
   getPreferences?: () => Promise<{ histogramBarTarget: number } | undefined>,
   callbacks?: ESQLCallbacks,
   supportsControls?: boolean
@@ -425,7 +420,7 @@ async function getSuggestionsWithinCommandExpression(
       getSourcesFromQuery: (type) => getSourcesFromCommands(commands, type),
       previousCommands: commands,
       callbacks,
-      getVariablesByType,
+      getESQLVariables,
       supportsControls,
     });
   } else {
@@ -953,7 +948,7 @@ async function getFunctionArgsSuggestions(
   getFieldsMap: GetFieldsMapFn,
   fullText: string,
   offset: number,
-  getVariablesByType?: (type: ESQLVariableType) => ESQLControlVariable[] | undefined,
+  getESQLVariables?: () => ESQLControlVariable[] | undefined,
   supportsControls?: boolean
 ): Promise<SuggestionRawDefinition[]> {
   const fnDefinition = getFunctionDefinition(node.name);
@@ -1084,7 +1079,7 @@ async function getFunctionArgsSuggestions(
           advanceCursorAndOpenSuggestions: hasMoreMandatoryArgs,
           supportsControls,
         },
-        getVariablesByType
+        getESQLVariables
       )
     );
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/join/index.ts
@@ -59,11 +59,11 @@ const suggestFields = async (
   ]);
 
   const supportsControls = callbacks?.canSuggestVariables?.() ?? false;
-  const getVariablesByType = callbacks?.getVariablesByType;
+  const getESQLVariables = callbacks?.getESQLVariables;
   const joinFields = buildFieldsDefinitionsWithMetadata(
     lookupIndexFields!,
     { supportsControls },
-    getVariablesByType
+    getESQLVariables
   );
 
   const intersection = suggestionIntersection(joinFields, sourceFields);

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/index.ts
@@ -26,7 +26,7 @@ export async function suggest({
   getColumnsByType,
   getSuggestedVariableName,
   getPreferences,
-  getVariablesByType,
+  getESQLVariables,
   supportsControls,
 }: CommandSuggestParams<'stats'>): Promise<SuggestionRawDefinition[]> {
   const pos = getPosition(innerText, command);
@@ -38,7 +38,7 @@ export async function suggest({
   const controlSuggestions = getControlSuggestionIfSupported(
     Boolean(supportsControls),
     ESQLVariableType.FUNCTIONS,
-    getVariablesByType
+    getESQLVariables
   );
 
   switch (pos) {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
@@ -210,7 +210,7 @@ export const buildFieldsDefinitionsWithMetadata = (
     variableType?: ESQLVariableType;
     supportsControls?: boolean;
   },
-  getVariablesByType?: (type: ESQLVariableType) => ESQLControlVariable[] | undefined
+  getESQLVariables?: () => ESQLControlVariable[] | undefined
 ): SuggestionRawDefinition[] => {
   const fieldsSuggestions = fields.map((field) => {
     const titleCaseType = field.type.charAt(0).toUpperCase() + field.type.slice(1);
@@ -231,7 +231,7 @@ export const buildFieldsDefinitionsWithMetadata = (
   const suggestions = [...fieldsSuggestions];
   if (options?.supportsControls) {
     const variableType = options?.variableType ?? ESQLVariableType.FIELDS;
-    const variables = getVariablesByType?.(variableType) ?? [];
+    const variables = (getESQLVariables?.() ?? []).filter((v) => v.type === variableType);
 
     const controlSuggestions = fields.length
       ? getControlSuggestion(
@@ -472,7 +472,7 @@ export function getCompatibleLiterals(
     addComma?: boolean;
     supportsControls?: boolean;
   },
-  getVariablesByType?: (type: ESQLVariableType) => ESQLControlVariable[] | undefined
+  getESQLVariables?: () => ESQLControlVariable[] | undefined
 ) {
   const suggestions: SuggestionRawDefinition[] = [];
   if (types.some(isNumericType)) {
@@ -490,7 +490,9 @@ export function getCompatibleLiterals(
       ...buildConstantsDefinitions(getUnitDuration(1), undefined, undefined, options),
     ];
     if (options?.supportsControls) {
-      const variables = getVariablesByType?.(ESQLVariableType.TIME_LITERAL) ?? [];
+      const variables = (getESQLVariables?.() ?? []).filter(
+        (v) => v.type === ESQLVariableType.TIME_LITERAL
+      );
       timeLiteralSuggestions.push(
         ...getControlSuggestion(
           ESQLVariableType.TIME_LITERAL,
@@ -574,13 +576,13 @@ export function getDateLiterals(options?: {
 export function getControlSuggestionIfSupported(
   supportsControls: boolean,
   type: ESQLVariableType,
-  getVariablesByType?: (type: ESQLVariableType) => ESQLControlVariable[] | undefined
+  getESQLVariables?: () => ESQLControlVariable[] | undefined
 ) {
   if (!supportsControls) {
     return [];
   }
   const variableType = type;
-  const variables = getVariablesByType?.(variableType) ?? [];
+  const variables = (getESQLVariables?.() ?? []).filter((v) => v.type === variableType);
   const controlSuggestion = getControlSuggestion(
     variableType,
     variables?.map((v) => `?${v.key}`)

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
@@ -16,12 +16,7 @@ import type {
   ESQLSource,
 } from '@kbn/esql-ast';
 import { GetColumnsByTypeFn, SuggestionRawDefinition } from '../autocomplete/types';
-import type {
-  ESQLCallbacks,
-  ESQLControlVariable,
-  ESQLVariableType,
-  ESQLSourceResult,
-} from '../shared/types';
+import type { ESQLCallbacks, ESQLControlVariable, ESQLSourceResult } from '../shared/types';
 
 /**
  * All supported field types in ES|QL. This is all the types
@@ -258,7 +253,7 @@ export interface CommandSuggestParams<CommandName extends string> {
    */
   previousCommands?: ESQLCommand[];
   callbacks?: ESQLCallbacks;
-  getVariablesByType?: (type: ESQLVariableType) => ESQLControlVariable[] | undefined;
+  getESQLVariables?: () => ESQLControlVariable[] | undefined;
   supportsControls?: boolean;
 }
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
@@ -6,6 +6,7 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
+import type { Datatable } from '@kbn/expressions-plugin/public';
 import type { ESQLRealField, JoinIndexAutocompleteItem } from '../validation/types';
 
 /** @internal **/
@@ -58,9 +59,10 @@ export interface ESQLCallbacks {
   >;
   getPreferences?: () => Promise<{ histogramBarTarget: number }>;
   getFieldsMetadata?: Promise<PartialFieldsMetadataClient>;
-  getVariablesByType?: (type: ESQLVariableType) => ESQLControlVariable[] | undefined;
+  getESQLVariables?: () => ESQLControlVariable[] | undefined;
   canSuggestVariables?: () => boolean;
   getJoinIndices?: () => Promise<{ indices: JoinIndexAutocompleteItem[] }>;
+  getHoverData?: ({ query }: { query: string }) => Promise<Datatable | undefined>;
 }
 
 export type ReasonTypes = 'missingCommand' | 'unsupportedFunction' | 'unknownFunction';

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -1733,7 +1733,7 @@ describe('validation logic', () => {
         getColumnsFor: /Unknown column|Argument of|it is unsupported or not indexed/,
         getPreferences: /Unknown/,
         getFieldsMetadata: /Unknown/,
-        getVariablesByType: /Unknown/,
+        getESQLVariables: /Unknown/,
         canSuggestVariables: /Unknown/,
       };
       return excludedCallback.map((callback) => (contentByCallback as any)[callback]) || [];

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -1351,8 +1351,9 @@ export const ignoreErrorsMap: Record<keyof ESQLCallbacks, ErrorTypes[]> = {
   getPolicies: ['unknownPolicy'],
   getPreferences: [],
   getFieldsMetadata: [],
-  getVariablesByType: [],
+  getESQLVariables: [],
   canSuggestVariables: [],
+  getHoverData: [],
   getJoinIndices: [],
 };
 


### PR DESCRIPTION
## Summary

Displays a preview of the data when hovering over a pipe, shows the variable values

<img width="784" alt="image" src="https://github.com/user-attachments/assets/d2634bd9-b3ca-4287-9b2c-e4692be62900" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


