### PR TITLE
[9.0] [Security Solution][Endpoint] Add validation to artifact create/update APIs for management of `ownerSpaceId` (#211325)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/authz.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/authz.ts
@@ -108,6 +108,12 @@ export const ENDPOINT_PRIVILEGES: Record<string, PrivilegeMapObject> = deepFreez
     privilegeType: 'api',
     privilegeName: 'readEventFilters',
   },
+  writeGlobalArtifacts: {
+    appId: DEFAULT_APP_CATEGORIES.security.id,
+    privilegeSplit: '-',
+    privilegeType: 'api',
+    privilegeName: 'writeGlobalArtifacts',
+  },
   writePolicyManagement: {
     appId: DEFAULT_APP_CATEGORIES.security.id,
     privilegeSplit: '-',

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/authz/authz.test.ts
@@ -179,6 +179,7 @@ describe('Endpoint Authz service', () => {
       ['canReadEventFilters', 'readEventFilters'],
       ['canReadWorkflowInsights', 'readWorkflowInsights'],
       ['canWriteWorkflowInsights', 'writeWorkflowInsights'],
+      ['canManageGlobalArtifacts', 'writeGlobalArtifacts'],
     ])('%s should be true if `packagePrivilege.%s` is `true`', (auth) => {
       const authz = calculateEndpointAuthz(licenseService, fleetAuthz, userRoles);
       expect(authz[auth]).toBe(true);
@@ -220,6 +221,7 @@ describe('Endpoint Authz service', () => {
       ['canReadEventFilters', ['readEventFilters']],
       ['canWriteWorkflowInsights', ['writeWorkflowInsights']],
       ['canReadWorkflowInsights', ['readWorkflowInsights']],
+      ['canManageGlobalArtifacts', ['writeGlobalArtifacts']],
       // all dependent privileges are false and so it should be false
       ['canAccessResponseConsole', responseConsolePrivileges],
     ])('%s should be false if `packagePrivilege.%s` is `false`', (auth, privileges) => {
@@ -271,6 +273,7 @@ describe('Endpoint Authz service', () => {
       ['canReadEventFilters', ['readEventFilters']],
       ['canWriteWorkflowInsights', ['writeWorkflowInsights']],
       ['canReadWorkflowInsights', ['readWorkflowInsights']],
+      ['canManageGlobalArtifacts', ['writeGlobalArtifacts']],
       // all dependent privileges are false and so it should be false
       ['canAccessResponseConsole', responseConsolePrivileges],
     ])(
@@ -339,6 +342,7 @@ describe('Endpoint Authz service', () => {
         canWriteExecuteOperations: false,
         canWriteScanOperations: false,
         canWriteFileOperations: false,
+        canManageGlobalArtifacts: false,
         canWriteTrustedApplications: false,
         canWriteWorkflowInsights: false,
         canReadTrustedApplications: false,

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/authz/authz.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/service/authz/authz.ts
@@ -97,6 +97,8 @@ export const calculateEndpointAuthz = (
   const canReadEndpointExceptions = hasAuth('showEndpointExceptions');
   const canWriteEndpointExceptions = hasAuth('crudEndpointExceptions');
 
+  const canManageGlobalArtifacts = hasAuth('writeGlobalArtifacts');
+
   const canReadWorkflowInsights = hasAuth('readWorkflowInsights');
   const canWriteWorkflowInsights = hasAuth('writeWorkflowInsights');
 
@@ -156,6 +158,7 @@ export const calculateEndpointAuthz = (
     canReadEventFilters,
     canReadEndpointExceptions,
     canWriteEndpointExceptions,
+    canManageGlobalArtifacts,
   };
 
   // Response console is only accessible when license is Enterprise and user has access to any
@@ -212,6 +215,7 @@ export const getEndpointAuthzInitialState = (): EndpointAuthz => {
     canReadEventFilters: false,
     canReadEndpointExceptions: false,
     canWriteEndpointExceptions: false,
+    canManageGlobalArtifacts: false,
     canReadWorkflowInsights: false,
     canWriteWorkflowInsights: false,
   };

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/authz.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/authz.ts
@@ -93,6 +93,9 @@ export interface EndpointAuthz {
   canReadEndpointExceptions: boolean;
   /** if the user has read permissions for endpoint exceptions */
   canWriteEndpointExceptions: boolean;
+  /** If user is allowed to manage global artifacts. Introduced support for spaces feature */
+  canManageGlobalArtifacts: boolean;
+
   /** if the user has write permissions for workflow insights */
   canWriteWorkflowInsights: boolean;
   /** if the user has read permissions for workflow insights */

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/formatted_error/formatted_error.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/formatted_error/formatted_error.tsx
@@ -18,7 +18,7 @@ export const ObjectContent = memo<ObjectContentProps>(({ data }) => {
     <EuiText size="s">
       {Object.entries(data).map(([key, value]) => {
         return (
-          <div key={key} className="eui-textBreakAll">
+          <div key={key} className="eui-textBreakWord">
             <strong>{key}</strong>
             {': '}
             {value}

--- a/x-pack/solutions/security/plugins/security_solution/public/management/hooks/artifacts/use_get_updated_tags.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/hooks/artifacts/use_get_updated_tags.test.tsx
@@ -142,7 +142,7 @@ describe('useGetUpdatedTags hook', () => {
       // add first
       rerender({ exception: { tags }, filters: getFiltersInOrder() });
       tags = result.current.getTagsUpdatedBy('first', ['first:brie']);
-      expect(tags).toStrictEqual(['first:brie', 'special_second', 'third:spaghetti']);
+      expect(tags).toStrictEqual(['special_second', 'third:spaghetti', 'first:brie']);
     });
 
     it('should update category order on any change if filter is changed (although it should not)', () => {
@@ -155,11 +155,9 @@ describe('useGetUpdatedTags hook', () => {
       expect(tags).toStrictEqual([
         'first:mozzarella',
         'first:roquefort',
-
-        'second:shiraz',
-
         'third:tagliatelle',
         'third:penne',
+        'second:shiraz',
       ]);
 
       const newFilterOrder = {
@@ -172,12 +170,10 @@ describe('useGetUpdatedTags hook', () => {
       tags = result.current.getTagsUpdatedBy('third', ['third:spaghetti']);
 
       expect(tags).toStrictEqual([
-        'third:spaghetti',
-
         'first:mozzarella',
         'first:roquefort',
-
         'second:shiraz',
+        'third:spaghetti',
       ]);
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/event_filters/view/components/form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/event_filters/view/components/form.tsx
@@ -41,6 +41,7 @@ import { OperatingSystem } from '@kbn/securitysolution-utils';
 import { getExceptionBuilderComponentLazy } from '@kbn/lists-plugin/public';
 import type { OnChangeProps } from '@kbn/lists-plugin/public';
 import type { ValueSuggestionsGetFn } from '@kbn/unified-search-plugin/public/autocomplete/providers/value_suggestion_provider';
+import { FormattedError } from '../../../../components/formatted_error';
 import { useIsExperimentalFeatureEnabled } from '../../../../../common/hooks/use_experimental_features';
 import { useGetUpdatedTags } from '../../../../hooks/artifacts';
 import {
@@ -48,11 +49,7 @@ import {
   PROCESS_DESCENDANT_EVENT_FILTER_EXTRA_ENTRY,
   PROCESS_DESCENDANT_EVENT_FILTER_EXTRA_ENTRY_TEXT,
 } from '../../../../../../common/endpoint/service/artifacts/constants';
-import {
-  isFilterProcessDescendantsEnabled,
-  isFilterProcessDescendantsTag,
-  isPolicySelectionTag,
-} from '../../../../../../common/endpoint/service/artifacts/utils';
+import { isFilterProcessDescendantsEnabled } from '../../../../../../common/endpoint/service/artifacts/utils';
 import {
   ENDPOINT_FIELDS_SEARCH_STRATEGY,
   eventsIndexPattern,
@@ -101,12 +98,6 @@ const osOptions: Array<EuiSuperSelectOption<OperatingSystem>> = OPERATING_SYSTEM
   inputDisplay: OS_TITLES[os],
 }));
 
-// Defines the tag categories for Event Filters, using the given order.
-const TAG_FILTERS = Object.freeze({
-  policySelection: isPolicySelectionTag,
-  processDescendantsFiltering: isFilterProcessDescendantsTag,
-});
-
 const getAddedFieldsCounts = (formFields: string[]): { [k: string]: number } =>
   formFields.reduce<{ [k: string]: number }>((allFields, field) => {
     if (field in allFields) {
@@ -148,613 +139,637 @@ type EventFilterItemEntries = Array<{
 }>;
 
 export const EventFiltersForm: React.FC<ArtifactFormComponentProps & { allowSelectOs?: boolean }> =
-  memo(({ allowSelectOs = true, item: exception, policies, policiesIsLoading, onChange, mode }) => {
-    const getTestId = useTestIdGenerator('eventFilters-form');
-    const { http } = useKibana().services;
+  memo(
+    ({
+      allowSelectOs = true,
+      item: exception,
+      policies,
+      policiesIsLoading,
+      onChange,
+      mode,
+      error: submitError,
+    }) => {
+      const getTestId = useTestIdGenerator('eventFilters-form');
+      const { http } = useKibana().services;
 
-    const getSuggestionsFn = useCallback<ValueSuggestionsGetFn>(
-      ({ field, query }) => {
-        const eventFiltersAPIClient = new EventFiltersApiClient(http);
-        return eventFiltersAPIClient.getSuggestions({ field: field.name, query });
-      },
-      [http]
-    );
-
-    const autocompleteSuggestions = useSuggestions(getSuggestionsFn);
-    const [hasFormChanged, setHasFormChanged] = useState(false);
-    const [hasNameError, toggleHasNameError] = useState<boolean>(!exception.name);
-    const [newComment, setNewComment] = useState('');
-    const [hasCommentError, setHasCommentError] = useState(false);
-    const [hasBeenInputNameVisited, setHasBeenInputNameVisited] = useState(false);
-    const [selectedPolicies, setSelectedPolicies] = useState<PolicyData[]>([]);
-    const isPlatinumPlus = useLicense().isPlatinumPlus();
-    const isGlobal = useMemo(() => isArtifactGlobal(exception), [exception]);
-    const [wasByPolicy, setWasByPolicy] = useState(!isArtifactGlobal(exception));
-    const [hasDuplicateFields, setHasDuplicateFields] = useState<boolean>(false);
-    const [hasWildcardWithWrongOperator, setHasWildcardWithWrongOperator] = useState<boolean>(
-      hasWrongOperatorWithWildcard([exception])
-    );
-
-    const [hasPartialCodeSignatureWarning, setHasPartialCodeSignatureWarning] =
-      useState<boolean>(false);
-
-    // This value has to be memoized to avoid infinite useEffect loop on useFetchIndex
-    const indexNames = useMemo(() => [eventsIndexPattern], []);
-    const [isIndexPatternLoading, { indexPatterns }] = useFetchIndex(
-      indexNames,
-      undefined,
-      ENDPOINT_FIELDS_SEARCH_STRATEGY
-    );
-    const { getTagsUpdatedBy } = useGetUpdatedTags(exception, TAG_FILTERS);
-    const euiTheme = useEuiTheme();
-
-    const isFilterProcessDescendantsFeatureEnabled = useIsExperimentalFeatureEnabled(
-      'filterProcessDescendantsForEventFiltersEnabled'
-    );
-
-    const isFilterProcessDescendantsSelected = useMemo(
-      () => isFilterProcessDescendantsEnabled(exception),
-      [exception]
-    );
-
-    const [areConditionsValid, setAreConditionsValid] = useState(
-      !!exception.entries.length || false
-    );
-    // compute this for initial render only
-    const existingComments = useMemo<ExceptionListItemSchema['comments']>(
-      () => (exception as ExceptionListItemSchema)?.comments,
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      []
-    );
-
-    const showAssignmentSection = useMemo(() => {
-      return (
-        isPlatinumPlus ||
-        (mode === 'edit' && (!isGlobal || (wasByPolicy && isGlobal && hasFormChanged)))
-      );
-    }, [mode, isGlobal, hasFormChanged, isPlatinumPlus, wasByPolicy]);
-
-    const isFormValid = useMemo(() => {
-      // verify that it has legit entries
-      // and not just default entry without values
-      return (
-        !hasNameError &&
-        !hasCommentError &&
-        !!exception.entries.length &&
-        (exception.entries as EventFilterItemEntries).some((e) => e.value !== '' || e.value.length)
-      );
-    }, [hasCommentError, hasNameError, exception.entries]);
-
-    const processChanged = useCallback(
-      (updatedItem?: Partial<ArtifactFormComponentProps['item']>) => {
-        const item = updatedItem
-          ? {
-              ...exception,
-              ...updatedItem,
-            }
-          : exception;
-        cleanupEntries(item);
-        onChange({
-          item,
-          isValid: isFormValid && areConditionsValid,
-          confirmModalLabels: hasWildcardWithWrongOperator
-            ? CONFIRM_WARNING_MODAL_LABELS(
-                i18n.translate('xpack.securitySolution.eventFilter.flyoutForm.confirmModal.name', {
-                  defaultMessage: 'event filter',
-                })
-              )
-            : undefined,
-        });
-      },
-      [areConditionsValid, exception, isFormValid, onChange, hasWildcardWithWrongOperator]
-    );
-
-    // set initial state of `wasByPolicy` that checks
-    // if the initial state of the exception was by policy or not
-    useEffect(() => {
-      if (!hasFormChanged && exception.tags) {
-        setWasByPolicy(!isArtifactGlobal({ tags: exception.tags }));
-      }
-    }, [exception.tags, hasFormChanged]);
-
-    // select policies if editing
-    useEffect(() => {
-      if (hasFormChanged) return;
-      const policyIds = exception.tags ? getPolicyIdsFromArtifact({ tags: exception.tags }) : [];
-
-      if (!policyIds.length) return;
-      const policiesData = policies.filter((policy) => policyIds.includes(policy.id));
-      setSelectedPolicies(policiesData);
-    }, [hasFormChanged, exception, policies]);
-
-    const eventFilterItem = useMemo<ArtifactFormComponentProps['item']>(() => {
-      const ef: ArtifactFormComponentProps['item'] = exception;
-      ef.entries = exception.entries.length
-        ? (exception.entries as ExceptionListItemSchema['entries'])
-        : defaultConditionEntry();
-
-      // TODO: `id` gets added to the exception.entries item
-      // Is there a simpler way to this?
-      cleanupEntries(ef);
-
-      setAreConditionsValid(!!exception.entries.length);
-      return ef;
-    }, [exception]);
-
-    // name and handler
-    const handleOnChangeName = useCallback(
-      (event: React.ChangeEvent<HTMLInputElement>) => {
-        if (!exception) return;
-        const name = event.target.value.trim();
-        toggleHasNameError(!name);
-        processChanged({ name });
-        if (!hasFormChanged) setHasFormChanged(true);
-      },
-      [exception, hasFormChanged, processChanged]
-    );
-
-    const nameInputMemo = useMemo(
-      () => (
-        <EuiFormRow
-          label={NAME_LABEL}
-          fullWidth
-          isInvalid={hasNameError && hasBeenInputNameVisited}
-          error={NAME_ERROR}
-        >
-          <EuiFieldText
-            aria-label={NAME_LABEL}
-            id="eventFiltersFormInputName"
-            defaultValue={exception?.name ?? ''}
-            data-test-subj={getTestId('name-input')}
-            fullWidth
-            maxLength={256}
-            required={hasBeenInputNameVisited}
-            onChange={handleOnChangeName}
-            onBlur={() => !hasBeenInputNameVisited && setHasBeenInputNameVisited(true)}
-          />
-        </EuiFormRow>
-      ),
-      [getTestId, hasNameError, handleOnChangeName, hasBeenInputNameVisited, exception?.name]
-    );
-
-    // description and handler
-    const handleOnDescriptionChange = useCallback(
-      (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        if (!exception) return;
-        if (!hasFormChanged) setHasFormChanged(true);
-        processChanged({ description: event.target.value.toString().trim() });
-      },
-      [exception, hasFormChanged, processChanged]
-    );
-    const descriptionInputMemo = useMemo(
-      () => (
-        <EuiFormRow label={DESCRIPTION_LABEL} fullWidth>
-          <EuiTextArea
-            id="eventFiltersFormInputDescription"
-            defaultValue={exception?.description ?? ''}
-            onChange={handleOnDescriptionChange}
-            fullWidth
-            data-test-subj={getTestId('description-input')}
-            aria-label={DESCRIPTION_LABEL}
-            maxLength={256}
-          />
-        </EuiFormRow>
-      ),
-      [exception?.description, getTestId, handleOnDescriptionChange]
-    );
-
-    // selected OS and handler
-    const selectedOs = useMemo((): OperatingSystem => {
-      if (!exception?.os_types?.length) {
-        return OperatingSystem.WINDOWS;
-      }
-      return exception.os_types[0] as OperatingSystem;
-    }, [exception?.os_types]);
-
-    const handleOnOsChange = useCallback(
-      (os: OperatingSystem) => {
-        if (!exception) return;
-        processChanged({
-          os_types: [os],
-          entries: exception.entries,
-        });
-        if (!hasFormChanged) setHasFormChanged(true);
-      },
-      [exception, hasFormChanged, processChanged]
-    );
-
-    const osInputMemo = useMemo(
-      () => (
-        <EuiFormRow label={OS_LABEL} fullWidth>
-          <EuiSuperSelect
-            name="os"
-            options={osOptions}
-            fullWidth
-            valueOfSelected={selectedOs}
-            onChange={handleOnOsChange}
-          />
-        </EuiFormRow>
-      ),
-      [handleOnOsChange, selectedOs]
-    );
-
-    // comments and handler
-    const handleOnChangeComment = useCallback(
-      (value: string) => {
-        if (!exception) return;
-        setNewComment(value);
-        processChanged({ comments: [{ comment: value }] });
-        if (!hasFormChanged) setHasFormChanged(true);
-      },
-      [exception, hasFormChanged, processChanged]
-    );
-    const commentsInputMemo = useMemo(
-      () => (
-        <ExceptionItemComments
-          exceptionItemComments={existingComments}
-          newCommentValue={newComment}
-          newCommentOnChange={handleOnChangeComment}
-          setCommentError={setHasCommentError}
-        />
-      ),
-      [existingComments, handleOnChangeComment, newComment]
-    );
-
-    // comments
-    const commentsSection = useMemo(
-      () => (
-        <>
-          <EuiText size="xs">
-            <h3>
-              <FormattedMessage
-                id="xpack.securitySolution.eventFilters.commentsSectionTitle"
-                defaultMessage="Comments"
-              />
-            </h3>
-          </EuiText>
-          <EuiSpacer size="xs" />
-          <EuiText size="s">
-            <p>
-              <FormattedMessage
-                id="xpack.securitySolution.eventFilters.commentsSectionDescription"
-                defaultMessage="Add a comment to your event filter."
-              />
-            </p>
-          </EuiText>
-          <EuiSpacer size="m" />
-          {commentsInputMemo}
-        </>
-      ),
-      [commentsInputMemo]
-    );
-
-    // details
-    const detailsSection = useMemo(
-      () => (
-        <>
-          <EuiText size="xs">
-            <h3>
-              <FormattedMessage
-                id="xpack.securitySolution.eventFilters.detailsSectionTitle"
-                defaultMessage="Details"
-              />
-            </h3>
-          </EuiText>
-          <EuiSpacer size="xs" />
-          <EuiText size="s">
-            <p>{ABOUT_EVENT_FILTERS}</p>
-          </EuiText>
-          <EuiSpacer size="m" />
-          {nameInputMemo}
-          {descriptionInputMemo}
-        </>
-      ),
-      [nameInputMemo, descriptionInputMemo]
-    );
-
-    const handleFilterTypeOnChange = useCallback(
-      (id: string) => {
-        const newTagsForDescendants = id === 'descendants' ? [FILTER_PROCESS_DESCENDANTS_TAG] : [];
-
-        const tags = getTagsUpdatedBy('processDescendantsFiltering', newTagsForDescendants);
-
-        processChanged({ tags });
-        if (!hasFormChanged) setHasFormChanged(true);
-      },
-      [getTagsUpdatedBy, hasFormChanged, processChanged]
-    );
-
-    const filterTypeOptions: EuiButtonGroupOptionProps[] = useMemo(() => {
-      return [
-        {
-          id: 'events',
-          label: (
-            <EuiText size="s">
-              <FormattedMessage
-                id="xpack.securitySolution.eventFilters.filterProcessDescendants.eventsButton"
-                defaultMessage="Events"
-              />
-            </EuiText>
-          ),
-          iconType: isFilterProcessDescendantsSelected ? 'empty' : 'checkInCircleFilled',
-          'data-test-subj': getTestId('filterEventsButton'),
+      const getSuggestionsFn = useCallback<ValueSuggestionsGetFn>(
+        ({ field, query }) => {
+          const eventFiltersAPIClient = new EventFiltersApiClient(http);
+          return eventFiltersAPIClient.getSuggestions({ field: field.name, query });
         },
-        {
-          id: 'descendants',
-          label: (
-            <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+        [http]
+      );
+
+      const autocompleteSuggestions = useSuggestions(getSuggestionsFn);
+      const [hasFormChanged, setHasFormChanged] = useState(false);
+      const [hasNameError, toggleHasNameError] = useState<boolean>(!exception.name);
+      const [newComment, setNewComment] = useState('');
+      const [hasCommentError, setHasCommentError] = useState(false);
+      const [hasBeenInputNameVisited, setHasBeenInputNameVisited] = useState(false);
+      const [selectedPolicies, setSelectedPolicies] = useState<PolicyData[]>([]);
+      const isPlatinumPlus = useLicense().isPlatinumPlus();
+      const isGlobal = useMemo(() => isArtifactGlobal(exception), [exception]);
+      const [wasByPolicy, setWasByPolicy] = useState(!isArtifactGlobal(exception));
+      const [hasDuplicateFields, setHasDuplicateFields] = useState<boolean>(false);
+      const [hasWildcardWithWrongOperator, setHasWildcardWithWrongOperator] = useState<boolean>(
+        hasWrongOperatorWithWildcard([exception])
+      );
+
+      const [hasPartialCodeSignatureWarning, setHasPartialCodeSignatureWarning] =
+        useState<boolean>(false);
+
+      // This value has to be memoized to avoid infinite useEffect loop on useFetchIndex
+      const indexNames = useMemo(() => [eventsIndexPattern], []);
+      const [isIndexPatternLoading, { indexPatterns }] = useFetchIndex(
+        indexNames,
+        undefined,
+        ENDPOINT_FIELDS_SEARCH_STRATEGY
+      );
+      const { getTagsUpdatedBy } = useGetUpdatedTags(exception);
+      const euiTheme = useEuiTheme();
+
+      const isFilterProcessDescendantsFeatureEnabled = useIsExperimentalFeatureEnabled(
+        'filterProcessDescendantsForEventFiltersEnabled'
+      );
+
+      const isFilterProcessDescendantsSelected = useMemo(
+        () => isFilterProcessDescendantsEnabled(exception),
+        [exception]
+      );
+
+      const [areConditionsValid, setAreConditionsValid] = useState(
+        !!exception.entries.length || false
+      );
+      // compute this for initial render only
+      const existingComments = useMemo<ExceptionListItemSchema['comments']>(
+        () => (exception as ExceptionListItemSchema)?.comments,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        []
+      );
+
+      const showAssignmentSection = useMemo(() => {
+        return (
+          isPlatinumPlus ||
+          (mode === 'edit' && (!isGlobal || (wasByPolicy && isGlobal && hasFormChanged)))
+        );
+      }, [mode, isGlobal, hasFormChanged, isPlatinumPlus, wasByPolicy]);
+
+      const isFormValid = useMemo(() => {
+        // verify that it has legit entries
+        // and not just default entry without values
+        return (
+          !hasNameError &&
+          !hasCommentError &&
+          !!exception.entries.length &&
+          (exception.entries as EventFilterItemEntries).some(
+            (e) => e.value !== '' || e.value.length
+          )
+        );
+      }, [hasCommentError, hasNameError, exception.entries]);
+
+      const processChanged = useCallback(
+        (updatedItem?: Partial<ArtifactFormComponentProps['item']>) => {
+          const item = updatedItem
+            ? {
+                ...exception,
+                ...updatedItem,
+              }
+            : exception;
+          cleanupEntries(item);
+          onChange({
+            item,
+            isValid: isFormValid && areConditionsValid,
+            confirmModalLabels: hasWildcardWithWrongOperator
+              ? CONFIRM_WARNING_MODAL_LABELS(
+                  i18n.translate(
+                    'xpack.securitySolution.eventFilter.flyoutForm.confirmModal.name',
+                    {
+                      defaultMessage: 'event filter',
+                    }
+                  )
+                )
+              : undefined,
+          });
+        },
+        [areConditionsValid, exception, isFormValid, onChange, hasWildcardWithWrongOperator]
+      );
+
+      // set initial state of `wasByPolicy` that checks
+      // if the initial state of the exception was by policy or not
+      useEffect(() => {
+        if (!hasFormChanged && exception.tags) {
+          setWasByPolicy(!isArtifactGlobal({ tags: exception.tags }));
+        }
+      }, [exception.tags, hasFormChanged]);
+
+      // select policies if editing
+      useEffect(() => {
+        if (hasFormChanged) return;
+        const policyIds = exception.tags ? getPolicyIdsFromArtifact({ tags: exception.tags }) : [];
+
+        if (!policyIds.length) return;
+        const policiesData = policies.filter((policy) => policyIds.includes(policy.id));
+        setSelectedPolicies(policiesData);
+      }, [hasFormChanged, exception, policies]);
+
+      const eventFilterItem = useMemo<ArtifactFormComponentProps['item']>(() => {
+        const ef: ArtifactFormComponentProps['item'] = exception;
+        ef.entries = exception.entries.length
+          ? (exception.entries as ExceptionListItemSchema['entries'])
+          : defaultConditionEntry();
+
+        // TODO: `id` gets added to the exception.entries item
+        // Is there a simpler way to this?
+        cleanupEntries(ef);
+
+        setAreConditionsValid(!!exception.entries.length);
+        return ef;
+      }, [exception]);
+
+      // name and handler
+      const handleOnChangeName = useCallback(
+        (event: React.ChangeEvent<HTMLInputElement>) => {
+          if (!exception) return;
+          const name = event.target.value.trim();
+          toggleHasNameError(!name);
+          processChanged({ name });
+          if (!hasFormChanged) setHasFormChanged(true);
+        },
+        [exception, hasFormChanged, processChanged]
+      );
+
+      const nameInputMemo = useMemo(
+        () => (
+          <EuiFormRow
+            label={NAME_LABEL}
+            fullWidth
+            isInvalid={hasNameError && hasBeenInputNameVisited}
+            error={NAME_ERROR}
+          >
+            <EuiFieldText
+              aria-label={NAME_LABEL}
+              id="eventFiltersFormInputName"
+              defaultValue={exception?.name ?? ''}
+              data-test-subj={getTestId('name-input')}
+              fullWidth
+              maxLength={256}
+              required={hasBeenInputNameVisited}
+              onChange={handleOnChangeName}
+              onBlur={() => !hasBeenInputNameVisited && setHasBeenInputNameVisited(true)}
+            />
+          </EuiFormRow>
+        ),
+        [getTestId, hasNameError, handleOnChangeName, hasBeenInputNameVisited, exception?.name]
+      );
+
+      // description and handler
+      const handleOnDescriptionChange = useCallback(
+        (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+          if (!exception) return;
+          if (!hasFormChanged) setHasFormChanged(true);
+          processChanged({ description: event.target.value.toString().trim() });
+        },
+        [exception, hasFormChanged, processChanged]
+      );
+      const descriptionInputMemo = useMemo(
+        () => (
+          <EuiFormRow label={DESCRIPTION_LABEL} fullWidth>
+            <EuiTextArea
+              id="eventFiltersFormInputDescription"
+              defaultValue={exception?.description ?? ''}
+              onChange={handleOnDescriptionChange}
+              fullWidth
+              data-test-subj={getTestId('description-input')}
+              aria-label={DESCRIPTION_LABEL}
+              maxLength={256}
+            />
+          </EuiFormRow>
+        ),
+        [exception?.description, getTestId, handleOnDescriptionChange]
+      );
+
+      // selected OS and handler
+      const selectedOs = useMemo((): OperatingSystem => {
+        if (!exception?.os_types?.length) {
+          return OperatingSystem.WINDOWS;
+        }
+        return exception.os_types[0] as OperatingSystem;
+      }, [exception?.os_types]);
+
+      const handleOnOsChange = useCallback(
+        (os: OperatingSystem) => {
+          if (!exception) return;
+          processChanged({
+            os_types: [os],
+            entries: exception.entries,
+          });
+          if (!hasFormChanged) setHasFormChanged(true);
+        },
+        [exception, hasFormChanged, processChanged]
+      );
+
+      const osInputMemo = useMemo(
+        () => (
+          <EuiFormRow label={OS_LABEL} fullWidth>
+            <EuiSuperSelect
+              name="os"
+              options={osOptions}
+              fullWidth
+              valueOfSelected={selectedOs}
+              onChange={handleOnOsChange}
+            />
+          </EuiFormRow>
+        ),
+        [handleOnOsChange, selectedOs]
+      );
+
+      // comments and handler
+      const handleOnChangeComment = useCallback(
+        (value: string) => {
+          if (!exception) return;
+          setNewComment(value);
+          processChanged({ comments: [{ comment: value }] });
+          if (!hasFormChanged) setHasFormChanged(true);
+        },
+        [exception, hasFormChanged, processChanged]
+      );
+      const commentsInputMemo = useMemo(
+        () => (
+          <ExceptionItemComments
+            exceptionItemComments={existingComments}
+            newCommentValue={newComment}
+            newCommentOnChange={handleOnChangeComment}
+            setCommentError={setHasCommentError}
+          />
+        ),
+        [existingComments, handleOnChangeComment, newComment]
+      );
+
+      // comments
+      const commentsSection = useMemo(
+        () => (
+          <>
+            <EuiText size="xs">
+              <h3>
+                <FormattedMessage
+                  id="xpack.securitySolution.eventFilters.commentsSectionTitle"
+                  defaultMessage="Comments"
+                />
+              </h3>
+            </EuiText>
+            <EuiSpacer size="xs" />
+            <EuiText size="s">
+              <p>
+                <FormattedMessage
+                  id="xpack.securitySolution.eventFilters.commentsSectionDescription"
+                  defaultMessage="Add a comment to your event filter."
+                />
+              </p>
+            </EuiText>
+            <EuiSpacer size="m" />
+            {commentsInputMemo}
+          </>
+        ),
+        [commentsInputMemo]
+      );
+
+      // details
+      const detailsSection = useMemo(
+        () => (
+          <>
+            <EuiText size="xs">
+              <h3>
+                <FormattedMessage
+                  id="xpack.securitySolution.eventFilters.detailsSectionTitle"
+                  defaultMessage="Details"
+                />
+              </h3>
+            </EuiText>
+            <EuiSpacer size="xs" />
+            <EuiText size="s">
+              <p>{ABOUT_EVENT_FILTERS}</p>
+            </EuiText>
+            <EuiSpacer size="m" />
+            {nameInputMemo}
+            {descriptionInputMemo}
+          </>
+        ),
+        [nameInputMemo, descriptionInputMemo]
+      );
+
+      const handleFilterTypeOnChange = useCallback(
+        (id: string) => {
+          const newTagsForDescendants =
+            id === 'descendants' ? [FILTER_PROCESS_DESCENDANTS_TAG] : [];
+
+          const tags = getTagsUpdatedBy('processDescendantsFiltering', newTagsForDescendants);
+
+          processChanged({ tags });
+          if (!hasFormChanged) setHasFormChanged(true);
+        },
+        [getTagsUpdatedBy, hasFormChanged, processChanged]
+      );
+
+      const filterTypeOptions: EuiButtonGroupOptionProps[] = useMemo(() => {
+        return [
+          {
+            id: 'events',
+            label: (
               <EuiText size="s">
                 <FormattedMessage
-                  id="xpack.securitySolution.eventFilters.filterProcessDescendants.processDescendantsButton"
-                  defaultMessage="Process Descendants"
+                  id="xpack.securitySolution.eventFilters.filterProcessDescendants.eventsButton"
+                  defaultMessage="Events"
                 />
               </EuiText>
-              <ProcessDescendantsTooltip
-                data-test-subj={getTestId('filterProcessDescendantsTooltip')}
-              />
-            </EuiFlexGroup>
-          ),
-          iconType: isFilterProcessDescendantsSelected ? 'checkInCircleFilled' : 'empty',
-          'data-test-subj': getTestId('filterProcessDescendantsButton'),
-        },
-      ];
-    }, [getTestId, isFilterProcessDescendantsSelected]);
-
-    const filterTypeSubsection = useMemo(() => {
-      if (!isFilterProcessDescendantsFeatureEnabled) return null;
-
-      return (
-        <>
-          <EuiButtonGroup
-            legend="Events or Process descendants selector"
-            color="primary"
-            onChange={handleFilterTypeOnChange}
-            css={css`
-              .euiButtonGroupButton {
-                padding-right: ${euiTheme.euiTheme.size.l};
-              }
-            `}
-            options={filterTypeOptions}
-            idSelected={isFilterProcessDescendantsSelected ? 'descendants' : 'events'}
-          />
-          <EuiSpacer size="m" />
-
-          {isFilterProcessDescendantsSelected && (
-            <>
-              <EuiText
-                size="s"
-                data-test-subj={getTestId(
-                  'filterProcessDescendants-additionalConditionDescription'
-                )}
-              >
-                <FormattedMessage
-                  id="xpack.securitySolution.eventFilters.filterProcessDescendants.additionalConditionDescription"
-                  defaultMessage="Additional condition added:"
+            ),
+            iconType: isFilterProcessDescendantsSelected ? 'empty' : 'checkInCircleFilled',
+            'data-test-subj': getTestId('filterEventsButton'),
+          },
+          {
+            id: 'descendants',
+            label: (
+              <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+                <EuiText size="s">
+                  <FormattedMessage
+                    id="xpack.securitySolution.eventFilters.filterProcessDescendants.processDescendantsButton"
+                    defaultMessage="Process Descendants"
+                  />
+                </EuiText>
+                <ProcessDescendantsTooltip
+                  data-test-subj={getTestId('filterProcessDescendantsTooltip')}
                 />
-              </EuiText>
-              <code>{PROCESS_DESCENDANT_EVENT_FILTER_EXTRA_ENTRY_TEXT}</code>
-              <EuiSpacer size="m" />
-            </>
-          )}
-        </>
-      );
-    }, [
-      isFilterProcessDescendantsFeatureEnabled,
-      handleFilterTypeOnChange,
-      euiTheme.euiTheme.size.l,
-      filterTypeOptions,
-      isFilterProcessDescendantsSelected,
-      getTestId,
-    ]);
+              </EuiFlexGroup>
+            ),
+            iconType: isFilterProcessDescendantsSelected ? 'checkInCircleFilled' : 'empty',
+            'data-test-subj': getTestId('filterProcessDescendantsButton'),
+          },
+        ];
+      }, [getTestId, isFilterProcessDescendantsSelected]);
 
-    // conditions and handler
-    const handleOnBuilderChange = useCallback(
-      (arg: OnChangeProps) => {
-        const hasDuplicates =
-          (!hasFormChanged && arg.exceptionItems[0] === undefined) ||
-          isEqual(arg.exceptionItems[0]?.entries, exception?.entries);
+      const filterTypeSubsection = useMemo(() => {
+        if (!isFilterProcessDescendantsFeatureEnabled) return null;
 
-        if (hasDuplicates) {
-          const addedFields = arg.exceptionItems[0]?.entries.map((e) => e.field) || [''];
+        return (
+          <>
+            <EuiButtonGroup
+              legend="Events or Process descendants selector"
+              color="primary"
+              onChange={handleFilterTypeOnChange}
+              css={css`
+                .euiButtonGroupButton {
+                  padding-right: ${euiTheme.euiTheme.size.l};
+                }
+              `}
+              options={filterTypeOptions}
+              idSelected={isFilterProcessDescendantsSelected ? 'descendants' : 'events'}
+            />
+            <EuiSpacer size="m" />
 
-          if (isFilterProcessDescendantsFeatureEnabled && isFilterProcessDescendantsSelected) {
-            addedFields.push(PROCESS_DESCENDANT_EVENT_FILTER_EXTRA_ENTRY.field);
+            {isFilterProcessDescendantsSelected && (
+              <>
+                <EuiText
+                  size="s"
+                  data-test-subj={getTestId(
+                    'filterProcessDescendants-additionalConditionDescription'
+                  )}
+                >
+                  <FormattedMessage
+                    id="xpack.securitySolution.eventFilters.filterProcessDescendants.additionalConditionDescription"
+                    defaultMessage="Additional condition added:"
+                  />
+                </EuiText>
+                <code>{PROCESS_DESCENDANT_EVENT_FILTER_EXTRA_ENTRY_TEXT}</code>
+                <EuiSpacer size="m" />
+              </>
+            )}
+          </>
+        );
+      }, [
+        isFilterProcessDescendantsFeatureEnabled,
+        handleFilterTypeOnChange,
+        euiTheme.euiTheme.size.l,
+        filterTypeOptions,
+        isFilterProcessDescendantsSelected,
+        getTestId,
+      ]);
+
+      // conditions and handler
+      const handleOnBuilderChange = useCallback(
+        (arg: OnChangeProps) => {
+          const hasDuplicates =
+            (!hasFormChanged && arg.exceptionItems[0] === undefined) ||
+            isEqual(arg.exceptionItems[0]?.entries, exception?.entries);
+
+          if (hasDuplicates) {
+            const addedFields = arg.exceptionItems[0]?.entries.map((e) => e.field) || [''];
+
+            if (isFilterProcessDescendantsFeatureEnabled && isFilterProcessDescendantsSelected) {
+              addedFields.push(PROCESS_DESCENDANT_EVENT_FILTER_EXTRA_ENTRY.field);
+            }
+
+            setHasDuplicateFields(computeHasDuplicateFields(getAddedFieldsCounts(addedFields)));
+            if (!hasFormChanged) setHasFormChanged(true);
+            return;
+          } else {
+            setHasDuplicateFields(false);
           }
 
-          setHasDuplicateFields(computeHasDuplicateFields(getAddedFieldsCounts(addedFields)));
+          // handle wildcard with wrong operator case
+          setHasWildcardWithWrongOperator(hasWrongOperatorWithWildcard(arg.exceptionItems));
+          setHasPartialCodeSignatureWarning(hasPartialCodeSignatureEntry(arg.exceptionItems));
+
+          const updatedItem: Partial<ArtifactFormComponentProps['item']> =
+            arg.exceptionItems[0] !== undefined
+              ? {
+                  ...arg.exceptionItems[0],
+                  name: exception?.name ?? '',
+                  description: exception?.description ?? '',
+                  comments: exception?.comments ?? [],
+                  os_types: exception?.os_types ?? [OperatingSystem.WINDOWS],
+                  tags: exception?.tags ?? [],
+                  meta: exception.meta,
+                }
+              : {
+                  ...exception,
+                  entries: [{ field: '', operator: 'included', type: 'match', value: '' }],
+                };
+          const hasValidConditions =
+            arg.exceptionItems[0] !== undefined
+              ? !(arg.errorExists && !arg.exceptionItems[0]?.entries?.length)
+              : false;
+
+          setAreConditionsValid(hasValidConditions);
+          processChanged(updatedItem);
           if (!hasFormChanged) setHasFormChanged(true);
-          return;
-        } else {
-          setHasDuplicateFields(false);
-        }
-
-        // handle wildcard with wrong operator case
-        setHasWildcardWithWrongOperator(hasWrongOperatorWithWildcard(arg.exceptionItems));
-        setHasPartialCodeSignatureWarning(hasPartialCodeSignatureEntry(arg.exceptionItems));
-
-        const updatedItem: Partial<ArtifactFormComponentProps['item']> =
-          arg.exceptionItems[0] !== undefined
-            ? {
-                ...arg.exceptionItems[0],
-                name: exception?.name ?? '',
-                description: exception?.description ?? '',
-                comments: exception?.comments ?? [],
-                os_types: exception?.os_types ?? [OperatingSystem.WINDOWS],
-                tags: exception?.tags ?? [],
-                meta: exception.meta,
-              }
-            : {
-                ...exception,
-                entries: [{ field: '', operator: 'included', type: 'match', value: '' }],
-              };
-        const hasValidConditions =
-          arg.exceptionItems[0] !== undefined
-            ? !(arg.errorExists && !arg.exceptionItems[0]?.entries?.length)
-            : false;
-
-        setAreConditionsValid(hasValidConditions);
-        processChanged(updatedItem);
-        if (!hasFormChanged) setHasFormChanged(true);
-      },
-      [
-        exception,
-        hasFormChanged,
-        isFilterProcessDescendantsFeatureEnabled,
-        isFilterProcessDescendantsSelected,
-        processChanged,
-      ]
-    );
-    const exceptionBuilderComponentMemo = useMemo(
-      () =>
-        getExceptionBuilderComponentLazy({
-          allowLargeValueLists: false,
-          httpService: http,
-          autocompleteService: autocompleteSuggestions,
-          exceptionListItems: [eventFilterItem as ExceptionListItemSchema],
-          listType: EVENT_FILTER_LIST_TYPE,
-          listId: ENDPOINT_EVENT_FILTERS_LIST_ID,
-          listNamespaceType: 'agnostic',
-          ruleName: RULE_NAME,
+        },
+        [
+          exception,
+          hasFormChanged,
+          isFilterProcessDescendantsFeatureEnabled,
+          isFilterProcessDescendantsSelected,
+          processChanged,
+        ]
+      );
+      const exceptionBuilderComponentMemo = useMemo(
+        () =>
+          getExceptionBuilderComponentLazy({
+            allowLargeValueLists: false,
+            httpService: http,
+            autocompleteService: autocompleteSuggestions,
+            exceptionListItems: [eventFilterItem as ExceptionListItemSchema],
+            listType: EVENT_FILTER_LIST_TYPE,
+            listId: ENDPOINT_EVENT_FILTERS_LIST_ID,
+            listNamespaceType: 'agnostic',
+            ruleName: RULE_NAME,
+            indexPatterns,
+            isOrDisabled: true,
+            isOrHidden: true,
+            isAndDisabled: false,
+            isNestedDisabled: false,
+            dataTestSubj: 'alert-exception-builder',
+            idAria: 'alert-exception-builder',
+            onChange: handleOnBuilderChange,
+            operatorsList: EVENT_FILTERS_OPERATORS,
+            osTypes: exception.os_types,
+            showValueListModal: ShowValueListModal,
+          }),
+        [
+          autocompleteSuggestions,
+          handleOnBuilderChange,
+          http,
           indexPatterns,
-          isOrDisabled: true,
-          isOrHidden: true,
-          isAndDisabled: false,
-          isNestedDisabled: false,
-          dataTestSubj: 'alert-exception-builder',
-          idAria: 'alert-exception-builder',
-          onChange: handleOnBuilderChange,
-          operatorsList: EVENT_FILTERS_OPERATORS,
-          osTypes: exception.os_types,
-          showValueListModal: ShowValueListModal,
-        }),
-      [
-        autocompleteSuggestions,
-        handleOnBuilderChange,
-        http,
-        indexPatterns,
-        exception,
-        eventFilterItem,
-      ]
-    );
+          exception,
+          eventFilterItem,
+        ]
+      );
 
-    // conditions
-    const criteriaSection = useMemo(
-      () => (
-        <>
-          <EuiText size="xs">
-            <h3>
-              <FormattedMessage
-                id="xpack.securitySolution.eventFilters.criteriaSectionTitle"
-                defaultMessage="Conditions"
-              />
-            </h3>
-          </EuiText>
-          <EuiSpacer size="xs" />
-          <EuiText size="s">
-            <p>
-              {allowSelectOs ? (
-                <FormattedMessage
-                  id="xpack.securitySolution.eventFilters.criteriaSectionDescription.withOs"
-                  defaultMessage="Select an operating system and add conditions."
-                />
-              ) : (
-                <FormattedMessage
-                  id="xpack.securitySolution.eventFilters.criteriaSectionDescription.withoutOs"
-                  defaultMessage="Add conditions."
-                />
-              )}
-            </p>
-          </EuiText>
-          <EuiSpacer size="m" />
-          {allowSelectOs ? (
-            <>
-              {osInputMemo}
-              <EuiSpacer />
-            </>
-          ) : null}
-          {filterTypeSubsection}
-          {exceptionBuilderComponentMemo}
-        </>
-      ),
-      [allowSelectOs, exceptionBuilderComponentMemo, osInputMemo, filterTypeSubsection]
-    );
-
-    // policy and handler
-    const handleOnPolicyChange = useCallback(
-      (change: EffectedPolicySelection) => {
-        const policySelectionTags = getArtifactTagsByPolicySelection(change);
-
-        // Preserve old selected policies when switching to global
-        if (!change.isGlobal) {
-          setSelectedPolicies(change.selected);
-        }
-
-        const tags = getTagsUpdatedBy('policySelection', policySelectionTags);
-        processChanged({ tags });
-        if (!hasFormChanged) setHasFormChanged(true);
-      },
-      [processChanged, getTagsUpdatedBy, hasFormChanged]
-    );
-
-    const policiesSection = useMemo(
-      () => (
-        <EffectedPolicySelect
-          selected={selectedPolicies}
-          options={policies}
-          isGlobal={isGlobal}
-          isLoading={policiesIsLoading}
-          isPlatinumPlus={isPlatinumPlus}
-          onChange={handleOnPolicyChange}
-          data-test-subj={getTestId('effectedPolicies')}
-        />
-      ),
-      [
-        selectedPolicies,
-        policies,
-        isGlobal,
-        policiesIsLoading,
-        isPlatinumPlus,
-        handleOnPolicyChange,
-        getTestId,
-      ]
-    );
-
-    useEffect(() => {
-      processChanged();
-    }, [processChanged]);
-
-    if (isIndexPatternLoading || !exception) {
-      return <Loader size="xl" />;
-    }
-
-    return (
-      <EuiForm component="div">
-        {detailsSection}
-        <EuiHorizontalRule />
-        {criteriaSection}
-        {hasWildcardWithWrongOperator && <WildCardWithWrongOperatorCallout />}
-        {hasPartialCodeSignatureWarning && <PartialCodeSignatureCallout />}
-        {hasDuplicateFields && (
+      // conditions
+      const criteriaSection = useMemo(
+        () => (
           <>
-            <EuiSpacer size="xs" />
-            <EuiText color="subdued" size="xs" data-test-subj="duplicate-fields-warning-message">
-              <FormattedMessage
-                id="xpack.securitySolution.eventFilters.warningMessage.duplicateFields"
-                defaultMessage="Using multiples of the same field values can degrade Endpoint performance and/or create ineffective rules"
-              />
+            <EuiText size="xs">
+              <h3>
+                <FormattedMessage
+                  id="xpack.securitySolution.eventFilters.criteriaSectionTitle"
+                  defaultMessage="Conditions"
+                />
+              </h3>
             </EuiText>
+            <EuiSpacer size="xs" />
+            <EuiText size="s">
+              <p>
+                {allowSelectOs ? (
+                  <FormattedMessage
+                    id="xpack.securitySolution.eventFilters.criteriaSectionDescription.withOs"
+                    defaultMessage="Select an operating system and add conditions."
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="xpack.securitySolution.eventFilters.criteriaSectionDescription.withoutOs"
+                    defaultMessage="Add conditions."
+                  />
+                )}
+              </p>
+            </EuiText>
+            <EuiSpacer size="m" />
+            {allowSelectOs ? (
+              <>
+                {osInputMemo}
+                <EuiSpacer />
+              </>
+            ) : null}
+            {filterTypeSubsection}
+            {exceptionBuilderComponentMemo}
           </>
-        )}
-        {showAssignmentSection && (
-          <>
-            <EuiHorizontalRule />
-            {policiesSection}
-          </>
-        )}
-        <EuiHorizontalRule />
-        {commentsSection}
-      </EuiForm>
-    );
-  });
+        ),
+        [allowSelectOs, exceptionBuilderComponentMemo, osInputMemo, filterTypeSubsection]
+      );
+
+      // policy and handler
+      const handleOnPolicyChange = useCallback(
+        (change: EffectedPolicySelection) => {
+          const policySelectionTags = getArtifactTagsByPolicySelection(change);
+
+          // Preserve old selected policies when switching to global
+          if (!change.isGlobal) {
+            setSelectedPolicies(change.selected);
+          }
+
+          const tags = getTagsUpdatedBy('policySelection', policySelectionTags);
+          processChanged({ tags });
+          if (!hasFormChanged) setHasFormChanged(true);
+        },
+        [getTagsUpdatedBy, processChanged, hasFormChanged]
+      );
+
+      const policiesSection = useMemo(
+        () => (
+          <EffectedPolicySelect
+            selected={selectedPolicies}
+            options={policies}
+            isGlobal={isGlobal}
+            isLoading={policiesIsLoading}
+            isPlatinumPlus={isPlatinumPlus}
+            onChange={handleOnPolicyChange}
+            data-test-subj={getTestId('effectedPolicies')}
+          />
+        ),
+        [
+          selectedPolicies,
+          policies,
+          isGlobal,
+          policiesIsLoading,
+          isPlatinumPlus,
+          handleOnPolicyChange,
+          getTestId,
+        ]
+      );
+
+      useEffect(() => {
+        processChanged();
+      }, [processChanged]);
+
+      if (isIndexPatternLoading || !exception) {
+        return <Loader size="xl" />;
+      }
+
+      return (
+        <EuiForm
+          component="div"
+          error={
+            submitError ? (
+              <FormattedError error={submitError} data-test-subj={getTestId('submitError')} />
+            ) : undefined
+          }
+          isInvalid={!!submitError}
+        >
+          {detailsSection}
+          <EuiHorizontalRule />
+          {criteriaSection}
+          {hasWildcardWithWrongOperator && <WildCardWithWrongOperatorCallout />}
+          {hasPartialCodeSignatureWarning && <PartialCodeSignatureCallout />}
+          {hasDuplicateFields && (
+            <>
+              <EuiSpacer size="xs" />
+              <EuiText color="subdued" size="xs" data-test-subj="duplicate-fields-warning-message">
+                <FormattedMessage
+                  id="xpack.securitySolution.eventFilters.warningMessage.duplicateFields"
+                  defaultMessage="Using multiples of the same field values can degrade Endpoint performance and/or create ineffective rules"
+                />
+              </EuiText>
+            </>
+          )}
+          {showAssignmentSection && (
+            <>
+              <EuiHorizontalRule />
+              {policiesSection}
+            </>
+          )}
+          <EuiHorizontalRule />
+          {commentsSection}
+        </EuiForm>
+      );
+    }
+  );
 
 EventFiltersForm.displayName = 'EventFiltersForm';

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/form.tsx
@@ -41,6 +41,7 @@ import {
 } from './translations';
 import type { ArtifactFormComponentProps } from '../../../../components/artifact_list_page';
 import { FormattedError } from '../../../../components/formatted_error';
+import { useGetUpdatedTags } from '../../../../hooks/artifacts';
 
 export const testIdPrefix = 'hostIsolationExceptions-form';
 
@@ -66,8 +67,8 @@ export const HostIsolationExceptionsForm = memo<ArtifactFormComponentProps>(
     const [hasBeenInputIpVisited, setHasBeenInputIpVisited] = useState(false);
     const [hasNameError, setHasNameError] = useState(!exception.name);
     const [hasIpError, setHasIpError] = useState(!ipEntry.value);
-
     const getTestId = useTestIdGenerator(testIdPrefix);
+    const { getTagsUpdatedBy } = useGetUpdatedTags(exception);
 
     const [selectedPolicies, setSelectedPolicies] = useState<EffectedPolicySelection>({
       isGlobal: isArtifactGlobal(exception),
@@ -137,11 +138,14 @@ export const HostIsolationExceptionsForm = memo<ArtifactFormComponentProps>(
           setSelectedPolicies(selection);
         }
 
-        notifyOfChange({
-          tags: getArtifactTagsByPolicySelection(selection),
-        });
+        const tags = getTagsUpdatedBy(
+          'policySelection',
+          getArtifactTagsByPolicySelection(selection)
+        );
+
+        notifyOfChange({ tags });
       },
-      [notifyOfChange]
+      [getTagsUpdatedBy, notifyOfChange]
     );
 
     const handleOnDescriptionChange = useCallback(
@@ -254,7 +258,14 @@ export const HostIsolationExceptionsForm = memo<ArtifactFormComponentProps>(
     return (
       <EuiForm
         component="div"
-        error={error && <FormattedError error={error} />}
+        error={
+          error && (
+            <FormattedError
+              error={error}
+              data-test-subj={'hostIsolationExceptions-form-submitError'}
+            />
+          )
+        }
         isInvalid={!!error}
         data-test-subj="hostIsolationExceptions-form"
       >

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/integration_tests/form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/host_isolation_exceptions/view/components/integration_tests/form.test.tsx
@@ -25,7 +25,7 @@ import {
   isEffectedPolicySelected,
 } from '../../../../../components/effected_policy_select/test_utils';
 import { BY_POLICY_ARTIFACT_TAG_PREFIX } from '../../../../../../../common/endpoint/service/artifacts';
-import type { HttpFetchOptionsWithPath } from '@kbn/core/public';
+import type { HttpFetchOptionsWithPath, IHttpFetchError } from '@kbn/core/public';
 import { testIdPrefix } from '../form';
 
 jest.mock('../../../../../../common/components/user_privileges');
@@ -294,6 +294,26 @@ describe('When on the host isolation exceptions entry form', () => {
       expect(
         renderResult.queryByTestId(`${testIdPrefix}-effectedPolicies-policiesSelectable`)
       ).toBeTruthy();
+    });
+
+    // FIXME:PT not sure why this test is not working but I have spent several hours now on it and can't
+    //          figure it out. Skipping for now and will try to come back to it.
+    it.skip('should display form submission errors', async () => {
+      const error = new Error('oh oh - error') as IHttpFetchError;
+      exceptionsApiMock.responseProvider.exceptionUpdate.mockImplementation(() => {
+        throw error;
+      });
+
+      const { getByTestId } = await render();
+      await userEvent.click(getByTestId('hostIsolationExceptionsListPage-flyout-submitButton'));
+
+      await waitFor(() => {
+        expect(exceptionsApiMock.responseProvider.exceptionUpdate).toHaveBeenCalled();
+      });
+
+      expect(getByTestId('hostIsolationExceptions-form-submitError').textContent).toMatch(
+        'oh oh - error'
+      );
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/errors.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/errors.ts
@@ -7,7 +7,13 @@
 
 /* eslint-disable max-classes-per-file */
 
+import { i18n } from '@kbn/i18n';
 import { EndpointError } from '../../common/endpoint/errors';
+
+export const ENDPOINT_AUTHZ_ERROR_MESSAGE = i18n.translate(
+  'xpack.securitySolution.errors.noEndpointAuthzApiErrorMessage',
+  { defaultMessage: 'Endpoint authorization failure' }
+);
 
 export class NotFoundError extends EndpointError {}
 
@@ -25,6 +31,6 @@ export class EndpointAppContentServicesNotStartedError extends EndpointError {
 
 export class EndpointAuthorizationError extends EndpointError {
   constructor(meta?: unknown) {
-    super('Endpoint authorization failure', meta);
+    super(ENDPOINT_AUTHZ_ERROR_MESSAGE, meta);
   }
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/mocks/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/mocks/mocks.ts
@@ -150,7 +150,11 @@ export const createMockEndpointAppContextService = (
     savedObjects: createSavedObjectsClientFactoryMock({ savedObjectsServiceStart }).service,
     isServerless: jest.fn().mockReturnValue(false),
     getInternalEsClient: jest.fn().mockReturnValue(esClient),
-    getActiveSpace: jest.fn(async () => DEFAULT_SPACE_ID),
+    getActiveSpace: jest.fn(async () => ({
+      id: DEFAULT_SPACE_ID,
+      name: 'default',
+      disabledFeatures: [],
+    })),
   } as unknown as jest.Mocked<EndpointAppContextService>;
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/actions/clients/lib/base_response_actions_client.ts
@@ -503,6 +503,8 @@ export abstract class ResponseActionsClientImpl implements ResponseActionsClient
         : {}),
     };
 
+    this.log.debug(() => `creating action request document:\n${stringify(doc)}`);
+
     try {
       const logsEndpointActionsResult = await this.options.esClient.index<LogsEndpointAction>(
         {
@@ -526,6 +528,9 @@ export abstract class ResponseActionsClientImpl implements ResponseActionsClient
       return doc;
     } catch (err) {
       this.sendActionCreationErrorTelemetry(actionRequest.command, err);
+      this.log.debug(
+        () => `attempt to index document into ${ENDPOINT_ACTIONS_INDEX} failed:\n${stringify(err)}`
+      );
 
       if (!(err instanceof ResponseActionsClientError)) {
         throw new ResponseActionsClientError(

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/handlers/exceptions_pre_update_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/handlers/exceptions_pre_update_handler.ts
@@ -76,7 +76,10 @@ export const getExceptionsPreUpdateItemHandler = (
         endpointAppContextService,
         request
       );
-      const validatedItem = await hostIsolationExceptionValidator.validatePreUpdateItem(data);
+      const validatedItem = await hostIsolationExceptionValidator.validatePreUpdateItem(
+        data,
+        currentSavedItem
+      );
       hostIsolationExceptionValidator.notifyFeatureUsage(
         data as ExceptionItemLikeOptions,
         'HOST_ISOLATION_EXCEPTION_BY_POLICY'
@@ -105,7 +108,10 @@ export const getExceptionsPreUpdateItemHandler = (
         endpointAppContextService,
         request
       );
-      const validatedItem = await endpointExceptionValidator.validatePreUpdateItem(data);
+      const validatedItem = await endpointExceptionValidator.validatePreUpdateItem(
+        data,
+        currentSavedItem
+      );
       endpointExceptionValidator.notifyFeatureUsage(
         data as ExceptionItemLikeOptions,
         'ENDPOINT_EXCEPTIONS'

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/blocklist_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/blocklist_validator.ts
@@ -243,6 +243,7 @@ export class BlocklistValidator extends BaseValidator {
     await this.validateBlocklistData(item);
     await this.validateCanCreateByPolicyArtifacts(item);
     await this.validateByPolicyItem(item);
+    await this.validateCreateOwnerSpaceIds(item);
 
     await this.setOwnerSpaceId(item);
 
@@ -299,6 +300,7 @@ export class BlocklistValidator extends BaseValidator {
     }
 
     await this.validateByPolicyItem(updatedItem);
+    await this.validateUpdateOwnerSpaceIds(updatedItem, currentItem);
 
     if (!hasArtifactOwnerSpaceId(_updatedItem)) {
       await this.setOwnerSpaceId(_updatedItem);

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/endpoint_exceptions_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/endpoint_exceptions_validator.ts
@@ -10,6 +10,7 @@ import type {
   UpdateExceptionListItemOptions,
 } from '@kbn/lists-plugin/server';
 import { ENDPOINT_LIST_ID } from '@kbn/securitysolution-list-constants';
+import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { hasArtifactOwnerSpaceId } from '../../../../common/endpoint/service/artifacts/utils';
 import { BaseValidator } from './base_validator';
 
@@ -28,14 +29,19 @@ export class EndpointExceptionsValidator extends BaseValidator {
 
   async validatePreCreateItem(item: CreateExceptionListItemOptions) {
     await this.validateHasWritePrivilege();
+    await this.validateCreateOwnerSpaceIds(item);
 
     await this.setOwnerSpaceId(item);
 
     return item;
   }
 
-  async validatePreUpdateItem(item: UpdateExceptionListItemOptions) {
+  async validatePreUpdateItem(
+    item: UpdateExceptionListItemOptions,
+    currentItem: ExceptionListItemSchema
+  ) {
     await this.validateHasWritePrivilege();
+    await this.validateUpdateOwnerSpaceIds(item, currentItem);
 
     if (!hasArtifactOwnerSpaceId(item)) {
       await this.setOwnerSpaceId(item);

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/event_filter_validator.ts
@@ -60,6 +60,8 @@ export class EventFilterValidator extends BaseValidator {
       await this.validateByPolicyItem(item);
     }
 
+    await this.validateCreateOwnerSpaceIds(item);
+
     await this.setOwnerSpaceId(item);
 
     return item;
@@ -86,6 +88,7 @@ export class EventFilterValidator extends BaseValidator {
     }
 
     await this.validateByPolicyItem(updatedItem);
+    await this.validateUpdateOwnerSpaceIds(_updatedItem, currentItem);
 
     if (!hasArtifactOwnerSpaceId(_updatedItem)) {
       await this.setOwnerSpaceId(_updatedItem);

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/host_isolation_exceptions_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/host_isolation_exceptions_validator.ts
@@ -12,6 +12,7 @@ import type {
   CreateExceptionListItemOptions,
   UpdateExceptionListItemOptions,
 } from '@kbn/lists-plugin/server';
+import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
 import { hasArtifactOwnerSpaceId } from '../../../../common/endpoint/service/artifacts/utils';
 import { BaseValidator, BasicEndpointExceptionDataSchema } from './base_validator';
 import { EndpointArtifactExceptionValidationError } from './errors';
@@ -79,6 +80,7 @@ export class HostIsolationExceptionsValidator extends BaseValidator {
     await this.validateHasWritePrivilege();
     await this.validateHostIsolationData(item);
     await this.validateByPolicyItem(item);
+    await this.validateCreateOwnerSpaceIds(item);
 
     await this.setOwnerSpaceId(item);
 
@@ -86,13 +88,15 @@ export class HostIsolationExceptionsValidator extends BaseValidator {
   }
 
   async validatePreUpdateItem(
-    _updatedItem: UpdateExceptionListItemOptions
+    _updatedItem: UpdateExceptionListItemOptions,
+    currentItem: ExceptionListItemSchema
   ): Promise<UpdateExceptionListItemOptions> {
     const updatedItem = _updatedItem as ExceptionItemLikeOptions;
 
     await this.validateHasWritePrivilege();
     await this.validateHostIsolationData(updatedItem);
     await this.validateByPolicyItem(updatedItem);
+    await this.validateUpdateOwnerSpaceIds(_updatedItem, currentItem);
 
     if (!hasArtifactOwnerSpaceId(_updatedItem)) {
       await this.setOwnerSpaceId(_updatedItem);

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/mocks.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/mocks.ts
@@ -45,6 +45,17 @@ export class BaseValidatorMock extends BaseValidator {
   ): boolean {
     return this.wasByPolicyEffectScopeChanged(updatedItem, currentItem);
   }
+
+  _validateCreateOwnerSpaceIds(item: ExceptionItemLikeOptions): Promise<void> {
+    return this.validateCreateOwnerSpaceIds(item);
+  }
+
+  _validateUpdateOwnerSpaceIds(
+    updatedItem: Partial<Pick<ExceptionListItemSchema, 'tags'>>,
+    currentItem: Pick<ExceptionListItemSchema, 'tags'>
+  ): Promise<void> {
+    return this.validateUpdateOwnerSpaceIds(updatedItem, currentItem);
+  }
 }
 
 export const createExceptionItemLikeOptionsMock = (

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/trusted_app_validator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/validators/trusted_app_validator.ts
@@ -207,6 +207,7 @@ export class TrustedAppValidator extends BaseValidator {
     await this.validateTrustedAppData(item);
     await this.validateCanCreateByPolicyArtifacts(item);
     await this.validateByPolicyItem(item);
+    await this.validateCreateOwnerSpaceIds(item);
 
     await this.setOwnerSpaceId(item);
 
@@ -258,6 +259,7 @@ export class TrustedAppValidator extends BaseValidator {
     }
 
     await this.validateByPolicyItem(updatedItem);
+    await this.validateUpdateOwnerSpaceIds(_updatedItem, currentItem);
 
     if (!hasArtifactOwnerSpaceId(_updatedItem)) {
       await this.setOwnerSpaceId(_updatedItem);

--- a/x-pack/test/security_solution_api_integration/config/services/security_solution_edr_workflows_roles_users.ts
+++ b/x-pack/test/security_solution_api_integration/config/services/security_solution_edr_workflows_roles_users.ts
@@ -12,6 +12,7 @@ import {
   getAllEndpointSecurityRoles,
 } from '@kbn/security-solution-plugin/scripts/endpoint/common/roles_users';
 
+import { EndpointSecurityTestRolesLoader } from '@kbn/security-solution-plugin/scripts/endpoint/common/role_and_user_loader';
 import { FtrProviderContext } from '../../ftr_provider_context_edr_workflows';
 
 export const ROLE = ENDPOINT_SECURITY_ROLE_NAMES;
@@ -20,10 +21,17 @@ const rolesMapping = getAllEndpointSecurityRoles();
 
 export function RolesUsersProvider({ getService }: FtrProviderContext) {
   const security = getService('security');
+  const kbnServer = getService('kibanaServer');
+  const log = getService('log');
+
   return {
+    /** Endpoint security test roles loader */
+    loader: new EndpointSecurityTestRolesLoader(kbnServer, log),
+
     /**
      * Creates an user with specific values
      * @param user
+     * @deprecated use `.loader.*` methods instead
      */
     async createUser(user: { name: string; roles: string[]; password?: string }): Promise<void> {
       const { name, roles, password } = user;
@@ -33,6 +41,7 @@ export function RolesUsersProvider({ getService }: FtrProviderContext) {
     /**
      * Deletes specified users by username
      * @param names[]
+     * @deprecated use `.loader.*` methods instead
      */
     async deleteUsers(names: string[]): Promise<void> {
       for (const name of names) {
@@ -43,6 +52,7 @@ export function RolesUsersProvider({ getService }: FtrProviderContext) {
     /**
      * Creates a role using predefined role config if defined or a custom one. It also allows define extra privileges.
      * @param options
+     * @deprecated use `.loader.*` methods instead
      */
     async createRole(options: {
       predefinedRole?: EndpointSecurityRoleNames;
@@ -87,6 +97,7 @@ export function RolesUsersProvider({ getService }: FtrProviderContext) {
     /**
      * Deletes specified roles by name
      * @param roles[]
+     * @deprecated use `.loader.*` methods instead
      */
     async deleteRoles(roles: string[]): Promise<void> {
       for (const role of roles) {

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/artifacts.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/artifacts.ts
@@ -1,0 +1,339 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import TestAgent from 'supertest/lib/agent';
+import { ensureSpaceIdExists } from '@kbn/security-solution-plugin/scripts/endpoint/common/spaces';
+import {
+  ENDPOINT_ARTIFACT_LISTS,
+  EXCEPTION_LIST_ITEM_URL,
+} from '@kbn/securitysolution-list-constants';
+import expect from '@kbn/expect';
+import {
+  buildPerPolicyTag,
+  buildSpaceOwnerIdTag,
+} from '@kbn/security-solution-plugin/common/endpoint/service/artifacts/utils';
+import { addSpaceIdToPath } from '@kbn/spaces-plugin/common';
+import { exceptionItemToCreateExceptionItem } from '@kbn/security-solution-plugin/common/endpoint/data_generators/exceptions_list_item_generator';
+import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
+import { Role } from '@kbn/security-plugin-types-common';
+import { GLOBAL_ARTIFACT_TAG } from '@kbn/security-solution-plugin/common/endpoint/service/artifacts';
+import { PolicyTestResourceInfo } from '../../../../../security_solution_endpoint/services/endpoint_policy';
+import { createSupertestErrorLogger } from '../../utils';
+import { ArtifactTestData } from '../../../../../security_solution_endpoint/services/endpoint_artifacts';
+import { FtrProviderContext } from '../../../../ftr_provider_context_edr_workflows';
+
+export default function ({ getService }: FtrProviderContext) {
+  const utils = getService('securitySolutionUtils');
+  const rolesUsersProvider = getService('rolesUsersProvider');
+  const endpointArtifactTestResources = getService('endpointArtifactTestResources');
+  const policyTestResources = getService('endpointPolicyTestResources');
+  const kbnServer = getService('kibanaServer');
+  const log = getService('log');
+
+  // @skipInServerless: due to the fact that the serverless builtin roles are not yet updated with new privilege
+  //                    and tests below are currently creating a new role/user
+  describe('@ess @skipInServerless, @skipInServerlessMKI Endpoint Artifacts space awareness support', function () {
+    const spaceOneId = 'space_one';
+    const spaceTwoId = 'space_two';
+
+    let artifactManagerRole: Role;
+    let globalArtifactManagerRole: Role;
+    let supertestArtifactManager: TestAgent;
+    let supertestGlobalArtifactManager: TestAgent;
+    let spaceOnePolicy: PolicyTestResourceInfo;
+
+    before(async () => {
+      // For testing, we're using the `t3_analyst` role which already has All privileges
+      // to all artifacts and manipulating that role definition to create two new roles/users
+      artifactManagerRole = Object.assign(
+        rolesUsersProvider.loader.getPreDefinedRole('t3_analyst'),
+        { name: 'artifactManager' }
+      );
+
+      if (artifactManagerRole.kibana[0].feature.siemV2.includes('global_artifact_management_all')) {
+        artifactManagerRole.kibana[0].feature.siemV2 =
+          artifactManagerRole.kibana[0].feature.siemV2.filter(
+            (privilege) => privilege !== 'global_artifact_management_all'
+          );
+      }
+
+      globalArtifactManagerRole = Object.assign(
+        rolesUsersProvider.loader.getPreDefinedRole('t3_analyst'),
+        { name: 'globalArtifactManager' }
+      );
+
+      if (
+        !globalArtifactManagerRole.kibana[0].feature.siemV2.includes(
+          'global_artifact_management_all'
+        )
+      ) {
+        globalArtifactManagerRole.kibana[0].feature.siemV2.push('global_artifact_management_all');
+      }
+
+      const [artifactManagerUser, globalArtifactManagerUser] = await Promise.all([
+        rolesUsersProvider.loader.create(artifactManagerRole),
+        rolesUsersProvider.loader.create(globalArtifactManagerRole),
+      ]);
+
+      supertestArtifactManager = await utils.createSuperTest(
+        artifactManagerUser.username,
+        artifactManagerUser.password
+      );
+      supertestGlobalArtifactManager = await utils.createSuperTest(
+        globalArtifactManagerUser.username,
+        globalArtifactManagerUser.password
+      );
+
+      await Promise.all([
+        ensureSpaceIdExists(kbnServer, spaceOneId, { log }),
+        ensureSpaceIdExists(kbnServer, spaceTwoId, { log }),
+      ]);
+
+      spaceOnePolicy = await policyTestResources.createPolicy();
+    });
+
+    // the endpoint uses data streams and es archiver does not support deleting them at the moment so we need
+    // to do it manually
+    after(async () => {
+      if (artifactManagerRole) {
+        await rolesUsersProvider.loader.delete(artifactManagerRole.name);
+        // @ts-expect-error
+        artifactManagerRole = undefined;
+      }
+
+      if (globalArtifactManagerRole) {
+        await rolesUsersProvider.loader.delete(globalArtifactManagerRole.name);
+        // @ts-expect-error
+        globalArtifactManagerRole = undefined;
+      }
+
+      if (spaceOnePolicy) {
+        await spaceOnePolicy.cleanup();
+        // @ts-expect-error
+        spaceOnePolicy = undefined;
+      }
+    });
+
+    const artifactLists = Object.keys(ENDPOINT_ARTIFACT_LISTS);
+
+    for (const artifactList of artifactLists) {
+      const listInfo =
+        ENDPOINT_ARTIFACT_LISTS[artifactList as keyof typeof ENDPOINT_ARTIFACT_LISTS];
+
+      describe(`for ${listInfo.name}`, () => {
+        let spaceOnePerPolicyArtifact: ArtifactTestData;
+        let spaceOneGlobalArtifact: ArtifactTestData;
+
+        beforeEach(async () => {
+          spaceOnePerPolicyArtifact = await endpointArtifactTestResources.createArtifact(
+            listInfo.id,
+            { tags: [buildPerPolicyTag(spaceOnePolicy.packagePolicy.id)] },
+            { supertest: supertestArtifactManager, spaceId: spaceOneId }
+          );
+
+          spaceOneGlobalArtifact = await endpointArtifactTestResources.createArtifact(
+            listInfo.id,
+            { tags: [GLOBAL_ARTIFACT_TAG] },
+            { supertest: supertestGlobalArtifactManager, spaceId: spaceOneId }
+          );
+        });
+
+        afterEach(async () => {
+          if (spaceOnePerPolicyArtifact) {
+            await spaceOnePerPolicyArtifact.cleanup();
+            // @ts-expect-error assigning `undefined`
+            spaceOnePerPolicyArtifact = undefined;
+          }
+        });
+
+        it('should add owner space id when item is created', async () => {
+          expect(spaceOnePerPolicyArtifact.artifact.tags).to.include.string(
+            buildSpaceOwnerIdTag(spaceOneId)
+          );
+        });
+
+        it('should not add owner space id during artifact update if one is already present', async () => {
+          const { body } = await supertestArtifactManager
+            .put(addSpaceIdToPath('/', spaceOneId, EXCEPTION_LIST_ITEM_URL))
+            .set('elastic-api-version', '2023-10-31')
+            .set('x-elastic-internal-origin', 'kibana')
+            .set('kbn-xsrf', 'true')
+            .on('error', createSupertestErrorLogger(log))
+            .send(
+              exceptionItemToCreateExceptionItem({
+                ...spaceOnePerPolicyArtifact.artifact,
+                description: 'item was updated',
+              })
+            )
+            .expect(200);
+
+          expect((body as ExceptionListItemSchema).tags).to.eql(
+            spaceOnePerPolicyArtifact.artifact.tags
+          );
+        });
+
+        describe('and user does NOT have global artifact management privilege', () => {
+          it('should error when attempting to create artifact with additional owner space id tags', async () => {
+            await supertestArtifactManager
+              .post(addSpaceIdToPath('/', spaceOneId, EXCEPTION_LIST_ITEM_URL))
+              .set('elastic-api-version', '2023-10-31')
+              .set('x-elastic-internal-origin', 'kibana')
+              .set('kbn-xsrf', 'true')
+              .on('error', createSupertestErrorLogger(log).ignoreCodes([403]))
+              .send(
+                Object.assign(
+                  exceptionItemToCreateExceptionItem({
+                    ...spaceOnePerPolicyArtifact.artifact,
+                    tags: [buildSpaceOwnerIdTag('foo')],
+                  }),
+                  { item_id: undefined }
+                )
+              )
+              .expect(403);
+          });
+
+          it('should error when attempting to update artifact with different owner space id tags', async () => {
+            await supertestArtifactManager
+              .put(addSpaceIdToPath('/', spaceOneId, EXCEPTION_LIST_ITEM_URL))
+              .set('elastic-api-version', '2023-10-31')
+              .set('x-elastic-internal-origin', 'kibana')
+              .set('kbn-xsrf', 'true')
+              .on('error', createSupertestErrorLogger(log).ignoreCodes([403]))
+              .send(
+                exceptionItemToCreateExceptionItem({
+                  ...spaceOnePerPolicyArtifact.artifact,
+                  tags: [buildSpaceOwnerIdTag('foo')],
+                })
+              )
+              .expect(403);
+          });
+
+          // TODO:PT Un-skip in next PR. I got a little ahead of myself and added a test for the change that wil come with the next PR.
+          it.skip('should error if attempting to update a global artifact', async () => {
+            await supertestArtifactManager
+              .put(addSpaceIdToPath('/', spaceOneId, EXCEPTION_LIST_ITEM_URL))
+              .set('elastic-api-version', '2023-10-31')
+              .set('x-elastic-internal-origin', 'kibana')
+              .set('kbn-xsrf', 'true')
+              .on('error', createSupertestErrorLogger(log).ignoreCodes([403]))
+              .send(
+                exceptionItemToCreateExceptionItem({
+                  ...spaceOneGlobalArtifact.artifact,
+                  description: 'updating a global here',
+                })
+              )
+              .expect(403);
+          });
+
+          // TODO:PT Un-skip in next PR. I got a little ahead of myself and added a test for the change that wil come with the next PR.
+          it.skip('should error when attempting to change a global artifact to per-policy', async () => {
+            await supertestArtifactManager
+              .put(addSpaceIdToPath('/', spaceOneId, EXCEPTION_LIST_ITEM_URL))
+              .set('elastic-api-version', '2023-10-31')
+              .set('x-elastic-internal-origin', 'kibana')
+              .set('kbn-xsrf', 'true')
+              .on('error', createSupertestErrorLogger(log).ignoreCodes([403]))
+              .send(
+                exceptionItemToCreateExceptionItem({
+                  ...spaceOneGlobalArtifact.artifact,
+                  tags: spaceOneGlobalArtifact.artifact.tags
+                    .filter((tag) => tag !== GLOBAL_ARTIFACT_TAG)
+                    .concat(buildPerPolicyTag(spaceOnePolicy.packagePolicy.id)),
+                })
+              )
+              .expect(403);
+          });
+        });
+
+        describe('and user has privilege to manage global artifacts', () => {
+          it('should allow creating artifact with additional owner space id tags', async () => {
+            const { body } = await supertestGlobalArtifactManager
+              .post(addSpaceIdToPath('/', spaceOneId, EXCEPTION_LIST_ITEM_URL))
+              .set('elastic-api-version', '2023-10-31')
+              .set('x-elastic-internal-origin', 'kibana')
+              .set('kbn-xsrf', 'true')
+              .on('error', createSupertestErrorLogger(log))
+              .send(
+                Object.assign(
+                  exceptionItemToCreateExceptionItem({
+                    ...spaceOnePerPolicyArtifact.artifact,
+                    tags: [buildSpaceOwnerIdTag('foo')],
+                  }),
+                  { item_id: undefined }
+                )
+              )
+              .expect(200);
+
+            expect((body as ExceptionListItemSchema).tags).to.eql([
+              buildSpaceOwnerIdTag('foo'),
+              buildSpaceOwnerIdTag(spaceOneId),
+            ]);
+          });
+
+          it('should add owner space id when item is updated without having an owner tag', async () => {
+            const { body } = await supertestGlobalArtifactManager
+              .put(addSpaceIdToPath('/', spaceOneId, EXCEPTION_LIST_ITEM_URL))
+              .set('elastic-api-version', '2023-10-31')
+              .set('x-elastic-internal-origin', 'kibana')
+              .set('kbn-xsrf', 'true')
+              .on('error', createSupertestErrorLogger(log))
+              .send(
+                exceptionItemToCreateExceptionItem({
+                  ...spaceOnePerPolicyArtifact.artifact,
+                  tags: [],
+                })
+              )
+              .expect(200);
+
+            expect((body as ExceptionListItemSchema).tags).to.eql([
+              buildSpaceOwnerIdTag(spaceOneId),
+            ]);
+          });
+
+          it('should allow creation of global artifacts', async () => {
+            // test is already covered by the fact that we created a global artifact for testing
+            expect(spaceOneGlobalArtifact.artifact).to.not.equal(undefined);
+          });
+
+          it('should allow updating of global artifacts', async () => {
+            await supertestGlobalArtifactManager
+              .put(addSpaceIdToPath('/', spaceOneId, EXCEPTION_LIST_ITEM_URL))
+              .set('elastic-api-version', '2023-10-31')
+              .set('x-elastic-internal-origin', 'kibana')
+              .set('kbn-xsrf', 'true')
+              .on('error', createSupertestErrorLogger(log))
+              .send(
+                exceptionItemToCreateExceptionItem({
+                  ...spaceOneGlobalArtifact.artifact,
+                  description: 'updating of global artifacts',
+                })
+              )
+              .expect(200);
+          });
+
+          it('should allow converting global artifact to per-policy', async () => {
+            await supertestGlobalArtifactManager
+              .put(addSpaceIdToPath('/', spaceOneId, EXCEPTION_LIST_ITEM_URL))
+              .set('elastic-api-version', '2023-10-31')
+              .set('x-elastic-internal-origin', 'kibana')
+              .set('kbn-xsrf', 'true')
+              .on('error', createSupertestErrorLogger(log))
+              .send(
+                exceptionItemToCreateExceptionItem({
+                  ...spaceOneGlobalArtifact.artifact,
+                  tags: spaceOneGlobalArtifact.artifact.tags
+                    .filter((tag) => tag !== GLOBAL_ARTIFACT_TAG)
+                    .concat(buildPerPolicyTag(spaceOnePolicy.packagePolicy.id)),
+                })
+              )
+              .expect(200);
+          });
+        });
+      });
+    }
+  });
+}

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/index.ts
@@ -57,5 +57,6 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
     });
 
     loadTestFile(require.resolve('./space_awareness'));
+    loadTestFile(require.resolve('./artifacts'));
   });
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/space_awareness.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/space_awareness.ts
@@ -15,21 +15,12 @@ import {
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
 } from '@kbn/security-solution-plugin/common/endpoint/constants';
-import {
-  ENDPOINT_ARTIFACT_LISTS,
-  EXCEPTION_LIST_ITEM_URL,
-} from '@kbn/securitysolution-list-constants';
-import { buildSpaceOwnerIdTag } from '@kbn/security-solution-plugin/common/endpoint/service/artifacts/utils';
-import { exceptionItemToCreateExceptionItem } from '@kbn/security-solution-plugin/common/endpoint/data_generators/exceptions_list_item_generator';
-import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types';
-import { ArtifactTestData } from '../../../../../security_solution_endpoint/services/endpoint_artifacts';
 import { createSupertestErrorLogger } from '../../utils';
 import { FtrProviderContext } from '../../../../ftr_provider_context_edr_workflows';
 
 export default function ({ getService }: FtrProviderContext) {
   const utils = getService('securitySolutionUtils');
   const endpointTestresources = getService('endpointTestResources');
-  const endpointArtifactTestResources = getService('endpointArtifactTestResources');
   const kbnServer = getService('kibanaServer');
   const log = getService('log');
 
@@ -194,79 +185,6 @@ export default function ({ getService }: FtrProviderContext) {
 
         expect(body.data[dataSpaceB.hosts[0].agent.id].found).to.eql(false);
       });
-    });
-
-    describe(`Artifact management (via Lists plugin)`, () => {
-      const artifactLists = Object.keys(ENDPOINT_ARTIFACT_LISTS);
-
-      for (const artifactList of artifactLists) {
-        const listInfo =
-          ENDPOINT_ARTIFACT_LISTS[artifactList as keyof typeof ENDPOINT_ARTIFACT_LISTS];
-
-        describe(`for ${listInfo.name}`, () => {
-          let itemDataSpaceA: ArtifactTestData;
-
-          beforeEach(async () => {
-            itemDataSpaceA = await endpointArtifactTestResources.createArtifact(
-              listInfo.id,
-              { tags: [] },
-              { supertest: adminSupertest, spaceId: dataSpaceA.spaceId }
-            );
-          });
-
-          afterEach(async () => {
-            if (itemDataSpaceA) {
-              await itemDataSpaceA.cleanup();
-              // @ts-expect-error assigning `undefined`
-              itemDataSpaceA = undefined;
-            }
-          });
-
-          it('should add owner space id when item is created', async () => {
-            expect(itemDataSpaceA.artifact.tags).to.include.string(
-              buildSpaceOwnerIdTag(dataSpaceA.spaceId)
-            );
-          });
-
-          it('should not add owner space id during artifact update if one is already present', async () => {
-            const { body } = await adminSupertest
-              .put(addSpaceIdToPath('/', dataSpaceA.spaceId, EXCEPTION_LIST_ITEM_URL))
-              .set('elastic-api-version', '2023-10-31')
-              .set('x-elastic-internal-origin', 'kibana')
-              .set('kbn-xsrf', 'true')
-              .on('error', createSupertestErrorLogger(log))
-              .send(
-                exceptionItemToCreateExceptionItem({
-                  ...itemDataSpaceA.artifact,
-                  description: 'item was updated',
-                })
-              )
-              .expect(200);
-
-            expect((body as ExceptionListItemSchema).tags).to.eql(itemDataSpaceA.artifact.tags);
-          });
-
-          it('should add owner space id when item is updated, if one is not present', async () => {
-            const { body } = await adminSupertest
-              .put(addSpaceIdToPath('/', dataSpaceA.spaceId, EXCEPTION_LIST_ITEM_URL))
-              .set('elastic-api-version', '2023-10-31')
-              .set('x-elastic-internal-origin', 'kibana')
-              .set('kbn-xsrf', 'true')
-              .on('error', createSupertestErrorLogger(log))
-              .send(
-                exceptionItemToCreateExceptionItem({
-                  ...itemDataSpaceA.artifact,
-                  tags: [],
-                })
-              )
-              .expect(200);
-
-            expect((body as ExceptionListItemSchema).tags).to.eql([
-              buildSpaceOwnerIdTag(dataSpaceA.spaceId),
-            ]);
-          });
-        });
-      }
     });
   });
 }

--- a/x-pack/test/security_solution_api_integration/tsconfig.json
+++ b/x-pack/test/security_solution_api_integration/tsconfig.json
@@ -54,5 +54,7 @@
     "@kbn/elastic-assistant-plugin",
     "@kbn/test-suites-src",
     "@kbn/openapi-common",
+    "@kbn/scout-info",
+    "@kbn/security-plugin-types-common",
   ]
 }

--- a/x-pack/test/security_solution_api_integration/tsconfig.json
+++ b/x-pack/test/security_solution_api_integration/tsconfig.json
@@ -54,7 +54,6 @@
     "@kbn/elastic-assistant-plugin",
     "@kbn/test-suites-src",
     "@kbn/openapi-common",
-    "@kbn/scout-info",
     "@kbn/security-plugin-types-common",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution][Endpoint] Add validation to artifact create/update APIs for management of `ownerSpaceId` (#211325)](https://github.com/elastic/kibana/pull/211325)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-25T19:52:08Z","message":"[Security Solution][Endpoint] Add validation to artifact create/update APIs for management of `ownerSpaceId` (#211325)\n\n## Summary\n\n\n#### Changes in support of space awareness\n\n> currently behind feature flag:\n`endpointManagementSpaceAwarenessEnabled`\n\n- Add logic to the server-side Lists plugin extension points for\nendpoint artifacts to ensure that only a user with the new Global\nArtifact Management privilege can update/change/add `ownerSpaceId` tags\non an artifact\n- Added validation to all endpoint artifacts (Trusted Apps, Event\nFilters, Blocklists, Host Isolation Exceptions and Endpoint Exceptions)\n\n\n#### Other changes:\n\n- Fix UI bug that failed to display artifact submit API failures. API\nerrors are now displayed in the artifact's respective edit/create forms\nif encountered\n- Fixed a bug where \"unknown\" artifact `tags` were being dropped\nwhenever the artifact assignment (global, per-policy) was updated in the\nUI\n\n\n\n\n\n\n\n\n## Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1ee97c3c8f3780cde8c23edb03b37738b506aefa","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","Team:Defend Workflows","backport:prev-minor","v9.1.0"],"title":"[Security Solution][Endpoint] Add validation to artifact create/update APIs for management of `ownerSpaceId`","number":211325,"url":"https://github.com/elastic/kibana/pull/211325","mergeCommit":{"message":"[Security Solution][Endpoint] Add validation to artifact create/update APIs for management of `ownerSpaceId` (#211325)\n\n## Summary\n\n\n#### Changes in support of space awareness\n\n> currently behind feature flag:\n`endpointManagementSpaceAwarenessEnabled`\n\n- Add logic to the server-side Lists plugin extension points for\nendpoint artifacts to ensure that only a user with the new Global\nArtifact Management privilege can update/change/add `ownerSpaceId` tags\non an artifact\n- Added validation to all endpoint artifacts (Trusted Apps, Event\nFilters, Blocklists, Host Isolation Exceptions and Endpoint Exceptions)\n\n\n#### Other changes:\n\n- Fix UI bug that failed to display artifact submit API failures. API\nerrors are now displayed in the artifact's respective edit/create forms\nif encountered\n- Fixed a bug where \"unknown\" artifact `tags` were being dropped\nwhenever the artifact assignment (global, per-policy) was updated in the\nUI\n\n\n\n\n\n\n\n\n## Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1ee97c3c8f3780cde8c23edb03b37738b506aefa"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211325","number":211325,"mergeCommit":{"message":"[Security Solution][Endpoint] Add validation to artifact create/update APIs for management of `ownerSpaceId` (#211325)\n\n## Summary\n\n\n#### Changes in support of space awareness\n\n> currently behind feature flag:\n`endpointManagementSpaceAwarenessEnabled`\n\n- Add logic to the server-side Lists plugin extension points for\nendpoint artifacts to ensure that only a user with the new Global\nArtifact Management privilege can update/change/add `ownerSpaceId` tags\non an artifact\n- Added validation to all endpoint artifacts (Trusted Apps, Event\nFilters, Blocklists, Host Isolation Exceptions and Endpoint Exceptions)\n\n\n#### Other changes:\n\n- Fix UI bug that failed to display artifact submit API failures. API\nerrors are now displayed in the artifact's respective edit/create forms\nif encountered\n- Fixed a bug where \"unknown\" artifact `tags` were being dropped\nwhenever the artifact assignment (global, per-policy) was updated in the\nUI\n\n\n\n\n\n\n\n\n## Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1ee97c3c8f3780cde8c23edb03b37738b506aefa"}}]}] BACKPORT-->