### PR TITLE
[ES|QL] Makes the clear control button optional

### DIFF
--- a/examples/controls_example/public/app/control_group_renderer_examples/search_example.tsx
+++ b/examples/controls_example/public/app/control_group_renderer_examples/search_example.tsx
@@ -38,6 +38,10 @@ interface Props {
   navigation: NavigationPublicPluginStart;
 }
 
+type ControlGroupAPI = DefaultControlApi & {
+  clearSelections: () => void;
+};
+
 const DEST_COUNTRY_CONTROL_ID = 'DEST_COUNTRY_CONTROL_ID';
 
 export const SearchExample = ({ data, dataView, navigation }: Props) => {
@@ -180,7 +184,7 @@ export const SearchExample = ({ data, dataView, navigation }: Props) => {
           onClick={() => {
             if (controlGroupAPI) {
               Object.values(controlGroupAPI.children$.getValue()).forEach((controlApi) => {
-                (controlApi as DefaultControlApi)?.clearSelections();
+                (controlApi as ControlGroupAPI)?.clearSelections();
               });
             }
           }}

--- a/examples/controls_example/public/app/control_group_renderer_examples/search_example.tsx
+++ b/examples/controls_example/public/app/control_group_renderer_examples/search_example.tsx
@@ -39,7 +39,7 @@ interface Props {
 }
 
 type ControlGroupAPI = DefaultControlApi & {
-  clearSelections: () => void;
+  clearSelections?: () => void;
 };
 
 const DEST_COUNTRY_CONTROL_ID = 'DEST_COUNTRY_CONTROL_ID';
@@ -184,7 +184,7 @@ export const SearchExample = ({ data, dataView, navigation }: Props) => {
           onClick={() => {
             if (controlGroupAPI) {
               Object.values(controlGroupAPI.children$.getValue()).forEach((controlApi) => {
-                (controlApi as ControlGroupAPI)?.clearSelections();
+                (controlApi as ControlGroupAPI)?.clearSelections?.();
               });
             }
           }}

--- a/examples/controls_example/public/app/control_group_renderer_examples/search_example.tsx
+++ b/examples/controls_example/public/app/control_group_renderer_examples/search_example.tsx
@@ -38,10 +38,6 @@ interface Props {
   navigation: NavigationPublicPluginStart;
 }
 
-type ControlGroupAPI = DefaultControlApi & {
-  clearSelections?: () => void;
-};
-
 const DEST_COUNTRY_CONTROL_ID = 'DEST_COUNTRY_CONTROL_ID';
 
 export const SearchExample = ({ data, dataView, navigation }: Props) => {
@@ -184,7 +180,7 @@ export const SearchExample = ({ data, dataView, navigation }: Props) => {
           onClick={() => {
             if (controlGroupAPI) {
               Object.values(controlGroupAPI.children$.getValue()).forEach((controlApi) => {
-                (controlApi as ControlGroupAPI)?.clearSelections?.();
+                (controlApi as DefaultControlApi)?.clearSelections?.();
               });
             }
           }}

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/types.ts
@@ -18,7 +18,6 @@ import {
 
 import { DefaultDataControlState } from '../../../common';
 import { ControlGroupApi } from '../../control_group/types';
-import { CanClearSelections } from '../../types';
 import { ControlFactory, DefaultControlApi } from '../types';
 import { PublishesAsyncFilters } from './publishes_async_filters';
 
@@ -31,7 +30,6 @@ export interface PublishesField {
 
 export type DataControlApi = DefaultControlApi &
   Omit<PublishesTitle, 'hideTitle$'> & // control titles cannot be hidden
-  CanClearSelections &
   HasEditCapabilities &
   PublishesDataViews &
   PublishesField &

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/types.ts
@@ -18,6 +18,7 @@ import {
 
 import { DefaultDataControlState } from '../../../common';
 import { ControlGroupApi } from '../../control_group/types';
+import { CanClearSelections } from '../../types';
 import { ControlFactory, DefaultControlApi } from '../types';
 import { PublishesAsyncFilters } from './publishes_async_filters';
 
@@ -30,6 +31,7 @@ export interface PublishesField {
 
 export type DataControlApi = DefaultControlApi &
   Omit<PublishesTitle, 'hideTitle$'> & // control titles cannot be hidden
+  CanClearSelections &
   HasEditCapabilities &
   PublishesDataViews &
   PublishesField &

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/get_esql_control_factory.tsx
@@ -96,9 +96,6 @@ export const getESQLControlFactory = (): ControlFactory<ESQLControlState, ESQLCo
               references: [],
             };
           },
-          clearSelections: () => {
-            // do nothing, not allowed for now;
-          },
         },
         {
           ...defaultControl.comparators,

--- a/src/platform/plugins/shared/controls/public/controls/timeslider_control/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/timeslider_control/types.ts
@@ -9,6 +9,7 @@
 
 import type { PublishesTitle, PublishesTimeslice } from '@kbn/presentation-publishing';
 import type { DefaultControlState } from '../../../common';
+import { CanClearSelections } from '../../types';
 import type { DefaultControlApi } from '../types';
 
 export type Timeslice = [number, number];
@@ -21,5 +22,6 @@ export interface TimesliderControlState extends DefaultControlState {
 }
 
 export type TimesliderControlApi = DefaultControlApi &
+  CanClearSelections &
   Pick<PublishesTitle, 'defaultTitle$'> &
   PublishesTimeslice;

--- a/src/platform/plugins/shared/controls/public/controls/timeslider_control/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/timeslider_control/types.ts
@@ -9,7 +9,6 @@
 
 import type { PublishesTitle, PublishesTimeslice } from '@kbn/presentation-publishing';
 import type { DefaultControlState } from '../../../common';
-import { CanClearSelections } from '../../types';
 import type { DefaultControlApi } from '../types';
 
 export type Timeslice = [number, number];
@@ -22,6 +21,5 @@ export interface TimesliderControlState extends DefaultControlState {
 }
 
 export type TimesliderControlApi = DefaultControlApi &
-  CanClearSelections &
   Pick<PublishesTitle, 'defaultTitle$'> &
   PublishesTimeslice;

--- a/src/platform/plugins/shared/controls/public/controls/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/types.ts
@@ -36,6 +36,7 @@ export type DefaultControlApi = PublishesDataLoading &
   PublishesBlockingError &
   PublishesUnsavedChanges &
   Partial<PublishesTitle & PublishesDisabledActionIds & HasCustomPrepend> &
+  Partial<CanClearSelections> &
   HasType &
   HasUniqueId &
   HasSerializableState<DefaultControlState> &

--- a/src/platform/plugins/shared/controls/public/controls/types.ts
+++ b/src/platform/plugins/shared/controls/public/controls/types.ts
@@ -36,7 +36,6 @@ export type DefaultControlApi = PublishesDataLoading &
   PublishesBlockingError &
   PublishesUnsavedChanges &
   Partial<PublishesTitle & PublishesDisabledActionIds & HasCustomPrepend> &
-  CanClearSelections &
   HasType &
   HasUniqueId &
   HasSerializableState<DefaultControlState> &


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/212605

Here we are removing the clear button from the ES|QL control as clearing will result in wrong charts. I also considered the reset but when there is no changes should be hidden or disabled. This seems to me as a smaller change and taken under consideration that dashboard already allows resetting I think it is ok to remove it.

We can always reconsider if any user complains.

Although by removing the clearSelections from the control config removes the button the `DefaultControlApi ` was marking it as required. So I had to tweak a bit the types.






<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->