### PR TITLE
[Cloud Security] Fix installing agent-based CSP integrations not displaying Add Agent flyout

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -47,6 +47,7 @@ import {
   useIntegrationsStateContext,
   useGetSettingsQuery,
 } from '../../../../hooks';
+import { useAgentless } from '../../../../../fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology';
 import { INTEGRATIONS_ROUTING_PATHS } from '../../../../constants';
 import {
   useGetPackageInfoByKeyQuery,
@@ -135,6 +136,7 @@ export function Detail() {
   const { getHref, getPath } = useLink();
   const history = useHistory();
   const { pathname, search, hash } = useLocation();
+  const { isAgentlessIntegration } = useAgentless();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
   const integration = useMemo(() => queryParams.get('integration'), [queryParams]);
   const prerelease = useMemo(() => Boolean(queryParams.get('prerelease')), [queryParams]);
@@ -412,6 +414,7 @@ export function Detail() {
         isFirstTimeAgentUser,
         isGuidedOnboardingActive,
         pkgkey,
+        isAgentlessIntegration: isAgentlessIntegration(packageInfo || undefined),
       });
 
       /** Users from Security Solution onboarding page will have onboardingLink and onboardingAppId in the query params
@@ -440,11 +443,13 @@ export function Detail() {
       hash,
       history,
       integration,
+      isAgentlessIntegration,
       isCloud,
       isFirstTimeAgentUser,
       isGuidedOnboardingActive,
       onboardingAppId,
       onboardingLink,
+      packageInfo,
       pathname,
       pkgkey,
       search,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
@@ -29,7 +29,7 @@ interface GetInstallPkgRouteOptionsParams {
   isCloud: boolean;
   isFirstTimeAgentUser: boolean;
   isGuidedOnboardingActive: boolean;
-  isAgentlessIntegration: boolean;
+  isAgentlessIntegration?: boolean;
 }
 
 export type InstallPkgRouteOptions = [

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
@@ -29,6 +29,7 @@ interface GetInstallPkgRouteOptionsParams {
   isCloud: boolean;
   isFirstTimeAgentUser: boolean;
   isGuidedOnboardingActive: boolean;
+  isAgentlessIntegration: boolean;
 }
 
 export type InstallPkgRouteOptions = [
@@ -50,6 +51,7 @@ export const getInstallPkgRouteOptions = ({
   isFirstTimeAgentUser,
   isCloud,
   isGuidedOnboardingActive,
+  isAgentlessIntegration,
 }: GetInstallPkgRouteOptionsParams): InstallPkgRouteOptions => {
   const integrationOpts: { integration?: string } = integration ? { integration } : {};
   const packageExemptFromStepsLayout = isPackageExemptFromStepsLayout(pkgkey);
@@ -97,7 +99,7 @@ export const getInstallPkgRouteOptions = ({
   }
 
   const state: CreatePackagePolicyRouteState = {
-    onSaveNavigateTo: redirectToPath,
+    onSaveNavigateTo: !isAgentlessIntegration ? redirectToPath : undefined,
     onSaveQueryParams,
     onCancelNavigateTo: [
       INTEGRATIONS_PLUGIN_ID,


### PR DESCRIPTION
## Summary
Fixes the onSaveNavigate route when creating an agentless-enabled integration. Since an integration can support both agentless and agent-based deployments, we need to dynamically determine the navigation destination after saving the integration.

- If the deployment is agentless, the navigation should go to the integration details' policy list view.
- If the deployment is agent-based, the navigation should go to the Fleet Agent Policy page, with the onboarding flyout visible.

We need a way to force the [onSaveNavigate function not to use routeState.onSaveNavigateTo](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/hooks/navigation.tsx#L102) if the integration is agentless. Therefore, [ not setting the routeState.onSaveNavigateTo](https://github.com/elastic/kibana/pull/212702/files#diff-ee99a509c381ffad499e755261930409e8faaacee99be68ca31b70b2ff15c38aR102) state seems like the most likely solution.


https://github.com/user-attachments/assets/a84964b6-1dd7-45e2-a757-a128fb2ef1f1

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed






<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->