### PR TITLE
[8.18] [Cloud Security] Fix installing agent-based CSP integrations not displaying Add Agent flyout (#212702)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -47,6 +47,7 @@ import {
   useIntegrationsStateContext,
   useGetSettingsQuery,
 } from '../../../../hooks';
+import { useAgentless } from '../../../../../fleet/sections/agent_policy/create_package_policy_page/single_page_layout/hooks/setup_technology';
 import { INTEGRATIONS_ROUTING_PATHS } from '../../../../constants';
 import { ExperimentalFeaturesService } from '../../../../services';
 import {
@@ -136,6 +137,7 @@ export function Detail() {
   const { getHref, getPath } = useLink();
   const history = useHistory();
   const { pathname, search, hash } = useLocation();
+  const { isAgentlessIntegration } = useAgentless();
   const queryParams = useMemo(() => new URLSearchParams(search), [search]);
   const integration = useMemo(() => queryParams.get('integration'), [queryParams]);
   const prerelease = useMemo(() => Boolean(queryParams.get('prerelease')), [queryParams]);
@@ -416,6 +418,7 @@ export function Detail() {
         isFirstTimeAgentUser,
         isGuidedOnboardingActive,
         pkgkey,
+        isAgentlessIntegration: isAgentlessIntegration(packageInfo || undefined),
       });
 
       /** Users from Security Solution onboarding page will have onboardingLink and onboardingAppId in the query params
@@ -444,12 +447,14 @@ export function Detail() {
       hash,
       history,
       integration,
+      isAgentlessIntegration,
       isCloud,
       isExperimentalAddIntegrationPageEnabled,
       isFirstTimeAgentUser,
       isGuidedOnboardingActive,
       onboardingAppId,
       onboardingLink,
+      packageInfo,
       pathname,
       pkgkey,
       search,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/utils/get_install_route_options.ts
@@ -30,6 +30,7 @@ interface GetInstallPkgRouteOptionsParams {
   isExperimentalAddIntegrationPageEnabled: boolean;
   isFirstTimeAgentUser: boolean;
   isGuidedOnboardingActive: boolean;
+  isAgentlessIntegration?: boolean;
 }
 
 export type InstallPkgRouteOptions = [
@@ -52,6 +53,7 @@ export const getInstallPkgRouteOptions = ({
   isCloud,
   isExperimentalAddIntegrationPageEnabled,
   isGuidedOnboardingActive,
+  isAgentlessIntegration,
 }: GetInstallPkgRouteOptionsParams): InstallPkgRouteOptions => {
   const integrationOpts: { integration?: string } = integration ? { integration } : {};
   const packageExemptFromStepsLayout = isPackageExemptFromStepsLayout(pkgkey);
@@ -102,7 +104,7 @@ export const getInstallPkgRouteOptions = ({
   }
 
   const state: CreatePackagePolicyRouteState = {
-    onSaveNavigateTo: redirectToPath,
+    onSaveNavigateTo: !isAgentlessIntegration ? redirectToPath : undefined,
     onSaveQueryParams,
     onCancelNavigateTo: [
       INTEGRATIONS_PLUGIN_ID,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Cloud Security] Fix installing agent-based CSP integrations not displaying Add Agent flyout (#212702)](https://github.com/elastic/kibana/pull/212702)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"seanrathier","email":"sean.rathier@gmail.com"},"sourceCommit":{"committedDate":"2025-02-28T20:55:09Z","message":"[Cloud Security] Fix installing agent-based CSP integrations not displaying Add Agent flyout (#212702)","sha":"42e094189cc70df68f03c6f3fb4dea887c6a2dfd","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","Team:Cloud Security","backport:prev-minor","v9.1.0"],"title":"[Cloud Security] Fix installing agent-based CSP integrations not displaying Add Agent flyout","number":212702,"url":"https://github.com/elastic/kibana/pull/212702","mergeCommit":{"message":"[Cloud Security] Fix installing agent-based CSP integrations not displaying Add Agent flyout (#212702)","sha":"42e094189cc70df68f03c6f3fb4dea887c6a2dfd"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212702","number":212702,"mergeCommit":{"message":"[Cloud Security] Fix installing agent-based CSP integrations not displaying Add Agent flyout (#212702)","sha":"42e094189cc70df68f03c6f3fb4dea887c6a2dfd"}},{"url":"https://github.com/elastic/kibana/pull/212812","number":212812,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->