### PR TITLE
chore(slo): replace error log level with debug

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
@@ -100,7 +100,7 @@ export class CreateSLO {
         this.summaryTransformManager.start(summaryTransformId),
       ]);
     } catch (err) {
-      this.logger.error(
+      this.logger.debug(
         `Cannot create the SLO [id: ${slo.id}, revision: ${slo.revision}]. Rolling back. ${err}`
       );
 
@@ -108,7 +108,7 @@ export class CreateSLO {
         try {
           await operation();
         } catch (rollbackErr) {
-          this.logger.error(`Rollback operation failed. ${rollbackErr}`);
+          this.logger.debug(`Rollback operation failed. ${rollbackErr}`);
         }
       });
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
@@ -86,7 +86,7 @@ export class ResetSLO {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(
+      this.logger.debug(
         `Cannot reset the SLO [id: ${slo.id}, revision: ${slo.revision}]. Rolling back. ${err}`
       );
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/resource_installer.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/resource_installer.ts
@@ -42,7 +42,7 @@ export class DefaultResourceInstaller implements ResourceInstaller {
     try {
       installTimeout = setTimeout(() => (this.isInstalling = false), 60000);
 
-      this.logger.info('Installing SLO shared resources');
+      this.logger.debug('Installing SLO shared resources');
       await Promise.all([
         this.createOrUpdateComponentTemplate(SLI_MAPPINGS_TEMPLATE),
         this.createOrUpdateComponentTemplate(SLI_SETTINGS_TEMPLATE),
@@ -71,9 +71,9 @@ export class DefaultResourceInstaller implements ResourceInstaller {
       this.esClient
     );
     if (template._meta?.version && currentVersion === template._meta.version) {
-      this.logger.info(`SLO component template found with version [${template._meta.version}]`);
+      this.logger.debug(`SLO component template found with version [${template._meta.version}]`);
     } else {
-      this.logger.info(`Installing SLO component template [${template.name}]`);
+      this.logger.debug(`Installing SLO component template [${template.name}]`);
       return this.execute(() => this.esClient.cluster.putComponentTemplate(template));
     }
   }
@@ -86,9 +86,9 @@ export class DefaultResourceInstaller implements ResourceInstaller {
     );
 
     if (template._meta?.version && currentVersion === template._meta.version) {
-      this.logger.info(`SLO index template found with version [${template._meta.version}]`);
+      this.logger.debug(`SLO index template found with version [${template._meta.version}]`);
     } else {
-      this.logger.info(`Installing SLO index template [${template.name}]`);
+      this.logger.debug(`Installing SLO index template [${template.name}]`);
       return this.execute(() => this.esClient.indices.putIndexTemplate(template));
     }
   }
@@ -114,19 +114,11 @@ async function fetchComponentTemplateVersion(
   esClient: ElasticsearchClient
 ) {
   const getTemplateRes = await retryTransientEsErrors(
-    () =>
-      esClient.cluster.getComponentTemplate(
-        {
-          name,
-        },
-        {
-          ignore: [404],
-        }
-      ),
+    () => esClient.cluster.getComponentTemplate({ name }, { ignore: [404] }),
     { logger }
   );
 
-  return getTemplateRes?.component_templates?.[0]?.component_template?._meta?.version || null;
+  return getTemplateRes?.component_templates?.[0]?.component_template?._meta?.version ?? null;
 }
 
 async function fetchIndexTemplateVersion(
@@ -135,17 +127,9 @@ async function fetchIndexTemplateVersion(
   esClient: ElasticsearchClient
 ) {
   const getTemplateRes = await retryTransientEsErrors(
-    () =>
-      esClient.indices.getIndexTemplate(
-        {
-          name,
-        },
-        {
-          ignore: [404],
-        }
-      ),
+    () => esClient.indices.getIndexTemplate({ name }, { ignore: [404] }),
     { logger }
   );
 
-  return getTemplateRes?.index_templates?.[0]?.index_template?._meta?.version || null;
+  return getTemplateRes?.index_templates?.[0]?.index_template?._meta?.version ?? null;
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_repository.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_repository.ts
@@ -166,7 +166,7 @@ export class KibanaSavedObjectsSLORepository implements SLORepository {
     });
 
     if (isLeft(result)) {
-      this.logger.error(`Invalid stored SLO with id [${storedSLO.id}]`);
+      this.logger.debug(`Invalid stored SLO with id [${storedSLO.id}]`);
       return undefined;
     }
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client/summary_search_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client/summary_search_client.ts
@@ -160,7 +160,7 @@ export class DefaultSummarySearchClient implements SummarySearchClient {
         }),
       };
     } catch (err) {
-      this.logger.error(`Error while searching SLO summary documents. ${err}`);
+      this.logger.debug(`Error while searching SLO summary documents. ${err}`);
       return { total: 0, ...pagination, results: [] };
     }
   }

--- a/x-pack/solutions/observability/plugins/slo/server/services/summay_transform_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summay_transform_manager.ts
@@ -32,7 +32,7 @@ export class DefaultSummaryTransformManager implements TransformManager {
         }
       );
     } catch (err) {
-      this.logger.error(`Cannot create summary transform for SLO [${slo.id}]. ${err}`);
+      this.logger.debug(`Cannot create summary transform for SLO [${slo.id}]. ${err}`);
       if (err.meta?.body?.error?.type === 'security_exception') {
         throw new SecurityException(err.meta.body.error.reason);
       }
@@ -57,7 +57,7 @@ export class DefaultSummaryTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot preview SLO summary transform [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot preview SLO summary transform [${transformId}]. ${err}`);
       throw err;
     }
   }
@@ -75,7 +75,7 @@ export class DefaultSummaryTransformManager implements TransformManager {
         }
       );
     } catch (err) {
-      this.logger.error(`Cannot start SLO summary transform [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot start SLO summary transform [${transformId}]. ${err}`);
       throw err;
     }
   }
@@ -91,7 +91,7 @@ export class DefaultSummaryTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot stop SLO summary transform [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot stop SLO summary transform [${transformId}]. ${err}`);
       throw err;
     }
   }
