### PR TITLE
[8.x] [AI Assistant] Fixed DataClient find method to pass fields param to esClient.msearch (#212465)

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/conversations/transforms.ts
@@ -11,6 +11,7 @@ import {
   Replacements,
   replaceOriginalValuesWithUuidValues,
 } from '@kbn/elastic-assistant-common';
+import _ from 'lodash';
 import { EsConversationSchema } from './types';
 
 export const transformESSearchToConversations = (
@@ -153,7 +154,7 @@ export const transformESToConversations = (
                 },
               }
             : {}),
-        })) ?? [],
+        })),
       updatedAt: conversationSchema.updated_at,
       replacements,
       namespace: conversationSchema.namespace,
@@ -161,5 +162,28 @@ export const transformESToConversations = (
     };
 
     return conversation;
+  });
+};
+
+export const transformFieldNamesToSourceScheme = (fields: string[]) => {
+  return fields.map((f) => {
+    switch (f) {
+      case 'timestamp':
+        return '@timestamp';
+      case 'apiConfig':
+        return 'api_config';
+      case 'apiConfig.actionTypeId':
+        return 'api_config.action_type_id';
+      case 'apiConfig.connectorId':
+        return 'api_config.connector_id';
+      case 'apiConfig.defaultSystemPromptId':
+        return 'api_config.default_system_prompt_id';
+      case 'apiConfig.model':
+        return 'api_config.model';
+      case 'apiConfig.provider':
+        return 'api_config.provider';
+      default:
+        return _.snakeCase(f);
+    }
   });
 };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/find.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/find.ts
