### PR TITLE
[8.x] [Obs AI Assistant] fix flaky test and add back test in settings (#213196)

### DIFF
--- a/x-pack/test/observability_ai_assistant_functional/common/ui/index.ts
+++ b/x-pack/test/observability_ai_assistant_functional/common/ui/index.ts
@@ -67,6 +67,8 @@ const pages = {
       'management-settings-editField-observability:aiAssistantSearchConnectorIndexPattern',
     saveButton: 'observabilityAiAssistantManagementBottomBarActionsButton',
     aiAssistantCard: 'aiAssistantSelectionPageObservabilityCard',
+    resetToDefaultLink:
+      'management-settings-resetField-observability:aiAssistantSearchConnectorIndexPattern',
   },
 };
 

--- a/x-pack/test/observability_ai_assistant_functional/tests/feature_controls/settings_security.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/feature_controls/settings_security.spec.ts
@@ -8,15 +8,17 @@
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { createAndLoginUserWithCustomRole, deleteAndLogoutUser } from './helpers';
+import { interceptRequest } from '../../common/intercept_request';
 
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
-  const browser = getService('browser');
   const PageObjects = getPageObjects(['common', 'error', 'navigationalSearch', 'security']);
   const ui = getService('observabilityAIAssistantUI');
   const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
+  const toasts = getService('toasts');
+  const driver = getService('__webdriver__');
 
-  // Failing: See https://github.com/elastic/kibana/issues/191707
-  describe.skip('ai assistant management privileges', () => {
+  describe('ai assistant management privileges', () => {
     describe('all privileges', () => {
       before(async () => {
         await createAndLoginUserWithCustomRole(getPageObjects, getService, {
@@ -59,22 +61,68 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await testSubjects.existOrFail(ui.pages.settings.settingsPage);
       });
       it('allows updating of an advanced setting', async () => {
-        const testSearchConnectorIndexPattern = 'my-logs-index-pattern';
+        await PageObjects.common.navigateToUrl('obsAIAssistantManagement', '', {
+          ensureCurrentUrl: false,
+          shouldLoginIfPrompted: false,
+          shouldUseHashForSubUrl: false,
+        });
+        const testSearchConnectorIndexPattern = 'my-search-index-pattern';
         const searchConnectorIndexPatternInput = await testSubjects.find(
           ui.pages.settings.searchConnectorIndexPatternInput
         );
+        // make sure the input is empty (default value)
         await searchConnectorIndexPatternInput.clearValue();
         await searchConnectorIndexPatternInput.type(testSearchConnectorIndexPattern);
         const saveButton = await testSubjects.find(ui.pages.settings.saveButton);
         await saveButton.click();
-        await browser.refresh();
-        const searchConnectorIndexPatternInputValue =
-          await searchConnectorIndexPatternInput.getAttribute('value');
-        expect(searchConnectorIndexPatternInputValue).to.be(testSearchConnectorIndexPattern);
-        // reset the value
-        await searchConnectorIndexPatternInput.clearValue();
-        await searchConnectorIndexPatternInput.type('logs-*');
+        // wait for page to refrsh
+        await testSubjects.missingOrFail(ui.pages.settings.searchConnectorIndexPatternInput, {
+          timeout: 2000,
+        });
+        // wait for the new page to fully load
+        await testSubjects.existOrFail(ui.pages.settings.searchConnectorIndexPatternInput, {
+          timeout: 2000,
+        });
+        expect(await searchConnectorIndexPatternInput.getAttribute('value')).to.be(
+          testSearchConnectorIndexPattern
+        );
+        // reset the value back to default
+        const resetToDefaultLink = await testSubjects.find(ui.pages.settings.resetToDefaultLink);
+        await resetToDefaultLink.click();
+
+        expect(await searchConnectorIndexPatternInput.getAttribute('value')).to.be('');
         await saveButton.click();
+        await testSubjects.missingOrFail(ui.pages.settings.searchConnectorIndexPatternInput, {
+          timeout: 2000,
+        });
+        // wait for the new page to fully load
+        await testSubjects.existOrFail(ui.pages.settings.searchConnectorIndexPatternInput, {
+          timeout: 2000,
+        });
+        expect(await searchConnectorIndexPatternInput.getAttribute('value')).to.be('');
+      });
+      it('displays failure toast on failed request', async () => {
+        const searchConnectorIndexPatternInput = await testSubjects.find(
+          ui.pages.settings.searchConnectorIndexPatternInput
+        );
+        await searchConnectorIndexPatternInput.clearValue();
+        await searchConnectorIndexPatternInput.type('test');
+
+        await interceptRequest(
+          driver.driver,
+          '*kibana\\/settings*',
+          (responseFactory) => {
+            return responseFactory.fail();
+          },
+          async () => {
+            await testSubjects.click(ui.pages.settings.saveButton);
+          }
+        );
+
+        await retry.waitFor('Error saving settings toast', async () => {
+          const count = await toasts.getCount();
+          return count > 0;
+        });
       });
     });
     describe('with advancedSettings read privilege', () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Obs AI Assistant] fix flaky test and add back test in settings (#213196)](https://github.com/elastic/kibana/pull/213196)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sandra G","email":"neptunian@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-05T16:46:02Z","message":"[Obs AI Assistant] fix flaky test and add back test in settings (#213196)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/191707\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\n- Fixes flaky test`allows updating of an advanced setting` by making\nsure to wait for page refresh\n- Adds back test to check for toast on error\nhttps://github.com/elastic/kibana/pull/191531\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>","sha":"bccbb933c0e2dea4c4d23c7174bbe0be638db252","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:all-open","Team:Obs AI Assistant","ci:project-deploy-observability","v9.1.0","v8.16.6"],"title":"[Obs AI Assistant] fix flaky test and add back test in settings","number":213196,"url":"https://github.com/elastic/kibana/pull/213196","mergeCommit":{"message":"[Obs AI Assistant] fix flaky test and add back test in settings (#213196)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/191707\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\n- Fixes flaky test`allows updating of an advanced setting` by making\nsure to wait for page refresh\n- Adds back test to check for toast on error\nhttps://github.com/elastic/kibana/pull/191531\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>","sha":"bccbb933c0e2dea4c4d23c7174bbe0be638db252"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213196","number":213196,"mergeCommit":{"message":"[Obs AI Assistant] fix flaky test and add back test in settings (#213196)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/191707\n\nSummarize your PR. If it involves visual changes include a screenshot or\ngif.\n\n- Fixes flaky test`allows updating of an advanced setting` by making\nsure to wait for page refresh\n- Adds back test to check for toast on error\nhttps://github.com/elastic/kibana/pull/191531\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>","sha":"bccbb933c0e2dea4c4d23c7174bbe0be638db252"}},{"branch":"8.16","label":"v8.16.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213271","number":213271,"state":"MERGED","mergeCommit":{"sha":"b400d81dfeff4274d6a708503c956f3b852cb10c","message":"[8.16] [Obs AI Assistant] fix flaky test and add back test in settings (#213196) (#213271)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.16`:\n- [[Obs AI Assistant] fix flaky test and add back test in settings\n(#213196)](https://github.com/elastic/kibana/pull/213196)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sandra G <neptunian@users.noreply.github.com>"}},{"url":"https://github.com/elastic/kibana/pull/213272","number":213272,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->