### PR TITLE
[Search] test: remove navigation skip in mki

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -19,8 +19,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
   const header = getPageObject('header');
 
   describe('navigation', function () {
-    // see details: https://github.com/elastic/kibana/issues/196823
-    this.tags(['failsOnMKI']);
     before(async () => {
       await svlCommonPage.loginWithRole('developer');
       await svlSearchNavigation.navigateToLandingPage();


### PR DESCRIPTION
## Summary

The navigation test was skipped in MKI because opening the maps page caused a modal that then prevented navigating away from maps to continue the test.

Opening the maps page has previously been removed from the navigation test suite and therefore this test doesn't need to be skipped in MKI any longer.

Closes #196823

### Checklist

- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
