### PR TITLE
spacetime(slo): Introduce basic maintenance window

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/assets/component_templates/sli_mappings_template.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/assets/component_templates/sli_mappings_template.ts
@@ -103,6 +103,9 @@ export const SLI_MAPPINGS_TEMPLATE: ClusterPutComponentTemplateRequest = {
             },
           },
         },
+        isDuringMaintenanceWindow: {
+          type: 'boolean',
+        },
       },
     },
   },

--- a/x-pack/solutions/observability/plugins/slo/server/assets/ingest_templates/sli_pipeline_template.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/assets/ingest_templates/sli_pipeline_template.ts
@@ -77,6 +77,20 @@ export const getSLIPipelineTemplate = (slo: SLODefinition) => ({
         name: `slo-${slo.id}@custom`,
       },
     },
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        ignore_failure: true,
+        name: `slo-${slo.id}@maintenance`,
+      },
+    },
+    {
+      pipeline: {
+        ignore_missing_pipeline: true,
+        ignore_failure: true,
+        name: `slo@maintenance`,
+      },
+    },
   ],
   _meta: {
     description: 'Ingest pipeline for SLO rollup data',

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/maintenance_windows.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/maintenance_windows.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import dedent from 'dedent';
+import * as t from 'io-ts';
+import { isEmpty } from 'lodash';
+import { createSloServerRoute } from '../create_slo_server_route';
+import { assertPlatinumLicense } from './utils/assert_platinum_license';
+
+const createSchema = t.type({
+  body: t.type({
+    sloIds: t.array(t.string),
+    // TODO: Add maintenance windows params, with recurrence and all...
+    // For the sake of spacetime, I will use a fix window
+  }),
+});
+
+export const createMaintenanceWindowsRoute = createSloServerRoute({
+  endpoint: 'POST /internal/observability/slos/_maintenance_windows',
+  options: { access: 'internal' },
+  security: {
+    authz: {
+      enabled: false,
+      reason: 'spacetime',
+    },
+  },
+  params: createSchema,
+  handler: async ({ context, plugins, request, params }) => {
+    await assertPlatinumLicense(plugins);
+    const esClient = (await context.core).elasticsearch.client.asCurrentUser;
+    const sloIds = params.body.sloIds;
+
+    // TODO: Previously defined maintenance windows need to be reused and set in the pipeline.
+    // 1. Store new maintenance window
+    // 2. Fetch all active and future maintenance windows
+    // 3. Create pipeline processors with previously fetch maintenance windows
+    if (isEmpty(sloIds)) {
+      await esClient.ingest.putPipeline({
+        id: 'slo@maintenance',
+        description: 'Global maintenance windows applied to any SLOs within the space.',
+        processors: [
+          {
+            script: {
+              lang: 'painless',
+              source: dedent(`
+                ZonedDateTime timestamp = ZonedDateTime.parse(ctx['@timestamp']);
+                int hour = timestamp.getHour();
+                if (hour >= 15 && hour < 16) {
+                  ctx.isDuringMaintenanceWindow = true;
+                } else {
+                  ctx.isDuringMaintenanceWindow = false;
+                }
+            `),
+            },
+          },
+        ],
+      });
+    } else {
+      for (const sloId of sloIds) {
+        await esClient.ingest.putPipeline({
+          id: `slo-${sloId}@maintenance`,
+          description: 'Maintenance windows applied to the SLO in that space',
+          processors: [
+            {
+              script: {
+                lang: 'painless',
+                source: dedent(`
+                  ZonedDateTime timestamp = ZonedDateTime.parse(ctx['@timestamp']);
+                  int hour = timestamp.getHour();
+                  if (hour >= 15 && hour < 16) {
+                    ctx.isDuringMaintenanceWindow = true;
+                  } else {
+                    ctx.isDuringMaintenanceWindow = false;
+                  }
+              `),
+              },
+            },
+          ],
+        });
+      }
+    }
+  },
+});

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/route.ts
@@ -27,6 +27,7 @@ import { getSLOSuggestionsRoute } from './get_suggestions';
 import { putSloSettings } from './put_slo_settings';
 import { resetSLORoute } from './reset_slo';
 import { getSLOStatsOverview } from './get_slo_stats_overview';
+import { createMaintenanceWindowsRoute } from './maintenance_windows';
 
 export const getSloRouteRepository = (isServerless?: boolean) => {
   return {
@@ -52,5 +53,6 @@ export const getSloRouteRepository = (isServerless?: boolean) => {
     ...findSLOGroupsRoute,
     ...getSLOSuggestionsRoute,
     ...getSLOStatsOverview,
+    ...createMaintenanceWindowsRoute,
   };
 };

--- a/x-pack/solutions/observability/plugins/slo/server/services/burn_rates_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/burn_rates_client.ts
@@ -111,6 +111,11 @@ function commonQuery(
     size: 0,
     query: {
       bool: {
+        must_not: {
+          term: {
+            isDuringMaintenanceWindow: true,
+          },
+        },
         filter,
       },
     },

--- a/x-pack/solutions/observability/plugins/slo/server/services/historical_summary_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/historical_summary_client.ts
@@ -305,6 +305,11 @@ function generateSearchQuery({
     size: 0,
     query: {
       bool: {
+        must_not: {
+          term: {
+            isDuringMaintenanceWindow: true,
+          },
+        },
         filter: [
           { term: { 'slo.id': sloId } },
           { term: { 'slo.revision': revision } },

--- a/x-pack/solutions/observability/plugins/slo/server/services/resource_installer.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/resource_installer.ts
@@ -15,8 +15,8 @@ import {
   SUMMARY_DESTINATION_INDEX_NAME,
   SUMMARY_TEMP_INDEX_NAME,
 } from '../../common/constants';
-import { SLI_MAPPINGS_TEMPLATE } from '../assets/component_templates/slI_mappings_template';
-import { SLI_SETTINGS_TEMPLATE } from '../assets/component_templates/slI_settings_template';
+import { SLI_MAPPINGS_TEMPLATE } from '../assets/component_templates/sli_mappings_template';
+import { SLI_SETTINGS_TEMPLATE } from '../assets/component_templates/sli_settings_template';
 import { SUMMARY_MAPPINGS_TEMPLATE } from '../assets/component_templates/summary_mappings_template';
 import { SUMMARY_SETTINGS_TEMPLATE } from '../assets/component_templates/summary_settings_template';
 import { SLI_INDEX_TEMPLATE } from '../assets/index_templates/sli_index_template';

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_client.ts
@@ -74,6 +74,11 @@ export class DefaultSummaryClient implements SummaryClient {
       size: 0,
       query: {
         bool: {
+          must_not: {
+            term: {
+              isDuringMaintenanceWindow: true,
+            },
+          },
           filter: [
             { term: { 'slo.id': slo.id } },
             { term: { 'slo.revision': slo.revision } },

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_transform_generator/generators/occurrences.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_transform_generator/generators/occurrences.ts
@@ -43,6 +43,11 @@ export function generateSummaryTransformForOccurrences(
       index: `${SLI_DESTINATION_INDEX_NAME}*`,
       query: {
         bool: {
+          must_not: {
+            term: {
+              isDuringMaintenanceWindow: true,
+            },
+          },
           filter: [
             {
               range: {

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_transform_generator/generators/timeslices_calendar_aligned.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_transform_generator/generators/timeslices_calendar_aligned.ts
@@ -33,6 +33,11 @@ export function generateSummaryTransformForTimeslicesAndCalendarAligned(
       index: `${SLI_DESTINATION_INDEX_NAME}*`,
       query: {
         bool: {
+          must_not: {
+            term: {
+              isDuringMaintenanceWindow: true,
+            },
+          },
           filter: [
             {
               range: {

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_transform_generator/generators/timeslices_rolling.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_transform_generator/generators/timeslices_rolling.ts
@@ -34,6 +34,11 @@ export function generateSummaryTransformForTimeslicesAndRolling(
       index: `${SLI_DESTINATION_INDEX_NAME}*`,
       query: {
         bool: {
+          must_not: {
+            term: {
+              isDuringMaintenanceWindow: true,
+            },
+          },
           filter: [
             {
               range: {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/observability-dev/issues/4351

### Solution

Add a `isDuringMaintenanceWindow: boolean` field in the SLI index. This field will be used to filter out documents that are part of a maintenance window, either from the summary transform or from the various read on the SLI index (historical data, burn rate, etc..)

Add 2 pipeline processors in the existing SLI pipeline:
- `slo-{id}@maintenance`: Used for defining the various painless scripts that will set the isDuringMaintenanceWindow to true, for that specific SLO id, e.g. when a maintenance window is created for a specific list of SLO
- `slo@maintenance`: Use for defining the various painless scripts that will set the isDuringMaintenanceWindow to true, shared by all SLOs, e.g. when a maintenance window is created for every SLO (no filter)


Creating a maintenance window should store it, and fetch the active and future maintenance window that applies to the same SLOs. Then, we generate the painless script based on these maintenance windows, and update the pipelines (global or SLO specific). Maintenance windows that are no longer active (i.e. older than the SLO time window, e.g. 7d or 30d or 90d) won't be included in the updated pipeline script. This will handle the case of resetting an SLO.

Deleting a maintenance window should remove it from its storage, refetch the active and future maintenance window as we do in the "create maintenance window" flow, recompute the painless script and update the pipelines.
1. Deleting a future maintenance window is seamless
2. Deleting an old or active maintenance window requires the SLO to be reseted in order for the SLI data to be recomputed without the maintenance window.


<img width="1717" alt="image" src="https://github.com/user-attachments/assets/b0371cc6-1ee2-49c5-afc5-2e30d6a5836e" />


### Limitations

**Spaces**
Ingest pipelines are not space aware, so the global `@maintenance` pipeline should include the space. The SLO specific `@maintenance` could include the space or not depending on the fix decided below:

> [!WARNING]
>  During this spacetime, I noticed we are not properly handling SLO spaces. Creating two SLOs with the same id in 2 spaces will result in the second SLO not created because some of the resources already exists (transform) but will also delete resources of the first SLO while rolling back (ingest pipeline) since their name/id are not space aware :panic:
Although this is an edge case, we should either make all resources space aware or enforce the uniqueness of an SLO id across all spaces (simpler).

**Maintenance windows**
If we limit the definition of maintenance window to only ones in the future, simply updating the related `@maintenance` ingest pipelines will be enough.


