### PR TITLE
[Shared UX] Omit Uptime integration/tutorial on Serverless

### DIFF
--- a/src/platform/plugins/shared/home/server/plugin.ts
+++ b/src/platform/plugins/shared/home/server/plugin.ts
@@ -36,10 +36,7 @@ export class HomeServerPlugin implements Plugin<HomeServerPluginSetup, HomeServe
 
   constructor(private readonly initContext: PluginInitializerContext) {
     this.sampleDataRegistry = new SampleDataRegistry(this.initContext);
-    this.tutorialsRegistry = new TutorialsRegistry(
-      this.initContext,
-      this.initContext.env.packageInfo.buildFlavor === 'serverless'
-    );
+    this.tutorialsRegistry = new TutorialsRegistry(this.initContext);
     this.isDevMode = this.initContext.env.mode.dev;
   }
 

--- a/src/platform/plugins/shared/home/server/plugin.ts
+++ b/src/platform/plugins/shared/home/server/plugin.ts
@@ -36,7 +36,10 @@ export class HomeServerPlugin implements Plugin<HomeServerPluginSetup, HomeServe
 
   constructor(private readonly initContext: PluginInitializerContext) {
     this.sampleDataRegistry = new SampleDataRegistry(this.initContext);
-    this.tutorialsRegistry = new TutorialsRegistry(this.initContext);
+    this.tutorialsRegistry = new TutorialsRegistry(
+      this.initContext,
+      this.initContext.env.packageInfo.buildFlavor === 'serverless'
+    );
     this.isDevMode = this.initContext.env.mode.dev;
   }
 

--- a/src/platform/plugins/shared/home/server/services/tutorials/lib/tutorial_schema.ts
+++ b/src/platform/plugins/shared/home/server/services/tutorials/lib/tutorial_schema.ts
@@ -137,6 +137,8 @@ export const tutorialSchema = schema.object({
   onPremElasticCloud: schema.maybe(instructionsSchema),
   // Elastic stack artifacts produced by product when it is setup and run.
   artifacts: schema.maybe(artifactsSchema),
+  // Indicates the tutorial will not be available in serverless
+  omitServerless: schema.maybe(schema.boolean()),
 
   customStatusCheckName: schema.maybe(schema.string()),
 

--- a/src/platform/plugins/shared/home/server/services/tutorials/tutorials_registry.ts
+++ b/src/platform/plugins/shared/home/server/services/tutorials/tutorials_registry.ts
@@ -156,6 +156,7 @@ export class TutorialsRegistry {
     if (customIntegrations) {
       builtInTutorials.forEach((provider) => {
         const tutorial = provider(this.baseTutorialContext);
+        if (tutorial.omitServerless && this.isServerless) return;
         registerBeatsTutorialsWithCustomIntegrations(core, customIntegrations, tutorial);
       });
     }

--- a/src/platform/plugins/shared/home/server/services/tutorials/tutorials_registry.ts
+++ b/src/platform/plugins/shared/home/server/services/tutorials/tutorials_registry.ts
@@ -74,7 +74,10 @@ export class TutorialsRegistry {
   private readonly scopedTutorialContextFactories: TutorialContextFactory[] = [];
   private staticAssets!: IStaticAssets;
 
-  constructor(private readonly initContext: PluginInitializerContext) {}
+  constructor(
+    private readonly initContext: PluginInitializerContext,
+    private readonly isServerless = false
+  ) {}
 
   public setup(core: CoreSetup, customIntegrations?: CustomIntegrationsPluginSetup) {
     this.staticAssets = core.http.staticAssets;
@@ -100,10 +103,13 @@ export class TutorialsRegistry {
           },
           initialContext
         );
+        const tutorials = this.tutorialProviders.map((tutorialProvider) => {
+          return tutorialProvider(scopedContext); // All the tutorialProviders need to be refactored so that they don't need the server.
+        });
         return res.ok({
-          body: this.tutorialProviders.map((tutorialProvider) => {
-            return tutorialProvider(scopedContext); // All the tutorialProviders need to be refactored so that they don't need the server.
-          }),
+          body: this.isServerless
+            ? tutorials.filter(({ omitServerless }) => !omitServerless)
+            : tutorials,
         });
       }
     );

--- a/src/platform/plugins/shared/home/server/services/tutorials/tutorials_registry.ts
+++ b/src/platform/plugins/shared/home/server/services/tutorials/tutorials_registry.ts
@@ -73,11 +73,11 @@ export class TutorialsRegistry {
   private tutorialProviders: TutorialProvider[] = []; // pre-register all the tutorials we know we want in here
   private readonly scopedTutorialContextFactories: TutorialContextFactory[] = [];
   private staticAssets!: IStaticAssets;
+  private readonly isServerless: boolean;
 
-  constructor(
-    private readonly initContext: PluginInitializerContext,
-    private readonly isServerless = false
-  ) {}
+  constructor(private readonly initContext: PluginInitializerContext) {
+    this.isServerless = this.initContext.env.packageInfo.buildFlavor === 'serverless';
+  }
 
   public setup(core: CoreSetup, customIntegrations?: CustomIntegrationsPluginSetup) {
     this.staticAssets = core.http.staticAssets;

--- a/src/platform/plugins/shared/home/server/tutorials/uptime_monitors/index.ts
+++ b/src/platform/plugins/shared/home/server/tutorials/uptime_monitors/index.ts
@@ -57,6 +57,7 @@ export function uptimeMonitorsSpecProvider(context: TutorialContext): TutorialSc
     previewImagePath: context.staticAssets.getPluginAssetHref('/uptime_monitors/screenshot.webp'),
     onPrem: onPremInstructions([], context),
     elasticCloud: cloudInstructions(context),
+    omitServerless: true,
     onPremElasticCloud: onPremCloudInstructions(context),
     integrationBrowserCategories: ['observability'],
   };


### PR DESCRIPTION
## Summary

Resolves #211945.

Uptime is not available on Serverless projects, so we are seeking to remove the tutorial and the integration search result. 

To achieve this, I added an optional `omitServerless` field to the tutorial spec and implemented it on the Uptime tutorial spec. I added additional filtering to the registration procedures, and referenced the `buildFlavor` in the plugin's setup code.

_NOTE:_ This resolves #211945, but if this solution is not acceptable to the maintainers please advise me on a better approach.

Example:

<img width="898" alt="image" src="https://github.com/user-attachments/assets/5ebd52a0-b8e8-4198-9a92-d67fa4ad0ff4" />

<img width="696" alt="image" src="https://github.com/user-attachments/assets/b2b1ec65-6353-4415-a55f-33ac9f7977fe" />



<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->