### PR TITLE
poc/related alerts

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/common/utils/alerting/get_related_alerts_query.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/utils/alerting/get_related_alerts_query.ts
@@ -103,5 +103,5 @@ export const getRelatedAlertKuery = ({
   const groupKueriesStr = groupKueries.length > 0 ? [`${groupKueries.join(' or ')}`] : [];
   const kueries = [...tagKueriesStr, ...groupKueriesStr, ...sharedFieldsKueries, ...ruleKueries];
 
-  return kueries.length ? kueries.join(' or ') : '';
+  return kueries.length ? kueries.join(' and ') : '';
 };

--- a/x-pack/solutions/observability/plugins/observability/common/utils/alerting/get_related_alerts_query.ts
+++ b/x-pack/solutions/observability/plugins/observability/common/utils/alerting/get_related_alerts_query.ts
@@ -101,6 +101,7 @@ export const getRelatedAlertKuery = ({
 
   const tagKueriesStr = tagKueries.length > 0 ? [`(${tagKueries.join(' or ')})`] : [];
   const groupKueriesStr = groupKueries.length > 0 ? [`${groupKueries.join(' or ')}`] : [];
+
   const kueries = [...tagKueriesStr, ...groupKueriesStr, ...sharedFieldsKueries, ...ruleKueries];
 
   return kueries.length ? kueries.join(' and ') : '';

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_actions/alert_actions.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_actions/alert_actions.tsx
@@ -300,6 +300,7 @@ export const AlertActions: GetObservabilityAlertsTableProp<'renderActionsCell'> 
             onClick={onExpandEvent}
             size="s"
             color="text"
+            aria-label="expand"
           />
         </EuiToolTip>
       </EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/observability/public/components/alerts_table/grouping/get_aggregations_by_grouping_field.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alerts_table/grouping/get_aggregations_by_grouping_field.ts
@@ -27,18 +27,8 @@ export const getAggregationsByGroupingField = (field: string): NamedAggregation[
           },
         },
       ];
-      break;
+
     case ALERT_INSTANCE_ID:
-      return [
-        {
-          rulesCountAggregation: {
-            cardinality: {
-              field: ALERT_RULE_UUID,
-            },
-          },
-        },
-      ];
-      break;
     default:
       return [
         {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -35,7 +35,7 @@ import { AlertFieldsTable } from '@kbn/alerts-ui-shared/src/alert_fields_table';
 import { css } from '@emotion/react';
 import { omit } from 'lodash';
 import { BetaBadge } from '../../components/experimental_badge';
-import { RelatedAlerts } from './components/related_alerts';
+import { RelatedAlerts } from './components/related_alerts/related_alerts';
 import { AlertDetailsSource } from './types';
 import { SourceBar } from './components';
 import { StatusBar } from './components/status_bar';

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/empty_state.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/empty_state.tsx
@@ -6,9 +6,9 @@
  */
 
 import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle, EuiImage } from '@elastic/eui';
-import { icon } from '@elastic/eui/src/components/icon/assets';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import icon from '../assets/illustration_product_no_results_magnifying_glass.svg';
 
 export function EmptyState() {
   const heights = {
@@ -44,7 +44,12 @@ export function EmptyState() {
                 </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiImage style={{ width: 200, height: 148 }} size="200" alt="" url={icon} />
+                <EuiImage
+                  style={{ width: 200, height: 148 }}
+                  size="200"
+                  alt="empty state"
+                  url={icon}
+                />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiPanel>

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/empty_state.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/empty_state.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle, EuiImage } from '@elastic/eui';
+import { icon } from '@elastic/eui/src/components/icon/assets';
+import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+export function EmptyState() {
+  const heights = {
+    tall: 490,
+    short: 250,
+  };
+  const panelStyle = {
+    maxWidth: 500,
+  };
+
+  return (
+    <EuiPanel color="subdued" data-test-subj="relatedAlertsTabEmptyState">
+      <EuiFlexGroup style={{ height: heights.tall }} alignItems="center" justifyContent="center">
+        <EuiFlexItem grow={false}>
+          <EuiPanel hasBorder={true} style={panelStyle}>
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiText size="s">
+                  <EuiTitle>
+                    <h3>
+                      <FormattedMessage
+                        id="xpack.observability.pages.alertDetails.relatedAlerts.empty.title"
+                        defaultMessage="Problem loading related alerts"
+                      />
+                    </h3>
+                  </EuiTitle>
+                  <p>
+                    <FormattedMessage
+                      id="xpack.observability.pages.alertDetails.relatedAlerts.empty.description"
+                      defaultMessage="Due to an unexpected error, no related alerts can be found."
+                    />
+                  </p>
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiImage style={{ width: 200, height: 148 }} size="200" alt="" url={icon} />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/groups_filter.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/groups_filter.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiComboBox, EuiFormRow } from '@elastic/eui';
+import React, { useState } from 'react';
+
+export interface GroupValue {
+  field: string;
+  value: string;
+}
+
+interface Props {
+  availableGroups: GroupValue[];
+  groups: GroupValue[];
+  onChange: (groups: GroupValue[]) => void;
+}
+
+export function GroupsFilter({ availableGroups, groups, onChange }: Props) {
+  const [selected, setSelected] = useState<GroupValue[]>(groups);
+
+  return (
+    <EuiFormRow label="Groups">
+      <EuiComboBox<GroupValue>
+        compressed
+        placeholder="Select related groups"
+        selectedOptions={selected.map((group) => ({ label: toLabel(group), value: group }))}
+        options={availableGroups.map((group) => ({ label: toLabel(group), value: group }))}
+        onChange={(selectedOptions) => {
+          const newGroups = selectedOptions.map((opt) => opt.value!);
+          setSelected(newGroups);
+          onChange(newGroups);
+        }}
+        isClearable={true}
+      />
+    </EuiFormRow>
+  );
+}
+
+function toLabel(group: GroupValue) {
+  return `${group.field}: ${group.value}`;
+}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.test.tsx
@@ -6,16 +6,16 @@
  */
 
 import React from 'react';
-import { render } from '../../../utils/test_helper';
-import { alertWithGroupsAndTags } from '../mock/alert';
-import { useKibana } from '../../../utils/kibana_react';
-import { kibanaStartMock } from '../../../utils/kibana_react.mock';
+import { render } from '../../../../utils/test_helper';
+import { alertWithGroupsAndTags } from '../../mock/alert';
+import { useKibana } from '../../../../utils/kibana_react';
+import { kibanaStartMock } from '../../../../utils/kibana_react.mock';
 import { RelatedAlerts } from './related_alerts';
-import { ObservabilityAlertsTable } from '../../../components/alerts_table/alerts_table_lazy';
+import { ObservabilityAlertsTable } from '../../../../components/alerts_table/alerts_table_lazy';
 import {
   OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
   observabilityAlertFeatureIds,
-} from '../../../../common/constants';
+} from '../../../../../common/constants';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
@@ -9,12 +9,13 @@ import {
   EuiCheckbox,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiFormRow,
   EuiSpacer,
   useGeneratedHtmlId,
 } from '@elastic/eui';
 import { AlertsGrouping } from '@kbn/alerts-grouping';
 import { i18n } from '@kbn/i18n';
-import { ALERT_GROUP, ALERT_RULE_UUID, ALERT_UUID, AlertStatus, TAGS } from '@kbn/rule-data-utils';
+import { ALERT_GROUP, ALERT_RULE_UUID, AlertStatus, TAGS } from '@kbn/rule-data-utils';
 import React, { useState } from 'react';
 import { ObservabilityAlertsTable, TopAlert } from '../../../..';
 import {
@@ -36,6 +37,7 @@ import { RELATED_ALERTS_TABLE_CONFIG_ID } from '../../../../constants';
 import { buildEsQuery } from '../../../../utils/build_es_query';
 import { useKibana } from '../../../../utils/kibana_react';
 import { EmptyState } from './empty_state';
+import { GroupValue, GroupsFilter } from './groups_filter';
 import { StatusFilter, getAssociatedStatusFilter } from './status_filter';
 import { TagsFilter } from './tags_filter';
 
@@ -49,28 +51,27 @@ interface Props {
 export function RelatedAlerts({ alert }: Props) {
   const { http, notifications, dataViews } = useKibana().services;
 
-  const groupsCheckboxId = useGeneratedHtmlId({ prefix: 'groups' });
   const ruleCheckboxId = useGeneratedHtmlId({ prefix: 'rule' });
 
-  const [groupsChecked, setGroupsChecked] = useState(false);
   const [ruleChecked, setRuleChecked] = useState(false);
 
   const [range, setRange] = useState({ from: 'now-24h', to: 'now' });
   const [status, setStatus] = useState<AlertStatus | undefined>('active');
   const [tags, setTags] = useState<string[]>(alert?.fields[TAGS] ?? []);
+  const [groups, setGroups] = useState<GroupValue[]>(alert?.fields[ALERT_GROUP] ?? []);
 
   if (!alert) {
     return null;
   }
 
   const statusFilter = getAssociatedStatusFilter(status);
-  const kuery = getKuery({ alert, tags, groupsChecked, ruleChecked });
+  const kuery = getKuery({ alert, tags, groups, ruleChecked });
 
   return (
     <EuiFlexGroup direction="column" gutterSize="m">
-      <EuiSpacer size="m" />
+      <EuiSpacer size="xs" />
       <EuiFlexGroup direction="row" gutterSize="s">
-        <EuiFlexItem>
+        <EuiFlexItem grow>
           <TagsFilter
             availableTags={alert?.fields[TAGS] ?? []}
             tags={tags}
@@ -78,31 +79,32 @@ export function RelatedAlerts({ alert }: Props) {
           />
         </EuiFlexItem>
 
-        <EuiFlexItem>
-          <EuiCheckbox
-            id={groupsCheckboxId}
-            label={i18n.translate('xpack.observability.relatedAlerts.useGroupsLabel', {
-              defaultMessage: 'Use groups',
-            })}
-            checked={groupsChecked}
-            onChange={(e) => setGroupsChecked(e.target.checked)}
+        <EuiFlexItem grow>
+          <GroupsFilter
+            availableGroups={alert?.fields[ALERT_GROUP] ?? []}
+            groups={groups}
+            onChange={(newGroups) => setGroups(newGroups)}
           />
         </EuiFlexItem>
+
         <EuiFlexItem>
-          <EuiCheckbox
-            id={ruleCheckboxId}
-            label={i18n.translate('xpack.observability.relatedAlerts.useRuleLabel', {
-              defaultMessage: 'Use rule',
-            })}
-            checked={ruleChecked}
-            onChange={(e) => setRuleChecked(e.target.checked)}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
           <StatusFilter
             status={status}
             onChange={(newStatus?: AlertStatus) => setStatus(newStatus)}
           />
+        </EuiFlexItem>
+
+        <EuiFlexItem grow>
+          <EuiFormRow label="Same rule">
+            <EuiCheckbox
+              id={ruleCheckboxId}
+              label={i18n.translate('xpack.observability.relatedAlerts.useRuleLabel', {
+                defaultMessage: 'Yes',
+              })}
+              checked={ruleChecked}
+              onChange={(e) => setRuleChecked(e.target.checked)}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiFlexItem>
@@ -161,16 +163,15 @@ export function RelatedAlerts({ alert }: Props) {
 function getKuery({
   alert,
   tags,
-  groupsChecked,
+  groups,
   ruleChecked,
 }: {
   alert: TopAlert<ObservabilityFields>;
   tags: string[];
-  groupsChecked: boolean;
+  groups: GroupValue[];
   ruleChecked: boolean;
 }): string {
-  const alertId = alert.fields[ALERT_UUID];
-  const groups = groupsChecked ? alert.fields[ALERT_GROUP] : [];
+  // const alertId = alert.fields[ALERT_UUID];
   const ruleId = ruleChecked ? alert.fields[ALERT_RULE_UUID] : undefined;
   const sharedFields = getSharedFields(alert.fields);
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
@@ -5,17 +5,9 @@
  * 2.0.
  */
 
-import React, { useState, useRef, useEffect } from 'react';
-import { FormattedMessage } from '@kbn/i18n-react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiImage,
-  EuiPanel,
-  EuiSpacer,
-  EuiText,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { AlertsGrouping } from '@kbn/alerts-grouping';
+import { BoolQuery, Filter, type Query } from '@kbn/es-query';
 import { getPaddedAlertTimeRange } from '@kbn/observability-get-padded-alert-time-range-util';
 import {
   ALERT_END,
@@ -25,41 +17,39 @@ import {
   ALERT_UUID,
   TAGS,
 } from '@kbn/rule-data-utils';
-import { BoolQuery, Filter, type Query } from '@kbn/es-query';
-import { AlertsGrouping } from '@kbn/alerts-grouping';
-import { GroupingToolbarControls } from '../../../components/alerts_table/grouping/grouping_toolbar_controls';
-import { ObservabilityFields } from '../../../../common/utils/alerting/types';
-
+import React, { useEffect, useRef, useState } from 'react';
+import { ObservabilityAlertsTable, TopAlert } from '../../../..';
 import {
   OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
   observabilityAlertFeatureIds,
-} from '../../../../common/constants';
+} from '../../../../../common/constants';
 import {
   getRelatedAlertKuery,
   getSharedFields,
-} from '../../../../common/utils/alerting/get_related_alerts_query';
-import { ObservabilityAlertsTable, TopAlert } from '../../..';
+} from '../../../../../common/utils/alerting/get_related_alerts_query';
+import { ObservabilityFields } from '../../../../../common/utils/alerting/types';
+import { ObservabilityAlertSearchbarWithUrlSync } from '../../../../components/alert_search_bar/alert_search_bar_with_url_sync';
+import { ALERT_STATUS_FILTER } from '../../../../components/alert_search_bar/constants';
+import {
+  Provider,
+  alertSearchBarStateContainer,
+  useAlertSearchBarStateContainer,
+} from '../../../../components/alert_search_bar/containers';
 import {
   AlertSearchBarContainerState,
   DEFAULT_STATE,
-} from '../../../components/alert_search_bar/containers/state_container';
-import { ObservabilityAlertSearchbarWithUrlSync } from '../../../components/alert_search_bar/alert_search_bar_with_url_sync';
-import { renderGroupPanel } from '../../../components/alerts_table/grouping/render_group_panel';
-import { getGroupStats } from '../../../components/alerts_table/grouping/get_group_stats';
-import { getAggregationsByGroupingField } from '../../../components/alerts_table/grouping/get_aggregations_by_grouping_field';
-import { DEFAULT_GROUPING_OPTIONS } from '../../../components/alerts_table/grouping/constants';
-import { ALERT_STATUS_FILTER } from '../../../components/alert_search_bar/constants';
-import { AlertsByGroupingAgg } from '../../../components/alerts_table/types';
-import {
-  alertSearchBarStateContainer,
-  Provider,
-  useAlertSearchBarStateContainer,
-} from '../../../components/alert_search_bar/containers';
-import { RELATED_ALERTS_TABLE_CONFIG_ID, SEARCH_BAR_URL_STORAGE_KEY } from '../../../constants';
-import { useKibana } from '../../../utils/kibana_react';
-import { buildEsQuery } from '../../../utils/build_es_query';
-import { mergeBoolQueries } from '../../alerts/helpers/merge_bool_queries';
-import icon from './assets/illustration_product_no_results_magnifying_glass.svg';
+} from '../../../../components/alert_search_bar/containers/state_container';
+import { DEFAULT_GROUPING_OPTIONS } from '../../../../components/alerts_table/grouping/constants';
+import { getAggregationsByGroupingField } from '../../../../components/alerts_table/grouping/get_aggregations_by_grouping_field';
+import { getGroupStats } from '../../../../components/alerts_table/grouping/get_group_stats';
+import { GroupingToolbarControls } from '../../../../components/alerts_table/grouping/grouping_toolbar_controls';
+import { renderGroupPanel } from '../../../../components/alerts_table/grouping/render_group_panel';
+import { AlertsByGroupingAgg } from '../../../../components/alerts_table/types';
+import { RELATED_ALERTS_TABLE_CONFIG_ID, SEARCH_BAR_URL_STORAGE_KEY } from '../../../../constants';
+import { buildEsQuery } from '../../../../utils/build_es_query';
+import { useKibana } from '../../../../utils/kibana_react';
+import { mergeBoolQueries } from '../../../alerts/helpers/merge_bool_queries';
+import { EmptyState } from './empty_state';
 
 const ALERTS_PER_PAGE = 50;
 const RELATED_ALERTS_SEARCH_BAR_ID = 'related-alerts-search-bar-o11y';
@@ -165,50 +155,6 @@ export function InternalRelatedAlerts({ alert }: Props) {
         )}
       </EuiFlexItem>
     </EuiFlexGroup>
-  );
-}
-
-const heights = {
-  tall: 490,
-  short: 250,
-};
-const panelStyle = {
-  maxWidth: 500,
-};
-
-function EmptyState() {
-  return (
-    <EuiPanel color="subdued" data-test-subj="relatedAlertsTabEmptyState">
-      <EuiFlexGroup style={{ height: heights.tall }} alignItems="center" justifyContent="center">
-        <EuiFlexItem grow={false}>
-          <EuiPanel hasBorder={true} style={panelStyle}>
-            <EuiFlexGroup>
-              <EuiFlexItem>
-                <EuiText size="s">
-                  <EuiTitle>
-                    <h3>
-                      <FormattedMessage
-                        id="xpack.observability.pages.alertDetails.relatedAlerts.empty.title"
-                        defaultMessage="Problem loading related alerts"
-                      />
-                    </h3>
-                  </EuiTitle>
-                  <p>
-                    <FormattedMessage
-                      id="xpack.observability.pages.alertDetails.relatedAlerts.empty.description"
-                      defaultMessage="Due to an unexpected error, no related alerts can be found."
-                    />
-                  </p>
-                </EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiImage style={{ width: 200, height: 148 }} size="200" alt="" url={icon} />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiPanel>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiPanel>
   );
 }
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
@@ -16,6 +16,7 @@ import {
 import { AlertsGrouping } from '@kbn/alerts-grouping';
 import { i18n } from '@kbn/i18n';
 import { ALERT_GROUP, ALERT_RULE_UUID, AlertStatus, TAGS } from '@kbn/rule-data-utils';
+import moment from 'moment';
 import React, { useState } from 'react';
 import { ObservabilityAlertsTable, TopAlert } from '../../../..';
 import {
@@ -54,6 +55,7 @@ export function RelatedAlerts({ alert }: Props) {
   const ruleCheckboxId = useGeneratedHtmlId({ prefix: 'rule' });
 
   const [ruleChecked, setRuleChecked] = useState(false);
+  const [timeChecked, setTimeChecked] = useState(false);
 
   const [range, setRange] = useState({ from: 'now-24h', to: 'now' });
   const [status, setStatus] = useState<AlertStatus | undefined>('active');
@@ -98,11 +100,38 @@ export function RelatedAlerts({ alert }: Props) {
           <EuiFormRow label="Same rule">
             <EuiCheckbox
               id={ruleCheckboxId}
-              label={i18n.translate('xpack.observability.relatedAlerts.useRuleLabel', {
+              label={i18n.translate('xpack.observability.relatedAlerts.useSameRuleDimensionLabel', {
                 defaultMessage: 'Yes',
               })}
               checked={ruleChecked}
               onChange={(e) => setRuleChecked(e.target.checked)}
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow>
+          <EuiFormRow label="Same time">
+            <EuiCheckbox
+              id={ruleCheckboxId}
+              label={i18n.translate('xpack.observability.relatedAlerts.useSameTimeDimensionLabel', {
+                defaultMessage: 'Yes',
+              })}
+              checked={timeChecked}
+              onChange={(e) => {
+                const alertStart = moment(new Date(alert.fields['kibana.alert.start']!));
+
+                // TODO: Should we always use the alertStart + 5 minutes?
+                // const alertEndField = alert.fields['kibana.alert.end'];
+                // const alertEnd = alertEndField ? moment(alertEndField) : alertStart.clone();
+                const alertEnd = alertStart.clone();
+
+                const heuristicRange = {
+                  from: alertStart.subtract(5, 'minutes').toISOString(),
+                  to: alertEnd.add(5, 'minutes').toISOString(),
+                };
+                setRange(heuristicRange);
+                setTimeChecked(true);
+              }}
             />
           </EuiFormRow>
         </EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
@@ -118,19 +118,28 @@ export function RelatedAlerts({ alert }: Props) {
               })}
               checked={timeChecked}
               onChange={(e) => {
-                const alertStart = moment(new Date(alert.fields['kibana.alert.start']!));
+                if (!timeChecked) {
+                  const alertStart = moment(new Date(alert.fields['kibana.alert.start']!));
 
-                // TODO: Should we always use the alertStart + 5 minutes?
-                // const alertEndField = alert.fields['kibana.alert.end'];
-                // const alertEnd = alertEndField ? moment(alertEndField) : alertStart.clone();
-                const alertEnd = alertStart.clone();
+                  // TODO: Should we always use the alertStart + 5 minutes?
+                  // const alertEndField = alert.fields['kibana.alert.end'];
+                  // const alertEnd = alertEndField ? moment(alertEndField) : alertStart.clone();
+                  const alertEnd = alertStart.clone();
 
-                const heuristicRange = {
-                  from: alertStart.subtract(5, 'minutes').toISOString(),
-                  to: alertEnd.add(5, 'minutes').toISOString(),
-                };
-                setRange(heuristicRange);
-                setTimeChecked(true);
+                  const heuristicRange = {
+                    from: alertStart.subtract(5, 'minutes').toISOString(),
+                    to: alertEnd.add(5, 'minutes').toISOString(),
+                  };
+                  setRange(heuristicRange);
+                  setTimeChecked(true);
+                } else {
+                  const heuristicRange = {
+                    from: 'now-24h',
+                    to: 'now',
+                  };
+                  setRange(heuristicRange);
+                  setTimeChecked(false);
+                }
               }}
             />
           </EuiFormRow>

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/related_alerts.tsx
@@ -9,21 +9,18 @@ import { EuiCheckbox, EuiFlexGroup, EuiFlexItem, useGeneratedHtmlId } from '@ela
 import { AlertsGrouping } from '@kbn/alerts-grouping';
 import { BoolQuery } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
-import { ALERT_GROUP, ALERT_RULE_UUID, ALERT_UUID, TAGS } from '@kbn/rule-data-utils';
+import { ALERT_GROUP, ALERT_RULE_UUID, ALERT_UUID, AlertStatus, TAGS } from '@kbn/rule-data-utils';
 import React, { useEffect, useState } from 'react';
 import { ObservabilityAlertsTable, TopAlert } from '../../../..';
 import {
   OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
   observabilityAlertFeatureIds,
 } from '../../../../../common/constants';
-import { AlertStatus } from '../../../../../common/typings';
 import {
   getRelatedAlertKuery,
   getSharedFields,
 } from '../../../../../common/utils/alerting/get_related_alerts_query';
 import { ObservabilityFields } from '../../../../../common/utils/alerting/types';
-import { AlertsStatusFilter } from '../../../../components/alert_search_bar/components';
-import { ALERT_STATUS_FILTER, ALL_ALERTS } from '../../../../components/alert_search_bar/constants';
 import { DEFAULT_GROUPING_OPTIONS } from '../../../../components/alerts_table/grouping/constants';
 import { getAggregationsByGroupingField } from '../../../../components/alerts_table/grouping/get_aggregations_by_grouping_field';
 import { getGroupStats } from '../../../../components/alerts_table/grouping/get_group_stats';
@@ -35,9 +32,9 @@ import { buildEsQuery } from '../../../../utils/build_es_query';
 import { useKibana } from '../../../../utils/kibana_react';
 import { mergeBoolQueries } from '../../../alerts/helpers/merge_bool_queries';
 import { EmptyState } from './empty_state';
+import { StatusFilter, getAssociatedStatusFilter } from './status_filter';
 
 const ALERTS_PER_PAGE = 50;
-
 const ALERTS_TABLE_ID = 'xpack.observability.related.alerts.table';
 
 interface Props {
@@ -55,9 +52,9 @@ export function RelatedAlerts({ alert }: Props) {
   const [groupsChecked, setGroupsChecked] = useState(false);
   const [ruleChecked, setRuleChecked] = useState(false);
 
-  const [range, setRange] = useState({ from: 'now-24', to: 'now' });
-  const [status, setStatus] = useState(ALL_ALERTS.status);
+  const [range, setRange] = useState({ from: 'now-24h', to: 'now' });
   const [kuery, setKuery] = useState('');
+  const [status, setStatus] = useState<AlertStatus | undefined>('active');
   const [esQuery, setEsQuery] = useState<{ bool: BoolQuery }>({
     bool: {
       must: [],
@@ -66,23 +63,21 @@ export function RelatedAlerts({ alert }: Props) {
       should: [],
     },
   });
+  const statusFilter = getAssociatedStatusFilter(status);
 
   useEffect(() => {
     if (alert) {
-      const ku = getKuery({ alert, tagsChecked, groupsChecked, ruleChecked });
-
-      const esQ = buildEsQuery({
+      const newKuery = getKuery({ alert, tagsChecked, groupsChecked, ruleChecked });
+      const newEsQuery = buildEsQuery({
         timeRange: range,
-        kuery: ku,
-        filters: ALERT_STATUS_FILTER[status],
+        kuery: newKuery,
+        filters: statusFilter ? [statusFilter] : [],
       });
 
-      setKuery(ku);
-      setEsQuery(esQ);
-
-      console.dir({ ku, esQ });
+      setKuery(newKuery);
+      setEsQuery(newEsQuery);
     }
-  }, [tagsChecked, groupsChecked, ruleChecked, status, alert, range]);
+  }, [tagsChecked, groupsChecked, ruleChecked, alert, range, statusFilter]);
 
   return (
     <EuiFlexGroup direction="column" gutterSize="m">
@@ -118,23 +113,22 @@ export function RelatedAlerts({ alert }: Props) {
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <AlertsStatusFilter
+          <StatusFilter
             status={status}
-            onChange={(newStatus: AlertStatus) => setStatus(newStatus)}
+            onChange={(newStatus?: AlertStatus) => setStatus(newStatus)}
           />
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiFlexItem>
-        {!kuery && <EmptyState />}
-        {kuery && (
+        {!esQuery && <EmptyState />}
+        {esQuery && (
           <AlertsGrouping<AlertsByGroupingAgg>
             ruleTypeIds={OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES}
             consumers={observabilityAlertFeatureIds}
             from={range.from}
             to={range.to}
-            defaultFilters={ALERT_STATUS_FILTER[status]}
-            globalFilters={ALERT_STATUS_FILTER[status]}
-            globalQuery={{ query: '', language: 'kuery' }}
+            globalFilters={statusFilter ? [statusFilter] : []}
+            globalQuery={{ query: kuery, language: 'kuery' }}
             groupingId={RELATED_ALERTS_TABLE_CONFIG_ID}
             defaultGroupingOptions={DEFAULT_GROUPING_OPTIONS}
             getAggregationsByGroupingField={getAggregationsByGroupingField}
@@ -150,6 +144,7 @@ export function RelatedAlerts({ alert }: Props) {
               const groupQuery = buildEsQuery({
                 filters: groupingFilters,
               });
+              // TODO: Need to use esQuery (derived from kuery + filters) + groupQuery
               return (
                 <ObservabilityAlertsTable
                   id={ALERTS_TABLE_ID}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/status_filter.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/status_filter.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
+import { Filter } from '@kbn/es-query';
+import {
+  ALERT_STATUS,
+  ALERT_STATUS_ACTIVE,
+  ALERT_STATUS_RECOVERED,
+  ALERT_STATUS_UNTRACKED,
+  AlertStatus,
+} from '@kbn/rule-data-utils';
+import React, { useState } from 'react';
+
+interface Props {
+  status?: AlertStatus;
+  onChange: (status?: AlertStatus) => void;
+}
+
+const STATUSES: Array<{ value: AlertStatus; label: string; filter: Filter }> = [
+  {
+    value: ALERT_STATUS_ACTIVE,
+    label: 'Active',
+    filter: {
+      query: {
+        match_phrase: {
+          [ALERT_STATUS]: ALERT_STATUS_ACTIVE,
+        },
+      },
+      meta: {},
+    },
+  },
+  {
+    value: ALERT_STATUS_RECOVERED,
+    label: 'Recovered',
+    filter: {
+      query: {
+        match_phrase: {
+          [ALERT_STATUS]: ALERT_STATUS_RECOVERED,
+        },
+      },
+      meta: {},
+    },
+  },
+  {
+    value: ALERT_STATUS_UNTRACKED,
+    label: 'Untracked',
+    filter: {
+      query: {
+        match_phrase: {
+          [ALERT_STATUS]: ALERT_STATUS_UNTRACKED,
+        },
+      },
+      meta: {},
+    },
+  },
+];
+
+export const getAssociatedStatusFilter = (status?: AlertStatus): Filter | undefined => {
+  if (!status) return undefined;
+  return STATUSES.find((s) => s.value === status)?.filter;
+};
+
+const options: Array<EuiComboBoxOptionOption<AlertStatus>> = STATUSES.map(({ value, label }) => ({
+  value,
+  label,
+}));
+
+export function StatusFilter({ status, onChange }: Props) {
+  const [selected, setSelected] = useState<AlertStatus | undefined>(status);
+  return (
+    <EuiComboBox
+      prepend="Status"
+      compressed
+      singleSelection={{ asPlainText: true }}
+      options={options}
+      selectedOptions={options.filter((opt) => opt.value === selected)}
+      onChange={(selectedOptions: Array<EuiComboBoxOptionOption<AlertStatus>>) => {
+        if (selectedOptions.length) {
+          setSelected(selectedOptions[0].value!);
+          onChange(selectedOptions[0].value!);
+        } else {
+          setSelected(undefined);
+          onChange(undefined);
+        }
+      }}
+    />
+  );
+}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/status_filter.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/status_filter.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
+import { EuiComboBox, EuiComboBoxOptionOption, EuiFormRow } from '@elastic/eui';
 import { Filter } from '@kbn/es-query';
 import {
   ALERT_STATUS,
@@ -73,21 +73,23 @@ const options: Array<EuiComboBoxOptionOption<AlertStatus>> = STATUSES.map(({ val
 export function StatusFilter({ status, onChange }: Props) {
   const [selected, setSelected] = useState<AlertStatus | undefined>(status);
   return (
-    <EuiComboBox
-      prepend="Status"
-      compressed
-      singleSelection={{ asPlainText: true }}
-      options={options}
-      selectedOptions={options.filter((opt) => opt.value === selected)}
-      onChange={(selectedOptions: Array<EuiComboBoxOptionOption<AlertStatus>>) => {
-        if (selectedOptions.length) {
-          setSelected(selectedOptions[0].value!);
-          onChange(selectedOptions[0].value!);
-        } else {
-          setSelected(undefined);
-          onChange(undefined);
-        }
-      }}
-    />
+    <EuiFormRow label="Status">
+      <EuiComboBox
+        compressed
+        isClearable
+        singleSelection={{ asPlainText: true }}
+        options={options}
+        selectedOptions={options.filter((opt) => opt.value === selected)}
+        onChange={(selectedOptions: Array<EuiComboBoxOptionOption<AlertStatus>>) => {
+          if (selectedOptions.length) {
+            setSelected(selectedOptions[0].value!);
+            onChange(selectedOptions[0].value!);
+          } else {
+            setSelected(undefined);
+            onChange(undefined);
+          }
+        }}
+      />
+    </EuiFormRow>
   );
 }

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/tags_filter.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/tags_filter.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiComboBox } from '@elastic/eui';
+import { EuiComboBox, EuiFormRow } from '@elastic/eui';
 import React, { useState } from 'react';
 
 interface Props {
@@ -18,17 +18,19 @@ export function TagsFilter({ availableTags, tags, onChange }: Props) {
   const [selected, setSelected] = useState<string[]>(tags);
 
   return (
-    <EuiComboBox<string>
-      compressed
-      placeholder="Select any tags"
-      selectedOptions={selected.map((tag) => ({ label: tag, value: tag }))}
-      options={availableTags.map((tag) => ({ label: tag, value: tag }))}
-      onChange={(selectedOptions) => {
-        const newTags = selectedOptions.map((opt) => opt.value!);
-        setSelected(newTags);
-        onChange(newTags);
-      }}
-      isClearable={true}
-    />
+    <EuiFormRow label="Tags">
+      <EuiComboBox<string>
+        compressed
+        placeholder="Select related tags"
+        selectedOptions={selected.map((tag) => ({ label: tag, value: tag }))}
+        options={availableTags.map((tag) => ({ label: tag, value: tag }))}
+        onChange={(selectedOptions) => {
+          const newTags = selectedOptions.map((opt) => opt.value!);
+          setSelected(newTags);
+          onChange(newTags);
+        }}
+        isClearable={true}
+      />
+    </EuiFormRow>
   );
 }

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/tags_filter.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/related_alerts/tags_filter.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiComboBox } from '@elastic/eui';
+import React, { useState } from 'react';
+
+interface Props {
+  availableTags: string[];
+  tags: string[];
+  onChange: (tags: string[]) => void;
+}
+
+export function TagsFilter({ availableTags, tags, onChange }: Props) {
+  const [selected, setSelected] = useState<string[]>(tags);
+
+  return (
+    <EuiComboBox<string>
+      compressed
+      placeholder="Select any tags"
+      selectedOptions={selected.map((tag) => ({ label: tag, value: tag }))}
+      options={availableTags.map((tag) => ({ label: tag, value: tag }))}
+      onChange={(selectedOptions) => {
+        const newTags = selectedOptions.map((opt) => opt.value!);
+        setSelected(newTags);
+        onChange(newTags);
+      }}
+      isClearable={true}
+    />
+  );
+}


### PR DESCRIPTION
Related alerts POC related to https://github.com/elastic/incident-management-initiative/issues/14

What has been explored in this POC:
- Using dimension's toggle to filter the alerts table

[tags] and [groups] and [rule] and [time] and [status]

Limitations:
- alerts table can be difficult to work around / lack of flexbility for our use case
- The alerts table cannot be modified in a way that it indicates what was the reason for being associated to the current alert or associate a score of "closeness" 
- The grouping table can be done on existing fields but not on what we consider dimensions, e.g. tags or groups. For example, if you choose to group by group, you'll get one group for each group value, when we would like to  see all the alerts that have been matched based on their group. 




