### PR TITLE
[9.0]  Siem Migrations - Fix rules upload API Error Test. (#212290)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/rules/sub_steps/rules_file_upload/rules_file_upload.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/data_input_flyout/steps/rules/sub_steps/rules_file_upload/rules_file_upload.test.tsx
@@ -132,42 +132,16 @@ describe('RulesFileUpload', () => {
       },
     ];
 
-    it('should not be able to upload on API Error', async () => {
+    it('should display API Error', async () => {
       renderTestComponent({
         apiError: mockApiError,
       });
 
-      const fileName = 'splunk_rules.test.data.json';
-      const ndJSONString = splunkTestRules.map((obj) => JSON.stringify(obj)).join('\n');
-      const testFile = createRulesFileFromRulesData(ndJSONString, getTestDir(), fileName);
-
-      const filePicker = screen.getByTestId('rulesFilePicker');
-
-      act(() => {
-        fireEvent.change(filePicker, {
-          target: {
-            files: [testFile],
-          },
-        });
-      });
-
-      await waitFor(() => {
-        expect(filePicker).toHaveAttribute('data-loading', 'true');
-      });
-
-      await waitFor(() => {
-        expect(filePicker).toHaveAttribute('data-loading', 'false');
-      });
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('uploadFileButton'));
-      });
-
       await waitFor(() => {
         expect(screen.getByText(mockApiError)).toBeVisible();
-        expect(screen.getByTestId('uploadFileButton')).toBeDisabled();
       });
     });
+
     scenarios.forEach((scenario, _idx) => {
       it(`should not be able to upload when file has - ${scenario.subject}`, async () => {
         const fileName = 'invalid_rule_file.json';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [ Siem Migrations - Fix rules upload API Error Test. (#212290)](https://github.com/elastic/kibana/pull/212290)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jatin Kathuria","email":"jatin.kathuria@elastic.co"},"sourceCommit":{"committedDate":"2025-02-24T18:59:41Z","message":" Siem Migrations - Fix rules upload API Error Test. (#212290)\n\n## Summary\n\nThis PR fixes a incorrect UI test :\n\n- Rules Upload File component should only display API Error in case it\noccurs, while previously the tests was check if the button is disabled\nor not. Disability of button is irrelevant.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"681cef4590e4847bdd1d6c9eaa68cd4f539e8cc2","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","Team:Threat Hunting","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":" Siem Migrations - Fix rules upload API Error Test.","number":212290,"url":"https://github.com/elastic/kibana/pull/212290","mergeCommit":{"message":" Siem Migrations - Fix rules upload API Error Test. (#212290)\n\n## Summary\n\nThis PR fixes a incorrect UI test :\n\n- Rules Upload File component should only display API Error in case it\noccurs, while previously the tests was check if the button is disabled\nor not. Disability of button is irrelevant.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"681cef4590e4847bdd1d6c9eaa68cd4f539e8cc2"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212300","number":212300,"state":"MERGED","mergeCommit":{"sha":"797a695ae413cb28c52fe238432e9686cb218ad9","message":"[8.18]  Siem Migrations - Fix rules upload API Error Test. (#212290) (#212300)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [ Siem Migrations - Fix rules upload API Error Test.\n(#212290)](https://github.com/elastic/kibana/pull/212290)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jatin Kathuria <jatin.kathuria@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212290","number":212290,"mergeCommit":{"message":" Siem Migrations - Fix rules upload API Error Test. (#212290)\n\n## Summary\n\nThis PR fixes a incorrect UI test :\n\n- Rules Upload File component should only display API Error in case it\noccurs, while previously the tests was check if the button is disabled\nor not. Disability of button is irrelevant.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"681cef4590e4847bdd1d6c9eaa68cd4f539e8cc2"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212301","number":212301,"state":"OPEN"}]}] BACKPORT-->