### PR TITLE
[Obs AI Assistant] Conversations generated by alert connector

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -604,6 +604,55 @@ export class ObservabilityAIAssistantClient {
     return createdConversation;
   };
 
+  setConversationUser = async ({
+    conversationId,
+    user,
+  }: {
+    conversationId: string;
+    user: { id?: string; name: string };
+  }): Promise<Conversation> => {
+    const response = await this.dependencies.esClient.asInternalUser.search<Conversation>({
+      index: resourceNames.aliases.conversations,
+      query: {
+        bool: {
+          filter: [
+            { term: { 'conversation.id': conversationId } },
+            {
+              bool: {
+                must_not: [{ exists: { field: 'user.id' } }, { exists: { field: 'user.name' } }],
+              },
+            },
+          ],
+        },
+      },
+      size: 1,
+      terminate_after: 1,
+    });
+
+    const persistedConversation = response.hits.hits[0];
+
+    if (!persistedConversation || !persistedConversation?._id) {
+      throw notFound();
+    }
+
+    const updatedConversation: Conversation = merge({}, persistedConversation._source, {
+      conversation: {
+        last_updated: new Date().toISOString(),
+      },
+      user,
+      namespace: this.dependencies.namespace,
+    });
+
+    await this.dependencies.esClient.asInternalUser.update({
+      id: persistedConversation._id,
+      index: persistedConversation._index,
+      doc: updatedConversation,
+      refresh: 'wait_for',
+    });
+
+    return updatedConversation;
+  };
+
   recall = async ({
     queries,
     categories,

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/rule_connector/index.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/rule_connector/index.test.ts
@@ -135,6 +135,17 @@ describe('observabilityAIAssistant rule_connector', () => {
             };
           },
         },
+        alerting: {
+          start: async () => {
+            return {
+              getRulesClientWithRequest: jest.fn().mockResolvedValue({
+                async get() {
+                  return { createdBy: 'user_1' };
+                },
+              }),
+            };
+          },
+        },
       },
     } as unknown as ObservabilityAIAssistantRouteHandlerResources);
 
@@ -226,7 +237,7 @@ describe('observabilityAIAssistant rule_connector', () => {
       expect(completeMock).toHaveBeenCalledWith(
         expect.objectContaining({
           persist: true,
-          isPublic: true,
+          isPublic: false,
           connectorId: 'azure-open-ai',
           kibanaPublicUrl: 'http://kibana.com',
           messages: buildConversation(message),
@@ -258,7 +269,7 @@ describe('observabilityAIAssistant rule_connector', () => {
       expect(completeMock).toHaveBeenCalledWith(
         expect.objectContaining({
           persist: true,
-          isPublic: true,
+          isPublic: false,
           connectorId: 'azure-open-ai',
           kibanaPublicUrl: 'http://kibana.com',
           messages: buildConversation(message),
@@ -294,7 +305,7 @@ describe('observabilityAIAssistant rule_connector', () => {
       expect(completeMock).toHaveBeenCalledWith(
         expect.objectContaining({
           persist: true,
-          isPublic: true,
+          isPublic: false,
           connectorId: 'azure-open-ai',
           kibanaPublicUrl: 'http://kibana.com',
           messages: buildConversation(message),
@@ -303,7 +314,7 @@ describe('observabilityAIAssistant rule_connector', () => {
       expect(completeMock).toHaveBeenCalledWith(
         expect.objectContaining({
           persist: true,
-          isPublic: true,
+          isPublic: false,
           connectorId: 'azure-open-ai',
           kibanaPublicUrl: 'http://kibana.com',
           messages: buildConversation(message2),

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/rule_connector/index.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/rule_connector/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { filter } from 'rxjs';
+import { filter, tap } from 'rxjs';
 import { get } from 'lodash';
 import dedent from 'dedent';
 import { i18n } from '@kbn/i18n';
@@ -194,12 +194,21 @@ async function executor(
     await resources.plugins.actions.start()
   ).getActionsClientWithRequest(request);
 
+  const rulesClient = await (
+    await resources.plugins.alerting.start()
+  ).getRulesClientWithRequest(request);
+
+  const rule = await rulesClient.get({
+    id: execOptions.params.rule.id,
+  });
+
   await Promise.all(
     params.prompts.map((prompt) =>
       executeAlertsChatCompletion(
         resources,
         prompt,
         params,
+        rule.createdBy ? { name: rule.createdBy } : undefined,
         alertDetailsContextService,
         client,
         functionClient,
@@ -216,6 +225,7 @@ async function executeAlertsChatCompletion(
   resources: ObservabilityAIAssistantRouteHandlerResources,
   prompt: { statuses: string[]; message: string },
   params: ConnectorParamsType,
+  ruleCreatedBy: { name: string } | undefined,
   alertDetailsContextService: AlertDetailsContextualInsightsService,
   client: ObservabilityAIAssistantClient,
   functionClient: ChatFunctionClient,
@@ -304,11 +314,13 @@ If available, include the link of the conversation at the end of your answer.`
     }
   );
 
+  let conversationId: string;
+
   client
     .complete({
       functionClient,
       persist: true,
-      isPublic: true,
+      isPublic: false,
       connectorId: params.connector,
       signal: new AbortController().signal,
       kibanaPublicUrl: (await resources.plugins.core.start()).http.basePath.publicBaseUrl,
@@ -366,6 +378,11 @@ If available, include the link of the conversation at the end of your answer.`
       ],
     })
     .pipe(
+      tap((event) => {
+        if (event.type === StreamingChatResponseEventType.ConversationCreate) {
+          conversationId = event.conversation.id;
+        }
+      }),
       filter(
         (event): event is ChatCompletionChunkEvent =>
           event.type === StreamingChatResponseEventType.ChatCompletionChunk
@@ -373,6 +390,14 @@ If available, include the link of the conversation at the end of your answer.`
     )
     .pipe(concatenateChatCompletionChunks())
     .subscribe({
+      complete: async () => {
+        if (ruleCreatedBy && conversationId) {
+          await client.setConversationUser({
+            conversationId,
+            user: { name: ruleCreatedBy.name },
+          });
+        }
+      },
       error: (err) => {
         logger.error(err);
       },


### PR DESCRIPTION
Closes #180710

### Summary:

The AI Assistant alert connector generates ~**system conversations** since these are background processes without a direct user~ private conversations owned by the alert creator. This PR introduces ~system conversations~ private conversations with the following characteristics:  

#### Public Conversation Properties  

- **Marked as private conversation** → The conversations started by the rule connector - `public: false` flag is added to distinguish these conversations.  
- **System conversation with owner** → Like user-created conversations, system conversations have an explicit owner.  


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



