### PR TITLE
chore: remove react-syntax-highlighter leftovers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3669,25 +3669,6 @@
       "enabled": true
     },
     {
-      "groupName": "react-syntax-highlighter",
-      "matchDepNames": [
-        "react-syntax-highlighter",
-        "@types/react-syntax-highlighter"
-      ],
-      "reviewers": [
-        "team:obs-ux-infra_services-team"
-      ],
-      "matchBaseBranches": [
-        "main"
-      ],
-      "labels": [
-        "release_note:skip",
-        "backport:all-open"
-      ],
-      "minimumReleaseAge": "7 days",
-      "enabled": true
-    },
-    {
       "groupName": "native-hdr-histogram",
       "matchDepNames": [
         "native-hdr-histogram"

--- a/src/platform/packages/shared/kbn-ambient-storybook-types/index.d.ts
+++ b/src/platform/packages/shared/kbn-ambient-storybook-types/index.d.ts
@@ -10,14 +10,6 @@
 // Storybook react doesn't declare this in its typings, but it's there.
 declare module '@storybook/react/standalone';
 
-// Storybook references this module. It's @ts-ignored in the codebase but when
-// built into its dist it strips that out. Add it here to avoid a type checking
-// error.
-//
-// See https://github.com/storybookjs/storybook/issues/11684
-declare module 'react-syntax-highlighter/dist/cjs/create-element';
-declare module 'react-syntax-highlighter/dist/cjs/prism-light';
-
 // Storybook uses this module and its types are defined in the source but not in the type output
 declare module 'file-system-cache' {
   interface Options {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,13 +9,5 @@
 
 declare module 'axios/lib/adapters/xhr';
 
-// Storybook references this module. It's @ts-ignored in the codebase but when
-// built into its dist it strips that out. Add it here to avoid a type checking
-// error.
-//
-// See https://github.com/storybookjs/storybook/issues/11684
-declare module 'react-syntax-highlighter/dist/cjs/create-element';
-declare module 'react-syntax-highlighter/dist/cjs/prism-light';
-
 declare module 'find-cypress-specs';
 declare module '@cypress/grep/src/plugin';


### PR DESCRIPTION
## Summary

Removes leftovers of react-syntax-highlighter removed in [this PR](https://github.com/elastic/kibana/pull/204902)

