### PR TITLE
[8.x] Rename FindingsBaseEsQuery interface in CSP package (#212427)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/types.ts
@@ -27,7 +27,7 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { IKibanaSearchResponse, IKibanaSearchRequest } from '@kbn/search-types';
 
 import type { BoolQuery } from '@kbn/es-query';
-export interface FindingsBaseEsQuery {
+export interface BaseEsQuery {
   query?: {
     bool: BoolQuery;
   };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings.ts
@@ -19,14 +19,14 @@ import {
 } from '@kbn/cloud-security-posture-common';
 import type { CspFinding } from '@kbn/cloud-security-posture-common';
 import type { CspBenchmarkRulesStates } from '@kbn/cloud-security-posture-common/schema/rules/latest';
-import type { FindingsBaseEsQuery } from '@kbn/cloud-security-posture';
+import type { BaseEsQuery } from '@kbn/cloud-security-posture';
 import { useGetCspBenchmarkRulesStatesApi } from '@kbn/cloud-security-posture/src/hooks/use_get_benchmark_rules_state_api';
 import type { RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
 import { CDR_MISCONFIGURATION_DATA_TABLE_RUNTIME_MAPPING_FIELDS } from '../../../common/constants';
 import { useKibana } from '../../../common/hooks/use_kibana';
 import { getAggregationCount, getFindingsCountAggQuery } from '../utils/utils';
 
-interface UseFindingsOptions extends FindingsBaseEsQuery {
+interface UseFindingsOptions extends BaseEsQuery {
   sort: string[][];
   enabled: boolean;
   pageSize: number;

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities.tsx
@@ -21,7 +21,7 @@ import {
   CDR_VULNERABILITIES_INDEX_PATTERN,
   CDR_3RD_PARTY_RETENTION_POLICY,
 } from '@kbn/cloud-security-posture-common';
-import { FindingsBaseEsQuery, showErrorToast } from '@kbn/cloud-security-posture';
+import { BaseEsQuery, showErrorToast } from '@kbn/cloud-security-posture';
 import type { CspVulnerabilityFinding } from '@kbn/cloud-security-posture-common/schema/vulnerabilities/latest';
 import type { RuntimePrimitiveTypes } from '@kbn/data-views-plugin/common';
 import {
@@ -38,7 +38,7 @@ type LatestFindingsResponse = IKibanaSearchResponse<
 interface FindingsAggs {
   count: AggregationsMultiBucketAggregateBase<AggregationsStringRareTermsBucketKeys>;
 }
-interface VulnerabilitiesQuery extends FindingsBaseEsQuery {
+interface VulnerabilitiesQuery extends BaseEsQuery {
   sort: string[][];
   enabled: boolean;
   pageSize: number;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Rename FindingsBaseEsQuery interface in CSP package (#212427)](https://github.com/elastic/kibana/pull/212427)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alberto Blázquez","email":"albertoblaz@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-27T10:20:06Z","message":"Rename FindingsBaseEsQuery interface in CSP package (#212427)\n\n## Summary\n\nRename the `FindingsBaseEsQuery` interface exposed by the\n`@kibana/cloud-security-posture` package as well as all references where\nit's imported.\n\nSeparating this renaming into its own PR also lets us tag it with\n`backport:prev-minor` and avoid potential merge conflicts in the future.\n\n### Depends on\n\n- https://github.com/elastic/kibana/pull/210938\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nNo risk whatsoever.","sha":"aac841353dabe25974dfb661c9f4b591eb8fe42b","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Cloud Security","backport:prev-minor","v9.1.0"],"title":"Rename FindingsBaseEsQuery interface in CSP package","number":212427,"url":"https://github.com/elastic/kibana/pull/212427","mergeCommit":{"message":"Rename FindingsBaseEsQuery interface in CSP package (#212427)\n\n## Summary\n\nRename the `FindingsBaseEsQuery` interface exposed by the\n`@kibana/cloud-security-posture` package as well as all references where\nit's imported.\n\nSeparating this renaming into its own PR also lets us tag it with\n`backport:prev-minor` and avoid potential merge conflicts in the future.\n\n### Depends on\n\n- https://github.com/elastic/kibana/pull/210938\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nNo risk whatsoever.","sha":"aac841353dabe25974dfb661c9f4b591eb8fe42b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212427","number":212427,"mergeCommit":{"message":"Rename FindingsBaseEsQuery interface in CSP package (#212427)\n\n## Summary\n\nRename the `FindingsBaseEsQuery` interface exposed by the\n`@kibana/cloud-security-posture` package as well as all references where\nit's imported.\n\nSeparating this renaming into its own PR also lets us tag it with\n`backport:prev-minor` and avoid potential merge conflicts in the future.\n\n### Depends on\n\n- https://github.com/elastic/kibana/pull/210938\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nNo risk whatsoever.","sha":"aac841353dabe25974dfb661c9f4b591eb8fe42b"}}]}] BACKPORT-->