### PR TITLE
[Search][Design] Search UX Sandbox plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -978,6 +978,7 @@ x-pack/solutions/search/plugins/search_notebooks @elastic/search-kibana
 x-pack/solutions/search/plugins/search_playground @elastic/search-kibana
 x-pack/solutions/search/plugins/search_solution/search_navigation @elastic/search-kibana
 x-pack/solutions/search/plugins/search_synonyms @elastic/search-kibana
+x-pack/solutions/search/plugins/search_ux_sandbox @elastic/search-design
 x-pack/solutions/search/plugins/serverless_search @elastic/search-kibana
 x-pack/solutions/security/packages/connectors @elastic/security-threat-hunting-explore
 x-pack/solutions/security/packages/data-stream-adapter @elastic/security-threat-hunting

--- a/package.json
+++ b/package.json
@@ -821,6 +821,7 @@
     "@kbn/search-shared-ui": "link:x-pack/solutions/search/packages/shared-ui",
     "@kbn/search-synonyms": "link:x-pack/solutions/search/plugins/search_synonyms",
     "@kbn/search-types": "link:src/platform/packages/shared/kbn-search-types",
+    "@kbn/search-ux-sandbox": "link:x-pack/solutions/search/plugins/search_ux_sandbox",
     "@kbn/searchprofiler-plugin": "link:x-pack/platform/plugins/shared/searchprofiler",
     "@kbn/security-ai-prompts": "link:x-pack/solutions/security/packages/security-ai-prompts",
     "@kbn/security-api-key-management": "link:x-pack/platform/packages/shared/security/api_key_management",

--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -146,6 +146,7 @@ pageLoadAssetSize:
   searchPlayground: 19325
   searchprofiler: 67080
   searchSynonyms: 20262
+  searchUxSandbox: 19725
   security: 81771
   securitySolution: 98429
   securitySolutionEss: 31781

--- a/src/platform/plugins/private/kibana_usage_collection/server/collectors/application_usage/schema.ts
+++ b/src/platform/plugins/private/kibana_usage_collection/server/collectors/application_usage/schema.ts
@@ -149,6 +149,7 @@ export const applicationUsageSchema = {
   enterpriseSearchElasticsearch: commonSchema,
   entity_manager: commonSchema,
   searchExperiences: commonSchema,
+  searchUxSandbox: commonSchema,
   graph: commonSchema,
   logs: commonSchema,
   metrics: commonSchema,

--- a/src/platform/plugins/shared/telemetry/schema/oss_platform.json
+++ b/src/platform/plugins/shared/telemetry/schema/oss_platform.json
@@ -3801,6 +3801,137 @@
             }
           }
         },
