### PR TITLE
[UA] Make the entire row in the deprecations table clickable

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/es_deprecations.helpers.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/es_deprecations.helpers.ts
@@ -48,6 +48,16 @@ const createActions = (testBed: TestBed) => {
 
       component.update();
     },
+    clickReindexColumnAt: async (
+      columnType: 'isCritical' | 'message' | 'type' | 'index' | 'correctiveAction',
+      index: number
+    ) => {
+      await act(async () => {
+        find(`reindexTableCell-${columnType}`).at(index).simulate('click');
+      });
+
+      component.update();
+    },
   };
 
   const clickFilterByIndex = async (index: number) => {
@@ -159,6 +169,12 @@ const createActions = (testBed: TestBed) => {
         find('startReindexingButton').simulate('click');
       });
 
+      component.update();
+    },
+    closeFlyout: async () => {
+      await act(async () => {
+        find('closeReindexButton').simulate('click');
+      });
       component.update();
     },
   };

--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/reindex_deprecation_flyout.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/reindex_deprecation_flyout.test.ts
@@ -69,6 +69,35 @@ describe('Reindex deprecation flyout', () => {
     testBed.component.update();
   });
 
+  it('opens a flyout when clicking in any part of the row', async () => {
+    const { actions, exists } = testBed;
+
+    await actions.table.clickReindexColumnAt('isCritical', 0);
+    expect(exists('reindexDetails')).toBe(true);
+    await actions.reindexDeprecationFlyout.closeFlyout();
+    expect(exists('reindexDetails')).toBe(false);
+
+    await actions.table.clickReindexColumnAt('message', 0);
+    expect(exists('reindexDetails')).toBe(true);
+    await actions.reindexDeprecationFlyout.closeFlyout();
+    expect(exists('reindexDetails')).toBe(false);
+
+    await actions.table.clickReindexColumnAt('type', 0);
+    expect(exists('reindexDetails')).toBe(true);
+    await actions.reindexDeprecationFlyout.closeFlyout();
+    expect(exists('reindexDetails')).toBe(false);
+
+    await actions.table.clickReindexColumnAt('index', 0);
+    expect(exists('reindexDetails')).toBe(true);
+    await actions.reindexDeprecationFlyout.closeFlyout();
+    expect(exists('reindexDetails')).toBe(false);
+
+    await actions.table.clickReindexColumnAt('correctiveAction', 0);
+    expect(exists('reindexDetails')).toBe(true);
+    await actions.reindexDeprecationFlyout.closeFlyout();
+    expect(exists('reindexDetails')).toBe(false);
+  });
+
   it('renders a flyout with reindexing details', async () => {
     const reindexDeprecation = esDeprecationsMockResponse.migrationsDeprecations[3];
     const { actions, find, exists } = testBed;

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/table_row.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { EuiTableRowCell } from '@elastic/eui';
+import { EuiTableRowCell, EuiTableRow } from '@elastic/eui';
 import { EnrichedDeprecationInfo, ResponseError } from '../../../../../../common/types';
 import { GlobalFlyout } from '../../../../../shared_imports';
 import { useAppContext } from '../../../../app_context';
@@ -20,11 +20,13 @@ const { useGlobalFlyout } = GlobalFlyout;
 interface Props {
   deprecation: EnrichedDeprecationInfo;
   rowFieldNames: DeprecationTableColumns[];
+  index: number;
 }
 
 export const ClusterSettingsTableRow: React.FunctionComponent<Props> = ({
   rowFieldNames,
   deprecation,
+  index,
 }) => {
   const [showFlyout, setShowFlyout] = useState(false);
   const [status, setStatus] = useState<{
@@ -88,7 +90,11 @@ export const ClusterSettingsTableRow: React.FunctionComponent<Props> = ({
   ]);
 
   return (
-    <>
+    <EuiTableRow
+      data-test-subj="deprecationTableRow"
+      key={`deprecation-row-${index}`}
+      onClick={() => setShowFlyout(true)}
+    >
       {rowFieldNames.map((field: DeprecationTableColumns) => {
         return (
           <EuiTableRowCell
@@ -105,6 +111,6 @@ export const ClusterSettingsTableRow: React.FunctionComponent<Props> = ({
           </EuiTableRowCell>
         );
       })}
-    </>
+    </EuiTableRow>
   );
 };

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/cluster_settings/table_row.tsx
@@ -104,7 +104,6 @@ export const ClusterSettingsTableRow: React.FunctionComponent<Props> = ({
           >
             <EsDeprecationsTableCells
               fieldName={field}
-              openFlyout={() => setShowFlyout(true)}
               deprecation={deprecation}
               resolutionTableCell={<ClusterSettingsResolutionCell status={status} />}
             />

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/table_row.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { EuiTableRowCell } from '@elastic/eui';
+import { EuiTableRowCell, EuiTableRow } from '@elastic/eui';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { EnrichedDeprecationInfo } from '../../../../../../common/types';
 import { GlobalFlyout } from '../../../../../shared_imports';
@@ -27,11 +27,13 @@ const { useGlobalFlyout } = GlobalFlyout;
 interface TableRowProps {
   deprecation: EnrichedDeprecationInfo;
   rowFieldNames: DeprecationTableColumns[];
+  index: number;
 }
 
 const DataStreamTableRowCells: React.FunctionComponent<TableRowProps> = ({
   rowFieldNames,
   deprecation,
+  index,
 }) => {
   const [showFlyout, setShowFlyout] = useState(false);
   const dataStreamContext = useDataStreamMigrationContext();
@@ -71,7 +73,11 @@ const DataStreamTableRowCells: React.FunctionComponent<TableRowProps> = ({
   }, [showFlyout]);
 
   return (
-    <>
+    <EuiTableRow
+      data-test-subj="deprecationTableRow"
+      key={`deprecation-row-${index}`}
+      onClick={() => setShowFlyout(true)}
+    >
       {rowFieldNames.map((field: DeprecationTableColumns) => {
         return (
           <EuiTableRowCell
@@ -88,7 +94,7 @@ const DataStreamTableRowCells: React.FunctionComponent<TableRowProps> = ({
           </EuiTableRowCell>
         );
       })}
-    </>
+    </EuiTableRow>
   );
 };
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/table_row.tsx
@@ -87,7 +87,6 @@ const DataStreamTableRowCells: React.FunctionComponent<TableRowProps> = ({
           >
             <EsDeprecationsTableCells
               fieldName={field}
-              openFlyout={() => setShowFlyout(true)}
               deprecation={deprecation}
               resolutionTableCell={<DataStreamReindexResolutionCell />}
             />

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/default/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/default/table_row.tsx
@@ -68,11 +68,7 @@ export const DefaultTableRow: React.FunctionComponent<Props> = ({
             truncateText={false}
             data-test-subj={`defaultTableCell-${field}`}
           >
-            <EsDeprecationsTableCells
-              fieldName={field}
-              deprecation={deprecation}
-              openFlyout={() => setShowFlyout(true)}
-            />
+            <EsDeprecationsTableCells fieldName={field} deprecation={deprecation} />
           </EuiTableRowCell>
         );
       })}

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/default/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/default/table_row.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { EuiTableRowCell } from '@elastic/eui';
+import { EuiTableRowCell, EuiTableRow } from '@elastic/eui';
 import { GlobalFlyout } from '../../../../../shared_imports';
 import { EnrichedDeprecationInfo } from '../../../../../../common/types';
 import { DeprecationTableColumns } from '../../../types';
@@ -18,9 +18,14 @@ const { useGlobalFlyout } = GlobalFlyout;
 interface Props {
   rowFieldNames: DeprecationTableColumns[];
   deprecation: EnrichedDeprecationInfo;
+  index: number;
 }
 
-export const DefaultTableRow: React.FunctionComponent<Props> = ({ rowFieldNames, deprecation }) => {
+export const DefaultTableRow: React.FunctionComponent<Props> = ({
+  rowFieldNames,
+  deprecation,
+  index,
+}) => {
   const [showFlyout, setShowFlyout] = useState(false);
 
   const { addContent: addContentToGlobalFlyout, removeContent: removeContentFromGlobalFlyout } =
@@ -51,7 +56,11 @@ export const DefaultTableRow: React.FunctionComponent<Props> = ({ rowFieldNames,
   }, [addContentToGlobalFlyout, closeFlyout, deprecation, showFlyout]);
 
   return (
-    <>
+    <EuiTableRow
+      data-test-subj="deprecationTableRow"
+      key={`deprecation-row-${index}`}
+      onClick={() => setShowFlyout(true)}
+    >
       {rowFieldNames.map((field) => {
         return (
           <EuiTableRowCell
@@ -67,6 +76,6 @@ export const DefaultTableRow: React.FunctionComponent<Props> = ({ rowFieldNames,
           </EuiTableRowCell>
         );
       })}
-    </>
+    </EuiTableRow>
   );
 };

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/health_indicator/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/health_indicator/table_row.tsx
@@ -68,11 +68,7 @@ export const HealthIndicatorTableRow: React.FunctionComponent<Props> = ({
             truncateText={false}
             data-test-subj={`healthIndicatorTableCell-${field}`}
           >
-            <EsDeprecationsTableCells
-              fieldName={field}
-              deprecation={deprecation}
-              openFlyout={() => setShowFlyout(true)}
-            />
+            <EsDeprecationsTableCells fieldName={field} deprecation={deprecation} />
           </EuiTableRowCell>
         );
       })}

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/health_indicator/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/health_indicator/table_row.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { EuiTableRowCell } from '@elastic/eui';
+import { EuiTableRowCell, EuiTableRow } from '@elastic/eui';
 import { GlobalFlyout } from '../../../../../shared_imports';
 import { EnrichedDeprecationInfo } from '../../../../../../common/types';
 import { DeprecationTableColumns } from '../../../types';
@@ -18,11 +18,13 @@ const { useGlobalFlyout } = GlobalFlyout;
 interface Props {
   rowFieldNames: DeprecationTableColumns[];
   deprecation: EnrichedDeprecationInfo;
+  index: number;
 }
 
 export const HealthIndicatorTableRow: React.FunctionComponent<Props> = ({
   rowFieldNames,
   deprecation,
+  index,
 }) => {
   const [showFlyout, setShowFlyout] = useState(false);
 
@@ -54,7 +56,11 @@ export const HealthIndicatorTableRow: React.FunctionComponent<Props> = ({
   }, [addContentToGlobalFlyout, closeFlyout, deprecation, showFlyout]);
 
   return (
-    <>
+    <EuiTableRow
+      data-test-subj="deprecationTableRow"
+      key={`deprecation-row-${index}`}
+      onClick={() => setShowFlyout(true)}
+    >
       {rowFieldNames.map((field) => {
         return (
           <EuiTableRowCell
@@ -70,6 +76,6 @@ export const HealthIndicatorTableRow: React.FunctionComponent<Props> = ({
           </EuiTableRowCell>
         );
       })}
-    </>
+    </EuiTableRow>
   );
 };

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/table_row.tsx
@@ -97,7 +97,6 @@ export const IndexSettingsTableRow: React.FunctionComponent<Props> = ({
           >
             <EsDeprecationsTableCells
               fieldName={field}
-              openFlyout={() => setShowFlyout(true)}
               deprecation={deprecation}
               resolutionTableCell={<IndexSettingsResolutionCell status={status} />}
             />

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/index_settings/table_row.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { EuiTableRowCell } from '@elastic/eui';
+import { EuiTableRowCell, EuiTableRow } from '@elastic/eui';
 import { EnrichedDeprecationInfo, ResponseError } from '../../../../../../common/types';
 import { GlobalFlyout } from '../../../../../shared_imports';
 import { useAppContext } from '../../../../app_context';
@@ -20,11 +20,13 @@ const { useGlobalFlyout } = GlobalFlyout;
 interface Props {
   deprecation: EnrichedDeprecationInfo;
   rowFieldNames: DeprecationTableColumns[];
+  index: number;
 }
 
 export const IndexSettingsTableRow: React.FunctionComponent<Props> = ({
   rowFieldNames,
   deprecation,
+  index: rowIndex,
 }) => {
   const [showFlyout, setShowFlyout] = useState(false);
   const [status, setStatus] = useState<{
@@ -81,7 +83,11 @@ export const IndexSettingsTableRow: React.FunctionComponent<Props> = ({
   }, [addContentToGlobalFlyout, deprecation, removeIndexSettings, showFlyout, closeFlyout, status]);
 
   return (
-    <>
+    <EuiTableRow
+      data-test-subj="deprecationTableRow"
+      key={`deprecation-row-${rowIndex}`}
+      onClick={() => setShowFlyout(true)}
+    >
       {rowFieldNames.map((field: DeprecationTableColumns) => {
         return (
           <EuiTableRowCell
@@ -98,6 +104,6 @@ export const IndexSettingsTableRow: React.FunctionComponent<Props> = ({
           </EuiTableRowCell>
         );
       })}
-    </>
+    </EuiTableRow>
   );
 };

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.test.tsx
@@ -159,6 +159,7 @@ describe('ReindexDetailsFlyoutStep', () => {
               grow={false}
             >
               <EuiButtonEmpty
+                data-test-subj="closeReindexButton"
                 flush="left"
                 iconType="cross"
                 onClick={[MockFunction]}
@@ -261,6 +262,7 @@ describe('ReindexDetailsFlyoutStep', () => {
               grow={false}
             >
               <EuiButtonEmpty
+                data-test-subj="closeReindexButton"
                 flush="left"
                 iconType="cross"
                 onClick={[MockFunction]}
@@ -344,6 +346,7 @@ describe('ReindexDetailsFlyoutStep', () => {
               grow={false}
             >
               <EuiButtonEmpty
+                data-test-subj="closeReindexButton"
                 flush="left"
                 iconType="cross"
                 onClick={[MockFunction]}
@@ -417,6 +420,7 @@ describe('ReindexDetailsFlyoutStep', () => {
               grow={false}
             >
               <EuiButtonEmpty
+                data-test-subj="closeReindexButton"
                 flush="left"
                 iconType="cross"
                 onClick={[MockFunction]}

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.tsx
@@ -279,7 +279,12 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
       <EuiFlyoutFooter>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty iconType="cross" onClick={closeFlyout} flush="left">
+            <EuiButtonEmpty
+              iconType="cross"
+              onClick={closeFlyout}
+              flush="left"
+              data-test-subj="closeReindexButton"
+            >
               <FormattedMessage
                 id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.closeButtonLabel"
                 defaultMessage="Close"

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/table_row.tsx
@@ -87,7 +87,6 @@ const IndexTableRowCells: React.FunctionComponent<TableRowProps> = ({
           >
             <EsDeprecationsTableCells
               fieldName={field}
-              openFlyout={() => setShowFlyout(true)}
               deprecation={deprecation}
               resolutionTableCell={<ReindexResolutionCell />}
             />

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/table_row.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { EuiTableRowCell } from '@elastic/eui';
+import { EuiTableRowCell, EuiTableRow } from '@elastic/eui';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { EnrichedDeprecationInfo } from '../../../../../../common/types';
 import { GlobalFlyout } from '../../../../../shared_imports';
@@ -27,11 +27,13 @@ const { useGlobalFlyout } = GlobalFlyout;
 interface TableRowProps {
   deprecation: EnrichedDeprecationInfo;
   rowFieldNames: DeprecationTableColumns[];
+  index: number;
 }
 
 const IndexTableRowCells: React.FunctionComponent<TableRowProps> = ({
   rowFieldNames,
   deprecation,
+  index,
 }) => {
   const [showFlyout, setShowFlyout] = useState(false);
   const indexContext = useIndexContext();
@@ -71,7 +73,11 @@ const IndexTableRowCells: React.FunctionComponent<TableRowProps> = ({
   }, [showFlyout]);
 
   return (
-    <>
+    <EuiTableRow
+      data-test-subj="deprecationTableRow"
+      key={`deprecation-row-${index}`}
+      onClick={() => setShowFlyout(true)}
+    >
       {rowFieldNames.map((field: DeprecationTableColumns) => {
         return (
           <EuiTableRowCell
@@ -88,7 +94,7 @@ const IndexTableRowCells: React.FunctionComponent<TableRowProps> = ({
           </EuiTableRowCell>
         );
       })}
-    </>
+    </EuiTableRow>
   );
 };
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/table_row.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { EuiTableRowCell } from '@elastic/eui';
+import { EuiTableRow, EuiTableRowCell } from '@elastic/eui';
 import { EnrichedDeprecationInfo, MlAction } from '../../../../../../common/types';
 import { GlobalFlyout } from '../../../../../shared_imports';
 import { useAppContext } from '../../../../app_context';
@@ -22,11 +22,13 @@ interface TableRowProps {
   deprecation: EnrichedDeprecationInfo;
   rowFieldNames: DeprecationTableColumns[];
   mlUpgradeModeEnabled: boolean;
+  index: number;
 }
 
 export const MlSnapshotsTableRowCells: React.FunctionComponent<TableRowProps> = ({
   rowFieldNames,
   deprecation,
+  index,
 }) => {
   const [showFlyout, setShowFlyout] = useState(false);
   const snapshotState = useMlSnapshotContext();
@@ -60,7 +62,11 @@ export const MlSnapshotsTableRowCells: React.FunctionComponent<TableRowProps> = 
   }, [snapshotState, addContentToGlobalFlyout, showFlyout, deprecation, closeFlyout]);
 
   return (
-    <>
+    <EuiTableRow
+      data-test-subj="deprecationTableRow"
+      key={`deprecation-row-${index}`}
+      onClick={() => setShowFlyout(true)}
+    >
       {rowFieldNames.map((field: DeprecationTableColumns) => {
         return (
           <EuiTableRowCell key={field} truncateText={false} data-test-subj={`mlTableCell-${field}`}>
@@ -73,7 +79,7 @@ export const MlSnapshotsTableRowCells: React.FunctionComponent<TableRowProps> = 
           </EuiTableRowCell>
         );
       })}
-    </>
+    </EuiTableRow>
   );
 };
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/ml_snapshots/table_row.tsx
@@ -72,7 +72,6 @@ export const MlSnapshotsTableRowCells: React.FunctionComponent<TableRowProps> = 
           <EuiTableRowCell key={field} truncateText={false} data-test-subj={`mlTableCell-${field}`}>
             <EsDeprecationsTableCells
               fieldName={field}
-              openFlyout={() => setShowFlyout(true)}
               deprecation={deprecation}
               resolutionTableCell={<MlSnapshotsResolutionCell />}
             />

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/es_deprecations_table.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/es_deprecations_table.tsx
@@ -105,9 +105,10 @@ const cellToLabelMap = {
 const cellTypes = Object.keys(cellToLabelMap) as DeprecationTableColumns[];
 const pageSizeOptions = PAGINATION_CONFIG.pageSizeOptions;
 
-const renderTableRowCells = (
+const renderTableRow = (
   deprecation: EnrichedDeprecationInfo,
-  mlUpgradeModeEnabled: boolean
+  mlUpgradeModeEnabled: boolean,
+  index: number
 ) => {
   switch (deprecation.correctiveAction?.type) {
     case 'mlSnapshot':
@@ -116,27 +117,44 @@ const renderTableRowCells = (
           deprecation={deprecation}
           rowFieldNames={cellTypes}
           mlUpgradeModeEnabled={mlUpgradeModeEnabled}
+          index={index}
         />
       );
 
     case 'indexSetting':
-      return <IndexSettingsTableRow deprecation={deprecation} rowFieldNames={cellTypes} />;
+      return (
+        <IndexSettingsTableRow deprecation={deprecation} rowFieldNames={cellTypes} index={index} />
+      );
 
     case 'clusterSetting':
-      return <ClusterSettingsTableRow deprecation={deprecation} rowFieldNames={cellTypes} />;
+      return (
+        <ClusterSettingsTableRow
+          deprecation={deprecation}
+          rowFieldNames={cellTypes}
+          index={index}
+        />
+      );
 
     case 'reindex':
     case 'unfreeze':
-      return <IndexTableRow deprecation={deprecation} rowFieldNames={cellTypes} />;
+      return <IndexTableRow deprecation={deprecation} rowFieldNames={cellTypes} index={index} />;
 
     case 'healthIndicator':
-      return <HealthIndicatorTableRow deprecation={deprecation} rowFieldNames={cellTypes} />;
+      return (
+        <HealthIndicatorTableRow
+          deprecation={deprecation}
+          rowFieldNames={cellTypes}
+          index={index}
+        />
+      );
 
     case 'dataStream':
-      return <DataStreamTableRow deprecation={deprecation} rowFieldNames={cellTypes} />;
+      return (
+        <DataStreamTableRow deprecation={deprecation} rowFieldNames={cellTypes} index={index} />
+      );
 
     default:
-      return <DefaultTableRow deprecation={deprecation} rowFieldNames={cellTypes} />;
+      return <DefaultTableRow deprecation={deprecation} rowFieldNames={cellTypes} index={index} />;
   }
 };
 
@@ -338,13 +356,9 @@ export const EsDeprecationsTable: React.FunctionComponent<Props> = ({
           </EuiTableBody>
         ) : (
           <EuiTableBody>
-            {visibleDeprecations.map((deprecation, index) => {
-              return (
-                <EuiTableRow data-test-subj="deprecationTableRow" key={`deprecation-row-${index}`}>
-                  {renderTableRowCells(deprecation, mlUpgradeModeEnabled)}
-                </EuiTableRow>
-              );
-            })}
+            {visibleDeprecations.map((deprecation, index) =>
+              renderTableRow(deprecation, mlUpgradeModeEnabled, index)
+            )}
           </EuiTableBody>
         )}
       </EuiTable>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/es_deprecations_table_cells.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/es_deprecations_table_cells.tsx
@@ -17,7 +17,6 @@ interface Props {
   resolutionTableCell?: React.ReactNode;
   fieldName: DeprecationTableColumns;
   deprecation: EnrichedDeprecationInfo;
-  openFlyout: () => void;
 }
 
 const i18nTexts = {
@@ -39,7 +38,6 @@ export const EsDeprecationsTableCells: React.FunctionComponent<Props> = ({
   resolutionTableCell,
   fieldName,
   deprecation,
-  openFlyout,
 }) => {
   // "Status column"
   if (fieldName === 'isCritical') {
@@ -49,10 +47,7 @@ export const EsDeprecationsTableCells: React.FunctionComponent<Props> = ({
   // "Issue" column
   if (fieldName === 'message') {
     return (
-      <EuiLink
-        data-test-subj={`deprecation-${deprecation.correctiveAction?.type ?? 'default'}`}
-        onClick={openFlyout}
-      >
+      <EuiLink data-test-subj={`deprecation-${deprecation.correctiveAction?.type ?? 'default'}`}>
         {deprecation.message}
       </EuiLink>
     );

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecations_table.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/kibana_deprecations/kibana_deprecations_table.tsx
@@ -257,8 +257,11 @@ export const KibanaDeprecationsTable: React.FunctionComponent<Props> = ({
       search={searchConfig}
       sorting={sorting}
       pagination={PAGINATION_CONFIG}
-      rowProps={() => ({
+      rowProps={(deprecation) => ({
         'data-test-subj': 'row',
+        onClick: () => {
+          toggleFlyout(deprecation);
+        },
       })}
       cellProps={(deprecation, field) => ({
         'data-test-subj': `${((field?.name as string) || 'table').toLowerCase()}Cell`,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/123469
Closing https://github.com/elastic/kibana/pull/212081 and opening this one

## Summary
In the deprecations table, the icon that we show in the resolution column can be confused with a call to action by some users. To avoid them to click it with no result, this PR changes the behavior of the table so clicking in anywhere in the row opens the resolution flyout. As agreed with @jovana-andjelkovic, I left the original link in the Issue column.

### How to test

* Follow the instructions in https://github.com/elastic/kibana-team/issues/1521. Use the data folder starting with [01] because it has the largest variety of deprecations.
* Go to "Stack Management > Upgrade Assistant"
    * Navigate to "Elasticsearch deprecation issues"
        * Click in the row outside of the issue link to verify that the flyout opens.
    * Navigate to "Kibana deprecation issues"
        * Click in the row outside of the issue link to verify that the flyout opens.

### Demo
<details>
<summary>Video</summary>


https://github.com/user-attachments/assets/b1fb277a-83b4-4709-89ff-a9fe5515c685


</details>