### PR TITLE
[Fleet] improve to_json handlebar helper

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
@@ -381,6 +381,21 @@ yaml_var: {{to_json yaml_var}}
         },
       });
     });
+
+    it('should encoding strings to JSON', () => {
+      const vars = {
+        user_input: `foo: "bar 'baz'"`,
+      };
+
+      const template = `
+rendered_value: {{ to_json user_input }}
+      `;
+
+      const output = compileTemplate(vars, template);
+      expect(output).toEqual({
+        rendered_value: `foo: "bar 'baz'"`,
+      });
+    });
   });
 
   it('should support optional yaml values at root level', () => {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.test.ts
@@ -338,12 +338,12 @@ with new lines`,
   describe('to_json helper', () => {
     const streamTemplate = `
 input: log
-json_var: {{to_json json_var}}
+json_var: {{json_var}}
       `;
 
     const streamTemplateWithNewYaml = `
 input: log
-yaml_var: {{to_json yaml_var}}
+yaml_var: {{to_json yaml_var_data}}
       `;
 
     it('should parse a json string into a json object', () => {
@@ -384,7 +384,7 @@ yaml_var: {{to_json yaml_var}}
 
     it('should encoding strings to JSON', () => {
       const vars = {
-        user_input: `foo: "bar 'baz'"`,
+        user_input: {type: 'text', value: `foo: "bar 'baz'"}`},
       };
 
       const template = `
@@ -393,7 +393,7 @@ rendered_value: {{ to_json user_input }}
 
       const output = compileTemplate(vars, template);
       expect(output).toEqual({
-        rendered_value: `foo: "bar 'baz'"`,
+        rendered_value: "foo: \"bar 'baz'\"}"
       });
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
@@ -103,7 +103,11 @@ function buildTemplateVariables(logger: Logger, variables: PackagePolicyConfigRe
     if (recordEntry.type && recordEntry.type === 'yaml') {
       const yamlKeyPlaceholder = `##${key}##`;
       varPart[lastKeyPart] = recordEntry.value ? `"${yamlKeyPlaceholder}"` : null;
-      yamlValues[yamlKeyPlaceholder] = recordEntry.value ? load(recordEntry.value) : null;
+
+      // HACK! Give templates access to the value via a key that has a '_data' suffix.
+      const v = recordEntry.value ? load(recordEntry.value) : null;
+      varPart[lastKeyPart+"_data"] = v;
+      yamlValues[yamlKeyPlaceholder] = v;
     } else if (recordEntry.value && recordEntry.value.isSecretRef) {
       varPart[lastKeyPart] = toCompiledSecretRef(recordEntry.value.id);
     } else {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
@@ -148,12 +148,8 @@ function escapeMultilineStringHelper(str: string) {
 }
 handlebars.registerHelper('escape_multiline_string', escapeMultilineStringHelper);
 
-// toJsonHelper will convert any object to a Json string.
+// toJsonHelper will convert any JavaScript value to a JSON string.
 function toJsonHelper(value: any) {
-  if (typeof value === 'string') {
-    // if we get a string we assume is an already serialized json
-    return value;
-  }
   return JSON.stringify(value);
 }
 handlebars.registerHelper('to_json', toJsonHelper);


### PR DESCRIPTION
# DRAFT

## Summary

The `to_json` handlebar helper function has inconsistent behavior across data types. While it properly serializes objects, arrays, numbers, and booleans to JSON, it treats strings as a special case - passing them through unchanged under the assumption they're already valid JSON. This exceptional treatment of strings makes it difficult for developers to use correctly.

By making `to_json` invariant across all data types, we improve the integration developer experience and template reliability. The helper would fulfill its semantic promise of "converting to JSON" rather than requiring developers to understand its "special" behavior. 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