@@ -107,7 +107,7 @@ export class DefaultSummaryTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot delete SLO summary transform [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot delete SLO summary transform [${transformId}]. ${err}`);
       throw err;
     }
   }
@@ -124,7 +124,7 @@ export class DefaultSummaryTransformManager implements TransformManager {
       );
       return response?.transforms[0]?._meta?.version;
     } catch (err) {
-      this.logger.error(`Cannot retrieve SLO transform version [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot retrieve SLO transform version [${transformId}]. ${err}`);
       throw err;
     }
   }

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/orphan_summary_cleanup_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/orphan_summary_cleanup_task.ts
@@ -100,7 +100,7 @@ export class SloOrphanSummaryCleanupTask {
         );
 
         if (sloSummaryIdsToDelete.length > 0) {
-          this.logger.info(
+          this.logger.debug(
             `[SLO] Deleting ${sloSummaryIdsToDelete.length} SLO Summary documents from the summary index`
           );
 
@@ -227,7 +227,7 @@ export class SloOrphanSummaryCleanupTask {
     this.esClient = esClient;
 
     if (!taskManager) {
-      this.logger.info(
+      this.logger.debug(
         'Missing required service during startup, skipping orphan-slo-summary-cleanup task.'
       );
       return;

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/temp_summary_cleanup_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/temp_summary_cleanup_task.ts
@@ -87,7 +87,7 @@ export class TempSummaryCleanupTask {
         params: {},
       });
     } catch (e) {
-      this.logger.debug(`Error scheduling task, error: ${e}`);
+      this.logger.error(`Error scheduling task, error: ${e}`);
     }
   }
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/temp_summary_cleanup_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/temp_summary_cleanup_task.ts
@@ -108,7 +108,7 @@ export class TempSummaryCleanupTask {
       return getDeleteTaskRunResult();
     }
 
-    this.logger.debug(`runTask() started`);
+    this.logger.debug(`runTask started`);
 
     const [coreStart] = await core.getStartServices();
     const esClient = coreStart.elasticsearch.client.asInternalUser;
@@ -126,7 +126,7 @@ export class TempSummaryCleanupTask {
 
         return;
       }
-      this.logger.error(`Error: ${err}`);
+      this.logger.debug(`Error: ${err}`);
     }
   }
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/temp_summary_cleanup_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/temp_summary_cleanup_task.ts
@@ -63,7 +63,7 @@ export class TempSummaryCleanupTask {
     }
 
     if (!plugins.taskManager) {
-      this.logger.error('Missing required service during start');
+      this.logger.debug('Missing required service during start');
       return;
     }
 
@@ -87,7 +87,7 @@ export class TempSummaryCleanupTask {
         params: {},
       });
     } catch (e) {
-      this.logger.error(`Error scheduling task, error: ${e}`);
+      this.logger.debug(`Error scheduling task, error: ${e}`);
     }
   }
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/common.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/common.ts
@@ -39,7 +39,7 @@ export function parseStringFilters(filters: string, logger: Logger) {
   try {
     return JSON.parse(filters);
   } catch (e) {
-    logger.info(`Failed to parse filters: ${e}`);
+    logger.debug(`Failed to parse filters: ${e}`);
     return {};
   }
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
@@ -47,7 +47,7 @@ export class DefaultTransformManager implements TransformManager {
         }
       );
     } catch (err) {
-      this.logger.error(
+      this.logger.debug(
         `Cannot create SLO transform for indicator type [${slo.indicator.type}]. ${err}`
       );
       if (err.meta?.body?.error?.type === 'security_exception') {
@@ -80,7 +80,7 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot preview SLO transform [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot preview SLO transform [${transformId}]. ${err}`);
       throw err;
     }
   }
