### PR TITLE
[Fleet] fix `latest_executed_state` error

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -22619,10 +22619,6 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "name",
-                                  "started_at"
-                                ],
                                 "type": "object"
                               },
                               "latest_install_failed_attempts": {
@@ -24278,10 +24274,6 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "name",
-                                "started_at"
-                              ],
                               "type": "object"
                             },
                             "latest_install_failed_attempts": {
@@ -25205,10 +25197,6 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "name",
-                                "started_at"
-                              ],
                               "type": "object"
                             },
                             "latest_install_failed_attempts": {

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -22619,10 +22619,6 @@
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "name",
-                                  "started_at"
-                                ],
                                 "type": "object"
                               },
                               "latest_install_failed_attempts": {
@@ -24278,10 +24274,6 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "name",
-                                "started_at"
-                              ],
                               "type": "object"
                             },
                             "latest_install_failed_attempts": {
@@ -25205,10 +25197,6 @@
                                   "type": "string"
                                 }
                               },
-                              "required": [
-                                "name",
-                                "started_at"
-                              ],
                               "type": "object"
                             },
                             "latest_install_failed_attempts": {

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -22367,9 +22367,6 @@ paths:
                                   type: string
                                 started_at:
                                   type: string
-                              required:
-                                - name
-                                - started_at
                             latest_install_failed_attempts:
                               items:
                                 additionalProperties: true
@@ -23235,9 +23232,6 @@ paths:
                                 type: string
                               started_at:
                                 type: string
-                            required:
-                              - name
-                              - started_at
                           latest_install_failed_attempts:
                             items:
                               additionalProperties: true
@@ -23864,9 +23858,6 @@ paths:
                                 type: string
                               started_at:
                                 type: string
-                            required:
-                              - name
-                              - started_at
                           latest_install_failed_attempts:
                             items:
                               additionalProperties: true

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -24454,9 +24454,6 @@ paths:
                                   type: string
                                 started_at:
                                   type: string
-                              required:
-                                - name
-                                - started_at
                             latest_install_failed_attempts:
                               items:
                                 additionalProperties: true
@@ -25318,9 +25315,6 @@ paths:
                                 type: string
                               started_at:
                                 type: string
-                            required:
-                              - name
-                              - started_at
                           latest_install_failed_attempts:
                             items:
                               additionalProperties: true
@@ -25945,9 +25939,6 @@ paths:
                                 type: string
                               started_at:
                                 type: string
-                            required:
-                              - name
-                              - started_at
                           latest_install_failed_attempts:
                             items:
                               additionalProperties: true

--- a/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/rest_spec/epm.ts
@@ -121,8 +121,8 @@ export const InstallationInfoSchema = schema.object({
   ),
   latest_executed_state: schema.maybe(
     schema.object({
-      name: schema.string(),
-      started_at: schema.string(),
+      name: schema.maybe(schema.string()),
+      started_at: schema.maybe(schema.string()),
       error: schema.maybe(schema.string()),
     })
   ),


### PR DESCRIPTION
Fix schema validation error when `latest_executed_state: {}`.

The logic sets an empty object here: https://github.com/elastic/kibana/blob/63394e6bfdedf8c8e76a457673d662d57afdc2a0/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/update_latest_executed_state.ts#L63
This caused an error on the Integration Details page:

`Failed output validation: [response body.items.4.installationInfo.latest_executed_state.name]: expected value of type [string] but got [undefined]`

Tested locally by manually updating `latest_executed_state` to `{}`, now the `/epm/packages` API works as expected.

<img width="1459" alt="image" src="https://github.com/user-attachments/assets/bbee7787-93a7-4099-ba9b-ff5d031f7637" />


<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->