### PR TITLE
[Spacetime][FTR] Less uses of home grown retry svcs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1126,6 +1126,7 @@
     "del": "^6.1.0",
     "diff": "^7.0.0",
     "dotenv": "^16.4.5",
+    "effect": "^3.13.2",
     "elastic-apm-node": "^4.11.0",
     "email-addresses": "^5.0.0",
     "eventsource-parser": "^3.0.0",

--- a/x-pack/test/api_integration/apis/slos/helper/wait_for_index_state.ts
+++ b/x-pack/test/api_integration/apis/slos/helper/wait_for_index_state.ts
@@ -7,10 +7,7 @@
 
 import type { Client } from '@elastic/elasticsearch';
 import type { AggregationsAggregate, SearchResponse } from '@elastic/elasticsearch/lib/api/types';
-import { retryForSuccess } from '@kbn/ftr-common-functional-services';
-import { ToolingLog } from '@kbn/tooling-log';
-
-const debugLog = ToolingLog.bind(ToolingLog, { level: 'debug', writeTo: process.stdout });
+import { Console, Effect } from 'effect';
 
 export async function waitForDocumentInIndex<T>({
   esClient,
@@ -21,22 +18,27 @@ export async function waitForDocumentInIndex<T>({
   indexName: string;
   docCountTarget?: number;
 }): Promise<SearchResponse<T, Record<string, AggregationsAggregate>>> {
-  return await retryForSuccess(new debugLog({ context: 'waitForDocumentInIndex' }), {
-    timeout: 20_000,
-    methodName: 'waitForDocumentInIndex',
-    block: async () => {
-      const response = await esClient.search<T>({ index: indexName, rest_total_hits_as_int: true });
-      if (
-        !response.hits.total ||
-        typeof response.hits.total !== 'number' ||
-        response.hits.total < docCountTarget
-      ) {
-        throw new Error('No hits found');
-      }
-      return response;
-    },
-    retryCount: 10,
-  });
+  const search = () =>
+    esClient.search<T>({ index: indexName, rest_total_hits_as_int: true }).then(inspect);
+
+  function inspect(response) {
+    if (
+      !response.hits.total ||
+      typeof response.hits.total !== 'number' ||
+      response.hits.total < docCountTarget
+    )
+      throw new Error('No hits found');
+
+    return response;
+  }
+
+  return await Effect.runPromise(
+    Effect.tryPromise(search).pipe(
+      Effect.retry({ times: 100 }),
+      Effect.timeout('90 seconds'),
+      Effect.catchAll(Console.error)
+    )
+  );
 }
 
 export async function waitForIndexToBeEmpty<T>({
@@ -46,17 +48,21 @@ export async function waitForIndexToBeEmpty<T>({
   esClient: Client;
   indexName: string;
 }): Promise<SearchResponse<T, Record<string, AggregationsAggregate>>> {
-  return await retryForSuccess(new debugLog({ context: 'waitForIndexToBeEmpty' }), {
-    timeout: 20_000,
-    methodName: 'waitForIndexToBeEmpty',
-    block: async () => {
-      const response = await esClient.search<T>({ index: indexName, rest_total_hits_as_int: true });
-      // @ts-expect-error upgrade typescript v5.1.6
-      if (response.hits.total != null && response.hits.total > 0) {
-        throw new Error(`Found ${response.hits.total} docs.`);
-      }
-      return response;
-    },
-    retryCount: 10,
-  });
+  const search = () =>
+    esClient.search<T>({ index: indexName, rest_total_hits_as_int: true }).then(inspect);
+
+  function inspect(response) {
+    if (response.hits.total != null && response.hits.total > 0)
+      throw new Error(`Found ${response.hits.total} docs.`);
+
+    return response;
+  }
+
+  return await Effect.runPromise(
+    Effect.tryPromise(search).pipe(
+      Effect.retry({ times: 100 }),
+      Effect.timeout('2 minutes'),
+      Effect.catchAll(Console.error)
+    )
+  );
 }

--- a/x-pack/test/apm_api_integration/tests/alerts/helpers/alerting_api_helper.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/helpers/alerting_api_helper.ts
@@ -11,8 +11,6 @@ import { ApmRuleParamsType } from '@kbn/apm-plugin/common/rules/apm_rule_types';
 import type { Agent as SuperTestAgent } from 'supertest';
 import { ApmRuleType } from '@kbn/rule-data-utils';
 import { ObservabilityApmAlert } from '@kbn/alerts-as-data-utils';
-import { retryForSuccess } from '@kbn/ftr-common-functional-services';
-import { ToolingLog } from '@kbn/tooling-log';
 import {
   APM_ACTION_VARIABLE_INDEX,
   APM_ALERTS_INDEX,

--- a/x-pack/test/apm_api_integration/tests/alerts/helpers/wait_for_active_rule.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/helpers/wait_for_active_rule.ts
@@ -7,10 +7,7 @@
 
 import { ToolingLog } from '@kbn/tooling-log';
 import type SuperTest from 'supertest';
-import { retryForSuccess } from '@kbn/ftr-common-functional-services';
-
-const debugLog = ToolingLog.bind(ToolingLog, { level: 'debug', writeTo: process.stdout });
-const retryCount = 10;
+import { Console, Effect } from 'effect';
 
 export async function waitForActiveRule({
   ruleId,
@@ -20,19 +17,37 @@ export async function waitForActiveRule({
   ruleId: string;
   supertest: SuperTest.Agent;
   logger?: ToolingLog;
-}): Promise<Record<string, any>> {
-  return await retryForSuccess(logger || new debugLog({ context: 'waitForActiveRule' }), {
-    timeout: 20_000,
-    methodName: 'waitForActiveRule',
-    block: async () => {
-      const response = await supertest.get(`/api/alerting/rule/${ruleId}`);
-      const status = response.body?.execution_status?.status;
-      const expectedStatus = 'active';
+}) {
+  const getRule = () => supertest.get(`/api/alerting/rule/${ruleId}`).then(logAndInspect);
 
-      if (status !== expectedStatus) throw new Error(`Expected: ${expectedStatus}: got ${status}`);
+  return await Effect.runPromise(
+    Effect.tryPromise(getRule).pipe(
+      Effect.retry({ times: 100 }),
+      Effect.timeout('90 seconds'),
+      Effect.catchAll(Console.error)
+    )
+  );
 
-      return status;
-    },
-    retryCount,
-  });
+  function logAndInspect(response: any): any {
+    if (logger) logResponse(logger, response);
+
+    const status = response.body?.execution_status?.status;
+    const expectedStatus = 'active';
+
+    if (status !== expectedStatus) throw new Error(`Expected: ${expectedStatus}: got ${status}`);
+
+    return status;
+  }
+}
+
+function logResponse(logger: ToolingLog, response: any) {
+  logger.debug(`\nλjs response.status: \n\t${response?.status}`);
+  logger.debug(`\nλjs response.body?.status: \n\t${response.body?.status}`);
+  logger.debug(
+    `\nλjs response.body?.execution_status?.status: \n${JSON.stringify(
+      response.body?.execution_status?.status,
+      null,
+      2
+    )}`
+  );
 }

--- a/x-pack/test/apm_api_integration/tests/alerts/helpers/wait_for_alerts_for_rule.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/helpers/wait_for_alerts_for_rule.ts
@@ -7,21 +7,19 @@
 
 import type { Client } from '@elastic/elasticsearch';
 import type { AggregationsAggregate, SearchResponse } from '@elastic/elasticsearch/lib/api/types';
-import { ToolingLog } from '@kbn/tooling-log';
-import { retryForSuccess } from '@kbn/ftr-common-functional-services';
+import { Console, Effect } from 'effect';
 import {
   APM_ALERTS_INDEX,
   ApmAlertFields,
 } from '../../../../api_integration/deployment_agnostic/apis/observability/apm/alerts/helpers/alerting_helper';
-
-const debugLog = ToolingLog.bind(ToolingLog, { level: 'debug', writeTo: process.stdout });
-
 async function getAlertByRuleId({ es, ruleId }: { es: Client; ruleId: string }) {
   const response = (await es.search({
     index: APM_ALERTS_INDEX,
-    query: {
-      term: {
-        'kibana.alert.rule.uuid': ruleId,
+    body: {
+      query: {
+        term: {
+          'kibana.alert.rule.uuid': ruleId,
+        },
       },
     },
   })) as SearchResponse<ApmAlertFields, Record<string, AggregationsAggregate>>;
@@ -38,17 +36,20 @@ export async function waitForAlertsForRule({
   ruleId: string;
   minimumAlertCount?: number;
 }) {
-  return await retryForSuccess(new debugLog({ context: 'waitForAlertsForRule' }), {
-    timeout: 20_000,
-    methodName: 'waitForAlertsForRule',
-    block: async () => {
-      const alerts = await getAlertByRuleId({ es, ruleId });
+  const getAlerts = () =>
+    getAlertByRuleId({ es, ruleId }).then((alerts) => {
       const actualAlertCount = alerts.length;
       if (actualAlertCount < minimumAlertCount)
         throw new Error(`Expected ${minimumAlertCount} but got ${actualAlertCount} alerts`);
 
       return alerts;
-    },
-    retryCount: 5,
-  });
+    });
+
+  return await Effect.runPromise(
+    Effect.tryPromise(getAlerts).pipe(
+      Effect.retry({ times: 100 }),
+      Effect.timeout('2 minutes'),
+      Effect.catchAll(Console.error)
+    )
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10021,6 +10021,11 @@
   resolved "https://registry.yarnpkg.com/@sovpro/delimited-stream/-/delimited-stream-1.1.0.tgz#4334bba7ee241036e580fdd99c019377630d26b4"
   integrity sha512-kQpk267uxB19X3X2T1mvNMjyvIEonpNSHrMlK5ZaBU6aZxw7wPbpgKJOjHN3+/GPVpXgAV9soVT2oyHpLkLtyw==
 
+"@standard-schema/spec@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.0.0.tgz#f193b73dc316c4170f2e82a881da0f550d551b9c"
+  integrity sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==
+
 "@statoscope/extensions@5.28.1":
   version "5.28.1"
   resolved "https://registry.yarnpkg.com/@statoscope/extensions/-/extensions-5.28.1.tgz#bc270f9366c4b2c13342f1a0d138520cf607a5bb"
@@ -18052,6 +18057,14 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
+effect@^3.13.2:
+  version "3.13.2"
+  resolved "https://registry.yarnpkg.com/effect/-/effect-3.13.2.tgz#21597290f3ea86043cf9ce3ef4ffe5629148ce5f"
+  integrity sha512-/w+CPqHDJ33Wq7xC4YKAchrEEPtjvxh563xH9kDTZp99seNYBoBs87vl8DJwartEjj+KLQLP8PzoDne+XmGT2A==
+  dependencies:
+    "@standard-schema/spec" "^1.0.0"
+    fast-check "^3.23.1"
+
 ejs@^3.1.10:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
@@ -19278,6 +19291,13 @@ fancy-log@^1.3.3:
     color-support "^1.1.3"
     parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
+
+fast-check@^3.23.1:
+  version "3.23.2"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-3.23.2.tgz#0129f1eb7e4f500f58e8290edc83c670e4a574a2"
+  integrity sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==
+  dependencies:
+    pure-rand "^6.1.0"
 
 fast-content-type-parse@^2.0.0:
   version "2.0.1"
@@ -27817,6 +27837,11 @@ pure-rand@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.2.tgz#a9c2ddcae9b68d736a8163036f088a2781c8b306"
   integrity sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==
+
+pure-rand@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
+  integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
 qs@6.13.0, qs@^6.10.0, qs@^6.11.0, qs@^6.7.0:
   version "6.13.0"


### PR DESCRIPTION
## Summary

I find the retrying code to be cumbersome and I wanted to learn if there was a simple way to have retries, without our homegrown implementations.

### Note
I'm only modifying usages where the enclosing function is actually in use.

### To verify
Place a `.only` on [this suite](https://github.com/elastic/kibana/blob/main/x-pack/test/apm_api_integration/tests/alerts/anomaly_alert.spec.ts#L80).

Then run it
`TEST_BROWSER_HEADLESS=1 node scripts/functional_tests --debug --bail --config x-pack/test/apm_api_integration/trial/config.ts`

### Big Idea?

What if we don't need a service to retry at all?
What if we could retry anything with custom retry policies, and perhaps even some good defaults?

The big idea is less code to debug through, less code to maintain, etc.

