### PR TITLE
[8.18] [Entity Analytics] Do not prompt users with the legacy risk engine installed to install the risk engine on the Entity Analytics dashboard (#210430)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_enablement_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_enablement_panel.tsx
@@ -46,7 +46,7 @@ interface EnableEntityStorePanelProps {
 }
 
 export const EnablementPanel: React.FC<EnableEntityStorePanelProps> = ({ state }) => {
-  const riskEngineStatus = state.riskEngine.data?.risk_engine_status;
+  const riskEngineStatus = state.riskEngine.data;
   const entityStoreStatus = state.entityStore.data?.status;
   const engines = state.entityStore.data?.engines;
   const enabledEntityTypes = useStoreEntityTypes();
@@ -183,14 +183,19 @@ export const EnablementPanel: React.FC<EnableEntityStorePanelProps> = ({ state }
     );
   }
 
+  const combinedRiskEngineStatus =
+    riskEngineStatus?.risk_engine_status !== RiskEngineStatusEnum.NOT_INSTALLED
+      ? riskEngineStatus?.risk_engine_status
+      : riskEngineStatus?.legacy_risk_engine_status;
+
   if (
-    riskEngineStatus !== RiskEngineStatusEnum.NOT_INSTALLED &&
+    combinedRiskEngineStatus !== RiskEngineStatusEnum.NOT_INSTALLED &&
     (entityStoreStatus === 'running' || entityStoreStatus === 'stopped')
   ) {
     return null;
   }
 
-  const [title, body] = getEnablementTexts(entityStoreStatus, riskEngineStatus);
+  const [title, body] = getEnablementTexts(entityStoreStatus, combinedRiskEngineStatus);
   return (
     <>
       <EuiEmptyPrompt
@@ -223,8 +228,8 @@ export const EnablementPanel: React.FC<EnableEntityStorePanelProps> = ({ state }
         toggle={(visible) => setModalState({ visible })}
         enableStore={enableEntityStore}
         riskScore={{
-          canToggle: riskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED,
-          checked: riskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED,
+          disabled: combinedRiskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED,
+          checked: combinedRiskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED,
         }}
         entityStore={{
           canToggle: entityStoreStatus !== 'running',

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_enablement_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_enablement_panel.tsx
@@ -228,7 +228,7 @@ export const EnablementPanel: React.FC<EnableEntityStorePanelProps> = ({ state }
         toggle={(visible) => setModalState({ visible })}
         enableStore={enableEntityStore}
         riskScore={{
-          disabled: combinedRiskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED,
+          canToggle: combinedRiskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED,
           checked: combinedRiskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED,
         }}
         entityStore={{

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_entity_store_panels.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/components/dashboard_entity_store_panels.tsx
@@ -59,6 +59,10 @@ const EntityStoreDashboardPanelsComponent = () => {
     );
   }
 
+  const atLeastOneRiskEngineInstalled =
+    riskEngineStatus.data?.risk_engine_status !== RiskEngineStatusEnum.NOT_INSTALLED ||
+    riskEngineStatus.data?.legacy_risk_engine_status !== RiskEngineStatusEnum.NOT_INSTALLED;
+
   return (
     <EuiFlexGroup direction="column" data-test-subj="entityStorePanelsGroup">
       {storeStatusQuery.status === 'error' ? (
@@ -72,7 +76,7 @@ const EntityStoreDashboardPanelsComponent = () => {
         />
       )}
 
-      {riskEngineStatus.data?.risk_engine_status !== RiskEngineStatusEnum.NOT_INSTALLED && (
+      {atLeastOneRiskEngineInstalled && (
         <>
           {entityTypes.map((entityType) => (
             <EuiFlexItem key={entityType}>


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[Entity Analytics] Do not prompt users with the legacy risk engine installed to install the risk engine on the Entity Analytics dashboard (#210430)](https://github.com/elastic/kibana/pull/210430)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mark Hopkin","email":"mark.hopkin@elastic.co"},"sourceCommit":{"committedDate":"2025-02-13T17:53:47Z","message":"[Entity Analytics] Do not prompt users with the legacy risk engine installed to install the risk engine on the Entity Analytics dashboard (#210430)","sha":"cd77f8629a1232cb307e4ba74249fd17bbf64801","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team: SecuritySolution","Team:Entity Analytics","backport:version","v8.18.0","v8.19.0"],"title":"[Entity Analytics] Do not prompt users with the legacy risk engine installed to install the risk engine on the Entity Analytics dashboard","number":210430,"url":"https://github.com/elastic/kibana/pull/210430","mergeCommit":{"message":"[Entity Analytics] Do not prompt users with the legacy risk engine installed to install the risk engine on the Entity Analytics dashboard (#210430)","sha":"cd77f8629a1232cb307e4ba74249fd17bbf64801"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->