### PR TITLE
OnWeek 2025-02 - alerting rule type: webhook

### DIFF
--- a/x-pack/platform/plugins/shared/stack_alerts/server/feature.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/feature.ts
@@ -19,11 +19,12 @@ import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
 import { ID as IndexThreshold } from './rule_types/index_threshold/rule_type';
 import { GEO_CONTAINMENT_ID as GeoContainment } from './rule_types/geo_containment';
+import { ID as Webhook } from './rule_types/webhook/rule_type';
 
 const TransformHealth = TRANSFORM_RULE_TYPE.TRANSFORM_HEALTH;
 const DISCOVER_CONSUMER = 'discover';
 
-const basicAlertingFeatures = [IndexThreshold, GeoContainment, TransformHealth].map(
+const basicAlertingFeatures = [IndexThreshold, GeoContainment, TransformHealth, Webhook].map(
   (ruleTypeId) => ({
     ruleTypeId,
     consumers: [STACK_ALERTS_FEATURE_ID, ALERTING_FEATURE_ID],

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/index.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/index.ts
@@ -9,6 +9,7 @@ import type { RegisterRuleTypesParams } from './types';
 import { register as registerIndexThreshold } from './index_threshold';
 import { register as registerGeoContainment } from './geo_containment';
 import { register as registerEsQuery } from './es_query';
+import { register as registerWebhook } from './webhook';
 
 export * from './constants';
 
@@ -18,4 +19,5 @@ export function registerBuiltInRuleTypes(params: RegisterRuleTypesParams, isServ
     registerGeoContainment(params);
   }
   registerEsQuery(params, isServerless);
+  registerWebhook(params);
 }

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/webhook/README.md
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/webhook/README.md
@@ -12,6 +12,8 @@ source code for the webhook:
 - https://glitch.com/edit/#!/kibana-webhook-alerting-rule-poc-2025
 
 ## create a rule in DevTools
+
+```json
 POST kbn:/api/alerting/rule
 {
   "rule_type_id": ".webhook",
@@ -26,3 +28,4 @@ POST kbn:/api/alerting/rule
   "consumer": "alerts",
   "actions": []
 }
+```

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/webhook/README.md
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/webhook/README.md
@@ -1,0 +1,28 @@
+# webhook rule type
+
+This rule type will send an HTTP request to a server to evaluate the rule, 
+returning the alerts to generate.
+
+url supporting this webhook structure:
+
+- https://kibana-webhook-alerting-rule-poc-2025.glitch.me/webhook-rules
+
+source code for the webhook:
+
+- https://glitch.com/edit/#!/kibana-webhook-alerting-rule-poc-2025
+
+## create a rule in DevTools
+POST kbn:/api/alerting/rule
+{
+  "rule_type_id": ".webhook",
+  "name": "webhook rule",
+  "schedule": { "interval": "10s" },
+  "params": {
+    "url": "https://kibana-webhook-alerting-rule-poc-2025.glitch.me/webhook-rule",
+    "method": "POST",
+    "headers": {},
+    "body": "{}"
+  },
+  "consumer": "alerts",
+  "actions": []
+}

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/webhook/index.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/webhook/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RegisterRuleTypesParams } from '../types';
+import { getRuleType } from './rule_type';
+
+export function register(params: RegisterRuleTypesParams) {
+  const { alerting } = params;
+  alerting.registerType(getRuleType());
+}

--- a/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/webhook/rule_type.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/server/rule_types/webhook/rule_type.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import axios from 'axios';
+
+import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
+import { schema, TypeOf } from '@kbn/config-schema';
+import { STACK_ALERTS_FEATURE_ID } from '@kbn/rule-data-utils';
+import { AlertsClientError } from '@kbn/alerting-plugin/server';
+import { AlertInstanceContext } from '@kbn/alerting-plugin/server';
+
+import { STACK_ALERTS_AAD_CONFIG } from '..';
+import { RuleType, RuleExecutorOptions } from '../../types';
+import { StackAlertType } from '../types';
+
+type JSONable = ReturnType<typeof JSON.parse> | null;
+
+// rule type context provided to actions
+export interface ActionContext extends AlertInstanceContext {
+  nothing: JSONable;
+}
+
+const StringML1 = schema.string({ minLength: 1 });
+
+type Params = TypeOf<typeof Params>;
+const Params = schema.object({
+  url: StringML1,
+  method: StringML1,
+  headers: schema.recordOf(StringML1, StringML1),
+  body: StringML1,
+});
+
+type AlertData = TypeOf<typeof AlertData>;
+const AlertData = schema.object({
+  alerts: schema.arrayOf(
+    schema.object({
+      instanceId: StringML1,
+      actionGroup: StringML1,
+      context: schema.any(),
+    })
+  ),
+});
+
+export const ID = '.webhook';
+export const NAME = 'Webhook';
+export const ActionGroupId = 'alert';
+export const ActionGroupName = 'Alert';
+
+type ActionGroupIdType = typeof ActionGroupId;
+
+export function getRuleType(): RuleType<
+  Params,
+  never,
+  {},
+  {},
+  ActionContext,
+  typeof ActionGroupId,
+  never,
+  StackAlertType
+> {
+  return {
+    id: ID,
+    name: NAME,
+    actionGroups: [{ id: ActionGroupId, name: ActionGroupName }],
+    defaultActionGroupId: ActionGroupId,
+    validate: {
+      params: Params,
+    },
+    schemas: {
+      params: {
+        type: 'config-schema',
+        schema: Params,
+      },
+    },
+    actionVariables: {
+      context: [],
+      params: [
+        { name: 'url', description: 'url' },
+        { name: 'method', description: 'method' },
+        { name: 'body', description: 'body' },
+        { name: 'headers', description: 'headers' },
+      ],
+    },
+    minimumLicenseRequired: 'basic',
+    isExportable: true,
+    executor,
+    category: DEFAULT_APP_CATEGORIES.management.id,
+    producer: STACK_ALERTS_FEATURE_ID,
+    doesSetRecoveryContext: false,
+    alerts: STACK_ALERTS_AAD_CONFIG,
+  };
+
+  async function executor(
+    options: RuleExecutorOptions<
+      Params,
+      {},
+      {},
+      ActionContext,
+      typeof ActionGroupId,
+      StackAlertType
+    >
+  ) {
+    const {
+      rule: { id: ruleId, name: ruleName },
+      services,
+      params,
+      logger,
+      executionId,
+      state,
+    } = options;
+    const { alertsClient } = services;
+    if (!alertsClient) {
+      throw new AlertsClientError();
+    }
+    const { url, method, headers, body } = params;
+    const ruleData = {
+      ruleId,
+      ruleName,
+      executionId,
+      body,
+      state,
+    };
+
+    const axiosInstance = axios.create();
+    const rawResponse = await axiosInstance.request({
+      url,
+      method,
+      data: ruleData,
+      headers,
+      validateStatus: null,
+    });
+
+    const { status, data } = rawResponse;
+    if (status !== 200) {
+      throw new Error(`webhook returned status ${status}: ${JSON.stringify(data)}`);
+    }
+
+    let response: AlertData;
+    try {
+      response = AlertData.validate(data);
+    } catch (err) {
+      const message = `webhook returned invalid data: ${err.message}`;
+      logger.error(`${message}: "${JSON.stringify(data)}"`);
+      throw new Error(message);
+    }
+
+    for (const alertData of response.alerts) {
+      const { instanceId: id, actionGroup: actionGroupUntyped, context } = alertData;
+      const actionGroup = actionGroupUntyped as ActionGroupIdType;
+      alertsClient.report({
+        id,
+        actionGroup,
+        context,
+      });
+    }
+
+    return { state: {} };
+  }
+}


### PR DESCRIPTION
Adds a new rule type whose executor sends webhook requests which send back alert data.

The basic POC is about moving alerting executors out-of-process.


