### PR TITLE
[8.18] [Security Solution][Threat Intelligence] - fix Cypress tests (#209195)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/block_list.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/block_list.cy.ts
@@ -8,6 +8,7 @@
 import { visitWithTimeRange } from '../../../tasks/navigation';
 import {
   closeFlyout,
+  navigateToBlocklist,
   navigateToThreatIntelligence,
   openFlyout,
   openFlyoutTakeAction,
@@ -19,7 +20,6 @@ import {
   openAddToBlockListFlyoutFromTable,
   openAddToBlocklistFromFlyout,
 } from '../../../tasks/threat_intelligence/blocklist';
-import { navigateToBlocklist } from '../../../tasks/threat_intelligence/common';
 import { login } from '../../../tasks/login';
 import {
   BLOCK_LIST_VALUE_INPUT,
@@ -70,7 +70,7 @@ describe('Block list interactions', { tags: ['@ess'] }, () => {
 
   it('should add to block list from the indicators table and from flyout', () => {
     // first indicator is a valid indicator for add to blocklist feature
-    const firstIndicatorId = 'd86e656455f985357df3063dff6637f7f3b95bb27d1769a6b88c7adecaf7763f';
+    const firstIndicatorId = '7cbf47ef916aa02a1b39cad40dfe71ea121d8d5b36d5a13fdec5977a8dcb4550';
 
     cy.log('add to blocklist from the table more action menu');
 
@@ -90,7 +90,7 @@ describe('Block list interactions', { tags: ['@ess'] }, () => {
     navigateToThreatIntelligence();
 
     // second indicator is a valid indicator for add to blocklist feature
-    const secondIndicatorId = 'd3e2cf87eabf84ef929aaf8dad1431b3387f5a26de8ffb7a0c3c2a13f973c0ab';
+    const secondIndicatorId = 'd4ba36cfa7e4191199836b228f6d79bd74e86793bc183563b78591f508b066ed';
 
     cy.log('add to blocklist from the flyout');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/cases.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/threat_intelligence/cases.cy.ts
@@ -105,7 +105,7 @@ describe('Cases interactions', { tags: ['@ess'] }, () => {
 
     cy.log('should add to new case when clicking on the button in the indicators flyout');
 
-    openFlyout(0);
+    openFlyout();
     openFlyoutTakeAction();
     openAddToNewCaseFromFlyout();
     createNewCaseFromTI();
@@ -122,7 +122,7 @@ describe('Cases interactions', { tags: ['@ess'] }, () => {
 
     cy.log('should add to existing case when clicking on the button in the indicators flyout');
 
-    openFlyout(0);
+    openFlyout();
     openFlyoutTakeAction();
     openAddToExistingCaseFromFlyout();
     selectExistingCase();

--- a/x-pack/test/security_solution_cypress/es_archives/ti_indicators_data_invalid/data.json
+++ b/x-pack/test/security_solution_cypress/es_archives/ti_indicators_data_invalid/data.json
@@ -5,7 +5,7 @@
     "id": "RP0HlUQkToBRTlZeGAItbyWMx1E=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.677Z",
+      "@timestamp": "2022-06-02T13:29:47.685Z",
       "abusech": {
         "malware": {
         }
@@ -97,7 +97,7 @@
     "id": "C4ObxkoTZzcjmk1jFwGlRadzMnA=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.678Z",
+      "@timestamp": "2022-06-02T13:29:47.684Z",
       "abusech": {
         "malware": {
           "virustotal": {
@@ -193,7 +193,7 @@
     "id": "5hGL0ETQsk+B0L7ryVcQVwsYhOk=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.678Z",
+      "@timestamp": "2022-06-02T13:29:47.683Z",
       "abusech": {
         "malware": {
           "virustotal": {
@@ -288,7 +288,7 @@
     "id": "qq3AKvjp1c/FBtEoh10Vt+PsT14=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.678Z",
+      "@timestamp": "2022-06-02T13:29:47.682Z",
       "abusech": {
         "malware": {
         }
@@ -377,7 +377,7 @@
     "id": "CNCiNUxTNHF5qyRWclltlrnxwhk=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.678Z",
+      "@timestamp": "2022-06-02T13:29:47.681Z",
       "abusech": {
         "malware": {
           "virustotal": {
@@ -470,7 +470,7 @@
     "id": "Rk80kuvgnMegEB+1jhGlgLO5h5Y=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.681Z",
+      "@timestamp": "2022-06-02T13:29:47.680Z",
       "abusech": {
         "malware": {
           "virustotal": {
@@ -562,7 +562,7 @@
     "id": "oF2/6vlWcu7040SDtfZuBX4sXEo=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.681Z",
+      "@timestamp": "2022-06-02T13:29:47.679Z",
       "abusech": {
         "malware": {
         }
@@ -648,7 +648,7 @@
     "id": "mgUWSsWrUtqPZFUpBNhFU75TKyc=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.681Z",
+      "@timestamp": "2022-06-02T13:29:47.678Z",
       "abusech": {
         "malware": {
         }
@@ -733,7 +733,7 @@
     "id": "auKnqhqoLKmnMsohKHQMvqvLSK4=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.681Z",
+      "@timestamp": "2022-06-02T13:29:47.677Z",
       "abusech": {
         "malware": {
         }
@@ -817,7 +817,7 @@
     "id": "Llc8xZPNZbUM6j5sAHAFCeyu+po=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.681Z",
+      "@timestamp": "2022-06-02T13:29:47.676Z",
       "abusech": {
         "malware": {
           "virustotal": {
@@ -905,7 +905,7 @@
     "id": "VbMLdKEoQI/Xli/LgjmvMOlGYZY=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.681Z",
+      "@timestamp": "2022-06-02T13:29:47.675Z",
       "abusech": {
         "malware": {
         }
@@ -987,7 +987,7 @@
     "id": "/6DDSx9lUsUoJUF8QSZiQ/oMvmQ=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.681Z",
+      "@timestamp": "2022-06-02T13:29:47.674Z",
       "abusech": {
         "malware": {
         }
@@ -1068,7 +1068,7 @@
     "id": "d+KIrgaxYVhvb/sqhlb5AYOHQDo=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.682Z",
+      "@timestamp": "2022-06-02T13:29:47.673Z",
       "abusech": {
         "malware": {
         }
@@ -1148,7 +1148,7 @@
     "id": "bAPvrGKWj/ess46s3KwFqAJ8+tc=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.682Z",
+      "@timestamp": "2022-06-02T13:29:47.672Z",
       "abusech": {
         "malware": {
         }
@@ -1227,7 +1227,7 @@
     "id": "uM8A5Yr/gMJ4tPHb9XIABYC/mRk=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.682Z",
+      "@timestamp": "2022-06-02T13:29:47.671Z",
       "abusech": {
         "malware": {
         }
@@ -1305,7 +1305,7 @@
     "id": "YPTTIf8ctfvqnTo2W9OpoJD6n9Q=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.682Z",
+      "@timestamp": "2022-06-02T13:29:47.670Z",
       "abusech": {
         "malware": {
         }
@@ -1382,7 +1382,7 @@
     "id": "UJBUWYV6AtCidXCm1NBsWtAYWZI=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.682Z",
+      "@timestamp": "2022-06-02T13:29:47.669Z",
       "abusech": {
         "malware": {
         }
@@ -1458,7 +1458,7 @@
     "id": "e1yn2nAO9PlprMEaPBhcjgg9lwE=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.682Z",
+      "@timestamp": "2022-06-02T13:29:47.668Z",
       "abusech": {
         "malware": {
         }
@@ -1533,7 +1533,7 @@
     "id": "e74l+UPbo6o0DotQc8Roo3OVcJQ=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.682Z",
+      "@timestamp": "2022-06-02T13:29:47.667Z",
       "abusech": {
         "malware": {
           "virustotal": {
@@ -1612,7 +1612,7 @@
     "id": "XIDmYG67Bs5j3njl7xYKAyH1emM=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.682Z",
+      "@timestamp": "2022-06-02T13:29:47.666Z",
       "abusech": {
         "malware": {
           "virustotal": {
@@ -1684,7 +1684,7 @@
     "id": "TxxcH4E0aWG8D8rloVjU3cK+sy0=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.685Z",
+      "@timestamp": "2022-06-02T13:29:47.665Z",
       "abusech": {
         "malware": {
           "virustotal": {
@@ -1750,7 +1750,7 @@
     "id": "0j+BQ8HFrDQYe5kbXMc9ANSCjBY=",
     "index": ".ds-logs-ti_abusech.malware-default-2022.06.02-000001",
     "source": {
-      "@timestamp": "2022-06-02T13:29:47.685Z",
+      "@timestamp": "2022-06-02T13:29:47.664Z",
       "abusech": {
         "malware": {
           "virustotal": {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security Solution][Threat Intelligence] - fix Cypress tests (#209195)](https://github.com/elastic/kibana/pull/209195)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-02-03T15:03:32Z","message":"[Security Solution][Threat Intelligence] - fix Cypress tests (#209195)\n\n## Summary\r\n\r\nThis PR fixes the few Threat Intelligence Cypress tests which started\r\nfailing recently.\r\n\r\n[This PR](https://github.com/elastic/kibana/pull/208990)\r\n([commit](https://github.com/elastic/kibana/commit/296c452345a568c5b3dc4c39af57acd652a95f35)\r\non `main`) which was a basic bump PR started had to skip a few Threat\r\nIntelligence Cypress tests that started failing.\r\n\r\nI tried to understand what happened but did not find the origin of the\r\nissue. The indicators table was previously showing data sorted from\r\noldest to newest (but only on Cypress, not when running the application\r\nlocally, really weird). After the commit mentioned above, the Cypress\r\ntests are now sorting the data from newest to oldest.\r\nLooking at the code, nothing mentions sorting, the\r\n`threatIntelligenceSearchStrategy` is identical between the application\r\nrunning locally and the Cypress tests.\r\n\r\n#### Payload\r\n\r\n| Local run  | Cypress |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-01-31 at 2 20\r\n33 PM](https://github.com/user-attachments/assets/7095eeef-3ceb-4a3c-85ee-7fee7e07b9ba)\r\n| ![Screenshot 2025-01-31 at 2 21\r\n39 PM](https://github.com/user-attachments/assets/7bce82d2-12ff-483f-bf85-ad8f0ce45054)\r\n|\r\n\r\n#### Result\r\n\r\nThe results are different, one sorted ascending, the other descending.\r\n\r\n| Local run  | Cypress |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-01-31 at 2 22\r\n19 PM](https://github.com/user-attachments/assets/09715344-0c6e-44e9-8abd-d0b56ae8c984)\r\n| ![Screenshot 2025-01-31 at 2 22\r\n03 PM](https://github.com/user-attachments/assets/b66412fc-0018-4a84-9ddf-98b90c200878)\r\n|\r\n\r\nNo code changes have been done to the Threat Intelligence plugin in many\r\nmonths. Fetching the data is done using `useQuery` (see\r\n[here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts#L101))\r\nand the logic to fetch the actual data is\r\n[here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/services/fetch_indicators.ts#L71).\r\nBoth haven't been touched in months...\r\n\r\nNothing in the commit mentioned above seems to give any details on why\r\nthese tests just started failing. Resetting to the commit right before\r\nmakes the tests pass...\r\n\r\nThe solution to fix the tests was to ensure that the data_archive files\r\nhad the correct timestamps, to know exactly which ones we select in the\r\nCypress tests to test against...\r\n\r\nhttps://github.com/elastic/kibana/issues/209050\r\nhttps://github.com/elastic/kibana/issues/209039\r\nhttps://github.com/elastic/kibana/issues/209051\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"48860619505c366b67ffd2028865e515878346cb","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Threat Hunting:Investigations","backport:version","v9.1.0"],"title":"[Security Solution][Threat Intelligence] - fix Cypress tests","number":209195,"url":"https://github.com/elastic/kibana/pull/209195","mergeCommit":{"message":"[Security Solution][Threat Intelligence] - fix Cypress tests (#209195)\n\n## Summary\r\n\r\nThis PR fixes the few Threat Intelligence Cypress tests which started\r\nfailing recently.\r\n\r\n[This PR](https://github.com/elastic/kibana/pull/208990)\r\n([commit](https://github.com/elastic/kibana/commit/296c452345a568c5b3dc4c39af57acd652a95f35)\r\non `main`) which was a basic bump PR started had to skip a few Threat\r\nIntelligence Cypress tests that started failing.\r\n\r\nI tried to understand what happened but did not find the origin of the\r\nissue. The indicators table was previously showing data sorted from\r\noldest to newest (but only on Cypress, not when running the application\r\nlocally, really weird). After the commit mentioned above, the Cypress\r\ntests are now sorting the data from newest to oldest.\r\nLooking at the code, nothing mentions sorting, the\r\n`threatIntelligenceSearchStrategy` is identical between the application\r\nrunning locally and the Cypress tests.\r\n\r\n#### Payload\r\n\r\n| Local run  | Cypress |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-01-31 at 2 20\r\n33 PM](https://github.com/user-attachments/assets/7095eeef-3ceb-4a3c-85ee-7fee7e07b9ba)\r\n| ![Screenshot 2025-01-31 at 2 21\r\n39 PM](https://github.com/user-attachments/assets/7bce82d2-12ff-483f-bf85-ad8f0ce45054)\r\n|\r\n\r\n#### Result\r\n\r\nThe results are different, one sorted ascending, the other descending.\r\n\r\n| Local run  | Cypress |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-01-31 at 2 22\r\n19 PM](https://github.com/user-attachments/assets/09715344-0c6e-44e9-8abd-d0b56ae8c984)\r\n| ![Screenshot 2025-01-31 at 2 22\r\n03 PM](https://github.com/user-attachments/assets/b66412fc-0018-4a84-9ddf-98b90c200878)\r\n|\r\n\r\nNo code changes have been done to the Threat Intelligence plugin in many\r\nmonths. Fetching the data is done using `useQuery` (see\r\n[here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts#L101))\r\nand the logic to fetch the actual data is\r\n[here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/services/fetch_indicators.ts#L71).\r\nBoth haven't been touched in months...\r\n\r\nNothing in the commit mentioned above seems to give any details on why\r\nthese tests just started failing. Resetting to the commit right before\r\nmakes the tests pass...\r\n\r\nThe solution to fix the tests was to ensure that the data_archive files\r\nhad the correct timestamps, to know exactly which ones we select in the\r\nCypress tests to test against...\r\n\r\nhttps://github.com/elastic/kibana/issues/209050\r\nhttps://github.com/elastic/kibana/issues/209039\r\nhttps://github.com/elastic/kibana/issues/209051\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"48860619505c366b67ffd2028865e515878346cb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209195","number":209195,"mergeCommit":{"message":"[Security Solution][Threat Intelligence] - fix Cypress tests (#209195)\n\n## Summary\r\n\r\nThis PR fixes the few Threat Intelligence Cypress tests which started\r\nfailing recently.\r\n\r\n[This PR](https://github.com/elastic/kibana/pull/208990)\r\n([commit](https://github.com/elastic/kibana/commit/296c452345a568c5b3dc4c39af57acd652a95f35)\r\non `main`) which was a basic bump PR started had to skip a few Threat\r\nIntelligence Cypress tests that started failing.\r\n\r\nI tried to understand what happened but did not find the origin of the\r\nissue. The indicators table was previously showing data sorted from\r\noldest to newest (but only on Cypress, not when running the application\r\nlocally, really weird). After the commit mentioned above, the Cypress\r\ntests are now sorting the data from newest to oldest.\r\nLooking at the code, nothing mentions sorting, the\r\n`threatIntelligenceSearchStrategy` is identical between the application\r\nrunning locally and the Cypress tests.\r\n\r\n#### Payload\r\n\r\n| Local run  | Cypress |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-01-31 at 2 20\r\n33 PM](https://github.com/user-attachments/assets/7095eeef-3ceb-4a3c-85ee-7fee7e07b9ba)\r\n| ![Screenshot 2025-01-31 at 2 21\r\n39 PM](https://github.com/user-attachments/assets/7bce82d2-12ff-483f-bf85-ad8f0ce45054)\r\n|\r\n\r\n#### Result\r\n\r\nThe results are different, one sorted ascending, the other descending.\r\n\r\n| Local run  | Cypress |\r\n| ------------- | ------------- |\r\n| ![Screenshot 2025-01-31 at 2 22\r\n19 PM](https://github.com/user-attachments/assets/09715344-0c6e-44e9-8abd-d0b56ae8c984)\r\n| ![Screenshot 2025-01-31 at 2 22\r\n03 PM](https://github.com/user-attachments/assets/b66412fc-0018-4a84-9ddf-98b90c200878)\r\n|\r\n\r\nNo code changes have been done to the Threat Intelligence plugin in many\r\nmonths. Fetching the data is done using `useQuery` (see\r\n[here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_indicators.ts#L101))\r\nand the logic to fetch the actual data is\r\n[here](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/services/fetch_indicators.ts#L71).\r\nBoth haven't been touched in months...\r\n\r\nNothing in the commit mentioned above seems to give any details on why\r\nthese tests just started failing. Resetting to the commit right before\r\nmakes the tests pass...\r\n\r\nThe solution to fix the tests was to ensure that the data_archive files\r\nhad the correct timestamps, to know exactly which ones we select in the\r\nCypress tests to test against...\r\n\r\nhttps://github.com/elastic/kibana/issues/209050\r\nhttps://github.com/elastic/kibana/issues/209039\r\nhttps://github.com/elastic/kibana/issues/209051\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"48860619505c366b67ffd2028865e515878346cb"}},{"url":"https://github.com/elastic/kibana/pull/213471","number":213471,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->