### PR TITLE
[8.x] [Security Solution][Document Flyout] Fix alert insights color order (#212980)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.test.tsx
@@ -153,9 +153,9 @@ describe('AlertCountInsight', () => {
         closed: {
           total: 6,
           severities: [
-            { key: 'high', value: 1, label: 'High' },
             { key: 'low', value: 1, label: 'Low' },
             { key: 'medium', value: 2, label: 'Medium' },
+            { key: 'high', value: 1, label: 'High' },
             { key: 'critical', value: 2, label: 'Critical' },
           ],
         },
@@ -173,9 +173,9 @@ describe('getFormattedAlertStats', () => {
   it('should return alert stats', () => {
     const alertStats = getFormattedAlertStats(mockAlertData, euiTheme);
     expect(alertStats).toEqual([
-      { key: 'High', count: 2, color: '#FF7E62' },
       { key: 'Low', count: 2, color: '#54B399' },
       { key: 'Medium', count: 2, color: '#F1D86F' },
+      { key: 'High', count: 2, color: '#FF7E62' },
       { key: 'Critical', count: 2, color: '#bd271e' },
     ]);
   });
@@ -186,8 +186,8 @@ describe('getFormattedAlertStats', () => {
         closed: {
           total: 2,
           severities: [
-            { key: 'high', value: 1, label: 'High' },
             { key: 'low', value: 1, label: 'Low' },
+            { key: 'high', value: 1, label: 'High' },
           ],
         },
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/components/alert_count_insight.tsx
@@ -48,6 +48,8 @@ import {
   EntityDetailsLeftPanelTab,
 } from '../../../entity_details/shared/components/left_panel/left_panel_header';
 
+const ORDER = ['Low', 'Medium', 'High', 'Critical'];
+
 interface AlertCountInsightProps {
   /**
    * The name of the entity to filter the alerts by.
@@ -97,7 +99,12 @@ export const getFormattedAlertStats = (
     key: capitalize(key),
     count,
     color: getSeverityColor(key, euiTheme),
-  }));
+  })).sort((a, b) => {
+    const aIndex = ORDER.indexOf(a.key);
+    const bIndex = ORDER.indexOf(b.key);
+    return aIndex - bIndex;
+  });
+
   return alertStats;
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Document Flyout] Fix alert insights color order (#212980)](https://github.com/elastic/kibana/pull/212980)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"christineweng","email":"18648970+christineweng@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-04T04:16:15Z","message":"[Security Solution][Document Flyout] Fix alert insights color order (#212980)\n\n## Summary\n\nUpdated order of the insights, following from left to right `Low` to\n`Critical`\n\n\n![image](https://github.com/user-attachments/assets/3b40bca0-4f29-421d-af34-fbacb49486dc)\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"bac5c30e1cfa7750f93899c9f39d29e39ca7b499","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:Threat Hunting:Investigations","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Security Solution][Document Flyout] Fix alert insights color order","number":212980,"url":"https://github.com/elastic/kibana/pull/212980","mergeCommit":{"message":"[Security Solution][Document Flyout] Fix alert insights color order (#212980)\n\n## Summary\n\nUpdated order of the insights, following from left to right `Low` to\n`Critical`\n\n\n![image](https://github.com/user-attachments/assets/3b40bca0-4f29-421d-af34-fbacb49486dc)\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"bac5c30e1cfa7750f93899c9f39d29e39ca7b499"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213032","number":213032,"state":"MERGED","mergeCommit":{"sha":"a722cc134a12dba005b14b96d4bdae5222d0a078","message":"[9.0] [Security Solution][Document Flyout] Fix alert insights color order (#212980) (#213032)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution][Document Flyout] Fix alert insights color order\n(#212980)](https://github.com/elastic/kibana/pull/212980)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: christineweng <18648970+christineweng@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212980","number":212980,"mergeCommit":{"message":"[Security Solution][Document Flyout] Fix alert insights color order (#212980)\n\n## Summary\n\nUpdated order of the insights, following from left to right `Low` to\n`Critical`\n\n\n![image](https://github.com/user-attachments/assets/3b40bca0-4f29-421d-af34-fbacb49486dc)\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"bac5c30e1cfa7750f93899c9f39d29e39ca7b499"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->