### PR TITLE
🌊 POC: Read streams

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/lifecycle.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/lifecycle.ts
@@ -16,6 +16,9 @@ export function findInheritedLifecycle(
   definition: WiredStreamDefinition,
   ancestors: WiredStreamDefinition[]
 ): WiredIngestStreamEffectiveLifecycle {
+  console.log('Finding inherited lifecycle for', definition.name);
+  console.log(JSON.stringify(ancestors, null, 2));
+  console.log(JSON.stringify(definition, null, 2));
   const originDefinition = [...ancestors, definition]
     .sort((a, b) => getSegments(a.name).length - getSegments(b.name).length)
     .findLast(({ ingest }) => !isInheritLifecycle(ingest.lifecycle));

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/base.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/base.ts
@@ -22,6 +22,7 @@ interface IngestBase {
 interface WiredIngest extends IngestBase {
   wired: {
     fields: FieldDefinition;
+    virtual?: boolean;
   };
 }
 
@@ -65,6 +66,7 @@ const wiredIngestSchema: z.Schema<WiredIngest> = z.intersection(
   z.object({
     wired: z.object({
       fields: fieldDefinitionSchema,
+      virtual: z.boolean().optional(),
     }),
   })
 );

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/conditions/index.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/models/ingest/conditions/index.ts
@@ -69,10 +69,15 @@ export interface NeverCondition {
   never: {};
 }
 
+export interface NotCondition {
+  not: Condition;
+}
+
 export type Condition =
   | FilterCondition
   | AndCondition
   | OrCondition
+  | NotCondition
   | NeverCondition
   | AlwaysCondition;
 
@@ -88,6 +93,7 @@ export const conditionSchema: z.Schema<Condition> = z.lazy(() =>
 
 export const andConditionSchema = z.object({ and: z.array(conditionSchema) });
 export const orConditionSchema = z.object({ or: z.array(conditionSchema) });
+export const notConditionSchema = z.object({ not: conditionSchema });
 export const neverConditionSchema = z.object({ never: z.strictObject({}) });
 export const alwaysConditionSchema = z.object({ always: z.strictObject({}) });
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/stream_crud.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/stream_crud.ts
@@ -28,6 +28,7 @@ interface BaseParams {
 
 interface DeleteStreamParams extends BaseParams {
   name: string;
+  isVirtual?: boolean;
   logger: Logger;
 }
 
@@ -113,7 +114,15 @@ export async function deleteStreamObjects({
   name,
   scopedClusterClient,
   logger,
+  isVirtual,
 }: DeleteStreamParams) {
+  if (isVirtual) {
+    await scopedClusterClient.asCurrentUser.indices.deleteAlias({
+      name,
+      index: '*',
+    });
+    return;
+  }
   await deleteDataStream({
     esClient: scopedClusterClient.asCurrentUser,
     name,
@@ -220,6 +229,7 @@ export async function checkAccessBulk({
   if (!names.length) {
     return {};
   }
+  console.log('checkAccessBulk for', names);
   const hasPrivilegesResponse = await scopedClusterClient.asCurrentUser.security.hasPrivileges({
     index: [{ names, privileges: ['read', 'write'] }],
   });

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
@@ -12,6 +12,7 @@ import {
   getInheritedFieldsFromAncestors,
   isGroupStreamDefinition,
   isUnwiredStreamDefinition,
+  isWiredStreamDefinition,
 } from '@kbn/streams-schema';
 import { IScopedClusterClient } from '@kbn/core/server';
 import { AssetClient } from '../../../lib/streams/assets/asset_client';
@@ -45,6 +46,15 @@ export async function readStream({
     return {
       stream: streamDefinition,
       dashboards,
+    };
+  }
+
+  if (isWiredStreamDefinition(streamDefinition) && streamDefinition.ingest.wired.virtual) {
+    return {
+      stream: streamDefinition,
+      dashboards,
+      inherited_fields: {},
+      effective_lifecycle: { inherit: {}, from: '<idk>' },
     };
   }
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/management/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/management/route.ts
@@ -33,7 +33,10 @@ export const forkStreamsRoute = createServerRoute({
     path: z.object({
       name: z.string(),
     }),
-    body: z.object({ stream: z.object({ name: z.string() }), if: conditionSchema }),
+    body: z.object({
+      stream: z.object({ name: z.string(), virtual: z.boolean().optional() }),
+      if: conditionSchema,
+    }),
   }),
   handler: async ({ params, request, getScopedClients }): Promise<{ acknowledged: true }> => {
     const { streamsClient } = await getScopedClients({
@@ -44,6 +47,7 @@ export const forkStreamsRoute = createServerRoute({
       parent: params.path.name,
       if: params.body.if,
       name: params.body.stream.name,
+      virtual: params.body.stream.virtual,
     });
   },
 });


### PR DESCRIPTION
This PR POCs read streams or "virtual" wired ingest streams:

```
POST kbn:/api/streams/_enable

# fork into a real child stream
POST kbn:/api/streams/logs/_fork
{
  "stream": { "name": "logs.child" },
  "if": {
    "field": "message",
    "operator": "exists"
  }
}


# map some fields
PUT kbn:/api/streams/logs.child/_ingest
{
  "ingest": {
    "lifecycle": {
      "inherit": {}
    },
    "processing": [],
    "routing": [],
    "wired": {
      "fields": {
        "agent.name": {
          "type": "keyword"
        },
        "cloud.provider": {
          "type": "keyword"
        }
      }
    }
  }
}

# fork and pass "virtual": true - this creates a "virtual stream" which is not reflected at ingest time at all
POST kbn:/api/streams/logs.child/_fork
{
  "stream": { "name": "logs.child.php", "virtual": true },
  "if": {
    "field": "agent.name",
    "operator": "eq",
    "value": "php"
  }
}

# Stream returns { wired: { virtual: true }} to mark it as virtual
GET kbn:/api/streams/logs.child.php

# This returns all results with agent.name == php
GET logs.child.php/_search
```

Under the hood this works with aliases - instead of writing a data stream, this is writing an alias that points to the nearest real parent plus the routing conditions as filter.

It works fine with some caveats:
* This only works with mapped fields (should be solved by ESQL views and the `FORCE FIELD` command)
* The semantics are different - virtual streams work retroactively for existing data while materialized streams do not. This is especially weird when switching modes. Lets say I'm using a virtual stream for a while and I want to speed it up. I materialize it, but suddenly it only includes data after the creation, not from a year ago (because the actual routing only just started after I materialized the stream). What can we do about this?
* We could try to "patch" this by keeping the wired stream "half virtual" for old data before it got materialized, but access the dedicated data stream for more recent data. But this becomes a mess quickly - what if the user changes the routing condition later on? Should we try to always keep everything consistent and try to filter historical data while routing recent data, or should we give the user the inconsistent state? The latter is what would happen for materialized streams right now, but they also don't try to retroactively fill historical data

In summary - building this made it clear to me that we need to find an answer for how we _want_ things to behave first:
* Should we try to fake query time to behave like ingest time and only apply routing and processing at query time to data in the time range where the config was active?
* Should we try to fake ingest time to behave like query time and always behave as if the current routing and processing was always active?
* Is it OK that query time and ingest time streams behave differently, even if that means a little "bump" when switching from one mode to the other?
* Should we maybe just not have "virtual wired streams", and instead keep it more separated into ingest streams and ESQL streams that are not part of the hierarchy?