### PR TITLE
[Docs] Add missing setting in advanced options

### DIFF
--- a/docs/management/advanced-options.asciidoc
+++ b/docs/management/advanced-options.asciidoc
@@ -55,6 +55,9 @@ Set this property to `true` to quote exported values.
 [[csv-separator]]`csv:separator`::
 A string that serves as the separator for exported values.
 
+[[data_views-fields_excluded_data_tiers]]`data_views:fields_excluded_data_tiers`::
+Allows the exclusion of listed data tiers when getting a field list for faster performance.
+
 [[dateformat]]`dateFormat`::
 The format to use for displaying
 https://momentjs.com/docs/#/displaying/format/[pretty formatted dates].


### PR DESCRIPTION
This PR reproduces https://github.com/elastic/kibana/pull/212514 to make it simpler to backport down to the 8.13 version.

I'll port the change to the new location for 9.0+ docs as well.

<!--ONMERGE {"backportTargets":["8.13","8.14","8.15","8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->