### PR TITLE
[Security Solution] Alert flyout - fix suppressed alerts alignment

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/suppressed_alerts.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/suppressed_alerts.tsx
@@ -57,7 +57,7 @@ export const SuppressedAlerts: React.VFC<SuppressedAlertsProps> = ({
 
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center">
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem>
         <InsightsSummaryRow
           text={text}
           value={alertSuppressionCount}


### PR DESCRIPTION
## Summary

Ref: https://github.com/elastic/kibana/issues/204184

Before
![image](https://github.com/user-attachments/assets/d578194a-aaf4-45c1-bccb-42d02110be28)


After
![image](https://github.com/user-attachments/assets/b183a2ae-dd73-47d8-8319-984246309d98)


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->