### PR TITLE
Add FTR random actions test

### DIFF
--- a/.buildkite/ftr_platform_stateful_configs.yml
+++ b/.buildkite/ftr_platform_stateful_configs.yml
@@ -165,6 +165,7 @@ enabled:
   - x-pack/test/api_integration/apis/monitoring/config.ts
   - x-pack/test/api_integration/apis/monitoring_collection/config.ts
   - x-pack/test/api_integration/apis/osquery/config.ts
+  - x-pack/test/api_integration/apis/random_actions/config.ts
   - x-pack/test/api_integration/apis/search/config.ts
   - x-pack/test/api_integration/apis/searchprofiler/config.ts
   - x-pack/test/api_integration/apis/security/config.ts

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/all.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/all.ts
@@ -22,6 +22,7 @@ import { SupertestWithoutAuthProvider } from './supertest_without_auth';
 import { SamlAuthProvider } from './saml_auth';
 import { KibanaSupertestProvider, ElasticsearchSupertestProvider } from './supertest';
 import { SecurityServiceProvider } from './security';
+import { RandomActionService } from './random_actions';
 
 export const services = {
   es: EsProvider,
@@ -34,6 +35,7 @@ export const services = {
   esDeleteAllIndices: EsDeleteAllIndicesProvider,
   indexPatterns: IndexPatternsService,
   savedObjectInfo: SavedObjectInfoService,
+  randomAction: RandomActionService,
   randomness: RandomnessService,
   samlAuth: SamlAuthProvider,
   supertest: KibanaSupertestProvider,

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/index.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { RandomActionService } from './random_action';

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/random_action.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/random_action.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FtrService } from '../ftr_provider_context';
+import { RandomDashboardService } from './random_dashboard';
+import { RandomDataViewService } from './random_data_view';
+
+enum ResourceAction {
+  CREATE = 'create',
+  UPDATE = 'update',
+  DELETE = 'delete',
+}
+
+enum ResourceType {
+  DATA_VIEW = 'DataView',
+  DASHBOARD = 'Dashboard',
+}
+
+export class RandomActionService extends FtrService {
+  private readonly randomness = this.ctx.getService('randomness');
+  private readonly randomDashboard = new RandomDashboardService(this.ctx);
+  private readonly randomDataView = new RandomDataViewService(this.ctx);
+
+  async createRandomDataView() {
+    await this.randomDataView.createDataView();
+  }
+
+  async updateRandomDataView() {
+    await this.randomDataView.updateDataView();
+  }
+
+  async deleteRandomDataView() {
+    await this.randomDataView.deleteDataView();
+  }
+
+  async createRandomDashboard() {
+    await this.randomDashboard.createDashboard();
+  }
+
+  async updateRandomDashboard() {
+    await this.randomDashboard.updateDashboard();
+  }
+
+  async deleteRandomDashboard() {
+    await this.randomDashboard.deleteDashboard();
+  }
+
+  async performRandomAction() {
+    const action = this.randomness.pickFromArray(Object.values(ResourceAction));
+    const type = this.randomness.pickFromArray(Object.values(ResourceType));
+    await this[`${action}Random${type}`]();
+  }
+}

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/random_dashboard.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/random_dashboard.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FtrService } from '../ftr_provider_context';
+import { COMMON_REQUEST_HEADERS, assertResponseStatusCode } from './shared';
+
+export class RandomDashboardService extends FtrService {
+  private readonly kbnSupertest = this.ctx.getService('supertest');
+  private readonly log = this.ctx.getService('log');
+  private readonly randomness = this.ctx.getService('randomness');
+
+  public getRandomDashboardBody() {
+    return {
+      attributes: {
+        title: this.randomness.string(),
+      },
+    };
+  }
+
+  public async getDashboardCount() {
+    const { body, status } = await this.kbnSupertest
+      .get('/api/dashboards/dashboard')
+      .query({ page: 1, perPage: 1 })
+      .set(COMMON_REQUEST_HEADERS);
+    assertResponseStatusCode(200, status, body);
+    return body.total;
+  }
+
+  public async getAllDashboardIds() {
+    const dashboardIds: string[] = [];
+    const dashboardCount = await this.getDashboardCount();
+    if (dashboardCount === 0) {
+      return dashboardIds;
+    }
+
+    const perPage = 100;
+    for (let page = 1; page <= Math.ceil(dashboardCount / perPage); page++) {
+      const { body, status } = await this.kbnSupertest
+        .get('/api/dashboards/dashboard')
+        .query({ page, perPage })
+        .set(COMMON_REQUEST_HEADERS);
+      assertResponseStatusCode(200, status, body);
+      for (const item of body.items) {
+        dashboardIds.push(item.id);
+      }
+    }
+
+    return dashboardIds;
+  }
+
+  public async getDashboard(dashboardId: string) {
+    const { body, status } = await this.kbnSupertest
+      .get(`/api/dashboards/dashboard/${dashboardId}`)
+      .set(COMMON_REQUEST_HEADERS);
+    assertResponseStatusCode(200, status, body);
+    return body;
+  }
+
+  public async getRandomDashboardId() {
+    const dashboardIds = await this.getAllDashboardIds();
+    if (dashboardIds.length === 0) {
+      return;
+    }
+    return this.randomness.pickFromArray(dashboardIds);
+  }
+
+  public async createDashboard() {
+    const id = this.randomness.string();
+
+    this.log.info(`Creating dashboard with id ${id}...`);
+    const { body, status } = await this.kbnSupertest
+      .post(`/api/dashboards/dashboard/${id}`)
+      .set(COMMON_REQUEST_HEADERS)
+      .send(this.getRandomDashboardBody());
+    assertResponseStatusCode(200, status, body);
+  }
+
+  public async updateDashboard() {
+    const id = await this.getRandomDashboardId();
+    if (id === undefined) {
+      this.log.warning('No dashboards exist. Nothing to update.');
+      return;
+    }
+
+    this.log.info(`Updating dashboard with id ${id}...`);
+    const { body, status } = await this.kbnSupertest
+      .put(`/api/dashboards/dashboard/${id}`)
+      .set(COMMON_REQUEST_HEADERS)
+      .send(this.getRandomDashboardBody());
+    // TODO: update expected status to 200 once it's fixed in the application
+    assertResponseStatusCode(201, status, body);
+  }
+
+  public async deleteDashboard() {
+    const id = await this.getRandomDashboardId();
+    if (id === undefined) {
+      this.log.warning('No dashboards exist. Nothing to delete.');
+      return;
+    }
+
+    this.log.info(`Deleting dashboard with id ${id}...`);
+    const { body, status } = await this.kbnSupertest
+      .delete(`/api/dashboards/dashboard/${id}`)
+      .set(COMMON_REQUEST_HEADERS);
+    assertResponseStatusCode(200, status, body);
+  }
+}

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/random_data_view.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/random_data_view.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FtrService } from '../ftr_provider_context';
+import { COMMON_REQUEST_HEADERS, assertResponseStatusCode } from './shared';
+
+export class RandomDataViewService extends FtrService {
+  private readonly kbnSupertest = this.ctx.getService('supertest');
+  private readonly log = this.ctx.getService('log');
+  private readonly randomness = this.ctx.getService('randomness');
+
+  public getRandomDataViewBody() {
+    return {
+      data_view: {
+        name: this.randomness.string(),
+        title: this.randomness.string(),
+      },
+    };
+  }
+
+  public async getAllDataViewIds() {
+    const dataViewIds: string[] = [];
+
+    const { body, status } = await this.kbnSupertest
+      .get('/api/data_views')
+      .set(COMMON_REQUEST_HEADERS);
+    assertResponseStatusCode(200, status, body);
+    for (const item of body.data_view) {
+      dataViewIds.push(item.id);
+    }
+
+    return dataViewIds;
+  }
+
+  public async getDataView(dataViewId: string) {
+    const { body, status } = await this.kbnSupertest
+      .get(`/api/data_views/data_view/${dataViewId}`)
+      .set(COMMON_REQUEST_HEADERS);
+    assertResponseStatusCode(200, status, body);
+    return body;
+  }
+
+  public async getRandomDataViewId() {
+    const dataViewIds = await this.getAllDataViewIds();
+    if (dataViewIds.length === 0) {
+      return;
+    }
+    return this.randomness.pickFromArray(dataViewIds);
+  }
+
+  public async createDataView() {
+    const requestBody = this.getRandomDataViewBody();
+
+    this.log.info(`Creating dataView with title ${requestBody.data_view.title}...`);
+    const { body, status } = await this.kbnSupertest
+      .post('/api/data_views/data_view')
+      .set(COMMON_REQUEST_HEADERS)
+      .send(this.getRandomDataViewBody());
+    assertResponseStatusCode(200, status, body);
+  }
+
+  public async updateDataView() {
+    const id = await this.getRandomDataViewId();
+    if (id === undefined) {
+      this.log.warning('No dataViews exist. Nothing to update.');
+      return;
+    }
+
+    this.log.info(`Updating dataView with id ${id}...`);
+    const { body, status } = await this.kbnSupertest
+      .post(`/api/data_views/data_view/${id}`)
+      .set(COMMON_REQUEST_HEADERS)
+      .send(this.getRandomDataViewBody());
+    assertResponseStatusCode(200, status, body);
+  }
+
+  public async deleteDataView() {
+    const id = await this.getRandomDataViewId();
+    if (id === undefined) {
+      this.log.warning('No dataViews exist. Nothing to delete.');
+      return;
+    }
+
+    this.log.info(`Deleting dataView with id ${id}...`);
+    const { body, status } = await this.kbnSupertest
+      .delete(`/api/data_views/data_view/${id}`)
+      .set(COMMON_REQUEST_HEADERS);
+    assertResponseStatusCode(200, status, body);
+  }
+}

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/shared.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/random_actions/shared.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import expect from '@kbn/expect';
+
+export const COMMON_REQUEST_HEADERS = {
+  'kbn-xsrf': 'some-xsrf-token',
+};
+
+export const INTERNAL_REQUEST_HEADERS = {
+  ...COMMON_REQUEST_HEADERS,
+  'x-elastic-internal-origin': 'kibana',
+};
+
+export function assertResponseStatusCode(
+  expectedStatus: number,
+  actualStatus: number,
+  responseBody: object
+) {
+  expect(actualStatus).to.eql(
+    expectedStatus,
+    `Expected status code ${expectedStatus}, got ${actualStatus} with body '${JSON.stringify(
+      responseBody
+    )}'`
+  );
+}

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/randomness.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/randomness.ts
@@ -61,7 +61,7 @@ export class RandomnessService extends FtrService {
   }
 
   /**
-   * Generate a random number, defaults to at least 4 and no more than 8 syllables
+   * Generate a random word, defaults to at least 4 and no more than 8 syllables
    */
   word(options: { syllables?: number } = {}) {
     const { syllables = this.naturalNumber({ min: 4, max: 8 }) } = options;
@@ -77,8 +77,12 @@ export class RandomnessService extends FtrService {
   string(options: StringOptions = {}) {
     return this.chance.string({
       length: this.naturalNumber({ min: 8, max: 15 }),
-      ...(options.pool === 'undefined' ? { alpha: true, numeric: true, symbols: false } : {}),
+      ...(options.pool === undefined ? { alpha: true, numeric: true, symbols: false } : {}),
       ...options,
     });
+  }
+
+  pickFromArray<T>(arr: T[]): T {
+    return this.chance.pickone(arr);
   }
 }

--- a/x-pack/test/api_integration/apis/random_actions/config.ts
+++ b/x-pack/test/api_integration/apis/random_actions/config.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrConfigProviderContext } from '@kbn/test';
+
+export default async function ({ readConfigFile }: FtrConfigProviderContext) {
+  const baseIntegrationTestsConfig = await readConfigFile(require.resolve('../../config.ts'));
+
+  return {
+    ...baseIntegrationTestsConfig.getAll(),
+    testFiles: [require.resolve('.')],
+    junit: {
+      reportName: 'X-Pack API Integration Tests - random actions',
+    },
+  };
+}

