### PR TITLE
[kbn/es] Workaround arm64 container startup error

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -133,7 +133,7 @@ const DEFAULT_DOCKER_ESARGS: Array<[string, string]> = [
   ['xpack.security.enabled', 'false'],
 ];
 // Temporary workaround for https://github.com/elastic/elasticsearch/issues/118583
-if (process.platform === 'darwin') {
+if (process.platform === 'darwin' && process.arch === 'arm64') {
   DEFAULT_DOCKER_ESARGS.push(
     ['ES_JAVA_OPTS', '-Xms1536m -Xmx1536m -XX:UseSVE=0'],
     ['CLI_JAVA_OPTS', '-XX:UseSVE=0']
@@ -218,7 +218,7 @@ const DEFAULT_SERVERLESS_ESARGS: Array<[string, string]> = [
   ['xpack.security.transport.ssl.verification_mode', 'certificate'],
 ];
 // Temporary workaround for https://github.com/elastic/elasticsearch/issues/118583
-if (process.platform === 'darwin') {
+if (process.platform === 'darwin' && process.arch === 'arm64') {
   DEFAULT_SERVERLESS_ESARGS.push(
     ['ES_JAVA_OPTS', '-Xms1g -Xmx1g -XX:UseSVE=0'],
     ['CLI_JAVA_OPTS', '-XX:UseSVE=0']

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -133,7 +133,7 @@ const DEFAULT_DOCKER_ESARGS: Array<[string, string]> = [
   ['xpack.security.enabled', 'false'],
 ];
 // Temporary workaround for https://github.com/elastic/elasticsearch/issues/118583
-if (process.platform === 'darwin' && process.arch === 'arm64') {
+if (process.arch === 'arm64') {
   DEFAULT_DOCKER_ESARGS.push(
     ['ES_JAVA_OPTS', '-Xms1536m -Xmx1536m -XX:UseSVE=0'],
     ['CLI_JAVA_OPTS', '-XX:UseSVE=0']
@@ -218,7 +218,7 @@ const DEFAULT_SERVERLESS_ESARGS: Array<[string, string]> = [
   ['xpack.security.transport.ssl.verification_mode', 'certificate'],
 ];
 // Temporary workaround for https://github.com/elastic/elasticsearch/issues/118583
-if (process.platform === 'darwin' && process.arch === 'arm64') {
+if (process.arch === 'arm64') {
   DEFAULT_SERVERLESS_ESARGS.push(
     ['ES_JAVA_OPTS', '-Xms1g -Xmx1g -XX:UseSVE=0'],
     ['CLI_JAVA_OPTS', '-XX:UseSVE=0']

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -126,14 +126,21 @@ const DOCKER_BASE_CMD = [
 ];
 
 const DEFAULT_DOCKER_ESARGS: Array<[string, string]> = [
-  ['ES_JAVA_OPTS', '-Xms1536m -Xmx1536m'],
-
   ['ES_LOG_STYLE', 'file'],
 
   ['discovery.type', 'single-node'],
 
   ['xpack.security.enabled', 'false'],
 ];
+// Temporary workaround for https://github.com/elastic/elasticsearch/issues/118583
+if (process.platform === 'darwin') {
+  DEFAULT_DOCKER_ESARGS.push(
+    ['ES_JAVA_OPTS', '-Xms1536m -Xmx1536m -XX:UseSVE=0'],
+    ['CLI_JAVA_OPTS', '-XX:UseSVE=0']
+  );
+} else {
+  DEFAULT_DOCKER_ESARGS.push(['ES_JAVA_OPTS', '-Xms1536m -Xmx1536m']);
+}
 
 export const DOCKER_REPO = `${DOCKER_REGISTRY}/elasticsearch/elasticsearch`;
 export const DOCKER_TAG = `${pkg.version}-SNAPSHOT`;
@@ -173,8 +180,6 @@ const SHARED_SERVERLESS_PARAMS = [
 
 // only allow certain ES args to be overwrote by options
 const DEFAULT_SERVERLESS_ESARGS: Array<[string, string]> = [
-  ['ES_JAVA_OPTS', '-Xms1g -Xmx1g'],
-
   ['ES_LOG_STYLE', 'file'],
 
   ['cluster.name', 'stateless'],
@@ -212,6 +217,15 @@ const DEFAULT_SERVERLESS_ESARGS: Array<[string, string]> = [
 
   ['xpack.security.transport.ssl.verification_mode', 'certificate'],
 ];
+// Temporary workaround for https://github.com/elastic/elasticsearch/issues/118583
+if (process.platform === 'darwin') {
+  DEFAULT_SERVERLESS_ESARGS.push(
+    ['ES_JAVA_OPTS', '-Xms1g -Xmx1g -XX:UseSVE=0'],
+    ['CLI_JAVA_OPTS', '-XX:UseSVE=0']
+  );
+} else {
+  DEFAULT_SERVERLESS_ESARGS.push(['ES_JAVA_OPTS', '-Xms1g -Xmx1g']);
+}
 
 const DEFAULT_SSL_ESARGS: Array<[string, string]> = [
   ['xpack.security.http.ssl.enabled', 'true'],


### PR DESCRIPTION
Adds a temporary workaround for an issue with ES containers starting on M4 based macs.
```
 info waiting for ES cluster to report a green status
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGILL (0x4) at pc=0x0000ffff93d400a8, pid=7, tid=16
#
# JRE version:  (23.0+37) (build )
# Java VM: OpenJDK 64-Bit Server VM (23+37-2369, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, serial gc, linux-aarch64)
# Problematic frame:
# j  java.lang.System.registerNatives()V+0 java.base@23
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
```