### PR TITLE
[Security Solution] Add note about removing bulk crud API in v9.0 and migrate examples

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -11123,7 +11123,7 @@ paths:
                     id: 7d2f5ed8-6c05-44ab-81ce-9160ae147057
                     name: Updated Google Workspace Suspended User Account Renewed
                     risk_score: 21
-                    severity: critical
+                    severity: low
                     tags:
                       - new_tag
                     type: query
@@ -11131,7 +11131,7 @@ paths:
                     id: 43b2dc3b-4f21-4a10-95e2-0dbc19e6e974
                     name: Updated AWS Redshift Cluster Creation
                     risk_score: 21
-                    severity: medium
+                    severity: low
                     tags:
                       - new_tag
                     type: query

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -10880,11 +10880,50 @@ paths:
   /api/detection_engine/rules/_bulk_create:
     post:
       deprecated: true
-      description: Create new detection rules in bulk.
+      description: |
+        Create new detection rules in bulk.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
+
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       operationId: BulkCreateRules
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - description: Process started by MS Office program - possible payload
+                    enabled: false
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-6m
+                    interval: 5m
+                    language: kuery
+                    name: MS Office child process
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program_possible_payload
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    type: query
+                  - description: Query with a rule_id for referencing an external id
+                    from: now-6m
+                    name: Second bulk rule
+                    query: 'user.name: root or user.name: admin'
+                    risk_score: 2
+                    rule_id: query-rule-id-2
+                    severity: low
+                    type: query
             schema:
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleCreateProps'
@@ -10904,11 +10943,19 @@ paths:
   /api/detection_engine/rules/_bulk_delete:
     delete:
       deprecated: true
-      description: Delete detection rules in bulk.
+      description: |
+        Delete detection rules in bulk.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       operationId: BulkDeleteRules
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                  - id: 51658332-a15e-4c9e-912a-67214e2e2359
             schema:
               items:
                 type: object
@@ -10952,11 +10999,19 @@ paths:
         - Security Detections API
     post:
       deprecated: true
-      description: Deletes multiple rules.
+      description: |
+        Deletes multiple rules.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       operationId: BulkDeleteRulesPost
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                  - id: 51658332-a15e-4c9e-912a-67214e2e2359
             schema:
               items:
                 type: object
@@ -11001,11 +11056,35 @@ paths:
   /api/detection_engine/rules/_bulk_update:
     patch:
       deprecated: true
-      description: Update specific fields of existing detection rules using the `rule_id` or `id` field.
+      description: |
+        Update specific fields of existing detection rules using the `rule_id` or `id` field.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
+
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       operationId: BulkPatchRules
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                    threat:
+                      - framework: MITRE ATT&CK
+                        id: TA0001
+                        name: Initial Access
+                        reference: https://attack.mitre.org/tactics/TA0001
+                        tactic: null
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: https://attack.mitre.org/techniques/T1193
+                  - id: 56b22b65-173e-4a5b-b27a-82599cb1433e
+                    name: New name
             schema:
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RulePatchProps'
@@ -11026,17 +11105,41 @@ paths:
       deprecated: true
       description: |
         Update multiple detection rules using the `rule_id` or `id` field. The original rules are replaced, and all unspecified fields are deleted.
-        > info
-        > You cannot modify the `id` or `rule_id` values.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
+
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       operationId: BulkUpdateRules
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                    threat:
+                      - framework: MITRE ATT&CK
+                        id: TA0001
+                        name: Initial Access
+                        reference: https://attack.mitre.org/tactics/TA0001
+                        tactic: null
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: https://attack.mitre.org/techniques/T1193
+                  - id: 56b22b65-173e-4a5b-b27a-82599cb1433e
+                    name: New name
             schema:
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleUpdateProps'
               type: array
-        description: A JSON array where each element includes the `id` or `rule_id` field of the rule you want to update and the fields you want to modify.
+        description: |
+          A JSON array where each element includes the `id` or `rule_id` field of the rule you want to update and the fields you want to modify.
+          > info
+          > All unspecified fields are deleted. You cannot modify the `id` or `rule_id` values.
         required: true
       responses:
         '200':

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -11130,8 +11130,6 @@ paths:
                           - id: T1193
                             name: Spearphishing Attachment
                             reference: https://attack.mitre.org/techniques/T1193
