### PR TITLE
[Lens] Navigate to original app fix

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/mounter.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/mounter.tsx
@@ -223,7 +223,7 @@ export async function mountApp(
         state: {
           embeddableId: isCopied ? undefined : embeddableId,
           type: LENS_EMBEDDABLE_TYPE,
-          input: { ...state, savedObject: state.savedObjectId },
+          input: state,
           searchSessionId: data.search.session.getSessionId(),
         },
       });


### PR DESCRIPTION
## Summary

In #186642 a typo was pushed into `main` about the savedObjectId when navigating from an app.
I've fixing it back.