### PR TITLE
Implement "Group by" feature in Asset Inventory page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_data_table.tsx
@@ -144,9 +144,15 @@ const getEntity = (record: DataTableRecord) => {
 
 export interface AssetInventoryDataTableProps {
   state: AssetInventoryURLStateResult;
+  height?: number;
+  groupSelectorComponent?: JSX.Element;
 }
 
-export const AssetInventoryDataTable = ({ state }: AssetInventoryDataTableProps) => {
+export const AssetInventoryDataTable = ({
+  state,
+  height,
+  groupSelectorComponent,
+}: AssetInventoryDataTableProps) => {
   const {
     pageSize,
     sort,
@@ -283,6 +289,8 @@ export const AssetInventoryDataTable = ({ state }: AssetInventoryDataTableProps)
     const isVirtualizationEnabled = pageSize >= 100;
 
     const getWrapperHeight = () => {
+      if (height) return height;
+
       // If virtualization is not needed the table will render unconstrained.
       if (!isVirtualizationEnabled) return 'auto';
 
@@ -294,7 +302,7 @@ export const AssetInventoryDataTable = ({ state }: AssetInventoryDataTableProps)
       wrapperHeight: getWrapperHeight(),
       mode: isVirtualizationEnabled ? 'virtualized' : 'standard',
     };
-  }, [pageSize]);
+  }, [pageSize, height]);
 
   const onAddFilter: AddFieldFilterHandler | undefined = useMemo(
     () =>
@@ -341,6 +349,7 @@ export const AssetInventoryDataTable = ({ state }: AssetInventoryDataTableProps)
       onAddColumn={onAddColumn}
       onRemoveColumn={onRemoveColumn}
       onResetColumns={onResetColumns}
+      groupSelectorComponent={groupSelectorComponent}
     />
   );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_table_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_table_section.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useState, useEffect } from 'react';