-                  - id: 56b22b65-173e-4a5b-b27a-82599cb1433e
-                    name: New name
             schema:
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleUpdateProps'

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -11119,17 +11119,22 @@ paths:
             examples:
               example1:
                 value:
-                  - rule_id: process_started_by_ms_office_program_possible_payload
-                    threat:
-                      - framework: MITRE ATT&CK
-                        id: TA0001
-                        name: Initial Access
-                        reference: https://attack.mitre.org/tactics/TA0001
-                        tactic: null
-                        technique:
-                          - id: T1193
-                            name: Spearphishing Attachment
-                            reference: https://attack.mitre.org/techniques/T1193
+                  - description: Detects when a previously suspended user's account is renewed in Google Workspace. An adversary may renew a suspended user account to maintain access to the Google Workspace organization with a valid account.
+                    id: 7d2f5ed8-6c05-44ab-81ce-9160ae147057
+                    name: Updated Google Workspace Suspended User Account Renewed
+                    risk_score: 21
+                    severity: critical
+                    tags:
+                      - new_tag
+                    type: query
+                  - description: Identifies the creation of an Amazon Redshift cluster. Unexpected creation of this cluster by a non-administrative user may indicate a permission or role issue with current users. If unexpected, the resource may not properly be configured and could introduce security vulnerabilities.
+                    id: 43b2dc3b-4f21-4a10-95e2-0dbc19e6e974
+                    name: Updated AWS Redshift Cluster Creation
+                    risk_score: 21
+                    severity: medium
+                    tags:
+                      - new_tag
+                    type: query
             schema:
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleUpdateProps'

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -11000,7 +11000,7 @@ paths:
     post:
       deprecated: true
       description: |
-        Deletes multiple rules.
+        Delete detection rules in bulk.
         > warn
         > This API is deprecated and will be removed in Kibana v9.0.
       operationId: BulkDeleteRulesPost
@@ -11137,7 +11137,7 @@ paths:
                 $ref: '#/components/schemas/Security_Detections_API_RuleUpdateProps'
               type: array
         description: |
-          A JSON array where each element includes the `id` or `rule_id` field of the rule you want to update and the fields you want to modify.
+          A JSON array where each element includes the `id` or `rule_id` field of the rule you want to update and the fields you want to be specified in this rule.
           > info
           > All unspecified fields are deleted. You cannot modify the `id` or `rule_id` values.
         required: true

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_create_rules/bulk_create_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_create_rules/bulk_create_rules_route.schema.yaml
@@ -10,7 +10,10 @@ paths:
       operationId: BulkCreateRules
       deprecated: true
       summary: Create multiple detection rules 
-      description: Create new detection rules in bulk.
+      description: |
+        Create new detection rules in bulk.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       tags:
         - Bulk API
       requestBody:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_create_rules/bulk_create_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_create_rules/bulk_create_rules_route.schema.yaml
@@ -14,6 +14,11 @@ paths:
         Create new detection rules in bulk.
         > warn
         > This API is deprecated and will be removed in Kibana v9.0.
+
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       tags:
         - Bulk API
       requestBody:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_create_rules/bulk_create_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_create_rules/bulk_create_rules_route.schema.yaml
@@ -25,6 +25,37 @@ paths:
               type: array
               items:
                 $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RuleCreateProps'
+            examples:
+              example1:
+                value: 
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                    risk_score: 50
+                    description: Process started by MS Office program - possible payload
+                    interval: 5m
+                    name: MS Office child process
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    type: query
+                    from: now-6m
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    language: kuery
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: "Process Create (rule: ProcessCreate)"
+                              type: phrase
+                    enabled: false
+                  - name: Second bulk rule
+                    description: Query with a rule_id for referencing an external id
+                    rule_id: query-rule-id-2
+                    risk_score: 2
+                    severity: low
+                    type: query
+                    from: now-6m
+                    query: "user.name: root or user.name: admin"
       responses:
         200:
           description: Indicates a successful call.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_delete_rules/bulk_delete_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_delete_rules/bulk_delete_rules_route.schema.yaml
