### PR TITLE
[ML] File upload auto expand single file

### DIFF
--- a/x-pack/platform/plugins/private/data_visualizer/public/lite/file_manager/file_wrapper.ts
+++ b/x-pack/platform/plugins/private/data_visualizer/public/lite/file_manager/file_wrapper.ts
@@ -92,9 +92,11 @@ export class FileWrapper {
       // analysis will be done in the background
 
       let analysisResults: AnalysisResults;
+      let parsedFileContents = fileContents;
 
       if (isTikaType(this.file.type)) {
         analysisResults = await this.analyzeTika(data);
+        parsedFileContents = analysisResults.fileContents;
       } else {
         analysisResults = await this.analyzeStandardFile(fileContents, {});
       }
@@ -104,7 +106,7 @@ export class FileWrapper {
         ...analysisResults,
         loaded: true,
         fileName: this.file.name,
-        fileContents,
+        fileContents: parsedFileContents,
         data,
         supportedFormat,
       });

--- a/x-pack/platform/plugins/private/data_visualizer/public/lite/file_status.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/lite/file_status.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { FC } from 'react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   EuiPanel,
   EuiSpacer,
@@ -34,6 +34,7 @@ interface Props {
   index: number;
   showFileContentPreview?: boolean;
   showFileSummary?: boolean;
+  autoExpand?: boolean;
 }
 
 enum TAB {
@@ -48,13 +49,19 @@ export const FileStatus: FC<Props> = ({
   index,
   showFileContentPreview = false,
   showFileSummary = false,
+  autoExpand = false,
 }) => {
   const fileClash = uploadStatus.fileClashes[index] ?? {
     clash: false,
   };
-
   const [expanded, setExpanded] = useState(false);
   const [selectedTab, setSelectedTab] = useState<TAB>(showFileSummary ? TAB.SUMMARY : TAB.CONTENT);
+
+  useEffect(() => {
+    if (autoExpand && fileStatus.results !== null) {
+      setExpanded(true);
+    }
+  }, [autoExpand, fileStatus.results]);
 
   const importStarted =
     uploadStatus.overallImportStatus === STATUS.STARTED ||
@@ -162,7 +169,7 @@ export const FileStatus: FC<Props> = ({
               </>
             ) : null}
 
-            {expanded ? (
+            {expanded && fileStatus.results !== null ? (
               <>
                 <EuiHorizontalRule margin="s" />
                 <EuiTabs size="s">
@@ -195,13 +202,13 @@ export const FileStatus: FC<Props> = ({
                 <EuiSpacer size="s" />
 
                 {selectedTab === TAB.SUMMARY ? (
-                  <AnalysisSummary results={fileStatus.results!} showTitle={false} />
+                  <AnalysisSummary results={fileStatus.results} showTitle={false} />
                 ) : null}
 
                 {selectedTab === TAB.CONTENT ? (
                   <FileContents
                     fileContents={fileStatus.fileContents}
-                    results={fileStatus.results!}
+                    results={fileStatus.results}
                     showTitle={false}
                     disableHighlighting={true}
                   />

--- a/x-pack/platform/plugins/private/data_visualizer/public/lite/file_upload_lite_view.tsx
+++ b/x-pack/platform/plugins/private/data_visualizer/public/lite/file_upload_lite_view.tsx
@@ -194,6 +194,7 @@ export const FileUploadLiteView: FC<Props> = ({
                     index={i}
                     showFileContentPreview={flyoutContent?.showFileContentPreview}
                     showFileSummary={flyoutContent?.showFileSummary}
+                    autoExpand={filesStatus.length === 1}
                   />
                 ))}
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/upload_file_button.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/upload_file_button.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiButton } from '@elastic/eui';
 import { type FileUploadResults, OPEN_FILE_UPLOAD_LITE_TRIGGER } from '@kbn/file-upload-common';
-import { i18n } from '@kbn/i18n';
 import { useKibana } from '../hooks/use_kibana';
 import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
 
@@ -30,17 +29,6 @@ export const UploadFileButton: React.FC<Props> = ({ isSetup }) => {
         onUploadComplete: (results: FileUploadResults) => {
           setSelectedIndices([results.index]);
         },
-        flyoutContent: {
-          showFileSummary: true,
-          showFileContentPreview: true,
-          title: i18n.translate('xpack.searchPlayground.setupPage.uploadFileFlyoutTitle', {
-            defaultMessage: 'Upload a file!!!',
-          }),
-          description: i18n.translate('xpack.searchPlayground.setupPage.uploadFileFlyoutTitle', {
-            defaultMessage: 'Upload a file test test test test',
-          }),
-        },
-        initialIndexName: 'test',
       });
     }
   }, [setSelectedIndices, uiActions]);

--- a/x-pack/solutions/search/plugins/search_playground/public/components/upload_file_button.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/upload_file_button.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiButton } from '@elastic/eui';
 import { type FileUploadResults, OPEN_FILE_UPLOAD_LITE_TRIGGER } from '@kbn/file-upload-common';
+import { i18n } from '@kbn/i18n';
 import { useKibana } from '../hooks/use_kibana';
 import { useSourceIndicesFields } from '../hooks/use_source_indices_field';
 
@@ -29,6 +30,17 @@ export const UploadFileButton: React.FC<Props> = ({ isSetup }) => {
         onUploadComplete: (results: FileUploadResults) => {
           setSelectedIndices([results.index]);
         },
+        flyoutContent: {
+          showFileSummary: true,
+          showFileContentPreview: true,
+          title: i18n.translate('xpack.searchPlayground.setupPage.uploadFileFlyoutTitle', {
+            defaultMessage: 'Upload a file!!!',
+          }),
+          description: i18n.translate('xpack.searchPlayground.setupPage.uploadFileFlyoutTitle', {
+            defaultMessage: 'Upload a file test test test test',
+          }),
+        },
+        initialIndexName: 'test',
       });
     }
   }, [setSelectedIndices, uiActions]);


### PR DESCRIPTION
When only one file has been added, it will be auto expanded.
Also fixes an issue where the contents of pdf/doc files was not rendered correctly.

To test in playground, [this file](https://github.com/elastic/kibana/blob/main/x-pack/solutions/search/plugins/search_playground/public/components/upload_file_button.tsx) can be edited to add:

```
flyoutContent: {
  showFileSummary: true,
  showFileContentPreview: true,
},
```

Changes added for https://github.com/elastic/kibana/pull/213525

![image](https://github.com/user-attachments/assets/1f354c65-6e5d-4fef-a9ce-2a434c1971dd)
