### PR TITLE
[UA] OpenSSL legacy provider deprecation warning

### DIFF
--- a/src/core/packages/deprecations/server-internal/src/deprecations/index.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/index.ts
@@ -14,3 +14,4 @@ export {
   getIsRouteApiDeprecation,
 } from './api_deprecations';
 export { registerConfigDeprecationsInfo } from './config_deprecations';
+export { registerNodeJsDeprecationsInfo } from './node_js_deprecations';

--- a/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.test.ts
@@ -14,6 +14,7 @@ jest.mock('node:crypto', () => {
 });
 
 import crypto from 'node:crypto';
+import { docLinksServiceMock } from '@kbn/core-doc-links-server-mocks';
 import type { GetDeprecationsContext } from '@kbn/core-deprecations-server';
 import { mockDeprecationsFactory, mockDeprecationsRegistry } from '../mocks';
 import { registerNodeJsDeprecationsInfo } from './node_js_deprecations';
@@ -21,6 +22,7 @@ import { registerNodeJsDeprecationsInfo } from './node_js_deprecations';
 describe('#registerNodeJsDeprecationsInfo', () => {
   const deprecationsFactory = mockDeprecationsFactory.create();
   const deprecationsRegistry = mockDeprecationsRegistry.create();
+  const docLinks = docLinksServiceMock.createSetupContract();
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -33,7 +35,7 @@ describe('#registerNodeJsDeprecationsInfo', () => {
       'flyfish',
     ]);
 
-    registerNodeJsDeprecationsInfo({ deprecationsFactory });
+    registerNodeJsDeprecationsInfo({ deprecationsFactory, docLinks });
 
     expect(deprecationsFactory.getRegistry).toHaveBeenCalledTimes(1);
     expect(deprecationsFactory.getRegistry).toHaveBeenCalledWith('core.node_js_deprecations');
@@ -57,7 +59,7 @@ describe('#registerNodeJsDeprecationsInfo', () => {
   it('does not register NodeJS deprecations if not running legacy provider', () => {
     (crypto.getCiphers as jest.Mock).mockReturnValue(['foo', 'bar']);
 
-    registerNodeJsDeprecationsInfo({ deprecationsFactory });
+    registerNodeJsDeprecationsInfo({ deprecationsFactory, docLinks });
 
     expect(deprecationsFactory.getRegistry).toHaveBeenCalledTimes(0);
     expect(deprecationsRegistry.registerDeprecations).toHaveBeenCalledTimes(0);

--- a/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+jest.mock('node:crypto', () => {
+  return {
+    getCiphers: jest.fn(() => []),
+  };
+});
+
+import crypto from 'node:crypto';
+import type { GetDeprecationsContext } from '@kbn/core-deprecations-server';
+import { mockDeprecationsFactory, mockDeprecationsRegistry } from '../mocks';
+import { registerNodeJsDeprecationsInfo } from './node_js_deprecations';
+
+describe('#registerNodeJsDeprecationsInfo', () => {
+  const deprecationsFactory = mockDeprecationsFactory.create();
+  const deprecationsRegistry = mockDeprecationsRegistry.create();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    deprecationsFactory.getRegistry.mockReturnValue(deprecationsRegistry);
+  });
+
+  it('registers NodeJS deprecations when running legacy provider', () => {
+    (crypto.getCiphers as jest.Mock).mockReturnValue([
+      'blowfish' /* this cipher is part of legacy SSL provider */,
+      'flyfish',
+    ]);
+
+    registerNodeJsDeprecationsInfo({ deprecationsFactory });
+
+    expect(deprecationsFactory.getRegistry).toHaveBeenCalledTimes(1);
+    expect(deprecationsFactory.getRegistry).toHaveBeenCalledWith('core.node_js_deprecations');
+
+    expect(deprecationsRegistry.registerDeprecations).toHaveBeenCalledTimes(1);
+    expect(deprecationsRegistry.registerDeprecations).toHaveBeenCalledWith({
+      getDeprecations: expect.any(Function),
+    });
+
+    const [[{ getDeprecations }]] = deprecationsRegistry.registerDeprecations.mock.calls;
+    const deprecations = getDeprecations({} as unknown as GetDeprecationsContext);
+    expect(deprecations).toEqual([
+      expect.objectContaining({
+        deprecationType: 'feature',
+        level: 'warning',
+        title: expect.stringMatching(/Detected legacy OpenSSL/),
+      }),
+    ]);
+  });
+
+  it('does not register NodeJS deprecations if not running legacy provider', () => {
+    (crypto.getCiphers as jest.Mock).mockReturnValue(['foo', 'bar']);
+
+    registerNodeJsDeprecationsInfo({ deprecationsFactory });
+
+    expect(deprecationsFactory.getRegistry).toHaveBeenCalledTimes(0);
+    expect(deprecationsRegistry.registerDeprecations).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
@@ -29,8 +29,11 @@ export const registerNodeJsDeprecationsInfo = ({
   /**
    * Note: this deprecation is being detected on a best effort basis. It is possible
    * that multiple Kibanas are running with differing configuration in which case it depends
-   * on which Kibana handles the request deprecations... For now, building on the
-   * assumption that for this configuration this is a very edge case possibility.
+   * on which Kibana handles the deprecations request... For now, building on the
+   * assumption that for this configuration this is a very edge case possibility,
+   * however it might be awkward if users start addressing this deprecation, see
+   * it becomes resolved but missed some Kibanas. One mitigiation is that we
+   * should emit a warning log about this when starting Kibana.
    */
   if (isOpenSslLegacyProviderEnabled()) {
     deprecationsFactory.getRegistry('core.node_js_deprecations').registerDeprecations({

--- a/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
@@ -9,10 +9,12 @@
 
 import crypto from 'node:crypto';
 import { i18n } from '@kbn/i18n';
+import type { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import type { DeprecationsFactory } from '../deprecations_factory';
 
 interface RegisterNodeJsDeprecationsInfo {
   deprecationsFactory: DeprecationsFactory;
+  docLinks: DocLinksServiceSetup;
 }
 
 // The blowfish cipher is only available when node is running with the --openssl-legacy-provider flag
@@ -22,6 +24,7 @@ const isOpenSslLegacyProviderEnabled = () => {
 
 export const registerNodeJsDeprecationsInfo = ({
   deprecationsFactory,
+  docLinks,
 }: RegisterNodeJsDeprecationsInfo) => {
   /**
    * Note: this deprecation is being detected on a best effort basis. It is possible
@@ -42,18 +45,21 @@ export const registerNodeJsDeprecationsInfo = ({
             message: {
               type: 'markdown',
               content: i18n.translate('core.deprecations.openSSLDeprecation.message.markdown', {
-                defaultMessage: `Kibana is currently running with the legacy OpenSSL provider enabled, which is not recommended. For your security, these providers will be disabled by default in 9.0. [Learn more](https://docs.openssl.org/3.0/man7/OSSL_PROVIDER-legacy/) about the legacy OpenSSL provider.`,
+                defaultMessage: `Kibana is currently running with the legacy OpenSSL provider enabled, which is not recommended. For your security, these providers will be disabled by default in 9.0. [Learn more]({learnMore}) about the legacy OpenSSL provider.`,
+                values: {
+                  learnMore: docLinks.links.kibana.legacyOpenSslProvider,
+                },
               }),
             },
             correctiveActions: {
               manualSteps: [
                 i18n.translate('core.deprecations.openSSLDeprecation.step1Description', {
                   defaultMessage:
-                    'Remove the --openssl-legacy-provider flag from the config/node.options file where Kibana server is running',
+                    'Remove the --openssl-legacy-provider flag from the config/node.options file where Kibana server is running.',
                 }),
                 i18n.translate('core.deprecations.openSSLDeprecation.step2Description', {
                   defaultMessage:
-                    'Ensure the --openssl-legacy-provider flag is not being provided via the NODE_OPTIONS environment variable to Kibana.',
+                    'Ensure the --openssl-legacy-provider flag is not being provided via the NODE_OPTIONS environment variable to Kibana server.',
                 }),
                 i18n.translate('core.deprecations.openSSLDeprecation.step3Description', {
                   defaultMessage: 'Restart Kibana.',

--- a/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
@@ -48,7 +48,7 @@ export const registerNodeJsDeprecationsInfo = ({
             message: {
               type: 'markdown',
               content: i18n.translate('core.deprecations.openSSLDeprecation.message.markdown', {
-                defaultMessage: `Kibana is currently running with the legacy OpenSSL provider enabled, which is not recommended. For your security, these providers will be disabled by default in 9.0. [Learn more]({learnMore}) about the legacy OpenSSL provider.`,
+                defaultMessage: `Kibana is currently running with the [legacy OpenSSL provider]({learnMore}) enabled, which is not recommended. For your security, legacy providers will be disabled by default in 9.0.`,
                 values: {
                   learnMore: docLinks.links.kibana.legacyOpenSslProvider,
                 },
@@ -58,11 +58,11 @@ export const registerNodeJsDeprecationsInfo = ({
               manualSteps: [
                 i18n.translate('core.deprecations.openSSLDeprecation.step1Description', {
                   defaultMessage:
-                    'Remove the --openssl-legacy-provider flag from the config/node.options file where Kibana server is running.',
+                    'Remove the --openssl-legacy-provider flag from the config/node.options file where the Kibana server is running.',
                 }),
                 i18n.translate('core.deprecations.openSSLDeprecation.step2Description', {
                   defaultMessage:
-                    'Ensure the --openssl-legacy-provider flag is not being provided via the NODE_OPTIONS environment variable to Kibana server.',
+                    'Ensure the --openssl-legacy-provider flag is not being provided via the NODE_OPTIONS environment variable to the Kibana server.',
                 }),
                 i18n.translate('core.deprecations.openSSLDeprecation.step3Description', {
                   defaultMessage: 'Restart Kibana.',

--- a/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
@@ -48,7 +48,7 @@ export const registerNodeJsDeprecationsInfo = ({
             message: {
               type: 'markdown',
               content: i18n.translate('core.deprecations.openSSLDeprecation.message.markdown', {
-                defaultMessage: `Kibana is currently running with the [legacy OpenSSL provider]({learnMore}) enabled, which is not recommended. For your security, legacy providers will be disabled by default in 9.0.`,
+                defaultMessage: `Kibana is currently running with the [legacy OpenSSL provider]({learnMore}) enabled, which is not recommended. For your security, the legacy provider will be disabled by default in 9.0.`,
                 values: {
                   learnMore: docLinks.links.kibana.legacyOpenSslProvider,
                 },

--- a/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/node_js_deprecations.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import crypto from 'node:crypto';
+import { i18n } from '@kbn/i18n';
+import type { DeprecationsFactory } from '../deprecations_factory';
+
+interface RegisterNodeJsDeprecationsInfo {
+  deprecationsFactory: DeprecationsFactory;
+}
+
+// The blowfish cipher is only available when node is running with the --openssl-legacy-provider flag
+const isOpenSslLegacyProviderEnabled = () => {
+  return crypto.getCiphers().includes('blowfish');
+};
+
+export const registerNodeJsDeprecationsInfo = ({
+  deprecationsFactory,
+}: RegisterNodeJsDeprecationsInfo) => {
+  /**
+   * Note: this deprecation is being detected on a best effort basis. It is possible
+   * that multiple Kibanas are running with differing configuration in which case it depends
+   * on which Kibana handles the request deprecations... For now, building on the
+   * assumption that for this configuration this is a very edge case possibility.
+   */
+  if (isOpenSslLegacyProviderEnabled()) {
+    deprecationsFactory.getRegistry('core.node_js_deprecations').registerDeprecations({
+      getDeprecations: () => {
+        return [
+          {
+            deprecationType: 'feature',
+            level: 'warning',
+            title: i18n.translate('core.deprecations.openSSLDeprecation.title', {
+              defaultMessage: 'Detected legacy OpenSSL provider',
+            }),
+            message: {
+              type: 'markdown',
+              content: i18n.translate('core.deprecations.openSSLDeprecation.message.markdown', {
+                defaultMessage: `Kibana is currently running with the legacy OpenSSL provider enabled, which is not recommended. For your security, these providers will be disabled by default in 9.0. [Learn more](https://docs.openssl.org/3.0/man7/OSSL_PROVIDER-legacy/) about the legacy OpenSSL provider.`,
+              }),
+            },
+            correctiveActions: {
+              manualSteps: [
+                i18n.translate('core.deprecations.openSSLDeprecation.step1Description', {
+                  defaultMessage:
+                    'Remove the --openssl-legacy-provider flag from the config/node.options file where Kibana server is running',
+                }),
+                i18n.translate('core.deprecations.openSSLDeprecation.step2Description', {
+                  defaultMessage:
+                    'Ensure the --openssl-legacy-provider flag is not being provided via the NODE_OPTIONS environment variable to Kibana.',
+                }),
+                i18n.translate('core.deprecations.openSSLDeprecation.step3Description', {
+                  defaultMessage: 'Restart Kibana.',
+                }),
+              ],
+            },
+          },
+        ];
+      },
+    });
+  }
+};

--- a/src/core/packages/deprecations/server-internal/src/deprecations_service.test.mocks.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_service.test.mocks.ts
@@ -16,6 +16,7 @@ export const DeprecationsFactoryMock = jest
 
 export const registerConfigDeprecationsInfoMock = jest.fn();
 export const registerApiDeprecationsInfoMock = jest.fn();
+export const registerNodeJsDeprecationsInfoMock = jest.fn();
 
 export const loggingMock = {
   configure: jest.fn(),
@@ -24,6 +25,7 @@ export const loggingMock = {
 jest.doMock('./deprecations', () => ({
   registerConfigDeprecationsInfo: registerConfigDeprecationsInfoMock,
   registerApiDeprecationsInfo: registerApiDeprecationsInfoMock,
+  registerNodeJsDeprecationsInfo: registerNodeJsDeprecationsInfoMock,
 }));
 
 jest.doMock('./deprecations_factory', () => ({

--- a/src/core/packages/deprecations/server-internal/src/deprecations_service.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_service.test.ts
@@ -10,6 +10,8 @@
 import {
   DeprecationsFactoryMock,
   registerConfigDeprecationsInfoMock,
+  registerApiDeprecationsInfoMock,
+  registerNodeJsDeprecationsInfoMock,
   loggingMock,
 } from './deprecations_service.test.mocks';
 import { mockCoreContext } from '@kbn/core-base-server-mocks';
@@ -45,8 +47,6 @@ describe('DeprecationsService', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    DeprecationsFactoryMock.mockClear();
-    registerConfigDeprecationsInfoMock.mockClear();
   });
 
   describe('#setup', () => {
@@ -63,10 +63,12 @@ describe('DeprecationsService', () => {
       );
     });
 
-    it('calls registerConfigDeprecationsInfo', async () => {
+    it('registers internal deprecations', async () => {
       const deprecationsService = new DeprecationsService(coreContext);
       await deprecationsService.setup(deprecationsCoreSetupDeps);
       expect(registerConfigDeprecationsInfoMock).toBeCalledTimes(1);
+      expect(registerApiDeprecationsInfoMock).toBeCalledTimes(1);
+      expect(registerNodeJsDeprecationsInfoMock).toBeCalledTimes(1);
     });
 
     describe('logging.configure tests', () => {

--- a/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
@@ -26,7 +26,11 @@ import { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import { DeprecationsFactory } from './deprecations_factory';
 import { registerRoutes } from './routes';
 import { config as deprecationConfig, DeprecationConfigType } from './deprecation_config';
-import { registerApiDeprecationsInfo, registerConfigDeprecationsInfo } from './deprecations';
+import {
+  registerApiDeprecationsInfo,
+  registerConfigDeprecationsInfo,
+  registerNodeJsDeprecationsInfo,
+} from './deprecations';
 
 /**
  * Deprecation Service: Internal Start contract
@@ -111,6 +115,8 @@ export class DeprecationsService
       coreUsageData,
       docLinks,
     });
+
+    registerNodeJsDeprecationsInfo({ deprecationsFactory: this.deprecationsFactory });
 
     const deprecationsFactory = this.deprecationsFactory;
     return {

--- a/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_service.ts
@@ -116,7 +116,7 @@ export class DeprecationsService
       docLinks,
     });
 
-    registerNodeJsDeprecationsInfo({ deprecationsFactory: this.deprecationsFactory });
+    registerNodeJsDeprecationsInfo({ deprecationsFactory: this.deprecationsFactory, docLinks });
 
     const deprecationsFactory = this.deprecationsFactory;
     return {

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -363,6 +363,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       xpackSecurity: `${KIBANA_DOCS}xpack-security.html`,
       restApis: `${KIBANA_DOCS}api.html`,
       dashboardImportExport: `${KIBANA_DOCS}dashboard-api.html`,
+      legacyOpenSslProvider: `${KIBANA_DOCS}production.html#openssl-legacy-provider`,
     },
     upgradeAssistant: {
       overview: `${KIBANA_DOCS}upgrade-assistant.html`,

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -320,6 +320,7 @@ export interface DocLinks {
     readonly secureSavedObject: string;
     readonly xpackSecurity: string;
     readonly dashboardImportExport: string;
+    readonly legacyOpenSslProvider: string;
   };
   readonly upgradeAssistant: {
     readonly overview: string;


### PR DESCRIPTION
## Summary

Related https://github.com/elastic/dev/issues/2989

<img width="834" alt="Screenshot 2025-03-05 at 11 58 14" src="https://github.com/user-attachments/assets/3f905a95-10af-4f25-9370-431508d3564f" />

<img width="447" alt="Screenshot 2025-03-05 at 12 12 00" src="https://github.com/user-attachments/assets/72f02b45-1ccc-4e4b-af4e-82a397d24687" />

Learn more is sending users to: https://www.elastic.co/guide/en/kibana/current/production.html#openssl-legacy-provider

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
