### PR TITLE
[Security Solution][Risk Score]Changes for deleting the component template when migrations start

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/migrations/index.ts
@@ -13,6 +13,7 @@ import { assetCrticalityCopyTimestampToEventIngested } from './asset_criticality
 import { riskScoreCopyTimestampToEventIngested } from './risk_score_copy_timestamp_to_event_ingested';
 import { updateAssetCriticalityMappings } from '../asset_criticality/migrations/update_asset_criticality_mappings';
 import { updateRiskScoreMappings } from '../risk_engine/migrations/update_risk_score_mappings';
+import { deleteRiskScoreComponent } from '../risk_engine/migrations/delete_risk_score_component_template';
 
 export interface EntityAnalyticsMigrationsParams {
   taskManager?: TaskManagerSetupContract;
@@ -44,6 +45,7 @@ export const scheduleEntityAnalyticsMigration = async (params: EntityAnalyticsMi
   await updateAssetCriticalityMappings({ ...params, logger: scopedLogger });
   await scheduleAssetCriticalityEcsCompliancyMigration({ ...params, logger: scopedLogger });
   await updateRiskScoreMappings({ ...params, logger: scopedLogger });
+  await deleteRiskScoreComponent({ ...params, logger: scopedLogger });
 };
 
 export const scheduleAssetCriticalityCopyTimestampToEventIngested = async (

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/delete_risk_score_component_template.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/delete_risk_score_component_template.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { deleteRiskScoreComponent } from './delete_risk_score_component_template';
+import { coreMock, loggingSystemMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+import { auditLoggerMock } from '@kbn/core-security-server-mocks';
+
+jest.mock('@kbn/alerting-plugin/server', () => ({
+  createOrUpdateIndexTemplate: jest.fn(),
+}));
+
+jest.mock('../../risk_score/configurations', () => ({
+  getIndexPatternDataStream: jest.fn(),
+  nameSpaceAwareMappingsComponentName: jest.fn(),
+}));
+
+describe('deleteRiskScoreComponent', () => {
+  const logger = loggingSystemMock.createLogger();
+  const coreStart = coreMock.createStart();
+  const soClient = savedObjectsClientMock.create();
+  const mockAuditLogger = auditLoggerMock.create();
+  const esClient = elasticsearchServiceMock.createElasticsearchClient();
+
+  const getStartServicesMock = jest.fn().mockReturnValue([
+    {
+      ...coreStart,
+      savedObjects: {
+        createInternalRepository: jest.fn().mockReturnValue(soClient),
+        getScopedClient: jest.fn().mockReturnValue(soClient),
+      },
+      elasticsearch: { client: { asInternalUser: esClient } },
+    },
+  ]);
+  const kibanaVersion = '8.0.0';
+
+  const buildSavedObject = (attributes = {}) => ({
+    namespaces: ['default'],
+    attributes,
+    id: 'id',
+    type: 'type',
+    references: [],
+    score: 1,
+  });
+
+  const mockSavedObjectsResponseDefaults = {
+    total: 1,
+    page: 1,
+    per_page: 10,
+    saved_objects: [],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should log the start and end of the migration', async () => {
+    await deleteRiskScoreComponent({
+      auditLogger: mockAuditLogger,
+      logger,
+      kibanaVersion,
+      getStartServices: getStartServicesMock,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Migration to to delete risk score component template  begins'
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('Migration to delete risk score component template for namespace')
+    );
+  });
+
+  it('should handle errors when namespace is undefined', async () => {
+    const mockSavedObjectsResponse = {
+      ...mockSavedObjectsResponseDefaults,
+      saved_objects: [buildSavedObject({ _meta: { mappingsVersion: '1.0.0' } })],
+    };
+
+    await deleteRiskScoreComponent({
+      auditLogger: mockAuditLogger,
+      logger,
+      kibanaVersion,
+      getStartServices: getStartServicesMock,
+    });
+
+    expect(logger.error).toHaveBeenCalledWith('Namespace is undefined for saved object 1');
+  });
+
+  it('should handle errors when creating/updating index template', async () => {
+    const mockSavedObjectsResponse = {
+      ...mockSavedObjectsResponseDefaults,
+      saved_objects: [buildSavedObject({ _meta: { mappingsVersion: '1.0.0' } })],
+    };
+
+    esClient.cluster.deleteComponentTemplate.mockRejectedValue(new Error('Test error'));
+
+    await deleteRiskScoreComponent({
+      auditLogger: mockAuditLogger,
+      logger,
+      kibanaVersion,
+      getStartServices: getStartServicesMock,
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Error deleting the component template for namespace default: Test error'
+      )
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/delete_risk_score_component_template.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/delete_risk_score_component_template.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { first } from 'lodash/fp';
+import { asyncForEach } from '@kbn/std';
+import { createOrUpdateIndexTemplate } from '@kbn/alerting-plugin/server';
+import type { EntityAnalyticsMigrationsParams } from '../../migrations';
+import type { RiskEngineConfiguration } from '../../types';
+import { riskEngineConfigurationTypeName } from '../saved_object';
+import {
+  getIndexPatternDataStream,
+  nameSpaceAwareMappingsComponentName,
+} from '../../risk_score/configurations';
+
+export const MAX_PER_PAGE = 10_000;
+
+export const deleteRiskScoreComponent = async ({
+  logger,
+  getStartServices,
+}: EntityAnalyticsMigrationsParams) => {
+  logger.info(`Migration to to delete risk score component template  begins`);
+  const [coreStart] = await getStartServices();
+  const soClientKibanaUser = coreStart.savedObjects.createInternalRepository();
+
+  // Get all installed Risk Engine Configurations
+  const savedObjectsResponse = await soClientKibanaUser.find<RiskEngineConfiguration>({
+    type: riskEngineConfigurationTypeName,
+    perPage: MAX_PER_PAGE,
+    namespaces: ['*'],
+  });
+
+  await asyncForEach(savedObjectsResponse.saved_objects, async (savedObject) => {
+    const namespace = first(savedObject.namespaces);
+    const esClient = coreStart.elasticsearch.client.asInternalUser;
+    if (!namespace) {
+      logger.error(`Namespace is undefined for saved object ${savedObject.id}`);
+      return;
+    }
+    const indexPatterns = getIndexPatternDataStream(namespace);
+
+    logger.info(
+      `Creating/Updating index template for namespace ${namespace} with composed_of field as ${nameSpaceAwareMappingsComponentName(
+        namespace
+      )}`
+    );
+    try {
+      await createOrUpdateIndexTemplate({
+        logger,
+        esClient,
+        template: {
+          name: indexPatterns.template,
+          index_patterns: [indexPatterns.alias],
+          composed_of: [nameSpaceAwareMappingsComponentName(namespace)],
+        },
+      });
+    } catch (e) {
+      logger.error(`Error creating/updating index template for namespace ${namespace}: ${e}`);
+      return;
+    }
+
+    logger.info(`Deleting the component template for namespace ${namespace}`);
+    try {
+      await esClient.cluster.deleteComponentTemplate(
+        {
+          name: nameSpaceAwareMappingsComponentName(namespace),
+        },
+        { ignore: [404] }
+      );
+    } catch (e) {
+      logger.error(`Error deleting the component template for namespace ${namespace}: ${e}`);
+    }
+    logger.info(
+      `Migration to delete risk score component template for namespace ${namespace} completed`
+    );
+  });
+};

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/update_risk_score_mappings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/risk_engine/migrations/update_risk_score_mappings.ts
@@ -76,6 +76,13 @@ export const updateRiskScoreMappings = async ({
         },
       });
 
+      await esClient.cluster.deleteComponentTemplate(
+        {
+          name: '.risk-score-mappings',
+        },
+        { ignore: [404] }
+      );
+
       logger.debug(
         `Risk score mappings updated to version ${newConfig._meta.mappingsVersion} on namespace ${namespace}`
       );


### PR DESCRIPTION
## Summary  

Figma diagram for explanation on the issue : [URL](https://www.figma.com/board/R0ehxbVPeGjZ9K7IYSMST8/RiskScore-component-template-bug?node-id=2-180&t=wbgj0R8tvVKbo6on-1)

### Code Removal  
The previously added code responsible for creating the correct component template and ensuring the proper deletion order for the old template has been removed.  

### Code Addition  
A new approach has been introduced to handle the deletion of the old component template that lacks the namespace in its name (e.g., `.risk-score-mappings`) during migrations.  

We plan to implement this in a separate migration file dedicated to deletion. The current changes are in draft mode and intended for testing.