### PR TITLE
[ES|QL] Correct the lens_map_to_columns function call arguments

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/text_based/to_expression.ts
@@ -122,6 +122,7 @@ function getExpressionForLayer(
           function: 'lens_map_to_columns',
           arguments: {
             idMap: [JSON.stringify(idMapper)],
+            isTextBased: [true],
           },
         },
         ...formatterOverrides,


### PR DESCRIPTION
## Summary

The else is being called atm only in Discover ES|QL mode, when the user is typing stats or keep.
The `isTextBased` flag is missing which means that we don't call the `mapToOriginalColumnsTextBased` but the one for the dsl mode which might cause bugs.

I don't think that Peter had any reason to do so, it seems more as it slipped.





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->