### PR TITLE
Rename FindingsBaseEsQuery interface in CSP package

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
@@ -27,7 +27,7 @@ import type { estypes } from '@elastic/elasticsearch';
 import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-types';
 
 import type { BoolQuery } from '@kbn/es-query';
-export interface FindingsBaseEsQuery {
+export interface BaseEsQuery {
   query?: {
     bool: BoolQuery;
   };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings.ts
@@ -19,14 +19,14 @@ import {
 } from '@kbn/cloud-security-posture-common';
 import type { CspFinding } from '@kbn/cloud-security-posture-common';
 import type { CspBenchmarkRulesStates } from '@kbn/cloud-security-posture-common/schema/rules/latest';
-import type { FindingsBaseEsQuery } from '@kbn/cloud-security-posture';
+import type { BaseEsQuery } from '@kbn/cloud-security-posture';
 import { useGetCspBenchmarkRulesStatesApi } from '@kbn/cloud-security-posture/src/hooks/use_get_benchmark_rules_state_api';
 import type { RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
 import { CDR_MISCONFIGURATION_DATA_TABLE_RUNTIME_MAPPING_FIELDS } from '../../../common/constants';
 import { useKibana } from '../../../common/hooks/use_kibana';
 import { getAggregationCount, getFindingsCountAggQuery } from '../utils/utils';
 
-interface UseFindingsOptions extends FindingsBaseEsQuery {
+interface UseFindingsOptions extends BaseEsQuery {
   sort: string[][];
   enabled: boolean;
   pageSize: number;

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities.tsx
@@ -21,7 +21,7 @@ import {
   CDR_VULNERABILITIES_INDEX_PATTERN,
   CDR_3RD_PARTY_RETENTION_POLICY,
 } from '@kbn/cloud-security-posture-common';
-import { FindingsBaseEsQuery, showErrorToast } from '@kbn/cloud-security-posture';
+import { BaseEsQuery, showErrorToast } from '@kbn/cloud-security-posture';
 import type { CspVulnerabilityFinding } from '@kbn/cloud-security-posture-common/schema/vulnerabilities/latest';
 import type { RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
 import {
@@ -38,7 +38,7 @@ type LatestFindingsResponse = IKibanaSearchResponse<
 interface FindingsAggs {
   count: AggregationsMultiBucketAggregateBase<AggregationsStringRareTermsBucketKeys>;
 }
-interface VulnerabilitiesQuery extends FindingsBaseEsQuery {
+interface VulnerabilitiesQuery extends BaseEsQuery {
   sort: string[][];
   enabled: boolean;
   pageSize: number;

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_fetch_chart_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_fetch_chart_data.ts
@@ -11,12 +11,12 @@ import { i18n } from '@kbn/i18n';
 import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { showErrorToast } from '@kbn/cloud-security-posture';
 import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-types';
-import type { FindingsBaseEsQuery } from '@kbn/cloud-security-posture';
+import type { BaseEsQuery } from '@kbn/cloud-security-posture';
 import { useKibana } from '../../common/lib/kibana';
 import { ASSET_INVENTORY_INDEX_PATTERN } from '../constants';
 import { getMultiFieldsSort } from './fetch_utils';
 
-interface UseTopAssetsOptions extends FindingsBaseEsQuery {
+interface UseTopAssetsOptions extends BaseEsQuery {
   sort: string[][];
   enabled: boolean;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_fetch_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_fetch_data.ts
@@ -13,12 +13,12 @@ import { buildDataTableRecord } from '@kbn/discover-utils';
 import type { EsHitRecord } from '@kbn/discover-utils/types';
 import { showErrorToast } from '@kbn/cloud-security-posture';
 import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-types';
-import type { FindingsBaseEsQuery } from '@kbn/cloud-security-posture';
+import type { BaseEsQuery } from '@kbn/cloud-security-posture';
 import { useKibana } from '../../common/lib/kibana';
 import { MAX_ASSETS_TO_LOAD, ASSET_INVENTORY_INDEX_PATTERN } from '../constants';
 import { getRuntimeMappingsFromSort, getMultiFieldsSort } from './fetch_utils';
 
-interface UseAssetsOptions extends FindingsBaseEsQuery {
+interface UseAssetsOptions extends BaseEsQuery {
   sort: string[][];
   enabled: boolean;
   pageSize: number;


### PR DESCRIPTION
## Summary

Rename the `FindingsBaseEsQuery` interface exposed by the `@kibana/cloud-security-posture` package as well as all references where it's imported.

Separating this renaming into its own PR also lets us tag it with `backport:prev-minor` and avoid potential merge conflicts in the future.

### Depends on

- https://github.com/elastic/kibana/pull/210938

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

No risk whatsoever.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->