### PR TITLE
chore(security,codeql): exclude `**/stub/**` folders from CodeQL scans

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -20,6 +20,7 @@ paths-ignore:
   - '**/kbn-scout-*'
   - '**/mocks.*'
   - '**/mocks/**'
+  - '**/stub/**'
   - '**/scripts/**'
   - '**/storybook/**'
   - '**/test_helpers/**'


### PR DESCRIPTION
## Summary

Eexclude `**/stub/**` folders from CodeQL scans.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->