+        "searchUxSandbox": {
+          "properties": {
+            "appId": {
+              "type": "keyword",
+              "_meta": {
+                "description": "The application being tracked"
+              }
+            },
+            "viewId": {
+              "type": "keyword",
+              "_meta": {
+                "description": "Always `main`"
+              }
+            },
+            "clicks_total": {
+              "type": "long",
+              "_meta": {
+                "description": "General number of clicks in the application since we started counting them"
+              }
+            },
+            "clicks_7_days": {
+              "type": "long",
+              "_meta": {
+                "description": "General number of clicks in the application over the last 7 days"
+              }
+            },
+            "clicks_30_days": {
+              "type": "long",
+              "_meta": {
+                "description": "General number of clicks in the application over the last 30 days"
+              }
+            },
+            "clicks_90_days": {
+              "type": "long",
+              "_meta": {
+                "description": "General number of clicks in the application over the last 90 days"
+              }
+            },
+            "minutes_on_screen_total": {
+              "type": "float",
+              "_meta": {
+                "description": "Minutes the application is active and on-screen since we started counting them."
+              }
+            },
+            "minutes_on_screen_7_days": {
+              "type": "float",
+              "_meta": {
+                "description": "Minutes the application is active and on-screen over the last 7 days"
+              }
+            },
+            "minutes_on_screen_30_days": {
+              "type": "float",
+              "_meta": {
+                "description": "Minutes the application is active and on-screen over the last 30 days"
+              }
+            },
+            "minutes_on_screen_90_days": {
+              "type": "float",
+              "_meta": {
+                "description": "Minutes the application is active and on-screen over the last 90 days"
+              }
+            },
+            "views": {
+              "type": "array",
+              "items": {
+                "properties": {
+                  "appId": {
+                    "type": "keyword",
+                    "_meta": {
+                      "description": "The application being tracked"
+                    }
+                  },
+                  "viewId": {
+                    "type": "keyword",
+                    "_meta": {
+                      "description": "The application view being tracked"
+                    }
+                  },
+                  "clicks_total": {
+                    "type": "long",
+                    "_meta": {
+                      "description": "General number of clicks in the application sub view since we started counting them"
+                    }
+                  },
+                  "clicks_7_days": {
+                    "type": "long",
+                    "_meta": {
+                      "description": "General number of clicks in the active application sub view over the last 7 days"
+                    }
+                  },
+                  "clicks_30_days": {
+                    "type": "long",
+                    "_meta": {
+                      "description": "General number of clicks in the active application sub view over the last 30 days"
+                    }
+                  },
+                  "clicks_90_days": {
+                    "type": "long",
+                    "_meta": {
+                      "description": "General number of clicks in the active application sub view over the last 90 days"
+                    }
+                  },
+                  "minutes_on_screen_total": {
+                    "type": "float",
+                    "_meta": {
+                      "description": "Minutes the application sub view is active and on-screen since we started counting them."
+                    }
+                  },
+                  "minutes_on_screen_7_days": {
+                    "type": "float",
+                    "_meta": {
+                      "description": "Minutes the application is active and on-screen active application sub view over the last 7 days"
+                    }
+                  },
+                  "minutes_on_screen_30_days": {
+                    "type": "float",
+                    "_meta": {
+                      "description": "Minutes the application is active and on-screen active application sub view over the last 30 days"
+                    }
+                  },
+                  "minutes_on_screen_90_days": {
+                    "type": "float",
+                    "_meta": {
+                      "description": "Minutes the application is active and on-screen active application sub view over the last 90 days"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "graph": {
           "properties": {
             "appId": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1624,6 +1624,8 @@
       "@kbn/search-synonyms/*": ["x-pack/solutions/search/plugins/search_synonyms/*"],
       "@kbn/search-types": ["src/platform/packages/shared/kbn-search-types"],
       "@kbn/search-types/*": ["src/platform/packages/shared/kbn-search-types/*"],
+      "@kbn/search-ux-sandbox": ["x-pack/solutions/search/plugins/search_ux_sandbox"],
+      "@kbn/search-ux-sandbox/*": ["x-pack/solutions/search/plugins/search_ux_sandbox/*"],
       "@kbn/searchprofiler-plugin": ["x-pack/platform/plugins/shared/searchprofiler"],
       "@kbn/searchprofiler-plugin/*": ["x-pack/platform/plugins/shared/searchprofiler/*"],
       "@kbn/security-ai-prompts": ["x-pack/solutions/security/packages/security-ai-prompts"],

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/README.md
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/README.md
@@ -1,0 +1,3 @@
+# Search UX Sandbox
+
+Search UX Sandbox plugin

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/__mocks__/index.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/__mocks__/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Mocked or static data for the search_ux_sandbox plugin

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/common/api_routes.ts
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/common/api_routes.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const PLUGIN_ROUTE_ROOT = '/app/elasticsearch/search_ux_sandbox';

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/common/constants.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/common/constants.tsx
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const SEARCH_UX_SLACK_CHANNEL_NAME = '#search-ux';
+export const SEARCH_UX_SLACK_CHANNEL_URL = 'https://elastic.slack.com/archives/C01UJ9ZQZ3D';
+export const SEARCH_UX_GITHUB_TEAM_HANDLER = '@elastic/kibana-search-ux';
+export const SEARCH_UX_GITHUB_TEAM_URL = 'https://github.com/orgs/elastic/teams/search-design';

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/common/index.ts
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/common/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const PLUGIN_ID = 'searchUxSandbox';
+export const PLUGIN_NAME = 'Search UX Sandbox';
+
+export const PLUGIN_TITLE = i18n.translate('xpack.searchUxSandbox.pluginTitle', {
+  defaultMessage: 'Search UX Sandbox',
+});

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/common/types.ts
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/common/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SearchUxSandboxPluginSetup {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SearchUxSandboxPluginStart {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AppPluginSetupDependencies {}
+
+export interface SearchSynonymsConfigType {
+  enabled: boolean;
+}

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/kibana.jsonc
@@ -1,0 +1,24 @@
+{
+  "type": "plugin",
+  "id": "@kbn/search-ux-sandbox",
+  "owner": "@elastic/search-design",
+  "group": "search",
+  "visibility": "private",
+  "description": "Search UX Sandbox application for prototyping and testing search experiences",
+  "plugin": {
+    "id": "searchUxSandbox",
+    "server": false,
+    "browser": true,
+    "configPath": ["xpack", "searchUxSandbox"],
+    "requiredPlugins": [
+      "features",
+    ],
+    "optionalPlugins": [
+      "console",
+      "searchNavigation",
+    ],
+    "requiredBundles": [
+      "kibanaReact",
+    ]
+  }
+} 

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/package.json
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/search-ux-sandbox",
+  "version": "1.0.0",
+  "license": "Elastic License 2.0",
+  "private": true
+} 

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/application.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/application.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { CoreStart } from '@kbn/core/public';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { I18nProvider } from '@kbn/i18n-react';
+import { Router } from '@kbn/shared-ux-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AppPluginStartDependencies } from './types';
+
+const queryClient = new QueryClient({});
+export const renderApp = async (
+  core: CoreStart,
+  services: AppPluginStartDependencies,
+  element: HTMLElement
+) => {
+  const { SearchUxSandboxRouter } = await import('./search_ux_sandbox_router');
+
+  ReactDOM.render(
+    <KibanaRenderContextProvider {...core}>
+      <KibanaContextProvider services={{ ...core, ...services }}>
+        <I18nProvider>
+          <QueryClientProvider client={queryClient}>
+            <Router history={services.history}>
+              <SearchUxSandboxRouter />
+            </Router>
+          </QueryClientProvider>
+        </I18nProvider>
+      </KibanaContextProvider>
+    </KibanaRenderContextProvider>,
+    element
+  );
+  return () => ReactDOM.unmountComponentAtNode(element);
+};

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/assets/index.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/assets/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Assets go here

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/components/index.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/components/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Reusable components go here

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/components/index.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/components/index.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+import { EuiCard, EuiFlexGrid, EuiFlexItem, EuiIcon, EuiLink, EuiText } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '../hooks/use_kibana';
+
+export const SearchUxSandboxOverview = () => {
+  const {
+    services: { console: consolePlugin, history, searchNavigation },
+  } = useKibana();
+
+  const embeddableConsole = useMemo(
+    () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),
+    [consolePlugin]
+  );
+  return (
+    <KibanaPageTemplate
+      offset={0}
+      restrictWidth={false}
+      grow={false}
+      data-test-subj="searchUxSandboxOverviewPage"
+      solutionNav={searchNavigation?.useClassicNavigation(history)}
+      color="primary"
+    >
+      <KibanaPageTemplate.Header pageTitle="Search UX Sandbox 🕹️" restrictWidth color="primary">
+        <EuiText>
+          <FormattedMessage
+            id="xpack.searchUxSandbox.searchUxSandboxOverview.description"
+            defaultMessage="Code prototypes made with ❤️ by the Search UX team. "
+          />
+          <EuiLink href="https://elastic.slack.com/archives/CA2JBRTEX" external>
+            #search-ux
+          </EuiLink>{' '}
+          <EuiLink href="https://github.com/orgs/elastic/teams/search-design" external>
+            @search-design
+          </EuiLink>
+        </EuiText>
+      </KibanaPageTemplate.Header>
+
+      <KibanaPageTemplate.Section restrictWidth>
+        <EuiFlexGrid columns={4}>
+          <EuiFlexItem>
+            <EuiCard
+              icon={<EuiIcon size="xxl" type="beaker" />}
+              title="Project 1"
+              description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+              onClick={() => {}}
+            />
+          </EuiFlexItem>
+        </EuiFlexGrid>
+      </KibanaPageTemplate.Section>
+      {embeddableConsole}
+    </KibanaPageTemplate>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/hooks/use_kibana.ts
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/hooks/use_kibana.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useKibana as _useKibana } from '@kbn/kibana-react-plugin/public';
+import { AppServicesContext } from '../types';
+
+export const useKibana = () => _useKibana<AppServicesContext>();

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/index.ts
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SearchUxSandboxPlugin } from './plugin';
+
+export function plugin() {
+  return new SearchUxSandboxPlugin();
+}

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/project_example.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/project_example.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+
+import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
+import { EuiButton, EuiCode, EuiSpacer, EuiText } from '@elastic/eui';
+import { useKibana } from '../hooks/use_kibana';
+
+export const ProjectExample = () => {
+  const {
+    services: { console: consolePlugin, history },
+  } = useKibana();
+
+  const embeddableConsole = useMemo(
+    () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),
+    [consolePlugin]
+  );
+  return (
+    <KibanaPageTemplate
+      offset={0}
+      restrictWidth={false}
+      grow={false}
+      data-test-subj="searchUxSandboxOverviewPage"
+      color="primary"
+    >
+      <KibanaPageTemplate.Header pageTitle="Project example" restrictWidth color="primary" />
+
+      <KibanaPageTemplate.Section restrictWidth>
+        <EuiText>
+          Your content goes here. And we can consume existing Kibana components like the
+          <EuiCode>Embeddable Console</EuiCode> plugin. You can see the at the bottom{' '}
+          <span role="img" aria-label="downwards arrow">
+            👇
+          </span>
+        </EuiText>
+        <EuiSpacer />
+        <EuiText>
+          This example does not load the left navigation intentionally. You can add it on demand if
+          needed.
+        </EuiText>
+        <EuiSpacer />
+        <EuiButton
+          data-test-subj="ProjectExampleBackButton"
+          onClick={() => {
+            history.goBack();
+          }}
+        >
+          Back
+        </EuiButton>
+      </KibanaPageTemplate.Section>
+      {embeddableConsole}
+    </KibanaPageTemplate>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/project_example.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/project_example.tsx
@@ -13,7 +13,7 @@ import { useKibana } from '../hooks/use_kibana';
 
 export const ProjectExample = () => {
   const {
-    services: { console: consolePlugin, history },
+    services: { console: consolePlugin, history, searchNavigation },
   } = useKibana();
 
   const embeddableConsole = useMemo(
@@ -25,6 +25,7 @@ export const ProjectExample = () => {
       offset={0}
       restrictWidth={false}
       grow={false}
+      solutionNav={searchNavigation?.useClassicNavigation(history)}
       data-test-subj="searchUxSandboxOverviewPage"
       color="primary"
     >
@@ -39,10 +40,7 @@ export const ProjectExample = () => {
           </span>
         </EuiText>
         <EuiSpacer />
-        <EuiText>
-          This example does not load the left navigation intentionally. You can add it on demand if
-          needed.
-        </EuiText>
+        <EuiText>This example loads the Classic Navigation as an example.</EuiText>
         <EuiSpacer />
         <EuiButton
           data-test-subj="ProjectExampleBackButton"

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/search_ux_sandbox_home.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/search_ux_sandbox_home.tsx
@@ -33,7 +33,7 @@ export const SearchUxSandboxHome = () => {
       solutionNav={searchNavigation?.useClassicNavigation(history)}
       color="primary"
     >
-      <KibanaPageTemplate.Header pageTitle="Search UX Sandbox 🕹️" restrictWidth color="primary">
+      <KibanaPageTemplate.Header pageTitle="Search UX Sandbox" restrictWidth color="primary">
         <EuiText>
           <FormattedMessage
             id="xpack.searchUxSandbox.searchUxSandboxOverview.description"
@@ -62,7 +62,7 @@ export const SearchUxSandboxHome = () => {
             <EuiCard
               icon={<EuiIcon size="xxl" type="beaker" />}
               title="Project example"
-              description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+              description="Basic example to start with."
               onClick={() => {
                 history.push('/project-example');
               }}

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/search_ux_sandbox_home.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/search_ux_sandbox_home.tsx
@@ -12,6 +12,13 @@ import { EuiCard, EuiFlexGrid, EuiFlexItem, EuiIcon, EuiLink, EuiText } from '@e
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '../hooks/use_kibana';
 
+import {
+  SEARCH_UX_GITHUB_TEAM_HANDLER,
+  SEARCH_UX_GITHUB_TEAM_URL,
+  SEARCH_UX_SLACK_CHANNEL_NAME,
+  SEARCH_UX_SLACK_CHANNEL_URL,
+} from '../../common/constants';
+
 export const SearchUxSandboxHome = () => {
   const {
     services: { history, searchNavigation },
@@ -34,17 +41,17 @@ export const SearchUxSandboxHome = () => {
           />
           <EuiLink
             data-test-subj="SearchUxSandboxHomeSearchUxLink"
-            href="https://elastic.slack.com/archives/CA2JBRTEX"
+            href={SEARCH_UX_SLACK_CHANNEL_URL}
             external
           >
-            #search-ux
+            {SEARCH_UX_SLACK_CHANNEL_NAME}
           </EuiLink>{' '}
           <EuiLink
             data-test-subj="SearchUxSandboxHomeSearchDesignLink"
-            href="https://github.com/orgs/elastic/teams/search-design"
+            href={SEARCH_UX_GITHUB_TEAM_URL}
             external
           >
-            @search-design
+            {SEARCH_UX_GITHUB_TEAM_HANDLER}
           </EuiLink>
         </EuiText>
       </KibanaPageTemplate.Header>

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/search_ux_sandbox_home.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/search_ux_sandbox_home.tsx
@@ -21,7 +21,7 @@ import {
 
 export const SearchUxSandboxHome = () => {
   const {
-    services: { history, searchNavigation },
+    services: { history },
   } = useKibana();
 
   return (
@@ -30,7 +30,6 @@ export const SearchUxSandboxHome = () => {
       restrictWidth={false}
       grow={false}
       data-test-subj="searchUxSandboxOverviewPage"
-      solutionNav={searchNavigation?.useClassicNavigation(history)}
       color="primary"
     >
       <KibanaPageTemplate.Header pageTitle="Search UX Sandbox" restrictWidth color="primary">

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/search_ux_sandbox_home.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/pages/search_ux_sandbox_home.tsx
@@ -5,22 +5,18 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import { KibanaPageTemplate } from '@kbn/shared-ux-page-kibana-template';
 import { EuiCard, EuiFlexGrid, EuiFlexItem, EuiIcon, EuiLink, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '../hooks/use_kibana';
 
-export const SearchUxSandboxOverview = () => {
+export const SearchUxSandboxHome = () => {
   const {
-    services: { console: consolePlugin, history, searchNavigation },
+    services: { history, searchNavigation },
   } = useKibana();
 
-  const embeddableConsole = useMemo(
-    () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),
-    [consolePlugin]
-  );
   return (
     <KibanaPageTemplate
       offset={0}
@@ -36,10 +32,18 @@ export const SearchUxSandboxOverview = () => {
             id="xpack.searchUxSandbox.searchUxSandboxOverview.description"
             defaultMessage="Code prototypes made with ❤️ by the Search UX team. "
           />
-          <EuiLink href="https://elastic.slack.com/archives/CA2JBRTEX" external>
+          <EuiLink
+            data-test-subj="SearchUxSandboxHomeSearchUxLink"
+            href="https://elastic.slack.com/archives/CA2JBRTEX"
+            external
+          >
             #search-ux
           </EuiLink>{' '}
-          <EuiLink href="https://github.com/orgs/elastic/teams/search-design" external>
+          <EuiLink
+            data-test-subj="SearchUxSandboxHomeSearchDesignLink"
+            href="https://github.com/orgs/elastic/teams/search-design"
+            external
+          >
             @search-design
           </EuiLink>
         </EuiText>
@@ -50,14 +54,15 @@ export const SearchUxSandboxOverview = () => {
           <EuiFlexItem>
             <EuiCard
               icon={<EuiIcon size="xxl" type="beaker" />}
-              title="Project 1"
+              title="Project example"
               description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-              onClick={() => {}}
+              onClick={() => {
+                history.push('/project-example');
+              }}
             />
           </EuiFlexItem>
         </EuiFlexGrid>
       </KibanaPageTemplate.Section>
-      {embeddableConsole}
     </KibanaPageTemplate>
   );
 };

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/plugin.ts
@@ -44,7 +44,7 @@ export class SearchUxSandboxPlugin
 
         return renderApp(coreStart, startDeps, element);
       },
-      visibleIn: ['sideNav', 'globalSearch'],
+      visibleIn: ['sideNav'],
       order: 3,
     });
 

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/plugin.ts
@@ -44,7 +44,7 @@ export class SearchUxSandboxPlugin
 
         return renderApp(coreStart, startDeps, element);
       },
-      visibleIn: ['sideNav'],
+      visibleIn: [],
       order: 3,
     });
 

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/plugin.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, Plugin, AppMountParameters, CoreStart } from '@kbn/core/public';
+import { PLUGIN_ID, PLUGIN_NAME, PLUGIN_TITLE } from '../common';
+import {
+  AppPluginSetupDependencies,
+  AppPluginStartDependencies,
+  SearchUxSandboxPluginSetup,
+  SearchUxSandboxPluginStart,
+} from './types';
+import { PLUGIN_ROUTE_ROOT } from '../common/api_routes';
+
+export class SearchUxSandboxPlugin
+  implements Plugin<SearchUxSandboxPluginSetup, SearchUxSandboxPluginStart>
+{
+  constructor() {}
+
+  public setup(
+    core: CoreSetup<AppPluginStartDependencies, SearchUxSandboxPluginStart>,
+    _: AppPluginSetupDependencies
+  ): SearchUxSandboxPluginSetup {
+    core.application.register({
+      id: PLUGIN_ID,
+      appRoute: PLUGIN_ROUTE_ROOT,
+      title: PLUGIN_TITLE,
+      euiIconType: 'beaker',
+      async mount({ element, history }: AppMountParameters) {
+        const { renderApp } = await import('./application');
+        const [coreStart, depsStart] = await core.getStartServices();
+
+        coreStart.chrome.docTitle.change(PLUGIN_NAME);
+
+        const startDeps: AppPluginStartDependencies = {
+          ...depsStart,
+          history,
+        };
+
+        depsStart.searchNavigation?.handleOnAppMount();
+
+        return renderApp(coreStart, startDeps, element);
+      },
+      visibleIn: ['sideNav', 'globalSearch'],
+      order: 3,
+    });
+
+    return {};
+  }
+
+  public start(core: CoreStart): SearchUxSandboxPluginStart {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/search_ux_sandbox_router.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/search_ux_sandbox_router.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Route, Routes } from '@kbn/shared-ux-router';
+import React from 'react';
+import { SearchUxSandboxOverview } from './components';
+
+export const SearchUxSandboxRouter = () => {
+  return (
+    <Routes>
+      <Route exact path="/">
+        <SearchUxSandboxOverview />
+      </Route>
+    </Routes>
+  );
+};

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/search_ux_sandbox_router.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/search_ux_sandbox_router.tsx
@@ -7,13 +7,17 @@
 
 import { Route, Routes } from '@kbn/shared-ux-router';
 import React from 'react';
-import { SearchUxSandboxOverview } from './components';
+import { SearchUxSandboxHome } from './pages/search_ux_sandbox_home';
+import { ProjectExample } from './pages/project_example';
 
 export const SearchUxSandboxRouter = () => {
   return (
     <Routes>
       <Route exact path="/">
-        <SearchUxSandboxOverview />
+        <SearchUxSandboxHome />
+      </Route>
+      <Route exact path="/project-example">
+        <ProjectExample />
       </Route>
     </Routes>
   );

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SearchNavigationPluginStart } from '@kbn/search-navigation/public';
+import { AppMountParameters, CoreStart } from '@kbn/core/public';
+import type { ConsolePluginStart } from '@kbn/console-plugin/public';
+
+export * from '../common/types';
+export interface AppPluginStartDependencies {
+  history: AppMountParameters['history'];
+  console?: ConsolePluginStart;
+  searchNavigation?: SearchNavigationPluginStart;
+}
+
+export type AppServicesContext = CoreStart & AppPluginStartDependencies;

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/public/utils/index.tsx
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/public/utils/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Utils go here

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/tsconfig.json
@@ -4,9 +4,9 @@
     "outDir": "target/types",
   },
   "include": [
+    "__mocks__/**/*",
     "common/**/*",
     "public/**/*",
-    "server/**/*",
   ],
   "kbn_references": [
     "@kbn/core",

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./target",
+    "skipLibCheck": true
+  },
+  "include": [
+    "common/**/*",
+    "public/**/*",
+    "server/**/*",
+  ],
+  "kbn_references": [
+    "@kbn/config-schema",
+    "@kbn/core",
+    "@kbn/i18n",
+    "@kbn/i18n-react",
+    "@kbn/kibana-react-plugin",
+    "@kbn/shared-ux-router",
+    "@kbn/react-kibana-context-render",
+    "@kbn/console-plugin",
+    "@kbn/search-navigation",
+    "@kbn/doc-links",
+    "@kbn/shared-ux-page-kibana-template",
+    "@kbn/core-http-server",
+    "@kbn/kibana-utils-plugin",
+    "@kbn/logging",
+  ],
+  "exclude": [
+    "target/**/*",
+  ]
+}

--- a/x-pack/solutions/search/plugins/search_ux_sandbox/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_ux_sandbox/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./target",
-    "skipLibCheck": true
+    "outDir": "target/types",
   },
   "include": [
     "common/**/*",
@@ -10,7 +9,6 @@
     "server/**/*",
   ],
   "kbn_references": [
-    "@kbn/config-schema",
     "@kbn/core",
     "@kbn/i18n",
     "@kbn/i18n-react",
@@ -19,11 +17,7 @@
     "@kbn/react-kibana-context-render",
     "@kbn/console-plugin",
     "@kbn/search-navigation",
-    "@kbn/doc-links",
     "@kbn/shared-ux-page-kibana-template",
-    "@kbn/core-http-server",
-    "@kbn/kibana-utils-plugin",
-    "@kbn/logging",
   ],
   "exclude": [
     "target/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7095,6 +7095,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/search-ux-sandbox@link:x-pack/solutions/search/plugins/search_ux_sandbox":
+  version "0.0.0"
+  uid ""
+
 "@kbn/searchprofiler-plugin@link:x-pack/platform/plugins/shared/searchprofiler":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

Creation of a new **Search UX Sandbox** plugin to experiment with code prototypes running in Kibana against a new `elastic:search-ux-sandbox` branch

### How to access? 



- Append the `/search_ux_sandbox` to your current `/app/elasticsearch/` base URL. e.g: `/app/elasticsearch/search_ux_sandbox`

- ~The plugin content can be reached in the global top search:~ Avoided for now. Read [this comment](https://github.com/elastic/kibana/pull/212733#discussion_r1975502887).

![CleanShot 2025-02-28 at 12 43 56@2x](https://github.com/user-attachments/assets/ab7e4fc5-5646-4c35-b26f-f3edee5aafa6)

### Home

It is the shuttler where we can start listing all the prototypes and examples performing like a hub or plugin homepage.

![CleanShot 2025-02-28 at 12 40 34@2x](https://github.com/user-attachments/assets/9a935254-9c56-4d85-9480-d849c83e6d95)

### Project example

Very simple prototype example to use as scaffolding. Having custom content, EUI components and consuming already existing Kibana plugins like the `embeddableConsole` and the `sideNav`

![CleanShot 2025-02-28 at 12 40 57@2x](https://github.com/user-attachments/assets/9988c0b7-0729-4784-a200-f9dfbcb8d1cd)

