### PR TITLE
Fix wrong permission key for dashboard in analytics overview

### DIFF
--- a/src/platform/plugins/private/kibana_overview/public/components/overview/overview.tsx
+++ b/src/platform/plugins/private/kibana_overview/public/components/overview/overview.tsx
@@ -167,8 +167,7 @@ export const Overview: FC<Props> = ({ newsFetchResult, solutions, features }) =>
   const remainingApps = kibanaApps.map(({ id }) => id).filter((id) => !mainApps.includes(id));
   const mainAppsUserHasAccessTo = useMemo(() => {
     const applications = [];
-
-    if (application.capabilities.dashboards_v2?.show) {
+    if (application.capabilities.dashboard_v2?.show) {
       applications.push('dashboards');
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug introduced in #213198 - wrong capability name was being used.

Related to the fix from https://github.com/elastic/kibana/issues/212171



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->