### PR TITLE
[8.x] [Security Solution] [AI Assistant] Clean up content references code (#208902)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock.ts
@@ -7,7 +7,7 @@
 
 import { ContentReferencesStore } from '../../types';
 
-export const contentReferencesStoreFactoryMock: () => ContentReferencesStore = jest
+export const newContentReferencesStoreMock: () => ContentReferencesStore = jest
   .fn()
   .mockReturnValue({
     add: jest.fn().mockImplementation((creator: Parameters<ContentReferencesStore['add']>[0]) => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/content_references_store.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/content_references_store.test.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { contentReferencesStoreFactory } from './content_references_store_factory';
+import { newContentReferencesStore } from './content_references_store';
 import { securityAlertsPageReference } from '../references';
 import { ContentReferencesStore } from '../types';
 
-describe('contentReferencesStoreFactory', () => {
+describe('newContentReferencesStore', () => {
   let contentReferencesStore: ContentReferencesStore;
   beforeEach(() => {
-    contentReferencesStore = contentReferencesStoreFactory();
+    contentReferencesStore = newContentReferencesStore();
   });
 
   it('adds multiple content reference', async () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/content_references_store.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/content_references_store.ts
@@ -14,7 +14,7 @@ const CONTENT_REFERENCE_ID_ALPHABET =
 /**
  * Creates a new ContentReferencesStore used for storing references (also known as citations)
  */
-export const contentReferencesStoreFactory: () => ContentReferencesStore = () => {
+export const newContentReferencesStore: () => ContentReferencesStore = () => {
   const store = new Map<string, ContentReference>();
 
   const add: ContentReferencesStore['add'] = (creator) => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/prune_content_references.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/prune_content_references.test.ts
@@ -9,12 +9,12 @@ import { pruneContentReferences } from './prune_content_references';
 import { securityAlertsPageReference } from '../references';
 import { contentReferenceBlock } from '../references/utils';
 import { ContentReferencesStore } from '../types';
-import { contentReferencesStoreFactory } from './content_references_store_factory';
+import { newContentReferencesStore } from './content_references_store';
 
 describe('pruneContentReferences', () => {
   let contentReferencesStore: ContentReferencesStore;
   beforeEach(() => {
-    contentReferencesStore = contentReferencesStoreFactory();
+    contentReferencesStore = newContentReferencesStore();
   });
 
   it('prunes content references correctly', async () => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export { contentReferencesStoreFactory } from './content_references_store/content_references_store_factory';
+export { newContentReferencesStore } from './content_references_store/content_references_store';
 export { pruneContentReferences } from './content_references_store/prune_content_references';
 export {
   securityAlertReference,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/index.ts
@@ -23,7 +23,7 @@ export {
 } from './impl/data_anonymization/helpers';
 
 export {
-  contentReferencesStoreFactory,
+  newContentReferencesStore,
   securityAlertReference,
   knowledgeBaseReference,
   securityAlertsPageReference,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.test.tsx
@@ -16,7 +16,7 @@ import {
 import { authenticatedUser } from '../../__mocks__/user';
 import { getCreateKnowledgeBaseEntrySchemaMock } from '../../__mocks__/knowledge_base_entry_schema.mock';
 import { ContentReferencesStore, IndexEntry } from '@kbn/elastic-assistant-common';
-import { contentReferencesStoreFactoryMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
+import { newContentReferencesStoreMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
 import { isString } from 'lodash';
 
 // Mock dependencies
@@ -146,7 +146,7 @@ describe('getStructuredToolForIndexEntry', () => {
   const mockEsClient = {} as ElasticsearchClient;
 
   const mockIndexEntry = getCreateKnowledgeBaseEntrySchemaMock({ type: 'index' }) as IndexEntry;
-  const contentReferencesStore = contentReferencesStoreFactoryMock();
+  const contentReferencesStore = newContentReferencesStoreMock();
 
   it('should return a DynamicStructuredTool with correct name and schema', () => {
     const tool = getStructuredToolForIndexEntry({

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/helpers.ts
@@ -153,7 +153,7 @@ export const getStructuredToolForIndexEntry = ({
 }: {
   indexEntry: IndexEntry;
   esClient: ElasticsearchClient;
-  contentReferencesStore: ContentReferencesStore | false;
+  contentReferencesStore: ContentReferencesStore | undefined;
   logger: Logger;
 }): DynamicStructuredTool => {
   const inputSchema = indexEntry.inputSchema?.reduce((prev, input) => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.test.ts
@@ -27,7 +27,7 @@ import {
   getSecurityLabsDocsCount,
 } from '../../lib/langchain/content_loaders/security_labs_loader';
 import { DynamicStructuredTool } from '@langchain/core/tools';
-import { contentReferencesStoreFactoryMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
+import { newContentReferencesStoreMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
 jest.mock('../../lib/langchain/content_loaders/security_labs_loader');
 jest.mock('p-retry');
 const date = '2023-03-28T22:27:28.159Z';
@@ -522,7 +522,7 @@ describe('AIAssistantKnowledgeBaseDataClient', () => {
 
       const result = await client.getAssistantTools({
         esClient: esClientMock,
-        contentReferencesStore: contentReferencesStoreFactoryMock(),
+        contentReferencesStore: newContentReferencesStoreMock(),
       });
 
       expect(result).toHaveLength(1);
@@ -537,7 +537,7 @@ describe('AIAssistantKnowledgeBaseDataClient', () => {
 
       const result = await client.getAssistantTools({
         esClient: esClientMock,
-        contentReferencesStore: contentReferencesStoreFactoryMock(),
+        contentReferencesStore: newContentReferencesStoreMock(),
       });
 
       expect(result).toEqual([]);
@@ -550,7 +550,7 @@ describe('AIAssistantKnowledgeBaseDataClient', () => {
 
       const result = await client.getAssistantTools({
         esClient: esClientMock,
-        contentReferencesStore: contentReferencesStoreFactoryMock(),
+        contentReferencesStore: newContentReferencesStoreMock(),
       });
 
       expect(result).toEqual([]);

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
@@ -817,7 +817,7 @@ export class AIAssistantKnowledgeBaseDataClient extends AIAssistantDataClient {
     contentReferencesStore,
     esClient,
   }: {
-    contentReferencesStore: ContentReferencesStore | false;
+    contentReferencesStore: ContentReferencesStore | undefined;
     esClient: ElasticsearchClient;
   }): Promise<StructuredTool[]> => {
     const user = this.options.currentUser;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/executors/types.ts
@@ -49,7 +49,7 @@ export interface AgentExecutorParams<T extends boolean> {
   assistantTools?: AssistantTool[];
   connectorId: string;
   conversationId?: string;
-  contentReferencesStore: ContentReferencesStore | false;
+  contentReferencesStore: ContentReferencesStore | undefined;
   dataClients?: AssistantDataClients;
   esClient: ElasticsearchClient;
   langChainMessages: BaseMessage[];

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/langchain/graphs/default_assistant_graph/index.test.ts
@@ -19,7 +19,7 @@ import {
   createStructuredChatAgent,
   createToolCallingAgent,
 } from 'langchain/agents';
-import { contentReferencesStoreFactoryMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
+import { newContentReferencesStoreMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
 import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
 import { AssistantTool, AssistantToolParams } from '../../../..';
 import { promptGroupId as toolsGroupId } from '../../../prompt/tool_prompts';
@@ -84,7 +84,7 @@ describe('callAssistantGraph', () => {
     telemetryParams: {},
     traceOptions: {},
     responseLanguage: 'English',
-    contentReferencesStore: contentReferencesStoreFactoryMock(),
+    contentReferencesStore: newContentReferencesStoreMock(),
   } as unknown as AgentExecutorParams<boolean>;
 
   beforeEach(() => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.ts
@@ -16,7 +16,7 @@ import {
   transformRawData,
   getAnonymizedValue,
   ConversationResponse,
-  contentReferencesStoreFactory,
+  newContentReferencesStore,
   pruneContentReferences,
 } from '@kbn/elastic-assistant-common';
 import { buildRouteValidationWithZod } from '@kbn/elastic-assistant-common/impl/schemas/common';
@@ -186,8 +186,9 @@ export const chatCompleteRoute = (
             }));
           }
 
-          const contentReferencesStore =
-            contentReferencesEnabled && contentReferencesStoreFactory();
+          const contentReferencesStore = contentReferencesEnabled
+            ? newContentReferencesStore()
+            : undefined;
 
           const onLlmResponse = async (
             content: string,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/helpers.ts
@@ -124,7 +124,7 @@ export function getAssistantToolParams({
   langSmithProject?: string;
   langSmithApiKey?: string;
   logger: Logger;
-  contentReferencesStore: ContentReferencesStore | false;
+  contentReferencesStore: ContentReferencesStore | undefined;
   latestReplacements: Replacements;
   onNewReplacements: (newReplacements: Replacements) => void;
   request: KibanaRequest<unknown, unknown, DefendInsightsPostRequestBody>;
@@ -136,7 +136,7 @@ export function getAssistantToolParams({
   langChainTimeout: number;
   llm: ActionsClientLlm;
   logger: Logger;
-  contentReferencesStore: ContentReferencesStore | false;
+  contentReferencesStore: ContentReferencesStore | undefined;
   replacements: Replacements;
   onNewReplacements: (newReplacements: Replacements) => void;
   request: KibanaRequest<unknown, unknown, DefendInsightsPostRequestBody>;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
@@ -152,7 +152,7 @@ export const postDefendInsightsRoute = (router: IRouter<ElasticAssistantRequestH
             apiConfig,
             esClient,
             latestReplacements,
-            contentReferencesStore: false,
+            contentReferencesStore: undefined,
             connectorTimeout: CONNECTOR_TIMEOUT,
             langChainTimeout: LANG_CHAIN_TIMEOUT,
             langSmithProject,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/evaluate/post_evaluate.ts
@@ -16,7 +16,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { getPrompt } from '@kbn/security-ai-prompts';
 import {
   API_VERSIONS,
-  contentReferencesStoreFactory,
+  newContentReferencesStore,
   ELASTIC_AI_ASSISTANT_EVALUATE_URL,
   ExecuteConnectorRequestBody,
   INTERNAL_API_ACCESS,
@@ -294,8 +294,9 @@ export const postEvaluateRoute = (
                 assistantContext.getRegisteredFeatures(
                   DEFAULT_PLUGIN_NAME
                 ).contentReferencesEnabled;
-              const contentReferencesStore =
-                contentReferencesEnabled && contentReferencesStoreFactory();
+              const contentReferencesStore = contentReferencesEnabled
+                ? newContentReferencesStore()
+                : undefined;
 
               // Fetch any applicable tools that the source plugin may have registered
               const assistantToolParams: AssistantToolParams = {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/helpers.ts
@@ -232,7 +232,7 @@ export interface LangChainExecuteParams {
   telemetry: AnalyticsServiceSetup;
   actionTypeId: string;
   connectorId: string;
-  contentReferencesStore: ContentReferencesStore | false;
+  contentReferencesStore: ContentReferencesStore | undefined;
   llmTasks?: LlmTasksPluginStart;
   inference: InferenceServerStart;
   isOssModel?: boolean;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
@@ -12,7 +12,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { schema } from '@kbn/config-schema';
 import {
   API_VERSIONS,
-  contentReferencesStoreFactory,
+  newContentReferencesStore,
   ExecuteConnectorRequestBody,
   Message,
   Replacements,
@@ -119,8 +119,9 @@ export const postActionsConnectorExecuteRoute = (
             });
           const promptsDataClient = await assistantContext.getAIAssistantPromptsDataClient();
 
-          const contentReferencesStore =
-            contentReferencesEnabled && contentReferencesStoreFactory();
+          const contentReferencesStore = contentReferencesEnabled
+            ? newContentReferencesStore()
+            : undefined;
 
           onLlmResponse = async (
             content: string,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/types.ts
@@ -239,8 +239,8 @@ export interface AssistantToolParams {
   inference?: InferenceServerStart;
   isEnabledKnowledgeBase: boolean;
   connectorId?: string;
-  contentReferencesStore: ContentReferencesStore | false;
   description?: string;
+  contentReferencesStore: ContentReferencesStore | undefined;
   esClient: ElasticsearchClient;
   kbDataClient?: AIAssistantKnowledgeBaseDataClient;
   langChainTimeout?: number;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.test.ts
@@ -13,7 +13,7 @@ import { ALERT_COUNTS_TOOL } from './alert_counts_tool';
 import type { RetrievalQAChain } from 'langchain/chains';
 import type { ExecuteConnectorRequestBody } from '@kbn/elastic-assistant-common/impl/schemas/actions_connector/post_actions_connector_execute_route.gen';
 import type { ContentReferencesStore } from '@kbn/elastic-assistant-common';
-import { contentReferencesStoreFactoryMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
+import { newContentReferencesStoreMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
 
 describe('AlertCountsTool', () => {
   const alertsIndexPattern = 'alerts-index';
@@ -32,7 +32,7 @@ describe('AlertCountsTool', () => {
   const isEnabledKnowledgeBase = true;
   const chain = {} as unknown as RetrievalQAChain;
   const logger = loggerMock.create();
-  const contentReferencesStore = contentReferencesStoreFactoryMock();
+  const contentReferencesStore = newContentReferencesStoreMock();
   const rest = {
     isEnabledKnowledgeBase,
     chain,
@@ -191,7 +191,7 @@ describe('AlertCountsTool', () => {
         replacements,
         request,
         ...rest,
-        contentReferencesStore: false,
+        contentReferencesStore: undefined,
       }) as DynamicTool;
 
       const result = await tool.func('');

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.test.ts
@@ -12,13 +12,13 @@ import type {
   ContentReferencesStore,
   KnowledgeBaseEntryContentReference,
 } from '@kbn/elastic-assistant-common';
-import { contentReferencesStoreFactoryMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
+import { newContentReferencesStoreMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
 import { loggerMock } from '@kbn/logging-mocks';
 import { Document } from 'langchain/document';
 
 describe('KnowledgeBaseRetievalTool', () => {
   const logger = loggerMock.create();
-  const contentReferencesStore = contentReferencesStoreFactoryMock();
+  const contentReferencesStore = newContentReferencesStoreMock();
   const getKnowledgeBaseDocumentEntries = jest.fn();
   const kbDataClient = { getKnowledgeBaseDocumentEntries };
   const defaultArgs = {
@@ -68,7 +68,7 @@ describe('KnowledgeBaseRetievalTool', () => {
     it('does not include citations if contentReferenceStore is false', async () => {
       const tool = KNOWLEDGE_BASE_RETRIEVAL_TOOL.getTool({
         ...defaultArgs,
-        contentReferencesStore: false,
+        contentReferencesStore: undefined,
       }) as DynamicStructuredTool;
 
       getKnowledgeBaseDocumentEntries.mockResolvedValue([

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.test.ts
@@ -18,7 +18,7 @@ import type {
   ContentReferencesStore,
   SecurityAlertContentReference,
 } from '@kbn/elastic-assistant-common';
-import { contentReferencesStoreFactoryMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
+import { newContentReferencesStoreMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
 
 const MAX_SIZE = 10000;
 
@@ -44,7 +44,7 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
   const isEnabledKnowledgeBase = true;
   const chain = {} as unknown as RetrievalQAChain;
   const logger = loggerMock.create();
-  const contentReferencesStore = contentReferencesStoreFactoryMock();
+  const contentReferencesStore = newContentReferencesStoreMock();
   const rest = {
     isEnabledKnowledgeBase,
     esClient,
@@ -274,7 +274,7 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
         request,
         size: request.body.size,
         ...rest,
-        contentReferencesStore: false,
+        contentReferencesStore: undefined,
       }) as DynamicTool;
 
       (esClient.search as jest.Mock).mockResolvedValue({

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.test.ts
@@ -20,7 +20,7 @@ import type {
   ContentReferencesStore,
   ProductDocumentationContentReference,
 } from '@kbn/elastic-assistant-common';
-import { contentReferencesStoreFactoryMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
+import { newContentReferencesStoreMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
 
 describe('ProductDocumentationTool', () => {
   const chain = {} as RetrievalQAChain;
@@ -35,7 +35,7 @@ describe('ProductDocumentationTool', () => {
     retrieveDocumentationAvailable: jest.fn(),
   } as LlmTasksPluginStart;
   const connectorId = 'fake-connector';
-  const contentReferencesStore = contentReferencesStoreFactoryMock();
+  const contentReferencesStore = newContentReferencesStoreMock();
   const defaultArgs = {
     chain,
     esClient,
@@ -144,7 +144,7 @@ describe('ProductDocumentationTool', () => {
     it('does not include citations if contentReferencesStore is false', async () => {
       const tool = PRODUCT_DOCUMENTATION_TOOL.getTool({
         ...defaultArgs,
-        contentReferencesStore: false,
+        contentReferencesStore: undefined,
       }) as DynamicStructuredTool;
 
       (retrieveDocumentation as jest.Mock).mockResolvedValue({

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/security_labs/security_labs_tool.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/security_labs/security_labs_tool.test.ts
@@ -11,11 +11,11 @@ import type {
   ContentReferencesStore,
   KnowledgeBaseEntryContentReference,
 } from '@kbn/elastic-assistant-common';
-import { contentReferencesStoreFactoryMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
+import { newContentReferencesStoreMock } from '@kbn/elastic-assistant-common/impl/content_references/content_references_store/__mocks__/content_references_store.mock';
 import type { AssistantToolParams } from '@kbn/elastic-assistant-plugin/server';
 
 describe('SecurityLabsTool', () => {
-  const contentReferencesStore = contentReferencesStoreFactoryMock();
+  const contentReferencesStore = newContentReferencesStoreMock();
   const getKnowledgeBaseDocumentEntries = jest.fn().mockResolvedValue([]);
   const kbDataClient = { getKnowledgeBaseDocumentEntries };
   const defaultArgs = {
@@ -54,7 +54,7 @@ describe('SecurityLabsTool', () => {
     it('does not include citations when contentReferencesStore is false', async () => {
       const tool = SECURITY_LABS_KNOWLEDGE_BASE_TOOL.getTool({
         ...defaultArgs,
-        contentReferencesStore: false,
+        contentReferencesStore: undefined,
       }) as DynamicStructuredTool;
 
       const result = await tool.func({ query: 'What is Kibana Security?', product: 'kibana' });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution] [AI Assistant] Clean up content references code (#208902)](https://github.com/elastic/kibana/pull/208902)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kenneth Kreindler","email":"42113355+KDKHD@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-03T14:53:43Z","message":"[Security Solution] [AI Assistant] Clean up content references code (#208902)\n\n## Summary\r\n\r\nThis PR addressed the remaining comments left in:\r\nhttps://github.com/elastic/kibana/pull/206683. This PR does not contain\r\nany material changes. It is just fixing some types and variable naming.\r\n\r\nChanges:\r\n- Fix the\r\n[type](https://github.com/elastic/kibana/pull/208902/files#diff-9f3f1c92910d7207ed15dd7bc3289d0a8a6bd7f656584fce33cfbad40823a32bL52)\r\nof the optional content reference store. Once the feature flag is\r\nremoved, the content reference store will no longer be optional.\r\n- Rename `contentReferencesStoreFactory()` to\r\n`newContentReferencesStore()` because it is not actually a factory\r\nmethod and was named poorly.\r\n- Update [structured system\r\nprompt](https://github.com/elastic/kibana/pull/208902/files#diff-1efcb0cc37b72d43ee9ff1036fad33f143c577a9c9818e3c8ace2efbfc9e64b0R26)\r\nto include instructions for citations too.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [X] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [X]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [X] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [X] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [X] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [X] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [X] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0f62fa1d3070df8cc7251274b294586efaf017a6","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Security Generative AI","backport:version","v8.18.0","v9.1.0"],"title":"[Security Solution] [AI Assistant] Clean up content references code","number":208902,"url":"https://github.com/elastic/kibana/pull/208902","mergeCommit":{"message":"[Security Solution] [AI Assistant] Clean up content references code (#208902)\n\n## Summary\r\n\r\nThis PR addressed the remaining comments left in:\r\nhttps://github.com/elastic/kibana/pull/206683. This PR does not contain\r\nany material changes. It is just fixing some types and variable naming.\r\n\r\nChanges:\r\n- Fix the\r\n[type](https://github.com/elastic/kibana/pull/208902/files#diff-9f3f1c92910d7207ed15dd7bc3289d0a8a6bd7f656584fce33cfbad40823a32bL52)\r\nof the optional content reference store. Once the feature flag is\r\nremoved, the content reference store will no longer be optional.\r\n- Rename `contentReferencesStoreFactory()` to\r\n`newContentReferencesStore()` because it is not actually a factory\r\nmethod and was named poorly.\r\n- Update [structured system\r\nprompt](https://github.com/elastic/kibana/pull/208902/files#diff-1efcb0cc37b72d43ee9ff1036fad33f143c577a9c9818e3c8ace2efbfc9e64b0R26)\r\nto include instructions for citations too.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [X] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [X]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [X] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [X] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [X] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [X] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [X] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0f62fa1d3070df8cc7251274b294586efaf017a6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209327","number":209327,"state":"MERGED","mergeCommit":{"sha":"ae16f8d469b576299e388d6acf66d25d72d428fc","message":"[9.0] [Security Solution] [AI Assistant] Clean up content references code (#208902) (#209327)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution] [AI Assistant] Clean up content references code\n(#208902)](https://github.com/elastic/kibana/pull/208902)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Kenneth Kreindler <42113355+KDKHD@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209326","number":209326,"state":"MERGED","mergeCommit":{"sha":"ab08a89bb20c3e93ebb1f2f679a100f3be6281ed","message":"[8.18] [Security Solution] [AI Assistant] Clean up content references code (#208902) (#209326)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Security Solution] [AI Assistant] Clean up content references code\n(#208902)](https://github.com/elastic/kibana/pull/208902)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Kenneth Kreindler <42113355+KDKHD@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208902","number":208902,"mergeCommit":{"message":"[Security Solution] [AI Assistant] Clean up content references code (#208902)\n\n## Summary\r\n\r\nThis PR addressed the remaining comments left in:\r\nhttps://github.com/elastic/kibana/pull/206683. This PR does not contain\r\nany material changes. It is just fixing some types and variable naming.\r\n\r\nChanges:\r\n- Fix the\r\n[type](https://github.com/elastic/kibana/pull/208902/files#diff-9f3f1c92910d7207ed15dd7bc3289d0a8a6bd7f656584fce33cfbad40823a32bL52)\r\nof the optional content reference store. Once the feature flag is\r\nremoved, the content reference store will no longer be optional.\r\n- Rename `contentReferencesStoreFactory()` to\r\n`newContentReferencesStore()` because it is not actually a factory\r\nmethod and was named poorly.\r\n- Update [structured system\r\nprompt](https://github.com/elastic/kibana/pull/208902/files#diff-1efcb0cc37b72d43ee9ff1036fad33f143c577a9c9818e3c8ace2efbfc9e64b0R26)\r\nto include instructions for citations too.\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [X] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\r\n- [X]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [X] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [X] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [X] This was checked for breaking HTTP API changes, and any breaking\r\nchanges have been approved by the breaking-change committee. The\r\n`release_note:breaking` label should be applied in these situations.\r\n- [X] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [X] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n### Identify risks\r\n\r\nDoes this PR introduce any risks? For example, consider risks like hard\r\nto test bugs, performance regression, potential of data loss.\r\n\r\nDescribe the risk, its severity, and mitigation for each identified\r\nrisk. Invite stakeholders and evaluate how to proceed before merging.\r\n\r\n- [ ] [See some risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\r\n- [ ] ...\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0f62fa1d3070df8cc7251274b294586efaf017a6"}}]}] BACKPORT-->