### PR TITLE
[streams] ui tweaks

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/metadata.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/metadata.tsx
@@ -103,7 +103,7 @@ export function RetentionMetadata({
   ) : null;
 
   const lifecycleOrigin = isInheritLifecycle(definition.stream.ingest.lifecycle) ? (
-    <EuiText>
+    <EuiText size="s">
       {i18n.translate('xpack.streams.streamDetailLifecycle.inheritedFrom', {
         defaultMessage: 'Inherited from',
       })}{' '}
@@ -127,9 +127,11 @@ export function RetentionMetadata({
       )}
     </EuiText>
   ) : (
-    i18n.translate('xpack.streams.streamDetailLifecycle.localOverride', {
-      defaultMessage: 'Local override',
-    })
+    <EuiText size="s">
+      {i18n.translate('xpack.streams.streamDetailLifecycle.localOverride', {
+        defaultMessage: 'Local override',
+      })}
+    </EuiText>
   );
 
   return (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/esql_chart/controlled_esql_chart.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/esql_chart/controlled_esql_chart.tsx
@@ -17,8 +17,10 @@ import {
   Settings,
   Tooltip,
   niceTimeFormatter,
+  LIGHT_THEME,
+  DARK_THEME,
 } from '@elastic/charts';
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, useEuiTheme } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/css';
 import { AbortableAsyncState } from '@kbn/react-hooks';
@@ -70,6 +72,7 @@ export function ControlledEsqlChart<T extends string>({
   const {
     core: { uiSettings },
   } = useKibana();
+  const { colorMode } = useEuiTheme();
 
   const allTimeseries = useMemo(
     () =>
@@ -147,6 +150,7 @@ export function ControlledEsqlChart<T extends string>({
         legendPosition={Position.Bottom}
         xDomain={xDomain}
         locale={i18n.getLocale()}
+        baseTheme={colorMode === 'LIGHT' ? LIGHT_THEME : DARK_THEME}
       />
       <Axis
         id="x-axis"


### PR DESCRIPTION
- make lifecycle source metadata text size consistent across the cases
- set stream overview chart base theme to the appropriate color

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->