@@ -74,7 +74,9 @@ export const findDocuments = async <TSearchSchema>({
           track_total_hits: true,
           sort,
         },
-        _source: true,
+        _source: {
+          includes: fields,
+        },
         from: (page - 1) * perPage,
         ignore_unavailable: true,
         index,
@@ -103,7 +105,9 @@ export const findDocuments = async <TSearchSchema>({
           seq_no_primary_term: true,
           from: (page - 1) * perPage,
           sort,
-          _source: true,
+          _source: {
+            includes: fields,
+          },
         },
         { index },
         {
@@ -113,7 +117,9 @@ export const findDocuments = async <TSearchSchema>({
           seq_no_primary_term: true,
           from: (page - 1) * mSearch.perPage,
           sort,
-          _source: true,
+          _source: {
+            includes: fields,
+          },
         },
       ],
       ignore_unavailable: true,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/anonymization_fields/find_route.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/anonymization_fields/find_route.ts
@@ -18,6 +18,7 @@ import {
   FindAnonymizationFieldsResponse,
 } from '@kbn/elastic-assistant-common/impl/schemas/anonymization_fields/find_anonymization_fields_route.gen';
 import { buildRouteValidationWithZod } from '@kbn/elastic-assistant-common/impl/schemas/common';
+import _ from 'lodash';
 import { ElasticAssistantPluginRouter } from '../../types';
 import { buildResponse } from '../utils';
 import { EsAnonymizationFieldsSchema } from '../../ai_assistant_data_clients/anonymization_fields/types';
@@ -76,7 +77,7 @@ export const findAnonymizationFieldsRoute = (
             sortField: query.sort_field,
             sortOrder: query.sort_order,
             filter: query.filter,
-            fields: query.fields,
+            fields: query.fields?.map((f) => _.snakeCase(f)),
           });
 
           if (result) {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/knowledge_base/entries/find_route.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/knowledge_base/entries/find_route.ts
@@ -7,7 +7,7 @@
 
 import type { IKibanaResponse } from '@kbn/core/server';
 import { transformError } from '@kbn/securitysolution-es-utils';
-import { find } from 'lodash';
+import _ from 'lodash';
 
 import {
   API_VERSIONS,
@@ -81,7 +81,7 @@ export const findKnowledgeBaseEntriesRoute = (router: ElasticAssistantPluginRout
             sortField: query.sort_field,
             sortOrder: query.sort_order,
             filter: `${userFilter}${systemFilter}${additionalFilter}`,
-            fields: query.fields,
+            fields: query.fields?.map((f) => _.snakeCase(f)),
             aggs: {
               global_aggs: {
                 global: {},
@@ -114,7 +114,7 @@ export const findKnowledgeBaseEntriesRoute = (router: ElasticAssistantPluginRout
             },
           ]
             .map(({ bucketId, kbResource, name, required }) => {
-              const bucket = find(
+              const bucket = _.find(
                 (
                   (result?.data.aggregations?.global_aggs as estypes.AggregationsGlobalAggregate)
                     ?.kb_resource_aggregation as {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/user_conversations/find_route.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/user_conversations/find_route.ts
@@ -20,7 +20,10 @@ import { buildRouteValidationWithZod } from '@kbn/elastic-assistant-common/impl/
 import { ElasticAssistantPluginRouter } from '../../types';
 import { buildResponse } from '../utils';
 import { EsConversationSchema } from '../../ai_assistant_data_clients/conversations/types';
-import { transformESSearchToConversations } from '../../ai_assistant_data_clients/conversations/transforms';
+import {
+  transformESSearchToConversations,
+  transformFieldNamesToSourceScheme,
+} from '../../ai_assistant_data_clients/conversations/transforms';
 import { performChecks } from '../helpers';
 
 export const findUserConversationsRoute = (router: ElasticAssistantPluginRouter) => {
@@ -78,7 +81,7 @@ export const findUserConversationsRoute = (router: ElasticAssistantPluginRouter)
             sortField: query.sort_field,
             sortOrder: query.sort_order,
             filter: `users:{ ${userFilter} }${additionalFilter} and not is_default: true`,
-            fields: query.fields,
+            fields: query.fields ? transformFieldNamesToSourceScheme(query.fields) : undefined,
             mSearch: {
               filter: `users:{ ${userFilter} }${additionalFilter} and is_default: true`,
               perPage: MAX_DEFAULT_CONVERSATION_TOTAL,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[AI Assistant] Fixed DataClient find method to pass fields param to esClient.msearch (#212465)](https://github.com/elastic/kibana/pull/212465)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Yuliia Naumenko","email":"jo.naumenko@gmail.com"},"sourceCommit":{"committedDate":"2025-03-03T17:43:16Z","message":"[AI Assistant] Fixed DataClient find method to pass fields param to esClient.msearch (#212465)\n\nFixed `AIAssistantDataClient` to send values of the `fields` param if is\nprovided to `esClient.msearch` request.\n\nTo test run the API query\n`http://localhost:5601/api/security_ai_assistant/current_user/conversations/_find?page=1&per_page=99&fields=id,users,apiConfig.connectorId`\nand makes sure the only provided fields are returned in the result.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7afe813b35ff4e1cd97be50dbaec2dec554eed26","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport:version","v9.1.0","v8.19.0"],"title":"[AI Assistant] Fixed DataClient find method to pass fields param to esClient.msearch","number":212465,"url":"https://github.com/elastic/kibana/pull/212465","mergeCommit":{"message":"[AI Assistant] Fixed DataClient find method to pass fields param to esClient.msearch (#212465)\n\nFixed `AIAssistantDataClient` to send values of the `fields` param if is\nprovided to `esClient.msearch` request.\n\nTo test run the API query\n`http://localhost:5601/api/security_ai_assistant/current_user/conversations/_find?page=1&per_page=99&fields=id,users,apiConfig.connectorId`\nand makes sure the only provided fields are returned in the result.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7afe813b35ff4e1cd97be50dbaec2dec554eed26"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212465","number":212465,"mergeCommit":{"message":"[AI Assistant] Fixed DataClient find method to pass fields param to esClient.msearch (#212465)\n\nFixed `AIAssistantDataClient` to send values of the `fields` param if is\nprovided to `esClient.msearch` request.\n\nTo test run the API query\n`http://localhost:5601/api/security_ai_assistant/current_user/conversations/_find?page=1&per_page=99&fields=id,users,apiConfig.connectorId`\nand makes sure the only provided fields are returned in the result.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"7afe813b35ff4e1cd97be50dbaec2dec554eed26"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->