### PR TITLE
🌊 Streams: Disable AI suggestions button if there is no sample data

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/processing/suggestions_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/processing/suggestions_handler.ts
@@ -66,14 +66,20 @@ export function extractAndGroupPatterns(samples: FlattenRecord[], field: string)
   const NUMBER_PATTERN_CATEGORIES = 5;
   const NUMBER_SAMPLES_PER_PATTERN = 8;
 
-  const samplesWithPatterns = samples.map((sample) => {
-    const pattern = evalPattern(get(sample, field) as string);
-    return {
-      document: sample,
-      fullPattern: pattern,
-      truncatedPattern: pattern.slice(0, 10),
-      fieldValue: get(sample, field) as string,
-    };
+  const samplesWithPatterns = samples.flatMap((sample) => {
+    const value = get(sample, field);
+    if (typeof value !== 'string') {
+      return [];
+    }
+    const pattern = evalPattern(value);
+    return [
+      {
+        document: sample,
+        fullPattern: pattern,
+        truncatedPattern: pattern.slice(0, 10),
+        fieldValue: get(sample, field) as string,
+      },
+    ];
   });
 
   // Group samples by their truncated patterns

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_ai_suggestions.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_ai_suggestions.tsx
@@ -220,8 +220,7 @@ function InnerGrokAiSuggestions({
     content = <EuiCallOut color="danger">{suggestionsError.message}</EuiCallOut>;
   }
 
-  const currentPatterns = form.getValues().patterns;
-  const currentFieldName = form.getValues().field;
+  const { field: currentFieldName, patterns: currentPatterns } = form.getValues();
 
   const hasValidField = useMemo(() => {
     return Boolean(currentFieldName && filteredSamples.some((sample) => sample[currentFieldName]));

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_ai_suggestions.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_ai_suggestions.tsx
@@ -223,7 +223,12 @@ function InnerGrokAiSuggestions({
   const { field: currentFieldName, patterns: currentPatterns } = form.getValues();
 
   const hasValidField = useMemo(() => {
-    return Boolean(currentFieldName && filteredSamples.some((sample) => sample[currentFieldName] && typeof sample[currentFieldName] === 'string'));
+    return Boolean(
+      currentFieldName &&
+        filteredSamples.some(
+          (sample) => sample[currentFieldName] && typeof sample[currentFieldName] === 'string'
+        )
+    );
   }, [filteredSamples, currentFieldName]);
 
   const filteredSuggestions = suggestions?.patterns

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_ai_suggestions.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_ai_suggestions.tsx
@@ -223,7 +223,7 @@ function InnerGrokAiSuggestions({
   const { field: currentFieldName, patterns: currentPatterns } = form.getValues();
 
   const hasValidField = useMemo(() => {
-    return Boolean(currentFieldName && filteredSamples.some((sample) => sample[currentFieldName]));
+    return Boolean(currentFieldName && filteredSamples.some((sample) => sample[currentFieldName] && typeof sample[currentFieldName] === 'string'));
   }, [filteredSamples, currentFieldName]);
 
   const filteredSuggestions = suggestions?.patterns

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_ai_suggestions.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/grok/grok_ai_suggestions.tsx
@@ -57,21 +57,34 @@ const RefreshButton = ({
   return (
     <EuiFlexGroup responsive={false} gutterSize="xs" alignItems="center">
       <EuiFlexItem grow={false}>
-        <EuiButton
-          size="s"
-          iconType="sparkles"
-          data-test-subj="streamsAppGrokAiSuggestionsRefreshSuggestionsButton"
-          onClick={generatePatterns}
-          isLoading={isLoading}
-          disabled={currentConnector === undefined || !hasValidField}
+        <EuiToolTip
+          content={
+            !hasValidField &&
+            i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processorFlyout.refreshSuggestionsTooltip',
+              {
+                defaultMessage:
+                  'Make sure the configured field is valid and has samples in existing documents',
+              }
+            )
+          }
         >
-          {i18n.translate(
-            'xpack.streams.streamDetailView.managementTab.enrichment.processorFlyout.refreshSuggestions',
-            {
-              defaultMessage: 'Generate patterns',
-            }
-          )}
-        </EuiButton>
+          <EuiButton
+            size="s"
+            iconType="sparkles"
+            data-test-subj="streamsAppGrokAiSuggestionsRefreshSuggestionsButton"
+            onClick={generatePatterns}
+            isLoading={isLoading}
+            disabled={currentConnector === undefined || !hasValidField}
+          >
+            {i18n.translate(
+              'xpack.streams.streamDetailView.managementTab.enrichment.processorFlyout.refreshSuggestions',
+              {
+                defaultMessage: 'Generate patterns',
+              }
+            )}
+          </EuiButton>
+        </EuiToolTip>
       </EuiFlexItem>
       {connectors && connectors.length > 1 && (
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
This PR makes the AI suggestions button more stable in case of misconfigured fields:
* Only make the button clickable if there are sample values
* Filter out sample documents that don't have the required field on the server (would have broken the request before)

<img width="344" alt="Screenshot 2025-03-04 at 15 43 23" src="https://github.com/user-attachments/assets/12045985-cfac-4a13-a23c-595ac6503c1a" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->