### PR TITLE
Decouple some modules from 'webpack'

### DIFF
--- a/packages/kbn-optimizer/src/common/webpack_helpers.ts
+++ b/packages/kbn-optimizer/src/common/webpack_helpers.ts
@@ -7,24 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  WebpackConcatenatedModule,
-  WebpackDelegatedModule,
-  WebpackExternalModule,
-  WebpackIgnoredModule,
-  WebpackNormalModule,
-  WebpackResolveData,
-} from './src/webpack_helpers';
+import webpack from 'webpack';
 
-export {
-  STATS_WARNINGS_FILTER,
-  STATS_OPTIONS_DEFAULT_USEFUL_FILTER,
-  isFailureStats,
-  failedStatsToErrorMessage,
-  getModulePath,
-  isConcatenatedModule,
-  isDelegatedModule,
-  isExternalModule,
-  isIgnoredModule,
-  isNormalModule,
-} from './src/webpack_helpers';
+export function isRuntimeModule(module: any): boolean {
+  return module instanceof webpack.RuntimeModule;
+}

--- a/packages/kbn-optimizer/src/worker/populate_bundle_cache_plugin.ts
+++ b/packages/kbn-optimizer/src/worker/populate_bundle_cache_plugin.ts
@@ -17,7 +17,6 @@ import {
   isIgnoredModule,
   isConcatenatedModule,
   isDelegatedModule,
-  isRuntimeModule,
   getModulePath,
 } from '@kbn/optimizer-webpack-helpers';
 
@@ -30,6 +29,7 @@ import {
   ParsedDllManifest,
 } from '../common';
 import { BundleRemoteModule } from './bundle_remote_module';
+import { isRuntimeModule } from '../common/webpack_helpers';
 
 interface InputFileSystem {
   readFile: (

--- a/src/platform/packages/private/kbn-optimizer-webpack-helpers/src/webpack_helpers.ts
+++ b/src/platform/packages/private/kbn-optimizer-webpack-helpers/src/webpack_helpers.ts
@@ -7,9 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import webpack from 'webpack';
+import type { Stats } from 'webpack';
 
-export function isFailureStats(stats: webpack.Stats) {
+export function isFailureStats(stats: Stats) {
   if (stats.hasErrors()) {
     return true;
   }
@@ -29,7 +29,7 @@ export const STATS_WARNINGS_FILTER = new RegExp(
   ].join('')
 );
 
-export function failedStatsToErrorMessage(stats: webpack.Stats) {
+export function failedStatsToErrorMessage(stats: Stats) {
   const details = stats.toString({
     ...stats.compilation.createStatsOptions('minimal'),
     colors: true,
@@ -168,8 +168,4 @@ export function isDelegatedModule(module: any): module is WebpackDelegatedModule
 export function getModulePath(module: WebpackNormalModule) {
   const queryIndex = module.resource.indexOf('?');
   return queryIndex === -1 ? module.resource : module.resource.slice(0, queryIndex);
-}
-
-export function isRuntimeModule(module: any): boolean {
-  return module instanceof webpack.RuntimeModule;
 }

--- a/x-pack/platform/plugins/private/canvas/shareable_runtime/webpack/ci_stats_plugin.ts
+++ b/x-pack/platform/plugins/private/canvas/shareable_runtime/webpack/ci_stats_plugin.ts
@@ -5,11 +5,9 @@
  * 2.0.
  */
 
-/* eslint-disable import/no-extraneous-dependencies */
-
 import Path from 'path';
 
-import webpack from 'webpack';
+import type { Compiler } from 'webpack';
 import { ToolingLog } from '@kbn/tooling-log';
 import { CiStatsReporter } from '@kbn/ci-stats-reporter';
 import { isNormalModule, isConcatenatedModule } from '@kbn/optimizer-webpack-helpers';
@@ -28,7 +26,7 @@ export class CiStatsPlugin {
     }
   ) {}
 
-  public apply(compiler: webpack.Compiler) {
+  public apply(compiler: Compiler) {
     const log = new ToolingLog({
       level: 'error',
       writeTo: process.stdout,


### PR DESCRIPTION
## Summary

Remove extraneous dependencies:
* `canvas` was depending on 'webpack' purely for a type (dev-time).
* `@kbn/optimizer-webpack-helpers` (canvas depends on it 🤨) was depending on 'webpack' solely for a function that could be defined in `@kbn/optimizer` (devOnly).

<!--ONMERGE {"backportTargets":["8.18"]} ONMERGE-->