### PR TITLE
[ResponseOps][MW] Public PATCH maintenance window

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { updateMaintenanceWindowRequestBodySchema } from './schemas/latest';
+export type {
+  UpdateMaintenanceWindowRequestBody,
+  UpdateMaintenanceWindowRequestParams,
+  UpdateMaintenanceWindowResponse,
+} from './types/latest';
+
+export {
+  updateMaintenanceWindowRequestBodySchema as updateMaintenanceWindowRequestBodySchemaV1,
+  updateMaintenanceWindowRequestParamsSchema as updateMaintenanceWindowRequestParamsSchemaV1,
+} from './schemas/v1';
+
+export type {
+  UpdateMaintenanceWindowRequestParams as UpdateMaintenanceWindowRequestParamsV1,
+  UpdateMaintenanceWindowRequestBody as UpdateMaintenanceWindowRequestBodyV1,
+  UpdateMaintenanceWindowResponse as UpdateMaintenanceWindowResponseV1,
+} from './types/v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/schemas/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/schemas/latest.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { updateMaintenanceWindowRequestBodySchema } from './v1';
+export { updateMaintenanceWindowRequestParamsSchema } from './v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/schemas/v1.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { schema } from '@kbn/config-schema';
+
+// TODO schedule schema
+const scheduleSchema = schema.object({
+  duration: schema.number(),
+  start: schema.string(),
+  recurring: schema.maybe(
+    schema.object({
+      end: schema.maybe(schema.string()),
+      every: schema.maybe(schema.string()),
+      onWeekDay: schema.maybe(schema.arrayOf(schema.string())),
+      onMonthDay: schema.maybe(schema.arrayOf(schema.number())),
+      onMonth: schema.maybe(schema.arrayOf(schema.string())),
+      occurrences: schema.maybe(schema.number()),
+    })
+  ),
+});
+
+export const updateMaintenanceWindowRequestBodySchema = schema.object({
+  title: schema.maybe(
+    schema.string({
+      meta: {
+        description:
+          'The name of the maintenance window. While this name does not have to be unique, a distinctive name can help you identify a specific maintenance window.',
+      },
+    })
+  ),
+  enabled: schema.maybe(
+    schema.boolean({
+      meta: {
+        description:
+          'Whether the current maintenance window is enabled. Disabled maintenance windows do not suppress notifications.',
+      },
+      defaultValue: true,
+    })
+  ),
+  scope: schema.maybe(
+    schema.object({
+      query: schema.object({
+        kql: schema.string({
+          meta: { description: 'A filter written in Kibana Query Language (KQL).' },
+        }),
+      }),
+    })
+  ),
+  schedule: schema.maybe(schema.object({ custom: schema.maybe(scheduleSchema) })),
+});
+
+export const updateMaintenanceWindowRequestParamsSchema = schema.object({
+  id: schema.string(),
+});

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/schemas/v1.ts
@@ -6,22 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-
-// TODO schedule schema
-const scheduleSchema = schema.object({
-  duration: schema.number(),
-  start: schema.string(),
-  recurring: schema.maybe(
-    schema.object({
-      end: schema.maybe(schema.string()),
-      every: schema.maybe(schema.string()),
-      onWeekDay: schema.maybe(schema.arrayOf(schema.string())),
-      onMonthDay: schema.maybe(schema.arrayOf(schema.number())),
-      onMonth: schema.maybe(schema.arrayOf(schema.string())),
-      occurrences: schema.maybe(schema.number()),
-    })
-  ),
-});
+import { scheduleRequestSchemaV1 } from '../../../../../schedule';
 
 export const updateMaintenanceWindowRequestBodySchema = schema.object({
   title: schema.maybe(
@@ -41,16 +26,22 @@ export const updateMaintenanceWindowRequestBodySchema = schema.object({
       defaultValue: true,
     })
   ),
+  schedule: schema.maybe(
+    schema.object({
+      custom: scheduleRequestSchemaV1,
+    })
+  ),
   scope: schema.maybe(
     schema.object({
-      query: schema.object({
-        kql: schema.string({
-          meta: { description: 'A filter written in Kibana Query Language (KQL).' },
+      alerting: schema.object({
+        query: schema.object({
+          kql: schema.string({
+            meta: { description: 'A filter written in Kibana Query Language (KQL).' },
+          }),
         }),
       }),
     })
   ),
-  schedule: schema.maybe(schema.object({ custom: schema.maybe(scheduleSchema) })),
 });
 
 export const updateMaintenanceWindowRequestParamsSchema = schema.object({

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/types/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/types/latest.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export type {
+  UpdateMaintenanceWindowRequestParams,
+  UpdateMaintenanceWindowRequestBody,
+  UpdateMaintenanceWindowResponse,
+} from './v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/types/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/types/v1.ts
@@ -6,8 +6,8 @@
  */
 
 import type { TypeOf } from '@kbn/config-schema';
-import { MaintenanceWindowResponseV1 } from '../../../response';
-import {
+import type { MaintenanceWindowResponseV1 } from '../../../response';
+import type {
   updateMaintenanceWindowRequestBodySchemaV1,
   updateMaintenanceWindowRequestParamsSchemaV1,
 } from '..';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/types/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/maintenance_window/external/apis/update/types/v1.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TypeOf } from '@kbn/config-schema';
+import { MaintenanceWindowResponseV1 } from '../../../response';
+import {
+  updateMaintenanceWindowRequestBodySchemaV1,
+  updateMaintenanceWindowRequestParamsSchemaV1,
+} from '..';
+
+export type UpdateMaintenanceWindowRequestParams = TypeOf<
+  typeof updateMaintenanceWindowRequestParamsSchemaV1
+>;
+export type UpdateMaintenanceWindowRequestBody = TypeOf<
+  typeof updateMaintenanceWindowRequestBodySchemaV1
+>;
+export type UpdateMaintenanceWindowResponse = MaintenanceWindowResponseV1;

--- a/x-pack/platform/plugins/shared/alerting/server/application/maintenance_window/methods/update/update_maintenance_window.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/maintenance_window/methods/update/update_maintenance_window.test.ts
@@ -395,56 +395,6 @@ describe('MaintenanceWindowClient - update', () => {
     `);
   });
 
-  it('should throw if trying to update a MW with a scoped query with other than 1 category ID', async () => {
-    jest.useFakeTimers().setSystemTime(new Date(firstTimestamp));
-    const mockMaintenanceWindow = getMockMaintenanceWindow({
-      expirationDate: moment(new Date(firstTimestamp)).tz('UTC').subtract(1, 'year').toISOString(),
-    });
-
-    savedObjectsClient.get.mockResolvedValueOnce({
-      attributes: mockMaintenanceWindow,
-      version: '123',
-      id: 'test-id',
-      categoryIds: ['observability', 'securitySolution'],
-    } as unknown as SavedObject);
-
-    await expect(async () => {
-      await updateMaintenanceWindow(mockContext, {
-        id: 'test-id',
-        data: {
-          scopedQuery: {
-            kql: "_id: '1234'",
-            filters: [
-              {
-                meta: {
-                  disabled: false,
-                  negate: false,
-                  alias: null,
-                  key: 'kibana.alert.action_group',
-                  field: 'kibana.alert.action_group',
-                  params: {
-                    query: 'test',
-                  },
-                  type: 'phrase',
-                },
-                $state: {
-                  store: FilterStateStore.APP_STATE,
-                },
-                query: {
-                  match_phrase: {
-                    'kibana.alert.action_group': 'test',
-                  },
-                },
-              },
-            ],
-          },
-        },
-      });
-    }).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Failed to update maintenance window by id: test-id, Error: Error: Cannot edit archived maintenance windows: Cannot edit archived maintenance windows"`
-    );
-  });
-
   it('should throw if updating a maintenance window that has expired', async () => {
     jest.useFakeTimers().setSystemTime(new Date(firstTimestamp));
     const mockMaintenanceWindow = getMockMaintenanceWindow({

--- a/x-pack/platform/plugins/shared/alerting/server/application/maintenance_window/methods/update/update_maintenance_window.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/application/maintenance_window/methods/update/update_maintenance_window.ts
@@ -128,14 +128,6 @@ async function updateWithOCC(
         updatedAt: modificationMetadata.updatedAt,
       });
 
-    if (updateMaintenanceWindowAttributes.scopedQuery) {
-      if (updateMaintenanceWindowAttributes.categoryIds?.length !== 1) {
-        throw Boom.badRequest(
-          `Error validating update maintenance window data - scoped query must be accompanied by 1 category ID`
-        );
-      }
-    }
-
     // We are deleting and then creating rather than updating because SO.update
     // performs a partial update on the rRule, we would need to null out all of the fields
     // that are removed from a new rRule if that were the case.

--- a/x-pack/platform/plugins/shared/alerting/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/index.ts
@@ -66,6 +66,7 @@ import { createMaintenanceWindowRoute } from './maintenance_window/apis/external
 import { deleteMaintenanceWindowRoute } from './maintenance_window/apis/external/delete/delete_maintenance_window_route';
 import { archiveMaintenanceWindowRoute } from './maintenance_window/apis/external/archive/archive_maintenance_window_route';
 import { unarchiveMaintenanceWindowRoute } from './maintenance_window/apis/external/unarchive/unarchive_maintenance_window_route';
+import { updateMaintenanceWindowRoute } from './maintenance_window/apis/external/update/update_maintenance_window_route';
 
 import { registerRulesValueSuggestionsRoute } from './suggestions/values_suggestion_rules';
 import { registerFieldsRoute } from './suggestions/fields_rules';
@@ -159,6 +160,7 @@ export function defineRoutes(opts: RouteOptions) {
   deleteMaintenanceWindowRoute(router, licenseState);
   archiveMaintenanceWindowRoute(router, licenseState);
   unarchiveMaintenanceWindowRoute(router, licenseState);
+  updateMaintenanceWindowRoute(router, licenseState);
 
   // backfill APIs
   scheduleBackfillRoute(router, licenseState);

--- a/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/transform_update_body/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/transform_update_body/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { transformUpdateBody } from './latest';
+
+export { transformUpdateBody as transformUpdateBodyV1 } from './v1';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/transform_update_body/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/transform_update_body/latest.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { transformUpdateBody } from './v1';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/transform_update_body/v1.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/transform_update_body/v1.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { transformUpdateBody } from './v1';
+
+describe('transformUpdateBody', () => {
+  it('transforms every field correctly', () => {
+    expect(
+      transformUpdateBody({
+        title: 'test-update-maintenance-window',
+        enabled: true,
+        schedule: {
+          custom: {
+            duration: '10d',
+            start: '2021-03-07T00:00:00.000Z',
+            recurring: { every: '1d', end: '2022-05-17T05:05:00.000Z', onWeekDay: ['MO', 'FR'] },
+          },
+        },
+        scope: {
+          alerting: {
+            query: {
+              kql: "_id: '1234'",
+            },
+          },
+        },
+      })
+    ).toEqual({
+      title: 'test-update-maintenance-window',
+      duration: 864000000,
+      enabled: true,
+      rRule: {
+        bymonth: undefined,
+        bymonthday: undefined,
+        byweekday: ['MO', 'FR'],
+        count: undefined,
+        dtstart: '2021-03-07T00:00:00.000Z',
+        freq: 3,
+        interval: 1,
+        tzid: 'UTC',
+        until: '2022-05-17T05:05:00.000Z',
+      },
+      scopedQuery: {
+        filters: [],
+        kql: "_id: '1234'",
+      },
+    });
+  });
+
+  it('does not include missing fields', () => {
+    expect(transformUpdateBody({})).toEqual({});
+  });
+
+  it('sets correctly enabled: false', () => {
+    expect(transformUpdateBody({ enabled: false })).toEqual({ enabled: false });
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/transform_update_body/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/transform_update_body/v1.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { UpdateMaintenanceWindowRequestBodyV1 } from '../../../../../../../common/routes/maintenance_window/external/apis/update';
+import { UpdateMaintenanceWindowParams } from '../../../../../../application/maintenance_window/methods/update/types';
+
+/**
+ *  This function converts from the external, human readable, Maintenance Window creation/POST
+ *  type expected by the public APIs, to the internal type used by the client.
+ */
+export const transformUpdateBody = (
+  updateBody: UpdateMaintenanceWindowRequestBodyV1
+): UpdateMaintenanceWindowParams['data'] => {
+  // TODO categoryIds
+  // const kql = updateBody.scope?.query.kql;
+
+  // TODO schedule schema
+  // const customSchedule = updateBody.schedule?.custom;
+
+  return {
+    title: updateBody.title,
+    enabled: updateBody.enabled,
+
+    // TODO categoryIds
+    // Updating the scope depends on the removal of categoryIds from the client
+    // See: https://github.com/elastic/kibana/issues/197530
+    // scopedQuery: kql ? { kql, filters: [] } : null,
+
+    // TODO schedule schema
+    // duration: customSchedule?.duration,
+    // rRule: {
+    //   dtstart: customSchedule?.start ?? '',
+    //   tzid: 'UTC',
+    // },
+  };
+};

--- a/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/update_maintenance_window_route.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/update_maintenance_window_route.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { httpServiceMock } from '@kbn/core/server/mocks';
+import { licenseStateMock } from '../../../../../lib/license_state.mock';
+import { verifyApiAccess } from '../../../../../lib/license_api_access';
+import { mockHandlerArguments } from '../../../../_mock_handler_arguments';
+import { maintenanceWindowClientMock } from '../../../../../maintenance_window_client.mock';
+import { updateMaintenanceWindowRoute } from './update_maintenance_window_route';
+import { getMockMaintenanceWindow } from '../../../../../data/maintenance_window/test_helpers';
+import { MaintenanceWindowStatus } from '../../../../../../common';
+import { MaintenanceWindow } from '../../../../../application/maintenance_window/types';
+import {
+  UpdateMaintenanceWindowRequestBody,
+  UpdateMaintenanceWindowRequestParams,
+} from '../../../../../../common/routes/maintenance_window/external/apis/update';
+import { transformMaintenanceWindowToResponseV1 } from '../common/transforms';
+
+const maintenanceWindowClient = maintenanceWindowClientMock.create();
+
+jest.mock('../../../../../lib/license_api_access', () => ({
+  verifyApiAccess: jest.fn(),
+}));
+
+const mockMaintenanceWindow = {
+  ...getMockMaintenanceWindow(),
+  eventStartTime: new Date().toISOString(),
+  eventEndTime: new Date().toISOString(),
+  status: MaintenanceWindowStatus.Running,
+  id: 'test-id',
+} as MaintenanceWindow;
+
+const updateRequestBody = {
+  title: 'test-maintenance-window',
+  enabled: false,
+
+  // TODO schedule schema
+  // schedule: {
+  //   custom: {
+  //     start: '2026-02-07T09:17:06.790Z',
+  //     duration: 60 * 60 * 1000, // 1 hr
+  //   },
+  // },
+
+  // TODO categoryIds
+  // Updating the scope depends on the removal of categoryIds from the client
+  // See: https://github.com/elastic/kibana/issues/197530
+  // scope: { query: { kql: "_id: '1234'" } },
+} as UpdateMaintenanceWindowRequestBody;
+
+const updateRequestParams = {
+  id: 'foo-bar',
+} as UpdateMaintenanceWindowRequestParams;
+
+describe('updateMaintenanceWindowRoute', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('should update a maintenance window', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    updateMaintenanceWindowRoute(router, licenseState);
+
+    maintenanceWindowClient.update.mockResolvedValueOnce(mockMaintenanceWindow);
+    const [config, handler] = router.patch.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments(
+      { maintenanceWindowClient },
+      { params: updateRequestParams, body: updateRequestBody }
+    );
+
+    expect(config.path).toEqual('/api/alerting/maintenance_window/{id}');
+    expect(config.options).toMatchInlineSnapshot(`
+      Object {
+        "access": "public",
+        "summary": "Update a maintenance window.",
+      }
+    `);
+
+    expect(config.security).toMatchInlineSnapshot(`
+      Object {
+        "authz": Object {
+          "requiredPrivileges": Array [
+            "write-maintenance-window",
+          ],
+        },
+      }
+    `);
+
+    await handler(context, req, res);
+
+    expect(maintenanceWindowClient.update).toHaveBeenLastCalledWith({
+      id: 'foo-bar',
+      data: {
+        title: 'test-maintenance-window',
+        enabled: false,
+
+        // TODO categoryIds
+        // scopedQuery: {
+        //   filters: [],
+        //   kql: "_id: '1234'",
+        // },
+
+        // TODO schedule schema
+        // duration: 60 * 60 * 1000, // 1 hr
+        // rRule: {
+        //   dtstart: '2026-02-07T09:17:06.790Z',
+        //   tzid: 'UTC',
+        // },
+      },
+    });
+    expect(res.ok).toHaveBeenLastCalledWith({
+      body: transformMaintenanceWindowToResponseV1(mockMaintenanceWindow),
+    });
+  });
+
+  test('ensures the license allows for creating maintenance windows', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    updateMaintenanceWindowRoute(router, licenseState);
+
+    maintenanceWindowClient.update.mockResolvedValueOnce(mockMaintenanceWindow);
+    const [, handler] = router.patch.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments(
+      { maintenanceWindowClient },
+      { params: updateRequestParams, body: updateRequestBody }
+    );
+    await handler(context, req, res);
+    expect(verifyApiAccess).toHaveBeenCalledWith(licenseState);
+  });
+
+  test('ensures the license check prevents updating maintenance windows', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    updateMaintenanceWindowRoute(router, licenseState);
+
+    (verifyApiAccess as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+    const [, handler] = router.patch.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments(
+      { maintenanceWindowClient },
+      { params: updateRequestParams, body: updateRequestBody }
+    );
+    await expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
+
+  test('ensures only platinum license can access API', async () => {
+    const licenseState = licenseStateMock.create();
+    const router = httpServiceMock.createRouter();
+
+    updateMaintenanceWindowRoute(router, licenseState);
+
+    (licenseState.ensureLicenseForMaintenanceWindow as jest.Mock).mockImplementation(() => {
+      throw new Error('Failure');
+    });
+
+    const [, handler] = router.patch.mock.calls[0];
+    const [context, req, res] = mockHandlerArguments({ maintenanceWindowClient }, { body: {} });
+    await expect(handler(context, req, res)).rejects.toMatchInlineSnapshot(`[Error: Failure]`);
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/update_maintenance_window_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/update_maintenance_window_route.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IRouter } from '@kbn/core/server';
+import { ILicenseState } from '../../../../../lib';
+import { verifyAccessAndContext } from '../../../../lib';
+import {
+  AlertingRequestHandlerContext,
+  BASE_MAINTENANCE_WINDOW_API_PATH,
+} from '../../../../../types';
+import { MAINTENANCE_WINDOW_API_PRIVILEGES } from '../../../../../../common';
+import { MaintenanceWindow } from '../../../../../application/maintenance_window/types';
+import {
+  updateMaintenanceWindowRequestBodySchemaV1,
+  updateMaintenanceWindowRequestParamsSchemaV1,
+  UpdateMaintenanceWindowRequestBodyV1,
+  UpdateMaintenanceWindowResponseV1,
+  UpdateMaintenanceWindowRequestParamsV1,
+} from '../../../../../../common/routes/maintenance_window/external/apis/update';
+import { maintenanceWindowResponseSchemaV1 } from '../../../../../../common/routes/maintenance_window/external/response';
+import { transformMaintenanceWindowToResponseV1 } from '../common/transforms';
+import { transformUpdateBodyV1 } from './transform_update_body';
+
+export const updateMaintenanceWindowRoute = (
+  router: IRouter<AlertingRequestHandlerContext>,
+  licenseState: ILicenseState
+) => {
+  router.patch(
+    {
+      path: `${BASE_MAINTENANCE_WINDOW_API_PATH}/{id}`,
+      validate: {
+        request: {
+          body: updateMaintenanceWindowRequestBodySchemaV1,
+          params: updateMaintenanceWindowRequestParamsSchemaV1,
+        },
+        response: {
+          200: {
+            body: () => maintenanceWindowResponseSchemaV1,
+            description: 'Indicates a successful call.',
+          },
+          400: {
+            description: 'Indicates an invalid schema or parameters.',
+          },
+          403: {
+            description: 'Indicates that this call is forbidden.',
+          },
+          404: {
+            description: 'Indicates a maintenance window with the given ID does not exist.',
+          },
+          409: {
+            description:
+              'Indicates that the maintenance window has already been updated by another user.',
+          },
+        },
+      },
+      security: {
+        authz: {
+          requiredPrivileges: [`${MAINTENANCE_WINDOW_API_PRIVILEGES.WRITE_MAINTENANCE_WINDOW}`],
+        },
+      },
+      options: {
+        access: 'public',
+        summary: 'Update a maintenance window.',
+      },
+    },
+    router.handleLegacyErrors(
+      verifyAccessAndContext(licenseState, async function (context, req, res) {
+        licenseState.ensureLicenseForMaintenanceWindow();
+
+        const body: UpdateMaintenanceWindowRequestBodyV1 = req.body;
+        const params: UpdateMaintenanceWindowRequestParamsV1 = req.params;
+
+        const maintenanceWindowClient = (await context.alerting).getMaintenanceWindowClient();
+
+        const maintenanceWindow: MaintenanceWindow = await maintenanceWindowClient.update({
+          id: params.id,
+          data: transformUpdateBodyV1(body),
+        });
+
+        const response: UpdateMaintenanceWindowResponseV1 =
+          transformMaintenanceWindowToResponseV1(maintenanceWindow);
+
+        return res.ok({
+          body: response,
+        });
+      })
+    )
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/update_maintenance_window_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/maintenance_window/apis/external/update/update_maintenance_window_route.ts
@@ -5,24 +5,25 @@
  * 2.0.
  */
 
-import { IRouter } from '@kbn/core/server';
-import { ILicenseState } from '../../../../../lib';
+import type { IRouter } from '@kbn/core/server';
+import type { ILicenseState } from '../../../../../lib';
 import { verifyAccessAndContext } from '../../../../lib';
-import {
-  AlertingRequestHandlerContext,
-  BASE_MAINTENANCE_WINDOW_API_PATH,
-} from '../../../../../types';
+import type { AlertingRequestHandlerContext } from '../../../../../types';
+import { BASE_MAINTENANCE_WINDOW_API_PATH } from '../../../../../types';
 import { MAINTENANCE_WINDOW_API_PRIVILEGES } from '../../../../../../common';
-import { MaintenanceWindow } from '../../../../../application/maintenance_window/types';
-import {
-  updateMaintenanceWindowRequestBodySchemaV1,
-  updateMaintenanceWindowRequestParamsSchemaV1,
+import type { MaintenanceWindow } from '../../../../../application/maintenance_window/types';
+import type {
   UpdateMaintenanceWindowRequestBodyV1,
   UpdateMaintenanceWindowResponseV1,
   UpdateMaintenanceWindowRequestParamsV1,
 } from '../../../../../../common/routes/maintenance_window/external/apis/update';
+import {
+  updateMaintenanceWindowRequestBodySchemaV1,
+  updateMaintenanceWindowRequestParamsSchemaV1,
+} from '../../../../../../common/routes/maintenance_window/external/apis/update';
 import { maintenanceWindowResponseSchemaV1 } from '../../../../../../common/routes/maintenance_window/external/response';
-import { transformMaintenanceWindowToResponseV1 } from '../common/transforms';
+import { transformInternalMaintenanceWindowToExternalV1 } from '../common/transforms';
+
 import { transformUpdateBodyV1 } from './transform_update_body';
 
 export const updateMaintenanceWindowRoute = (
@@ -82,7 +83,7 @@ export const updateMaintenanceWindowRoute = (
         });
 
         const response: UpdateMaintenanceWindowResponseV1 =
-          transformMaintenanceWindowToResponseV1(maintenanceWindow);
+          transformInternalMaintenanceWindowToExternalV1(maintenanceWindow);
 
         return res.ok({
           body: response,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/external/create_maintenance_window.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/external/create_maintenance_window.ts
@@ -79,12 +79,9 @@ export default function createMaintenanceWindowTests({ getService }: FtrProvider
               expect(response.body.title).to.eql('test-maintenance-window');
               expect(response.body.status).to.eql('upcoming');
               expect(response.body.enabled).to.eql(false);
-
               expect(response.body.scope.alerting.query.kql).to.eql("_id: '1234'");
-
               expect(response.body.created_by).to.eql(scenario.user.username);
               expect(response.body.updated_by).to.eql(scenario.user.username);
-
               expect(response.body.schedule.custom.duration).to.eql('1m');
               expect(response.body.schedule.custom.start).to.eql(start.toISOString());
               expect(response.body.schedule.custom.recurring.every).to.eql('2d');
@@ -127,6 +124,17 @@ export default function createMaintenanceWindowTests({ getService }: FtrProvider
               // test scenario: incomplete schedule, missing start
             },
           },
+        })
+        .expect(400);
+    });
+
+    it('should throw if creating maintenance window with unknown field', async () => {
+      await supertest
+        .post(`${getUrlPrefix('space1')}/api/alerting/maintenance_window`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          ...createRequestBody,
+          foo: 'bar',
         })
         .expect(400);
     });

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/external/update_maintenance_window.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/external/update_maintenance_window.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { UserAtSpaceScenarios } from '../../../../scenarios';
+import { getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
+import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+
+// eslint-disable-next-line import/no-default-export
+export default function createMaintenanceWindowTests({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  describe.only('updateMaintenanceWindow', () => {
+    const objectRemover = new ObjectRemover(supertest);
+    const createRequestBody = {
+      title: 'test-maintenance-window',
+      enabled: false,
+      start: '2026-02-07T09:17:06.790Z',
+      duration: 60 * 60 * 1000, // 1 hr
+      scope: { query: { kql: "_id: '1234'" } },
+    };
+
+    const updateRequestBody = {
+      title: 'updated-maintenance-window',
+      enabled: true,
+
+      // TODO categoryIds
+      // Updating the scope depends on the removal of categoryIds from the client
+      // See: https://github.com/elastic/kibana/issues/197530
+      // scope: { query: { kql: "_id: '12345'" } },
+
+      // TODO schedule schema
+      // every possible field should be passed
+      // recurring: {
+      //   end: '',
+      //   every: '',
+      //   onWeekDay: '',
+      //   onMonthDay: '',
+      //   onMonth: '',
+      //   ocurrences: 1234,
+      // },
+    };
+    afterEach(() => objectRemover.removeAll());
+
+    for (const scenario of UserAtSpaceScenarios) {
+      const { user, space } = scenario;
+      describe(scenario.id, () => {
+        it('should handle an update maintenance window request appropriately', async () => {
+          const { body: createdMaintenanceWindow } = await supertest
+            .post(`${getUrlPrefix(space.id)}/api/alerting/maintenance_window`)
+            .set('kbn-xsrf', 'foo')
+            .send(createRequestBody);
+
+          if (createdMaintenanceWindow.id) {
+            objectRemover.add(
+              space.id,
+              createdMaintenanceWindow.id,
+              'rules/maintenance_window',
+              'alerting',
+              true
+            );
+          }
+
+          const response = await supertestWithoutAuth
+            .patch(
+              `${getUrlPrefix(space.id)}/api/alerting/maintenance_window/${
+                createdMaintenanceWindow.id
+              }`
+            )
+            .set('kbn-xsrf', 'foo')
+            .auth(user.username, user.password)
+            .send(updateRequestBody);
+
+          switch (scenario.id) {
+            case 'no_kibana_privileges at space1':
+            case 'global_read at space1':
+            case 'space_1_all at space2':
+            case 'space_1_all_with_restricted_fixture at space1':
+            case 'space_1_all_alerts_none_actions at space1':
+              expect(response.statusCode).to.eql(403);
+              expect(response.body).to.eql({
+                error: 'Forbidden',
+                message: `API [PATCH /api/alerting/maintenance_window/${createdMaintenanceWindow.id}] is unauthorized for user, this action is granted by the Kibana privileges [write-maintenance-window]`,
+                statusCode: 403,
+              });
+              break;
+            case 'superuser at space1':
+            case 'space_1_all at space1':
+              expect(response.statusCode).to.eql(200);
+              expect(response.body.title).to.eql('updated-maintenance-window');
+              expect(response.body.enabled).to.eql(true);
+
+              expect(response.body.updated_by).to.eql(scenario.user.username);
+
+              // TODO schedule schema
+              // We want to guarantee every field is returned as expected
+              // expect(response.body.duration).to.eql(updateRequestBody.schedule.custom.duration);
+              // expect(response.body.start).to.eql(updateRequestBody.schedule.custom.start);
+              // expect(response.body.expiration_date).to.eql('???');
+              // expect(response.body.recurring.end).to.eql();
+              // expect(response.body.recurring.every).to.eql();
+              // expect(response.body.recurring.onWeekDay).to.eql();
+              // expect(response.body.recurring.onMonthDay).to.eql();
+              // expect(response.body.recurring.onMonth).to.eql();
+              // expect(response.body.recurring.occurrences).to.eql();
+              break;
+            default:
+              throw new Error(`Scenario untested: ${JSON.stringify(scenario)}`);
+          }
+        });
+      });
+    }
+
+    it('should throw if creating maintenance window with invalid scoped query', async () => {
+      await supertest
+        .post(`${getUrlPrefix('space1')}/api/alerting/maintenance_window`)
+        .set('kbn-xsrf', 'foo')
+        .send({
+          ...updateRequestBody,
+          scope: {
+            query: {
+              kql: 'invalid_kql:',
+            },
+          },
+        })
+        .expect(400);
+    });
+  });
+}

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/index.ts
@@ -26,6 +26,7 @@ export default function maintenanceWindowTests({ loadTestFile, getService }: Ftr
       loadTestFile(require.resolve('./external/delete_maintenance_window'));
       loadTestFile(require.resolve('./external/archive_maintenance_window'));
       loadTestFile(require.resolve('./external/unarchive_maintenance_window'));
+      loadTestFile(require.resolve('./external/update_maintenance_window'));
 
       // Internal APIs
       loadTestFile(require.resolve('./internal/get_maintenance_window'));


### PR DESCRIPTION
Closes #208881

## Merging into a feature branch

## Summary

Public PATCH maintenance window API.

- Partial updates.
- `category_id` is not updated.
- The validation in the maintenance window client that requires scoped queries to be sent with a `category_id`, has been removed.

## Testing

A Maintenance window has first to be created. It can be done via the UI or the new public API.

The API URL is:
- `https://localhost:5601/api/alerting/maintenance_window`

Here is an example request for **creating** a maintenance window in Postman:

```
{
    "title": "test-maintenance-window",
    "schedule": {
        "custom": {
            "duration": "1d",
            "start": "1992-01-01T05:00:00.200Z",
            "recurring": {
                "every": "10d",
                "onWeekDay": ["MO", "FR"]
            }
        }
    },
    "scope": {
        "alerting": {
            "query": {
                "kql": "_id: '1234'"
            }
        }
    }
}
```

The maintenance window can now be updated by sending a patch request to the same URL with the maintenance window ID appended to it.

- PATCH to `https://localhost:5601/api/alerting/maintenance_window/<MW_ID>`

The request body is the same as for the POST request. The only difference is every field is now optional.
