### PR TITLE
[8.17] [Bug][Assistant API] - chat/complete endpoint is not persisting the model response to the chosen conversation ID (#11783) (#212122)

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/routes/chat/chat_complete_route.test.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/chat/chat_complete_route.test.ts
@@ -44,6 +44,7 @@ jest.mock('../helpers', () => {
   };
 });
 const mockAppendAssistantMessageToConversation = appendAssistantMessageToConversation as jest.Mock;
+const mockCreateConversationWithUserInput = createConversationWithUserInput as jest.Mock;
 
 const mockLangChainExecute = langChainExecute as jest.Mock;
 const mockStream = jest.fn().mockImplementation(() => new PassThrough());
@@ -149,7 +150,7 @@ describe('chatCompleteRoute', () => {
     jest.clearAllMocks();
     mockAppendAssistantMessageToConversation.mockResolvedValue(true);
     license.hasAtLeast.mockReturnValue(true);
-    (createConversationWithUserInput as jest.Mock).mockResolvedValue({ id: 'something' });
+    mockCreateConversationWithUserInput.mockResolvedValue({ id: 'something' });
     mockLangChainExecute.mockImplementation(
       async ({
         connectorId,
@@ -165,12 +166,14 @@ describe('chatCompleteRoute', () => {
         ) => Promise<void>;
       }) => {
         if (!isStream && connectorId === 'mock-connector-id') {
+          onLlmResponse('Non-streamed test reply.', {}, false).catch(() => {});
           return {
             connector_id: 'mock-connector-id',
             data: mockActionResponse,
             status: 'ok',
           };
         } else if (isStream && connectorId === 'mock-connector-id') {
+          onLlmResponse('Streamed test reply.', {}, false).catch(() => {});
           return mockStream;
         } else {
           onLlmResponse('simulated error', {}, true).catch(() => {});
@@ -394,6 +397,143 @@ describe('chatCompleteRoute', () => {
       },
     };
     await chatCompleteRoute(
+      mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>,
+      mockGetElser
+    );
+  });
+
+  it('should add assistant reply to existing conversation when `persist=true`', async () => {
+    const mockRouter = {
+      versioned: {
+        post: jest.fn().mockImplementation(() => {
+          return {
+            addVersion: jest.fn().mockImplementation(async (_, handler) => {
+              await handler(
+                mockContext,
+                {
+                  ...mockRequest,
+                  body: {
+                    ...mockRequest.body,
+                    conversationId: existingConversation.id,
+                  },
+                },
+                mockResponse
+              );
+              expect(mockAppendAssistantMessageToConversation).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  messageContent: 'Non-streamed test reply.',
+                  isError: false,
+                })
+              );
+              expect(mockCreateConversationWithUserInput).toHaveBeenCalledTimes(0);
+            }),
+          };
+        }),
+      },
+    };
+
+    chatCompleteRoute(
+      mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>,
+      mockGetElser
+    );
+  });
+
+  it('should not add assistant reply to existing conversation when `persist=false`', async () => {
+    const mockRouter = {
+      versioned: {
+        post: jest.fn().mockImplementation(() => {
+          return {
+            addVersion: jest.fn().mockImplementation(async (_, handler) => {
+              await handler(
+                mockContext,
+                {
+                  ...mockRequest,
+                  body: {
+                    ...mockRequest.body,
+                    conversationId: existingConversation.id,
+                    persist: false,
+                  },
+                },
+                mockResponse
+              );
+              expect(mockAppendAssistantMessageToConversation).toHaveBeenCalledTimes(0);
+              expect(mockCreateConversationWithUserInput).toHaveBeenCalledTimes(0);
+            }),
+          };
+        }),
+      },
+    };
+
+    chatCompleteRoute(
+      mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>,
+      mockGetElser
+    );
+  });
+
+  it('should add assistant reply to new conversation when `persist=true`', async () => {
+    const mockRouter = {
+      versioned: {
+        post: jest.fn().mockImplementation(() => {
+          return {
+            addVersion: jest.fn().mockImplementation(async (_, handler) => {
+              await handler(
+                mockContext,
+                {
+                  ...mockRequest,
+                  body: {
+                    ...mockRequest.body,
+                    conversationId: undefined,
+                    persist: true,
+                  },
+                },
+                mockResponse
+              );
+              expect(mockAppendAssistantMessageToConversation).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  messageContent: 'Non-streamed test reply.',
+                  isError: false,
+                })
+              );
+              expect(mockCreateConversationWithUserInput).toHaveBeenCalledTimes(1);
+            }),
+          };
+        }),
+      },
+    };
+
+    chatCompleteRoute(
+      mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>,
+      mockGetElser
+    );
+  });
+
+  it('should not create a new conversation when `persist=false`', async () => {
+    const mockRouter = {
+      versioned: {
+        post: jest.fn().mockImplementation(() => {
+          return {
+            addVersion: jest.fn().mockImplementation(async (_, handler) => {
+              await handler(
+                mockContext,
+                {
+                  ...mockRequest,
+                  body: {
+                    ...mockRequest.body,
+                    conversationId: undefined,
+                    persist: false,
+                  },
+                },
+                mockResponse
+              );
+              expect(mockAppendAssistantMessageToConversation).toHaveBeenCalledTimes(0);
+              expect(mockCreateConversationWithUserInput).toHaveBeenCalledTimes(0);
+            }),
+          };
+        }),
+      },
+    };
+
+    chatCompleteRoute(
       mockRouter as unknown as IRouter<ElasticAssistantRequestHandlerContext>,
       mockGetElser
     );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Bug][Assistant API] - chat/complete endpoint is not persisting the model response to the chosen conversation ID (#11783) (#212122)](https://github.com/elastic/kibana/pull/212122)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2025-02-26T11:03:09Z","message":"[Bug][Assistant API] - chat/complete endpoint is not persisting the model response to the chosen conversation ID (#11783) (#212122)\n\n## Summary\n\nBUG: https://github.com/elastic/security-team/issues/11783\n\nThis PR fixes the behaviour of the\n`/api/security_ai_assistant/chat/complete` route where the `persist`\nflag:\n1. when set to `true` does not append the assistant reply to existing\nconversation\n2. when set to `false` appends user message to existing conversation\n\n### Expected behaviour\n\n\n[Details](https://github.com/elastic/security-team/issues/11783#issuecomment-2674565194).\n\n1. `conversationId == undefined && persist == false`: no new\nconversations and nothing persisted\n2. `conversationId == undefined && persist == true`: new conversations\nis created and both user message and assistant reply appended to the new\nconversation\n3. `conversationId == 'existing-id' && persist == false`: nothing\nappended to the existing conversation\n4. `conversationId == 'existing-id' && persist == true`: both user\nmessage and assistant reply appended to the existing conversation\n\n### Testing\n\n* Use this `curl` command (with replace `connectorId` and\n`conversationId`) to test the endpoint.\n\n```\ncurl --location 'http://localhost:5601/api/security_ai_assistant/chat/complete' \\\n--header 'kbn-xsrf: true' \\\n--header 'Content-Type: application/json' \\\n--data '{\n  \"connectorId\": \"{{my-gpt4o-ai}}\",\n  \"conversationId\": \"{{existing-conversation-id | undefined}}\",\n  \"isStream\": false,\n  \"messages\": [\n    {\n      \"content\": \"Follow up\",\n      \"role\": \"user\"\n    }\n  ],\n  \"persist\": true\n}'\n```\n\n* To retrieve the conversation ID:\n(/api/security_ai_assistant/current_user/conversations/_find)\n* `conversationId` can be either existing conversation id or `undefined`","sha":"a2b2e81b5b74ffc56302953d186a36984b3b1c23","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team: SecuritySolution","Team:Security Generative AI","backport:version","v8.17.0","v8.18.0","v9.1.0","v8.19.0"],"title":"[Bug][Assistant API] - chat/complete endpoint is not persisting the model response to the chosen conversation ID (#11783)","number":212122,"url":"https://github.com/elastic/kibana/pull/212122","mergeCommit":{"message":"[Bug][Assistant API] - chat/complete endpoint is not persisting the model response to the chosen conversation ID (#11783) (#212122)\n\n## Summary\n\nBUG: https://github.com/elastic/security-team/issues/11783\n\nThis PR fixes the behaviour of the\n`/api/security_ai_assistant/chat/complete` route where the `persist`\nflag:\n1. when set to `true` does not append the assistant reply to existing\nconversation\n2. when set to `false` appends user message to existing conversation\n\n### Expected behaviour\n\n\n[Details](https://github.com/elastic/security-team/issues/11783#issuecomment-2674565194).\n\n1. `conversationId == undefined && persist == false`: no new\nconversations and nothing persisted\n2. `conversationId == undefined && persist == true`: new conversations\nis created and both user message and assistant reply appended to the new\nconversation\n3. `conversationId == 'existing-id' && persist == false`: nothing\nappended to the existing conversation\n4. `conversationId == 'existing-id' && persist == true`: both user\nmessage and assistant reply appended to the existing conversation\n\n### Testing\n\n* Use this `curl` command (with replace `connectorId` and\n`conversationId`) to test the endpoint.\n\n```\ncurl --location 'http://localhost:5601/api/security_ai_assistant/chat/complete' \\\n--header 'kbn-xsrf: true' \\\n--header 'Content-Type: application/json' \\\n--data '{\n  \"connectorId\": \"{{my-gpt4o-ai}}\",\n  \"conversationId\": \"{{existing-conversation-id | undefined}}\",\n  \"isStream\": false,\n  \"messages\": [\n    {\n      \"content\": \"Follow up\",\n      \"role\": \"user\"\n    }\n  ],\n  \"persist\": true\n}'\n```\n\n* To retrieve the conversation ID:\n(/api/security_ai_assistant/current_user/conversations/_find)\n* `conversationId` can be either existing conversation id or `undefined`","sha":"a2b2e81b5b74ffc56302953d186a36984b3b1c23"}},"sourceBranch":"main","suggestedTargetBranches":["8.17","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212501","number":212501,"state":"OPEN"},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212500","number":212500,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212122","number":212122,"mergeCommit":{"message":"[Bug][Assistant API] - chat/complete endpoint is not persisting the model response to the chosen conversation ID (#11783) (#212122)\n\n## Summary\n\nBUG: https://github.com/elastic/security-team/issues/11783\n\nThis PR fixes the behaviour of the\n`/api/security_ai_assistant/chat/complete` route where the `persist`\nflag:\n1. when set to `true` does not append the assistant reply to existing\nconversation\n2. when set to `false` appends user message to existing conversation\n\n### Expected behaviour\n\n\n[Details](https://github.com/elastic/security-team/issues/11783#issuecomment-2674565194).\n\n1. `conversationId == undefined && persist == false`: no new\nconversations and nothing persisted\n2. `conversationId == undefined && persist == true`: new conversations\nis created and both user message and assistant reply appended to the new\nconversation\n3. `conversationId == 'existing-id' && persist == false`: nothing\nappended to the existing conversation\n4. `conversationId == 'existing-id' && persist == true`: both user\nmessage and assistant reply appended to the existing conversation\n\n### Testing\n\n* Use this `curl` command (with replace `connectorId` and\n`conversationId`) to test the endpoint.\n\n```\ncurl --location 'http://localhost:5601/api/security_ai_assistant/chat/complete' \\\n--header 'kbn-xsrf: true' \\\n--header 'Content-Type: application/json' \\\n--data '{\n  \"connectorId\": \"{{my-gpt4o-ai}}\",\n  \"conversationId\": \"{{existing-conversation-id | undefined}}\",\n  \"isStream\": false,\n  \"messages\": [\n    {\n      \"content\": \"Follow up\",\n      \"role\": \"user\"\n    }\n  ],\n  \"persist\": true\n}'\n```\n\n* To retrieve the conversation ID:\n(/api/security_ai_assistant/current_user/conversations/_find)\n* `conversationId` can be either existing conversation id or `undefined`","sha":"a2b2e81b5b74ffc56302953d186a36984b3b1c23"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->