### PR TITLE
[Security Solution] Remove prebuilt rule changelog link for v9

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -78,9 +78,13 @@ export const AddPrebuiltRulesTable = React.memo(() => {
           ) : (
             <>
               <EuiFlexGroup direction="column">
+                {/*
+                TODO: The rules changelog link is not yet available for v9. Uncomment this when it is available.
+                Issue to uncomment: https://github.com/elastic/kibana/issues/213709
                 <EuiFlexItem grow={false} css={{ alignSelf: 'start' }}>
                   <RulesChangelogLink />
                 </EuiFlexItem>
+                */}
                 <EuiFlexItem grow={false}>
                   <AddPrebuiltRulesTableFilters />
                 </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/add_prebuilt_rules_table/add_prebuilt_rules_table.tsx
@@ -19,7 +19,6 @@ import React, { useCallback, useState } from 'react';
 
 import type { RuleResponse } from '../../../../../../common/api/detection_engine/model/rule_schema';
 import { RULES_TABLE_INITIAL_PAGE_SIZE, RULES_TABLE_PAGE_SIZE_OPTIONS } from '../constants';
-import { RulesChangelogLink } from '../rules_changelog_link';
 import { AddPrebuiltRulesTableNoItemsMessage } from './add_prebuilt_rules_no_items_message';
 import { useAddPrebuiltRulesTableContext } from './add_prebuilt_rules_table_context';
 import { AddPrebuiltRulesTableFilters } from './add_prebuilt_rules_table_filters';

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -97,9 +97,13 @@ export const UpgradePrebuiltRulesTable = React.memo(() => {
           ) : (
             <>
               <EuiFlexGroup direction="column">
+                {/*
+                TODO: The rules changelog link is not yet available for v9. Uncomment this when it is available.
+                Issue to uncomment: https://github.com/elastic/kibana/issues/213709
                 <EuiFlexItem grow={false} css={{ alignSelf: 'start' }}>
                   <RulesChangelogLink />
                 </EuiFlexItem>
+                */}
                 <EuiFlexItem grow={false}>
                   <EuiFlexGroup
                     alignItems="flexStart"

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/upgrade_prebuilt_rules_table.tsx
@@ -20,7 +20,6 @@ import React, { useCallback, useState } from 'react';
 import type { RuleUpgradeState } from '../../../../rule_management/model/prebuilt_rule_upgrade';
 import * as i18n from '../../../../../detections/pages/detection_engine/rules/translations';
 import { RULES_TABLE_PAGE_SIZE_OPTIONS } from '../constants';
-import { RulesChangelogLink } from '../rules_changelog_link';
 import { UpgradePrebuiltRulesTableButtons } from './upgrade_prebuilt_rules_table_buttons';
 import type { UpgradePrebuiltRulesSortingOptions } from './upgrade_prebuilt_rules_table_context';
 import { useUpgradePrebuiltRulesTableContext } from './upgrade_prebuilt_rules_table_context';


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/213103**

## Summary
This PR removes a link to prebuilt rule changelog from rule installation and upgrade tables. With the migration to the new docs system, there will be no [page](https://www.elastic.co/guide/en/security/8.17/prebuilt-rules-downloadable-updates.html) with the downloadable rule updates initially in the 9.0 version. We'll add this link back ([issue](https://github.com/elastic/kibana/issues/213709)) once the v9 page is live.

![Image](https://github.com/user-attachments/assets/2ffbb758-9902-4117-93ed-d259f4ca825f)


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->