### PR TITLE
[Security AI Assistant] Bedrock prompt updates

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/prompts.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/prompts.ts
@@ -15,7 +15,7 @@ const BASE_GEMINI_PROMPT =
 const KB_CATCH =
   'If the knowledge base tool gives empty results, do your best to answer the question from the perspective of an expert security analyst.';
 export const GEMINI_SYSTEM_PROMPT = `${BASE_GEMINI_PROMPT} ${INCLUDE_CITATIONS} ${KB_CATCH} \n{formattedTime}`;
-export const BEDROCK_SYSTEM_PROMPT = `${DEFAULT_SYSTEM_PROMPT} Use tools as often as possible, as they have access to the latest data and syntax. Never return <thinking> tags in the response, but make sure to include <result> tags content in the response. Do not reflect on the quality of the returned search results in your response. ALWAYS return the exact response from NaturalLanguageESQLTool verbatim in the final response, without adding further description.`;
+export const BEDROCK_SYSTEM_PROMPT = `${DEFAULT_SYSTEM_PROMPT}\n\nUse tools as often as possible, as they have access to the latest data and syntax. Never return <thinking> tags in the response, but make sure to include <result> tags content in the response. Do not reflect on the quality of the returned search results in your response. ALWAYS return the exact response from NaturalLanguageESQLTool verbatim in the final response, without adding further description.\n\n Only format the response for the final output.`;
 export const GEMINI_USER_PROMPT = `Now, always using the tools at your disposal, step by step, come up with a response to this request:\n\n`;
 
 export const STRUCTURED_SYSTEM_PROMPT = `Respond to the human as helpfully and accurately as possible. ${KNOWLEDGE_HISTORY} ${INCLUDE_CITATIONS} You have access to the following tools:
@@ -137,7 +137,7 @@ export const ATTACK_DISCOVERY_GENERATION_TITLE =
   'A short, no more than 7 words, title for the insight, NOT formatted with special syntax or markdown. This must be as brief as possible.';
 export const ATTACK_DISCOVERY_GENERATION_INSIGHTS = `Insights with markdown that always uses special ${SYNTAX} syntax for field names and values from the source data. ${GOOD_SYNTAX_EXAMPLES} ${BAD_SYNTAX_EXAMPLES}`;
 
-export const BEDROCK_CHAT_TITLE = `You are a helpful assistant for Elastic Security. Assume the following user message is the start of a conversation between you and a user; give this conversation a title based on the content below. DO NOT UNDER ANY CIRCUMSTANCES wrap this title in single or double quotes. This title is shown in a list of conversations to the user, so title it for the user, not for you. Respond with the title only with no other text explaining your response. As an example, for the given MESSAGE, this is the TITLE:
+export const BEDROCK_CHAT_TITLE = `You are a helpful assistant for Elastic Security. Assume the following user message is the start of a conversation between you and a user; give this conversation a short title no longer than 100 characters based on the content below. DO NOT UNDER ANY CIRCUMSTANCES wrap this title in single or double quotes. This title is shown in a list of conversations to the user, so title it for the user, not for you. Respond with the title only, rather than answering the user's question. As an example, for the given MESSAGE, this is the TITLE:
 
 MESSAGE: I am having trouble with the Elastic Security app.
 TITLE: Troubleshooting Elastic Security app issues

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/prompts.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/prompt/prompts.ts
@@ -15,7 +15,7 @@ const BASE_GEMINI_PROMPT =
 const KB_CATCH =
   'If the knowledge base tool gives empty results, do your best to answer the question from the perspective of an expert security analyst.';
 export const GEMINI_SYSTEM_PROMPT = `${BASE_GEMINI_PROMPT} ${INCLUDE_CITATIONS} ${KB_CATCH} \n{formattedTime}`;
-export const BEDROCK_SYSTEM_PROMPT = `${DEFAULT_SYSTEM_PROMPT}\n\nUse tools as often as possible, as they have access to the latest data and syntax. Never return <thinking> tags in the response, but make sure to include <result> tags content in the response. Do not reflect on the quality of the returned search results in your response. ALWAYS return the exact response from NaturalLanguageESQLTool verbatim in the final response, without adding further description.\n\n Only format the response for the final output.`;
+export const BEDROCK_SYSTEM_PROMPT = `${DEFAULT_SYSTEM_PROMPT}\n\nUse tools as often as possible, as they have access to the latest data and syntax. Never return <thinking> tags in the response, but make sure to include <result> tags content in the response. Do not reflect on the quality of the returned search results in your response. ALWAYS return the exact response from NaturalLanguageESQLTool verbatim in the final response, without adding further description.\n\n Ensure that the final response always includes all instructions from the tool responses. Never omit earlier parts of the response.`;
 export const GEMINI_USER_PROMPT = `Now, always using the tools at your disposal, step by step, come up with a response to this request:\n\n`;
 
 export const STRUCTURED_SYSTEM_PROMPT = `Respond to the human as helpfully and accurately as possible. ${KNOWLEDGE_HISTORY} ${INCLUDE_CITATIONS} You have access to the following tools:
