### PR TITLE
[ES|QL] Fixes some problems with numeric control values

### DIFF
--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
@@ -36,7 +36,9 @@ export function initializeESQLControlSelections(initialState: ESQLControlState) 
   // derive ESQL control variable from state.
   const getEsqlVariable = () => ({
     key: variableName$.value,
-    value: selectedOptions$.value[0],
+    value: Number.isNaN(selectedOptions$.value[0])
+      ? selectedOptions$.value[0]
+      : Number(selectedOptions$.value[0]),
     type: variableType$.value,
   });
   const esqlVariable$ = new BehaviorSubject<ESQLControlVariable>(getEsqlVariable());

--- a/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
+++ b/src/platform/plugins/shared/controls/public/controls/esql_control/esql_control_selections.ts
@@ -36,7 +36,7 @@ export function initializeESQLControlSelections(initialState: ESQLControlState) 
   // derive ESQL control variable from state.
   const getEsqlVariable = () => ({
     key: variableName$.value,
-    value: Number.isNaN(selectedOptions$.value[0])
+    value: isNaN(Number(selectedOptions$.value[0]))
       ? selectedOptions$.value[0]
       : Number(selectedOptions$.value[0]),
     type: variableType$.value,


### PR DESCRIPTION
## Summary

ES|QL doesnt have sometimes the ability to compare a numeric field with a string when this string is a numeric value. For example:

```
FROM kibana_sample_data_logs | WHERE bytes > "6193"
```

This is going to fail, the value should be numeric to work as expected. For this reason controls that have numeric values do not work correctly. This PR is fixing this



<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->