### PR TITLE
Hide main analytics applications on overview page if unavailable

### DIFF
--- a/src/platform/plugins/private/kibana_overview/public/components/overview/overview.tsx
+++ b/src/platform/plugins/private/kibana_overview/public/components/overview/overview.tsx
@@ -165,6 +165,9 @@ export const Overview: FC<Props> = ({ newsFetchResult, solutions, features }) =>
   // Dashboard and discover are displayed in larger cards
   const mainApps = ['dashboards', 'discover'];
   const remainingApps = kibanaApps.map(({ id }) => id).filter((id) => !mainApps.includes(id));
+  const mainAppsUserHasAccessTo = mainApps.filter(
+    (id) => application.capabilities[`${id}_v2`]?.show === true
+  );
 
   const onDataViewCreated = () => {
     setNewKibanaInstance(false);
@@ -256,13 +259,13 @@ export const Overview: FC<Props> = ({ newsFetchResult, solutions, features }) =>
           </h2>
         </EuiScreenReaderOnly>
 
-        {mainApps.length ? (
+        {mainAppsUserHasAccessTo.length ? (
           <>
             <EuiFlexGroup
               className="kbnOverviewApps__group kbnOverviewApps__group--primary"
               justifyContent="center"
             >
-              {mainApps.map(renderAppCard)}
+              {mainAppsUserHasAccessTo.map(renderAppCard)}
             </EuiFlexGroup>
 
             <EuiSpacer size="l" />

--- a/src/platform/plugins/private/kibana_overview/public/components/overview/overview.tsx
+++ b/src/platform/plugins/private/kibana_overview/public/components/overview/overview.tsx
@@ -10,7 +10,7 @@
 import './overview.scss';
 
 import { snakeCase } from 'lodash';
-import React, { FC, useState, useEffect } from 'react';
+import React, { FC, useState, useEffect, useMemo } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import {
   EuiCard,
@@ -165,9 +165,19 @@ export const Overview: FC<Props> = ({ newsFetchResult, solutions, features }) =>
   // Dashboard and discover are displayed in larger cards
   const mainApps = ['dashboards', 'discover'];
   const remainingApps = kibanaApps.map(({ id }) => id).filter((id) => !mainApps.includes(id));
-  const mainAppsUserHasAccessTo = mainApps.filter(
-    (id) => application.capabilities[`${id}_v2`]?.show === true
-  );
+  const mainAppsUserHasAccessTo = useMemo(() => {
+    const applications = [];
+
+    if (application.capabilities.dashboards_v2?.show) {
+      applications.push('dashboards');
+    }
+
+    if (application.capabilities.discover_v2?.show) {
+      applications.push('discover');
+    }
+
+    return applications;
+  }, [application.capabilities]);
 
   const onDataViewCreated = () => {
     setNewKibanaInstance(false);


### PR DESCRIPTION
## Summary

This PR fixes a bug where unavailable (due to lack of permissions) "main" analytics applications would show for users on Kibana overview page.
Closes: #212171





<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->