### PR TITLE
[Siem Migrations] `GET /integrations` integration Test

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/get_integrations.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/get_integrations.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+import { migrationRulesRouteHelpersFactory } from '../../utils';
+
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertest');
+  const migrationRulesRoutes = migrationRulesRouteHelpersFactory(supertest);
+
+  describe('Get Integrations', () => {
+    it('should return all integrations successfully', async () => {
+      const response = await migrationRulesRoutes.getIntegrations({});
+
+      const integrationsObj = response.body;
+      const integrationIds = Object.keys(integrationsObj);
+
+      expect(integrationIds.length).to.be.greaterThan(0);
+      expect(integrationsObj[integrationIds[0]]).to.have.keys('package', 'version');
+    });
+  });
+};

--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/index.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/rules/trial_license_complete_tier/index.ts
@@ -16,5 +16,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./update'));
     loadTestFile(require.resolve('./start'));
     loadTestFile(require.resolve('./stop'));
+    loadTestFile(require.resolve('./get_integrations'));
   });
 }

--- a/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/utils/rules.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/siem_migrations/utils/rules.ts
@@ -22,10 +22,12 @@ import {
   SIEM_RULE_MIGRATION_STATS_PATH,
   SIEM_RULE_MIGRATION_TRANSLATION_STATS_PATH,
   SIEM_RULE_MIGRATION_STOP_PATH,
+  SIEM_RULE_MIGRATIONS_INTEGRATIONS_PATH,
 } from '@kbn/security-solution-plugin/common/siem_migrations/constants';
 import {
   CreateRuleMigrationResponse,
   GetAllStatsRuleMigrationResponse,
+  GetRuleMigrationIntegrationsResponse,
   GetRuleMigrationPrebuiltRulesResponse,
   GetRuleMigrationRequestQuery,
   GetRuleMigrationResponse,
@@ -253,6 +255,23 @@ export const migrationRulesRouteHelpersFactory = (supertest: SuperTest.Agent) =>
             migration_id: migrationId,
           })
         )
+        .set('kbn-xsrf', 'true')
+        .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1)
+        .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+        .send();
+
+      assertStatusCode(expectStatusCode, response);
+
+      return response;
+    },
+
+    getIntegrations: async ({
+      expectStatusCode = 200,
+    }: RequestParams): Promise<{
+      body: GetRuleMigrationIntegrationsResponse;
+    }> => {
+      const response = await supertest
+        .get(SIEM_RULE_MIGRATIONS_INTEGRATIONS_PATH)
         .set('kbn-xsrf', 'true')
         .set(ELASTIC_HTTP_VERSION_HEADER, API_VERSIONS.internal.v1)
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')


### PR DESCRIPTION
## Summary

Adds a smoke test for `GET /integrations` endpoint.

Handles

- https://github.com/elastic/security-team/issues/11232

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->