### PR TITLE
[8.x] chore(security,codeql): exclude `**/stub/**` folders from CodeQL scans (#212608)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -19,6 +19,7 @@ paths-ignore:
   - '**/jest.integration.config.*'
   - '**/mocks.*'
   - '**/mocks/**'
+  - '**/stub/**'
   - '**/storybook/**'
   - '**/test_helpers/**'
   - '**/test_utils/**'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [chore(security,codeql): exclude `**/stub/**` folders from CodeQL scans (#212608)](https://github.com/elastic/kibana/pull/212608)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2025-02-27T10:20:48Z","message":"chore(security,codeql): exclude `**/stub/**` folders from CodeQL scans (#212608)\n\n## Summary\n\nEexclude `**/stub/**` folders from CodeQL scans.","sha":"7155c05bd9954cacfd1f7f075fdda40b9350f9fb","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","security","backport:version","v9.1.0","v8.19.0"],"title":"chore(security,codeql): exclude `**/stub/**` folders from CodeQL scans","number":212608,"url":"https://github.com/elastic/kibana/pull/212608","mergeCommit":{"message":"chore(security,codeql): exclude `**/stub/**` folders from CodeQL scans (#212608)\n\n## Summary\n\nEexclude `**/stub/**` folders from CodeQL scans.","sha":"7155c05bd9954cacfd1f7f075fdda40b9350f9fb"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212608","number":212608,"mergeCommit":{"message":"chore(security,codeql): exclude `**/stub/**` folders from CodeQL scans (#212608)\n\n## Summary\n\nEexclude `**/stub/**` folders from CodeQL scans.","sha":"7155c05bd9954cacfd1f7f075fdda40b9350f9fb"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->