### PR TITLE
Skip `'No connectors or conversations exist'` on serverless

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
@@ -67,7 +67,7 @@ describe('AI Assistant Conversations', { tags: ['@ess', '@serverless'] }, () => 
     waitForConversation(mockConvo1);
     waitForConversation(mockConvo2);
   });
-  describe('No connectors or conversations exist', () => {
+  describe('No connectors or conversations exist', { tags: ['@skipInServerless'] }, () => {
     it('Shows welcome setup when no connectors or conversations exist', () => {
       visitGetStartedPage();
       openAssistant();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/ai_assistant/conversations.cy.ts
@@ -67,6 +67,7 @@ describe('AI Assistant Conversations', { tags: ['@ess', '@serverless'] }, () => 
     waitForConversation(mockConvo1);
     waitForConversation(mockConvo2);
   });
+  // On serverless we provide deafult .inference `Elastic LLM` connector
   describe('No connectors or conversations exist', { tags: ['@skipInServerless'] }, () => {
     it('Shows welcome setup when no connectors or conversations exist', () => {
       visitGetStartedPage();


### PR DESCRIPTION
## Summary

Fixes  https://buildkite.com/elastic/kibana-serverless-security-solution-quality-gate-gen-ai/builds/2139#_

![image](https://github.com/user-attachments/assets/0e2db8db-28d8-4097-968c-52a42b2e9b07)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->