### PR TITLE
Set from & to as optional args in @kbn/grouping

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
@@ -15,7 +15,10 @@ import { groupingBucket } from '../../mocks';
 
 const testProps: GroupingQueryArgs = {
   additionalFilters: [],
-  from: '2022-12-28T15:35:32.871Z',
+  timeRange: {
+    from: '2022-12-28T15:35:32.871Z',
+    to: '2023-02-23T06:59:59.999Z',
+  },
   groupByField: 'host.name',
   statsAggregations: [
     {
@@ -59,7 +62,6 @@ const testProps: GroupingQueryArgs = {
   runtimeMappings: {},
   uniqueValue: 'whatAGreatAndUniqueValue',
   size: 25,
-  to: '2023-02-23T06:59:59.999Z',
 };
 describe('group selector', () => {
   beforeEach(() => {

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
@@ -38,7 +38,6 @@ export const MAX_QUERY_SIZE = 10000;
 
 export const getGroupingQuery = ({
   additionalFilters = [],
-  from,
   groupByField,
   pageNumber,
   rootAggregations,
@@ -46,8 +45,8 @@ export const getGroupingQuery = ({
   size = DEFAULT_GROUP_BY_FIELD_SIZE,
   sort,
   statsAggregations,
-  to,
   uniqueValue,
+  timeRange,
 }: GroupingQueryArgs): GroupingQuery => ({
   size: 0,
   runtime_mappings: {
@@ -104,14 +103,18 @@ export const getGroupingQuery = ({
     bool: {
       filter: [
         ...additionalFilters,
-        {
-          range: {
-            '@timestamp': {
-              gte: from,
-              lte: to,
-            },
-          },
-        },
+        ...(timeRange
+          ? [
+              {
+                range: {
+                  '@timestamp': {
+                    gte: timeRange.from,
+                    lte: timeRange.to,
+                  },
+                },
+              },
+            ]
+          : []),
       ],
     },
   },

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/types.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/types.ts
@@ -32,7 +32,6 @@ export type NamedAggregation = Record<string, estypes.AggregationsAggregationCon
 
 export interface GroupingQueryArgs {
   additionalFilters: BoolAgg[];
-  from: string;
   groupByField: string;
   rootAggregations?: NamedAggregation[];
   runtimeMappings?: RunTimeMappings;
@@ -42,7 +41,10 @@ export interface GroupingQueryArgs {
   size?: number;
   sort?: Array<{ [category: string]: { order: 'asc' | 'desc' } }>;
   statsAggregations?: NamedAggregation[];
-  to: string;
+  timeRange?: {
+    from: string;
+    to: string;
+  };
 }
 
 export interface MainAggregation extends NamedAggregation {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings_grouping.tsx
@@ -207,8 +207,10 @@ export const useLatestFindingsGrouping = ({
     additionalFilters: query ? [query, additionalFilters] : [additionalFilters],
     groupByField: currentSelectedGroup,
     uniqueValue,
-    from: `now-${CDR_3RD_PARTY_RETENTION_POLICY}`,
-    to: 'now',
+    timeRange: {
+      from: `now-${CDR_3RD_PARTY_RETENTION_POLICY}`,
+      to: 'now',
+    },
     pageNumber: activePageIndex * pageSize,
     size: pageSize,
     sort: [{ groupByField: { order: 'desc' } }, { complianceScore: { order: 'asc' } }],

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
@@ -180,8 +180,10 @@ export const useLatestVulnerabilitiesGrouping = ({
     additionalFilters: query ? [query, additionalFilters] : [additionalFilters],
     groupByField: currentSelectedGroup,
     uniqueValue,
-    from: `now-${CDR_3RD_PARTY_RETENTION_POLICY}`,
-    to: 'now',
+    timeRange: {
+      from: `now-${CDR_3RD_PARTY_RETENTION_POLICY}`,
+      to: 'now',
+    },
     pageNumber: activePageIndex * pageSize,
     size: pageSize,
     sort: [{ groupByField: { order: 'desc' } }],

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/query_builder.ts
@@ -35,7 +35,10 @@ export const getAlertsGroupingQuery = ({
 }: AlertsGroupingQueryParams) =>
   getGroupingQuery({
     additionalFilters,
-    from,
+    timeRange: {
+      from,
+      to,
+    },
     groupByField: selectedGroup,
     statsAggregations: !isNoneGroup([selectedGroup])
       ? getAggregationsByGroupField(selectedGroup)
@@ -45,7 +48,6 @@ export const getAlertsGroupingQuery = ({
     uniqueValue,
     size: pageSize,
     sort: [{ unitsCount: { order: 'desc' } }],
-    to,
   });
 
 const getAggregationsByGroupField = (field: string): NamedAggregation[] => {


### PR DESCRIPTION
## Summary

Set `from` and `to` as optional args in `getGroupingQuery`, a function exposed by `@kbn/grouping`. 

It will unblock this PR:
- https://github.com/elastic/kibana/pull/212955

### Motivation 

`getGroupingQuery` returns an ES aggregation for grouping documents. This function assumes data will be queried in a certain interval of time. However, Asset Inventory needs to query data from the beginning of time because the UI will not provide any time-range filter. So in order to reuse this logic, we need to set both args as optional.

Reason for wrapping both fields in an optional `timeRange` record is to have either both present or both undefined, not only one of them present.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Risks

No risk at all. It would be a breaking change otherwise, if we had to require args that were optional before.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->