### PR TITLE
[8.18] [ES|QL] Add _score in the autocomplete (#212741)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -1046,9 +1046,10 @@ describe('autocomplete', () => {
           { filterText: '_source', text: '_source, ', command: TRIGGER_SUGGESTION_COMMAND },
         ]);
         // no comma if there are no more fields
-        testSuggestions('FROM a METADATA _id, _ignored, _index, _source, _index_mode, _version/', [
-          { filterText: '_version', text: '_version | ', command: TRIGGER_SUGGESTION_COMMAND },
-        ]);
+        testSuggestions(
+          'FROM a METADATA _id, _ignored, _index, _source, _index_mode, _score, _version/',
+          [{ filterText: '_version', text: '_version | ', command: TRIGGER_SUGGESTION_COMMAND }]
+        );
       });
 
       describe.each(['KEEP', 'DROP'])('%s <field>', (commandName) => {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/constants.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/constants.ts
@@ -15,7 +15,15 @@ export const SINGLE_TICK_REGEX = /`/g;
 export const DOUBLE_BACKTICK = '``';
 export const SINGLE_BACKTICK = '`';
 
-export const METADATA_FIELDS = ['_version', '_id', '_index', '_source', '_ignored', '_index_mode'];
+export const METADATA_FIELDS = [
+  '_version',
+  '_id',
+  '_index',
+  '_source',
+  '_ignored',
+  '_index_mode',
+  '_score',
+];
 
 export const FULL_TEXT_SEARCH_FUNCTIONS = ['match', 'match_operator', 'qstr', 'kql'];
 export const UNSUPPORTED_COMMANDS_BEFORE_QSTR = new Set([


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ES|QL] Add _score in the autocomplete (#212741)](https://github.com/elastic/kibana/pull/212741)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2025-03-03T09:18:08Z","message":"[ES|QL] Add _score in the autocomplete (#212741)\n\n## Summary\n\nAdding _score in the metadata autocomplete suggestions\n\n<img width=\"948\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/58174ab8-72fc-4c84-81e6-6e6fba5e0cde\"\n/>","sha":"6efa46a1ab66426ac1622778201d39bc2afbd871","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:ES|QL","Team:ESQL","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[ES|QL] Add _score in the autocomplete","number":212741,"url":"https://github.com/elastic/kibana/pull/212741","mergeCommit":{"message":"[ES|QL] Add _score in the autocomplete (#212741)\n\n## Summary\n\nAdding _score in the metadata autocomplete suggestions\n\n<img width=\"948\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/58174ab8-72fc-4c84-81e6-6e6fba5e0cde\"\n/>","sha":"6efa46a1ab66426ac1622778201d39bc2afbd871"}},"sourceBranch":"main","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212741","number":212741,"mergeCommit":{"message":"[ES|QL] Add _score in the autocomplete (#212741)\n\n## Summary\n\nAdding _score in the metadata autocomplete suggestions\n\n<img width=\"948\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/58174ab8-72fc-4c84-81e6-6e6fba5e0cde\"\n/>","sha":"6efa46a1ab66426ac1622778201d39bc2afbd871"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212861","number":212861,"state":"OPEN"}]}] BACKPORT-->