### PR TITLE
[Security Solution] Fix session view navigation when in alert preview and add preview banner

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/analyze_graph.tsx
@@ -26,7 +26,7 @@ export const ANALYZER_PREVIEW_BANNER = {
   title: i18n.translate(
     'xpack.securitySolution.flyout.left.visualizations.analyzer.panelPreviewTitle',
     {
-      defaultMessage: 'Preview analyzer panels',
+      defaultMessage: 'Preview analyzer panel',
     }
   ),
   backgroundColor: 'warning',

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
@@ -10,6 +10,7 @@ import React, { memo, useCallback, useMemo } from 'react';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import { EuiPanel } from '@elastic/eui';
 import type { Process } from '@kbn/session-view-plugin/common';
+import { i18n } from '@kbn/i18n';
 import type { CustomProcess } from '../../session_view/context';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { SESSION_VIEW_TEST_ID } from './test_ids';
@@ -28,6 +29,14 @@ import { SessionViewNoDataMessage } from '../../shared/components/session_view_n
 import { DocumentEventTypes } from '../../../../common/lib/telemetry';
 
 export const SESSION_VIEW_ID = 'session-view';
+
+export const SESSION_VIEWER_BANNER = {
+  title: i18n.translate('xpack.securitySolution.flyout.preview.sessionViewerTitle', {
+    defaultMessage: 'Preview session view panel',
+  }),
+  backgroundColor: 'warning',
+  textColor: 'warning',
+};
 
 /**
  * Session view displayed in the document details expandable flyout left section under the Visualize tab
@@ -107,6 +116,7 @@ export const SessionView: FC = memo(() => {
           scopeId,
           jumpToEntityId,
           jumpToCursor,
+          banner: SESSION_VIEWER_BANNER,
         },
       });
     },

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.test.tsx
@@ -235,7 +235,7 @@ describe('SessionPreviewContainer', () => {
 
       const { getByTestId, queryByTestId } = renderSessionPreview({
         ...mockContextValue,
-        isPreview: true,
+        isPreviewMode: true,
       });
 
       expect(getByTestId(SESSION_PREVIEW_TEST_ID)).toBeInTheDocument();

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/session_preview_container.tsx
@@ -88,6 +88,7 @@ export const SessionPreviewContainer: FC = () => {
     indexName,
     isFlyoutOpen: true,
     scopeId,
+    isPreviewMode,
   });
 
   const iconType = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/index.tsx
@@ -16,6 +16,7 @@ import { useSessionViewPanelContext } from './context';
 import type { SessionViewPanelTabType } from './tabs';
 import * as tabs from './tabs';
 import { DocumentDetailsSessionViewPanelKey } from '../shared/constants/panel_keys';
+import { SESSION_VIEWER_BANNER } from '../left/components/session_view';
 
 export const allTabs = [tabs.processTab, tabs.metadataTab, tabs.alertsTab];
 export type SessionViewPanelPaths = 'process' | 'metadata' | 'alerts';
@@ -80,6 +81,7 @@ export const SessionViewPanel: FC<Partial<SessionViewPanelProps>> = memo(({ path
           sessionStartTime,
           scopeId,
           investigatedAlertId,
+          banner: SESSION_VIEWER_BANNER,
         },
       });
     },


### PR DESCRIPTION
## Summary

Before: when in an alert preview, clicking session preview header opens session view in details panel, but the preview persists.

This PR addressed the bug by including `isPreviewMode` as an indicator that the panel is opened in preview. Clicking a link in preview should opens a new flyout and preview should not appear.

https://github.com/user-attachments/assets/484daa16-adb0-48f2-b14e-a971878817c0

Added banner to session viewer in flyout

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/e228b35f-938a-4ad1-a97f-818caf36a284" />


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->