### PR TITLE
[Playground] Increase the height of the indices container

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
@@ -65,7 +65,7 @@ export const SelectIndicesFlyout: React.FC<SelectIndicesFlyout> = ({ onClose }) 
             searchable
             height="full"
             css={css`
-              height: calc(100vh - var(--euiFixedHeadersOffset, 0));
+              height: calc(70vh - var(--euiFixedHeadersOffset, 0));
             `}
             searchProps={{
               onChange: handleSearchChange,

--- a/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
@@ -65,7 +65,7 @@ export const SelectIndicesFlyout: React.FC<SelectIndicesFlyout> = ({ onClose }) 
             searchable
             height="full"
             css={css`
-              height: calc(70vh - var(--euiFixedHeadersOffset, 0));
+              height: 70vh;
             `}
             searchProps={{
               onChange: handleSearchChange,

--- a/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
@@ -64,6 +64,9 @@ export const SelectIndicesFlyout: React.FC<SelectIndicesFlyout> = ({ onClose }) 
           <EuiSelectable
             searchable
             height="full"
+            css={css`
+              height: calc(100vh - var(--euiFixedHeadersOffset, 0));
+            `}
             searchProps={{
               onChange: handleSearchChange,
             }}
@@ -93,9 +96,6 @@ export const SelectIndicesFlyout: React.FC<SelectIndicesFlyout> = ({ onClose }) 
             }}
             isLoading={isIndicesLoading}
             renderOption={undefined}
-            css={css`
-              height: calc(100vh - var(--euiFixedHeadersOffset, 0));
-            `}
           >
             {(list, search) => (
               <>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
@@ -23,6 +23,7 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
 import { EuiSelectableOption } from '@elastic/eui/src/components/selectable/selectable_option';
 import { getIndicesWithNoSourceFields } from '../utils/create_query';
 import { useIndicesFields } from '../hooks/use_indices_fields';
@@ -62,7 +63,7 @@ export const SelectIndicesFlyout: React.FC<SelectIndicesFlyout> = ({ onClose }) 
           <EuiSpacer />
           <EuiSelectable
             searchable
-            height={650}
+            height="full"
             searchProps={{
               onChange: handleSearchChange,
             }}
@@ -92,6 +93,9 @@ export const SelectIndicesFlyout: React.FC<SelectIndicesFlyout> = ({ onClose }) 
             }}
             isLoading={isIndicesLoading}
             renderOption={undefined}
+            css={css`
+              height: calc(100vh - var(--euiFixedHeadersOffset, 0));
+            `}
           >
             {(list, search) => (
               <>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/select_indices_flyout.tsx
@@ -62,6 +62,7 @@ export const SelectIndicesFlyout: React.FC<SelectIndicesFlyout> = ({ onClose }) 
           <EuiSpacer />
           <EuiSelectable
             searchable
+            height={650}
             searchProps={{
               onChange: handleSearchChange,
             }}

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_query_indices.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_query_indices.ts
@@ -31,7 +31,7 @@ export const useQueryIndices = (
           query: {
             search_query: query,
             exact,
-            size: 50,
+            size: 100,
           },
         });
 


### PR DESCRIPTION
This PR increase the height of the container for indices in the playground



https://github.com/user-attachments/assets/0fbacb11-ce8e-4566-b07e-b6058de89af0








<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->