### PR TITLE
[9.0] [Infra] Fix hosts total count query (#212749)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_hosts_count.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_hosts_count.ts
@@ -25,8 +25,14 @@ export async function getHostsCount({
 }) {
   assertQueryStructure(query);
 
+  const apmDocumentSources = await apmDataAccessServices?.getDocumentSources({
+    start: from,
+    end: to,
+  });
+
   const documentsFilter = await getDocumentsFilter({
     apmDataAccessServices,
+    apmDocumentSources,
     from,
     to,
   });
@@ -38,8 +44,15 @@ export async function getHostsCount({
       track_total_hits: false,
       query: {
         bool: {
-          filter: [query, ...rangeQuery(from, to)],
-          should: [...documentsFilter],
+          filter: [
+            query,
+            ...rangeQuery(from, to),
+            {
+              bool: {
+                should: [...documentsFilter],
+              },
+            },
+          ],
         },
       },
       aggs: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Infra] Fix hosts total count query (#212749)](https://github.com/elastic/kibana/pull/212749)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-04T15:46:21Z","message":"[Infra] Fix hosts total count query (#212749)\n\nFixes [#212745](https://github.com/elastic/kibana/issues/212745)\n\n## Summary\n\nFix for the hosts total count query, which was not correctly filtering\nhosts from system integration and APM\n\n<img width=\"584\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/05c3b244-3a0f-425a-82db-3498c1a6dbb7\"\n/>\n\n\n### How to test\n- Connect Kibana to an edge cluster\n- Navigate to Infrastructure > Hosts\n- The total number of items on the table should be equal to the number\nin the hosts count KPI\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"8e5b8580f461b4f057ade98cf340e3a8bf8b9d6f","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:prev-minor","backport:prev-major","Team:obs-ux-infra_services","v9.1.0"],"title":"[Infra] Fix hosts total count query","number":212749,"url":"https://github.com/elastic/kibana/pull/212749","mergeCommit":{"message":"[Infra] Fix hosts total count query (#212749)\n\nFixes [#212745](https://github.com/elastic/kibana/issues/212745)\n\n## Summary\n\nFix for the hosts total count query, which was not correctly filtering\nhosts from system integration and APM\n\n<img width=\"584\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/05c3b244-3a0f-425a-82db-3498c1a6dbb7\"\n/>\n\n\n### How to test\n- Connect Kibana to an edge cluster\n- Navigate to Infrastructure > Hosts\n- The total number of items on the table should be equal to the number\nin the hosts count KPI\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"8e5b8580f461b4f057ade98cf340e3a8bf8b9d6f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212749","number":212749,"mergeCommit":{"message":"[Infra] Fix hosts total count query (#212749)\n\nFixes [#212745](https://github.com/elastic/kibana/issues/212745)\n\n## Summary\n\nFix for the hosts total count query, which was not correctly filtering\nhosts from system integration and APM\n\n<img width=\"584\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/05c3b244-3a0f-425a-82db-3498c1a6dbb7\"\n/>\n\n\n### How to test\n- Connect Kibana to an edge cluster\n- Navigate to Infrastructure > Hosts\n- The total number of items on the table should be equal to the number\nin the hosts count KPI\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"8e5b8580f461b4f057ade98cf340e3a8bf8b9d6f"}}]}] BACKPORT-->