### PR TITLE
[8.16] [Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k (#212786)

### DIFF
--- a/x-pack/plugins/security_solution/server/ui_settings.ts
+++ b/x-pack/plugins/security_solution/server/ui_settings.ts
@@ -340,7 +340,7 @@ export const initUiSettings = (
       value: DEFAULT_MAX_UNASSOCIATED_NOTES,
       schema: schema.number({
         min: 1,
-        max: 1000,
+        max: 10000,
         defaultValue: DEFAULT_MAX_UNASSOCIATED_NOTES,
       }),
       category: [APP_ID],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k (#212786)](https://github.com/elastic/kibana/pull/212786)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-02-28T21:21:37Z","message":"[Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k (#212786)\n\n## Summary\n\nThis previous [PR](https://github.com/elastic/kibana/pull/194947) made\nthe maximum number of unassociated notes an advanced settings so that\nuser can change the value within a certain limit. The intent was to\nallow that value to be between 1 and 10,000 (see acceptance criteria of\nthe [original ticket](https://github.com/elastic/kibana/issues/193097))\nbut we missed one 0 and the maximum value allowed got set to 1000.\n\nThis PR fixes that.\n\n#### Before\n\n![Screenshot 2025-02-28 at 9 18\n14 AM](https://github.com/user-attachments/assets/cf1d473c-5bd5-4759-a834-60888b0c8f78)\n\n#### After\n\n![Screenshot 2025-02-28 at 9 18\n47 AM](https://github.com/user-attachments/assets/129ba898-bbad-420a-b615-b0a456640af4)","sha":"eabf95d6dc157d1c1ac2bb8832c7021986285aef","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Threat Hunting:Investigations","backport:all-open","v8.18.0","v9.1.0","v8.19.0","v8.17.3","v8.16.5"],"title":"[Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k","number":212786,"url":"https://github.com/elastic/kibana/pull/212786","mergeCommit":{"message":"[Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k (#212786)\n\n## Summary\n\nThis previous [PR](https://github.com/elastic/kibana/pull/194947) made\nthe maximum number of unassociated notes an advanced settings so that\nuser can change the value within a certain limit. The intent was to\nallow that value to be between 1 and 10,000 (see acceptance criteria of\nthe [original ticket](https://github.com/elastic/kibana/issues/193097))\nbut we missed one 0 and the maximum value allowed got set to 1000.\n\nThis PR fixes that.\n\n#### Before\n\n![Screenshot 2025-02-28 at 9 18\n14 AM](https://github.com/user-attachments/assets/cf1d473c-5bd5-4759-a834-60888b0c8f78)\n\n#### After\n\n![Screenshot 2025-02-28 at 9 18\n47 AM](https://github.com/user-attachments/assets/129ba898-bbad-420a-b615-b0a456640af4)","sha":"eabf95d6dc157d1c1ac2bb8832c7021986285aef"}},"sourceBranch":"main","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212825","number":212825,"state":"MERGED","mergeCommit":{"sha":"aa141aa281bb5c6f6c6503536349cb8bfefa7e7b","message":"[9.0] [Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k (#212786) (#212825)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution][Notes] change upper limit for max unassociated\nnotes advanced setting to be 10k instead of 1k\n(#212786)](https://github.com/elastic/kibana/pull/212786)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212823","number":212823,"state":"MERGED","mergeCommit":{"sha":"b32e708ffc49f3d28cec6a85cc72dfcca3e7052d","message":"[8.18] [Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k (#212786) (#212823)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Security Solution][Notes] change upper limit for max unassociated\nnotes advanced setting to be 10k instead of 1k\n(#212786)](https://github.com/elastic/kibana/pull/212786)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212786","number":212786,"mergeCommit":{"message":"[Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k (#212786)\n\n## Summary\n\nThis previous [PR](https://github.com/elastic/kibana/pull/194947) made\nthe maximum number of unassociated notes an advanced settings so that\nuser can change the value within a certain limit. The intent was to\nallow that value to be between 1 and 10,000 (see acceptance criteria of\nthe [original ticket](https://github.com/elastic/kibana/issues/193097))\nbut we missed one 0 and the maximum value allowed got set to 1000.\n\nThis PR fixes that.\n\n#### Before\n\n![Screenshot 2025-02-28 at 9 18\n14 AM](https://github.com/user-attachments/assets/cf1d473c-5bd5-4759-a834-60888b0c8f78)\n\n#### After\n\n![Screenshot 2025-02-28 at 9 18\n47 AM](https://github.com/user-attachments/assets/129ba898-bbad-420a-b615-b0a456640af4)","sha":"eabf95d6dc157d1c1ac2bb8832c7021986285aef"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212824","number":212824,"state":"MERGED","mergeCommit":{"sha":"b35c244503bff376b44ca7e2eca2a8ba06c263b2","message":"[8.x] [Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k (#212786) (#212824)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Security Solution][Notes] change upper limit for max unassociated\nnotes advanced setting to be 10k instead of 1k\n(#212786)](https://github.com/elastic/kibana/pull/212786)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"8.17","label":"v8.17.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212822","number":212822,"state":"MERGED","mergeCommit":{"sha":"229aac1adf86b96d2718bc66670496263c1dc6c8","message":"[8.17] [Security Solution][Notes] change upper limit for max unassociated notes advanced setting to be 10k instead of 1k (#212786) (#212822)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [[Security Solution][Notes] change upper limit for max unassociated\nnotes advanced setting to be 10k instead of 1k\n(#212786)](https://github.com/elastic/kibana/pull/212786)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Philippe Oberti <philippe.oberti@elastic.co>"}},{"branch":"8.16","label":"v8.16.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->