### PR TITLE
[8.x] [streams] ilm lifecycle summary (#210875)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/lifecycle/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/lifecycle/index.ts
@@ -98,3 +98,35 @@ export const isDisabledLifecycle = createIsNarrowSchema(
   ingestStreamEffectiveLifecycleSchema,
   disabledLifecycleSchema
 );
+
+export type PhaseName = 'hot' | 'warm' | 'cold' | 'frozen' | 'delete';
+
+export interface IlmPolicyPhase {
+  name: PhaseName;
+  size_in_bytes: number;
+  min_age?: string;
+}
+
+export interface IlmPolicyHotPhase extends IlmPolicyPhase {
+  name: 'hot';
+  rollover: {
+    max_size?: number | string;
+    max_primary_shard_size?: number | string;
+    max_age?: string;
+    max_docs?: number;
+    max_primary_shard_docs?: number;
+  };
+}
+
+export interface IlmPolicyDeletePhase {
+  name: 'delete';
+  min_age: string;
+}
+
+export interface IlmPolicyPhases {
+  hot?: IlmPolicyHotPhase;
+  warm?: IlmPolicyPhase;
+  cold?: IlmPolicyPhase;
+  frozen?: IlmPolicyPhase;
+  delete?: IlmPolicyDeletePhase;
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/get_effective_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/get_effective_lifecycle.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IndicesDataStream } from '@elastic/elasticsearch/lib/api/types';
+import {
+  IngestStreamDefinition,
+  findInheritedLifecycle,
+  isInheritLifecycle,
+  isUnwiredStreamDefinition,
+} from '@kbn/streams-schema';
+import { StreamsClient } from '../client';
+import { getDataStreamLifecycle } from '../stream_crud';
+
+export async function getEffectiveLifecycle({
+  definition,
+  streamsClient,
+  dataStream,
+}: {
+  definition: IngestStreamDefinition;
+  streamsClient: StreamsClient;
+  dataStream: IndicesDataStream;
+}) {
+  if (isUnwiredStreamDefinition(definition)) {
+    return getDataStreamLifecycle(dataStream);
+  }
+
+  if (isInheritLifecycle(definition.ingest.lifecycle)) {
+    const ancestors = await streamsClient.getAncestors(definition.name);
+    return findInheritedLifecycle(definition, ancestors);
+  }
+
+  return definition.ingest.lifecycle;
+}

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ilmPhases } from './ilm_phases';
+
+describe('lifecycle helpers', () => {
+  describe('ilmPhases', () => {
+    it('aggregates size of each phase', () => {
+      const stats = ilmPhases({
+        policy: {
+          phases: {
+            hot: {},
+            warm: { min_age: '2d' },
+            cold: { min_age: '5d' },
+            frozen: { min_age: '7d' },
+            delete: { min_age: '10d' },
+          },
+        },
+        indicesIlmDetails: {
+          index_name_001: {
+            index: 'index_name_001',
+            managed: true,
+            phase: 'frozen',
+            policy: 'mypolicy',
+          },
+          index_name_002: {
+            index: 'index_name_002',
+            managed: true,
+            phase: 'frozen',
+            policy: 'mypolicy',
+          },
+          index_name_003: {
+            index: 'index_name_003',
+            managed: true,
+            phase: 'cold',
+            policy: 'mypolicy',
+          },
+          index_name_004: {
+            index: 'index_name_004',
+            managed: true,
+            phase: 'warm',
+            policy: 'mypolicy',
+          },
+          index_name_005: {
+            index: 'index_name_005',
+            managed: true,
+            phase: 'hot',
+            policy: 'mypolicy',
+          },
+          index_name_006: {
+            index: 'index_name_006',
+            managed: true,
+            phase: 'hot',
+            policy: 'mypolicy',
+          },
+        },
+        indicesStats: {
+          index_name_001: { total: { store: { size_in_bytes: 10, reserved_in_bytes: 0 } } },
+          index_name_002: { total: { store: { size_in_bytes: 15, reserved_in_bytes: 0 } } },
+          index_name_003: { total: { store: { size_in_bytes: 20, reserved_in_bytes: 0 } } },
+          index_name_004: { total: { store: { size_in_bytes: 30, reserved_in_bytes: 0 } } },
+          index_name_005: { total: { store: { size_in_bytes: 100, reserved_in_bytes: 0 } } },
+          index_name_006: { total: { store: { size_in_bytes: 100, reserved_in_bytes: 0 } } },
+        },
+      });
+
+      expect(stats).toEqual({
+        hot: {
+          name: 'hot',
+          size_in_bytes: 200,
+          min_age: undefined,
+          rollover: {
+            max_age: undefined,
+            max_docs: undefined,
+            max_primary_shard_docs: undefined,
+            max_primary_shard_size: undefined,
+            max_size: undefined,
+          },
+        },
+        warm: { name: 'warm', size_in_bytes: 30, min_age: '2d' },
+        cold: { name: 'cold', size_in_bytes: 20, min_age: '5d' },
+        frozen: { name: 'frozen', size_in_bytes: 25, min_age: '7d' },
+        delete: { name: 'delete', min_age: '10d' },
+      });
+    });
+
+    it('only aggregates managed indices', () => {
+      const stats = ilmPhases({
+        policy: {
+          phases: {
+            hot: {},
+            warm: { min_age: '2d' },
+          },
+        },
+        indicesIlmDetails: {
+          index_name_001: {
+            index: 'index_name_001',
+            managed: true,
+            phase: 'hot',
+            policy: 'mypolicy',
+          },
+          index_name_002: {
+            index: 'index_name_002',
+            managed: true,
+            phase: 'hot',
+            policy: 'mypolicy',
+          },
+          index_name_003: {
+            index: 'index_name_003',
+            managed: false,
+          },
+        },
+        indicesStats: {
+          index_name_001: { total: { store: { size_in_bytes: 10, reserved_in_bytes: 0 } } },
+          index_name_002: { total: { store: { size_in_bytes: 10, reserved_in_bytes: 0 } } },
+          index_name_003: { total: { store: { size_in_bytes: 20, reserved_in_bytes: 0 } } },
+        },
+      });
+
+      expect(stats).toEqual({
+        hot: {
+          name: 'hot',
+          size_in_bytes: 20,
+          min_age: undefined,
+          rollover: {
+            max_age: undefined,
+            max_docs: undefined,
+            max_primary_shard_docs: undefined,
+            max_primary_shard_size: undefined,
+            max_size: undefined,
+          },
+        },
+        warm: { name: 'warm', size_in_bytes: 0, min_age: '2d' },
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/lifecycle/ilm_phases.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { compact, pick } from 'lodash';
+import { IlmPolicyPhases } from '@kbn/streams-schema';
+import {
+  IlmExplainLifecycleLifecycleExplain,
+  IlmPolicy,
+  IlmPhase,
+  IndicesStatsIndicesStats,
+} from '@elastic/elasticsearch/lib/api/types';
+
+export function ilmPhases({
+  policy,
+  indicesIlmDetails,
+  indicesStats,
+}: {
+  policy: IlmPolicy;
+  indicesIlmDetails: Record<string, IlmExplainLifecycleLifecycleExplain>;
+  indicesStats: Record<string, IndicesStatsIndicesStats>;
+}) {
+  const phaseWithName = (name: keyof IlmPolicyPhases, phase?: IlmPhase) => {
+    if (!phase) return undefined;
+    return { ...pick(phase, ['min_age'], ['actions']), name };
+  };
+
+  const ilmDetails = Object.values(indicesIlmDetails);
+  const phasesWithName = compact([
+    phaseWithName('hot' as const, policy.phases.hot),
+    phaseWithName('warm' as const, policy.phases.warm),
+    phaseWithName('cold' as const, policy.phases.cold),
+    phaseWithName('frozen' as const, policy.phases.frozen),
+    phaseWithName('delete' as const, policy.phases.delete),
+  ]);
+
+  return phasesWithName.reduce((phases, phase) => {
+    if (phase.name === 'delete') {
+      phases[phase.name] = { name: phase.name, min_age: phase.min_age!.toString() };
+      return phases;
+    }
+
+    const sizeInBytes = ilmDetails
+      .filter((detail) => detail.managed && detail.phase === phase.name)
+      .map((detail) => indicesStats[detail.index!])
+      .reduce((size, stats) => size + (stats?.total?.store?.size_in_bytes ?? 0), 0);
+
+    const policyPhase = {
+      name: phase.name,
+      size_in_bytes: sizeInBytes,
+      min_age: phase.min_age?.toString(),
+    };
+    if (phase.name === 'hot') {
+      const rollover = phase.actions?.rollover;
+      const maxAge = !rollover?.max_age || rollover?.max_age === -1 ? undefined : rollover.max_age;
+      phases[phase.name] = {
+        ...policyPhase,
+        name: 'hot',
+        rollover: {
+          max_age: maxAge,
+          max_size: phase.actions?.rollover?.max_size,
+          max_primary_shard_size: phase.actions?.rollover?.max_primary_shard_size,
+          max_docs: phase.actions?.rollover?.max_docs,
+          max_primary_shard_docs: phase.actions?.rollover?.max_primary_shard_docs,
+        },
+      };
+    } else {
+      phases[phase.name] = policyPhase;
+    }
+
+    return phases;
+  }, {} as IlmPolicyPhases);
+}

--- a/x-pack/platform/plugins/shared/streams/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/index.ts
@@ -13,6 +13,7 @@ import { managementRoutes } from './streams/management/route';
 import { schemaRoutes } from './streams/schema/route';
 import { processingRoutes } from './streams/processing/route';
 import { ingestRoutes } from './streams/ingest/route';
+import { lifecycleRoutes } from './streams/lifecycle/route';
 import { groupRoutes } from './streams/group/route';
 
 export const streamsRouteRepository = {
@@ -24,6 +25,7 @@ export const streamsRouteRepository = {
   ...schemaRoutes,
   ...processingRoutes,
   ...ingestRoutes,
+  ...lifecycleRoutes,
   ...groupRoutes,
 };
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/lifecycle/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/lifecycle/route.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isIlmLifecycle, isIngestStreamDefinition } from '@kbn/streams-schema';
+import { z } from '@kbn/zod';
+import { createServerRoute } from '../../create_server_route';
+import { ilmPhases } from '../../../lib/streams/lifecycle/ilm_phases';
+import { getEffectiveLifecycle } from '../../../lib/streams/lifecycle/get_effective_lifecycle';
+import { StatusError } from '../../../lib/streams/errors/status_error';
+
+const lifecycleStatsRoute = createServerRoute({
+  endpoint: 'GET /api/streams/{name}/lifecycle/_stats',
+  options: {
+    access: 'internal',
+  },
+  security: {
+    authz: {
+      enabled: false,
+      reason:
+        'This API delegates security to the currently logged in user and their Elasticsearch permissions.',
+    },
+  },
+  params: z.object({
+    path: z.object({ name: z.string() }),
+  }),
+  handler: async ({ params, request, getScopedClients }) => {
+    const { scopedClusterClient, streamsClient } = await getScopedClients({ request });
+    const name = params.path.name;
+
+    const definition = await streamsClient.getStream(name);
+    if (!isIngestStreamDefinition(definition)) {
+      throw new StatusError('Lifecycle stats are only available for ingest streams', 400);
+    }
+
+    const dataStream = await streamsClient.getDataStream(name);
+    const lifecycle = await getEffectiveLifecycle({ definition, streamsClient, dataStream });
+    if (!isIlmLifecycle(lifecycle)) {
+      throw new StatusError('Lifecycle stats are only available for ILM policy', 400);
+    }
+
+    const { policy } = await scopedClusterClient.asCurrentUser.ilm
+      .getLifecycle({ name: lifecycle.ilm.policy })
+      .then((policies) => policies[lifecycle.ilm.policy]);
+
+    const [{ indices: indicesIlmDetails }, { indices: indicesStats = {} }] = await Promise.all([
+      scopedClusterClient.asCurrentUser.ilm.explainLifecycle({ index: name }),
+      scopedClusterClient.asCurrentUser.indices.stats({ index: dataStream.name }),
+    ]);
+
+    return { phases: ilmPhases({ policy, indicesIlmDetails, indicesStats }) };
+  },
+});
+
+const lifecycleIlmExplainRoute = createServerRoute({
+  endpoint: 'GET /api/streams/{name}/lifecycle/_explain',
+  options: {
+    access: 'internal',
+  },
+  security: {
+    authz: {
+      enabled: false,
+      reason:
+        'This API delegates security to the currently logged in user and their Elasticsearch permissions.',
+    },
+  },
+  params: z.object({
+    path: z.object({ name: z.string() }),
+  }),
+  handler: async ({ params, request, getScopedClients }) => {
+    const { scopedClusterClient, streamsClient } = await getScopedClients({ request });
+    const name = params.path.name;
+
+    // verifies read privileges
+    await streamsClient.getStream(name);
+
+    return scopedClusterClient.asCurrentUser.ilm.explainLifecycle({
+      index: name,
+    });
+  },
+});
+
+export const lifecycleRoutes = {
+  ...lifecycleStatsRoute,
+  ...lifecycleIlmExplainRoute,
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IlmPolicyDeletePhase, IlmPolicyPhase, IlmPolicyPhases } from '@kbn/streams-schema';
+
+export const parseDuration = (duration: string = '') => {
+  const result = /^(\d+)([d|m|s|h])$/.exec(duration);
+  if (!result) return undefined;
+  return { value: Number(result[1]), unit: result[2] };
+};
+
+export function parseDurationInSeconds(duration: string = ''): number {
+  const parsed = parseDuration(duration);
+  if (!parsed) {
+    return 0;
+  }
+
+  const { value, unit } = parsed;
+  if (unit === 's') {
+    return value;
+  } else if (unit === 'm') {
+    return value * 60;
+  } else if (unit === 'h') {
+    return value * 60 * 60;
+  } else if (unit === 'd') {
+    return value * 24 * 60 * 60;
+  }
+
+  throw new Error(`Invalid duration unit [${unit}]`);
+}
+
+export function orderIlmPhases(phases: IlmPolicyPhases) {
+  const isPhase = (
+    phase?: IlmPolicyPhase | IlmPolicyDeletePhase
+  ): phase is IlmPolicyPhase | IlmPolicyDeletePhase => Boolean(phase);
+  return [phases.hot, phases.warm, phases.cold, phases.frozen, phases.delete].filter(isPhase);
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/rollover_condition.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/helpers/rollover_condition.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { IlmPolicyHotPhase } from '@kbn/streams-schema';
+
+export function rolloverCondition(rollover?: IlmPolicyHotPhase['rollover']) {
+  const conditions = [
+    rollover?.max_age &&
+      i18n.translate('xpack.streams.streamDetailLifecycle.rolloverConditionMaxAge', {
+        defaultMessage: 'max age {maxAge}',
+        values: { maxAge: rollover.max_age },
+      }),
+    rollover?.max_docs &&
+      i18n.translate('xpack.streams.streamDetailLifecycle.rolloverConditionMaxDocs', {
+        defaultMessage: 'max docs {maxDocs}',
+        values: { maxDocs: rollover.max_docs },
+      }),
+    rollover?.max_primary_shard_docs &&
+      i18n.translate('xpack.streams.streamDetailLifecycle.rolloverConditionMaxPrimaryShardDocs', {
+        defaultMessage: 'primary shard docs {shardDocs}',
+        values: { shardDocs: rollover.max_primary_shard_docs },
+      }),
+    rollover?.max_primary_shard_size &&
+      i18n.translate('xpack.streams.streamDetailLifecycle.rolloverConditionMaxPrimaryShardSize', {
+        defaultMessage: 'primary shard size {shardSize}',
+        values: { shardSize: rollover.max_primary_shard_size },
+      }),
+    rollover?.max_size &&
+      i18n.translate('xpack.streams.streamDetailLifecycle.rolloverConditionMaxSize', {
+        defaultMessage: 'index size {maxSize}',
+        values: { maxSize: rollover.max_size },
+      }),
+  ].filter(Boolean);
+
+  return conditions.join(
+    i18n.translate('xpack.streams.streamDetailLifecycle.rolloverConditionOr', {
+      defaultMessage: ' or ',
+    })
+  );
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_data_stream_stats.tsx
@@ -34,7 +34,7 @@ export const useDataStreamStats = ({ definition }: { definition?: IngestStreamGe
       includeCreationDate: true,
     });
 
-    if (!dsStats || !dsStats.creationDate || !dsStats.sizeBytes) {
+    if (!dsStats || !dsStats.creationDate) {
       return undefined;
     }
     const daysSinceCreation = Math.max(
@@ -44,8 +44,9 @@ export const useDataStreamStats = ({ definition }: { definition?: IngestStreamGe
 
     return {
       ...dsStats,
-      bytesPerDay: dsStats.sizeBytes / daysSinceCreation,
-      bytesPerDoc: dsStats.totalDocs ? dsStats.sizeBytes / dsStats.totalDocs : 0,
+      bytesPerDay: dsStats.sizeBytes ? dsStats.sizeBytes / daysSinceCreation : 0,
+      bytesPerDoc:
+        dsStats.totalDocs && dsStats.sizeBytes ? dsStats.sizeBytes / dsStats.totalDocs : 0,
     };
   }, [dataStreamsClient, definition]);
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_ilm_phases_color_and_description.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_ilm_phases_color_and_description.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { compact } from 'lodash';
+import { useEuiTheme } from '@elastic/eui';
+import {
+  IlmPolicyDeletePhase,
+  IlmPolicyHotPhase,
+  IlmPolicyPhase,
+  IlmPolicyPhases,
+} from '@kbn/streams-schema';
+import { rolloverCondition } from '../helpers/rollover_condition';
+
+export const useIlmPhasesColorAndDescription = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return {
+    ilmPhases: {
+      hot: {
+        color: euiTheme.colors.vis.euiColorVis6,
+        description: (phase: IlmPolicyPhase | IlmPolicyDeletePhase, phases: IlmPolicyPhases) => {
+          const hotPhase = phase as IlmPolicyHotPhase;
+          const hasNextPhase = Boolean(
+            phases.warm || phases.cold || phases.frozen || phases.delete
+          );
+          const condition = rolloverCondition(hotPhase.rollover);
+          return compact([
+            i18n.translate('xpack.streams.streamDetailLifecycle.hotPhaseDescription', {
+              defaultMessage:
+                'Recent, frequently-searched data. Best indexing and search performance.',
+            }),
+            hasNextPhase
+              ? condition
+                ? i18n.translate(
+                    'xpack.streams.streamDetailLifecycle.hotPhaseRolloverDescription',
+                    {
+                      defaultMessage:
+                        '*Time since rollover. Current rollover condition: {condition}.',
+                      values: { condition },
+                    }
+                  )
+                : i18n.translate(
+                    'xpack.streams.streamDetailLifecycle.hotPhaseNoRolloverDescription',
+                    {
+                      defaultMessage:
+                        '*Time since rollover. Data will not move to the next phase because rollover is not enabled.',
+                    }
+                  )
+              : '',
+          ]);
+        },
+      },
+      warm: {
+        color: euiTheme.colors.vis.euiColorVis9,
+        description: () => [
+          i18n.translate('xpack.streams.streamDetailLifecycle.warmPhaseDescription', {
+            defaultMessage:
+              'Frequently searched data, rarely updated. Optimized for search, not indexing.',
+          }),
+        ],
+      },
+      cold: {
+        color: euiTheme.colors.vis.euiColorVis1,
+        description: () => [
+          i18n.translate('xpack.streams.streamDetailLifecycle.coldPhaseDescription', {
+            defaultMessage:
+              'Data searched infrequently, not updated. Optimized for cost savings over search performance.',
+          }),
+        ],
+      },
+      frozen: {
+        color: euiTheme.colors.vis.euiColorVis2,
+        description: () => [
+          i18n.translate('xpack.streams.streamDetailLifecycle.frozenPhaseDescription', {
+            defaultMessage:
+              'Most cost-effective way to store your data and still be able to search it.',
+          }),
+        ],
+      },
+      delete: {
+        color: euiTheme.border.color,
+        description: (phase: IlmPolicyPhase | IlmPolicyDeletePhase) => [
+          i18n.translate('xpack.streams.streamDetailLifecycle.deletePhaseDescription', {
+            defaultMessage: 'Data deleted after {duration}.',
+            values: { duration: phase.min_age! },
+          }),
+        ],
+      },
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_ingestion_rate.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/hooks/use_ingestion_rate.tsx
@@ -1,0 +1,261 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import datemath from '@elastic/datemath';
+import { TimeRange, getCalculateAutoTimeExpression } from '@kbn/data-plugin/common';
+import { IngestStreamGetResponse, PhaseName } from '@kbn/streams-schema';
+import { lastValueFrom } from 'rxjs';
+import { IKibanaSearchRequest, IKibanaSearchResponse } from '@kbn/search-types';
+import { useKibana } from '../../../../hooks/use_kibana';
+import { useStreamsAppFetch } from '../../../../hooks/use_streams_app_fetch';
+import { DataStreamStats } from './use_data_stream_stats';
+import { useIlmPhasesColorAndDescription } from './use_ilm_phases_color_and_description';
+
+const TIMESTAMP_FIELD = '@timestamp';
+const RANDOM_SAMPLER_PROBABILITY = 0.1;
+
+export const useIngestionRate = ({
+  definition,
+  stats,
+  timeRange,
+}: {
+  definition?: IngestStreamGetResponse;
+  stats?: DataStreamStats;
+  timeRange: TimeRange;
+}) => {
+  const {
+    core,
+    dependencies: {
+      start: { data },
+    },
+  } = useKibana();
+
+  const ingestionRateFetch = useStreamsAppFetch(
+    async ({ signal }) => {
+      if (!definition || !stats) {
+        return;
+      }
+
+      const start = datemath.parse(timeRange.from);
+      const end = datemath.parse(timeRange.to);
+      const interval = getCalculateAutoTimeExpression((key) => core.uiSettings.get(key))(timeRange);
+      if (!start || !end || !interval) {
+        return;
+      }
+
+      const {
+        rawResponse: { aggregations },
+      } = await lastValueFrom(
+        data.search.search<
+          IKibanaSearchRequest,
+          IKibanaSearchResponse<{
+            aggregations: {
+              sampler: { docs_count: { buckets: Array<{ key: number; doc_count: number }> } };
+            };
+          }>
+        >(
+          {
+            params: {
+              index: definition.stream.name,
+              track_total_hits: false,
+              body: {
+                size: 0,
+                query: {
+                  bool: {
+                    filter: [{ range: { [TIMESTAMP_FIELD]: { gte: start, lte: end } } }],
+                  },
+                },
+                aggs: {
+                  sampler: {
+                    random_sampler: {
+                      probability: RANDOM_SAMPLER_PROBABILITY,
+                    },
+                    aggs: {
+                      docs_count: {
+                        date_histogram: {
+                          field: TIMESTAMP_FIELD,
+                          fixed_interval: interval,
+                          min_doc_count: 0,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          { abortSignal: signal }
+        )
+      );
+
+      return {
+        start,
+        end,
+        interval,
+        buckets: aggregations.sampler.docs_count.buckets.map(({ key, doc_count: docCount }) => ({
+          key,
+          value: docCount * stats.bytesPerDoc,
+        })),
+      };
+    },
+    [data.search, definition, timeRange, stats]
+  );
+
+  return {
+    ingestionRate: ingestionRateFetch.value,
+    isLoading: ingestionRateFetch.loading,
+    error: ingestionRateFetch.error,
+  };
+};
+
+type PhaseNameWithoutDelete = Exclude<PhaseName, 'delete'>;
+
+export const useIngestionRatePerTier = ({
+  definition,
+  stats,
+  timeRange,
+}: {
+  definition?: IngestStreamGetResponse;
+  stats?: DataStreamStats;
+  timeRange: TimeRange;
+}) => {
+  const {
+    core,
+    dependencies: {
+      start: {
+        data,
+        streams: { streamsRepositoryClient },
+      },
+    },
+  } = useKibana();
+
+  const { ilmPhases } = useIlmPhasesColorAndDescription();
+
+  const ingestionRateFetch = useStreamsAppFetch(
+    async ({ signal }) => {
+      if (!definition || !stats) {
+        return;
+      }
+
+      const start = datemath.parse(timeRange.from);
+      const end = datemath.parse(timeRange.to);
+      const interval = getCalculateAutoTimeExpression((key) => core.uiSettings.get(key))(timeRange);
+      if (!start || !end || !interval) {
+        return;
+      }
+
+      const {
+        rawResponse: { aggregations },
+      } = await lastValueFrom(
+        data.search.search<
+          IKibanaSearchRequest,
+          IKibanaSearchResponse<{
+            aggregations: {
+              sampler: {
+                docs_count: {
+                  buckets: Array<{
+                    key: number;
+                    doc_count: number;
+                    indices: { buckets: Array<{ key: string; doc_count: number }> };
+                  }>;
+                };
+              };
+            };
+          }>
+        >(
+          {
+            params: {
+              index: definition.stream.name,
+              track_total_hits: false,
+              body: {
+                size: 0,
+                query: {
+                  bool: {
+                    filter: [{ range: { [TIMESTAMP_FIELD]: { gte: start, lte: end } } }],
+                  },
+                },
+                aggs: {
+                  sampler: {
+                    random_sampler: {
+                      probability: RANDOM_SAMPLER_PROBABILITY,
+                    },
+                    aggs: {
+                      docs_count: {
+                        date_histogram: {
+                          field: TIMESTAMP_FIELD,
+                          fixed_interval: interval,
+                          min_doc_count: 0,
+                        },
+                        aggs: {
+                          indices: {
+                            terms: { field: '_index' },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          { abortSignal: signal }
+        )
+      );
+
+      if (aggregations.sampler.docs_count.buckets.length === 0) {
+        return { start, end, interval, buckets: {} };
+      }
+
+      const ilmExplain = await streamsRepositoryClient.fetch(
+        'GET /api/streams/{name}/lifecycle/_explain',
+        {
+          params: { path: { name: definition.stream.name } },
+          signal,
+        }
+      );
+
+      const fallbackTier = 'hot';
+      const buckets = aggregations.sampler.docs_count.buckets.reduce(
+        (acc, { key, doc_count: docCount, indices }) => {
+          if (docCount === 0) {
+            // there's no data for this bucket. push an empty data point
+            // so we still graph the timestamp.
+            (acc[fallbackTier] = acc[fallbackTier] ?? []).push({ key, value: 0 });
+            return acc;
+          }
+
+          const countByTier = indices.buckets.reduce((tiers, index) => {
+            const explain = ilmExplain.indices[index.key];
+            const tier =
+              explain.managed && explain.phase in ilmPhases
+                ? (explain.phase as PhaseNameWithoutDelete)
+                : fallbackTier;
+            tiers[tier] = (tiers[tier] ?? 0) + index.doc_count;
+            return tiers;
+          }, {} as Record<PhaseNameWithoutDelete, number>);
+
+          for (const entry of Object.entries(countByTier)) {
+            const tier = entry[0] as PhaseNameWithoutDelete;
+            (acc[tier] = acc[tier] ?? []).push({ key, value: entry[1] * stats.bytesPerDoc });
+          }
+
+          return acc;
+        },
+        {} as Record<PhaseNameWithoutDelete, Array<{ key: number; value: number }>>
+      );
+
+      return { start, end, interval, buckets };
+    },
+    [data.search, streamsRepositoryClient, definition, timeRange, stats]
+  );
+
+  return {
+    ingestionRate: ingestionRateFetch.value,
+    isLoading: ingestionRateFetch.loading,
+    error: ingestionRateFetch.error,
+  };
+};

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ilm_link.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ilm_link.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiLink } from '@elastic/eui';
+import { IlmLocatorParams } from '@kbn/index-lifecycle-management-common-shared';
+import { LocatorPublic } from '@kbn/share-plugin/common';
+import { IngestStreamLifecycleILM } from '@kbn/streams-schema';
+import { i18n } from '@kbn/i18n';
+
+export function IlmLink({
+  ilmLocator,
+  lifecycle,
+}: {
+  ilmLocator?: LocatorPublic<IlmLocatorParams>;
+  lifecycle: IngestStreamLifecycleILM;
+}) {
+  return (
+    <EuiLink
+      target="_blank"
+      data-test-subj="streamsAppLifecycleBadgeIlmPolicyNameLink"
+      href={ilmLocator?.getRedirectUrl({
+        page: 'policy_edit',
+        policyName: lifecycle.ilm.policy,
+      })}
+    >
+      {i18n.translate('xpack.streams.entityDetailViewWithoutParams.ilmBadgeLabel', {
+        defaultMessage: 'ILM Policy: {name}',
+        values: { name: lifecycle.ilm.policy },
+      })}
+    </EuiLink>
+  );
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ilm_summary.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ilm_summary.tsx
@@ -1,0 +1,309 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { capitalize, last } from 'lodash';
+import React, { useMemo } from 'react';
+import {
+  IlmPolicyDeletePhase,
+  IlmPolicyPhase,
+  IlmPolicyPhases,
+  IngestStreamGetResponse,
+  IngestStreamLifecycleILM,
+  PhaseName,
+} from '@kbn/streams-schema';
+import { i18n } from '@kbn/i18n';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTextColor,
+  formatNumber,
+  useEuiTheme,
+} from '@elastic/eui';
+import { LocatorPublic } from '@kbn/share-plugin/common';
+import { IlmLocatorParams } from '@kbn/index-lifecycle-management-common-shared';
+import { useStreamsAppFetch } from '../../../hooks/use_streams_app_fetch';
+import { useKibana } from '../../../hooks/use_kibana';
+import { orderIlmPhases, parseDurationInSeconds } from './helpers';
+import { IlmLink } from './ilm_link';
+import { useIlmPhasesColorAndDescription } from './hooks/use_ilm_phases_color_and_description';
+
+export function IlmSummary({
+  definition,
+  lifecycle,
+  ilmLocator,
+}: {
+  definition: IngestStreamGetResponse;
+  lifecycle: IngestStreamLifecycleILM;
+  ilmLocator?: LocatorPublic<IlmLocatorParams>;
+}) {
+  const {
+    dependencies: {
+      start: {
+        streams: { streamsRepositoryClient },
+      },
+    },
+  } = useKibana();
+
+  const { value, loading, error } = useStreamsAppFetch(
+    ({ signal }) => {
+      if (!definition) return;
+
+      return streamsRepositoryClient.fetch('GET /api/streams/{name}/lifecycle/_stats', {
+        params: { path: { name: definition.stream.name } },
+        signal,
+      });
+    },
+    [streamsRepositoryClient, definition]
+  );
+
+  const phasesWithGrow = useMemo(() => {
+    if (!value) return undefined;
+
+    const orderedPhases = orderIlmPhases(value.phases);
+    const totalDuration = parseDurationInSeconds(last(orderedPhases)!.min_age);
+
+    return orderedPhases.map((phase, index, phases) => {
+      const nextPhase = phases[index + 1];
+      if (!nextPhase) {
+        return { ...phase, grow: phase.name === 'delete' ? false : 2 };
+      }
+
+      const phaseDuration =
+        parseDurationInSeconds(nextPhase!.min_age) - parseDurationInSeconds(phase!.min_age);
+      return {
+        ...phase,
+        grow: Math.max(2, Math.round((phaseDuration / totalDuration) * 10)),
+      };
+    });
+  }, [value]);
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="none">
+      <EuiPanel hasShadow={false} hasBorder={false} paddingSize="s">
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem>
+            <EuiText>
+              <h5>
+                {i18n.translate('xpack.streams.streamDetailLifecycle.policySummary', {
+                  defaultMessage: 'Policy summary',
+                })}
+              </h5>
+            </EuiText>
+            <EuiTextColor color="subdued">
+              {i18n.translate('xpack.streams.streamDetailLifecycle.policySummaryInfo', {
+                defaultMessage: 'Phases and details of the lifecycle applied to this stream',
+              })}
+            </EuiTextColor>
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={false}>
+            <IlmLink lifecycle={lifecycle} ilmLocator={ilmLocator} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+
+      <EuiPanel grow={true} hasShadow={false} hasBorder={false} paddingSize="s">
+        {error ? (
+          '-'
+        ) : loading || !phasesWithGrow ? (
+          <EuiLoadingSpinner />
+        ) : (
+          <EuiFlexGroup direction="row" gutterSize="none" responsive={false}>
+            {phasesWithGrow.map((phase, index) => (
+              <EuiFlexItem
+                key={`${phase.name}-timeline`}
+                grow={phase.grow as false | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10}
+              >
+                <IlmPhase phase={phase} minAge={phasesWithGrow[index + 1]?.min_age} />
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        )}
+      </EuiPanel>
+
+      <EuiSpacer size="m" />
+
+      <PhasesLegend phases={value?.phases} />
+    </EuiFlexGroup>
+  );
+}
+
+function IlmPhase({
+  phase,
+  minAge,
+}: {
+  phase: IlmPolicyPhase | IlmPolicyDeletePhase;
+  minAge?: string;
+}) {
+  const borderRadius =
+    phase.name === 'delete'
+      ? undefined
+      : phase.name === 'hot'
+      ? minAge
+        ? '0px 16px 16px 0px'
+        : '0px'
+      : minAge
+      ? '16px'
+      : '16px 0px 0px 16px';
+  const { ilmPhases } = useIlmPhasesColorAndDescription();
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <>
+      <EuiFlexGroup
+        direction="column"
+        gutterSize="xs"
+        style={phase.name !== 'delete' ? { borderRight: '1px dashed black' } : undefined}
+      >
+        <EuiPanel
+          paddingSize="s"
+          hasBorder={false}
+          hasShadow={false}
+          css={{
+            backgroundColor: ilmPhases[phase.name].color,
+            margin: '0 2px',
+            borderRadius,
+          }}
+          grow={false}
+        >
+          {phase.name === 'delete' ? (
+            <EuiText size="xs" style={{ margin: '0 2px' }}>
+              <EuiIcon size="s" type="trash" />
+            </EuiText>
+          ) : (
+            <EuiText size="xs" color={euiTheme.colors.plainDark}>
+              <b>{capitalize(phase.name)}</b>
+            </EuiText>
+          )}
+        </EuiPanel>
+        {'size_in_bytes' in phase ? (
+          <EuiPanel
+            paddingSize="s"
+            borderRadius="none"
+            hasBorder={false}
+            hasShadow={false}
+            grow={false}
+            style={{ marginBottom: '40px' }}
+          >
+            <EuiText size="xs">
+              <p>
+                <b>Size</b> {formatNumber(phase.size_in_bytes, '0.0 b')}
+              </p>
+            </EuiText>
+          </EuiPanel>
+        ) : null}
+      </EuiFlexGroup>
+
+      <EuiFlexGroup justifyContent="flexEnd">
+        {phase.name !== 'delete' ? (
+          <EuiPanel
+            paddingSize="xs"
+            style={{
+              marginRight: minAge ? '-20px' : '-5px',
+              width: '50px',
+              backgroundColor: ilmPhases.delete.color,
+            }}
+            grow={false}
+            hasBorder={false}
+            hasShadow={false}
+          >
+            <EuiText textAlign="center" size="xs">
+              {minAge ? minAge + (phase.name === 'hot' ? '*' : '') : '∞'}
+            </EuiText>
+          </EuiPanel>
+        ) : undefined}
+      </EuiFlexGroup>
+    </>
+  );
+}
+
+function PhasesLegend({ phases }: { phases?: IlmPolicyPhases }) {
+  const { ilmPhases } = useIlmPhasesColorAndDescription();
+  const descriptions = useMemo(() => {
+    if (!phases) return [];
+
+    const desc = orderIlmPhases(phases)
+      .filter(({ name }) => name !== 'delete')
+      .map((phase) => ({
+        name: phase.name,
+        description: ilmPhases[phase.name].description(phase, phases),
+        color: ilmPhases[phase.name].color,
+      })) as Array<
+      {
+        name: PhaseName | 'indefinite';
+        description: string[];
+      } & ({ color: string } | { icon: string })
+    >;
+
+    if (phases.delete) {
+      desc.push({
+        name: 'delete',
+        description: ilmPhases.delete.description(phases.delete),
+        icon: 'trash',
+      });
+    } else {
+      desc.push({
+        name: 'indefinite',
+        description: [
+          i18n.translate('xpack.streams.streamDetailLifecycle.noRetentionDescription', {
+            defaultMessage: 'Data is stored indefinitely.',
+          }),
+        ],
+        icon: 'infinity',
+      });
+    }
+
+    return desc;
+  }, [phases, ilmPhases]);
+
+  if (!phases) return null;
+
+  return (
+    <EuiPanel hasBorder={false} hasShadow={false} paddingSize="s">
+      {descriptions.map((phase, index) => (
+        <React.Fragment key={phase.name}>
+          <EuiFlexGroup alignItems="center">
+            <EuiFlexItem grow={false} style={{ width: '20px', alignItems: 'center' }}>
+              {'color' in phase ? (
+                <span
+                  style={{
+                    height: '12px',
+                    width: '12px',
+                    borderRadius: '50%',
+                    backgroundColor: phase.color,
+                    display: 'inline-block',
+                  }}
+                />
+              ) : (
+                <EuiIcon type={phase.icon} />
+              )}
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={2}>
+              <b>{capitalize(phase.name)}</b>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={10}>
+              {phase.description.map((desc, idx) => (
+                <EuiTextColor key={`${phase.name}-desc-${idx}`} color="subdued">
+                  {desc}
+                </EuiTextColor>
+              ))}
+            </EuiFlexItem>
+          </EuiFlexGroup>
+
+          {index === descriptions.length - 1 ? null : <EuiSpacer size="s" />}
+        </React.Fragment>
+      ))}
+    </EuiPanel>
+  );
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/index.tsx
@@ -27,6 +27,7 @@ import { useKibana } from '../../../hooks/use_kibana';
 import { EditLifecycleModal, LifecycleEditAction } from './modal';
 import { RetentionSummary } from './summary';
 import { RetentionMetadata } from './metadata';
+import { IlmSummary } from './ilm_summary';
 import { IngestionRate } from './ingestion_rate';
 import { useDataStreamStats } from './hooks/use_data_stream_stats';
 import { getFormattedError } from '../../../util/errors';
@@ -205,18 +206,34 @@ export function StreamDetailLifecycle({
         </EuiFlexGroup>
       </EuiPanel>
 
-      <EuiSpacer size="s" />
+      <EuiSpacer size="m" />
 
-      <EuiFlexGroup>
-        <EuiPanel hasShadow={false} hasBorder paddingSize="s">
-          <IngestionRate
-            definition={definition}
-            refreshStats={refreshStats}
-            isLoadingStats={isLoadingStats}
-            stats={stats}
-          />
-        </EuiPanel>
-      </EuiFlexGroup>
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup gutterSize="m">
+          <EuiFlexItem grow={2}>
+            <EuiPanel grow={true} hasShadow={false} hasBorder paddingSize="s">
+              <IngestionRate
+                definition={definition}
+                refreshStats={refreshStats}
+                isLoadingStats={isLoadingStats}
+                stats={stats}
+              />
+            </EuiPanel>
+          </EuiFlexItem>
+
+          {isIlmLifecycle(definition.effective_lifecycle) ? (
+            <EuiFlexItem grow={3}>
+              <EuiPanel grow={true} hasShadow={false} hasBorder paddingSize="s">
+                <IlmSummary
+                  definition={definition}
+                  lifecycle={definition.effective_lifecycle}
+                  ilmLocator={ilmLocator}
+                />
+              </EuiPanel>
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
+      </EuiFlexItem>
     </>
   );
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ingestion_rate.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ingestion_rate.tsx
@@ -7,10 +7,10 @@
 
 import moment from 'moment';
 import React from 'react';
-import { lastValueFrom } from 'rxjs';
-import { IKibanaSearchRequest, IKibanaSearchResponse } from '@kbn/search-types';
+import { capitalize } from 'lodash';
+import { TimeRange } from '@kbn/data-plugin/common';
 import { i18n } from '@kbn/i18n';
-import { IngestStreamGetResponse } from '@kbn/streams-schema';
+import { IngestStreamGetResponse, PhaseName, isIlmLifecycle } from '@kbn/streams-schema';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,15 +18,24 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
+  useEuiTheme,
 } from '@elastic/eui';
-import { AreaSeries, Axis, Chart, Settings } from '@elastic/charts';
+import {
+  AreaSeries,
+  Axis,
+  BarSeries,
+  Chart,
+  DARK_THEME,
+  LIGHT_THEME,
+  Settings,
+} from '@elastic/charts';
 import { useKibana } from '../../../hooks/use_kibana';
 import { DataStreamStats } from './hooks/use_data_stream_stats';
-import { useStreamsAppFetch } from '../../../hooks/use_streams_app_fetch';
-import { ingestionRateQuery } from './helpers/ingestion_rate_query';
 import { formatBytes } from './helpers/format_bytes';
 import { StreamsAppSearchBar } from '../../streams_app_search_bar';
 import { useDateRange } from '../../../hooks/use_date_range';
+import { useIngestionRate, useIngestionRatePerTier } from './hooks/use_ingestion_rate';
+import { useIlmPhasesColorAndDescription } from './hooks/use_ilm_phases_color_and_description';
 
 export function IngestionRate({
   definition,
@@ -45,42 +54,6 @@ export function IngestionRate({
     },
   } = useKibana();
   const { timeRange, setTimeRange } = useDateRange({ data });
-
-  const {
-    loading: isLoadingIngestionRate,
-    value: ingestionRate,
-    error: ingestionRateError,
-  } = useStreamsAppFetch(
-    async ({ signal }) => {
-      if (!definition || isLoadingStats || !stats?.bytesPerDay) {
-        return;
-      }
-
-      const { rawResponse } = await lastValueFrom(
-        data.search.search<
-          IKibanaSearchRequest,
-          IKibanaSearchResponse<{
-            aggregations: { docs_count: { buckets: Array<{ key: string; doc_count: number }> } };
-          }>
-        >(
-          {
-            params: ingestionRateQuery({
-              start: timeRange.from,
-              end: timeRange.to,
-              index: definition.stream.name,
-            }),
-          },
-          { abortSignal: signal }
-        )
-      );
-
-      return rawResponse.aggregations.docs_count.buckets.map(({ key, doc_count: docCount }) => ({
-        key,
-        value: docCount * stats.bytesPerDoc,
-      }));
-    },
-    [data.search, definition, stats, isLoadingStats, timeRange]
-  );
 
   return (
     <>
@@ -119,51 +92,169 @@ export function IngestionRate({
         </EuiFlexGroup>
       </EuiPanel>
 
-      <EuiSpacer size="s" />
+      <EuiSpacer />
 
-      {ingestionRateError ? (
-        <EuiFlexGroup
-          justifyContent="center"
-          alignItems="center"
-          style={{ width: '100%', height: '250px' }}
-        >
-          Failed to load ingestion rate
-        </EuiFlexGroup>
-      ) : isLoadingIngestionRate || isLoadingStats || !ingestionRate ? (
-        <EuiFlexGroup
-          justifyContent="center"
-          alignItems="center"
-          style={{ width: '100%', height: '250px' }}
-        >
-          <EuiLoadingChart />
-        </EuiFlexGroup>
-      ) : (
-        <Chart size={{ height: 250 }}>
-          <Settings showLegend={false} />
-          <AreaSeries
-            id="ingestionRate"
-            name="Ingestion rate"
-            data={ingestionRate}
-            color="#61A2FF"
+      <EuiFlexGroup
+        justifyContent="center"
+        alignItems="center"
+        style={{ width: '100%', minHeight: '250px' }}
+        direction="column"
+        gutterSize="xs"
+      >
+        {!definition ? null : isIlmLifecycle(definition?.effective_lifecycle) ? (
+          <ChartBarSeries
+            definition={definition}
+            stats={stats}
+            timeRange={timeRange}
+            isLoadingStats={isLoadingStats}
+          />
+        ) : (
+          <ChartAreaSeries
+            definition={definition}
+            stats={stats}
+            timeRange={timeRange}
+            isLoadingStats={isLoadingStats}
+          />
+        )}
+      </EuiFlexGroup>
+    </>
+  );
+}
+
+function ChartAreaSeries({
+  definition,
+  stats,
+  timeRange,
+  isLoadingStats,
+}: {
+  definition?: IngestStreamGetResponse;
+  stats?: DataStreamStats;
+  timeRange: TimeRange;
+  isLoadingStats: boolean;
+}) {
+  const {
+    ingestionRate,
+    isLoading: isLoadingIngestionRate,
+    error: ingestionRateError,
+  } = useIngestionRate({ definition, stats, timeRange });
+  const { colorMode } = useEuiTheme();
+
+  return ingestionRateError ? (
+    'Failed to load ingestion rate'
+  ) : !definition || isLoadingStats || isLoadingIngestionRate || !ingestionRate ? (
+    <EuiLoadingChart />
+  ) : (
+    <>
+      <Chart size={{ height: 250 }}>
+        <Settings showLegend={false} baseTheme={colorMode === 'LIGHT' ? LIGHT_THEME : DARK_THEME} />
+
+        <AreaSeries
+          id="ingestionRate"
+          name="Ingestion rate"
+          data={ingestionRate.buckets}
+          color="#61A2FF"
+          xScaleType="time"
+          xAccessor={'key'}
+          yAccessors={['value']}
+        />
+
+        <Axis
+          id="bottom-axis"
+          position="bottom"
+          tickFormat={(value) => moment(value).format('YYYY-MM-DD HH:mm:ss')}
+          gridLine={{ visible: true }}
+        />
+        <Axis
+          id="left-axis"
+          position="left"
+          tickFormat={(value) => formatBytes(value)}
+          gridLine={{ visible: true }}
+        />
+      </Chart>
+
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow>
+          <EuiText size="xs">
+            <b>
+              {toLegendFormat(ingestionRate.start)} - {toLegendFormat(ingestionRate.end)} (interval:{' '}
+              {ingestionRate.interval})
+            </b>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+}
+
+function ChartBarSeries({
+  definition,
+  stats,
+  timeRange,
+  isLoadingStats,
+}: {
+  definition?: IngestStreamGetResponse;
+  stats?: DataStreamStats;
+  timeRange: TimeRange;
+  isLoadingStats: boolean;
+}) {
+  const {
+    ingestionRate,
+    isLoading: isLoadingIngestionRate,
+    error: ingestionRateError,
+  } = useIngestionRatePerTier({ definition, stats, timeRange });
+  const { ilmPhases } = useIlmPhasesColorAndDescription();
+  const { colorMode } = useEuiTheme();
+
+  return ingestionRateError ? (
+    'Failed to load ingestion rate'
+  ) : !definition || isLoadingStats || isLoadingIngestionRate || !ingestionRate ? (
+    <EuiLoadingChart />
+  ) : (
+    <>
+      <Chart size={{ height: 250 }}>
+        <Settings showLegend={false} baseTheme={colorMode === 'LIGHT' ? LIGHT_THEME : DARK_THEME} />
+        {Object.entries(ingestionRate.buckets).map(([tier, buckets]) => (
+          <BarSeries
+            id={`ingestionRate-${tier}`}
+            key={`ingestionRate-${tier}`}
+            name={capitalize(tier)}
+            data={buckets}
+            color={ilmPhases[tier as PhaseName].color}
             xScaleType="time"
             xAccessor={'key'}
             yAccessors={['value']}
+            stackAccessors={[0]}
           />
+        ))}
 
-          <Axis
-            id="bottom-axis"
-            position="bottom"
-            tickFormat={(value) => moment(value).format('YYYY-MM-DD')}
-            gridLine={{ visible: false }}
-          />
-          <Axis
-            id="left-axis"
-            position="left"
-            tickFormat={(value) => formatBytes(value)}
-            gridLine={{ visible: true }}
-          />
-        </Chart>
-      )}
+        <Axis
+          id="bottom-axis"
+          position="bottom"
+          tickFormat={(value) => moment(value).format('YYYY-MM-DD HH:mm:ss')}
+          gridLine={{ visible: true }}
+        />
+        <Axis
+          id="left-axis"
+          position="left"
+          tickFormat={(value) => formatBytes(value)}
+          gridLine={{ visible: true }}
+        />
+      </Chart>
+
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow>
+          <EuiText size="xs">
+            <b>
+              {toLegendFormat(ingestionRate.start)} - {toLegendFormat(ingestionRate.end)} (interval:{' '}
+              {ingestionRate.interval})
+            </b>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </>
   );
+}
+
+function toLegendFormat(date: moment.Moment) {
+  return date.format('MMM DD, YYYY @ HH:mm:ss');
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/metadata.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/metadata.tsx
@@ -25,6 +25,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
+  EuiIconTip,
   EuiLink,
   EuiLoadingSpinner,
   EuiPanel,
@@ -33,6 +34,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { LifecycleEditAction } from './modal';
+import { IlmLink } from './ilm_link';
 import { useStreamsAppRouter } from '../../../hooks/use_streams_app_router';
 import { DataStreamStats } from './hooks/use_data_stream_stats';
 import { formatBytes } from './helpers/format_bytes';
@@ -96,19 +98,7 @@ export function RetentionMetadata({
 
   const ilmLink = isIlmLifecycle(lifecycle) ? (
     <EuiBadge color="hollow">
-      <EuiLink
-        target="_blank"
-        data-test-subj="streamsAppLifecycleBadgeIlmPolicyNameLink"
-        href={ilmLocator?.getRedirectUrl({
-          page: 'policy_edit',
-          policyName: lifecycle.ilm.policy,
-        })}
-      >
-        {i18n.translate('xpack.streams.entityDetailViewWithoutParams.ilmBadgeLabel', {
-          defaultMessage: 'ILM Policy: {name}',
-          values: { name: lifecycle.ilm.policy },
-        })}
-      </EuiLink>
+      <IlmLink lifecycle={lifecycle} ilmLocator={ilmLocator} />
     </EuiBadge>
   ) : null;
 
@@ -143,7 +133,7 @@ export function RetentionMetadata({
   );
 
   return (
-    <EuiPanel hasBorder={false} hasShadow={false}>
+    <EuiPanel hasBorder={false} hasShadow={false} paddingSize="s">
       <MetadataRow
         metadata={i18n.translate('xpack.streams.streamDetailLifecycle.retentionPeriodLabel', {
           defaultMessage: 'Retention period',
@@ -167,7 +157,7 @@ export function RetentionMetadata({
         }
         button={contextualMenu}
       />
-      <EuiHorizontalRule margin="m" />
+      <EuiHorizontalRule margin="s" />
       <MetadataRow
         metadata={i18n.translate('xpack.streams.streamDetailLifecycle.retentionSourceLabel', {
           defaultMessage: 'Source',
@@ -179,10 +169,14 @@ export function RetentionMetadata({
           </EuiFlexGroup>
         }
       />
-      <EuiHorizontalRule margin="m" />
+      <EuiHorizontalRule margin="s" />
       <MetadataRow
         metadata={i18n.translate('xpack.streams.streamDetailLifecycle.ingestionRate', {
           defaultMessage: 'Ingestion',
+        })}
+        tip={i18n.translate('xpack.streams.streamDetailLifecycle.ingestionRateDetails', {
+          defaultMessage:
+            'Estimated average (stream total size divided by the number of days since creation).',
         })}
         value={
           statsError ? (
@@ -196,7 +190,7 @@ export function RetentionMetadata({
           )
         }
       />
-      <EuiHorizontalRule margin="m" />
+      <EuiHorizontalRule margin="s" />
       <MetadataRow
         metadata={i18n.translate('xpack.streams.streamDetailLifecycle.totalDocs', {
           defaultMessage: 'Total doc count',
@@ -218,19 +212,28 @@ export function RetentionMetadata({
 function MetadataRow({
   metadata,
   value,
+  tip,
   button,
 }: {
   metadata: string;
   value: ReactNode;
-  action?: string;
+  tip?: string;
   button?: ReactNode;
 }) {
   return (
     <EuiFlexGroup alignItems="center" gutterSize="xl" responsive={false}>
       <EuiFlexItem grow={1}>
-        <EuiText>
-          <b>{metadata}</b>
-        </EuiText>
+        <EuiFlexGroup gutterSize="xs" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <b>{metadata}</b>
+          </EuiFlexItem>
+
+          {tip ? (
+            <EuiFlexItem grow={false}>
+              <EuiIconTip content={tip} position="right" />
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem grow={4}>{value}</EuiFlexItem>
       <EuiFlexItem grow={1}>{button}</EuiFlexItem>

--- a/x-pack/platform/plugins/shared/streams_app/tsconfig.json
+++ b/x-pack/platform/plugins/shared/streams_app/tsconfig.json
@@ -52,11 +52,11 @@
     "@kbn/fields-metadata-plugin",
     "@kbn/observability-ai-assistant-plugin",
     "@kbn/actions-plugin",
-    "@kbn/object-utils",
-    "@kbn/traced-es-client",
-    "@kbn/datemath",
     "@kbn/dataset-quality-plugin",
     "@kbn/search-types",
-    "@kbn/licensing-plugin"
+    "@kbn/object-utils",
+    "@kbn/traced-es-client",
+    "@kbn/licensing-plugin",
+    "@kbn/datemath"
   ]
 }

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/helpers/requests.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/helpers/requests.ts
@@ -91,3 +91,20 @@ export async function getStream(
     .expect(expectStatusCode)
     .then((response) => response.body);
 }
+
+export async function getIlmStats(
+  apiClient: StreamsSupertestRepositoryClient,
+  name: string,
+  expectStatusCode: number = 200
+) {
+  return await apiClient
+    .fetch('GET /api/streams/{name}/lifecycle/_stats', {
+      params: {
+        path: {
+          name,
+        },
+      },
+    })
+    .expect(expectStatusCode)
+    .then((response) => response.body);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[streams] ilm lifecycle summary (#210875)](https://github.com/elastic/kibana/pull/210875)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kevin Lacabane","email":"kevin.lacabane@elastic.co"},"sourceCommit":{"committedDate":"2025-02-26T13:39:44Z","message":"[streams] ilm lifecycle summary (#210875)\n\nAdds a panel to the lifecycle tab that describes the effective ILM\nphases with their respective size and updates the ingestion rate graph\nto show the ilm phases.\n\nAdded two endpoints:\n- `/api/streams/{name}/lifecycle/_stats` to compute the data stream ilm\nphases size\n- `/api/streams/{name}/lifecycle/{indices}/_explain` which is a proxy to\nilm explain api\n\n### Screenshots\n![Screenshot 2025-02-23 at 23 24\n07](https://github.com/user-attachments/assets/27b216f7-01a1-49a8-adcd-f01ee5b6e8a6)\n\n\n![Screenshot 2025-02-17 at 21 52\n23](https://github.com/user-attachments/assets/eb9ba4cd-2a7d-4b04-a93d-2b6e10515cc6)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>","sha":"9df41ff688057b0cfb6bd0e40adf242df68999c6","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Feature:Streams","v9.1.0","v8.19.0"],"title":"[streams] ilm lifecycle summary","number":210875,"url":"https://github.com/elastic/kibana/pull/210875","mergeCommit":{"message":"[streams] ilm lifecycle summary (#210875)\n\nAdds a panel to the lifecycle tab that describes the effective ILM\nphases with their respective size and updates the ingestion rate graph\nto show the ilm phases.\n\nAdded two endpoints:\n- `/api/streams/{name}/lifecycle/_stats` to compute the data stream ilm\nphases size\n- `/api/streams/{name}/lifecycle/{indices}/_explain` which is a proxy to\nilm explain api\n\n### Screenshots\n![Screenshot 2025-02-23 at 23 24\n07](https://github.com/user-attachments/assets/27b216f7-01a1-49a8-adcd-f01ee5b6e8a6)\n\n\n![Screenshot 2025-02-17 at 21 52\n23](https://github.com/user-attachments/assets/eb9ba4cd-2a7d-4b04-a93d-2b6e10515cc6)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>","sha":"9df41ff688057b0cfb6bd0e40adf242df68999c6"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210875","number":210875,"mergeCommit":{"message":"[streams] ilm lifecycle summary (#210875)\n\nAdds a panel to the lifecycle tab that describes the effective ILM\nphases with their respective size and updates the ingestion rate graph\nto show the ilm phases.\n\nAdded two endpoints:\n- `/api/streams/{name}/lifecycle/_stats` to compute the data stream ilm\nphases size\n- `/api/streams/{name}/lifecycle/{indices}/_explain` which is a proxy to\nilm explain api\n\n### Screenshots\n![Screenshot 2025-02-23 at 23 24\n07](https://github.com/user-attachments/assets/27b216f7-01a1-49a8-adcd-f01ee5b6e8a6)\n\n\n![Screenshot 2025-02-17 at 21 52\n23](https://github.com/user-attachments/assets/eb9ba4cd-2a7d-4b04-a93d-2b6e10515cc6)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>","sha":"9df41ff688057b0cfb6bd0e40adf242df68999c6"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->