### PR TITLE
[Fleet] fix telemetry test

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -602,11 +602,11 @@ describe('fleet usage telemetry', () => {
             message: 'stderr panic some other panic',
           },
         ],
-        agent_logs_top_errors: [
+        agent_logs_top_errors: expect.arrayContaining([
+          'this should not be included in metrics',
           'stderr panic some other panic',
           'stderr panic close of closed channel',
-          'this should not be included in metrics',
-        ],
+        ]),
         fleet_server_logs_top_errors: ['failed to unenroll offline agents'],
         integrations_details: [
           {


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/211514

It seems the failure is because of the order difference in `agent_logs_top_errors`.

The other differences shouldn't matter because we are using ` expect.objectContaining` on the result object.