### PR TITLE
[Search] fix(index_details): reduce sample documents from 50 to 10

### DIFF
--- a/x-pack/solutions/search/packages/kbn-search-index-documents/lib/fetch_search_results.ts
+++ b/x-pack/solutions/search/packages/kbn-search-index-documents/lib/fetch_search_results.ts
@@ -19,9 +19,9 @@ export const fetchSearchResults = async (
   size: number = DEFAULT_DOCS_PER_PAGE,
   trackTotalHits: boolean = false
 ): Promise<Paginate<SearchHit>> => {
-  const result = await fetchWithPagination(
-    async () =>
-      await client.search({
+  return fetchWithPagination(
+    () =>
+      client.search({
         from,
         index: indexName,
         size,
@@ -31,8 +31,4 @@ export const fetchSearchResults = async (
     from,
     size
   );
-  return {
-    ...result,
-    data: result.data,
-  };
 };

--- a/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/constants.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/constants.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
- */
-
-export const DEFAULT_PAGE_SIZE = 50;

--- a/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/recent_docs_action_message.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/recent_docs_action_message.tsx
@@ -10,8 +10,7 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiLink, EuiPanel } from '@elastic/eui';
 import { useKibana } from '../../hooks/use_kibana';
-
-import { DEFAULT_PAGE_SIZE } from './constants';
+import { DEFAULT_DOCUMENT_PAGE_SIZE } from '../../constants';
 
 export interface RecentDocsActionMessageProps {
   indexName: string;
@@ -40,7 +39,7 @@ export const RecentDocsActionMessage: React.FC<RecentDocsActionMessageProps> = (
               defaultMessage:
                 'You are viewing the {pageSize} most recently ingested documents in this index. To see all documents, view in',
               values: {
-                pageSize: DEFAULT_PAGE_SIZE,
+                pageSize: DEFAULT_DOCUMENT_PAGE_SIZE,
               },
             })}{' '}
             <EuiLink onClick={onClick}>

--- a/x-pack/solutions/search/plugins/search_indices/public/constants.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/constants.ts
@@ -23,4 +23,4 @@ export const ELASTICSEARCH_URL_PLACEHOLDER = 'https://your_deployment_url';
 export const API_KEY_PLACEHOLDER = 'YOUR_API_KEY';
 export const INDEX_PLACEHOLDER = 'my-index';
 
-export const DEFAULT_DOCUMENT_PAGE_SIZE = 50;
+export const DEFAULT_DOCUMENT_PAGE_SIZE = 10;


### PR DESCRIPTION
## Summary

Reduced the number of documents we show on the index details page from 50 to 10 to reduce the memory footprint of polling with this query. Additionally I refactored some of the server code to be have less intermediate variables that were unnecessary.

### Alternative

This is the easier approach, I did consider updating the endpoint to stream the response instead which could also solve this problem. But that would require a lot of custom handling for pagination etc. so I opted for this simpler solution for now if it is acceptable.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
