### PR TITLE
Fix Incomplete string escaping or encoding

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/server/util/processors.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/util/processors.ts
@@ -70,11 +70,11 @@ export function createKVProcessor(kvInput: KVProcessor, state: KVState): ESProce
   });
   const template = env.getTemplate('kv.yml.njk');
   if (kvInput.trim_key) {
-    kvInput.trim_key = kvInput.trim_key.replace(/['"]/g, '\\$&');
+    kvInput.trim_key = kvInput.trim_key.replace(/\\/g, '\\\\').replace(/['"]/g, '\\$&');
   }
 
   if (kvInput.trim_value) {
-    kvInput.trim_value = kvInput.trim_value.replace(/['"]/g, '\\$&');
+    kvInput.trim_value = kvInput.trim_value.replace(/\\/g, '\\\\').replace(/['"]/g, '\\$&');
   }
   const renderedTemplate = template.render({
     kvInput,


### PR DESCRIPTION
Fix for [https://github.com/elastic/kibana/security/code-scanning/546](https://github.com/elastic/kibana/security/code-scanning/546)

To fix the problem, we need to ensure that backslashes are also escaped in the `trim_key` and `trim_value` properties of the `kvInput` object. This can be done by adding an additional replace call to escape backslashes before escaping single and double quotes. The best way to fix this without changing existing functionality is to use a regular expression with the `g` flag to replace all occurrences of backslashes with double backslashes.


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->