@@ -30,6 +30,11 @@ paths:
                     $ref: '../../../model/rule_schema/common_attributes.schema.yaml#/components/schemas/RuleObjectId'
                   rule_id:
                     $ref: '../../../model/rule_schema/common_attributes.schema.yaml#/components/schemas/RuleSignatureId'
+            examples:
+              example1: 
+                value: 
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                  - id: 51658332-a15e-4c9e-912a-67214e2e2359
       responses:
         200:
           description: Indicates a successful call.
@@ -84,6 +89,11 @@ paths:
                     $ref: '../../../model/rule_schema/common_attributes.schema.yaml#/components/schemas/RuleObjectId'
                   rule_id:
                     $ref: '../../../model/rule_schema/common_attributes.schema.yaml#/components/schemas/RuleSignatureId'
+            examples:
+              example1: 
+                value: 
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                  - id: 51658332-a15e-4c9e-912a-67214e2e2359
       responses:
         200:
           description: Indicates a successful call.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_delete_rules/bulk_delete_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_delete_rules/bulk_delete_rules_route.schema.yaml
@@ -10,7 +10,10 @@ paths:
       operationId: BulkDeleteRules
       deprecated: true
       summary: Delete multiple detection rules
-      description: Delete detection rules in bulk.
+      description: |
+        Delete detection rules in bulk.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       tags:
         - Bulk API
       requestBody:
@@ -61,7 +64,10 @@ paths:
       operationId: BulkDeleteRulesPost
       deprecated: true
       summary: Delete multiple detection rules
-      description: Deletes multiple rules.
+      description: |
+        Deletes multiple rules.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       tags:
         - Bulk API
       requestBody:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_delete_rules/bulk_delete_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_delete_rules/bulk_delete_rules_route.schema.yaml
@@ -70,7 +70,7 @@ paths:
       deprecated: true
       summary: Delete multiple detection rules
       description: |
-        Deletes multiple rules.
+        Delete detection rules in bulk.
         > warn
         > This API is deprecated and will be removed in Kibana v9.0.
       tags:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_patch_rules/bulk_patch_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_patch_rules/bulk_patch_rules_route.schema.yaml
@@ -25,6 +25,22 @@ paths:
               type: array
               items:
                 $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RulePatchProps'
+            examples:
+              example1:
+                value:
+                  - threat:
+                      - framework: MITRE ATT&CK
+                        tactic:
+                        id: TA0001
+                        reference: https://attack.mitre.org/tactics/TA0001
+                        name: Initial Access
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: https://attack.mitre.org/techniques/T1193
+                    rule_id: process_started_by_ms_office_program_possible_payload
+                  - name: New name
+                    id: 56b22b65-173e-4a5b-b27a-82599cb1433e
       responses:
         200:
           description: Indicates a successful call.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_patch_rules/bulk_patch_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_patch_rules/bulk_patch_rules_route.schema.yaml
@@ -14,6 +14,11 @@ paths:
         Update specific fields of existing detection rules using the `rule_id` or `id` field.
         > warn
         > This API is deprecated and will be removed in Kibana v9.0.
+
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       tags:
         - Bulk API
       requestBody:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_patch_rules/bulk_patch_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_patch_rules/bulk_patch_rules_route.schema.yaml
@@ -10,7 +10,10 @@ paths:
       summary: Patch multiple detection rules
       operationId: BulkPatchRules
       deprecated: true
-      description: Update specific fields of existing detection rules using the `rule_id` or `id` field.
+      description: |
+        Update specific fields of existing detection rules using the `rule_id` or `id` field.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       tags:
         - Bulk API
       requestBody:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
@@ -36,17 +36,22 @@ paths:
             examples:
               example1:
                 value:
-                  - threat:
-                      - framework: MITRE ATT&CK
-                        tactic:
-                        id: TA0001
-                        reference: https://attack.mitre.org/tactics/TA0001
-                        name: Initial Access
-                        technique:
-                          - id: T1193
-                            name: Spearphishing Attachment
-                            reference: https://attack.mitre.org/techniques/T1193
-                    rule_id: process_started_by_ms_office_program_possible_payload
+                  - id: "7d2f5ed8-6c05-44ab-81ce-9160ae147057"
+                    name: "Updated Google Workspace Suspended User Account Renewed"
+                    tags:
+                      - "new_tag"
+                    description: "Detects when a previously suspended user's account is renewed in Google Workspace. An adversary may renew a suspended user account to maintain access to the Google Workspace organization with a valid account."
+                    risk_score: 21
+                    severity: "critical"
+                    type: "query"
+                  - id: "43b2dc3b-4f21-4a10-95e2-0dbc19e6e974"
+                    name: "Updated AWS Redshift Cluster Creation"
+                    tags:
+                      - "new_tag"
+                    description: "Identifies the creation of an Amazon Redshift cluster. Unexpected creation of this cluster by a non-administrative user may indicate a permission or role issue with current users. If unexpected, the resource may not properly be configured and could introduce security vulnerabilities."
+                    risk_score: 21
+                    severity: "medium"
+                    type: "query"
       responses:
         200:
           description: Indicates a successful call.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
@@ -14,6 +14,9 @@ paths:
         Update multiple detection rules using the `rule_id` or `id` field. The original rules are replaced, and all unspecified fields are deleted.
         > info
         > You cannot modify the `id` or `rule_id` values.
+        
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       tags:
         - Bulk API
       requestBody:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
@@ -12,15 +12,20 @@ paths:
       summary: Update multiple detection rules
       description: |
         Update multiple detection rules using the `rule_id` or `id` field. The original rules are replaced, and all unspecified fields are deleted.
-        > info
-        > You cannot modify the `id` or `rule_id` values.
-
         > warn
         > This API is deprecated and will be removed in Kibana v9.0.
+
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       tags:
         - Bulk API
       requestBody:
-        description: A JSON array where each element includes the `id` or `rule_id` field of the rule you want to update and the fields you want to modify.
+        description: |
+          A JSON array where each element includes the `id` or `rule_id` field of the rule you want to update and the fields you want to modify.
+          > info
+          > All unspecified fields are deleted. You cannot modify the `id` or `rule_id` values.
         required: true
         content:
           application/json:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
@@ -42,7 +42,7 @@ paths:
                       - "new_tag"
                     description: "Detects when a previously suspended user's account is renewed in Google Workspace. An adversary may renew a suspended user account to maintain access to the Google Workspace organization with a valid account."
                     risk_score: 21
-                    severity: "critical"
+                    severity: "low"
                     type: "query"
                   - id: "43b2dc3b-4f21-4a10-95e2-0dbc19e6e974"
                     name: "Updated AWS Redshift Cluster Creation"
@@ -50,7 +50,7 @@ paths:
                       - "new_tag"
                     description: "Identifies the creation of an Amazon Redshift cluster. Unexpected creation of this cluster by a non-administrative user may indicate a permission or role issue with current users. If unexpected, the resource may not properly be configured and could introduce security vulnerabilities."
                     risk_score: 21
-                    severity: "medium"
+                    severity: "low"
                     type: "query"
       responses:
         200:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
@@ -23,7 +23,7 @@ paths:
         - Bulk API
       requestBody:
         description: |
-          A JSON array where each element includes the `id` or `rule_id` field of the rule you want to update and the fields you want to modify.
+          A JSON array where each element includes the `id` or `rule_id` field of the rule you want to update and the fields you want to be specified in this rule.
           > info
           > All unspecified fields are deleted. You cannot modify the `id` or `rule_id` values.
         required: true

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
@@ -47,8 +47,6 @@ paths:
                             name: Spearphishing Attachment
                             reference: https://attack.mitre.org/techniques/T1193
                     rule_id: process_started_by_ms_office_program_possible_payload
-                  - name: New name
-                    id: 56b22b65-173e-4a5b-b27a-82599cb1433e
       responses:
         200:
           description: Indicates a successful call.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml
@@ -14,7 +14,7 @@ paths:
         Update multiple detection rules using the `rule_id` or `id` field. The original rules are replaced, and all unspecified fields are deleted.
         > info
         > You cannot modify the `id` or `rule_id` values.
-        
+
         > warn
         > This API is deprecated and will be removed in Kibana v9.0.
       tags:
@@ -28,6 +28,22 @@ paths:
               type: array
               items:
                 $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RuleUpdateProps'
+            examples:
+              example1:
+                value:
+                  - threat:
+                      - framework: MITRE ATT&CK
+                        tactic:
+                        id: TA0001
+                        reference: https://attack.mitre.org/tactics/TA0001
+                        name: Initial Access
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: https://attack.mitre.org/techniques/T1193
+                    rule_id: process_started_by_ms_office_program_possible_payload
+                  - name: New name
+                    id: 56b22b65-173e-4a5b-b27a-82599cb1433e
       responses:
         200:
           description: Indicates a successful call.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
@@ -491,8 +491,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Create new detection rules in bulk.
-   */
+    * Create new detection rules in bulk.
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
+
+    */
   async bulkCreateRules(props: BulkCreateRulesProps) {
     this.log.info(`${new Date().toISOString()} Calling API BulkCreateRules`);
     return this.kbnClient
@@ -507,8 +510,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Delete detection rules in bulk.
-   */
+    * Delete detection rules in bulk.
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
+
+    */
   async bulkDeleteRules(props: BulkDeleteRulesProps) {
     this.log.info(`${new Date().toISOString()} Calling API BulkDeleteRules`);
     return this.kbnClient
@@ -523,8 +529,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Deletes multiple rules.
-   */
+    * Deletes multiple rules.
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
+
+    */
   async bulkDeleteRulesPost(props: BulkDeleteRulesPostProps) {
     this.log.info(`${new Date().toISOString()} Calling API BulkDeleteRulesPost`);
     return this.kbnClient
@@ -539,8 +548,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Update specific fields of existing detection rules using the `rule_id` or `id` field.
-   */
+    * Update specific fields of existing detection rules using the `rule_id` or `id` field.
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
+
+    */
   async bulkPatchRules(props: BulkPatchRulesProps) {
     this.log.info(`${new Date().toISOString()} Calling API BulkPatchRules`);
     return this.kbnClient
@@ -558,6 +570,9 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
     * Update multiple detection rules using the `rule_id` or `id` field. The original rules are replaced, and all unspecified fields are deleted.
 > info
 > You cannot modify the `id` or `rule_id` values.
+
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
 
     */
   async bulkUpdateRules(props: BulkUpdateRulesProps) {

--- a/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
@@ -495,6 +495,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
 > warn
 > This API is deprecated and will be removed in Kibana v9.0.
 
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
     */
   async bulkCreateRules(props: BulkCreateRulesProps) {
     this.log.info(`${new Date().toISOString()} Calling API BulkCreateRules`);
@@ -552,6 +557,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
 > warn
 > This API is deprecated and will be removed in Kibana v9.0.
 
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
     */
   async bulkPatchRules(props: BulkPatchRulesProps) {
     this.log.info(`${new Date().toISOString()} Calling API BulkPatchRules`);
@@ -568,11 +578,13 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
   }
   /**
     * Update multiple detection rules using the `rule_id` or `id` field. The original rules are replaced, and all unspecified fields are deleted.
-> info
-> You cannot modify the `id` or `rule_id` values.
-
 > warn
 > This API is deprecated and will be removed in Kibana v9.0.
+
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
 
     */
   async bulkUpdateRules(props: BulkUpdateRulesProps) {

--- a/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
@@ -534,7 +534,7 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-    * Deletes multiple rules.
+    * Delete detection rules in bulk.
 > warn
 > This API is deprecated and will be removed in Kibana v9.0.
 

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -643,17 +643,32 @@ paths:
             examples:
               example1:
                 value:
-                  - rule_id: process_started_by_ms_office_program_possible_payload
-                    threat:
-                      - framework: MITRE ATT&CK
-                        id: TA0001
-                        name: Initial Access
-                        reference: 'https://attack.mitre.org/tactics/TA0001'
-                        tactic: null
-                        technique:
-                          - id: T1193
-                            name: Spearphishing Attachment
-                            reference: 'https://attack.mitre.org/techniques/T1193'
+                  - description: >-
+                      Detects when a previously suspended user's account is
+                      renewed in Google Workspace. An adversary may renew a
+                      suspended user account to maintain access to the Google
+                      Workspace organization with a valid account.
+                    id: 7d2f5ed8-6c05-44ab-81ce-9160ae147057
+                    name: Updated Google Workspace Suspended User Account Renewed
+                    risk_score: 21
+                    severity: critical
+                    tags:
+                      - new_tag
+                    type: query
+                  - description: >-
+                      Identifies the creation of an Amazon Redshift cluster.
+                      Unexpected creation of this cluster by a
+                      non-administrative user may indicate a permission or role
+                      issue with current users. If unexpected, the resource may
+                      not properly be configured and could introduce security
+                      vulnerabilities.
+                    id: 43b2dc3b-4f21-4a10-95e2-0dbc19e6e974
+                    name: Updated AWS Redshift Cluster Creation
+                    risk_score: 21
+                    severity: medium
+                    tags:
+                      - new_tag
+                    type: query
             schema:
               items:
                 $ref: '#/components/schemas/RuleUpdateProps'

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -363,6 +363,43 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - description: Process started by MS Office program - possible payload
+                    enabled: false
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-6m
+                    interval: 5m
+                    language: kuery
+                    name: MS Office child process
+                    query: >-
+                      process.parent.name:EXCEL.EXE or
+                      process.parent.name:MSPUB.EXE or
+                      process.parent.name:OUTLOOK.EXE or
+                      process.parent.name:POWERPNT.EXE or
+                      process.parent.name:VISIO.EXE or
+                      process.parent.name:WINWORD.EXE
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program_possible_payload
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    type: query
+                  - description: Query with a rule_id for referencing an external id
+                    from: now-6m
+                    name: Second bulk rule
+                    query: 'user.name: root or user.name: admin'
+                    risk_score: 2
+                    rule_id: query-rule-id-2
+                    severity: low
+                    type: query
             schema:
               items:
                 $ref: '#/components/schemas/RuleCreateProps'
@@ -391,6 +428,11 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                  - id: 51658332-a15e-4c9e-912a-67214e2e2359
             schema:
               items:
                 type: object
@@ -445,6 +487,11 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                  - id: 51658332-a15e-4c9e-912a-67214e2e2359
             schema:
               items:
                 type: object
@@ -503,6 +550,22 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                    threat:
+                      - framework: MITRE ATT&CK
+                        id: TA0001
+                        name: Initial Access
+                        reference: 'https://attack.mitre.org/tactics/TA0001'
+                        tactic: null
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: 'https://attack.mitre.org/techniques/T1193'
+                  - id: 56b22b65-173e-4a5b-b27a-82599cb1433e
+                    name: New name
             schema:
               items:
                 $ref: '#/components/schemas/RulePatchProps'
@@ -538,6 +601,22 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                value:
+                  - rule_id: process_started_by_ms_office_program_possible_payload
+                    threat:
+                      - framework: MITRE ATT&CK
+                        id: TA0001
+                        name: Initial Access
+                        reference: 'https://attack.mitre.org/tactics/TA0001'
+                        tactic: null
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: 'https://attack.mitre.org/techniques/T1193'
+                  - id: 56b22b65-173e-4a5b-b27a-82599cb1433e
+                    name: New name
             schema:
               items:
                 $ref: '#/components/schemas/RuleUpdateProps'

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -496,7 +496,7 @@ paths:
     post:
       deprecated: true
       description: |
-        Deletes multiple rules.
+        Delete detection rules in bulk.
         > warn
         > This API is deprecated and will be removed in Kibana v9.0.
       operationId: BulkDeleteRulesPost
@@ -662,7 +662,8 @@ paths:
               type: array
         description: >
           A JSON array where each element includes the `id` or `rule_id` field
-          of the rule you want to update and the fields you want to modify.
+          of the rule you want to update and the fields you want to be specified
+          in this rule.
 
           > info
 

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -654,8 +654,6 @@ paths:
                           - id: T1193
                             name: Spearphishing Attachment
                             reference: 'https://attack.mitre.org/techniques/T1193'
-                  - id: 56b22b65-173e-4a5b-b27a-82599cb1433e
-                    name: New name
             schema:
               items:
                 $ref: '#/components/schemas/RuleUpdateProps'

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -355,10 +355,26 @@ paths:
   /api/detection_engine/rules/_bulk_create:
     post:
       deprecated: true
-      description: |
+      description: >
         Create new detection rules in bulk.
+
         > warn
+
         > This API is deprecated and will be removed in Kibana v9.0.
+
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
       operationId: BulkCreateRules
       requestBody:
         content:
@@ -546,6 +562,20 @@ paths:
         > warn
 
         > This API is deprecated and will be removed in Kibana v9.0.
+
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
       operationId: BulkPatchRules
       requestBody:
         content:
@@ -589,14 +619,23 @@ paths:
         Update multiple detection rules using the `rule_id` or `id` field. The
         original rules are replaced, and all unspecified fields are deleted.
 
-        > info
+        > warn
 
-        > You cannot modify the `id` or `rule_id` values.
+        > This API is deprecated and will be removed in Kibana v9.0.
 
 
         > warn
 
-        > This API is deprecated and will be removed in Kibana v9.0.
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
       operationId: BulkUpdateRules
       requestBody:
         content:
@@ -621,9 +660,14 @@ paths:
               items:
                 $ref: '#/components/schemas/RuleUpdateProps'
               type: array
-        description: >-
+        description: >
           A JSON array where each element includes the `id` or `rule_id` field
           of the rule you want to update and the fields you want to modify.
+
+          > info
+
+          > All unspecified fields are deleted. You cannot modify the `id` or
+          `rule_id` values.
         required: true
       responses:
         '200':

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -355,7 +355,10 @@ paths:
   /api/detection_engine/rules/_bulk_create:
     post:
       deprecated: true
-      description: Create new detection rules in bulk.
+      description: |
+        Create new detection rules in bulk.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       operationId: BulkCreateRules
       requestBody:
         content:
@@ -380,7 +383,10 @@ paths:
   /api/detection_engine/rules/_bulk_delete:
     delete:
       deprecated: true
-      description: Delete detection rules in bulk.
+      description: |
+        Delete detection rules in bulk.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       operationId: BulkDeleteRules
       requestBody:
         content:
@@ -431,7 +437,10 @@ paths:
         - Bulk API
     post:
       deprecated: true
-      description: Deletes multiple rules.
+      description: |
+        Deletes multiple rules.
+        > warn
+        > This API is deprecated and will be removed in Kibana v9.0.
       operationId: BulkDeleteRulesPost
       requestBody:
         content:
@@ -483,9 +492,13 @@ paths:
   /api/detection_engine/rules/_bulk_update:
     patch:
       deprecated: true
-      description: >-
+      description: >
         Update specific fields of existing detection rules using the `rule_id`
         or `id` field.
+
+        > warn
+
+        > This API is deprecated and will be removed in Kibana v9.0.
       operationId: BulkPatchRules
       requestBody:
         content:
@@ -516,6 +529,11 @@ paths:
         > info
 
         > You cannot modify the `id` or `rule_id` values.
+
+
+        > warn
+
+        > This API is deprecated and will be removed in Kibana v9.0.
       operationId: BulkUpdateRules
       requestBody:
         content:

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -651,7 +651,7 @@ paths:
                     id: 7d2f5ed8-6c05-44ab-81ce-9160ae147057
                     name: Updated Google Workspace Suspended User Account Renewed
                     risk_score: 21
-                    severity: critical
+                    severity: low
                     tags:
                       - new_tag
                     type: query
@@ -665,7 +665,7 @@ paths:
                     id: 43b2dc3b-4f21-4a10-95e2-0dbc19e6e974
                     name: Updated AWS Redshift Cluster Creation
                     risk_score: 21
-                    severity: medium
+                    severity: low
                     tags:
                       - new_tag
                     type: query

--- a/x-pack/test/api_integration/services/security_solution_api.gen.ts
+++ b/x-pack/test/api_integration/services/security_solution_api.gen.ts
@@ -226,6 +226,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
 > warn
 > This API is deprecated and will be removed in Kibana v9.0.
 
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
       */
     bulkCreateRules(props: BulkCreateRulesProps, kibanaSpace: string = 'default') {
       return supertest
@@ -268,6 +273,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
 > warn
 > This API is deprecated and will be removed in Kibana v9.0.
 
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
       */
     bulkPatchRules(props: BulkPatchRulesProps, kibanaSpace: string = 'default') {
       return supertest
@@ -279,11 +289,13 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
     },
     /**
       * Update multiple detection rules using the `rule_id` or `id` field. The original rules are replaced, and all unspecified fields are deleted.
-> info
-> You cannot modify the `id` or `rule_id` values.
-
 > warn
 > This API is deprecated and will be removed in Kibana v9.0.
+
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
 
       */
     bulkUpdateRules(props: BulkUpdateRulesProps, kibanaSpace: string = 'default') {

--- a/x-pack/test/api_integration/services/security_solution_api.gen.ts
+++ b/x-pack/test/api_integration/services/security_solution_api.gen.ts
@@ -255,7 +255,7 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
         .send(props.body as object);
     },
     /**
-      * Deletes multiple rules.
+      * Delete detection rules in bulk.
 > warn
 > This API is deprecated and will be removed in Kibana v9.0.
 

--- a/x-pack/test/api_integration/services/security_solution_api.gen.ts
+++ b/x-pack/test/api_integration/services/security_solution_api.gen.ts
@@ -222,8 +222,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
     /**
-     * Create new detection rules in bulk.
-     */
+      * Create new detection rules in bulk.
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
+
+      */
     bulkCreateRules(props: BulkCreateRulesProps, kibanaSpace: string = 'default') {
       return supertest
         .post(routeWithNamespace('/api/detection_engine/rules/_bulk_create', kibanaSpace))
@@ -233,8 +236,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
         .send(props.body as object);
     },
     /**
-     * Delete detection rules in bulk.
-     */
+      * Delete detection rules in bulk.
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
+
+      */
     bulkDeleteRules(props: BulkDeleteRulesProps, kibanaSpace: string = 'default') {
       return supertest
         .delete(routeWithNamespace('/api/detection_engine/rules/_bulk_delete', kibanaSpace))
@@ -244,8 +250,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
         .send(props.body as object);
     },
     /**
-     * Deletes multiple rules.
-     */
+      * Deletes multiple rules.
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
+
+      */
     bulkDeleteRulesPost(props: BulkDeleteRulesPostProps, kibanaSpace: string = 'default') {
       return supertest
         .post(routeWithNamespace('/api/detection_engine/rules/_bulk_delete', kibanaSpace))
@@ -255,8 +264,11 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
         .send(props.body as object);
     },
     /**
-     * Update specific fields of existing detection rules using the `rule_id` or `id` field.
-     */
+      * Update specific fields of existing detection rules using the `rule_id` or `id` field.
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
+
+      */
     bulkPatchRules(props: BulkPatchRulesProps, kibanaSpace: string = 'default') {
       return supertest
         .patch(routeWithNamespace('/api/detection_engine/rules/_bulk_update', kibanaSpace))
@@ -269,6 +281,9 @@ after 30 days. It also deletes other artifacts specific to the migration impleme
       * Update multiple detection rules using the `rule_id` or `id` field. The original rules are replaced, and all unspecified fields are deleted.
 > info
 > You cannot modify the `id` or `rule_id` values.
+
+> warn
+> This API is deprecated and will be removed in Kibana v9.0.
 
       */
     bulkUpdateRules(props: BulkUpdateRulesProps, kibanaSpace: string = 'default') {


### PR DESCRIPTION
**Partially addresses:** #211808, https://github.com/elastic/security-docs/issues/5981 (internal)

## Summary

This is the third part of the migration effort, containing changes for BULK CRUD:
- adding a note informing of removing this API in v.9.0
- migrating examples
- adding infos in description

This PR will be backported only to versions for Kibana v8

# Testing
1. cd x-pack/solutions/security/plugins/security_solution
2. yarn openapi:bundle:detections 
3. Take the bundled file (docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml) and load it into bump.sh console to see the changes. 
4. Compare the changes with the [Legacy documentation](https://www.elastic.co/guide/en/security/current/rule-api-overview.html)

You can also use this [link](https://bump.sh/jkelas2/doc/kibana_wip3/) where I deployed the generated bundled doc.