### PR TITLE
[Security Solution][Notes] show timeline bottom bar on the notes management page to allow user to visualize timeline

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/notes/links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/notes/links.ts
@@ -27,6 +27,6 @@ export const links: LinkItem = {
   capabilities: [[`${SECURITY_FEATURE_ID}.show`, `${NOTES_FEATURE_ID}.read`]],
   landingIcon: 'filebeatApp',
   skipUrlState: true,
-  hideTimeline: true,
+  hideTimeline: false,
   hideWhenExperimentalKey: 'securitySolutionNotesDisabled',
 };


### PR DESCRIPTION
## Summary

This previous [PR](https://github.com/elastic/kibana/pull/199374) that unified the notes management links introduced a small issue where the Timeline bottom bar was not shown anymore, and Timelines couldn't be opened from the icon in the notes table.

This PR brings back the Timeline feature to that page, which fixes the issue with Timeline not opening when clicking on the button in the table.

#### Before

https://github.com/user-attachments/assets/ce3fdf1f-f7e4-43ff-b5c8-240f0e3a6770

#### After

https://github.com/user-attachments/assets/a8c7a39c-8913-4c12-8191-7e171ff5050e


<!--ONMERGE {"backportTargets":["8.17","8.18","8.x","9.0"]} ONMERGE-->