### PR TITLE
[8.17] [SecuritySolution] Fix Risk score Insufficient privileges warning missing cluster privileges (#212405)

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_analytics_risk_score/index.tsx
@@ -161,7 +161,7 @@ const EntityAnalyticsRiskScoresComponent = ({ riskEntity }: { riskEntity: RiskSc
 
   const refreshPage = useRefetchQueries();
 
-  const privileges = useMissingRiskEnginePrivileges(['read']);
+  const privileges = useMissingRiskEnginePrivileges({ readonly: true });
 
   if (!isAuthorized) {
     return null;

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_store/components/enablement_modal.tsx
@@ -24,8 +24,10 @@ import {
   useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import type { RiskEngineStatus, StoreStatus } from '../../../../../common/api/entity_analytics';
+import { RiskEngineStatusEnum } from '../../../../../common/api/entity_analytics';
 import { useContractComponents } from '../../../../common/hooks/use_contract_component';
 import { TECHNICAL_PREVIEW, TECHNICAL_PREVIEW_TOOLTIP } from '../../../../common/translations';
 import {
@@ -33,66 +35,86 @@ import {
   ENABLEMENT_DESCRIPTION_ENTITY_STORE_ONLY,
   ENABLEMENT_WARNING_SELECT_TO_PROCEED,
 } from '../translations';
-import { useEntityEnginePrivileges } from '../hooks/use_entity_engine_privileges';
 import { MissingPrivilegesCallout } from './missing_privileges_callout';
 import { useMissingRiskEnginePrivileges } from '../../../hooks/use_missing_risk_engine_privileges';
 import { RiskEnginePrivilegesCallOut } from '../../risk_engine_privileges_callout';
+import { useEntityEnginePrivileges } from '../hooks/use_entity_engine_privileges';
 
 export interface Enablements {
   riskScore: boolean;
   entityStore: boolean;
 }
 
-interface EntityStoreEnablementModalProps {
+export interface EntityStoreEnablementModalProps {
   visible: boolean;
   toggle: (visible: boolean) => void;
   enableStore: (enablements: Enablements) => () => void;
-  riskScore: {
-    canToggle?: boolean;
-    checked?: boolean;
-  };
-  entityStore: {
-    canToggle?: boolean;
-    checked?: boolean;
-  };
+  riskEngineStatus?: RiskEngineStatus;
+  entityStoreStatus?: StoreStatus;
 }
 
-const shouldAllowEnablement = (
-  riskScoreEnabled: boolean,
-  entityStoreEnabled: boolean,
+const isInstallButtonEnabled = (
+  canInstallRiskScore: boolean,
+  canInstallEntityStore: boolean,
   userHasEnabled: Enablements
 ) => {
-  if (riskScoreEnabled) {
-    return userHasEnabled.entityStore;
+  if (canInstallRiskScore || canInstallEntityStore) {
+    return userHasEnabled.riskScore || userHasEnabled.entityStore;
   }
-  if (entityStoreEnabled) {
-    return userHasEnabled.riskScore;
-  }
-  return userHasEnabled.riskScore || userHasEnabled.entityStore;
+
+  return false;
 };
 
 export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProps> = ({
   visible,
   toggle,
   enableStore,
-  riskScore,
-  entityStore,
+  riskEngineStatus,
+  entityStoreStatus,
 }) => {
-  const { euiTheme } = useEuiTheme();
-  const [enablements, setEnablements] = useState({
-    riskScore: !!riskScore.checked,
-    entityStore: !!entityStore.checked,
-  });
+  const riskEnginePrivileges = useMissingRiskEnginePrivileges();
   const { data: entityEnginePrivileges, isLoading: isLoadingEntityEnginePrivileges } =
     useEntityEnginePrivileges();
-  const riskEnginePrivileges = useMissingRiskEnginePrivileges();
 
-  const enablementOptions = shouldAllowEnablement(
-    !riskScore.canToggle,
-    !entityStore.canToggle,
-    enablements
+  const hasRiskScorePrivileges = !(
+    riskEnginePrivileges.isLoading || !riskEnginePrivileges?.hasAllRequiredPrivileges
   );
   const { EnablementModalCallout } = useContractComponents();
+
+  const canInstallRiskScore =
+    hasRiskScorePrivileges && riskEngineStatus === RiskEngineStatusEnum.NOT_INSTALLED;
+
+  const hasEntityStorePrivileges = !(
+    isLoadingEntityEnginePrivileges || !entityEnginePrivileges?.has_all_required
+  );
+
+  const canInstallEntityStore = hasEntityStorePrivileges && entityStoreStatus === 'not_installed';
+
+  const { euiTheme } = useEuiTheme();
+  const [toggleState, setToggleState] = useState({
+    riskScore: false,
+    entityStore: false,
+  });
+
+  /**
+   * Update the toggle state when the install status changes because privileges are async.
+   * We automatically toggle the switch when the user can enable the engine.
+   *
+   */
+  useEffect(() => {
+    setToggleState({
+      riskScore: canInstallRiskScore,
+      entityStore: canInstallEntityStore,
+    });
+  }, [canInstallRiskScore, canInstallEntityStore]);
+
+  const isInstallButtonDisabled = !isInstallButtonEnabled(
+    canInstallRiskScore,
+    canInstallEntityStore,
+    toggleState
+  );
+
+  const { AdditionalChargesMessage } = useContractComponents();
 
   if (!visible) {
     return null;
@@ -130,12 +152,10 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
                   defaultMessage="Risk Score"
                 />
               }
-              checked={enablements.riskScore}
-              disabled={
-                !riskScore.canToggle ||
-                (!riskEnginePrivileges.isLoading && !riskEnginePrivileges?.hasAllRequiredPrivileges)
-              }
-              onChange={() => setEnablements((prev) => ({ ...prev, riskScore: !prev.riskScore }))}
+              checked={toggleState.riskScore}
+              disabled={!canInstallRiskScore}
+              onChange={() => setToggleState((prev) => ({ ...prev, riskScore: !prev.riskScore }))}
+              data-test-subj="enablementRiskScoreSwitch"
             />
           </EuiFlexItem>
           {!riskEnginePrivileges.isLoading && !riskEnginePrivileges.hasAllRequiredPrivileges && (
@@ -156,13 +176,10 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
                     defaultMessage="Entity Store"
                   />
                 }
-                checked={enablements.entityStore}
-                disabled={
-                  !entityStore.canToggle ||
-                  (!isLoadingEntityEnginePrivileges && !entityEnginePrivileges?.has_all_required)
-                }
+                checked={toggleState.entityStore}
+                disabled={!canInstallEntityStore}
                 onChange={() =>
-                  setEnablements((prev) => ({ ...prev, entityStore: !prev.entityStore }))
+                  setToggleState((prev) => ({ ...prev, entityStore: !prev.entityStore }))
                 }
               />
               <EuiToolTip content={TECHNICAL_PREVIEW_TOOLTIP}>
@@ -183,15 +200,18 @@ export const EntityStoreEnablementModal: React.FC<EntityStoreEnablementModalProp
 
       <EuiModalFooter>
         <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
-          {!enablementOptions ? <EuiFlexItem>{proceedWarning}</EuiFlexItem> : null}
+          {isInstallButtonDisabled && (canInstallRiskScore || canInstallEntityStore) ? (
+            <EuiFlexItem>{proceedWarning}</EuiFlexItem>
+          ) : null}
           <EuiFlexItem grow={false}>
             <EuiFlexGroup direction="row" justifyContent="flexEnd">
               <EuiButtonEmpty onClick={() => toggle(false)}>{'Cancel'}</EuiButtonEmpty>
               <EuiButton
-                onClick={enableStore(enablements)}
+                onClick={enableStore(toggleState)}
                 fill
-                isDisabled={!enablementOptions}
-                aria-disabled={!enablementOptions}
+                isDisabled={isInstallButtonDisabled}
+                aria-disabled={isInstallButtonDisabled}
+                data-test-subj="entityStoreEnablementModalButton"
               >
                 <FormattedMessage
                   id="xpack.securitySolution.entityAnalytics.enablements.modal.enable"

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.tsx
@@ -128,7 +128,7 @@ const RiskDetailsTabBodyComponent: React.FC<
     },
     [setOverTimeToggleStatus]
   );
-  
+
   const privileges = useMissingRiskEnginePrivileges({ readonly: true });
 
   const RiskScoreUpsell = useUpsellingComponent('entity_analytics_panel');

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/risk_details_tab_body/index.tsx
@@ -128,8 +128,8 @@ const RiskDetailsTabBodyComponent: React.FC<
     },
     [setOverTimeToggleStatus]
   );
-
-  const privileges = useMissingRiskEnginePrivileges();
+  
+  const privileges = useMissingRiskEnginePrivileges({ readonly: true });
 
   const RiskScoreUpsell = useUpsellingComponent('entity_analytics_panel');
   if (RiskScoreUpsell) {

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/user_risk_score_tab_body.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/user_risk_score_tab_body.tsx
@@ -67,7 +67,7 @@ export const UserRiskScoreQueryTabBody = ({
 
   const timerange = useMemo(() => ({ from, to }), [from, to]);
 
-  const privileges = useMissingRiskEnginePrivileges();
+  const privileges = useMissingRiskEnginePrivileges({ readonly: true });
 
   const {
     data,

--- a/x-pack/plugins/security_solution/public/entity_analytics/hooks/use_missing_risk_engine_privileges.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/hooks/use_missing_risk_engine_privileges.ts
@@ -22,8 +22,14 @@ export type RiskEngineMissingPrivilegesResponse =
       hasAllRequiredPrivileges: false;
     };
 
+interface UseMissingRiskEnginePrivilegesParams {
+  /**
+   * If `true`, only read privileges are required.
+   */
+  readonly: boolean;
+}
 export const useMissingRiskEnginePrivileges = (
-  required: NonEmptyArray<RiskEngineIndexPrivilege> = ['read', 'write']
+  { readonly }: UseMissingRiskEnginePrivilegesParams = { readonly: false }
 ): RiskEngineMissingPrivilegesResponse => {
   const { data: privilegesResponse, isLoading } = useRiskEnginePrivileges();
 
@@ -41,14 +47,21 @@ export const useMissingRiskEnginePrivileges = (
       };
     }
 
+    const requiredIndexPrivileges: NonEmptyArray<RiskEngineIndexPrivilege> = readonly
+      ? ['read']
+      : ['read', 'write'];
+
     const { indexPrivileges, clusterPrivileges } = getMissingRiskEnginePrivileges(
       privilegesResponse.privileges,
-      required
+      requiredIndexPrivileges
     );
 
     // privilegesResponse.has_all_required` is slightly misleading, it checks if it has *all* default required privileges.
     // Here we check if there are no missing privileges of the provided set of required privileges
-    if (indexPrivileges.every(([_, missingPrivileges]) => missingPrivileges.length === 0)) {
+    if (
+      indexPrivileges.every(([_, missingPrivileges]) => missingPrivileges.length === 0) &&
+      (readonly || clusterPrivileges.length === 0) // cluster privileges check is required for write operations
+    ) {
       return {
         isLoading: false,
         hasAllRequiredPrivileges: true,
@@ -60,8 +73,8 @@ export const useMissingRiskEnginePrivileges = (
       hasAllRequiredPrivileges: false,
       missingPrivileges: {
         indexPrivileges,
-        clusterPrivileges,
+        clusterPrivileges: readonly ? [] : clusterPrivileges, // cluster privileges are not required for readonly
       },
     };
-  }, [isLoading, privilegesResponse, required]);
+  }, [isLoading, privilegesResponse, readonly]);
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[SecuritySolution] Fix Risk score Insufficient privileges warning missing cluster privileges (#212405)](https://github.com/elastic/kibana/pull/212405)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2025-03-06T09:51:08Z","message":"[SecuritySolution] Fix Risk score Insufficient privileges warning missing cluster privileges (#212405)\n\n## Summary\n\n### \n* Fixes Bug: User with no cluster privileges should not be able to\nenable the risk score\nWhen users with no cluster privileges open the risk score page, they\ndon't see any errors and are able to click the install button.\n\nThis happened because we were only checking for index privileges in the\nUI, but for the enablement flow we also need to check cluster\nprivileges. I also introduced a new parameter to the missing privileges\nhook so pages that only need to check for `read` privileges can work as\nbefore.\n\n\nhttps://github.com/user-attachments/assets/fe162005-ee2b-497d-8744-6262e4511d2d\n\n\n* Fixed Bug: The install button was enabled when all toggles were\ndisabled\nThere were too many booleans in the panel, which was confusing and led\nme to introduce more bugs while trying to fix this one, so I refactored\nthe code to understand it before fixing it.\nI also simplified the logic to display the modal. Now, it only shows\nwhen one of the engines' status is \"not_installed\"\n\n<img width=\"300\"\nsrc=\"https://github.com/user-attachments/assets/a2e8fbba-ac64-4c97-9ef0-ef6fe61e60cd\"\n/>\n\n\n\n\n\n\n\n### To Reproduce\n\n1. Create a user with security privileges and index privileges but no\ncluster privileges\n2. Go to the risk score page and enable the toggle\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or","sha":"b69b696e7fddf4bb26d038f1deaa6388051c428d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team: SecuritySolution","Theme: entity_analytics","Feature:Entity Analytics","Team:Entity Analytics","backport:version","v8.17.0","v8.18.0","v9.1.0","v8.19.0"],"title":"[SecuritySolution] Fix Risk score Insufficient privileges warning missing cluster privileges","number":212405,"url":"https://github.com/elastic/kibana/pull/212405","mergeCommit":{"message":"[SecuritySolution] Fix Risk score Insufficient privileges warning missing cluster privileges (#212405)\n\n## Summary\n\n### \n* Fixes Bug: User with no cluster privileges should not be able to\nenable the risk score\nWhen users with no cluster privileges open the risk score page, they\ndon't see any errors and are able to click the install button.\n\nThis happened because we were only checking for index privileges in the\nUI, but for the enablement flow we also need to check cluster\nprivileges. I also introduced a new parameter to the missing privileges\nhook so pages that only need to check for `read` privileges can work as\nbefore.\n\n\nhttps://github.com/user-attachments/assets/fe162005-ee2b-497d-8744-6262e4511d2d\n\n\n* Fixed Bug: The install button was enabled when all toggles were\ndisabled\nThere were too many booleans in the panel, which was confusing and led\nme to introduce more bugs while trying to fix this one, so I refactored\nthe code to understand it before fixing it.\nI also simplified the logic to display the modal. Now, it only shows\nwhen one of the engines' status is \"not_installed\"\n\n<img width=\"300\"\nsrc=\"https://github.com/user-attachments/assets/a2e8fbba-ac64-4c97-9ef0-ef6fe61e60cd\"\n/>\n\n\n\n\n\n\n\n### To Reproduce\n\n1. Create a user with security privileges and index privileges but no\ncluster privileges\n2. Go to the risk score page and enable the toggle\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or","sha":"b69b696e7fddf4bb26d038f1deaa6388051c428d"}},"sourceBranch":"main","suggestedTargetBranches":["8.17","8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213344","number":213344,"state":"OPEN"},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212405","number":212405,"mergeCommit":{"message":"[SecuritySolution] Fix Risk score Insufficient privileges warning missing cluster privileges (#212405)\n\n## Summary\n\n### \n* Fixes Bug: User with no cluster privileges should not be able to\nenable the risk score\nWhen users with no cluster privileges open the risk score page, they\ndon't see any errors and are able to click the install button.\n\nThis happened because we were only checking for index privileges in the\nUI, but for the enablement flow we also need to check cluster\nprivileges. I also introduced a new parameter to the missing privileges\nhook so pages that only need to check for `read` privileges can work as\nbefore.\n\n\nhttps://github.com/user-attachments/assets/fe162005-ee2b-497d-8744-6262e4511d2d\n\n\n* Fixed Bug: The install button was enabled when all toggles were\ndisabled\nThere were too many booleans in the panel, which was confusing and led\nme to introduce more bugs while trying to fix this one, so I refactored\nthe code to understand it before fixing it.\nI also simplified the logic to display the modal. Now, it only shows\nwhen one of the engines' status is \"not_installed\"\n\n<img width=\"300\"\nsrc=\"https://github.com/user-attachments/assets/a2e8fbba-ac64-4c97-9ef0-ef6fe61e60cd\"\n/>\n\n\n\n\n\n\n\n### To Reproduce\n\n1. Create a user with security privileges and index privileges but no\ncluster privileges\n2. Go to the risk score page and enable the toggle\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or","sha":"b69b696e7fddf4bb26d038f1deaa6388051c428d"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->