### PR TITLE
[Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/ui_settings.ts
@@ -381,7 +381,7 @@ export const initUiSettings = (
       value: DEFAULT_MAX_UNASSOCIATED_NOTES,
       schema: schema.number({
         min: 1,
-        max: 1000,
+        max: 10000,
         defaultValue: DEFAULT_MAX_UNASSOCIATED_NOTES,
       }),
       category: [APP_ID],


### PR DESCRIPTION
## Summary

This previous [PR](https://github.com/elastic/kibana/pull/194947) made the maximum number of unassociated notes an advanced settings so that user can change the value within a certain limit. The intent was to allow that value to be between 1 and 10,000 (see acceptance criteria of the [original ticket](https://github.com/elastic/kibana/issues/193097)) but we missed one 0 and the maximum value allowed got set to 1000.

This PR fixes that.

#### Before

![Screenshot 2025-02-28 at 9 18 14 AM](https://github.com/user-attachments/assets/cf1d473c-5bd5-4759-a834-60888b0c8f78)

#### After

![Screenshot 2025-02-28 at 9 18 47 AM](https://github.com/user-attachments/assets/129ba898-bbad-420a-b615-b0a456640af4)


<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->