@@ -97,7 +97,7 @@ export class DefaultTransformManager implements TransformManager {
       );
       await this.scheduleNowTransform(transformId);
     } catch (err) {
-      this.logger.error(`Cannot start SLO transform [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot start SLO transform [${transformId}]. ${err}`);
       throw err;
     }
   }
@@ -113,7 +113,7 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot stop SLO transform [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot stop SLO transform [${transformId}]. ${err}`);
       throw err;
     }
   }
@@ -129,7 +129,7 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot delete SLO transform [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot delete SLO transform [${transformId}]. ${err}`);
       throw err;
     }
   }
@@ -146,7 +146,7 @@ export class DefaultTransformManager implements TransformManager {
       );
       return response?.transforms[0]?._meta?.version;
     } catch (err) {
-      this.logger.error(`Cannot retrieve SLO transform version [${transformId}]. ${err}`);
+      this.logger.debug(`Cannot retrieve SLO transform version [${transformId}]. ${err}`);
       throw err;
     }
   }
@@ -158,7 +158,7 @@ export class DefaultTransformManager implements TransformManager {
         this.logger.debug(`SLO transform [${transformId}] scheduled now successfully`);
       })
       .catch((e) => {
-        this.logger.error(`Cannot schedule now SLO transform [${transformId}]. ${e}`);
+        this.logger.debug(`Cannot schedule now SLO transform [${transformId}]. ${e}`);
       });
   }
 }

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
@@ -34,7 +34,7 @@ export class DefaultTransformManager implements TransformManager {
   async install(slo: SLODefinition): Promise<TransformId> {
     const generator = this.generators[slo.indicator.type];
     if (!generator) {
-      this.logger.error(`No transform generator found for indicator type [${slo.indicator.type}]`);
+      this.logger.debug(`No transform generator found for indicator type [${slo.indicator.type}]`);
       throw new Error(`Unsupported indicator type [${slo.indicator.type}]`);
     }
 
@@ -63,7 +63,7 @@ export class DefaultTransformManager implements TransformManager {
   async inspect(slo: SLODefinition): Promise<TransformPutTransformRequest> {
     const generator = this.generators[slo.indicator.type];
     if (!generator) {
-      this.logger.error(`No transform generator found for indicator type [${slo.indicator.type}]`);
+      this.logger.debug(`No transform generator found for indicator type [${slo.indicator.type}]`);
       throw new Error(`Unsupported indicator type [${slo.indicator.type}]`);
     }
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/unsafe_federated/remote_summary_doc_to_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/unsafe_federated/remote_summary_doc_to_slo.ts
@@ -48,8 +48,8 @@ export function fromRemoteSummaryDocumentToSloDefinition(
 
   if (isLeft(res)) {
     const errors = formatErrors(res.left);
-    logger.error(`Invalid remote stored summary SLO with id [${summaryDoc.slo.id}]`);
-    logger.error(errors.join('|'));
+    logger.debug(`Invalid remote stored summary SLO with id [${summaryDoc.slo.id}]`);
+    logger.debug(errors.join('|'));
 
     return undefined;
   }

--- a/x-pack/solutions/observability/plugins/slo/server/services/unsafe_federated/remote_summary_doc_to_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/unsafe_federated/remote_summary_doc_to_slo.ts
@@ -65,10 +65,10 @@ function getIndicator(summaryDoc: EsSummaryDocument, logger: Logger): Indicator 
 
   if (isLeft(res)) {
     const errors = formatErrors(res.left);
-    logger.info(
+    logger.debug(
       `Invalid indicator from remote summary SLO id [${summaryDoc.slo.id}] - Fallback on dummy indicator`
     );
-    logger.info(errors.join('|'));
+    logger.debug(errors.join('|'));
 
     return getDummyIndicator(summaryDoc);
   }

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -82,7 +82,7 @@ export class UpdateSLO {
           { logger: this.logger }
         );
       } catch (err) {
-        this.logger.error(
+        this.logger.debug(
           `Cannot update the SLO summary pipeline [id: ${updatedSlo.id}, revision: ${updatedSlo.revision}]. ${err}`
         );
 
@@ -90,7 +90,7 @@ export class UpdateSLO {
           try {
             await operation();
           } catch (rollbackErr) {
-            this.logger.error(`Rollback operation failed. ${rollbackErr}`);
+            this.logger.debug(`Rollback operation failed. ${rollbackErr}`);
           }
         });
 
@@ -161,7 +161,7 @@ export class UpdateSLO {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(
+      this.logger.debug(
         `Cannot update the SLO [id: ${updatedSlo.id}, revision: ${updatedSlo.revision}]. Rolling back. ${err}`
       );
 
@@ -169,7 +169,7 @@ export class UpdateSLO {
         try {
           await operation();
         } catch (rollbackErr) {
-          this.logger.error(`Rollback operation failed. ${rollbackErr}`);
+          this.logger.debug(`Rollback operation failed. ${rollbackErr}`);
         }
       });
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/212972

This PR replaces the info and error log levels with debug since most of these errors are for developers or users. Not operations.