### PR TITLE
[Security Solution] Rework test plan for importing prebuilt rules

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -45,7 +45,8 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
     - [Scenario: Importing a mixture of new prebuilt and custom rules](#scenario-importing-a-mixture-of-new-prebuilt-and-custom-rules)
     - [Scenario: Importing a mixture of prebuilt and custom rules on top of existing rules](#scenario-importing-a-mixture-of-prebuilt-and-custom-rules-on-top-of-existing-rules)
   - [Importing prebuilt rules when the package is not installed](#importing-prebuilt-rules-when-the-package-is-not-installed)
-    - [Scenario: Importing a prebuilt rule when the rules package is not installed](#scenario-importing-a-prebuilt-rule-when-the-rules-package-is-not-installed)
+    - [Scenario: Importing new prebuilt rules when the package is not installed](#scenario-importing-new-prebuilt-rules-when-the-package-is-not-installed)
+    - [Scenario: Importing prebuilt rules on top of existing rules when the package is not installed](#scenario-importing-prebuilt-rules-on-top-of-existing-rules-when-the-package-is-not-installed)
   - [Converting between prebuilt and custom rules](#converting-between-prebuilt-and-custom-rules)
     - [Scenario: Importing a custom rule with a matching prebuilt `rule_id` and `version`](#scenario-importing-a-custom-rule-with-a-matching-prebuilt-rule_id-and-version)
     - [Scenario: Importing a prebuilt rule with a non-existent `rule_id`](#scenario-importing-a-prebuilt-rule-with-a-non-existent-rule_id)
@@ -79,6 +80,8 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
 - **This rule is already installed**: a prebuilt rule with the same `rule_id` has been already installed and exists as an alerting rule saved object.
 - **This rule is not created yet**: a custom rule with the same `rule_id` hasn't been created yet and doesn't exist as an alerting rule saved object.
 - **This rule is already created**: a custom rule with the same `rule_id` has been already created and exists as an alerting rule saved object.
+- **This rule has a base version in the installed package**: package with prebuilt rules has been installed, and the rule's `rule_id` and `version` fields match one of the rule assets from this package.
+- **This rule has a base version in the latest package**: the rule's `rule_id` and `version` fields match one of the rule assets from the latest version of the package with prebuilt rules. It is likely assumed or stated explicitly that the latest package hasn't been installed yet.
 
 ## Requirements
 
@@ -86,8 +89,11 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
 
 Assumptions about test environments and scenarios outlined in this test plan.
 
+Unless explicitly indicated otherwise:
+
 - [Common assumptions](./prebuilt_rules_common_info.md#common-assumptions).
-- The `overwrite` import request parameter is set to `true`, unless explicitly indicated otherwise.
+- Package with prebuilt rules is already installed, and rule assets from it are stored in Elasticsearch.
+- The `overwrite` import request parameter is set to `true`.
 
 ### Technical requirements
 
@@ -119,7 +125,7 @@ User stories:
 
 ```Gherkin
 Given the import payload contains a prebuilt rule
-And this rule has a base version (its rule_id and version match a rule asset)
+And this rule has a base version in the installed package
 And this rule is equal to its base version
 And this rule is not installed
 When the user imports the rule
@@ -135,7 +141,7 @@ And the created rule's parameters should match the import payload
 
 ```Gherkin
 Given the import payload contains a prebuilt rule
-And this rule has a base version (its rule_id and version match a rule asset)
+And this rule has a base version in the installed package
 And this rule is equal to its base version
 And this rule is already installed and is not customized
 When the user imports the rule
@@ -151,7 +157,7 @@ And the updated rule's parameters should match the import payload
 
 ```Gherkin
 Given the import payload contains a prebuilt rule
-And this rule has a base version (its rule_id and version match a rule asset)
+And this rule has a base version in the installed package
 And this rule is equal to its base version
 And this rule is already installed and is customized
 When the user imports the rule
@@ -169,7 +175,7 @@ And the updated rule's parameters should match the import payload
 
 ```Gherkin
 Given the import payload contains a prebuilt rule
-And this rule has a base version (its rule_id and version match a rule asset)
+And this rule has a base version in the installed package
 And this rule is different from its base version
 And this rule is not installed
 When the user imports the rule
@@ -185,7 +191,7 @@ And the created rule's parameters should match the import payload
 
 ```Gherkin
 Given the import payload contains a prebuilt rule
-And this rule has a base version (its rule_id and version match a rule asset)
+And this rule has a base version in the installed package
 And this rule is different from its base version
 And this rule is already installed and is not customized
 When the user imports the rule
@@ -201,7 +207,7 @@ And the updated rule's parameters should match the import payload
 
 ```Gherkin
 Given the import payload contains a prebuilt rule
-And this rule has a base version (its rule_id and version match a rule asset)
+And this rule has a base version in the installed package
 And this rule is different from its base version
 And this rule is already installed and is customized
 When the user imports the rule
@@ -251,7 +257,7 @@ This scenario is a "smoke test" for all the user stories from the [Product requi
 
 ```Gherkin
 Given the import payload contains prebuilt non-customized, prebuilt customized, and custom rules
-And the prebuilt rules have a base version (their rule_id and version match a rule asset)
+And the prebuilt rules have a base version in the installed package
 And the custom rules' rule_id does NOT match any rule assets from the installed package
 And the rules are not installed or created yet
 When the user imports these rules
@@ -269,7 +275,7 @@ This scenario is a "smoke test" for all the user stories from the [Product requi
 
 ```Gherkin
 Given the import payload contains prebuilt non-customized, prebuilt customized, and custom rules
-And the prebuilt rules have a base version (their rule_id and version match a rule asset)
+And the prebuilt rules have a base version in the installed package
 And the custom rules' rule_id does NOT match any rule assets from the installed package
 And the rules are already installed or created
 When the user imports these rules
@@ -281,18 +287,38 @@ And the updated rules' parameters should match the import payload
 
 ### Importing prebuilt rules when the package is not installed
 
-#### Scenario: Importing a prebuilt rule when the rules package is not installed
+#### Scenario: Importing new prebuilt rules when the package is not installed
 
-**Automation**: 1 integration test.
+**Automation**: 1 API integration test.
 
 ```Gherkin
-Given the import payload contains a prebuilt rule
-And its rule_id matches one or a few rule assets from the latest package
-And the package hasn't been installed yet
-When the user imports the rule
-Then the latest package should get installed automatically
-And the rule should be created or updated
-And the ruleSource type should be "external"
+Given the import payload contains two prebuilt rules (non-customized + customized)
+And these rules have a base version in the latest package
+And these rules are not installed yet
+And the package is not installed yet
+When the user imports the rules
+Then the latest package should be installed automatically
+And the rules should be created
+And the created rules should be prebuilt
+And the created rules should be correctly marked as non-customized or customized
+And the created rules' parameters should match the import payload
+```
+
+#### Scenario: Importing prebuilt rules on top of existing rules when the package is not installed
+
+**Automation**: 1 API integration test.
+
+```Gherkin
+Given the import payload contains two prebuilt rules (non-customized + customized)
+And these rules have a base version in the latest package
+And these rules are already installed
+And the package has been deleted
+When the user imports the rules
+Then the latest package should be installed automatically
+And the rules should be updated
+And the updated rules should be prebuilt
+And the updated rules should be correctly marked as non-customized or customized
+And the updated rules' parameters should match the import payload
 ```
 
 ### Converting between prebuilt and custom rules

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -42,7 +42,8 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
     - [Scenario: Importing a new custom rule](#scenario-importing-a-new-custom-rule)
     - [Scenario: Importing a custom rule on top of an existing custom rule](#scenario-importing-a-custom-rule-on-top-of-an-existing-custom-rule)
   - [Importing multiple rules in bulk](#importing-multiple-rules-in-bulk)
-    - [Scenario: Importing both custom and prebuilt rules](#scenario-importing-both-custom-and-prebuilt-rules)
+    - [Scenario: Importing a mixture of new prebuilt and custom rules](#scenario-importing-a-mixture-of-new-prebuilt-and-custom-rules)
+    - [Scenario: Importing a mixture of prebuilt and custom rules on top of existing rules](#scenario-importing-a-mixture-of-prebuilt-and-custom-rules-on-top-of-existing-rules)
   - [Importing prebuilt rules when the package is not installed](#importing-prebuilt-rules-when-the-package-is-not-installed)
     - [Scenario: Importing a prebuilt rule when the rules package is not installed](#scenario-importing-a-prebuilt-rule-when-the-rules-package-is-not-installed)
   - [Converting between prebuilt and custom rules](#converting-between-prebuilt-and-custom-rules)
@@ -242,16 +243,40 @@ And the updated rule's parameters should match the import payload
 
 ### Importing multiple rules in bulk
 
-#### Scenario: Importing both custom and prebuilt rules
+#### Scenario: Importing a mixture of new prebuilt and custom rules
 
-**Automation**: 1 integration test.
+This scenario is a "smoke test" for all the user stories from the [Product requirements](#product-requirements) section.
+
+**Automation**: 1 API integration test, 1 e2e test.
 
 ```Gherkin
 Given the import payload contains prebuilt non-customized, prebuilt customized, and custom rules
+And the prebuilt rules have a base version (their rule_id and version match a rule asset)
+And the custom rules' rule_id does NOT match any rule assets from the installed package
+And the rules are not installed or created yet
 When the user imports these rules
-Then custom rules should be created or updated, with versions defaulted to 1
-And prebuilt rules should be created or updated,
-And prebuilt rules missing versions should be rejected
+Then the rules should be created
+And the created rules should be correctly identified as prebuilt or custom
+And the created rules' is_customized field should be correctly calculated
+And the created rules' parameters should match the import payload
+```
+
+#### Scenario: Importing a mixture of prebuilt and custom rules on top of existing rules
+
+This scenario is a "smoke test" for all the user stories from the [Product requirements](#product-requirements) section.
+
+**Automation**: 1 API integration test, 1 e2e test.
+
+```Gherkin
+Given the import payload contains prebuilt non-customized, prebuilt customized, and custom rules
+And the prebuilt rules have a base version (their rule_id and version match a rule asset)
+And the custom rules' rule_id does NOT match any rule assets from the installed package
+And the rules are already installed or created
+When the user imports these rules
+Then the rules should be updated
+And the updated rules should be correctly identified as prebuilt or custom
+And the updated rules' is_customized field should be correctly calculated
+And the updated rules' parameters should match the import payload
 ```
 
 ### Importing prebuilt rules when the package is not installed

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -31,37 +31,37 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
   - [Product requirements](#product-requirements)
 - [Scenarios](#scenarios)
   - [Importing single prebuilt non-customized rules](#importing-single-prebuilt-non-customized-rules)
-    - [Scenario: Importing a non-customized rule when it's not installed](#scenario-importing-a-non-customized-rule-when-its-not-installed)
-    - [Scenario: Importing a non-customized rule on top of an installed non-customized rule](#scenario-importing-a-non-customized-rule-on-top-of-an-installed-non-customized-rule)
-    - [Scenario: Importing a non-customized rule on top of an installed customized rule](#scenario-importing-a-non-customized-rule-on-top-of-an-installed-customized-rule)
+    - [**Scenario: Importing a non-customized rule when it's not installed**](#scenario-importing-a-non-customized-rule-when-its-not-installed)
+    - [**Scenario: Importing a non-customized rule on top of an installed non-customized rule**](#scenario-importing-a-non-customized-rule-on-top-of-an-installed-non-customized-rule)
+    - [**Scenario: Importing a non-customized rule on top of an installed customized rule**](#scenario-importing-a-non-customized-rule-on-top-of-an-installed-customized-rule)
   - [Importing single prebuilt customized rules](#importing-single-prebuilt-customized-rules)
-    - [Scenario: Importing a customized rule when it's not installed](#scenario-importing-a-customized-rule-when-its-not-installed)
-    - [Scenario: Importing a customized rule on top of an installed non-customized rule](#scenario-importing-a-customized-rule-on-top-of-an-installed-non-customized-rule)
-    - [Scenario: Importing a customized rule on top of an installed customized rule](#scenario-importing-a-customized-rule-on-top-of-an-installed-customized-rule)
+    - [**Scenario: Importing a customized rule when it's not installed**](#scenario-importing-a-customized-rule-when-its-not-installed)
+    - [**Scenario: Importing a customized rule on top of an installed non-customized rule**](#scenario-importing-a-customized-rule-on-top-of-an-installed-non-customized-rule)
+    - [**Scenario: Importing a customized rule on top of an installed customized rule**](#scenario-importing-a-customized-rule-on-top-of-an-installed-customized-rule)
   - [Importing single custom rules](#importing-single-custom-rules)
-    - [Scenario: Importing a new custom rule](#scenario-importing-a-new-custom-rule)
-    - [Scenario: Importing a custom rule on top of an existing custom rule](#scenario-importing-a-custom-rule-on-top-of-an-existing-custom-rule)
+    - [**Scenario: Importing a new custom rule**](#scenario-importing-a-new-custom-rule)
+    - [**Scenario: Importing a custom rule on top of an existing custom rule**](#scenario-importing-a-custom-rule-on-top-of-an-existing-custom-rule)
   - [Importing multiple rules in bulk](#importing-multiple-rules-in-bulk)
-    - [Scenario: Importing a mixture of new prebuilt and custom rules](#scenario-importing-a-mixture-of-new-prebuilt-and-custom-rules)
-    - [Scenario: Importing a mixture of prebuilt and custom rules on top of existing rules](#scenario-importing-a-mixture-of-prebuilt-and-custom-rules-on-top-of-existing-rules)
+    - [**Scenario: Importing a mixture of new prebuilt and custom rules**](#scenario-importing-a-mixture-of-new-prebuilt-and-custom-rules)
+    - [**Scenario: Importing a mixture of prebuilt and custom rules on top of existing rules**](#scenario-importing-a-mixture-of-prebuilt-and-custom-rules-on-top-of-existing-rules)
   - [Importing prebuilt rules when the package is not installed](#importing-prebuilt-rules-when-the-package-is-not-installed)
-    - [Scenario: Importing new prebuilt rules when the package is not installed](#scenario-importing-new-prebuilt-rules-when-the-package-is-not-installed)
-    - [Scenario: Importing prebuilt rules on top of existing rules when the package is not installed](#scenario-importing-prebuilt-rules-on-top-of-existing-rules-when-the-package-is-not-installed)
+    - [**Scenario: Importing new prebuilt rules when the package is not installed**](#scenario-importing-new-prebuilt-rules-when-the-package-is-not-installed)
+    - [**Scenario: Importing prebuilt rules on top of existing rules when the package is not installed**](#scenario-importing-prebuilt-rules-on-top-of-existing-rules-when-the-package-is-not-installed)
   - [Converting between prebuilt and custom rules](#converting-between-prebuilt-and-custom-rules)
-    - [Scenario: Converting a custom rule to a customized prebuilt rule on import](#scenario-converting-a-custom-rule-to-a-customized-prebuilt-rule-on-import)
-    - [Scenario: Converting a custom rule to a non-customized prebuilt rule on import](#scenario-converting-a-custom-rule-to-a-non-customized-prebuilt-rule-on-import)
-    - [Scenario: Converting a prebuilt rule to a custom rule on import](#scenario-converting-a-prebuilt-rule-to-a-custom-rule-on-import)
-    - [Scenario: Making an imported custom rule upgradeable to a prebuilt rule](#scenario-making-an-imported-custom-rule-upgradeable-to-a-prebuilt-rule)
+    - [**Scenario: Converting a custom rule to a customized prebuilt rule on import**](#scenario-converting-a-custom-rule-to-a-customized-prebuilt-rule-on-import)
+    - [**Scenario: Converting a custom rule to a non-customized prebuilt rule on import**](#scenario-converting-a-custom-rule-to-a-non-customized-prebuilt-rule-on-import)
+    - [**Scenario: Converting a prebuilt rule to a custom rule on import**](#scenario-converting-a-prebuilt-rule-to-a-custom-rule-on-import)
+    - [**Scenario: Making an imported custom rule upgradeable to a prebuilt rule**](#scenario-making-an-imported-custom-rule-upgradeable-to-a-prebuilt-rule)
   - [Handling missing base versions](#handling-missing-base-versions)
-    - [Scenario: Importing a prebuilt rule with a missing base version when it's not installed](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-not-installed)
-    - [Scenario: Importing a prebuilt rule with a missing base version when it's already installed but not equal to the import payload](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-already-installed-but-not-equal-to-the-import-payload)
-    - [Scenario: Importing a prebuilt rule with a missing base version when it's already installed, is not customized, and is equal to the import payload](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-already-installed-is-not-customized-and-is-equal-to-the-import-payload)
-    - [Scenario: Importing a prebuilt rule with a missing base version when it's already installed, is customized, and is equal to the import payload](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-already-installed-is-customized-and-is-equal-to-the-import-payload)
+    - [**Scenario: Importing a prebuilt rule with a missing base version when it's not installed**](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-not-installed)
+    - [**Scenario: Importing a prebuilt rule with a missing base version when it's already installed but not equal to the import payload**](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-already-installed-but-not-equal-to-the-import-payload)
+    - [**Scenario: Importing a prebuilt rule with a missing base version when it's already installed, is not customized, and is equal to the import payload**](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-already-installed-is-not-customized-and-is-equal-to-the-import-payload)
+    - [**Scenario: Importing a prebuilt rule with a missing base version when it's already installed, is customized, and is equal to the import payload**](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-already-installed-is-customized-and-is-equal-to-the-import-payload)
   - [Handling missing fields in the import request payload](#handling-missing-fields-in-the-import-request-payload)
-    - [Scenario: Importing a prebuilt rule without a `rule_id` field](#scenario-importing-a-prebuilt-rule-without-a-rule_id-field)
-    - [Scenario: Importing a prebuilt rule with a matching `rule_id` but missing a `version` field](#scenario-importing-a-prebuilt-rule-with-a-matching-rule_id-but-missing-a-version-field)
-    - [Scenario: Importing a new custom rule missing a `version` field](#scenario-importing-a-new-custom-rule-missing-a-version-field)
-    - [Scenario: Importing an existing custom rule missing a `version` field](#scenario-importing-an-existing-custom-rule-missing-a-version-field)
+    - [**Scenario: Importing a prebuilt rule without a `rule_id` field**](#scenario-importing-a-prebuilt-rule-without-a-rule_id-field)
+    - [**Scenario: Importing a prebuilt rule with a matching `rule_id` but missing a `version` field**](#scenario-importing-a-prebuilt-rule-with-a-matching-rule_id-but-missing-a-version-field)
+    - [**Scenario: Importing a new custom rule missing a `version` field**](#scenario-importing-a-new-custom-rule-missing-a-version-field)
+    - [**Scenario: Importing an existing custom rule missing a `version` field**](#scenario-importing-an-existing-custom-rule-missing-a-version-field)
   - [Licensing](#licensing)
 
 ## Useful information
@@ -121,7 +121,7 @@ User stories:
 
 ### Importing single prebuilt non-customized rules
 
-#### Scenario: Importing a non-customized rule when it's not installed
+#### **Scenario: Importing a non-customized rule when it's not installed**
 
 **Automation**: 1 API integration test.
 
@@ -137,7 +137,7 @@ And the created rule should be marked as non-customized
 And the created rule's parameters should match the import payload
 ```
 
-#### Scenario: Importing a non-customized rule on top of an installed non-customized rule
+#### **Scenario: Importing a non-customized rule on top of an installed non-customized rule**
 
 **Automation**: 1 API integration test.
 
@@ -153,7 +153,7 @@ And the updated rule should be marked as non-customized
 And the updated rule's parameters should match the import payload
 ```
 
-#### Scenario: Importing a non-customized rule on top of an installed customized rule
+#### **Scenario: Importing a non-customized rule on top of an installed customized rule**
 
 **Automation**: 1 API integration test.
 
@@ -171,7 +171,7 @@ And the updated rule's parameters should match the import payload
 
 ### Importing single prebuilt customized rules
 
-#### Scenario: Importing a customized rule when it's not installed
+#### **Scenario: Importing a customized rule when it's not installed**
 
 **Automation**: 1 API integration test.
 
@@ -187,7 +187,7 @@ And the created rule should be marked as customized
 And the created rule's parameters should match the import payload
 ```
 
-#### Scenario: Importing a customized rule on top of an installed non-customized rule
+#### **Scenario: Importing a customized rule on top of an installed non-customized rule**
 
 **Automation**: 1 API integration test.
 
@@ -203,7 +203,7 @@ And the updated rule should be marked as customized
 And the updated rule's parameters should match the import payload
 ```
 
-#### Scenario: Importing a customized rule on top of an installed customized rule
+#### **Scenario: Importing a customized rule on top of an installed customized rule**
 
 **Automation**: 1 API integration test.
 
@@ -221,7 +221,7 @@ And the updated rule's parameters should match the import payload
 
 ### Importing single custom rules
 
-#### Scenario: Importing a new custom rule
+#### **Scenario: Importing a new custom rule**
 
 **Automation**: 1 API integration test.
 
@@ -235,7 +235,7 @@ And the created rule should be custom
 And the created rule's parameters should match the import payload
 ```
 
-#### Scenario: Importing a custom rule on top of an existing custom rule
+#### **Scenario: Importing a custom rule on top of an existing custom rule**
 
 **Automation**: 1 API integration test.
 
@@ -251,7 +251,7 @@ And the updated rule's parameters should match the import payload
 
 ### Importing multiple rules in bulk
 
-#### Scenario: Importing a mixture of new prebuilt and custom rules
+#### **Scenario: Importing a mixture of new prebuilt and custom rules**
 
 This scenario is a "smoke test" for all the user stories from the [Product requirements](#product-requirements) section.
 
@@ -269,7 +269,7 @@ And the created rules' is_customized field should be correctly calculated
 And the created rules' parameters should match the import payload
 ```
 
-#### Scenario: Importing a mixture of prebuilt and custom rules on top of existing rules
+#### **Scenario: Importing a mixture of prebuilt and custom rules on top of existing rules**
 
 This scenario is a "smoke test" for all the user stories from the [Product requirements](#product-requirements) section.
 
@@ -289,7 +289,7 @@ And the updated rules' parameters should match the import payload
 
 ### Importing prebuilt rules when the package is not installed
 
-#### Scenario: Importing new prebuilt rules when the package is not installed
+#### **Scenario: Importing new prebuilt rules when the package is not installed**
 
 **Automation**: 1 API integration test.
 
@@ -306,7 +306,7 @@ And the created rules should be correctly marked as non-customized or customized
 And the created rules' parameters should match the import payload
 ```
 
-#### Scenario: Importing prebuilt rules on top of existing rules when the package is not installed
+#### **Scenario: Importing prebuilt rules on top of existing rules when the package is not installed**
 
 **Automation**: 1 API integration test.
 
@@ -325,7 +325,7 @@ And the updated rules' parameters should match the import payload
 
 ### Converting between prebuilt and custom rules
 
-#### Scenario: Converting a custom rule to a customized prebuilt rule on import
+#### **Scenario: Converting a custom rule to a customized prebuilt rule on import**
 
 This is an edge case that can happen when the user manually edits an ndjson file and:
 
@@ -345,7 +345,7 @@ And the created rule should be marked as customized
 And the created rule's parameters should match the import payload
 ```
 
-#### Scenario: Converting a custom rule to a non-customized prebuilt rule on import
+#### **Scenario: Converting a custom rule to a non-customized prebuilt rule on import**
 
 This is an edge case that can happen when the user manually edits an ndjson file and:
 
@@ -365,7 +365,7 @@ And the created rule should be marked as non-customized
 And the created rule's parameters should match the import payload
 ```
 
-#### Scenario: Converting a prebuilt rule to a custom rule on import
+#### **Scenario: Converting a prebuilt rule to a custom rule on import**
 
 This is an edge case that can happen when the user manually edits an ndjson file and:
 
@@ -383,7 +383,7 @@ And the created rule should be custom
 And the created rule's parameters should match the import payload
 ```
 
-#### Scenario: Making an imported custom rule upgradeable to a prebuilt rule
+#### **Scenario: Making an imported custom rule upgradeable to a prebuilt rule**
 
 This is an edge case that can happen when Elastic ships a new prebuilt rule with a `rule_id` accidentally matching the `rule_id` of a user's custom rule.
 
@@ -412,7 +412,7 @@ NOTE: These are not edge cases but rather normal cases. In many package upgrade 
 
 **When the base version** of a prebuilt rule that is being imported **is missing** among the `security-rule` asset saved objects, and the user imports this rule, the following scenarios apply.
 
-#### Scenario: Importing a prebuilt rule with a missing base version when it's not installed
+#### **Scenario: Importing a prebuilt rule with a missing base version when it's not installed**
 
 If this rule is not installed, it should be created with `is_customized` field set to `false`.
 
@@ -431,7 +431,7 @@ And the created rule's version should match the import payload
 And the created rule's parameters should match the import payload
 ```
 
-#### Scenario: Importing a prebuilt rule with a missing base version when it's already installed but not equal to the import payload
+#### **Scenario: Importing a prebuilt rule with a missing base version when it's already installed but not equal to the import payload**
 
 If this rule is already installed, it should be updated. Its `is_customized` field should be set to `true` if the rule from the import payload is not equal to the installed rule.
 
@@ -451,7 +451,7 @@ And the updated rule's version should match the import payload
 And the updated rule's parameters should match the import payload
 ```
 
-#### Scenario: Importing a prebuilt rule with a missing base version when it's already installed, is not customized, and is equal to the import payload
+#### **Scenario: Importing a prebuilt rule with a missing base version when it's already installed, is not customized, and is equal to the import payload**
 
 If this rule is already installed, it should be updated. Its `is_customized` field should stay unchanged (`false` or `true`) if the rule from the import payload is equal to the installed rule.
 
@@ -471,7 +471,7 @@ And the updated rule's version should stay unchanged
 And the updated rule's parameters should stay unchanged
 ```
 
-#### Scenario: Importing a prebuilt rule with a missing base version when it's already installed, is customized, and is equal to the import payload
+#### **Scenario: Importing a prebuilt rule with a missing base version when it's already installed, is customized, and is equal to the import payload**
 
 If this rule is already installed, it should be updated. Its `is_customized` field should stay unchanged (`false` or `true`) if the rule from the import payload is equal to the installed rule.
 
@@ -493,7 +493,7 @@ And the updated rule's parameters should stay unchanged
 
 ### Handling missing fields in the import request payload
 
-#### Scenario: Importing a prebuilt rule without a `rule_id` field
+#### **Scenario: Importing a prebuilt rule without a `rule_id` field**
 
 **Automation**: 1 API integration test.
 
@@ -503,7 +503,7 @@ When the user imports the rule
 Then the import should be rejected with a message "rule_id field is required"
 ```
 
-#### Scenario: Importing a prebuilt rule with a matching `rule_id` but missing a `version` field
+#### **Scenario: Importing a prebuilt rule with a matching `rule_id` but missing a `version` field**
 
 **Automation**: 1 API integration test.
 
@@ -514,7 +514,7 @@ When the user imports the rule
 Then the import should be rejected with a message "version field is required"
 ```
 
-#### Scenario: Importing a new custom rule missing a `version` field
+#### **Scenario: Importing a new custom rule missing a `version` field**
 
 **Automation**: 1 API integration test.
 
@@ -528,7 +528,7 @@ And the created rule should be custom
 And the created rule's "version" field should be set to 1
 ```
 
-#### Scenario: Importing an existing custom rule missing a `version` field
+#### **Scenario: Importing an existing custom rule missing a `version` field**
 
 **Automation**: 1 API integration test.
 

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -52,6 +52,11 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
     - [**Scenario: Converting a custom rule to a non-customized prebuilt rule on import**](#scenario-converting-a-custom-rule-to-a-non-customized-prebuilt-rule-on-import)
     - [**Scenario: Converting a prebuilt rule to a custom rule on import**](#scenario-converting-a-prebuilt-rule-to-a-custom-rule-on-import)
     - [**Scenario: Making an imported custom rule upgradeable to a prebuilt rule**](#scenario-making-an-imported-custom-rule-upgradeable-to-a-prebuilt-rule)
+  - [Handling historical base versions](#handling-historical-base-versions)
+    - [**Scenario: Importing an old rule when it's not installed**](#scenario-importing-an-old-rule-when-its-not-installed)
+    - [**Scenario: Importing an old rule on top of an installed rule of the same version**](#scenario-importing-an-old-rule-on-top-of-an-installed-rule-of-the-same-version)
+    - [**Scenario: Importing an older rule on top of an installed rule of a newer version**](#scenario-importing-an-older-rule-on-top-of-an-installed-rule-of-a-newer-version)
+    - [**Scenario: Importing an newer rule on top of an installed rule of an older version**](#scenario-importing-an-newer-rule-on-top-of-an-installed-rule-of-an-older-version)
   - [Handling missing base versions](#handling-missing-base-versions)
     - [**Scenario: Importing a prebuilt rule with a missing base version when it's not installed**](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-not-installed)
     - [**Scenario: Importing a prebuilt rule with a missing base version when it's already installed but not equal to the import payload**](#scenario-importing-a-prebuilt-rule-with-a-missing-base-version-when-its-already-installed-but-not-equal-to-the-import-payload)
@@ -404,6 +409,115 @@ Then the rule should be upgraded to the asset's version
 And the upgraded rule should be prebuilt
 And the upgraded rule should be marked as non-customized
 And the upgraded rule's parameters should match the asset
+```
+
+### Handling historical base versions
+
+Importing prebuilt rules which version matches one of the older, historical rule assets from the installed package.
+
+#### **Scenario: Importing an old rule when it's not installed**
+
+**Automation**: 1 API integration test that tests 2 different rules at the same time, one rule per each example.
+
+```Gherkin
+Given the import payload contains a prebuilt rule
+And this rule has a base version in the installed package which is NOT the latest one
+And this rule has newer versions in the installed package
+And this rule <is_equal> to its base version
+And this rule is not installed
+When the user imports the rule
+Then the rule should be created
+And the created rule should be prebuilt
+And the created rule should be marked as <created_customized>
+And the created rule's version should match the import payload
+And the created rule's parameters should match the import payload
+And the created rule should be available for upgrade to its latest version
+
+Examples:
+  | is_equal     | created_customized |
+  | is equal     | non-customized     |
+  | is NOT equal | customized         |
+```
+
+#### **Scenario: Importing an old rule on top of an installed rule of the same version**
+
+**Automation**: 1 API integration test that tests 4 different rules at the same time, one rule per each example.
+
+```Gherkin
+Given the import payload contains a prebuilt rule
+And this rule has a base version in the installed package which is NOT the latest one
+And this rule has newer versions in the installed package
+And this rule <is_equal> to its base version
+And this rule is already installed and is <installed_customized>
+And the installed rule's version is equal to the imported rule's version
+When the user imports the rule
+Then the rule should be updated
+And the updated rule should be prebuilt
+And the updated rule should be marked as <updated_customized>
+And the updated rule's version should stay unchanged
+And the updated rule's parameters should match the import payload
+And the updated rule should be available for upgrade to its latest version
+
+Examples:
+  | is_equal     | installed_customized | updated_customized |
+  | is equal     | non-customized       | non-customized     |
+  | is equal     | customized           | non-customized     |
+  | is NOT equal | non-customized       | customized         |
+  | is NOT equal | customized           | customized         |
+```
+
+#### **Scenario: Importing an older rule on top of an installed rule of a newer version**
+
+**Automation**: 1 API integration test that tests 4 different rules at the same time, one rule per each example.
+
+```Gherkin
+Given the import payload contains a prebuilt rule
+And this rule has a base version in the installed package which is NOT the latest one
+And this rule has newer versions in the installed package
+And this rule <is_equal> to its base version
+And this rule is already installed and is <installed_customized>
+And the imported rule's version is less than the installed rule's version
+When the user imports the rule
+Then the rule should be updated
+And the updated rule should be prebuilt
+And the updated rule should be marked as <updated_customized>
+And the updated rule's version should match the import payload
+And the updated rule's parameters should match the import payload
+And the updated rule should be available for upgrade to its latest version
+
+Examples:
+  | is_equal     | installed_customized | updated_customized |
+  | is equal     | non-customized       | non-customized     |
+  | is equal     | customized           | non-customized     |
+  | is NOT equal | non-customized       | customized         |
+  | is NOT equal | customized           | customized         |
+```
+
+#### **Scenario: Importing an newer rule on top of an installed rule of an older version**
+
+**Automation**: 1 API integration test that tests 4 different rules at the same time, one rule per each example.
+
+```Gherkin
+Given the import payload contains a prebuilt rule
+And this rule has a base version in the installed package which is NOT the latest one
+And this rule has newer versions in the installed package
+And this rule <is_equal> to its base version
+And this rule is already installed and is <installed_customized>
+And the imported rule's version is greater than the installed rule's version
+When the user imports the rule
+Then the rule should be updated
+And the updated rule should be prebuilt
+And the updated rule should be marked as <updated_customized>
+And the updated rule's version should match the import payload
+And the updated rule's parameters should match the import payload
+And the updated rule should be available for upgrade to its latest version
+
+Examples:
+  | is_equal     | installed_customized | updated_customized |
+  | is equal     | non-customized       | non-customized     |
+  | is equal     | customized           | non-customized     |
+  | is NOT equal | non-customized       | customized         |
+  | is NOT equal | customized           | customized         |
 ```
 
 ### Handling missing base versions

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -30,11 +30,17 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
   - [Technical requirements](#technical-requirements)
   - [Product requirements](#product-requirements)
 - [Scenarios](#scenarios)
-  - [Importing single prebuilt rules](#importing-single-prebuilt-rules)
-    - [Scenario: Importing a non-customized prebuilt rule with a matching `rule_id` and `version`](#scenario-importing-a-non-customized-prebuilt-rule-with-a-matching-rule_id-and-version)
-    - [Scenario: Importing a customized prebuilt rule with a matching `rule_id` and `version`](#scenario-importing-a-customized-prebuilt-rule-with-a-matching-rule_id-and-version)
+  - [Importing single prebuilt non-customized rules](#importing-single-prebuilt-non-customized-rules)
+    - [Scenario: Importing a non-customized rule when it's not installed](#scenario-importing-a-non-customized-rule-when-its-not-installed)
+    - [Scenario: Importing a non-customized rule on top of an installed non-customized rule](#scenario-importing-a-non-customized-rule-on-top-of-an-installed-non-customized-rule)
+    - [Scenario: Importing a non-customized rule on top of an installed customized rule](#scenario-importing-a-non-customized-rule-on-top-of-an-installed-customized-rule)
+  - [Importing single prebuilt customized rules](#importing-single-prebuilt-customized-rules)
+    - [Scenario: Importing a customized rule when it's not installed](#scenario-importing-a-customized-rule-when-its-not-installed)
+    - [Scenario: Importing a customized rule on top of an installed non-customized rule](#scenario-importing-a-customized-rule-on-top-of-an-installed-non-customized-rule)
+    - [Scenario: Importing a customized rule on top of an installed customized rule](#scenario-importing-a-customized-rule-on-top-of-an-installed-customized-rule)
   - [Importing single custom rules](#importing-single-custom-rules)
-    - [Scenario: Importing a custom rule with a matching custom `rule_id` and `version`](#scenario-importing-a-custom-rule-with-a-matching-custom-rule_id-and-version)
+    - [Scenario: Importing a new custom rule](#scenario-importing-a-new-custom-rule)
+    - [Scenario: Importing a custom rule on top of an existing custom rule](#scenario-importing-a-custom-rule-on-top-of-an-existing-custom-rule)
   - [Importing multiple rules in bulk](#importing-multiple-rules-in-bulk)
     - [Scenario: Importing both custom and prebuilt rules](#scenario-importing-both-custom-and-prebuilt-rules)
   - [Importing prebuilt rules when the package is not installed](#importing-prebuilt-rules-when-the-package-is-not-installed)
@@ -68,6 +74,10 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
 ### Terminology
 
 - [Common terminology](./prebuilt_rules_common_info.md#common-terminology).
+- **This rule is not installed**: a prebuilt rule with the same `rule_id` hasn't been installed yet and doesn't exist as an alerting rule saved object.
+- **This rule is already installed**: a prebuilt rule with the same `rule_id` has been already installed and exists as an alerting rule saved object.
+- **This rule is not created yet**: a custom rule with the same `rule_id` hasn't been created yet and doesn't exist as an alerting rule saved object.
+- **This rule is already created**: a custom rule with the same `rule_id` has been already created and exists as an alerting rule saved object.
 
 ## Requirements
 
@@ -76,6 +86,7 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
 Assumptions about test environments and scenarios outlined in this test plan.
 
 - [Common assumptions](./prebuilt_rules_common_info.md#common-assumptions).
+- The `overwrite` import request parameter is set to `true`, unless explicitly indicated otherwise.
 
 ### Technical requirements
 
@@ -99,47 +110,134 @@ User stories:
 
 ## Scenarios
 
-### Importing single prebuilt rules
+### Importing single prebuilt non-customized rules
 
-#### Scenario: Importing a non-customized prebuilt rule with a matching `rule_id` and `version`
+#### Scenario: Importing a non-customized rule when it's not installed
 
-**Automation**: 1 cypress test and 1 integration test.
+**Automation**: 1 API integration test.
 
 ```Gherkin
-Given the import payload contains a non-customized prebuilt rule
-And its rule_id and version match a rule asset from the installed package
+Given the import payload contains a prebuilt rule
+And this rule has a base version (its rule_id and version match a rule asset)
+And this rule is equal to its base version
+And this rule is not installed
 When the user imports the rule
-Then the rule should be created or updated
-And the ruleSource type should be "external"
-And isCustomized should be false
+Then the rule should be created
+And the created rule should be prebuilt
+And the created rule should be marked as non-customized
+And the created rule's parameters should match the import payload
 ```
 
-#### Scenario: Importing a customized prebuilt rule with a matching `rule_id` and `version`
+#### Scenario: Importing a non-customized rule on top of an installed non-customized rule
 
-**Automation**: 1 cypress test and 1 integration test.
+**Automation**: 1 API integration test.
 
 ```Gherkin
-Given the import payload contains a customized prebuilt rule
-And its rule_id and version match a rule asset from the installed package
+Given the import payload contains a prebuilt rule
+And this rule has a base version (its rule_id and version match a rule asset)
+And this rule is equal to its base version
+And this rule is already installed and is not customized
 When the user imports the rule
-Then the rule should be created or updated
-And the ruleSource type should be "external"
-And isCustomized should be true
+Then the rule should be updated
+And the updated rule should be prebuilt
+And the updated rule should be marked as non-customized
+And the updated rule's parameters should match the import payload
+```
+
+#### Scenario: Importing a non-customized rule on top of an installed customized rule
+
+**Automation**: 1 API integration test.
+
+```Gherkin
+Given the import payload contains a prebuilt rule
+And this rule has a base version (its rule_id and version match a rule asset)
+And this rule is equal to its base version
+And this rule is already installed and is customized
+When the user imports the rule
+Then the rule should be updated
+And the updated rule should be prebuilt
+And the updated rule should be marked as non-customized
+And the updated rule's parameters should match the import payload
+```
+
+### Importing single prebuilt customized rules
+
+#### Scenario: Importing a customized rule when it's not installed
+
+**Automation**: 1 API integration test.
+
+```Gherkin
+Given the import payload contains a prebuilt rule
+And this rule has a base version (its rule_id and version match a rule asset)
+And this rule is different from its base version
+And this rule is not installed
+When the user imports the rule
+Then the rule should be created
+And the created rule should be prebuilt
+And the created rule should be marked as customized
+And the created rule's parameters should match the import payload
+```
+
+#### Scenario: Importing a customized rule on top of an installed non-customized rule
+
+**Automation**: 1 API integration test.
+
+```Gherkin
+Given the import payload contains a prebuilt rule
+And this rule has a base version (its rule_id and version match a rule asset)
+And this rule is different from its base version
+And this rule is already installed and is not customized
+When the user imports the rule
+Then the rule should be updated
+And the updated rule should be prebuilt
+And the updated rule should be marked as customized
+And the updated rule's parameters should match the import payload
+```
+
+#### Scenario: Importing a customized rule on top of an installed customized rule
+
+**Automation**: 1 API integration test.
+
+```Gherkin
+Given the import payload contains a prebuilt rule
+And this rule has a base version (its rule_id and version match a rule asset)
+And this rule is different from its base version
+And this rule is already installed and is customized
+When the user imports the rule
+Then the rule should be updated
+And the updated rule should be prebuilt
+And the updated rule should be marked as customized
+And the updated rule's parameters should match the import payload
 ```
 
 ### Importing single custom rules
 
-#### Scenario: Importing a custom rule with a matching custom `rule_id` and `version`
+#### Scenario: Importing a new custom rule
 
-**Automation**: 1 cypress test and 1 integration test.
+**Automation**: 1 API integration test.
 
 ```Gherkin
 Given the import payload contains a custom rule
-And its rule_id and version match a rule asset from the installed package
-And the overwrite flag is set to true
+And its rule_id does NOT match any rule assets from the installed package
+And this rule is not created yet
 When the user imports the rule
-Then the rule should be created or updated
-And the ruleSource type should be "internal"
+Then the rule should be created
+And the created rule should be custom
+And the created rule's parameters should match the import payload
+```
+
+#### Scenario: Importing a custom rule on top of an existing custom rule
+
+**Automation**: 1 API integration test.
+
+```Gherkin
+Given the import payload contains a custom rule
+And its rule_id does NOT match any rule assets from the installed package
+And this rule is already created
+When the user imports the rule
+Then the rule should be updated
+And the updated rule should be custom
+And the updated rule's parameters should match the import payload
 ```
 
 ### Importing multiple rules in bulk

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -30,15 +30,15 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
   - [Technical requirements](#technical-requirements)
   - [Product requirements](#product-requirements)
 - [Scenarios](#scenarios)
-  - [Importing single prebuilt non-customized rules](#importing-single-prebuilt-non-customized-rules)
+  - [Importing a single non-customized prebuilt rule](#importing-a-single-non-customized-prebuilt-rule)
     - [**Scenario: Importing a non-customized rule when it's not installed**](#scenario-importing-a-non-customized-rule-when-its-not-installed)
     - [**Scenario: Importing a non-customized rule on top of an installed non-customized rule**](#scenario-importing-a-non-customized-rule-on-top-of-an-installed-non-customized-rule)
     - [**Scenario: Importing a non-customized rule on top of an installed customized rule**](#scenario-importing-a-non-customized-rule-on-top-of-an-installed-customized-rule)
-  - [Importing single prebuilt customized rules](#importing-single-prebuilt-customized-rules)
+  - [Importing a single customized prebuilt rule](#importing-a-single-customized-prebuilt-rule)
     - [**Scenario: Importing a customized rule when it's not installed**](#scenario-importing-a-customized-rule-when-its-not-installed)
     - [**Scenario: Importing a customized rule on top of an installed non-customized rule**](#scenario-importing-a-customized-rule-on-top-of-an-installed-non-customized-rule)
     - [**Scenario: Importing a customized rule on top of an installed customized rule**](#scenario-importing-a-customized-rule-on-top-of-an-installed-customized-rule)
-  - [Importing single custom rules](#importing-single-custom-rules)
+  - [Importing a single custom rule](#importing-a-single-custom-rule)
     - [**Scenario: Importing a new custom rule**](#scenario-importing-a-new-custom-rule)
     - [**Scenario: Importing a custom rule on top of an existing custom rule**](#scenario-importing-a-custom-rule-on-top-of-an-existing-custom-rule)
   - [Importing multiple rules in bulk](#importing-multiple-rules-in-bulk)
@@ -119,7 +119,7 @@ User stories:
 
 ## Scenarios
 
-### Importing single prebuilt non-customized rules
+### Importing a single non-customized prebuilt rule
 
 #### **Scenario: Importing a non-customized rule when it's not installed**
 
@@ -169,7 +169,7 @@ And the updated rule should be marked as non-customized
 And the updated rule's parameters should match the import payload
 ```
 
-### Importing single prebuilt customized rules
+### Importing a single customized prebuilt rule
 
 #### **Scenario: Importing a customized rule when it's not installed**
 
@@ -219,7 +219,7 @@ And the updated rule should be marked as customized
 And the updated rule's parameters should match the import payload
 ```
 
-### Importing single custom rules
+### Importing a single custom rule
 
 #### **Scenario: Importing a new custom rule**
 
@@ -258,7 +258,7 @@ This scenario is a "smoke test" for all the user stories from the [Product requi
 **Automation**: 1 API integration test, 1 e2e test.
 
 ```Gherkin
-Given the import payload contains prebuilt non-customized, prebuilt customized, and custom rules
+Given the import payload contains non-customized prebuilt, customized prebuilt, and custom rules
 And the prebuilt rules have a base version in the installed package
 And the custom rules' rule_id does NOT match any rule assets from the installed package
 And the rules are not installed or created yet
@@ -276,7 +276,7 @@ This scenario is a "smoke test" for all the user stories from the [Product requi
 **Automation**: 1 API integration test, 1 e2e test.
 
 ```Gherkin
-Given the import payload contains prebuilt non-customized, prebuilt customized, and custom rules
+Given the import payload contains non-customized prebuilt, customized prebuilt, and custom rules
 And the prebuilt rules have a base version in the installed package
 And the custom rules' rule_id does NOT match any rule assets from the installed package
 And the rules are already installed or created
@@ -420,7 +420,7 @@ If this rule is not installed, it should be created with `is_customized` field s
 
 ```Gherkin
 Given the import payload contains a prebuilt rule
-And its rule_id matches one or a few rule assets from the installed package
+And its rule_id matches one or more rule assets from the installed package
 And its version does NOT match any of those rule assets
 And this rule is not installed yet
 When the user imports the rule
@@ -439,7 +439,7 @@ If this rule is already installed, it should be updated. Its `is_customized` fie
 
 ```Gherkin
 Given the import payload contains a non-customized prebuilt rule
-And its rule_id matches one or a few rule assets from the installed package
+And its rule_id matches one or more rule assets from the installed package
 And its version does NOT match any of those rule assets
 And this rule is already installed and marked as non-customized
 And the installed rule is NOT equal to the import payload
@@ -459,7 +459,7 @@ If this rule is already installed, it should be updated. Its `is_customized` fie
 
 ```Gherkin
 Given the import payload contains a customized prebuilt rule
-And its rule_id matches one or a few rule assets from the installed package
+And its rule_id matches one or more rule assets from the installed package
 And its version does NOT match any of those rule assets
 And this rule is already installed and marked as non-customized
 And the installed rule is equal to the import payload
@@ -479,7 +479,7 @@ If this rule is already installed, it should be updated. Its `is_customized` fie
 
 ```Gherkin
 Given the import payload contains a non-customized prebuilt rule
-And its rule_id matches one or a few rule assets from the installed package
+And its rule_id matches one or more rule assets from the installed package
 And its version does NOT match any of those rule assets
 And this rule is already installed and marked as customized
 And the installed rule is equal to the import payload
@@ -509,7 +509,7 @@ Then the import should be rejected with a message "rule_id field is required"
 
 ```Gherkin
 Given the import payload contains a prebuilt rule without a version field
-And its rule_id matches one or a few rule assets from the installed package
+And its rule_id matches one or more rule assets from the installed package
 When the user imports the rule
 Then the import should be rejected with a message "version field is required"
 ```

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -62,9 +62,6 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
     - [Scenario: Importing a prebuilt rule with a matching `rule_id` but missing a `version` field](#scenario-importing-a-prebuilt-rule-with-a-matching-rule_id-but-missing-a-version-field)
     - [Scenario: Importing a new custom rule missing a `version` field](#scenario-importing-a-new-custom-rule-missing-a-version-field)
     - [Scenario: Importing an existing custom rule missing a `version` field](#scenario-importing-an-existing-custom-rule-missing-a-version-field)
-  - [Handling request parameters: `overwrite` flag](#handling-request-parameters-overwrite-flag)
-    - [Scenario: Importing a rule with `overwrite` flag set to true](#scenario-importing-a-rule-with-overwrite-flag-set-to-true)
-    - [Scenario: Importing a rule with `overwrite` flag set to false](#scenario-importing-a-rule-with-overwrite-flag-set-to-false)
   - [Licensing](#licensing)
 
 ## Useful information
@@ -543,35 +540,6 @@ When the user imports the rule
 Then the rule should be updated
 And the updated rule should be custom
 And the updated rule's "version" field should stay unchanged
-```
-
-### Handling request parameters: `overwrite` flag
-
-#### Scenario: Importing a rule with `overwrite` flag set to true
-
-**Automation**: 1 integration test.
-
-```Gherkin
-Given the import payload contains a rule
-And its rule_id matches a rule_id of one of the installed rules
-And the overwrite flag is set to true
-When the user imports the rule
-Then the rule should be overwritten
-And the ruleSource should be based on rule_id and version
-```
-
-#### Scenario: Importing a rule with `overwrite` flag set to false
-
-**Automation**: 1 integration test.
-
-```Gherkin
-Given the import payload contains a rule
-And its rule_id matches a rule_id of one of the installed rules
-And the overwrite flag is set to false
-When the user imports the rule
-Then the import should be rejected with a message "rule_id already exists"
-
-CASE: should have the same outcome for all rule types
 ```
 
 ### Licensing

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -60,8 +60,8 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
   - [Handling missing fields in the import request payload](#handling-missing-fields-in-the-import-request-payload)
     - [Scenario: Importing a prebuilt rule without a `rule_id` field](#scenario-importing-a-prebuilt-rule-without-a-rule_id-field)
     - [Scenario: Importing a prebuilt rule with a matching `rule_id` but missing a `version` field](#scenario-importing-a-prebuilt-rule-with-a-matching-rule_id-but-missing-a-version-field)
-    - [Scenario: Importing an existing custom rule missing a `version` field](#scenario-importing-an-existing-custom-rule-missing-a-version-field)
     - [Scenario: Importing a new custom rule missing a `version` field](#scenario-importing-a-new-custom-rule-missing-a-version-field)
+    - [Scenario: Importing an existing custom rule missing a `version` field](#scenario-importing-an-existing-custom-rule-missing-a-version-field)
   - [Handling request parameters: `overwrite` flag](#handling-request-parameters-overwrite-flag)
     - [Scenario: Importing a rule with `overwrite` flag set to true](#scenario-importing-a-rule-with-overwrite-flag-set-to-true)
     - [Scenario: Importing a rule with `overwrite` flag set to false](#scenario-importing-a-rule-with-overwrite-flag-set-to-false)
@@ -498,7 +498,7 @@ And the updated rule's parameters should stay unchanged
 
 #### Scenario: Importing a prebuilt rule without a `rule_id` field
 
-**Automation**: 1 integration test.
+**Automation**: 1 API integration test.
 
 ```Gherkin
 Given the import payload contains a prebuilt rule without a rule_id field
@@ -508,7 +508,7 @@ Then the import should be rejected with a message "rule_id field is required"
 
 #### Scenario: Importing a prebuilt rule with a matching `rule_id` but missing a `version` field
 
-**Automation**: 1 integration test.
+**Automation**: 1 API integration test.
 
 ```Gherkin
 Given the import payload contains a prebuilt rule without a version field
@@ -517,32 +517,32 @@ When the user imports the rule
 Then the import should be rejected with a message "version field is required"
 ```
 
-#### Scenario: Importing an existing custom rule missing a `version` field
-
-**Automation**: 1 integration test.
-
-```Gherkin
-Given the import payload contains a custom rule without a version field
-And its rule_id does NOT match any rule assets from the installed package
-And this custom rule has already been created
-When the user imports the rule
-Then the rule should be updated
-And the ruleSource type should be "internal"
-And the "version" field should be set to the existing rule's "version"
-```
-
 #### Scenario: Importing a new custom rule missing a `version` field
 
-**Automation**: 1 integration test.
+**Automation**: 1 API integration test.
 
 ```Gherkin
 Given the import payload contains a custom rule without a version field
 And its rule_id does NOT match any rule assets from the installed package
-And this custom rule hasn't been created yet
+And this rule is not created yet
 When the user imports the rule
 Then the rule should be created
-And the ruleSource type should be "internal"
-And the "version" field should be set to 1
+And the created rule should be custom
+And the created rule's "version" field should be set to 1
+```
+
+#### Scenario: Importing an existing custom rule missing a `version` field
+
+**Automation**: 1 API integration test.
+
+```Gherkin
+Given the import payload contains a custom rule without a version field
+And its rule_id does NOT match any rule assets from the installed package
+And this rule is already created and has "version > 1"
+When the user imports the rule
+Then the rule should be updated
+And the updated rule should be custom
+And the updated rule's "version" field should stay unchanged
 ```
 
 ### Handling request parameters: `overwrite` flag

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -89,6 +89,7 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
 - **This rule is already created**: a custom rule with the same `rule_id` has been already created and exists as an alerting rule saved object.
 - **This rule has a base version in the installed package**: package with prebuilt rules has been installed, and the rule's `rule_id` and `version` fields match one of the rule assets from this package.
 - **This rule has a base version in the latest package**: the rule's `rule_id` and `version` fields match one of the rule assets from the latest version of the package with prebuilt rules. It is likely assumed or stated explicitly that the latest package hasn't been installed yet.
+- **Rule should be updated**: the saved object of the rule should be updated by the Alerting Framework; in practice this means, for example, updating the `updated_at` and `updated_by` fields, which can be checked in tests.
 
 ## Requirements
 

--- a/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
+++ b/x-pack/solutions/security/plugins/security_solution/docs/testing/test_plans/detection_response/prebuilt_rules/prebuilt_rule_import.md
@@ -30,22 +30,30 @@ https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
   - [Technical requirements](#technical-requirements)
   - [Product requirements](#product-requirements)
 - [Scenarios](#scenarios)
-  - [Core Functionality](#core-functionality)
+  - [Importing single prebuilt rules](#importing-single-prebuilt-rules)
     - [Scenario: Importing a non-customized prebuilt rule with a matching `rule_id` and `version`](#scenario-importing-a-non-customized-prebuilt-rule-with-a-matching-rule_id-and-version)
     - [Scenario: Importing a customized prebuilt rule with a matching `rule_id` and `version`](#scenario-importing-a-customized-prebuilt-rule-with-a-matching-rule_id-and-version)
-    - [Scenario: Importing a custom rule with a matching prebuilt `rule_id` and `version`](#scenario-importing-a-custom-rule-with-a-matching-prebuilt-rule_id-and-version)
+  - [Importing single custom rules](#importing-single-custom-rules)
     - [Scenario: Importing a custom rule with a matching custom `rule_id` and `version`](#scenario-importing-a-custom-rule-with-a-matching-custom-rule_id-and-version)
-    - [Scenario: Importing a prebuilt rule with a matching `rule_id` but no matching `version`](#scenario-importing-a-prebuilt-rule-with-a-matching-rule_id-but-no-matching-version)
+  - [Importing multiple rules in bulk](#importing-multiple-rules-in-bulk)
+    - [Scenario: Importing both custom and prebuilt rules](#scenario-importing-both-custom-and-prebuilt-rules)
+  - [Importing prebuilt rules when the package is not installed](#importing-prebuilt-rules-when-the-package-is-not-installed)
+    - [Scenario: Importing a prebuilt rule when the rules package is not installed](#scenario-importing-a-prebuilt-rule-when-the-rules-package-is-not-installed)
+  - [Converting between prebuilt and custom rules](#converting-between-prebuilt-and-custom-rules)
+    - [Scenario: Importing a custom rule with a matching prebuilt `rule_id` and `version`](#scenario-importing-a-custom-rule-with-a-matching-prebuilt-rule_id-and-version)
     - [Scenario: Importing a prebuilt rule with a non-existent `rule_id`](#scenario-importing-a-prebuilt-rule-with-a-non-existent-rule_id)
+    - [Scenario: Importing a custom rule before a prebuilt rule asset is created with the same `rule_id`](#scenario-importing-a-custom-rule-before-a-prebuilt-rule-asset-is-created-with-the-same-rule_id)
+  - [Handling missing base versions](#handling-missing-base-versions)
+    - [Scenario: Importing a prebuilt rule with a matching `rule_id` but no matching `version`](#scenario-importing-a-prebuilt-rule-with-a-matching-rule_id-but-no-matching-version)
+  - [Handling missing fields in the import request payload](#handling-missing-fields-in-the-import-request-payload)
     - [Scenario: Importing a prebuilt rule without a `rule_id` field](#scenario-importing-a-prebuilt-rule-without-a-rule_id-field)
     - [Scenario: Importing a prebuilt rule with a matching `rule_id` but missing a `version` field](#scenario-importing-a-prebuilt-rule-with-a-matching-rule_id-but-missing-a-version-field)
     - [Scenario: Importing an existing custom rule missing a `version` field](#scenario-importing-an-existing-custom-rule-missing-a-version-field)
     - [Scenario: Importing a new custom rule missing a `version` field](#scenario-importing-a-new-custom-rule-missing-a-version-field)
+  - [Handling request parameters: `overwrite` flag](#handling-request-parameters-overwrite-flag)
     - [Scenario: Importing a rule with `overwrite` flag set to true](#scenario-importing-a-rule-with-overwrite-flag-set-to-true)
     - [Scenario: Importing a rule with `overwrite` flag set to false](#scenario-importing-a-rule-with-overwrite-flag-set-to-false)
-    - [Scenario: Importing both custom and prebuilt rules](#scenario-importing-both-custom-and-prebuilt-rules)
-    - [Scenario: Importing a prebuilt rule when the rules package is not installed](#scenario-importing-a-prebuilt-rule-when-the-rules-package-is-not-installed)
-    - [Scenario: Importing a custom rule before a prebuilt rule asset is created with the same `rule_id`](#scenario-importing-a-custom-rule-before-a-prebuilt-rule-asset-is-created-with-the-same-rule_id)
+  - [Licensing](#licensing)
 
 ## Useful information
 
@@ -91,7 +99,7 @@ User stories:
 
 ## Scenarios
 
-### Core Functionality
+### Importing single prebuilt rules
 
 #### Scenario: Importing a non-customized prebuilt rule with a matching `rule_id` and `version`
 
@@ -119,18 +127,7 @@ And the ruleSource type should be "external"
 And isCustomized should be true
 ```
 
-#### Scenario: Importing a custom rule with a matching prebuilt `rule_id` and `version`
-
-**Automation**: 1 cypress test and 1 integration test.
-
-```Gherkin
-Given the import payload contains a custom rule
-And its rule_id and version match a rule asset from the installed package
-When the user imports the rule
-Then the rule should be created or updated
-And the ruleSource type should be "external"
-And isCustomized should be true
-```
+### Importing single custom rules
 
 #### Scenario: Importing a custom rule with a matching custom `rule_id` and `version`
 
@@ -145,14 +142,45 @@ Then the rule should be created or updated
 And the ruleSource type should be "internal"
 ```
 
-#### Scenario: Importing a prebuilt rule with a matching `rule_id` but no matching `version`
+### Importing multiple rules in bulk
+
+#### Scenario: Importing both custom and prebuilt rules
+
+**Automation**: 1 integration test.
+
+```Gherkin
+Given the import payload contains prebuilt non-customized, prebuilt customized, and custom rules
+When the user imports these rules
+Then custom rules should be created or updated, with versions defaulted to 1
+And prebuilt rules should be created or updated,
+And prebuilt rules missing versions should be rejected
+```
+
+### Importing prebuilt rules when the package is not installed
+
+#### Scenario: Importing a prebuilt rule when the rules package is not installed
 
 **Automation**: 1 integration test.
 
 ```Gherkin
 Given the import payload contains a prebuilt rule
-And its rule_id matches one or a few rule assets from the installed package
-And its version does NOT match any of those rule assets
+And its rule_id matches one or a few rule assets from the latest package
+And the package hasn't been installed yet
+When the user imports the rule
+Then the latest package should get installed automatically
+And the rule should be created or updated
+And the ruleSource type should be "external"
+```
+
+### Converting between prebuilt and custom rules
+
+#### Scenario: Importing a custom rule with a matching prebuilt `rule_id` and `version`
+
+**Automation**: 1 cypress test and 1 integration test.
+
+```Gherkin
+Given the import payload contains a custom rule
+And its rule_id and version match a rule asset from the installed package
 When the user imports the rule
 Then the rule should be created or updated
 And the ruleSource type should be "external"
@@ -170,6 +198,35 @@ When the user imports the rule
 Then the rule should be created
 And the ruleSource type should be "internal"
 ```
+
+#### Scenario: Importing a custom rule before a prebuilt rule asset is created with the same `rule_id`
+
+**Automation**: 1 integration test.
+
+```Gherkin
+Given the environment contains an imported custom rule
+And this rule has a rule_id of X
+When a prebuilt rule asset is added with a rule_id of X
+Then the imported custom rule should be upgradeable as if it were a prebuilt rule
+```
+
+### Handling missing base versions
+
+#### Scenario: Importing a prebuilt rule with a matching `rule_id` but no matching `version`
+
+**Automation**: 1 integration test.
+
+```Gherkin
+Given the import payload contains a prebuilt rule
+And its rule_id matches one or a few rule assets from the installed package
+And its version does NOT match any of those rule assets
+When the user imports the rule
+Then the rule should be created or updated
+And the ruleSource type should be "external"
+And isCustomized should be true
+```
+
+### Handling missing fields in the import request payload
 
 #### Scenario: Importing a prebuilt rule without a `rule_id` field
 
@@ -220,6 +277,8 @@ And the ruleSource type should be "internal"
 And the "version" field should be set to 1
 ```
 
+### Handling request parameters: `overwrite` flag
+
 #### Scenario: Importing a rule with `overwrite` flag set to true
 
 **Automation**: 1 integration test.
@@ -247,39 +306,6 @@ Then the import should be rejected with a message "rule_id already exists"
 CASE: should have the same outcome for all rule types
 ```
 
-#### Scenario: Importing both custom and prebuilt rules
+### Licensing
 
-**Automation**: 1 integration test.
-
-```Gherkin
-Given the import payload contains prebuilt non-customized, prebuilt customized, and custom rules
-When the user imports these rules
-Then custom rules should be created or updated, with versions defaulted to 1
-And prebuilt rules should be created or updated,
-And prebuilt rules missing versions should be rejected
-```
-
-#### Scenario: Importing a prebuilt rule when the rules package is not installed
-
-**Automation**: 1 integration test.
-
-```Gherkin
-Given the import payload contains a prebuilt rule
-And its rule_id matches one or a few rule assets from the latest package
-And the package hasn't been installed yet
-When the user imports the rule
-Then the latest package should get installed automatically
-And the rule should be created or updated
-And the ruleSource type should be "external"
-```
-
-#### Scenario: Importing a custom rule before a prebuilt rule asset is created with the same `rule_id`
-
-**Automation**: 1 integration test.
-
-```Gherkin
-Given the environment contains an imported custom rule
-And this rule has a rule_id of X
-When a prebuilt rule asset is added with a rule_id of X
-Then the imported custom rule should be upgradeable as if it were a prebuilt rule
-```
+TODO: describe licensing restrictions that apply to rule import.


### PR DESCRIPTION
**Epic:** https://github.com/elastic/kibana/issues/174168
**Partially addresses:** https://github.com/elastic/kibana/issues/202079, https://github.com/elastic/kibana/issues/210358

## Summary

We started to rework and introduce functional changes to our existing test plans for prebuilt rule customization, upgrade, and export/import workflows.

Specifically, this PR:

- Restructures the test plan, introduces a more fine-grained list of sections.
- Rewrites almost all the existing scenarios. In most cases it boils down to splitting a scenario into 2+ more specific scenarios, where each describes _exactly_ what happens in the GIVEN and THEN sections. This is very important, as it:
  - makes these scenarios ready to be implemented right away: 1 scenario = 1 test to write
  - helps with ensuring that we covered edge cases
- Adds new scenarios for handling missing base versions according to [#210358](https://github.com/elastic/kibana/issues/210358).
- Adds a placeholder section for licensing scenarios according to [#11502](https://github.com/elastic/security-team/issues/11502).
- Removes scenarios for the `overwrite` request parameter - this is common importing logic which is not related to prebuilt rules. 
- Addresses my own comments from [this review](https://github.com/elastic/kibana/pull/206893#pullrequestreview-2633863218).

The new test plan should be in line with the changes discussed in https://github.com/elastic/kibana/issues/210358.

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->