### PR TITLE
[ES|QL] Fixes the wrong validation when a named param is used as function

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -151,10 +151,11 @@ const statsValidator = (command: ESQLCommand) => {
       // * the agg function is at root level
       // * or if it's a operators function, then all operands are agg functions or literals
       // * or if it's a eval function then all arguments are agg functions or literals
+      // * or if a named param is used
       function checkFunctionContent(arg: ESQLFunction) {
         // TODO the grouping function check may not
         // hold true for all future cases
-        if (isAggFunction(arg)) {
+        if (isAggFunction(arg) || isFunctionOperatorParam(arg)) {
           return true;
         }
         return (arg as ESQLFunction).args.every(

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.stats.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/__tests__/test_suites/validation.command.stats.ts
@@ -170,6 +170,7 @@ export const validationStatsCommandTestSuite = (setup: helpers.Setup) => {
               'from a_index | stats avg(doubleField), percentile(doubleField, 50) + 1 by ipField',
               []
             );
+            await expectErrors('from a_index | stats ?func(doubleField)', []);
             for (const op of ['+', '-', '*', '/', '%']) {
               await expectErrors(
                 `from a_index | stats avg(doubleField) ${op} percentile(doubleField, 50) BY ipField`,


### PR DESCRIPTION
## Summary

Fixes the bug described here https://github.com/elastic/kibana/issues/192255#issuecomment-2684125449


<img width="1094" alt="image" src="https://github.com/user-attachments/assets/69d4f004-6a66-416b-8aa6-e477b0380010" />

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->