--- a/x-pack/test/api_integration/apis/random_actions/index.ts
+++ b/x-pack/test/api_integration/apis/random_actions/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('Random Actions', function () {
+    loadTestFile(require.resolve('./random_action_test'));
+  });
+}

--- a/x-pack/test/api_integration/apis/random_actions/random_action_test.ts
+++ b/x-pack/test/api_integration/apis/random_actions/random_action_test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default ({ getService }: FtrProviderContext) => {
+  const randomAction = getService('randomAction');
+
+  describe('Random Actions Suite', () => {
+    it('performs 100 random actions', async () => {
+      for (let i = 0; i < 100; i++) {
+        await randomAction.performRandomAction();
+      }
+    });
+  });
+};

--- a/x-pack/test/api_integration/apis/random_actions/random_action_test.ts
+++ b/x-pack/test/api_integration/apis/random_actions/random_action_test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-// import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default ({ getService }: FtrProviderContext) => {

--- a/x-pack/test/api_integration/apis/random_actions/random_action_test.ts
+++ b/x-pack/test/api_integration/apis/random_actions/random_action_test.ts
@@ -12,8 +12,20 @@ export default ({ getService }: FtrProviderContext) => {
   const randomAction = getService('randomAction');
 
   describe('Random Actions Suite', () => {
-    it('performs 100 random actions', async () => {
-      for (let i = 0; i < 100; i++) {
+    it('performs 20 random create actions', async () => {
+      for (let i = 0; i < 20; i++) {
+        await randomAction.performRandomAction({ actionDistribution: 'createOnly' });
+      }
+    });
+
+    it('performs 20 random actions with a higher chance of create', async () => {
+      for (let i = 0; i < 20; i++) {
+        await randomAction.performRandomAction({ actionDistribution: 'preferCreate' });
+      }
+    });
+
+    it('performs 20 random actions with equal action distribution', async () => {
+      for (let i = 0; i < 20; i++) {
         await randomAction.performRandomAction();
       }
     });


### PR DESCRIPTION
## Summary

This PR adds an initial version of FTR random action testing.

### Change list

- Add FTR service `randomAction` that can be used to call `performRandomAction`
- Initially support actions create, update, delete
- Initially support resources DataViews and Dashboards with minimum valid configuration
- Add `pickFromArray` method to the existing `randomness` service
- Add a new random action test suite to demonstrate the usage of the new service


