### PR TITLE
[Bug] [Assistant API] - Do not allow empty conversation ID in chat/complete route (#11783)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -45256,7 +45256,7 @@ components:
         connectorId:
           type: string
         conversationId:
-          type: string
+          $ref: '#/components/schemas/Security_AI_Assistant_API_NonEmptyString'
         isStream:
           type: boolean
         langSmithApiKey:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -51833,7 +51833,7 @@ components:
         connectorId:
           type: string
         conversationId:
-          type: string
+          $ref: '#/components/schemas/Security_AI_Assistant_API_NonEmptyString'
         isStream:
           type: boolean
         langSmithApiKey:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -1093,7 +1093,7 @@ components:
         connectorId:
           type: string
         conversationId:
-          type: string
+          $ref: '#/components/schemas/NonEmptyString'
         isStream:
           type: boolean
         langSmithApiKey:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -1093,7 +1093,7 @@ components:
         connectorId:
           type: string
         conversationId:
-          type: string
+          $ref: '#/components/schemas/NonEmptyString'
         isStream:
           type: boolean
         langSmithApiKey:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/chat/post_chat_complete_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/chat/post_chat_complete_route.gen.ts
@@ -16,6 +16,8 @@
 
 import { z } from '@kbn/zod';
 
+import { NonEmptyString } from '../common_attributes.gen';
+
 export type RootContext = z.infer<typeof RootContext>;
 export const RootContext = z.literal('security');
 
@@ -52,7 +54,7 @@ export const ChatMessage = z.object({
 
 export type ChatCompleteProps = z.infer<typeof ChatCompleteProps>;
 export const ChatCompleteProps = z.object({
-  conversationId: z.string().optional(),
+  conversationId: NonEmptyString.optional(),
   promptId: z.string().optional(),
   isStream: z.boolean().optional(),
   responseLanguage: z.string().optional(),

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/chat/post_chat_complete_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/chat/post_chat_complete_route.schema.yaml
@@ -83,7 +83,7 @@ components:
       type: object
       properties:
         conversationId:
-          type: string
+          $ref: '../common_attributes.schema.yaml#/components/schemas/NonEmptyString'
         promptId:
           type: string
         isStream:
@@ -103,7 +103,7 @@ components:
         messages:
           type: array
           items:
-              $ref: '#/components/schemas/ChatMessage'
+            $ref: '#/components/schemas/ChatMessage'
       required:
         - messages
         - persist


### PR DESCRIPTION
## Summary

BUG: https://github.com/elastic/security-team/issues/11783

This PR fixes the behaviour of the `/api/security_ai_assistant/chat/complete` route where the `conversationId` can be passed as an empty string. This may lead to unexpected results described in https://github.com/elastic/security-team/issues/11783#issuecomment-2696529040.

### Expected behaviour

We should throw a bad request (400) http error when empty `conversationId` has been passed.

### Testing

* Use this `curl` command to test the endpoint.

```
curl --location 'http://localhost:5601/api/security_ai_assistant/chat/complete' \
--header 'kbn-xsrf: true' \
--header 'Content-Type: application/json' \
--data '{
  "connectorId": "{{my-gpt4o-ai}}",
  "conversationId": "",
  "isStream": false,
  "messages": [
    {
      "content": "Follow up",
      "role": "user"
    }
  ],
  "persist": true
}'
```

You should see next error as a response:

```
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "[request body]: conversationId: String must contain at least 1 character(s), conversationId: No empty strings allowed"
}
```


<!--ONMERGE {"backportTargets":["8.17","8.18","8.x","9.0"]} ONMERGE-->