+import type { Filter } from '@kbn/es-query';
+import type { AssetInventoryURLStateResult } from '../hooks/use_asset_inventory_url_state/use_asset_inventory_url_state';
+import { DEFAULT_TABLE_SECTION_HEIGHT } from '../constants';
+import { AssetInventoryGrouping } from './grouping/asset_inventory_grouping';
+import { useAssetInventoryGrouping } from './grouping/use_asset_inventory_grouping';
+import { AssetInventoryDataTable } from './asset_inventory_data_table';
+
+interface TopLevelGroupProps {
+  state: AssetInventoryURLStateResult;
+  renderChildComponent: (groupFilters: Filter[]) => JSX.Element;
+  selectedGroup: string;
+  groupSelectorComponent?: JSX.Element;
+}
+
+interface SubGroupProps extends TopLevelGroupProps {
+  groupingLevel: number;
+  parentGroupFilters?: string;
+}
+
+const TopLevelGroup = ({
+  state,
+  renderChildComponent,
+  selectedGroup,
+  groupSelectorComponent,
+}: TopLevelGroupProps) => {
+  const { groupData, grouping, isFetching } = useAssetInventoryGrouping({
+    state,
+    selectedGroup,
+    groupFilters: [],
+  });
+
+  /**
+   * This is used to reset the active page index when the selected group changes
+   * It is needed because the grouping number of pages can change according to the selected group
+   */
+  useEffect(() => {
+    state.onChangePage(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedGroup]);
+
+  return (
+    <AssetInventoryGrouping
+      data={groupData}
+      grouping={grouping}
+      renderChildComponent={renderChildComponent}
+      activePageIndex={state.pageIndex}
+      pageSize={state.pageSize}
+      onChangeGroupsPage={state.onChangePage}
+      onChangeGroupsItemsPerPage={state.onChangeItemsPerPage}
+      isFetching={isFetching}
+      selectedGroup={selectedGroup}
+      groupingLevel={0}
+      groupSelectorComponent={groupSelectorComponent}
+    />
+  );
+};
+
+const SubGroup = ({
+  state,
+  renderChildComponent,
+  groupingLevel,
+  parentGroupFilters,
+  selectedGroup,
+  groupSelectorComponent,
+}: SubGroupProps) => {
+  const [subgroupPageIndex, setSubgroupPageIndex] = useState(0);
+  const [subgroupPageSize, setSubgroupPageSize] = useState(10);
+
+  const subgroupState = { ...state, pageIndex: subgroupPageIndex, pageSize: subgroupPageSize };
+
+  const { groupData, grouping, isFetching } = useAssetInventoryGrouping({
+    state: subgroupState,
+    selectedGroup,
+    groupFilters: parentGroupFilters ? JSON.parse(parentGroupFilters) : [],
+  });
+
+  /**
+   * This is used to reset the active page index when the selected group changes
+   * It is needed because the grouping number of pages can change according to the selected group
+   */
+  useEffect(() => {
+    setSubgroupPageIndex(0);
+  }, [selectedGroup]);
+
+  return (
+    <AssetInventoryGrouping
+      data={groupData}
+      grouping={grouping}
+      renderChildComponent={renderChildComponent}
+      activePageIndex={subgroupPageIndex}
+      pageSize={subgroupPageSize}
+      onChangeGroupsPage={setSubgroupPageIndex}
+      onChangeGroupsItemsPerPage={setSubgroupPageSize}
+      isFetching={isFetching}
+      selectedGroup={selectedGroup}
+      groupingLevel={groupingLevel}
+      groupSelectorComponent={groupSelectorComponent}
+    />
+  );
+};
+
+interface DataTableWithLocalPagination {
+  state: AssetInventoryURLStateResult;
+  currentGroupFilters: Filter[];
+  parentGroupFilters?: string;
+}
+
+const DataTableWithLocalPagination = ({
+  state,
+  currentGroupFilters,
+  parentGroupFilters,
+}: DataTableWithLocalPagination) => {
+  // Reusable parts
+  const [tablePageIndex, setTablePageIndex] = useState(0);
+  const [tablePageSize, setTablePageSize] = useState(10);
+
+  /**
+   * This is used to reset the active page index when the selected group changes
+   * It is needed because the grouping number of pages can change according to the selected group
+   */
+  useEffect(() => {
+    setTablePageIndex(0);
+  }, [tablePageSize]);
+
+  // End of Reusable parts
+
+  const combinedFilters = [
+    ...currentGroupFilters,
+    ...(parentGroupFilters ? JSON.parse(parentGroupFilters) : []),
+  ]
+    .map(({ query }) => (query.match_phrase ? query : null))
+    .filter(Boolean);
+
+  const newState: AssetInventoryURLStateResult = {
+    ...state,
+    query: {
+      ...state.query,
+      bool: {
+        ...state.query.bool,
+        filter: [...state.query.bool.filter, ...combinedFilters],
+      },
+    },
+    pageIndex: tablePageIndex,
+    pageSize: tablePageSize,
+    onChangePage: setTablePageIndex,
+    onChangeItemsPerPage: setTablePageSize,
+  };
+
+  return <AssetInventoryDataTable state={newState} height={DEFAULT_TABLE_SECTION_HEIGHT} />;
+};
+
+const renderChildComponent = ({
+  state,
+  level,
+  currentSelectedGroup,
+  selectedGroupOptions,
+  parentGroupFilters,
+  groupSelectorComponent,
+}: {
+  state: AssetInventoryURLStateResult;
+  level: number;
+  currentSelectedGroup: string;
+  selectedGroupOptions: string[];
+  parentGroupFilters?: string;
+  groupSelectorComponent?: JSX.Element;
+}) => {
+  let getChildComponent: (groupFilters: Filter[]) => JSX.Element;
+
+  if (currentSelectedGroup === 'none') {
+    return (
+      <AssetInventoryDataTable state={state} groupSelectorComponent={groupSelectorComponent} />
+    );
+  }
+
+  if (level < selectedGroupOptions.length - 1 && !selectedGroupOptions.includes('none')) {
+    getChildComponent = (currentGroupFilters: Filter[]) => {
+      const nextGroupingLevel = level + 1;
+      return renderChildComponent({
+        state,
+        level: nextGroupingLevel,
+        currentSelectedGroup: selectedGroupOptions[nextGroupingLevel],
+        selectedGroupOptions,
+        parentGroupFilters: JSON.stringify([
+          ...currentGroupFilters,
+          ...(parentGroupFilters ? JSON.parse(parentGroupFilters) : []),
+        ]),
+        groupSelectorComponent,
+      });
+    };
+  } else {
+    getChildComponent = (currentGroupFilters: Filter[]) => {
+      return (
+        <DataTableWithLocalPagination
+          state={state}
+          currentGroupFilters={currentGroupFilters}
+          parentGroupFilters={parentGroupFilters}
+        />
+      );
+    };
+  }
+
+  if (level === 0) {
+    return (
+      <TopLevelGroup
+        state={state}
+        renderChildComponent={getChildComponent}
+        selectedGroup={selectedGroupOptions[level]}
+        groupSelectorComponent={groupSelectorComponent}
+      />
+    );
+  }
+
+  return (
+    <SubGroup
+      state={state}
+      renderChildComponent={getChildComponent}
+      selectedGroup={selectedGroupOptions[level]}
+      groupingLevel={level}
+      parentGroupFilters={parentGroupFilters}
+      groupSelectorComponent={groupSelectorComponent}
+    />
+  );
+};
+
+export interface AssetInventoryTableSectionProps {
+  state: AssetInventoryURLStateResult;
+}
+
+export const AssetInventoryTableSection = ({ state }: AssetInventoryTableSectionProps) => {
+  const { grouping } = useAssetInventoryGrouping({ state });
+
+  return (
+    <div>
+      {renderChildComponent({
+        state,
+        level: 0,
+        currentSelectedGroup: grouping.selectedGroups[0],
+        selectedGroupOptions: grouping.selectedGroups,
+        groupSelectorComponent: grouping.groupSelector,
+      })}
+    </div>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/asset_inventory_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/asset_inventory_grouping.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { useGrouping } from '@kbn/grouping';
+import type { ParsedGroupingAggregation } from '@kbn/grouping/src';
+import type { Filter } from '@kbn/es-query';
+import React from 'react';
+import { css } from '@emotion/react';
+import { TEST_SUBJ_GROUPING, TEST_SUBJ_GROUPING_LOADING } from '../../constants';
+
+interface AssetInventoryGroupingProps<T> {
+  data: ParsedGroupingAggregation<T>;
+  renderChildComponent: (groupFilter: Filter[]) => JSX.Element;
+  grouping: ReturnType<typeof useGrouping<T>>;
+  activePageIndex: number;
+  isFetching: boolean;
+  pageSize: number;
+  onChangeGroupsItemsPerPage: (size: number) => void;
+  onChangeGroupsPage: (index: number) => void;
+  selectedGroup: string;
+  groupingLevel?: number;
+  groupSelectorComponent?: JSX.Element;
+}
+
+/**
+ * This component is used to render the loading state of the AssetInventoryGrouping component
+ * It's used to avoid the flickering of the table when the data is loading
+ */
+export const AssetInventoryGroupingLoading = <T,>({
+  grouping,
+  pageSize,
+}: Pick<AssetInventoryGroupingProps<T>, 'grouping' | 'pageSize'>) => {
+  return (
+    <div data-test-subj={TEST_SUBJ_GROUPING_LOADING}>
+      {grouping.getGrouping({
+        activePage: 0,
+        data: {
+          groupsCount: { value: 1 },
+          unitsCount: { value: 1 },
+        },
+        groupingLevel: 0,
+        inspectButton: undefined,
+        isLoading: true,
+        itemsPerPage: pageSize,
+        renderChildComponent: () => <></>,
+        onGroupClose: () => {},
+        selectedGroup: '',
+        takeActionItems: () => [],
+      })}
+    </div>
+  );
+};
+
+export const AssetInventoryGrouping = <T,>({
+  data,
+  renderChildComponent,
+  grouping,
+  activePageIndex,
+  isFetching,
+  pageSize,
+  onChangeGroupsItemsPerPage,
+  onChangeGroupsPage,
+  selectedGroup,
+  groupingLevel = 0,
+  groupSelectorComponent,
+}: AssetInventoryGroupingProps<T>) => {
+  if (!data || isFetching) {
+    return <AssetInventoryGroupingLoading grouping={grouping} pageSize={pageSize} />;
+  }
+
+  return (
+    <div
+      data-test-subj={TEST_SUBJ_GROUPING}
+      css={css`
+        position: relative;
+      `}
+    >
+      {groupSelectorComponent && (
+        <div
+          css={css`
+            position: absolute;
+            right: 0;
+            top: 16px;
+          `}
+        >
+          {groupSelectorComponent}
+        </div>
+      )}
+      <div
+        css={
+          groupSelectorComponent
+            ? css`
+                && [data-test-subj='alerts-table-group-selector'] {
+                  display: none;
+                }
+              `
+            : undefined
+        }
+      >
+        {grouping.getGrouping({
+          activePage: activePageIndex,
+          data,
+          groupingLevel,
+          selectedGroup,
+          inspectButton: undefined,
+          isLoading: isFetching,
+          itemsPerPage: pageSize,
+          onChangeGroupsItemsPerPage,
+          onChangeGroupsPage,
+          renderChildComponent,
+          onGroupClose: () => {},
+          takeActionItems: () => [],
+        })}
+      </div>
+    </div>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/asset_inventory_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/asset_inventory_grouping.tsx
@@ -29,7 +29,7 @@ interface AssetInventoryGroupingProps<T> {
  * This component is used to render the loading state of the AssetInventoryGrouping component
  * It's used to avoid the flickering of the table when the data is loading
  */
-export const AssetInventoryGroupingLoading = <T,>({
+export const GroupWrapperLoading = <T,>({
   grouping,
   pageSize,
 }: Pick<AssetInventoryGroupingProps<T>, 'grouping' | 'pageSize'>) => {
@@ -54,7 +54,7 @@ export const AssetInventoryGroupingLoading = <T,>({
   );
 };
 
-export const AssetInventoryGrouping = <T,>({
+export const GroupWrapper = <T,>({
   data,
   renderChildComponent,
   grouping,
@@ -68,7 +68,7 @@ export const AssetInventoryGrouping = <T,>({
   groupSelectorComponent,
 }: AssetInventoryGroupingProps<T>) => {
   if (!data || isFetching) {
-    return <AssetInventoryGroupingLoading grouping={grouping} pageSize={pageSize} />;
+    return <GroupWrapperLoading grouping={grouping} pageSize={pageSize} />;
   }
 
   return (

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/translations.ts
@@ -22,25 +22,25 @@ export const assetGroupsUnit = (
   const groupCount = hasNullGroup ? totalCount - 1 : totalCount;
 
   switch (selectedGroup) {
-    case ASSET_GROUPING_OPTIONS.ASSET_TYPE:
-      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.assetType', {
+    case ASSET_GROUPING_OPTIONS.ASSET_CRITICALITY:
+      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.assetCriticality', {
         values: { groupCount },
-        defaultMessage: `{groupCount} {groupCount, plural, =1 {asset type} other {asset types}}`,
+        defaultMessage: `{groupCount} {groupCount, plural, =1 {asset criticality} other {asset criticalities}}`,
       });
-    case ASSET_GROUPING_OPTIONS.ASSET_CATEGORY:
-      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.assetCategory', {
+    case ASSET_GROUPING_OPTIONS.ENTITY_TYPE:
+      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.entityType', {
         values: { groupCount },
-        defaultMessage: `{groupCount} {groupCount, plural, =1 {asset category} other {asset categories}}`,
+        defaultMessage: `{groupCount} {groupCount, plural, =1 {entity type} other {entity types}}`,
       });
-    case ASSET_GROUPING_OPTIONS.RISK:
-      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.risk', {
+    case ASSET_GROUPING_OPTIONS.CLOUD_ACCOUNT:
+      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.cloudAccount', {
         values: { groupCount },
-        defaultMessage: `{groupCount} {groupCount, plural, =1 {risk} other {risks}}`,
+        defaultMessage: `{groupCount} {groupCount, plural, =1 {cloud account} other {cloud accounts}}`,
       });
-    case ASSET_GROUPING_OPTIONS.CRITICALITY:
-      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.criticality', {
+    case ASSET_GROUPING_OPTIONS.SOURCE:
+      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.source', {
         values: { groupCount },
-        defaultMessage: `{groupCount} {groupCount, plural, =1 {criticality} other {criticalities}}`,
+        defaultMessage: `{groupCount} {groupCount, plural, =1 {source} other {sources}}`,
       });
     default:
       return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.default', {
@@ -58,44 +58,47 @@ export const NULL_GROUPING_UNIT = i18n.translate(
 );
 
 export const NULL_GROUPING_MESSAGES = {
-  ASSET_TYPE: i18n.translate(
-    'xpack.securitySolution.assetInventory.grouping.assetType.nullGroupTitle',
+  ASSET_CRITICALITY: i18n.translate(
+    'xpack.securitySolution.assetInventory.grouping.assetCriticality.nullGroupTitle',
     {
-      defaultMessage: 'No asset type',
+      defaultMessage: 'No asset criticality',
     }
   ),
-  ASSET_CATEGORY: i18n.translate(
-    'xpack.securitySolution.assetInventory.grouping.assetCategory.nullGroupTitle',
+  ENTITY_TYPE: i18n.translate(
+    'xpack.securitySolution.assetInventory.grouping.entityType.nullGroupTitle',
     {
-      defaultMessage: 'No asset category',
+      defaultMessage: 'No entity type',
     }
   ),
-  RISK: i18n.translate('xpack.securitySolution.assetInventory.grouping.risk.nullGroupTitle', {
-    defaultMessage: 'No risk',
+  CLOUD_ACCOUNT: i18n.translate(
+    'xpack.securitySolution.assetInventory.grouping.cloudAccount.nullGroupTitle',
+    {
+      defaultMessage: 'No cloud account',
+    }
+  ),
+  SOURCE: i18n.translate('xpack.securitySolution.assetInventory.grouping.source.nullGroupTitle', {
+    defaultMessage: 'No source',
   }),
-  CRITICALITY: i18n.translate(
-    'xpack.securitySolution.assetInventory.grouping.criticality.nullGroupTitle',
-    {
-      defaultMessage: 'No criticality',
-    }
-  ),
   DEFAULT: i18n.translate('xpack.securitySolution.assetInventory.grouping.default.nullGroupTitle', {
     defaultMessage: 'No grouping',
   }),
 };
 
 export const GROUPING_LABELS = {
-  ASSET_TYPE: i18n.translate('xpack.securitySolution.assetInventory.groupBy.assetType', {
-    defaultMessage: 'Asset type',
+  ASSET_CRITICALITY: i18n.translate(
+    'xpack.securitySolution.assetInventory.groupBy.assetCriticality',
+    {
+      defaultMessage: 'Asset criticality',
+    }
+  ),
+  ENTITY_TYPE: i18n.translate('xpack.securitySolution.assetInventory.groupBy.entityType', {
+    defaultMessage: 'Entity type',
   }),
-  ASSET_CATEGORY: i18n.translate('xpack.securitySolution.assetInventory.groupBy.assetCategory', {
-    defaultMessage: 'Asset category',
+  CLOUD_ACCOUNT: i18n.translate('xpack.securitySolution.assetInventory.groupBy.cloudAccount', {
+    defaultMessage: 'Cloud account',
   }),
-  RISK: i18n.translate('xpack.securitySolution.assetInventory.groupBy.risk', {
-    defaultMessage: 'Risk',
-  }),
-  CRITICALITY: i18n.translate('xpack.securitySolution.assetInventory.groupBy.criticality', {
-    defaultMessage: 'Criticality',
+  SOURCE: i18n.translate('xpack.securitySolution.assetInventory.groupBy.source', {
+    defaultMessage: 'Source',
   }),
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/translations.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { ASSET_GROUPING_OPTIONS } from '../../constants';
+
+export const assetsUnit = (totalCount: number) =>
+  i18n.translate('xpack.securitySolution.assetInventory.unit', {
+    values: { totalCount },
+    defaultMessage: `{totalCount, plural, =1 {asset} other {assets}}`,
+  });
+
+export const assetGroupsUnit = (
+  totalCount: number,
+  selectedGroup: string,
+  hasNullGroup: boolean
+) => {
+  const groupCount = hasNullGroup ? totalCount - 1 : totalCount;
+
+  switch (selectedGroup) {
+    case ASSET_GROUPING_OPTIONS.ASSET_TYPE:
+      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.assetType', {
+        values: { groupCount },
+        defaultMessage: `{groupCount} {groupCount, plural, =1 {asset type} other {asset types}}`,
+      });
+    case ASSET_GROUPING_OPTIONS.ASSET_CATEGORY:
+      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.assetCategory', {
+        values: { groupCount },
+        defaultMessage: `{groupCount} {groupCount, plural, =1 {asset category} other {asset categories}}`,
+      });
+    case ASSET_GROUPING_OPTIONS.RISK:
+      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.risk', {
+        values: { groupCount },
+        defaultMessage: `{groupCount} {groupCount, plural, =1 {risk} other {risks}}`,
+      });
+    case ASSET_GROUPING_OPTIONS.CRITICALITY:
+      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.criticality', {
+        values: { groupCount },
+        defaultMessage: `{groupCount} {groupCount, plural, =1 {criticality} other {criticalities}}`,
+      });
+    default:
+      return i18n.translate('xpack.securitySolution.assetInventory.groupUnit.default', {
+        values: { groupCount },
+        defaultMessage: `{groupCount} {groupCount, plural, =1 {group} other {groups}}`,
+      });
+  }
+};
+
+export const NULL_GROUPING_UNIT = i18n.translate(
+  'xpack.securitySolution.assetInventory.grouping.nullGroupUnit',
+  {
+    defaultMessage: 'assets',
+  }
+);
+
+export const NULL_GROUPING_MESSAGES = {
+  ASSET_TYPE: i18n.translate(
+    'xpack.securitySolution.assetInventory.grouping.assetType.nullGroupTitle',
+    {
+      defaultMessage: 'No asset type',
+    }
+  ),
+  ASSET_CATEGORY: i18n.translate(
+    'xpack.securitySolution.assetInventory.grouping.assetCategory.nullGroupTitle',
+    {
+      defaultMessage: 'No asset category',
+    }
+  ),
+  RISK: i18n.translate('xpack.securitySolution.assetInventory.grouping.risk.nullGroupTitle', {
+    defaultMessage: 'No risk',
+  }),
+  CRITICALITY: i18n.translate(
+    'xpack.securitySolution.assetInventory.grouping.criticality.nullGroupTitle',
+    {
+      defaultMessage: 'No criticality',
+    }
+  ),
+  DEFAULT: i18n.translate('xpack.securitySolution.assetInventory.grouping.default.nullGroupTitle', {
+    defaultMessage: 'No grouping',
+  }),
+};
+
+export const GROUPING_LABELS = {
+  ASSET_TYPE: i18n.translate('xpack.securitySolution.assetInventory.groupBy.assetType', {
+    defaultMessage: 'Asset type',
+  }),
+  ASSET_CATEGORY: i18n.translate('xpack.securitySolution.assetInventory.groupBy.assetCategory', {
+    defaultMessage: 'Asset category',
+  }),
+  RISK: i18n.translate('xpack.securitySolution.assetInventory.groupBy.risk', {
+    defaultMessage: 'Risk',
+  }),
+  CRITICALITY: i18n.translate('xpack.securitySolution.assetInventory.groupBy.criticality', {
+    defaultMessage: 'Criticality',
+  }),
+};
+
+export const groupingTitle = i18n.translate('xpack.securitySolution.assetInventory.groupBy', {
+  defaultMessage: 'Group assets by',
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
@@ -36,9 +36,6 @@ import { groupPanelRenderer, groupStatsRenderer } from './utils/asset_inventory_
 import { type AssetsGroupingAggregation, useFetchGroupedData } from './use_fetch_grouped_data';
 import { assetsUnit, groupingTitle, assetGroupsUnit, GROUPING_LABELS } from './translations';
 
-// TODO Remove?
-export const ASSETS_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {};
-
 const MAX_GROUPING_LEVELS = 3;
 
 // TODO Move to other file?
@@ -108,28 +105,6 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
 };
 
 /**
- * Get runtime mappings for the given group field
- * Some fields require additional runtime mappings to aggregate additional information
- * Fallback to keyword type to support custom fields grouping
- */
-const getRuntimeMappingsByGroupField = (
-  field: string
-): Record<string, { type: 'keyword' }> | undefined => {
-  if (ASSETS_GROUPING_RUNTIME_MAPPING_FIELDS?.[field]) {
-    return ASSETS_GROUPING_RUNTIME_MAPPING_FIELDS[field].reduce(
-      (acc, runtimeField) => ({
-        ...acc,
-        [runtimeField]: {
-          type: 'keyword',
-        },
-      }),
-      {}
-    );
-  }
-  return {};
-};
-
-/**
  * Type Guard for checking if the given source is a AssetsRootGroupingAggregation
  */
 export const isAssetsRootGroupingAggregation = (
@@ -191,7 +166,6 @@ export const useAssetInventoryGrouping = ({
     size: pageSize,
     sort: [{ groupByField: { order: 'desc' } }],
     statsAggregations: getAggregationsByGroupField(currentSelectedGroup),
-    runtimeMappings: getRuntimeMappingsByGroupField(currentSelectedGroup),
     rootAggregations: [
       {
         ...(!isNoneGroup([currentSelectedGroup]) && {

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
@@ -38,27 +38,25 @@ import { assetsUnit, groupingTitle, assetGroupsUnit, GROUPING_LABELS } from './t
 
 const MAX_GROUPING_LEVELS = 3;
 
-// TODO Move to other file?
-export const defaultGroupingOptions: GroupOption[] = [
+const defaultGroupingOptions: GroupOption[] = [
   {
-    label: GROUPING_LABELS.ASSET_TYPE,
-    key: ASSET_GROUPING_OPTIONS.ASSET_TYPE,
+    label: GROUPING_LABELS.ASSET_CRITICALITY,
+    key: ASSET_GROUPING_OPTIONS.ASSET_CRITICALITY,
   },
   {
-    label: GROUPING_LABELS.ASSET_CATEGORY,
-    key: ASSET_GROUPING_OPTIONS.ASSET_CATEGORY,
+    label: GROUPING_LABELS.ENTITY_TYPE,
+    key: ASSET_GROUPING_OPTIONS.ENTITY_TYPE,
   },
   {
-    label: GROUPING_LABELS.RISK,
-    key: ASSET_GROUPING_OPTIONS.RISK,
+    label: GROUPING_LABELS.CLOUD_ACCOUNT,
+    key: ASSET_GROUPING_OPTIONS.CLOUD_ACCOUNT,
   },
   {
-    label: GROUPING_LABELS.CRITICALITY,
-    key: ASSET_GROUPING_OPTIONS.CRITICALITY,
+    label: GROUPING_LABELS.SOURCE,
+    key: ASSET_GROUPING_OPTIONS.SOURCE,
   },
 ];
 
-// TODO Move to other file?
 export const getDefaultQuery = ({
   query,
   filters,
@@ -67,7 +65,6 @@ export const getDefaultQuery = ({
 } => ({
   query,
   filters,
-  // TODO how to sort asset fields?
   sort: [[]],
 });
 
@@ -92,14 +89,17 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
   ];
 
   switch (field) {
-    case ASSET_GROUPING_OPTIONS.ASSET_TYPE:
-      return [...aggMetrics, getTermAggregation('assetType', ASSET_FIELDS.ASSET_TYPE)];
-    case ASSET_GROUPING_OPTIONS.ASSET_CATEGORY:
-      return [...aggMetrics, getTermAggregation('assetCategory', ASSET_FIELDS.ASSET_CATEGORY)];
-    case ASSET_GROUPING_OPTIONS.RISK:
-      return [...aggMetrics, getTermAggregation('risk', ASSET_FIELDS.RISK)];
-    case ASSET_GROUPING_OPTIONS.CRITICALITY:
-      return [...aggMetrics, getTermAggregation('criticality', ASSET_FIELDS.CRITICALITY)];
+    case ASSET_GROUPING_OPTIONS.ASSET_CRITICALITY:
+      return [
+        ...aggMetrics,
+        getTermAggregation('assetCriticality', ASSET_FIELDS.ASSET_CRITICALITY),
+      ];
+    case ASSET_GROUPING_OPTIONS.ENTITY_TYPE:
+      return [...aggMetrics, getTermAggregation('entityType', ASSET_FIELDS.ENTITY_TYPE)];
+    case ASSET_GROUPING_OPTIONS.CLOUD_ACCOUNT:
+      return [...aggMetrics, getTermAggregation('cloudAccount', ASSET_FIELDS.CLOUD_ACCOUNT)];
+    case ASSET_GROUPING_OPTIONS.SOURCE:
+      return [...aggMetrics, getTermAggregation('source', ASSET_FIELDS.SOURCE)];
   }
   return aggMetrics;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
@@ -97,7 +97,12 @@ const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
     case ASSET_GROUPING_OPTIONS.ENTITY_TYPE:
       return [...aggMetrics, getTermAggregation('entityType', ASSET_FIELDS.ENTITY_TYPE)];
     case ASSET_GROUPING_OPTIONS.CLOUD_ACCOUNT:
-      return [...aggMetrics, getTermAggregation('cloudAccount', ASSET_FIELDS.CLOUD_ACCOUNT)];
+      return [
+        ...aggMetrics,
+        getTermAggregation('accountId', ASSET_FIELDS.CLOUD_ACCOUNT_ID),
+        getTermAggregation('accountName', ASSET_FIELDS.CLOUD_ACCOUNT_NAME),
+        getTermAggregation('cloudProvider', ASSET_FIELDS.CLOUD_PROVIDER),
+      ];
     case ASSET_GROUPING_OPTIONS.SOURCE:
       return [...aggMetrics, getTermAggregation('source', ASSET_FIELDS.SOURCE)];
   }

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
@@ -14,7 +14,7 @@ import {
   getGroupingQuery,
   useGrouping,
 } from '@kbn/grouping';
-import { parseGroupingQuery } from '@kbn/grouping/src';
+import { type ParsedGroupingAggregation, parseGroupingQuery } from '@kbn/grouping/src';
 import { buildEsQuery, type Filter } from '@kbn/es-query';
 import {
   GROUP_BY_CLICK,
@@ -33,11 +33,7 @@ import {
   LOCAL_STORAGE_ASSETS_GROUPING_KEY,
 } from '../../constants';
 import { groupPanelRenderer, groupStatsRenderer } from './utils/asset_inventory_group_renderer';
-import {
-  type AssetsGroupingAggregation,
-  type AssetsRootGroupingAggregation,
-  useFetchGroupedData,
-} from './use_fetch_grouped_data';
+import { type AssetsGroupingAggregation, useFetchGroupedData } from './use_fetch_grouped_data';
 import { assetsUnit, groupingTitle, assetGroupsUnit, GROUPING_LABELS } from './translations';
 
 // TODO Remove?
@@ -137,10 +133,13 @@ const getRuntimeMappingsByGroupField = (
  * Type Guard for checking if the given source is a AssetsRootGroupingAggregation
  */
 export const isAssetsRootGroupingAggregation = (
-  // TODO Replace any with correct type
-  groupData: Record<string, any> | undefined // eslint-disable-line @typescript-eslint/no-explicit-any
-): groupData is AssetsRootGroupingAggregation => {
-  return groupData?.unitsCount?.value !== undefined;
+  groupData: {} | ParsedGroupingAggregation<AssetsGroupingAggregation>
+): groupData is ParsedGroupingAggregation<AssetsGroupingAggregation> => {
+  return (
+    typeof groupData === 'object' &&
+    'unitsCount' in groupData &&
+    groupData.unitsCount?.value !== undefined
+  );
 };
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_asset_inventory_grouping.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useMemo } from 'react';
+import * as uuid from 'uuid';
+import {
+  type GroupOption,
+  type GroupingAggregation,
+  type NamedAggregation,
+  isNoneGroup,
+  getGroupingQuery,
+  useGrouping,
+} from '@kbn/grouping';
+import { parseGroupingQuery } from '@kbn/grouping/src';
+import { buildEsQuery, type Filter } from '@kbn/es-query';
+import {
+  GROUP_BY_CLICK,
+  uiMetricService,
+} from '@kbn/cloud-security-posture-common/utils/ui_metrics';
+import { METRIC_TYPE } from '@kbn/analytics';
+
+import { useDataViewContext } from '../../hooks/data_view_context';
+import type {
+  AssetInventoryURLStateResult,
+  AssetsBaseURLQuery,
+} from '../../hooks/use_asset_inventory_url_state/use_asset_inventory_url_state';
+import {
+  ASSET_GROUPING_OPTIONS,
+  ASSET_FIELDS,
+  LOCAL_STORAGE_ASSETS_GROUPING_KEY,
+} from '../../constants';
+import { groupPanelRenderer, groupStatsRenderer } from './utils/asset_inventory_group_renderer';
+import {
+  type AssetsGroupingAggregation,
+  type AssetsRootGroupingAggregation,
+  useFetchGroupedData,
+} from './use_fetch_grouped_data';
+import { assetsUnit, groupingTitle, assetGroupsUnit, GROUPING_LABELS } from './translations';
+
+// TODO Remove?
+export const ASSETS_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {};
+
+const MAX_GROUPING_LEVELS = 3;
+
+// TODO Move to other file?
+export const defaultGroupingOptions: GroupOption[] = [
+  {
+    label: GROUPING_LABELS.ASSET_TYPE,
+    key: ASSET_GROUPING_OPTIONS.ASSET_TYPE,
+  },
+  {
+    label: GROUPING_LABELS.ASSET_CATEGORY,
+    key: ASSET_GROUPING_OPTIONS.ASSET_CATEGORY,
+  },
+  {
+    label: GROUPING_LABELS.RISK,
+    key: ASSET_GROUPING_OPTIONS.RISK,
+  },
+  {
+    label: GROUPING_LABELS.CRITICALITY,
+    key: ASSET_GROUPING_OPTIONS.CRITICALITY,
+  },
+];
+
+// TODO Move to other file?
+export const getDefaultQuery = ({
+  query,
+  filters,
+}: AssetsBaseURLQuery): AssetsBaseURLQuery & {
+  sort: string[][];
+} => ({
+  query,
+  filters,
+  // TODO how to sort asset fields?
+  sort: [[]],
+});
+
+const getTermAggregation = (key: keyof AssetsGroupingAggregation, field: string) => ({
+  [key]: {
+    terms: { field, size: 1 },
+  },
+});
+
+const getAggregationsByGroupField = (field: string): NamedAggregation[] => {
+  if (isNoneGroup([field])) {
+    return [];
+  }
+  const aggMetrics: NamedAggregation[] = [
+    {
+      groupByField: {
+        cardinality: {
+          field,
+        },
+      },
+    },
+  ];
+
+  switch (field) {
+    case ASSET_GROUPING_OPTIONS.ASSET_TYPE:
+      return [...aggMetrics, getTermAggregation('assetType', ASSET_FIELDS.ASSET_TYPE)];
+    case ASSET_GROUPING_OPTIONS.ASSET_CATEGORY:
+      return [...aggMetrics, getTermAggregation('assetCategory', ASSET_FIELDS.ASSET_CATEGORY)];
+    case ASSET_GROUPING_OPTIONS.RISK:
+      return [...aggMetrics, getTermAggregation('risk', ASSET_FIELDS.RISK)];
+    case ASSET_GROUPING_OPTIONS.CRITICALITY:
+      return [...aggMetrics, getTermAggregation('criticality', ASSET_FIELDS.CRITICALITY)];
+  }
+  return aggMetrics;
+};
+
+/**
+ * Get runtime mappings for the given group field
+ * Some fields require additional runtime mappings to aggregate additional information
+ * Fallback to keyword type to support custom fields grouping
+ */
+const getRuntimeMappingsByGroupField = (
+  field: string
+): Record<string, { type: 'keyword' }> | undefined => {
+  if (ASSETS_GROUPING_RUNTIME_MAPPING_FIELDS?.[field]) {
+    return ASSETS_GROUPING_RUNTIME_MAPPING_FIELDS[field].reduce(
+      (acc, runtimeField) => ({
+        ...acc,
+        [runtimeField]: {
+          type: 'keyword',
+        },
+      }),
+      {}
+    );
+  }
+  return {};
+};
+
+/**
+ * Type Guard for checking if the given source is a AssetsRootGroupingAggregation
+ */
+export const isAssetsRootGroupingAggregation = (
+  // TODO Replace any with correct type
+  groupData: Record<string, any> | undefined // eslint-disable-line @typescript-eslint/no-explicit-any
+): groupData is AssetsRootGroupingAggregation => {
+  return groupData?.unitsCount?.value !== undefined;
+};
+
+/**
+ * Utility hook to get the latest assets grouping data for the assets page
+ */
+export const useAssetInventoryGrouping = ({
+  state,
+  groupFilters = [],
+  selectedGroup,
+}: {
+  state: AssetInventoryURLStateResult;
+  groupFilters?: Filter[];
+  selectedGroup?: string;
+}) => {
+  const { query, setUrlQuery, pageSize, pageIndex } = state;
+  const { dataView, dataViewIsLoading } = useDataViewContext();
+
+  const grouping = useGrouping({
+    componentProps: {
+      unit: assetsUnit,
+      groupPanelRenderer,
+      getGroupStats: groupStatsRenderer,
+      groupsUnit: assetGroupsUnit,
+    },
+    defaultGroupingOptions,
+    fields: dataViewIsLoading ? [] : dataView.fields,
+    groupingId: LOCAL_STORAGE_ASSETS_GROUPING_KEY,
+    maxGroupingLevels: MAX_GROUPING_LEVELS,
+    title: groupingTitle,
+    onGroupChange: ({ groupByFields }) => {
+      setUrlQuery({
+        groupBy: groupByFields,
+      });
+      uiMetricService.trackUiMetric(METRIC_TYPE.CLICK, GROUP_BY_CLICK);
+    },
+  });
+
+  const additionalFilters = buildEsQuery(dataView, [], groupFilters);
+  const currentSelectedGroup = selectedGroup || grouping.selectedGroups[0];
+  const isNoneSelected = isNoneGroup(grouping.selectedGroups);
+  // This is recommended by the grouping component to cover an edge case where `selectedGroup` has multiple values
+  const uniqueValue = useMemo(() => `${selectedGroup}-${uuid.v4()}`, [selectedGroup]);
+
+  const groupingQuery = getGroupingQuery({
+    additionalFilters: query ? [query, additionalFilters] : [additionalFilters],
+    groupByField: currentSelectedGroup,
+    uniqueValue,
+    pageNumber: pageIndex * pageSize,
+    size: pageSize,
+    sort: [{ groupByField: { order: 'desc' } }],
+    statsAggregations: getAggregationsByGroupField(currentSelectedGroup),
+    runtimeMappings: getRuntimeMappingsByGroupField(currentSelectedGroup),
+    rootAggregations: [
+      {
+        ...(!isNoneGroup([currentSelectedGroup]) && {
+          nullGroupItems: {
+            missing: { field: currentSelectedGroup },
+          },
+        }),
+      },
+    ],
+  });
+
+  const { data, isFetching } = useFetchGroupedData({
+    query: groupingQuery,
+    enabled: !isNoneSelected,
+  });
+
+  const groupData = useMemo(
+    () =>
+      parseGroupingQuery(
+        currentSelectedGroup,
+        uniqueValue,
+        data as GroupingAggregation<AssetsGroupingAggregation>
+      ),
+    [data, currentSelectedGroup, uniqueValue]
+  );
+
+  const isEmptyResults =
+    !isFetching && isAssetsRootGroupingAggregation(groupData) && groupData.unitsCount?.value === 0;
+
+  return {
+    groupData,
+    grouping,
+    isFetching,
+    selectedGroup,
+    isGroupSelected: !isNoneSelected,
+    isEmptyResults,
+  };
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_fetch_grouped_data.ts
@@ -26,16 +26,16 @@ export interface AssetsGroupingAggregation {
   groupByFields?: {
     buckets?: GenericBuckets[];
   };
-  assetType?: {
+  assetCriticality?: {
     buckets?: GenericBuckets[];
   };
-  assetCategory?: {
+  entityType?: {
     buckets?: GenericBuckets[];
   };
-  risk?: {
+  cloudAccount?: {
     buckets?: GenericBuckets[];
   };
-  criticality?: {
+  source?: {
     buckets?: GenericBuckets[];
   };
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_fetch_grouped_data.ts
@@ -32,7 +32,13 @@ export interface AssetsGroupingAggregation {
   entityType?: {
     buckets?: GenericBuckets[];
   };
-  cloudAccount?: {
+  accountId?: {
+    buckets?: GenericBuckets[];
+  };
+  accountName?: {
+    buckets?: GenericBuckets[];
+  };
+  cloudProvider?: {
     buckets?: GenericBuckets[];
   };
   source?: {

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_fetch_grouped_data.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/use_fetch_grouped_data.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
+import type { IKibanaSearchResponse } from '@kbn/search-types';
+import type { GenericBuckets, GroupingQuery, RootAggregation } from '@kbn/grouping/src';
+import { useQuery } from '@tanstack/react-query';
+import { lastValueFrom } from 'rxjs';
+import { showErrorToast } from '@kbn/cloud-security-posture';
+import { useKibana } from '../../../common/lib/kibana';
+import { ASSET_INVENTORY_INDEX_PATTERN, QUERY_KEY_GROUPING_DATA } from '../../constants';
+
+type NumberOrNull = number | null;
+
+export interface AssetsGroupingAggregation {
+  unitsCount?: {
+    value?: NumberOrNull;
+  };
+  groupsCount?: {
+    value?: NumberOrNull;
+  };
+  groupByFields?: {
+    buckets?: GenericBuckets[];
+  };
+  assetType?: {
+    buckets?: GenericBuckets[];
+  };
+  assetCategory?: {
+    buckets?: GenericBuckets[];
+  };
+  risk?: {
+    buckets?: GenericBuckets[];
+  };
+  criticality?: {
+    buckets?: GenericBuckets[];
+  };
+}
+
+export type AssetsRootGroupingAggregation = RootAggregation<AssetsGroupingAggregation>;
+
+export const getGroupedAssetsQuery = (query: GroupingQuery) => ({
+  ...query,
+  index: ASSET_INVENTORY_INDEX_PATTERN,
+  ignore_unavailable: true,
+  size: 0,
+});
+
+export const useFetchGroupedData = ({
+  query,
+  enabled = true,
+}: {
+  query: GroupingQuery;
+  enabled: boolean;
+}) => {
+  const {
+    data,
+    notifications: { toasts },
+  } = useKibana().services;
+
+  return useQuery(
+    [QUERY_KEY_GROUPING_DATA, { query }],
+    async () => {
+      const {
+        rawResponse: { aggregations },
+      } = await lastValueFrom(
+        data.search.search<
+          {},
+          IKibanaSearchResponse<SearchResponse<{}, AssetsRootGroupingAggregation>>
+        >({
+          params: getGroupedAssetsQuery(query),
+        })
+      );
+
+      if (!aggregations) throw new Error('Failed to aggregate by, missing resource id');
+
+      return aggregations;
+    },
+    {
+      onError: (err: Error) => showErrorToast(toasts, err),
+      enabled,
+      keepPreviousData: true,
+    }
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/asset_inventory_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/asset_inventory_group_renderer.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import {
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiTextBlockTruncate,
+  EuiToolTip,
+  useEuiTheme,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import type {
+  GenericBuckets,
+  GroupPanelRenderer,
+  GroupStatsItem,
+  RawBucket,
+} from '@kbn/grouping/src';
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
+import { ASSET_GROUPING_OPTIONS, TEST_SUBJ_GROUPING_COUNTER } from '../../../constants';
+import { firstNonNullValue } from './first_non_null_value';
+import { NullGroup } from './null_group';
+import { LoadingGroup } from './loading_group';
+import type { AssetsGroupingAggregation } from '../use_fetch_grouped_data';
+import { NULL_GROUPING_MESSAGES, NULL_GROUPING_UNIT } from '../translations';
+
+export const groupPanelRenderer: GroupPanelRenderer<AssetsGroupingAggregation> = (
+  selectedGroup: string,
+  bucket: RawBucket<AssetsGroupingAggregation>,
+  nullGroupMessage: string | undefined,
+  isLoading: boolean | undefined
+) => {
+  if (isLoading) {
+    return <LoadingGroup />;
+  }
+
+  const renderNullGroup = (title: string) => (
+    <NullGroup title={title} field={selectedGroup} unit={NULL_GROUPING_UNIT} />
+  );
+
+  const getGroupPanelTitle = (aggregationField?: keyof AssetsGroupingAggregation) => {
+    const aggregationFieldValue = aggregationField
+      ? (bucket[aggregationField] as { buckets?: GenericBuckets[] })?.buckets?.[0]?.key
+      : null;
+
+    if (aggregationFieldValue) {
+      return (
+        <>
+          <strong>{aggregationFieldValue}</strong>
+          {' - '}
+          {bucket.key_as_string}
+        </>
+      );
+    }
+
+    return <strong>{bucket.key_as_string}</strong>;
+  };
+
+  switch (selectedGroup) {
+    case ASSET_GROUPING_OPTIONS.ASSET_TYPE:
+      return nullGroupMessage ? (
+        renderNullGroup(NULL_GROUPING_MESSAGES.ASSET_TYPE)
+      ) : (
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem>
+            <EuiFlexGroup direction="column" gutterSize="none">
+              <EuiFlexItem
+                css={css`
+                  display: inline;
+                `}
+              >
+                <EuiText size="s">
+                  <EuiTextBlockTruncate
+                    lines={2}
+                    css={css`
+                      word-break: break-all;
+                    `}
+                    title={bucket.assetType?.buckets?.[0]?.key as string}
+                  >
+                    {getGroupPanelTitle('assetType')}
+                  </EuiTextBlockTruncate>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    case ASSET_GROUPING_OPTIONS.ASSET_CATEGORY:
+      return nullGroupMessage ? (
+        renderNullGroup(NULL_GROUPING_MESSAGES.ASSET_CATEGORY)
+      ) : (
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem>
+            <EuiFlexGroup direction="column" gutterSize="none">
+              <EuiFlexItem>
+                <EuiText size="s"> {getGroupPanelTitle()}</EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="xs" color="subdued">
+                  {firstNonNullValue(bucket.assetCategory?.buckets?.[0]?.key)}{' '}
+                  {firstNonNullValue(bucket.assetCategory?.buckets?.[0]?.key)}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    case ASSET_GROUPING_OPTIONS.RISK:
+      return nullGroupMessage ? (
+        renderNullGroup(NULL_GROUPING_MESSAGES.RISK)
+      ) : (
+        <EuiFlexGroup alignItems="center" gutterSize="m">
+          <EuiFlexItem>
+            <EuiFlexGroup direction="column" gutterSize="none">
+              <EuiFlexItem>
+                <EuiText size="s">{getGroupPanelTitle('risk')}</EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="xs" color="subdued">
+                  {bucket.risk?.buckets?.[0]?.key}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    case ASSET_GROUPING_OPTIONS.CRITICALITY:
+      return nullGroupMessage ? (
+        renderNullGroup(NULL_GROUPING_MESSAGES.CRITICALITY)
+      ) : (
+        <EuiFlexGroup alignItems="center" gutterSize="m">
+          <EuiFlexItem>
+            <EuiFlexGroup direction="column" gutterSize="none">
+              <EuiFlexItem>
+                <EuiText size="s">{getGroupPanelTitle('criticality')}</EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="xs" color="subdued">
+                  {bucket.criticality?.buckets?.[0]?.key}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    default:
+      return nullGroupMessage ? (
+        renderNullGroup(NULL_GROUPING_MESSAGES.DEFAULT)
+      ) : (
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem>
+            <EuiFlexGroup direction="column" gutterSize="none">
+              <EuiFlexItem>
+                <EuiText size="s">{getGroupPanelTitle()}</EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+  }
+};
+
+const AssetsCountComponent = ({ bucket }: { bucket: RawBucket<AssetsGroupingAggregation> }) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <EuiToolTip content={bucket.doc_count}>
+      <EuiBadge
+        css={css`
+          margin-left: ${euiTheme.size.s};
+        `}
+        color="hollow"
+        data-test-subj={TEST_SUBJ_GROUPING_COUNTER}
+      >
+        {getAbbreviatedNumber(bucket.doc_count)}
+      </EuiBadge>
+    </EuiToolTip>
+  );
+};
+
+const AssetsCount = React.memo(AssetsCountComponent);
+
+export const groupStatsRenderer = (
+  _selectedGroup: string,
+  bucket: RawBucket<AssetsGroupingAggregation>
+): GroupStatsItem[] => [
+  {
+    title: i18n.translate('xpack.securitySolution.assetInventory.grouping.stats.badges.assets', {
+      defaultMessage: 'Assets',
+    }),
+    component: <AssetsCount bucket={bucket} />,
+  },
+];

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/asset_inventory_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/asset_inventory_group_renderer.tsx
@@ -23,7 +23,7 @@ import type {
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
-import { CISBenchmarkIcon } from '@kbn/cloud-security-posture';
+import { CloudProviderIcon, type CloudProvider } from '@kbn/custom-icons';
 import { ASSET_GROUPING_OPTIONS, TEST_SUBJ_GROUPING_COUNTER } from '../../../constants';
 import { firstNonNullValue } from './first_non_null_value';
 import { NullGroup } from './null_group';
@@ -41,7 +41,7 @@ export const groupPanelRenderer: GroupPanelRenderer<AssetsGroupingAggregation> =
     return <LoadingGroup />;
   }
 
-  const cloudProvider = firstNonNullValue(bucket.cloudProvider?.buckets?.[0]?.key);
+  const cloudProvider = firstNonNullValue(bucket.cloudProvider?.buckets?.[0]?.key) as CloudProvider;
 
   const renderNullGroup = (title: string) => (
     <NullGroup title={title} field={selectedGroup} unit={NULL_GROUPING_UNIT} />
@@ -121,10 +121,7 @@ export const groupPanelRenderer: GroupPanelRenderer<AssetsGroupingAggregation> =
         <EuiFlexGroup alignItems="center" gutterSize="m">
           {cloudProvider && (
             <EuiFlexItem grow={0}>
-              <CISBenchmarkIcon
-                type={`cis_${cloudProvider}`}
-                name={firstNonNullValue(bucket.accountName?.buckets?.[0]?.key)}
-              />
+              <CloudProviderIcon cloudProvider={cloudProvider} />
             </EuiFlexItem>
           )}
           <EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/asset_inventory_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/asset_inventory_group_renderer.tsx
@@ -23,6 +23,7 @@ import type {
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
+import { CISBenchmarkIcon } from '@kbn/cloud-security-posture';
 import { ASSET_GROUPING_OPTIONS, TEST_SUBJ_GROUPING_COUNTER } from '../../../constants';
 import { firstNonNullValue } from './first_non_null_value';
 import { NullGroup } from './null_group';
@@ -39,6 +40,8 @@ export const groupPanelRenderer: GroupPanelRenderer<AssetsGroupingAggregation> =
   if (isLoading) {
     return <LoadingGroup />;
   }
+
+  const cloudProvider = firstNonNullValue(bucket.cloudProvider?.buckets?.[0]?.key);
 
   const renderNullGroup = (title: string) => (
     <NullGroup title={title} field={selectedGroup} unit={NULL_GROUPING_UNIT} />
@@ -116,15 +119,18 @@ export const groupPanelRenderer: GroupPanelRenderer<AssetsGroupingAggregation> =
         renderNullGroup(NULL_GROUPING_MESSAGES.CLOUD_ACCOUNT)
       ) : (
         <EuiFlexGroup alignItems="center" gutterSize="m">
+          {cloudProvider && (
+            <EuiFlexItem grow={0}>
+              <CISBenchmarkIcon
+                type={`cis_${cloudProvider}`}
+                name={firstNonNullValue(bucket.accountName?.buckets?.[0]?.key)}
+              />
+            </EuiFlexItem>
+          )}
           <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
-                <EuiText size="s">{getGroupPanelTitle('cloudAccount')}</EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiText size="xs" color="subdued">
-                  {bucket.cloudAccount?.buckets?.[0]?.key}
-                </EuiText>
+                <EuiText size="s">{getGroupPanelTitle('accountName')}</EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/asset_inventory_group_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/asset_inventory_group_renderer.tsx
@@ -63,9 +63,29 @@ export const groupPanelRenderer: GroupPanelRenderer<AssetsGroupingAggregation> =
   };
 
   switch (selectedGroup) {
-    case ASSET_GROUPING_OPTIONS.ASSET_TYPE:
+    case ASSET_GROUPING_OPTIONS.ASSET_CRITICALITY:
       return nullGroupMessage ? (
-        renderNullGroup(NULL_GROUPING_MESSAGES.ASSET_TYPE)
+        renderNullGroup(NULL_GROUPING_MESSAGES.ASSET_CRITICALITY)
+      ) : (
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem>
+            <EuiFlexGroup direction="column" gutterSize="none">
+              <EuiFlexItem>
+                <EuiText size="s"> {getGroupPanelTitle()}</EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText size="xs" color="subdued">
+                  {firstNonNullValue(bucket.assetCriticality?.buckets?.[0]?.key)}{' '}
+                  {firstNonNullValue(bucket.assetCriticality?.buckets?.[0]?.key)}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    case ASSET_GROUPING_OPTIONS.ENTITY_TYPE:
+      return nullGroupMessage ? (
+        renderNullGroup(NULL_GROUPING_MESSAGES.ENTITY_TYPE)
       ) : (
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem>
@@ -81,9 +101,9 @@ export const groupPanelRenderer: GroupPanelRenderer<AssetsGroupingAggregation> =
                     css={css`
                       word-break: break-all;
                     `}
-                    title={bucket.assetType?.buckets?.[0]?.key as string}
+                    title={bucket.entityType?.buckets?.[0]?.key as string}
                   >
-                    {getGroupPanelTitle('assetType')}
+                    {getGroupPanelTitle('entityType')}
                   </EuiTextBlockTruncate>
                 </EuiText>
               </EuiFlexItem>
@@ -91,58 +111,38 @@ export const groupPanelRenderer: GroupPanelRenderer<AssetsGroupingAggregation> =
           </EuiFlexItem>
         </EuiFlexGroup>
       );
-    case ASSET_GROUPING_OPTIONS.ASSET_CATEGORY:
+    case ASSET_GROUPING_OPTIONS.CLOUD_ACCOUNT:
       return nullGroupMessage ? (
-        renderNullGroup(NULL_GROUPING_MESSAGES.ASSET_CATEGORY)
+        renderNullGroup(NULL_GROUPING_MESSAGES.CLOUD_ACCOUNT)
       ) : (
-        <EuiFlexGroup alignItems="center">
+        <EuiFlexGroup alignItems="center" gutterSize="m">
           <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
-                <EuiText size="s"> {getGroupPanelTitle()}</EuiText>
+                <EuiText size="s">{getGroupPanelTitle('cloudAccount')}</EuiText>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiText size="xs" color="subdued">
-                  {firstNonNullValue(bucket.assetCategory?.buckets?.[0]?.key)}{' '}
-                  {firstNonNullValue(bucket.assetCategory?.buckets?.[0]?.key)}
+                  {bucket.cloudAccount?.buckets?.[0]?.key}
                 </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
       );
-    case ASSET_GROUPING_OPTIONS.RISK:
+    case ASSET_GROUPING_OPTIONS.SOURCE:
       return nullGroupMessage ? (
-        renderNullGroup(NULL_GROUPING_MESSAGES.RISK)
+        renderNullGroup(NULL_GROUPING_MESSAGES.SOURCE)
       ) : (
         <EuiFlexGroup alignItems="center" gutterSize="m">
           <EuiFlexItem>
             <EuiFlexGroup direction="column" gutterSize="none">
               <EuiFlexItem>
-                <EuiText size="s">{getGroupPanelTitle('risk')}</EuiText>
+                <EuiText size="s">{getGroupPanelTitle('source')}</EuiText>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiText size="xs" color="subdued">
-                  {bucket.risk?.buckets?.[0]?.key}
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      );
-    case ASSET_GROUPING_OPTIONS.CRITICALITY:
-      return nullGroupMessage ? (
-        renderNullGroup(NULL_GROUPING_MESSAGES.CRITICALITY)
-      ) : (
-        <EuiFlexGroup alignItems="center" gutterSize="m">
-          <EuiFlexItem>
-            <EuiFlexGroup direction="column" gutterSize="none">
-              <EuiFlexItem>
-                <EuiText size="s">{getGroupPanelTitle('criticality')}</EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiText size="xs" color="subdued">
-                  {bucket.criticality?.buckets?.[0]?.key}
+                  {bucket.source?.buckets?.[0]?.key}
                 </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/first_non_null_value.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/first_non_null_value.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { firstNonNullValue } from './first_non_null_value';
+
+describe('firstNonNullValue', () => {
+  it('returns the value itself for non-null single value', () => {
+    expect(firstNonNullValue(5)).toBe(5);
+  });
+
+  it('returns undefined for a null single value', () => {
+    expect(firstNonNullValue(null)).toBeUndefined();
+  });
+
+  it('returns undefined for an array of all null values', () => {
+    expect(firstNonNullValue([null, null, null])).toBeUndefined();
+  });
+
+  it('returns the first non-null value in an array of mixed values', () => {
+    expect(firstNonNullValue([null, 7, 8])).toBe(7);
+  });
+
+  it('returns the first value in an array of all non-null values', () => {
+    expect(firstNonNullValue([3, 4, 5])).toBe(3);
+  });
+
+  it('returns undefined for an empty array', () => {
+    expect(firstNonNullValue([])).toBeUndefined();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/first_non_null_value.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/first_non_null_value.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ECSField } from '@kbn/grouping/src';
+
+/**
+ * Return first non-null value. If the field contains an array, this will return the first value that isn't null.
+ * If the field isn't an array it'll be returned unless it's null.
+ */
+export function firstNonNullValue<T>(valueOrCollection: ECSField<T>): T | undefined {
+  if (valueOrCollection === null) {
+    return undefined;
+  } else if (Array.isArray(valueOrCollection)) {
+    for (const value of valueOrCollection) {
+      if (value !== null) {
+        return value;
+      }
+    }
+  } else {
+    return valueOrCollection;
+  }
+}

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/loading_group.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/loading_group.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiSkeletonTitle } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React from 'react';
+
+export const LoadingGroup = () => {
+  return (
+    <EuiSkeletonTitle size="s" isLoading={true}>
+      <FormattedMessage
+        id="xpack.securitySolution.assetInventory.grouping.loadingGroupPanelTitle"
+        defaultMessage="Loading"
+      />
+    </EuiSkeletonTitle>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/null_group.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/grouping/utils/null_group.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiIconTip } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React from 'react';
+
+export const NullGroup = ({
+  title,
+  field,
+  unit,
+}: {
+  title: string;
+  field: string;
+  unit: string;
+}) => {
+  return (
+    <EuiFlexGroup alignItems="center" gutterSize="xs">
+      <strong>{title}</strong>
+      <EuiIconTip
+        anchorProps={{
+          css: css`
+            display: inline-flex;
+          `,
+        }}
+        content={
+          <>
+            <FormattedMessage
+              id="xpack.securitySolution.assetInventory.grouping.nullGroupTooltip"
+              defaultMessage="The selected {groupingTitle} field, {field} is missing a value for this group of {unit}."
+              values={{
+                groupingTitle: (
+                  <strong>
+                    <FormattedMessage
+                      id="xpack.securitySolution.assetInventory.grouping.nullGroupTooltip.groupingTitle"
+                      defaultMessage="group by"
+                    />
+                  </strong>
+                ),
+                field: <code>{field}</code>,
+                unit,
+              }}
+            />
+          </>
+        }
+        position="right"
+      />
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/constants.ts
@@ -11,6 +11,7 @@ export const ASSET_INVENTORY_INDEX_PATTERN = 'logs-cloud_asset_inventory.asset_i
 
 export const QUERY_KEY_GRID_DATA = 'asset_inventory_grid_data';
 export const QUERY_KEY_CHART_DATA = 'asset_inventory_chart_data';
+export const QUERY_KEY_GROUPING_DATA = 'asset-inventory-grouping-data';
 
 export const ASSET_INVENTORY_TABLE_ID = 'asset-inventory-table';
 
@@ -20,6 +21,7 @@ export const LOCAL_STORAGE_COLUMNS_SETTINGS_KEY = `${LOCAL_STORAGE_COLUMNS_KEY}:
 export const LOCAL_STORAGE_DATA_TABLE_PAGE_SIZE_KEY = `${LOCAL_STORAGE_PREFIX}:dataTable:pageSize`;
 export const LOCAL_STORAGE_DATA_TABLE_COLUMNS_KEY = `${LOCAL_STORAGE_PREFIX}:dataTable:columns`;
 export const LOCAL_STORAGE_ONBOARDING_SUCCESS_CALLOUT_KEY = `${LOCAL_STORAGE_PREFIX}:onboarding:successCallout`;
+export const LOCAL_STORAGE_ASSETS_GROUPING_KEY = `${LOCAL_STORAGE_PREFIX}:grouping`;
 
 export const TEST_SUBJ_DATA_GRID = 'asset-inventory-test-subj-grid-wrapper';
 export const TEST_SUBJ_PAGE_TITLE = 'asset-inventory-test-subj-page-title';
@@ -29,5 +31,25 @@ export const TEST_SUBJ_ONBOARDING_GET_STARTED = 'asset-inventory-onboarding-get-
 export const TEST_SUBJ_ONBOARDING_INITIALIZING = 'asset-inventory-onboarding-initializing';
 export const TEST_SUBJ_ONBOARDING_NO_DATA_FOUND = 'asset-inventory-onboarding-no-data-found';
 export const TEST_SUBJ_ONBOARDING_SUCCESS_CALLOUT = 'asset-inventory-onboarding-success-callout';
+export const TEST_SUBJ_GROUPING = 'asset-inventory-grouping';
+export const TEST_SUBJ_GROUPING_LOADING = 'asset-inventory-grouping-loading';
+export const TEST_SUBJ_GROUPING_COUNTER = 'asset-inventory-grouping-counter';
 
 export const DOCS_URL = 'https://ela.st/asset-inventory';
+
+export const DEFAULT_TABLE_SECTION_HEIGHT = 512; // px
+
+export const ASSET_FIELDS = {
+  ASSET_TYPE: 'entity.type',
+  ASSET_CATEGORY: 'entity.category',
+  RISK: 'host.risk.calculated_level',
+  CRITICALITY: 'asset.criticality',
+} as const;
+
+export const ASSET_GROUPING_OPTIONS = {
+  NONE: 'none',
+  ASSET_TYPE: ASSET_FIELDS.ASSET_TYPE,
+  ASSET_CATEGORY: ASSET_FIELDS.ASSET_CATEGORY,
+  RISK: ASSET_FIELDS.RISK,
+  CRITICALITY: ASSET_FIELDS.CRITICALITY,
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/constants.ts
@@ -40,16 +40,16 @@ export const DOCS_URL = 'https://ela.st/asset-inventory';
 export const DEFAULT_TABLE_SECTION_HEIGHT = 512; // px
 
 export const ASSET_FIELDS = {
-  ASSET_TYPE: 'entity.type',
-  ASSET_CATEGORY: 'entity.category',
-  RISK: 'host.risk.calculated_level',
-  CRITICALITY: 'asset.criticality',
+  ASSET_CRITICALITY: 'asset.criticality',
+  ENTITY_TYPE: 'entity.category',
+  CLOUD_ACCOUNT: 'cloud.account.id',
+  SOURCE: 'entity.type',
 } as const;
 
 export const ASSET_GROUPING_OPTIONS = {
   NONE: 'none',
-  ASSET_TYPE: ASSET_FIELDS.ASSET_TYPE,
-  ASSET_CATEGORY: ASSET_FIELDS.ASSET_CATEGORY,
-  RISK: ASSET_FIELDS.RISK,
-  CRITICALITY: ASSET_FIELDS.CRITICALITY,
+  ASSET_CRITICALITY: ASSET_FIELDS.ASSET_CRITICALITY,
+  ENTITY_TYPE: ASSET_FIELDS.ENTITY_TYPE,
+  CLOUD_ACCOUNT: ASSET_FIELDS.CLOUD_ACCOUNT,
+  SOURCE: ASSET_FIELDS.SOURCE,
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/constants.ts
@@ -42,7 +42,9 @@ export const DEFAULT_TABLE_SECTION_HEIGHT = 512; // px
 export const ASSET_FIELDS = {
   ASSET_CRITICALITY: 'asset.criticality',
   ENTITY_TYPE: 'entity.category',
-  CLOUD_ACCOUNT: 'cloud.account.id',
+  CLOUD_ACCOUNT_ID: 'cloud.account.id',
+  CLOUD_ACCOUNT_NAME: 'cloud.account.name',
+  CLOUD_PROVIDER: 'cloud.provider',
   SOURCE: 'entity.type',
 } as const;
 
@@ -50,6 +52,6 @@ export const ASSET_GROUPING_OPTIONS = {
   NONE: 'none',
   ASSET_CRITICALITY: ASSET_FIELDS.ASSET_CRITICALITY,
   ENTITY_TYPE: ASSET_FIELDS.ENTITY_TYPE,
-  CLOUD_ACCOUNT: ASSET_FIELDS.CLOUD_ACCOUNT,
+  CLOUD_ACCOUNT: ASSET_FIELDS.CLOUD_ACCOUNT_ID,
   SOURCE: ASSET_FIELDS.SOURCE,
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
@@ -12,7 +12,7 @@ import { EuiPageTemplate } from '@elastic/eui';
 import { AssetInventorySearchBar } from '../components/asset_inventory_search_bar';
 import { AssetInventoryFilters } from '../components/filters/asset_inventory_filters';
 import { AssetInventoryBarChart } from '../components/asset_inventory_bar_chart';
-import { AssetInventoryDataTable } from '../components/asset_inventory_data_table';
+import { AssetInventoryTableSection } from '../components/asset_inventory_table_section';
 import { AssetInventoryTitle } from '../components/asset_inventory_title';
 import { useFetchChartData } from '../hooks/use_fetch_chart_data';
 import {
@@ -59,7 +59,7 @@ export const AllAssets = () => {
           isFetching={isFetchingChartData}
           entities={!!chartData && chartData.length > 0 ? chartData : []}
         />
-        <AssetInventoryDataTable state={state} />
+        <AssetInventoryTableSection state={state} />
       </EuiPageTemplate.Section>
     </I18nProvider>
   );

--- a/x-pack/solutions/security/plugins/security_solution/tsconfig.json
+++ b/x-pack/solutions/security/plugins/security_solution/tsconfig.json
@@ -242,5 +242,6 @@
     "@kbn/shared-ux-error-boundary",
     "@kbn/security-ai-prompts",
     "@kbn/scout-security",
+    "@kbn/custom-icons",
   ]
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/202092

Depends on:

- https://github.com/elastic/kibana/pull/213212
- https://github.com/elastic/kibana/pull/215963
- ~~https://github.com/elastic/kibana/pull/216354~~ <- cancelled, I reused `<CloudProviderIcon>` from `@kbn/custom-icons` instead

Add a "Group by" menu dropdown on the right side of the data grid to render rows grouped recursively with a maximum of 3 group levels i.e. entities grouped by type (1), category (2), risk(3). It supports grouping by custom fields as in Findings.

Pagination state of each recursive group is kept locally, while the top-level group's pagination is kept in the URL query-string. This is to preserve consistency with the data-table's pagination state which is also kept in the URL.

### Component hierarchy

<img width="1389" alt="Screenshot 2025-03-28 at 16 00 31" src="https://github.com/user-attachments/assets/d4c30849-5d76-4589-867f-718847e11e8b" />

### Screenshots

<details><summary>Menu Dropdown</summary>
<img width="295" alt="Screenshot 2025-03-31 at 17 12 25" src="https://github.com/user-attachments/assets/558e6160-806d-4e08-92d1-3285c0e688b6" />
</details> 

<details><summary>Group by none</summary>
<img width="1374" alt="Screenshot 2025-03-26 at 17 00 58" src="https://github.com/user-attachments/assets/5b319f7b-d63a-4bce-bf24-15549cda254d" />
</details>

<details><summary>Group by entity type</summary>
<img width="1306" alt="Screenshot 2025-03-31 at 17 13 20" src="https://github.com/user-attachments/assets/9a0cb35e-0a4e-415b-95c7-0fccc78031e1" />
</details>

<details><summary>Group by source</summary>
<img width="1301" alt="Screenshot 2025-03-31 at 17 13 32" src="https://github.com/user-attachments/assets/dee33d76-9468-4eb4-bf24-aecbffa707b0" />
</details>

<details><summary>Group by entity type, then source</summary>
<img width="1297" alt="Screenshot 2025-03-31 at 17 14 21" src="https://github.com/user-attachments/assets/e5785fe6-ab8d-4e69-9156-9cbab4870d6b" />
</details>

<details><summary>Group by source, then entity type</summary>
<img width="1294" alt="Screenshot 2025-03-31 at 17 14 02" src="https://github.com/user-attachments/assets/5fa01569-08f6-445b-80ca-cd8a12a50e1e" />
</details>

<details><summary>Group by cloud account</summary>
<img width="1316" alt="Screenshot 2025-03-31 at 17 12 13" src="https://github.com/user-attachments/assets/8422ce10-4366-4347-bdcc-aaa10a06d4d2" />
</details>

<details><summary>Group by custom field (entity.id)</summary>
<img width="1348" alt="Screenshot 2025-03-26 at 17 02 45" src="https://github.com/user-attachments/assets/46dc1f25-2bd4-4571-888d-5becf011b7c6" />
</details>

> [!IMPORTANT]
> We can't group by asset criticality at the moment because the field is not present in the current dataset.

<details><summary>TBD Group by asset criticality</summary>
</details>

### Definition of done

- [x] Add a toggle to switch between **DataGrid** and **Group by View** visualizations.
- [x] Implement the **Group by View** using the `@kbn/grouping` package for consistency and reusability.
- [x] Provide a dropdown menu to select grouping fields, including: (updated as per [this epic](https://github.com/elastic/security-team/issues/10344))
  - ~~**Asset type (asset.type)**~~ -> **Asset criticality (asset.criticality)**
  - ~~**Asset category (asset.category)**~~ -> **Entity type (entity.category)**
  - ~~**Risk (host.risk.calculated_level)**~~ -> **Cloud account (cloud.account.id)**
  - ~~**Criticality (asset.criticality)**~~ -> **Source (entity.type)**
  - **Custom field**: Allow users to input/select a custom field for grouping.
- [x] Display the following information for each group row:
  - The grouped term value.
  - The count of assets in that group.
  - A button to expand the group and view the assets in a filtered **DataGrid**.
- [x] Ensure group expansion dynamically displays assets in a DataGrid filtered by the selected grouping field.
- [x] **Pagination**: Display 10 groups per page by default, with pagination controls to navigate between pages.
- [x] **Rows per page dropdown**: Allow users to adjust the number of groups displayed per page (options: 10, 25, 50, 100).

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Risks

No risk since code is still hidden behind the *Enable Asset Inventory* advanced setting and the beta *Cloud Asset* integration must be installed.