### PR TITLE
[8.x] [EDR Workflows] Unskip uninstall_agent_from_host.cy.ts (#210348)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/tamper_protection/disabled/uninstall_agent_from_host.cy.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/e2e/tamper_protection/disabled/uninstall_agent_from_host.cy.ts
@@ -21,8 +21,7 @@ import { enableAllPolicyProtections } from '../../../tasks/endpoint_policy';
 import { createEndpointHost } from '../../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../../tasks/delete_all_endpoint_data';
 
-// Failing: See https://github.com/elastic/kibana/issues/207423
-describe.skip(
+describe(
   'Uninstall agent from host when agent tamper protection is disabled',
   { tags: ['@ess'] },
   () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[EDR Workflows] Unskip uninstall_agent_from_host.cy.ts (#210348)](https://github.com/elastic/kibana/pull/210348)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Szwarc","email":"konrad.szwarc@elastic.co"},"sourceCommit":{"committedDate":"2025-02-12T13:02:00Z","message":"[EDR Workflows] Unskip uninstall_agent_from_host.cy.ts (#210348)\n\nIt seems the reason for skipping was a temporary hiccup that is no\nlonger occurring. Unskipping after verifying with the flaky test runner.\n\ncloses https://github.com/elastic/kibana/issues/183638\ncloses https://github.com/elastic/kibana/issues/207423\n\nFlaky test runner (x50)\n✅ `main`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7857\n✅ `9.0`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7858\n✅ `8.18`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7859\n✅ `8.17`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7860","sha":"bc08247b7f5eb46fb3d7d1624d74bef6ba195a06","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Defend Workflows","backport:version","v8.17.0","v8.18.0","v9.1.0","v8.17.3"],"title":"[EDR Workflows] Unskip uninstall_agent_from_host.cy.ts","number":210348,"url":"https://github.com/elastic/kibana/pull/210348","mergeCommit":{"message":"[EDR Workflows] Unskip uninstall_agent_from_host.cy.ts (#210348)\n\nIt seems the reason for skipping was a temporary hiccup that is no\nlonger occurring. Unskipping after verifying with the flaky test runner.\n\ncloses https://github.com/elastic/kibana/issues/183638\ncloses https://github.com/elastic/kibana/issues/207423\n\nFlaky test runner (x50)\n✅ `main`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7857\n✅ `9.0`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7858\n✅ `8.18`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7859\n✅ `8.17`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7860","sha":"bc08247b7f5eb46fb3d7d1624d74bef6ba195a06"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210822","number":210822,"state":"MERGED","mergeCommit":{"sha":"7f7f063696d68f3e45c1f4d597ed3d39252cf280","message":"[9.0] [EDR Workflows] Unskip uninstall_agent_from_host.cy.ts (#210348) (#210822)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[EDR Workflows] Unskip uninstall_agent_from_host.cy.ts\n(#210348)](https://github.com/elastic/kibana/pull/210348)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Konrad Szwarc <konrad.szwarc@elastic.co>"}},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210833","number":210833,"state":"MERGED","mergeCommit":{"sha":"244d3a654c0ff7bc545e1c85cb20c33591c5f74b","message":"[8.17] [EDR Workflows] Unskip uninstall_agent_from_host.cy.ts (#210348) (#210833)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [[EDR Workflows] Unskip uninstall_agent_from_host.cy.ts\n(#210348)](https://github.com/elastic/kibana/pull/210348)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210830","number":210830,"state":"MERGED","mergeCommit":{"sha":"78a45a1ae6e7fff1531b44e777a5a4f471197a92","message":"[8.18] [EDR Workflows] Unskip uninstall_agent_from_host.cy.ts (#210348) (#210830)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[EDR Workflows] Unskip uninstall_agent_from_host.cy.ts\n(#210348)](https://github.com/elastic/kibana/pull/210348)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210348","number":210348,"mergeCommit":{"message":"[EDR Workflows] Unskip uninstall_agent_from_host.cy.ts (#210348)\n\nIt seems the reason for skipping was a temporary hiccup that is no\nlonger occurring. Unskipping after verifying with the flaky test runner.\n\ncloses https://github.com/elastic/kibana/issues/183638\ncloses https://github.com/elastic/kibana/issues/207423\n\nFlaky test runner (x50)\n✅ `main`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7857\n✅ `9.0`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7858\n✅ `8.18`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7859\n✅ `8.17`\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/7860","sha":"bc08247b7f5eb46fb3d7d1624d74bef6ba195a06"}}]}] BACKPORT-->