### PR TITLE
[8.16] [Search][Connectors] Fixing custom connector icon rendering (#212225)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
@@ -57,6 +57,12 @@ export const ConnectorConfiguration: React.FC = () => {
     [connectors]
   );
 
+  // TODO service_type === "" is considered unknown/custom connector multiple places replace all of them with a better solution
+  const CUSTOM_CONNECTOR = useMemo(
+    () => connectors.filter(({ serviceType }) => serviceType === ''),
+    [connectors]
+  );
+
   const { updateConnectorConfiguration } = useActions(ConnectorViewLogic);
 
   if (!connector) {
@@ -69,19 +75,10 @@ export const ConnectorConfiguration: React.FC = () => {
 
   const isWaitingForConnector = !connector.status || connector.status === ConnectorStatus.CREATED;
 
-  const nativeConnector = NATIVE_CONNECTORS.find(
-    (connectorDefinition) => connectorDefinition.serviceType === connector.service_type
-  ) || {
-    docsUrl: '',
-    externalAuthDocsUrl: '',
-    externalDocsUrl: '',
-    iconPath: 'custom.svg',
-    isBeta: true,
-    isNative: false,
-    keywords: [],
-    name: connector.name,
-    serviceType: connector.service_type ?? '',
-  };
+  const nativeConnector =
+    NATIVE_CONNECTORS.find(
+      (connectorDefinition) => connectorDefinition.serviceType === connector.service_type
+    ) || CUSTOM_CONNECTOR[0];
 
   const iconPath = nativeConnector.iconPath;
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
@@ -93,7 +93,7 @@ const configureLabel = i18n.translate(
 
 export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ connector, indexData }) => {
   const { connectorTypes } = useValues(KibanaLogic);
-   // TODO service_type === "" is considered unknown/custom connector multiple places replace all of them with a better solution
+  // TODO service_type === "" is considered unknown/custom connector multiple places replace all of them with a better solution
   const CUSTOM_CONNECTOR = useMemo(
     () => connectorTypes.filter(({ serviceType }) => serviceType === ''),
     [connectorTypes]

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 
 import { useValues } from 'kea';
 
@@ -93,7 +93,13 @@ const configureLabel = i18n.translate(
 
 export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ connector, indexData }) => {
   const { connectorTypes } = useValues(KibanaLogic);
-  const connectorDefinition = connectorTypes.find((c) => c.serviceType === connector.service_type);
+   // TODO service_type === "" is considered unknown/custom connector multiple places replace all of them with a better solution
+  const CUSTOM_CONNECTOR = useMemo(
+    () => connectorTypes.filter(({ serviceType }) => serviceType === ''),
+    [connectorTypes]
+  );
+  const connectorDefinition =
+    connectorTypes.find((c) => c.serviceType === connector.service_type) || CUSTOM_CONNECTOR[0];
   return (
     <EuiFlexGrid columns={3} direction="row">
       <EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
@@ -47,30 +47,27 @@ export const NativeConnectorConfiguration: React.FC = () => {
     () => connectors.filter(({ isNative }) => isNative),
     [connectors]
   );
+
+  // TODO service_type === "" is considered unknown/custom connector multiple places replace all of them with a better solution
+  const CUSTOM_CONNECTOR = useMemo(
+    () => connectors.filter(({ serviceType }) => serviceType === ''),
+    [connectors]
+  );
+
   const BETA_CONNECTORS = useMemo(() => connectors.filter(({ isBeta }) => isBeta), [connectors]);
 
   if (!connector) {
     return <></>;
   }
 
-  const nativeConnector = NATIVE_CONNECTORS.find(
-    (connectorDefinition) => connectorDefinition.serviceType === connector.service_type
-  ) || {
-    docsUrl: '',
-    externalAuthDocsUrl: '',
-    externalDocsUrl: '',
-    iconPath: 'custom.svg',
-    isBeta: true,
-    isNative: true,
-    keywords: [],
-    name: connector.name,
-    serviceType: connector.service_type ?? '',
-  };
+  const nativeConnector =
+    NATIVE_CONNECTORS.find(
+      (connectorDefinition) => connectorDefinition.serviceType === connector.service_type
+    ) || CUSTOM_CONNECTOR[0];
 
   const iconPath = nativeConnector.iconPath;
   const hasApiKey = !!(connector.api_key_id ?? apiKeyData);
 
-  // TODO service_type === "" is considered unknown/custom connector multipleplaces replace all of them with a better solution
   const isBeta =
     !connector.service_type ||
     Boolean(BETA_CONNECTORS.find(({ serviceType }) => serviceType === connector.service_type));

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_type.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_type.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { useValues } from 'kea';
 
@@ -23,7 +23,13 @@ export interface ConnectorTypeProps {
 
 export const ConnectorType: React.FC<ConnectorTypeProps> = ({ serviceType }) => {
   const { connectorTypes } = useValues(KibanaLogic);
-  const connector = connectorTypes.find((c) => c.serviceType === serviceType);
+  // TODO service_type === "" is considered unknown/custom connector multiple places replace all of them with a better solution
+  const CUSTOM_CONNECTOR = useMemo(
+    () => connectorTypes.filter(({ serviceType: type }) => type === ''),
+    [connectorTypes]
+  );
+  const connector =
+    connectorTypes.find((c) => c.serviceType === serviceType) || CUSTOM_CONNECTOR[0];
   return (
     <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
       {connector && connector.iconPath && (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Search][Connectors] Fixing custom connector icon rendering (#212225)](https://github.com/elastic/kibana/pull/212225)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"José Luis González","email":"joseluisgj@gmail.com"},"sourceCommit":{"committedDate":"2025-02-25T14:49:33Z","message":"[Search][Connectors] Fixing custom connector icon rendering (#212225)\n\n## Summary\r\n\r\nFixing areas where we were not rendering well the custom connector icon\r\nas described in this ticket:\r\nhttps://github.com/elastic/search-team/issues/9362\r\n\r\n![CleanShot 2025-02-24 at 13 16\r\n44@2x](https://github.com/user-attachments/assets/9db5a0f6-92a7-4d92-97e2-620ad93b617d)\r\n\r\n![CleanShot 2025-02-24 at 13 16\r\n58@2x](https://github.com/user-attachments/assets/392dc640-ad01-43d8-9b6a-112d439b3486)\r\n\r\n![CleanShot 2025-02-24 at 13 17\r\n07@2x](https://github.com/user-attachments/assets/c92efa28-8a4b-4941-acc2-be59f08e5a21)\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...","sha":"965cbbabc0d59fa3419d0238b4eb460ab930d2db","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Search","backport:prev-major","backport:version","v9.1.0"],"title":"[Search][Connectors] Fixing custom connector icon rendering","number":212225,"url":"https://github.com/elastic/kibana/pull/212225","mergeCommit":{"message":"[Search][Connectors] Fixing custom connector icon rendering (#212225)\n\n## Summary\r\n\r\nFixing areas where we were not rendering well the custom connector icon\r\nas described in this ticket:\r\nhttps://github.com/elastic/search-team/issues/9362\r\n\r\n![CleanShot 2025-02-24 at 13 16\r\n44@2x](https://github.com/user-attachments/assets/9db5a0f6-92a7-4d92-97e2-620ad93b617d)\r\n\r\n![CleanShot 2025-02-24 at 13 16\r\n58@2x](https://github.com/user-attachments/assets/392dc640-ad01-43d8-9b6a-112d439b3486)\r\n\r\n![CleanShot 2025-02-24 at 13 17\r\n07@2x](https://github.com/user-attachments/assets/c92efa28-8a4b-4941-acc2-be59f08e5a21)\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...","sha":"965cbbabc0d59fa3419d0238b4eb460ab930d2db"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212386","number":212386,"state":"MERGED","mergeCommit":{"sha":"e6799ea001e2ef5178294d3e7dc570e7861d19c7","message":"[9.0] [Search][Connectors] Fixing custom connector icon rendering (#212225) (#212386)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Search][Connectors] Fixing custom connector icon rendering\n(#212225)](https://github.com/elastic/kibana/pull/212225)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: José Luis González <joseluisgj@gmail.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212225","number":212225,"mergeCommit":{"message":"[Search][Connectors] Fixing custom connector icon rendering (#212225)\n\n## Summary\r\n\r\nFixing areas where we were not rendering well the custom connector icon\r\nas described in this ticket:\r\nhttps://github.com/elastic/search-team/issues/9362\r\n\r\n![CleanShot 2025-02-24 at 13 16\r\n44@2x](https://github.com/user-attachments/assets/9db5a0f6-92a7-4d92-97e2-620ad93b617d)\r\n\r\n![CleanShot 2025-02-24 at 13 16\r\n58@2x](https://github.com/user-attachments/assets/392dc640-ad01-43d8-9b6a-112d439b3486)\r\n\r\n![CleanShot 2025-02-24 at 13 17\r\n07@2x](https://github.com/user-attachments/assets/c92efa28-8a4b-4941-acc2-be59f08e5a21)\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...","sha":"965cbbabc0d59fa3419d0238b4eb460ab930d2db"}}]}] BACKPORT-->