@@ -137,11 +137,20 @@ export const ATTACK_DISCOVERY_GENERATION_TITLE =
   'A short, no more than 7 words, title for the insight, NOT formatted with special syntax or markdown. This must be as brief as possible.';
 export const ATTACK_DISCOVERY_GENERATION_INSIGHTS = `Insights with markdown that always uses special ${SYNTAX} syntax for field names and values from the source data. ${GOOD_SYNTAX_EXAMPLES} ${BAD_SYNTAX_EXAMPLES}`;
 
-export const BEDROCK_CHAT_TITLE = `You are a helpful assistant for Elastic Security. Assume the following user message is the start of a conversation between you and a user; give this conversation a short title no longer than 100 characters based on the content below. DO NOT UNDER ANY CIRCUMSTANCES wrap this title in single or double quotes. This title is shown in a list of conversations to the user, so title it for the user, not for you. Respond with the title only, rather than answering the user's question. As an example, for the given MESSAGE, this is the TITLE:
+export const BEDROCK_CHAT_TITLE = `You are a strictly rule-following assistant for Elastic Security.
+Your task is to ONLY generate a short, user-friendly title based on the given user message.
 
-MESSAGE: I am having trouble with the Elastic Security app.
-TITLE: Troubleshooting Elastic Security app issues
-`;
+Instructions (You Must Follow Exactly)
+DO NOT ANSWER the user's question. You are forbidden from doing so.
+Your response MUST contain only the generated title. Nothing else.
+Absolutely NO explanations, disclaimers, or additional text.
+The title must be concise, relevant to the user’s message, and never exceed 100 characters.
+DO NOT wrap the title in quotes or any other formatting.
+Example:
+User Message: "I am having trouble with the Elastic Security app."
+Correct Response: Troubleshooting Elastic Security app issues
+
+Final Rule: If you include anything other than the title, you have failed this task.`;
 
 export const GEMINI_CHAT_TITLE = `You are a title generator for a helpful assistant for Elastic Security. Assume the following human message is the start of a conversation between you and a human. Generate a relevant conversation title for the human's message in plain text. Make sure the title is formatted for the user, without using quotes or markdown. The title should clearly reflect the content of the message and be appropriate for a list of conversations. Respond only with the title. As an example, for the given MESSAGE, this is the TITLE:
 


### PR DESCRIPTION
## Summary

When given a complex prompt instructing multiple tool use with Bedrock selected, the assistant would give a partial response https://smith.langchain.com/public/2ba23ac9-fd60-4eb4-ad3b-e7cce96b53a9/r 

I noticed this was happening when multiple tool outputs included formatted steps. I added an instruction to the system prompt to ` Ensure that the final response always includes all instructions from the tool responses. Never omit earlier parts of the response.` and this seems to have improved the response: https://smith.langchain.com/public/9756d4c9-a0d0-4558-a613-331bea8974d0/r

I ran ESQL regression suite for Sonnet 3.5 and Sonnet 3.7. The correctness for 3.5 remained 94% while 3.7 went from 90% to 100%. 😮 

Additionally, I noticed the title being generated was extremely long and actually answering the user's question: https://smith.langchain.com/public/5483cda3-10fa-4388-9c53-666ef27ac43f/r

I entirely redid the title prompt because small changes were not fixing the issue. Claude tends to follow clear and structured instructions well but can sometimes try to be "helpful" by answering anyway. The refined version enforces compliance by using strong prohibitive language (explicitly forbidding answers), failure consequences (stating that any extra output is a failure), step-by-step clarity (breaking down the process), and removing loopholes (ensuring no additional text is allowed). These changes eliminate ambiguity and force Claude to follow the instructions strictly. This seems to have resolved the issue: https://smith.langchain.com/public/60b2028c-a1b8-4ed9-886a-e319645448fd/r


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->