### PR TITLE
[ES|QL] Fixes warnings with escaped quotes

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -202,6 +202,36 @@ describe('helpers', function () {
         },
       ]);
     });
+
+    it('should return the correct array of warningsif the quotes are escaped (at that case we dont have a new warning)', function () {
+      const warning = `299 Elasticsearch-9.1.0 "No limit defined, adding default limit of [1000]", "Line 1:9: evaluation of [TO_LOWER([\\"FOO\\", \\"BAR\\"])] failed", "Line 1:9: java.lang.IllegalArgumentException: single-value function encountered multi-value"`;
+      expect(parseWarning(warning)).toEqual([
+        {
+          endColumn: 10,
+          endLineNumber: 1,
+          message: 'No limit defined, adding default limit of [1000]',
+          severity: 4,
+          startColumn: 1,
+          startLineNumber: 1,
+        },
+        {
+          endColumn: 40,
+          endLineNumber: 1,
+          message: 'evaluation of [TO_LOWER([\\FOO\\, \\BAR\\])] failed',
+          severity: 4,
+          startColumn: 9,
+          startLineNumber: 1,
+        },
+        {
+          endColumn: 18,
+          endLineNumber: 1,
+          message: 'single-value function encountered multi-value',
+          severity: 4,
+          startColumn: 9,
+          startLineNumber: 1,
+        },
+      ]);
+    });
   });
 
   describe('getIndicesList', function () {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -215,9 +215,9 @@ describe('helpers', function () {
           startLineNumber: 1,
         },
         {
-          endColumn: 40,
+          endColumn: 36,
           endLineNumber: 1,
-          message: 'evaluation of [TO_LOWER([\\FOO\\, \\BAR\\])] failed',
+          message: 'evaluation of [TO_LOWER([FOO, BAR])] failed',
           severity: 4,
           startColumn: 9,
           startLineNumber: 1,

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.test.ts
@@ -215,9 +215,9 @@ describe('helpers', function () {
           startLineNumber: 1,
         },
         {
-          endColumn: 36,
+          endColumn: 40,
           endLineNumber: 1,
-          message: 'evaluation of [TO_LOWER([FOO, BAR])] failed',
+          message: 'evaluation of [TO_LOWER(["FOO", "BAR"])] failed',
           severity: 4,
           startColumn: 9,
           startLineNumber: 1,

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -63,7 +63,10 @@ export const useDebounceWithOptions = (
   );
 };
 
-const quotedWarningMessageRegexp = /"(.*?)"/g;
+// Quotes can be used as separators for multiple warnings unless
+// they are escaped with backslashes. This regexp will match any
+// quoted string that is not escaped.
+const quotedWarningMessageRegexp = /(?<!\\)"(.*?)(?<!\\)"/g;
 
 export const parseWarning = (warning: string): MonacoMessage[] => {
   if (quotedWarningMessageRegexp.test(warning)) {

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -66,7 +66,7 @@ export const useDebounceWithOptions = (
 // Quotes can be used as separators for multiple warnings unless
 // they are escaped with backslashes. This regexp will match any
 // quoted string that is not escaped.
-const quotedWarningMessageRegexp = /(?<!\\)"(.*?)(?<!\\)"/g;
+const quotedWarningMessageRegexp = /"(?:[^"\\]*(?:\\.[^"\\]*)*)"/g;
 
 export const parseWarning = (warning: string): MonacoMessage[] => {
   if (quotedWarningMessageRegexp.test(warning)) {
@@ -74,7 +74,7 @@ export const parseWarning = (warning: string): MonacoMessage[] => {
     if (matches) {
       return matches.map((message) => {
         // start extracting the quoted message and with few default positioning
-        let warningMessage = message.replace(/"/g, '');
+        let warningMessage = message.replace(/\\"/g, '').replace(/"/g, '');
         let startColumn = 1;
         let startLineNumber = 1;
         // initialize the length to 10 in case no error word found

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -75,7 +75,7 @@ export const parseWarning = (warning: string): MonacoMessage[] => {
       return matches.map((message) => {
         // start extracting the quoted message and with few default positioning
         // replaces the quotes only if they are not escaped
-        let warningMessage = message.replace(/(?<!\\)"/g, '').replace(/\\/g, '');
+        let warningMessage = message.replace(/(?<!\\)"|\\/g, '');
         let startColumn = 1;
         let startLineNumber = 1;
         // initialize the length to 10 in case no error word found

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -74,7 +74,8 @@ export const parseWarning = (warning: string): MonacoMessage[] => {
     if (matches) {
       return matches.map((message) => {
         // start extracting the quoted message and with few default positioning
-        let warningMessage = message.replace(/\\"/g, '').replace(/"/g, '');
+        // replaces the quotes only if they are not escaped
+        let warningMessage = message.replace(/(?<!\\)"/g, '').replace(/\\/g, '');
         let startColumn = 1;
         let startLineNumber = 1;
         // initialize the length to 10 in case no error word found


### PR DESCRIPTION
## Summary

Fixes a big where the warning appear wrong when the warning message has escaped quotes.

**Before**
![image (84)](https://github.com/user-attachments/assets/db7eaca1-bb04-4785-ae3e-2ecb3da694ee)


**Now**
![image](https://github.com/user-attachments/assets/afc107e1-b83d-4d3b-862c-6c2bffc27656)



### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


Brought at my attention from @nik9000 ❤️ 



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->