### PR TITLE
[docs] Fix external links

### DIFF
--- a/docs/extend/development-tests.md
+++ b/docs/extend/development-tests.md
@@ -755,7 +755,7 @@ Packaging tests use Vagrant virtual machines as hosts and Ansible for provisioni
 
 ### Setup [_setup]
 
-* [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.md)
+* [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 
     ```
     # Ubuntu
@@ -818,7 +818,7 @@ vagrant destroy <hostname>
 
 **Note:** IE11 is not supported from 7.9 onwards.
 
-* [Download VMWare Fusion](http://www.vmware.com/products/fusion/fusion-evaluation.md).
+* [Download VMWare Fusion](http://www.vmware.com/products/fusion/fusion-evaluation.html).
 * [Download IE virtual machines](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/#downloads) for VMWare.
 * Open VMWare and go to Window > Virtual Machine Library. Unzip the virtual machine and drag the .vmx file into your Virtual Machine Library.
 * Right-click on the virtual machine you just added to your library and select "`Snapshots…`", and then click the "`Take`" button in the modal that opens. You can roll back to this snapshot when the VM expires in 90 days.

--- a/docs/extend/security-best-practices.md
+++ b/docs/extend/security-best-practices.md
@@ -17,10 +17,10 @@ XSS is a class of attacks where malicious scripts are injected into vulnerable w
 
 * Check for dangerous functions or assignments that can result in unescaped user input in the browser DOM. Avoid using:
 
-    * **React:** [`dangerouslySetInnerHtml`](https://reactjs.org/docs/dom-elements.md#dangerouslysetinnerhtml).
+    * **React:** [`dangerouslySetInnerHtml`](https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml).
     * **Browser DOM:** `Element.innerHTML` and `Element.outerHTML`.
 
-* If using the aforementioned unsafe functions or assignments is absolutely necessary, follow [these XSS prevention rules](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md#xss-prevention-rules) to ensure that user input is not inserted into unsafe locations and that it is escaped properly.
+* If using the aforementioned unsafe functions or assignments is absolutely necessary, follow [these XSS prevention rules](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#xss-prevention-rules) to ensure that user input is not inserted into unsafe locations and that it is escaped properly.
 * Use EUI components to build your UI, particularly when rendering `href` links. Otherwise, sanitize user input before rendering links to ensure that they do not use the `javascript:` protocol.
 * Don’t use the `eval`, `Function`, and `_.template` functions — these are restricted by ESLint rules.
 * Be careful when using `setTimeout` and `setInterval` in client-side code. If an attacker can manipulate the arguments and pass a string to one of these, it is evaluated dynamically, which is equivalent to the dangerous `eval` function.
@@ -30,7 +30,7 @@ XSS is a class of attacks where malicious scripts are injected into vulnerable w
 
 [*OWASP reference for CSRF*](https://owasp.org/www-community/attacks/csrf)
 
-CSRF is a class of attacks where a user is forced to execute an action on a vulnerable website that they’re logged into, usually without their knowledge. {{kib}} defends against this by requiring [custom request headers](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md#use-of-custom-request-headers) for API endpoints. For more information, see [API Request Headers](https://www.elastic.co/guide/en/kibana/current/api.html#api-request-headers).
+CSRF is a class of attacks where a user is forced to execute an action on a vulnerable website that they’re logged into, usually without their knowledge. {{kib}} defends against this by requiring [custom request headers](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#use-of-custom-request-headers) for API endpoints. For more information, see [API Request Headers](https://www.elastic.co/guide/en/kibana/current/api.html#api-request-headers).
 
 **Best practices**
 

--- a/docs/extend/typescript.md
+++ b/docs/extend/typescript.md
@@ -10,7 +10,7 @@ Although this is not a requirement, we encourage if all new code is developed in
 
 ## Project references [_project_references]
 
-Kibana has crossed the 2m LoC mark. The current situation creates some scaling problems when the default out-of-the-box setup stops working. As a result, developers suffer from slow project compilation and IDE unresponsiveness. As a part of [Developer Experience project](https://github.com/elastic/kibana/projects/63), we are migrating our tooling to use built-in TypeScript features addressing the scaling problems - [project references](https://www.typescriptlang.org/docs/handbook/project-references.md) & [incremental builds](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.md#faster-subsequent-builds-with-the---incremental-flag)
+Kibana has crossed the 2m LoC mark. The current situation creates some scaling problems when the default out-of-the-box setup stops working. As a result, developers suffer from slow project compilation and IDE unresponsiveness. As a part of [Developer Experience project](https://github.com/elastic/kibana/projects/63), we are migrating our tooling to use built-in TypeScript features addressing the scaling problems - [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) & [incremental builds](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#faster-subsequent-builds-with-the---incremental-flag)
 
 In a nutshell - instead of compiling the whole Kibana codebase at once, this setup enforces splitting the code base into independent projects that form a directed acyclic graph (DAG). This allows the TypeScript compiler (`tsc`) to apply several advanced optimizations:
 
@@ -18,7 +18,7 @@ In a nutshell - instead of compiling the whole Kibana codebase at once, this set
 * These generated `d.ts` type declarations are used whenever a referenced project is imported in a depending project
 * This makes it possible to determine which project needs rebuilding when the source code has changed to use a more aggressive caching strategy.
 
-More details are available in the [official docs](https://www.typescriptlang.org/docs/handbook/project-references.md)
+More details are available in the [official docs](https://www.typescriptlang.org/docs/handbook/project-references.html)
 
 
 ### Caveats [_caveats]

--- a/docs/reference/osquery-exported-fields.md
+++ b/docs/reference/osquery-exported-fields.md
@@ -250,7 +250,7 @@ For more information about osquery tables, see the [osquery schema documentation
 
 **attributes** - keyword, text.text
 
-* *file.attributes* - File attrib string. See: [https://ss64.com/nt/attrib.html](https://ss64.com/nt/attrib.md)
+* *file.attributes* - File attrib string. See: [https://ss64.com/nt/attrib.html](https://ss64.com/nt/attrib.html)
 
 **audible_alarm** - keyword, text.text
 


### PR DESCRIPTION
Fix external links that incorrectly use `.md` instead of `.html`.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->