### PR TITLE
[8.18] [Security GenAI] "Select a Connector" popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907) (#208969)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/connector_selector/index.tsx
@@ -219,7 +219,7 @@ export const ConnectorSelector: React.FC<Props> = React.memo(
             <AddConnectorModal
               actionTypeRegistry={actionTypeRegistry}
               actionTypes={actionTypes}
-              onClose={() => setIsConnectorModalVisible(false)}
+              onClose={cleanupAndCloseModal}
               onSaveConnector={onSaveConnector}
               onSelectActionType={(actionType: ActionType) => setSelectedActionType(actionType)}
               selectedActionType={selectedActionType}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security GenAI] "Select a Connector" popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907) (#208969)](https://github.com/elastic/kibana/pull/208969)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2025-01-30T16:53:36Z","message":"[Security GenAI] \"Select a Connector\" popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907) (#208969)\n\n## Summary\r\n\r\nBUG: https://github.com/elastic/kibana/issues/208907\r\n\r\nThis PR fixes the issue where user cannot select a different connector\r\ntype after mistakenly selecting a wrong one.\r\n\r\n### Steps to reproduce without required endpoint installation:\r\n\r\n1. Make sure there are no connectors\r\n2. Open \"AI Assistant\" on one of the security solution pages\r\n3. Press \"(+) Add connector\" button\r\n4. Connector type selection modal is visible\r\n5. Select \"Amazon Bedrock\" type (or any other connector type)\r\n6. Cancel the modal\r\n7. Press \"(+) Add connector\" button again\r\n\r\n**ISSUE**: previously selected connector type is being displayed and\r\nthere is no way to switch between types\r\n**EXPECTED**: we should show connector type selection modal once\r\nprevious one was closed\r\n\r\n### Issue recording\r\n\r\n\r\nhttps://github.com/user-attachments/assets/48052bf1-4e00-43b7-a63e-f8a7969b9dbf\r\n\r\n### Fixed state recording\r\n\r\n\r\nhttps://github.com/user-attachments/assets/48be1cc4-0326-43a1-bd57-bb82fc1f19eb","sha":"b28036a2e0f13358b4da614761d32667612ac03a","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team: SecuritySolution","backport:prev-major","Team:Security Generative AI","v8.18.0","v8.16.4","v8.17.2"],"title":"[Security GenAI] \"Select a Connector\" popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907)","number":208969,"url":"https://github.com/elastic/kibana/pull/208969","mergeCommit":{"message":"[Security GenAI] \"Select a Connector\" popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907) (#208969)\n\n## Summary\r\n\r\nBUG: https://github.com/elastic/kibana/issues/208907\r\n\r\nThis PR fixes the issue where user cannot select a different connector\r\ntype after mistakenly selecting a wrong one.\r\n\r\n### Steps to reproduce without required endpoint installation:\r\n\r\n1. Make sure there are no connectors\r\n2. Open \"AI Assistant\" on one of the security solution pages\r\n3. Press \"(+) Add connector\" button\r\n4. Connector type selection modal is visible\r\n5. Select \"Amazon Bedrock\" type (or any other connector type)\r\n6. Cancel the modal\r\n7. Press \"(+) Add connector\" button again\r\n\r\n**ISSUE**: previously selected connector type is being displayed and\r\nthere is no way to switch between types\r\n**EXPECTED**: we should show connector type selection modal once\r\nprevious one was closed\r\n\r\n### Issue recording\r\n\r\n\r\nhttps://github.com/user-attachments/assets/48052bf1-4e00-43b7-a63e-f8a7969b9dbf\r\n\r\n### Fixed state recording\r\n\r\n\r\nhttps://github.com/user-attachments/assets/48be1cc4-0326-43a1-bd57-bb82fc1f19eb","sha":"b28036a2e0f13358b4da614761d32667612ac03a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208969","number":208969,"mergeCommit":{"message":"[Security GenAI] \"Select a Connector\" popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907) (#208969)\n\n## Summary\r\n\r\nBUG: https://github.com/elastic/kibana/issues/208907\r\n\r\nThis PR fixes the issue where user cannot select a different connector\r\ntype after mistakenly selecting a wrong one.\r\n\r\n### Steps to reproduce without required endpoint installation:\r\n\r\n1. Make sure there are no connectors\r\n2. Open \"AI Assistant\" on one of the security solution pages\r\n3. Press \"(+) Add connector\" button\r\n4. Connector type selection modal is visible\r\n5. Select \"Amazon Bedrock\" type (or any other connector type)\r\n6. Cancel the modal\r\n7. Press \"(+) Add connector\" button again\r\n\r\n**ISSUE**: previously selected connector type is being displayed and\r\nthere is no way to switch between types\r\n**EXPECTED**: we should show connector type selection modal once\r\nprevious one was closed\r\n\r\n### Issue recording\r\n\r\n\r\nhttps://github.com/user-attachments/assets/48052bf1-4e00-43b7-a63e-f8a7969b9dbf\r\n\r\n### Fixed state recording\r\n\r\n\r\nhttps://github.com/user-attachments/assets/48be1cc4-0326-43a1-bd57-bb82fc1f19eb","sha":"b28036a2e0f13358b4da614761d32667612ac03a"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/208992","number":208992,"state":"MERGED","mergeCommit":{"sha":"5c65fcf815440c5d2a8db08f8591cc3e57849859","message":"[8.x] [Security GenAI] &quot;Select a Connector&quot; popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907) (#208969) (#208992)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Security GenAI] &quot;Select a Connector&quot; popup does not show\nup after the user selects any connector and then cancels it from\nEndpoint Insights. (#208907)\n(#208969)](https://github.com/elastic/kibana/pull/208969)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Ievgen Sorokopud <ievgen.sorokopud@elastic.co>"}},{"branch":"8.16","label":"v8.16.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/208989","number":208989,"state":"MERGED","mergeCommit":{"sha":"310514fd16025211903ba09a6c86d6f977caaf4f","message":"[8.16] [Security GenAI] &quot;Select a Connector&quot; popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907) (#208969) (#208989)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.16`:\n- [[Security GenAI] &quot;Select a Connector&quot; popup does not show\nup after the user selects any connector and then cancels it from\nEndpoint Insights. (#208907)\n(#208969)](https://github.com/elastic/kibana/pull/208969)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Ievgen Sorokopud <ievgen.sorokopud@elastic.co>"}},{"branch":"8.17","label":"v8.17.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/208991","number":208991,"state":"MERGED","mergeCommit":{"sha":"5a829eb7bdda7e7bd6ff06736d5c8895d838d98d","message":"[8.17] [Security GenAI] &quot;Select a Connector&quot; popup does not show up after the user selects any connector and then cancels it from Endpoint Insights. (#208907) (#208969) (#208991)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [[Security GenAI] &quot;Select a Connector&quot; popup does not show\nup after the user selects any connector and then cancels it from\nEndpoint Insights. (#208907)\n(#208969)](https://github.com/elastic/kibana/pull/208969)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Ievgen Sorokopud <ievgen.sorokopud@elastic.co>"}}]}] BACKPORT-->