### PR TITLE
[Attack Discovery][Scheduling] Add a new feature flag to hide scheduling feature (#12005)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/capabilities/index.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/capabilities/index.ts
@@ -21,4 +21,5 @@ export type AssistantFeatureKey = keyof AssistantFeatures;
 export const defaultAssistantFeatures = Object.freeze({
   assistantModelEvaluation: false,
   defendInsights: true,
+  assistantAttackDiscoverySchedulingEnabled: false,
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.gen.ts
@@ -20,4 +20,5 @@ export type GetCapabilitiesResponse = z.infer<typeof GetCapabilitiesResponse>;
 export const GetCapabilitiesResponse = z.object({
   assistantModelEvaluation: z.boolean(),
   defendInsights: z.boolean(),
+  assistantAttackDiscoverySchedulingEnabled: z.boolean(),
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/capabilities/get_capabilities_route.schema.yaml
@@ -24,9 +24,12 @@ paths:
                     type: boolean
                   defendInsights:
                     type: boolean
+                  assistantAttackDiscoverySchedulingEnabled:
+                    type: boolean
                 required:
                   - assistantModelEvaluation
                   - defendInsights
+                  - assistantAttackDiscoverySchedulingEnabled
         '400':
           description: Generic Error
           content:

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/services/app_context.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/services/app_context.test.ts
@@ -55,6 +55,7 @@ describe('AppContextService', () => {
       appContextService.registerFeatures('super', {
         assistantModelEvaluation: true,
         defendInsights: true,
+        assistantAttackDiscoverySchedulingEnabled: true,
       });
       appContextService.stop();
 
@@ -106,6 +107,7 @@ describe('AppContextService', () => {
         ...defaultAssistantFeatures,
         assistantModelEvaluation: true,
         defendInsights: true,
+        assistantAttackDiscoverySchedulingEnabled: true,
       };
 
       appContextService.start(mockAppContext);
@@ -122,12 +124,14 @@ describe('AppContextService', () => {
         ...defaultAssistantFeatures,
         assistantModelEvaluation: true,
         defendInsights: true,
+        assistantAttackDiscoverySchedulingEnabled: true,
       };
       const pluginTwo = 'plugin2';
       const featuresTwo: AssistantFeatures = {
         ...defaultAssistantFeatures,
         assistantModelEvaluation: false,
         defendInsights: false,
+        assistantAttackDiscoverySchedulingEnabled: false,
       };
 
       appContextService.start(mockAppContext);
@@ -144,11 +148,13 @@ describe('AppContextService', () => {
         ...defaultAssistantFeatures,
         assistantModelEvaluation: true,
         defendInsights: true,
+        assistantAttackDiscoverySchedulingEnabled: true,
       };
       const featuresTwo: AssistantFeatures = {
         ...defaultAssistantFeatures,
         assistantModelEvaluation: false,
         defendInsights: false,
+        assistantAttackDiscoverySchedulingEnabled: false,
       };
 
       appContextService.start(mockAppContext);
@@ -171,6 +177,7 @@ describe('AppContextService', () => {
       const featuresSubset: Partial<AssistantFeatures> = {
         assistantModelEvaluation: true,
         defendInsights: true,
+        assistantAttackDiscoverySchedulingEnabled: true,
       };
 
       appContextService.start(mockAppContext);

--- a/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/experimental_features.ts
@@ -115,6 +115,11 @@ export const allowedExperimentalValues = Object.freeze({
   assistantModelEvaluation: false,
 
   /**
+   * Enables the Attack Discovery Scheduling functionality and API endpoint`.
+   */
+  assistantAttackDiscoverySchedulingEnabled: false,
+
+  /**
    * Enables the Managed User section inside the new user details flyout.
    */
   newUserDetailsFlyoutManagedUser: false,

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -602,6 +602,8 @@ export class Plugin implements ISecuritySolutionPlugin {
     plugins.elasticAssistant.registerTools(APP_UI_ID, assistantTools);
     const features = {
       assistantModelEvaluation: config.experimentalFeatures.assistantModelEvaluation,
+      assistantAttackDiscoverySchedulingEnabled:
+        config.experimentalFeatures.assistantAttackDiscoverySchedulingEnabled,
     };
     plugins.elasticAssistant.registerFeatures(APP_UI_ID, features);
     plugins.elasticAssistant.registerFeatures('management', features);


### PR DESCRIPTION
## Summary

Feature description: [internal link](https://github.com/elastic/security-team/issues/10142)
Addresses: [internal link](https://github.com/elastic/security-team/issues/12005)

These changes introduce a new feature flag to control visibility of the Attack Discovery Scheduling feature.

To enable the flag:

> xpack.securitySolution.enableExperimental: ['assistantAttackDiscoverySchedulingEnabled']

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->