### PR TITLE
[8.x] [Upgrade Assistant][Core] Data stream 8.18 fixes (#211586)

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/helpers/app_context.mock.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/helpers/app_context.mock.ts
@@ -77,6 +77,7 @@ shareMock.url.locators.get = (id: IdKey) => ({
 });
 
 export const getAppContextMock = (kibanaVersion: SemVer) => ({
+  dataSourceExclusions: {},
   featureSet: {
     mlSnapshots: true,
     migrateSystemIndices: true,

--- a/x-pack/platform/plugins/private/upgrade_assistant/common/data_stream_types.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/common/data_stream_types.ts
@@ -6,6 +6,7 @@
  */
 
 export interface DataStreamsActionMetadata {
+  excludedActions?: Array<'readOnly' | 'reindex'>;
   totalBackingIndices: number;
   indicesRequiringUpgradeCount: number;
   indicesRequiringUpgrade: string[];
@@ -72,23 +73,27 @@ export interface DataStreamReindexStatusNotStarted {
 }
 
 export interface DataStreamReindexStatusInProgress {
+  resolutionType: 'reindex' | 'readonly';
   status: DataStreamMigrationStatus.inProgress;
   taskPercComplete: number;
   progressDetails: DataStreamProgressDetails;
 }
 
 export interface DataStreamReindexStatusCompleted {
+  resolutionType: 'reindex' | 'readonly';
   status: DataStreamMigrationStatus.completed;
   taskPercComplete: number;
   progressDetails: DataStreamProgressDetails;
 }
 
 export interface DataStreamReindexStatusFailed {
+  resolutionType: 'reindex' | 'readonly';
   status: DataStreamMigrationStatus.failed;
   errorMessage: string;
 }
 
 export interface DataStreamReindexStatusCancelled {
+  resolutionType: 'reindex' | 'readonly';
   status: DataStreamMigrationStatus.cancelled;
 }
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
@@ -208,6 +208,11 @@ export interface ReindexAction {
    * The transform IDs that are currently targeting this index
    */
   transformIds?: string[];
+
+  /**
+   * The actions that should be excluded from the reindex corrective action.
+   */
+  excludedActions?: string[];
 }
 
 export interface UnfreezeAction {
@@ -335,3 +340,5 @@ export interface FeatureSet {
   reindexCorrectiveActions: boolean;
   migrateDataStreams: boolean;
 }
+
+export type DataSourceExclusions = Record<string, Array<'readOnly' | 'reindex'>>;

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/container.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/container.tsx
@@ -21,6 +21,7 @@ import numeral from '@elastic/numeral';
 import { i18n } from '@kbn/i18n';
 import {
   DataStreamMigrationStatus,
+  DataStreamsAction,
   EnrichedDeprecationInfo,
 } from '../../../../../../../common/types';
 
@@ -63,7 +64,7 @@ export const DataStreamReindexFlyout: React.FunctionComponent<Props> = ({
   deprecation,
 }) => {
   const { status, migrationWarnings, errorMessage, resolutionType, meta } = migrationState;
-  const { index } = deprecation;
+  const { index, correctiveAction } = deprecation;
   const [flyoutStep, setFlyoutStep] = useState<FlyoutStep>('initializing');
 
   const switchFlyoutStep = useCallback(() => {
@@ -158,6 +159,7 @@ export const DataStreamReindexFlyout: React.FunctionComponent<Props> = ({
 
         return (
           <DataStreamDetailsFlyoutStep
+            correctiveAction={correctiveAction as DataStreamsAction}
             closeFlyout={closeFlyout}
             initAction={(selectedResolutionType) => {
               initMigration(selectedResolutionType);
@@ -226,20 +228,7 @@ export const DataStreamReindexFlyout: React.FunctionComponent<Props> = ({
         );
       }
       case 'completed': {
-        if (!meta || !resolutionType) {
-          return (
-            <InitializingFlyoutStep
-              errorMessage={errorMessage || containerMessages.errorLoadingDataStreamInfo}
-            />
-          );
-        }
-        return (
-          <MigrationCompletedFlyoutStep
-            meta={meta}
-            resolutionType={resolutionType}
-            closeFlyout={closeFlyout}
-          />
-        );
+        return <MigrationCompletedFlyoutStep meta={meta} resolutionType={resolutionType} closeFlyout={closeFlyout} />;
       }
     }
   }, [
@@ -256,6 +245,7 @@ export const DataStreamReindexFlyout: React.FunctionComponent<Props> = ({
     onStopReadonly,
     resolutionType,
     initMigration,
+    correctiveAction,
   ]);
 
   return (

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/container.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/container.tsx
@@ -228,7 +228,13 @@ export const DataStreamReindexFlyout: React.FunctionComponent<Props> = ({
         );
       }
       case 'completed': {
-        return <MigrationCompletedFlyoutStep meta={meta} resolutionType={resolutionType} closeFlyout={closeFlyout} />;
+        return (
+          <MigrationCompletedFlyoutStep
+            meta={meta}
+            resolutionType={resolutionType}
+            closeFlyout={closeFlyout}
+          />
+        );
       }
     }
   }, [

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/messages.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/messages.tsx
@@ -30,7 +30,7 @@ export const getPrimaryButtonLabel = (
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.reindexButton.reindexingLabel"
-          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {Migrating}}…"
+          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migrating}}…"
           values={{ resolutionType }}
         />
       );
@@ -38,7 +38,7 @@ export const getPrimaryButtonLabel = (
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.reindexButton.restartLabel"
-          defaultMessage="{resolutionType, select, reindex {Restart reindexing} readonly {Restart marking as read only} other {Restart migration}}"
+          defaultMessage="{resolutionType, select, reindex {Restart reindexing} readonly {Restart marking as read-only} other {Restart migration}}"
           values={{ resolutionType }}
         />
       );
@@ -46,7 +46,7 @@ export const getPrimaryButtonLabel = (
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.reindexButton.runReindexLabel"
-          defaultMessage="{resolutionType, select, reindex {Start reindexing} readonly {Start marking as read only} other {Start migration}}"
+          defaultMessage="{resolutionType, select, reindex {Start reindexing} readonly {Start marking as read-only} other {Start migration}}"
           values={{ resolutionType }}
         />
       );

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/checklist_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/checklist_step.tsx
@@ -133,7 +133,7 @@ export const ChecklistFlyoutStep: React.FunctionComponent<{
                 ) : (
                   <FormattedMessage
                     id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.migrationFailedCalloutTitle"
-                    defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {Migration}} error"
+                    defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} error"
                     values={{ resolutionType }}
                   />
                 )
@@ -180,7 +180,7 @@ export const ChecklistFlyoutStep: React.FunctionComponent<{
                   >
                     <FormattedMessage
                       id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.cancelMigrationButtonLabel"
-                      defaultMessage="Cancel {resolutionType, select, reindex {reindexing} readonly {marking as read only} other {migration}}"
+                      defaultMessage="Cancel {resolutionType, select, reindex {reindexing} readonly {marking as read-only} other {migration}}"
                       values={{ resolutionType }}
                     />
                   </EuiButton>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/progress.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/progress.tsx
@@ -94,13 +94,13 @@ export const MigrationProgress: React.FunctionComponent<Props> = (props) => {
             {status === DataStreamMigrationStatus.inProgress ? (
               <FormattedMessage
                 id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingInProgressTitle"
-                defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {Migration}} in progress…"
+                defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} in progress…"
                 values={{ resolutionType }}
               />
             ) : (
               <FormattedMessage
                 id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklistTitle"
-                defaultMessage="{resolutionType, select, reindex {Reindex data stream} readonly {Mark data stream as read only} other {Migrate data stream}}"
+                defaultMessage="{resolutionType, select, reindex {Reindex data stream} readonly {Mark data stream as read-only} other {Migrate data stream}}"
                 values={{ resolutionType }}
               />
             )}
@@ -158,7 +158,7 @@ export const MigrationProgress: React.FunctionComponent<Props> = (props) => {
                         'xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.progressStep.failedTitle',
                         {
                           defaultMessage:
-                            '{count, plural, =1 {# Index} other {# Indices}} failed to get {resolutionType, select, reindex {reindexed} readonly {marked as read only} other {migrated}}.',
+                            '{count, plural, =1 {# Index} other {# Indices}} failed to get {resolutionType, select, reindex {reindexed} readonly {marked as read-only} other {migrated}}.',
                           values: { count: taskStatus.errorsCount, resolutionType },
                         }
                       )}
@@ -173,7 +173,7 @@ export const MigrationProgress: React.FunctionComponent<Props> = (props) => {
                       'xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.progressStep.completeTitle',
                       {
                         defaultMessage:
-                          '{count, plural, =1 {# Index} other {# Indices}} successfully {resolutionType, select, reindex {reindexed} readonly {marked as read only} other {migrated}}.',
+                          '{count, plural, =1 {# Index} other {# Indices}} successfully {resolutionType, select, reindex {reindexed} readonly {marked as read-only} other {migrated}}.',
                         values: { count: taskStatus.successCount, resolutionType },
                       }
                     )}
@@ -187,7 +187,7 @@ export const MigrationProgress: React.FunctionComponent<Props> = (props) => {
                       'xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.progressStep.inProgressTitle',
                       {
                         defaultMessage:
-                          '{count, plural, =1 {# Index} other {# Indices}} currently getting {resolutionType, select, reindex {reindexed} readonly {marked as read only} other {migrated}}.',
+                          '{count, plural, =1 {# Index} other {# Indices}} currently getting {resolutionType, select, reindex {reindexed} readonly {marked as read-only} other {migrated}}.',
                         values: { count: taskStatus.inProgressCount, resolutionType },
                       }
                     )}

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/progress_title.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/checklist/progress_title.tsx
@@ -37,7 +37,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.cancelButton.errorLabel"
-          defaultMessage="Failed to cancel {resolutionType, select, reindex {reindexing} readonly {read only} other {}}"
+          defaultMessage="Failed to cancel {resolutionType, select, reindex {reindexing} readonly {read-only} other {}}"
           values={{ resolutionType }}
         />
       );
@@ -49,7 +49,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.inProgress.reindexingDocumentsStepTitle"
-          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {}}"
+          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {}}"
           values={{ resolutionType }}
         />
       );
@@ -58,7 +58,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.failed.reindexingDocumentsStepTitle"
-          defaultMessage="Failed to {resolutionType, select, reindex {reindex} readonly {mark as read only} other {}}"
+          defaultMessage="Failed to {resolutionType, select, reindex {reindex} readonly {mark as read-only} other {}}"
           values={{ resolutionType }}
         />
       );
@@ -73,7 +73,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.cancelled.reindexingDocumentsStepTitle"
-          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {}} cancelled"
+          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {}} cancelled"
           values={{ resolutionType }}
         />
       );
@@ -81,7 +81,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.completed.reindexingDocumentsStepTitle"
-          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {}} completed"
+          defaultMessage="{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {}} completed"
           values={{ resolutionType }}
         />
       );
@@ -90,7 +90,7 @@ export const MigrateDocumentsStepTitle: React.FunctionComponent<{
       return (
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.reindexingChecklist.inProgress.reindexingDocumentsStepTitle"
-          defaultMessage="{resolutionType, select, reindex {Reindex data stream} readonly {Mark data stream as read only} other {Unknown action}}"
+          defaultMessage="{resolutionType, select, reindex {Reindex data stream} readonly {Mark data stream as read-only} other {Unknown action}}"
         />
       );
     }

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/completed/completed_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/completed/completed_step.tsx
@@ -23,7 +23,7 @@ import type {
 } from '../../../../../../../../../common/types';
 
 interface Props {
-  meta: DataStreamMetadata;
+  meta?: DataStreamMetadata | null;
   resolutionType?: DataStreamResolutionType;
   closeFlyout: () => void;
 }
@@ -48,8 +48,8 @@ export const MigrationCompletedFlyoutStep: React.FunctionComponent<Props> = ({
         <p>
           <FormattedMessage
             id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.acceptChangesTitle"
-            defaultMessage="Success! {count, plural, =1 {# backing index} other {# backing indices}} successfully {resolutionType, select, reindex {reindexed} readonly {marked as read only} other {migrated}}."
-            values={{ count: meta.indicesRequiringUpgradeCount, resolutionType }}
+            defaultMessage="Success! {count, plural, =0 {backing indices} =1 {# backing index} other {# backing indices}} successfully {resolutionType, select, reindex {reindexed} readonly {marked as read-only} other {migrated}}."
+            values={{ count: meta?.indicesRequiringUpgradeCount || 0, resolutionType }}
           />
         </p>
       </EuiFlyoutBody>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/callouts.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/callouts.tsx
@@ -37,7 +37,7 @@ export const ReadonlyWarningCallout: React.FunctionComponent<{}> = () => {
       title={
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.readonly.calloutTitle"
-          defaultMessage="Marking this data read only could affect some of the existing setups"
+          defaultMessage="Marking this data read-only could affect some of the existing setups"
         />
       }
       color="warning"

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/confirm_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/confirm_step.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexItem,
   EuiFlyoutBody,
   EuiFlyoutFooter,
+  EuiLink,
   EuiSpacer,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -63,7 +64,6 @@ export const ConfirmMigrationFlyoutStep: React.FunctionComponent<{
     },
   } = useAppContext();
   const { links } = docLinks;
-
   const [checkedIds, setCheckedIds] = useState<CheckedIds>(
     warnings.reduce((initialCheckedIds, warning, index) => {
       initialCheckedIds[idForWarning(index)] = false;
@@ -96,28 +96,54 @@ export const ConfirmMigrationFlyoutStep: React.FunctionComponent<{
       : i18n.translate(
           'xpack.upgradeAssistant.dataStream.migration.flyout.checklistStep.startActionButtonLabel',
           {
-            defaultMessage: 'Mark all read only',
+            defaultMessage: 'Mark all read-only',
           }
         );
 
   const actionClarification =
-    resolutionType === 'reindex'
-      ? i18n.translate(
-          'xpack.upgradeAssistant.dataStream.flyout.warningsStep.reindex.acceptChangesTitle',
-          {
-            defaultMessage:
-              '{count, plural, =1 {# backing index} other {# backing indices}}, including current write index, will be re-indexed. Current write index will be rolled over first.',
-            values: { count: meta.indicesRequiringUpgradeCount },
-          }
-        )
-      : i18n.translate(
-          'xpack.upgradeAssistant.dataStream.flyout.warningsStep.readonly.acceptChangesTitle',
-          {
-            defaultMessage:
-              '{count, plural, =1 {# backing index} other {# backing indices}}, including current write index, will be marked as read only.',
-            values: { count: meta.indicesRequiringUpgradeCount },
-          }
-        );
+    resolutionType === 'reindex' ? (
+      <>
+        <p>
+          <FormattedMessage
+            id="xpack.upgradeAssistant.dataStream.flyout.warningsStep.reindex.acceptChangesTitle"
+            defaultMessage="{count, plural, =1 {# backing index} other {# backing indices}}, including current write index, will be re-indexed. Current write index will be rolled over first."
+            values={{
+              count: meta.indicesRequiringUpgradeCount,
+            }}
+          />
+        </p>
+        <EuiSpacer size="s" />
+        <p>
+          <FormattedMessage
+            id="xpack.upgradeAssistant.dataStream.flyout.warningsStep.reindex.acceptChangesTitle"
+            defaultMessage="You can increase the speed of reindexing by changing throttling configuration on ES. Where changing throttling configuration allows you to utilize more resources to speed up the reindexing process. {learnMoreHtml}"
+            values={{
+              learnMoreHtml: (
+                <EuiLink
+                  href={`${links.elasticsearch.docsBase}data-stream-reindex-api.html#reindex-data-stream-api-settings`}
+                  target="_blank"
+                >
+                  <FormattedMessage
+                    id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.learnMoreLink"
+                    defaultMessage="Learn more"
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
+        </p>
+      </>
+    ) : (
+      <p>
+        <FormattedMessage
+          id="xpack.upgradeAssistant.dataStream.flyout.warningsStep.readonly.acceptChangesTitle"
+          defaultMessage="{count, plural, =1 {# backing index} other {# backing indices}}, including current write index, will be marked as read-only."
+          values={{
+            count: meta.indicesRequiringUpgradeCount,
+          }}
+        />
+      </p>
+    );
 
   return (
     <>
@@ -127,7 +153,7 @@ export const ConfirmMigrationFlyoutStep: React.FunctionComponent<{
             {resolutionType === 'reindex' && <ReindexWarningCallout />}
             {resolutionType === 'readonly' && <ReadonlyWarningCallout />}
             <EuiSpacer />
-            <p>{actionClarification}</p>
+            {actionClarification}
             <EuiSpacer size="m" />
             {warnings.map((warning, index) => {
               const WarningCheckbox = warningToComponentMap[warning.warningType];

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/warnings/existing_setups.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/warnings/existing_setups.tsx
@@ -22,7 +22,7 @@ export const AffectExistingSetupsWarningCheckbox: React.FunctionComponent<Warnin
       label={
         <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.affectExistingSetupsWarningTitle"
-          defaultMessage="Mark as read only all incompatible data for this data stream"
+          defaultMessage="Mark as read-only all incompatible data for this data stream"
         />
       }
       description={null}

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/readonly_state.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/readonly_state.tsx
@@ -33,6 +33,7 @@ export async function* readOnlyExecute(
     return {
       migrationOp: {
         status: DataStreamMigrationStatus.completed,
+        resolutionType: 'readonly',
         taskPercComplete: 1,
         progressDetails: {
           startTimeMs,
@@ -65,6 +66,7 @@ export async function* readOnlyExecute(
 
       yield {
         migrationOp: {
+          resolutionType: 'readonly',
           status,
           taskPercComplete,
           progressDetails: {
@@ -80,6 +82,7 @@ export async function* readOnlyExecute(
   } catch (error) {
     return {
       migrationOp: {
+        resolutionType: 'readonly',
         status: DataStreamMigrationStatus.failed,
         errorMessage: error.message || 'Unknown error occurred',
       },
@@ -88,6 +91,7 @@ export async function* readOnlyExecute(
 
   return {
     migrationOp: {
+      resolutionType: 'readonly',
       status: DataStreamMigrationStatus.completed,
       taskPercComplete: 1,
       progressDetails: {

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/resolution_table_cell.tsx
@@ -19,77 +19,127 @@ import {
 import {
   DataStreamMigrationStatus,
   DataStreamResolutionType,
+  DataStreamsAction,
 } from '../../../../../../common/types';
 import { getDataStreamReindexProgressLabel } from '../../../../lib/utils';
 import { LoadingState } from '../../../types';
 import { useDataStreamMigrationContext } from './context';
 
-const getI18nTexts = (resolutionType?: DataStreamResolutionType) => {
+const getI18nTexts = (
+  resolutionType?: DataStreamResolutionType,
+  excludedActions: Array<'readOnly' | 'reindex'> = []
+) => {
+  const resolutionAction = excludedActions.includes('readOnly')
+    ? 'reindex'
+    : excludedActions.includes('reindex')
+    ? 'readOnly'
+    : 'readOnlyOrReindex';
+
+  const resolutionTexts = {
+    readOnlyOrReindex: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionReadOnlyOrReindexLabel',
+      {
+        defaultMessage: 'Mark as read-only, or reindex',
+      }
+    ),
+    readOnly: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionReadOnlyLabel',
+      {
+        defaultMessage: 'Mark as read-only',
+      }
+    ),
+    reindex: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionReindexLabel',
+      {
+        defaultMessage: 'Reindex',
+      }
+    ),
+  };
+
+  const resolutionTooltipLabels = {
+    readOnlyOrReindex: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionTooltipReadOnlyOrReindexLabel',
+      {
+        defaultMessage:
+          'Resolve this issue by reindexing this data stream or marking its indices as read-only. This issue can be resolved automatically.',
+      }
+    ),
+    readOnly: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionTooltipReadOnlyLabel',
+      {
+        defaultMessage:
+          'Resolve this issue by marking its indices as read-only. This issue can be resolved automatically.',
+      }
+    ),
+    reindex: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionTooltipReindexLabel',
+      {
+        defaultMessage:
+          'Resolve this issue by reindexing this data stream. This issue can be resolved automatically.',
+      }
+    ),
+  };
+
   return {
-    reindexLoadingStatusText: i18n.translate(
-      'xpack.upgradeAssistant.esDeprecations.dataStream.reindexLoadingStatusText',
+    loadingStatusText: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionLoadingStatusText',
       {
         defaultMessage: 'Loading status…',
       }
     ),
-    reindexInProgressText: i18n.translate(
-      'xpack.upgradeAssistant.esDeprecations.dataStream.reindexInProgressText',
+    resolutionInProgressText: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionInProgressText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {Migration}} in progress…',
+          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} in progress…',
         values: { resolutionType },
       }
     ),
-    reindexCompleteText: i18n.translate(
-      'xpack.upgradeAssistant.esDeprecations.dataStream.reindexCompleteText',
+    resolutionCompleteText: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionCompleteText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {Migration}} complete',
+          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} complete',
         values: { resolutionType },
       }
     ),
-    reindexFailedText: i18n.translate(
-      'xpack.upgradeAssistant.esDeprecations.dataStream.reindexFailedText',
+    resolutionFailedText: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resulutionFailedText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {Migration}} failed',
+          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} failed',
         values: { resolutionType },
       }
     ),
-    reindexFetchFailedText: i18n.translate(
-      'xpack.upgradeAssistant.esDeprecations.dataStream.reindexFetchFailedText',
+    resolutionFetchFailedText: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionFetchFailedText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {Migration}} status not available',
+          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} status not available',
         values: { resolutionType },
       }
     ),
     reindexCanceledText: i18n.translate(
-      'xpack.upgradeAssistant.esDeprecations.dataStream.reindexCanceledText',
+      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionCanceledText',
       {
         defaultMessage:
-          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read only} other {Migration}} cancelled',
+          '{resolutionType, select, reindex {Reindexing} readonly {Marking as read-only} other {Migration}} cancelled',
         values: { resolutionType },
       }
     ),
-    resolutionText: i18n.translate(
-      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionLabel',
-      {
-        defaultMessage: 'Mark as read only, or reindex',
-      }
-    ),
-    resolutionTooltipLabel: i18n.translate(
-      'xpack.upgradeAssistant.esDeprecations.dataStream.resolutionTooltipLabel',
-      {
-        defaultMessage:
-          'Resolve this issue by reindexing this data stream or marking its indices as read only. This issue can be resolved automatically.',
-      }
-    ),
+    resolutionText: resolutionTexts[resolutionAction],
+    resolutionTooltipLabel: resolutionTooltipLabels[resolutionAction],
   };
 };
 
-export const DataStreamReindexResolutionCell: React.FunctionComponent = () => {
+export const DataStreamReindexResolutionCell: React.FunctionComponent<{
+  correctiveAction: DataStreamsAction;
+}> = ({ correctiveAction }) => {
   const { migrationState } = useDataStreamMigrationContext();
+  const i18nTexts = getI18nTexts(
+    migrationState.resolutionType,
+    correctiveAction.metadata.excludedActions
+  );
 
   if (migrationState.loadingState === LoadingState.Loading) {
     return (
@@ -98,9 +148,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent = () => {
           <EuiLoadingSpinner size="m" />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiText size="s">
-            {getI18nTexts(migrationState.resolutionType).reindexLoadingStatusText}
-          </EuiText>
+          <EuiText size="s">{i18nTexts.loadingStatusText}</EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
     );
@@ -115,7 +163,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent = () => {
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiText size="s">
-              {getI18nTexts(migrationState.resolutionType).reindexInProgressText}{' '}
+              {i18nTexts.resolutionInProgressText}{' '}
               {getDataStreamReindexProgressLabel(
                 migrationState.status,
                 migrationState.taskPercComplete
@@ -131,9 +179,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent = () => {
             <EuiIcon type="check" color="success" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              {getI18nTexts(migrationState.resolutionType).reindexCompleteText}
-            </EuiText>
+            <EuiText size="s">{i18nTexts.resolutionCompleteText}</EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       );
@@ -144,9 +190,7 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent = () => {
             <EuiIcon type="warning" color="danger" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              {getI18nTexts(migrationState.resolutionType).reindexFailedText}
-            </EuiText>
+            <EuiText size="s">{i18nTexts.resolutionFailedText}</EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       );
@@ -157,26 +201,19 @@ export const DataStreamReindexResolutionCell: React.FunctionComponent = () => {
             <EuiIcon type="warning" color="danger" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              {getI18nTexts(migrationState.resolutionType).reindexFetchFailedText}
-            </EuiText>
+            <EuiText size="s">{i18nTexts.resolutionFetchFailedText}</EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
       );
     default:
       return (
-        <EuiToolTip
-          position="top"
-          content={getI18nTexts(migrationState.resolutionType).resolutionTooltipLabel}
-        >
+        <EuiToolTip position="top" content={i18nTexts.resolutionTooltipLabel}>
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
               <EuiIcon type="indexSettings" />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiText size="s">
-                {getI18nTexts(migrationState.resolutionType).resolutionText}
-              </EuiText>
+              <EuiText size="s">{i18nTexts.resolutionText}</EuiText>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiToolTip>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/table_row.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/table_row.tsx
@@ -8,7 +8,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { EuiTableRowCell, EuiTableRow } from '@elastic/eui';
 import { METRIC_TYPE } from '@kbn/analytics';
-import { EnrichedDeprecationInfo } from '../../../../../../common/types';
+import { DataStreamsAction, EnrichedDeprecationInfo } from '../../../../../../common/types';
 import { GlobalFlyout } from '../../../../../shared_imports';
 import { useAppContext } from '../../../../app_context';
 import {
@@ -88,7 +88,11 @@ const DataStreamTableRowCells: React.FunctionComponent<TableRowProps> = ({
             <EsDeprecationsTableCells
               fieldName={field}
               deprecation={deprecation}
-              resolutionTableCell={<DataStreamReindexResolutionCell />}
+              resolutionTableCell={
+                <DataStreamReindexResolutionCell
+                  correctiveAction={deprecation.correctiveAction as DataStreamsAction}
+                />
+              }
             />
           </EuiTableRowCell>
         );

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/use_migration_state.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/use_migration_state.tsx
@@ -48,6 +48,8 @@ const getMigrationState = (
 ) => {
   const newMigrationState: MigrationState = {
     ...migrationState,
+    // @ts-expect-error - resolutionType does non exist in all migration states.
+    resolutionType: migrationOp?.resolutionType || migrationState.resolutionType,
     meta: updatedMeta || migrationState.meta,
     loadingState: LoadingState.Success,
   };
@@ -180,6 +182,7 @@ export const useMigrationStatus = ({
         });
       }
     },
+
     [clearPollInterval, api, dataStreamName, migrationState.resolutionType]
   );
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/messages.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/messages.tsx
@@ -7,6 +7,9 @@
 
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiLink } from '@elastic/eui';
+import { EuiText } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { ReindexStatus } from '../../../../../../../../../common/types';
 
 export const getReindexButtonLabel = (status?: ReindexStatus) => {
@@ -41,4 +44,99 @@ export const getReindexButtonLabel = (status?: ReindexStatus) => {
         />
       );
   }
+};
+
+export const getDefaultGuideanceText = ({
+  readOnlyExcluded,
+  reindexExcluded,
+  indexBlockUrl,
+  indexManagementUrl,
+}: {
+  readOnlyExcluded: boolean;
+  reindexExcluded: boolean;
+  indexBlockUrl: string;
+  indexManagementUrl: string;
+}) => {
+  const guideanceListItems = [];
+  if (!reindexExcluded) {
+    guideanceListItems.push({
+      title: i18n.translate(
+        'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option1.title',
+        {
+          defaultMessage: 'Option {optionCount}: Reindex data',
+          values: { optionCount: guideanceListItems.length + 1 },
+        }
+      ),
+      description: (
+        <EuiText size="m">
+          <FormattedMessage
+            id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option1.description"
+            defaultMessage="The reindex operation allows transforming an index into a new, compatible one. It will copy all of the existing documents into a new index and remove the old one. Depending on size and resources, reindexing may take extended time and your data will be in a read-only state until the job has completed."
+          />
+        </EuiText>
+      ),
+    });
+  }
+
+  if (!readOnlyExcluded) {
+    guideanceListItems.push({
+      title: i18n.translate(
+        'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option2.title',
+        {
+          defaultMessage: 'Option {optionCount}: Mark as read-only',
+          values: { optionCount: guideanceListItems.length + 1 },
+        }
+      ),
+      description: (
+        <EuiText size="m">
+          <FormattedMessage
+            id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option2.description"
+            defaultMessage="Old indices can maintain compatibility with the next major version if they are turned into read-only mode. If you no longer need to update documents in this index (or add new ones), you might want to convert it to a read-only index. {docsLink}"
+            values={{
+              docsLink: (
+                <EuiLink target="_blank" href={indexBlockUrl}>
+                  {i18n.translate(
+                    'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.learnMoreLinkLabel',
+                    {
+                      defaultMessage: 'Learn more',
+                    }
+                  )}
+                </EuiLink>
+              ),
+            }}
+          />
+        </EuiText>
+      ),
+    });
+  }
+
+  guideanceListItems.push({
+    title: i18n.translate(
+      'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option3.title',
+      {
+        defaultMessage: 'Option {optionCount}: Delete index',
+        values: { optionCount: guideanceListItems.length + 1 },
+      }
+    ),
+    description: (
+      <EuiText size="m">
+        <FormattedMessage
+          id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option3.description"
+          defaultMessage="If you no longer need it, you can also delete the index from {indexManagementLinkHtml}."
+          values={{
+            indexManagementLinkHtml: (
+              <EuiLink href={indexManagementUrl}>
+                <FormattedMessage
+                  id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.indexMgmtLink"
+                  defaultMessage="Index Management"
+                />
+              </EuiLink>
+            ),
+          }}
+        />
+      </EuiText>
+    ),
+  });
+
+  return guideanceListItems;
 };

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.test.tsx
@@ -180,8 +180,10 @@ describe('ReindexDetailsFlyoutStep', () => {
                   grow={false}
                 >
                   <EuiButton
+                    color="accent"
                     data-test-subj="startIndexReadonlyButton"
                     disabled={false}
+                    fill={false}
                     onClick={[MockFunction]}
                   >
                     <MemoizedFormattedMessage
@@ -441,8 +443,10 @@ describe('ReindexDetailsFlyoutStep', () => {
                   grow={false}
                 >
                   <EuiButton
+                    color="accent"
                     data-test-subj="startIndexReadonlyButton"
                     disabled={false}
+                    fill={false}
                     onClick={[MockFunction]}
                   >
                     <MemoizedFormattedMessage

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.tsx
@@ -16,12 +16,10 @@ import {
   EuiFlexItem,
   EuiFlyoutBody,
   EuiFlyoutFooter,
-  EuiLink,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { i18n } from '@kbn/i18n';
 
 import {
   EnrichedDeprecationInfo,
@@ -31,7 +29,7 @@ import {
 import { LoadingState } from '../../../../../../types';
 import type { ReindexState } from '../../../use_reindex';
 import { useAppContext } from '../../../../../../../app_context';
-import { getReindexButtonLabel } from './messages';
+import { getDefaultGuideanceText, getReindexButtonLabel } from './messages';
 import { FrozenCallOut } from '../frozen_callout';
 import type { UpdateIndexState } from '../../../use_update_index';
 import { FetchFailedCallOut } from '../fetch_failed_callout';
@@ -76,6 +74,9 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
   const correctiveAction = deprecation.correctiveAction as ReindexAction | undefined;
   const isESTransformTarget = !!correctiveAction?.transformIds?.length;
   const isMLAnomalyIndex = Boolean(indexName?.startsWith(ML_ANOMALIES_PREFIX));
+  const { excludedActions = [] } = (deprecation.correctiveAction as ReindexAction) || {};
+  const readOnlyExcluded = excludedActions.includes('readOnly');
+  const reindexExcluded = excludedActions.includes('reindex');
 
   const { data: nodes } = api.useLoadNodeDiskSpace();
 
@@ -191,85 +192,14 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
               </p>
               <EuiDescriptionList
                 rowGutterSize="m"
-                listItems={[
-                  {
-                    title: i18n.translate(
-                      'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option1.title',
-                      {
-                        defaultMessage: 'Option 1: Reindex data',
-                      }
-                    ),
-                    description: (
-                      <EuiText size="m">
-                        <FormattedMessage
-                          id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option1.description"
-                          defaultMessage="The reindex operation allows transforming an index into a new, compatible one. It will copy all of the existing documents into a new index and remove the old one. Depending on size and resources, reindexing may take extended time and your data will be in a read-only state until the job has completed."
-                        />
-                      </EuiText>
-                    ),
-                  },
-                  {
-                    title: i18n.translate(
-                      'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option2.title',
-                      {
-                        defaultMessage: 'Option 2: Mark as read-only',
-                      }
-                    ),
-                    description: (
-                      <EuiText size="m">
-                        <FormattedMessage
-                          id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option2.description"
-                          defaultMessage="Old indices can maintain compatibility with the next major version if they are turned into read-only mode. If you no longer need to update documents in this index (or add new ones), you might want to convert it to a read-only index. {docsLink}"
-                          values={{
-                            docsLink: (
-                              <EuiLink
-                                target="_blank"
-                                href={docLinks.links.upgradeAssistant.indexBlocks}
-                              >
-                                {i18n.translate(
-                                  'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.learnMoreLinkLabel',
-                                  {
-                                    defaultMessage: 'Learn more',
-                                  }
-                                )}
-                              </EuiLink>
-                            ),
-                          }}
-                        />
-                      </EuiText>
-                    ),
-                  },
-                  {
-                    title: i18n.translate(
-                      'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option3.title',
-                      {
-                        defaultMessage: 'Option 3: Delete index',
-                      }
-                    ),
-                    description: (
-                      <EuiText size="m">
-                        <FormattedMessage
-                          id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option3.description"
-                          defaultMessage="If you no longer need it, you can also delete the index from {indexManagementLinkHtml}."
-                          values={{
-                            indexManagementLinkHtml: (
-                              <EuiLink
-                                href={`${http.basePath.prepend(
-                                  `/app/management/data/index_management/indices/index_details?indexName=${indexName}`
-                                )}`}
-                              >
-                                <FormattedMessage
-                                  id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.indexMgmtLink"
-                                  defaultMessage="Index Management"
-                                />
-                              </EuiLink>
-                            ),
-                          }}
-                        />
-                      </EuiText>
-                    ),
-                  },
-                ]}
+                listItems={getDefaultGuideanceText({
+                  readOnlyExcluded,
+                  reindexExcluded,
+                  indexManagementUrl: `${http.basePath.prepend(
+                    `/app/management/data/index_management/indices/index_details?indexName=${indexName}`
+                  )}`,
+                  indexBlockUrl: docLinks.links.upgradeAssistant.indexBlocks,
+                })}
               />
             </Fragment>
           )}
@@ -297,11 +227,14 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
                 !hasFetchFailed &&
                 !isCompleted &&
                 hasRequiredPrivileges &&
-                !isESTransformTarget && (
+                !isESTransformTarget &&
+                !readOnlyExcluded && (
                   <EuiFlexItem grow={false}>
                     <EuiButton
                       onClick={startReadonly}
                       disabled={loading}
+                      color={reindexExcluded ? 'primary' : 'accent'}
+                      fill={reindexExcluded}
                       data-test-subj="startIndexReadonlyButton"
                     >
                       <FormattedMessage
@@ -311,7 +244,7 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
                     </EuiButton>
                   </EuiFlexItem>
                 )}
-              {!hasFetchFailed && !isCompleted && hasRequiredPrivileges && (
+              {!hasFetchFailed && !isCompleted && hasRequiredPrivileges && !reindexExcluded && (
                 <EuiFlexItem grow={false}>
                   <EuiButton
                     fill

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/config.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/config.ts
@@ -21,6 +21,22 @@ const configSchema = schema.object({
     serverless: schema.boolean({ defaultValue: true }),
   }),
 
+  /**
+   * Exlcude certain data streams or indices from getting certain correctiveActions.
+   * The key is the data source name or pattern and the value is an array of corrective actions to exclude.
+   *
+   * Exclude readOnly data sources from getting read-only corrective actions.
+   * This is needed to avoid breaking certain built-in/system functionality that might rely on writing to these data sources.
+   * Example (excludes read-only corrective actions for 7_17_data_stream):
+   * xpack.upgrade_assistant.dataSourceExclusions:
+   *    7_17_data_stream: ["readOnly"]
+   */
+  dataSourceExclusions: schema.recordOf(
+    schema.string(),
+    schema.arrayOf(schema.oneOf([schema.literal('readOnly'), schema.literal('reindex')])),
+    { defaultValue: {} }
+  ),
+
   featureSet: schema.object({
     /**
      * Ml Snapshot should only be enabled for major version upgrades. Currently this

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/data_source_exclusions.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/data_source_exclusions.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { matchExclusionPattern } from './data_source_exclusions';
+import { DataSourceExclusions } from '../../common/types';
+
+describe('matchExclusionPattern', () => {
+  it('should return the actions that should be excluded', () => {
+    const exclusions: DataSourceExclusions = {
+      data_stream_1: ['readOnly'],
+    };
+
+    const result = matchExclusionPattern('data_stream_1', exclusions);
+    expect(result).toEqual(['readOnly']);
+  });
+
+  it('should return an empty array if no exclusions match', () => {
+    const exclusions: DataSourceExclusions = {
+      data_stream_1: ['readOnly'],
+    };
+
+    const result = matchExclusionPattern('data_stream_2', exclusions);
+    expect(result).toEqual([]);
+  });
+
+  it(`should match patterns ending with '*'`, () => {
+    const exclusions: DataSourceExclusions = {
+      'data_stream_*': ['readOnly'],
+    };
+
+    const result = matchExclusionPattern('data_stream_1', exclusions);
+    expect(result).toEqual(['readOnly']);
+  });
+});

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/data_source_exclusions.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/data_source_exclusions.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DataSourceExclusions } from '../../common/types';
+
+/**
+ * These are the default exclusions for data sources (data streams and indices).
+ *
+ * They are used to exclude migrations from getting certain corrective actions.
+ * This is needed to avoid breaking certain built-in/system functionality that might rely on writing to these data source.
+ *
+ * These indices can be overridden by the user in the Kibana configuration:
+ *
+ * For Example this will renenable all corrective actions for the siem-signals data source:
+ * xpack.upgrade_assistant.dataSourceExclusions:
+ *    '.siem-signals*': []
+ */
+export const defaultExclusions: DataSourceExclusions = {
+  '.siem-signals*': ['readOnly'],
+  '.alerts*': ['readOnly'],
+  '.internal.alerts*': ['readOnly'],
+  '.preview.alerts*': ['readOnly'],
+  '.internal.preview.alerts*': ['readOnly'],
+  '.lists-*': ['readOnly'],
+  '.items-*': ['readOnly'],
+  '.logs-endpoint.actions-*': ['readOnly'],
+  '.logs-endpoint.action.responses-*': ['readOnly'],
+  '.metrics-endpoint.metadata_united_default': ['readOnly'],
+  '.logs-osquery_manager.actions-*': ['readOnly'],
+  '.logs-osquery_manager.action.responses-*': ['readOnly'],
+  '.logs-endpoint.diagnostic.collection-*': ['readOnly'],
+  'kibana_sample_data_*': ['readOnly'],
+  '.ent-search*': ['readOnly'],
+  'monitoring-ent-search-*': ['readOnly'],
+  'app-search-*': ['readOnly'],
+  'metricbeat-ent-search-*': ['readOnly'],
+  'enterprise-search-*': ['readOnly'],
+  'elastic-analytics-collections': ['readOnly'],
+  '.elastic-connectors*': ['readOnly'],
+  'logs-elastic_analytics.events-*': ['readOnly'],
+};
+
+/**
+ * Matches the data source name against the exclusion pattern and returns the actions that should be excluded.
+ * If the exclusion ends with a `*` it will match any data source that starts with the excluded pattern.
+ * Otherwise it will match the data source name exactly.
+ */
+export const matchExclusionPattern = (dataStreamName: string, exclusions: DataSourceExclusions) => {
+  const result = Object.entries(exclusions).find(([excludedPattern]) => {
+    const isPattern = /.+\*$/.test(excludedPattern);
+    if (isPattern) {
+      const matcher = excludedPattern.slice(0, -1);
+      return dataStreamName.startsWith(matcher);
+    }
+    return dataStreamName === excludedPattern;
+  });
+
+  if (!result) {
+    return [];
+  }
+
+  return result[1];
+};

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/__snapshots__/index.test.ts.snap
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/__snapshots__/index.test.ts.snap
@@ -81,6 +81,7 @@ Object {
     Object {
       "correctiveAction": Object {
         "blockerForReindexing": undefined,
+        "excludedActions": Array [],
         "type": "reindex",
       },
       "details": "This index was created using version: 6.8.13",
@@ -94,6 +95,7 @@ Object {
     Object {
       "correctiveAction": Object {
         "blockerForReindexing": undefined,
+        "excludedActions": Array [],
         "type": "reindex",
       },
       "details": "This index has version: 7.17.28-8.0.0",
@@ -107,6 +109,7 @@ Object {
     Object {
       "correctiveAction": Object {
         "blockerForReindexing": "index-closed",
+        "excludedActions": Array [],
         "type": "reindex",
       },
       "details": "This index was created using version: 6.8.13",
@@ -175,6 +178,7 @@ Object {
     Object {
       "correctiveAction": Object {
         "blockerForReindexing": undefined,
+        "excludedActions": Array [],
         "transformIds": Array [
           "abc",
         ],
@@ -191,6 +195,7 @@ Object {
     Object {
       "correctiveAction": Object {
         "blockerForReindexing": undefined,
+        "excludedActions": Array [],
         "type": "reindex",
       },
       "details": "This index has version: 7.17.25",
@@ -204,6 +209,7 @@ Object {
     Object {
       "correctiveAction": Object {
         "metadata": Object {
+          "excludedActions": Array [],
           "ignoredIndicesRequiringUpgrade": Array [],
           "ignoredIndicesRequiringUpgradeCount": 0,
           "indicesRequiringUpgrade": Array [

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/get_corrective_actions.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/get_corrective_actions.ts
@@ -30,6 +30,8 @@ interface IndexActionMetadata {
 
 interface DataStreamActionMetadata {
   actions?: Action[];
+
+  excludedActions?: Array<'readOnly' | 'reindex'>;
   total_backing_indices: number;
   reindex_required: boolean;
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/index.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/index.test.ts
@@ -12,7 +12,7 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import fakeDeprecations from '../__fixtures__/fake_deprecations.json';
 import * as healthIndicatorsMock from '../__fixtures__/health_indicators';
 import * as esMigrationsMock from '../__fixtures__/es_deprecations';
-import type { FeatureSet } from '../../../common/types';
+import type { DataSourceExclusions, FeatureSet } from '../../../common/types';
 import { getESUpgradeStatus } from '.';
 import { MigrationDeprecationsResponse } from '@elastic/elasticsearch/lib/api/types';
 const fakeIndexNames = Object.keys(fakeDeprecations.index_settings);
@@ -24,6 +24,7 @@ describe('getESUpgradeStatus', () => {
     mlSnapshots: true,
     migrateDataStreams: true,
   };
+  const dataSourceExclusions: DataSourceExclusions = {};
 
   const resolvedIndices = {
     indices: fakeIndexNames.map((indexName) => {
@@ -65,12 +66,12 @@ describe('getESUpgradeStatus', () => {
   esClient.asCurrentUser.indices.resolveIndex.mockResponse(resolvedIndices);
 
   it('calls /_migration/deprecations', async () => {
-    await getESUpgradeStatus(esClient, featureSet);
+    await getESUpgradeStatus(esClient, { featureSet, dataSourceExclusions });
     expect(esClient.asCurrentUser.migration.deprecations).toHaveBeenCalled();
   });
 
   it('returns the correct shape of data', async () => {
-    const resp = await getESUpgradeStatus(esClient, featureSet);
+    const resp = await getESUpgradeStatus(esClient, { featureSet, dataSourceExclusions });
     expect(resp).toMatchSnapshot();
   });
 
@@ -86,10 +87,9 @@ describe('getESUpgradeStatus', () => {
       templates: {},
     });
 
-    await expect(getESUpgradeStatus(esClient, featureSet)).resolves.toHaveProperty(
-      'totalCriticalDeprecations',
-      1
-    );
+    await expect(
+      getESUpgradeStatus(esClient, { featureSet, dataSourceExclusions })
+    ).resolves.toHaveProperty('totalCriticalDeprecations', 1);
   });
 
   it('returns totalCriticalDeprecations === 0 when no critical issues found', async () => {
@@ -104,10 +104,9 @@ describe('getESUpgradeStatus', () => {
       templates: {},
     });
 
-    await expect(getESUpgradeStatus(esClient, featureSet)).resolves.toHaveProperty(
-      'totalCriticalDeprecations',
-      0
-    );
+    await expect(
+      getESUpgradeStatus(esClient, { featureSet, dataSourceExclusions })
+    ).resolves.toHaveProperty('totalCriticalDeprecations', 0);
   });
 
   it('filters out system indices returned by upgrade system indices API', async () => {
@@ -132,7 +131,7 @@ describe('getESUpgradeStatus', () => {
       templates: {},
     });
 
-    const upgradeStatus = await getESUpgradeStatus(esClient, featureSet);
+    const upgradeStatus = await getESUpgradeStatus(esClient, { featureSet, dataSourceExclusions });
     const {
       totalCriticalDeprecations,
       migrationsDeprecations,
@@ -152,7 +151,10 @@ describe('getESUpgradeStatus', () => {
     // @ts-ignore missing property definitions in ES resolve_during_rolling_upgrade and _meta
     esClient.asCurrentUser.migration.deprecations.mockResponse(mockResponse);
 
-    const enabledUpgradeStatus = await getESUpgradeStatus(esClient, { ...featureSet });
+    const enabledUpgradeStatus = await getESUpgradeStatus(esClient, {
+      featureSet,
+      dataSourceExclusions,
+    });
     expect([
       ...enabledUpgradeStatus.migrationsDeprecations,
       ...enabledUpgradeStatus.enrichedHealthIndicators,
@@ -160,8 +162,11 @@ describe('getESUpgradeStatus', () => {
     expect(enabledUpgradeStatus.totalCriticalDeprecations).toBe(1);
 
     const disabledUpgradeStatus = await getESUpgradeStatus(esClient, {
-      ...featureSet,
-      mlSnapshots: false,
+      featureSet: {
+        ...featureSet,
+        mlSnapshots: false,
+      },
+      dataSourceExclusions,
     });
 
     expect([
@@ -178,7 +183,10 @@ describe('getESUpgradeStatus', () => {
     } as MigrationDeprecationsResponse;
     esClient.asCurrentUser.migration.deprecations.mockResponse(mockResponse);
 
-    const enabledUpgradeStatus = await getESUpgradeStatus(esClient, { ...featureSet });
+    const enabledUpgradeStatus = await getESUpgradeStatus(esClient, {
+      featureSet,
+      dataSourceExclusions,
+    });
     expect([
       ...enabledUpgradeStatus.migrationsDeprecations,
       ...enabledUpgradeStatus.enrichedHealthIndicators,
@@ -186,8 +194,11 @@ describe('getESUpgradeStatus', () => {
     expect(enabledUpgradeStatus.totalCriticalDeprecations).toBe(1);
 
     const disabledUpgradeStatus = await getESUpgradeStatus(esClient, {
-      ...featureSet,
-      migrateDataStreams: false,
+      featureSet: {
+        ...featureSet,
+        migrateDataStreams: false,
+      },
+      dataSourceExclusions,
     });
 
     expect([
@@ -227,8 +238,11 @@ describe('getESUpgradeStatus', () => {
     });
 
     const upgradeStatus = await getESUpgradeStatus(esClient, {
-      ...featureSet,
-      reindexCorrectiveActions: false,
+      dataSourceExclusions,
+      featureSet: {
+        ...featureSet,
+        reindexCorrectiveActions: false,
+      },
     });
 
     expect([
@@ -236,52 +250,6 @@ describe('getESUpgradeStatus', () => {
       ...upgradeStatus.enrichedHealthIndicators,
     ]).toHaveLength(0);
     expect(upgradeStatus.totalCriticalDeprecations).toBe(0);
-  });
-
-  it('filters out frozen indices if old index deprecations exist for the same indices', async () => {
-    esClient.asCurrentUser.migration.deprecations.mockResponse({
-      cluster_settings: [],
-      node_settings: [],
-      ml_settings: [],
-      index_settings: {
-        frozen_index: [
-          {
-            level: 'critical',
-            message: 'Old index with a compatibility version < 8.0',
-            url: 'https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0',
-            details: 'This index has version: 7.17.28-8.0.0',
-            resolve_during_rolling_upgrade: false,
-            _meta: { reindex_required: true },
-          },
-          {
-            level: 'critical',
-            message:
-              'Index [frozen_index] is a frozen index. The frozen indices feature is deprecated and will be removed in version 9.0.',
-            url: 'https://www.elastic.co/guide/en/elasticsearch/reference/master/frozen-indices.html',
-            details:
-              'Frozen indices must be unfrozen before upgrading to version 9.0. (The legacy frozen indices feature no longer offers any advantages. You may consider cold or frozen tiers in place of frozen indices.)',
-            resolve_during_rolling_upgrade: false,
-          },
-        ],
-      },
-      data_streams: {},
-      // @ts-expect-error not in types yet
-      ilm_policies: {},
-      templates: {},
-    });
-
-    // @ts-expect-error not full interface of response
-    esClient.asCurrentUser.indices.resolveIndex.mockResponse(resolvedIndices);
-
-    const upgradeStatus = await getESUpgradeStatus(esClient, {
-      ...featureSet,
-    });
-
-    expect([
-      ...upgradeStatus.migrationsDeprecations,
-      ...upgradeStatus.enrichedHealthIndicators,
-    ]).toHaveLength(1);
-    expect(upgradeStatus.totalCriticalDeprecations).toBe(1);
   });
 
   it('filters out old index deprecations enterprise search indices and data streams', async () => {
@@ -345,7 +313,8 @@ describe('getESUpgradeStatus', () => {
     });
 
     const upgradeStatus = await getESUpgradeStatus(esClient, {
-      ...featureSet,
+      featureSet,
+      dataSourceExclusions: {},
     });
 
     expect(upgradeStatus.migrationsDeprecations).toHaveLength(2);
@@ -366,6 +335,52 @@ describe('getESUpgradeStatus', () => {
     ).toMatchObject({
       details: expect.stringContaining('Frozen indices'),
     });
+  });
+  it('filters out frozen indices if old index deprecations exist for the same indices', async () => {
+    esClient.asCurrentUser.migration.deprecations.mockResponse({
+      cluster_settings: [],
+      node_settings: [],
+      ml_settings: [],
+      index_settings: {
+        frozen_index: [
+          {
+            level: 'critical',
+            message: 'Old index with a compatibility version < 8.0',
+            url: 'https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0',
+            details: 'This index has version: 7.17.28-8.0.0',
+            resolve_during_rolling_upgrade: false,
+            _meta: { reindex_required: true },
+          },
+          {
+            level: 'critical',
+            message:
+              'Index [frozen_index] is a frozen index. The frozen indices feature is deprecated and will be removed in version 9.0.',
+            url: 'https://www.elastic.co/guide/en/elasticsearch/reference/master/frozen-indices.html',
+            details:
+              'Frozen indices must be unfrozen before upgrading to version 9.0. (The legacy frozen indices feature no longer offers any advantages. You may consider cold or frozen tiers in place of frozen indices.)',
+            resolve_during_rolling_upgrade: false,
+          },
+        ],
+      },
+      data_streams: {},
+      // @ts-expect-error not in types yet
+      ilm_policies: {},
+      templates: {},
+    });
+
+    // @ts-expect-error not full interface of response
+    esClient.asCurrentUser.indices.resolveIndex.mockResponse(resolvedIndices);
+
+    const upgradeStatus = await getESUpgradeStatus(esClient, {
+      featureSet,
+      dataSourceExclusions: {},
+    });
+
+    expect([
+      ...upgradeStatus.migrationsDeprecations,
+      ...upgradeStatus.enrichedHealthIndicators,
+    ]).toHaveLength(1);
+    expect(upgradeStatus.totalCriticalDeprecations).toBe(1);
   });
 
   it('returns health indicators', async () => {
@@ -398,7 +413,7 @@ describe('getESUpgradeStatus', () => {
       },
     });
 
-    const upgradeStatus = await getESUpgradeStatus(esClient, featureSet);
+    const upgradeStatus = await getESUpgradeStatus(esClient, { featureSet, dataSourceExclusions });
     expect(upgradeStatus.totalCriticalHealthIssues + upgradeStatus.totalCriticalDeprecations).toBe(
       2
     );
@@ -434,6 +449,7 @@ describe('getESUpgradeStatus', () => {
         },
         Object {
           "correctiveAction": Object {
+            "excludedActions": Array [],
             "type": "reindex",
           },
           "details": "This index was created using version: 6.8.13",

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/plugin.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/plugin.ts
@@ -37,8 +37,9 @@ import {
 import { handleEsError } from './shared_imports';
 import { RouteDependencies } from './types';
 import type { UpgradeAssistantConfig } from './config';
-import type { FeatureSet } from '../common/types';
+import type { DataSourceExclusions, FeatureSet } from '../common/types';
 import { getEntepriseSearchRegisteredDeprecations } from './lib/enterprise_search/enterprise_search_deprecations';
+import { defaultExclusions } from './lib/data_source_exclusions';
 
 interface PluginsSetup {
   usageCollection: UsageCollectionSetup;
@@ -57,6 +58,7 @@ export class UpgradeAssistantServerPlugin implements Plugin {
   private readonly credentialStore: CredentialStore;
   private readonly kibanaVersion: string;
   private readonly initialFeatureSet: FeatureSet;
+  private readonly initialDataSourceExclusions: DataSourceExclusions;
 
   // Properties set at setup
   private licensing?: LicensingPluginSetup;
@@ -71,8 +73,9 @@ export class UpgradeAssistantServerPlugin implements Plugin {
     this.credentialStore = credentialStoreFactory(this.logger);
     this.kibanaVersion = env.packageInfo.version;
 
-    const { featureSet } = config.get();
+    const { featureSet, dataSourceExclusions } = config.get();
     this.initialFeatureSet = featureSet;
+    this.initialDataSourceExclusions = Object.assign({}, defaultExclusions, dataSourceExclusions);
   }
 
   private getWorker() {
@@ -140,6 +143,7 @@ export class UpgradeAssistantServerPlugin implements Plugin {
       },
       config: {
         featureSet: this.initialFeatureSet,
+        dataSourceExclusions: this.initialDataSourceExclusions,
         isSecurityEnabled: () => security !== undefined && security.license.isEnabled(),
       },
       current: versionService.getCurrentVersion(),

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/es_deprecations.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/es_deprecations.ts
@@ -13,7 +13,7 @@ import { reindexActionsFactory } from '../lib/reindexing/reindex_actions';
 import { reindexServiceFactory } from '../lib/reindexing';
 
 export function registerESDeprecationRoutes({
-  config: { featureSet },
+  config: { featureSet, dataSourceExclusions },
   router,
   lib: { handleEsError },
   licensing,
@@ -36,7 +36,7 @@ export function registerESDeprecationRoutes({
           savedObjects: { client: savedObjectsClient },
           elasticsearch: { client },
         } = await core;
-        const status = await getESUpgradeStatus(client, featureSet);
+        const status = await getESUpgradeStatus(client, { featureSet, dataSourceExclusions });
 
         const asCurrentUser = client.asCurrentUser;
         const reindexActions = reindexActionsFactory(savedObjectsClient, asCurrentUser);

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/migrate_data_streams/data_stream_routes.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/migrate_data_streams/data_stream_routes.ts
@@ -276,7 +276,7 @@ export function registerMigrateDataStreamRoutes({
           );
         }
 
-        await migrationService.readonlyIndices(indices);
+        await migrationService.readonlyIndices(dataStreamName, indices);
         return response.ok({ body: { acknowledged: true } });
       } catch (err) {
         if (err instanceof errors.ResponseError) {

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.ts
@@ -18,7 +18,7 @@ import { getUpgradeType } from '../lib/upgrade_type';
  * Note that this route is primarily intended for consumption by Cloud.
  */
 export function registerUpgradeStatusRoute({
-  config: { featureSet },
+  config: { featureSet, dataSourceExclusions },
   router,
   lib: { handleEsError },
   current,
@@ -57,7 +57,7 @@ export function registerUpgradeStatusRoute({
         const {
           totalCriticalDeprecations, // critical deprecations
           totalCriticalHealthIssues, // critical health issues
-        } = await getESUpgradeStatus(esClient, featureSet);
+        } = await getESUpgradeStatus(esClient, { featureSet, dataSourceExclusions });
 
         const getSystemIndicesMigrationStatus = async () => {
           /**

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/types.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/types.ts
@@ -11,7 +11,7 @@ import { SecurityPluginStart } from '@kbn/security-plugin/server';
 import SemVer from 'semver/classes/semver';
 import { CredentialStore } from './lib/reindexing/credential_store';
 import { handleEsError } from './shared_imports';
-import type { FeatureSet } from '../common/types';
+import type { DataSourceExclusions, FeatureSet } from '../common/types';
 
 export interface RouteDependencies {
   router: IRouter;
@@ -24,6 +24,7 @@ export interface RouteDependencies {
     handleEsError: typeof handleEsError;
   };
   config: {
+    dataSourceExclusions: DataSourceExclusions;
     featureSet: FeatureSet;
     isSecurityEnabled: () => boolean;
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.18` to `8.x`:
 - [[Upgrade Assistant][Core] Data stream 8.18 fixes (#211586)](https://github.com/elastic/kibana/pull/211586)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ahmad Bamieh","email":"ahmad.bamyeh@elastic.co"},"sourceCommit":{"committedDate":"2025-03-06T19:40:49Z","message":"[Upgrade Assistant][Core] Data stream 8.18 fixes (#211586)\n\n## UA Read-only exclusion list\n\nExlcude certain data streams or backing indices from getting certain\ncorrectiveActions.\nThe key is the data stream pattern and the value is an array of\ncorrective actions to exclude.\n\nExclude readOnly data streams from getting read-only corrective actions.\nThis is needed to avoid breaking certain built-in/system functionality\nthat might rely on writing to these data streams.\n\nExample (excludes read-only corrective actions for 7_17_data_stream):\n\n```yaml\nxpack.upgrade_assistant.dataStreamExclusions:\n    7_17_data_stream: [\"readOnly\"]\n```\n\n### Copy changes\n1. Table Resolution cell copy changes:\nResolution gives you only 1 option instead of 2, tooltip text updated as\nwell\n<img width=\"404\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d49d007f-8d12-4fe9-8551-58bb2fcca54d\"\n/>\n\n2. Flyout copy changes:\nReadonly corrective action removed, reindex is the primary button.\nReaonly option in the deteails is removed.\n<img width=\"512\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69f600e0-fc92-4f5f-b94a-45a43ec59f9f\"\n/>\n\n\n3. For Reindexing\nExclusion works for indices and data streams\n<img width=\"707\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e01f4e13-ddfd-4fc6-acab-37202101d731\"\n/>\n\n\n## UA Other Important fixes\n\n- [x] UA copy updates\nhttps://github.com/elastic/kibana/issues/210332#issuecomment-2656331584\n\t- [x] Read only -> read-only\n\t- [x] remove “all” from mark all as read-only in the first flyout step\n\t- [x] Fix \"Migrate\" to \"Reindex\" button text in the first flyout step.\n<img width=\"508\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b3cc0611-1dc3-4346-b04a-b7d38210773c\"\n/>\n\n- [x] Document in the warnings step that users can modify the data flow\nreindexing speed\n<img width=\"536\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1a7381a1-280e-49a6-8b8a-1d7bbdd8d6e7\"\n/>\n\n- [x] Fixing ES Bugs with data stream flows with an ES error not\npropagating when reindexing (they return it in an `error: string[]`\nwhile complete remains `false` ) currently we only account for errors\nwhen the task status `complete: true`\n\n- [x] Fixed an issue in data stream reindex when there is a cached\n‘completed’ task but there are indices requiring reindexing we should\ndelete the task on ES side. otherwise it shows complete though it is not\ncomplete.\n\n- [x] Fix an issue in data stream when job is started and we refresh the\npage we get this error:\n<img width=\"563\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5d70b56e-2bb9-41a0-a10d-2fec5431447f\"\n/>\n\n- [x] Roll over before setting readonly\nhttps://github.com/elastic/kibana-team/issues/1510\n- [x] Use `primaries.count` instead of `total.count` to count data\nstream docs. https://github.com/elastic/kibana/issues/211866\n\nCloses https://github.com/elastic/kibana-team/issues/1502\nCloses https://github.com/elastic/kibana-team/issues/1510\nCloses https://github.com/elastic/kibana-team/issues/1511\nCloses https://github.com/elastic/kibana-team/issues/1512\nCloses https://github.com/elastic/kibana/issues/211866\nComplets 3/5 tasks in copy issue:\nhttps://github.com/elastic/kibana/issues/210332","sha":"089c5e80bdb3acc1bab158b8fe2a0151bd2d7005","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","v8.18.0","v8.19.0"],"title":"[Upgrade Assistant][Core] Data stream 8.18 fixes","number":211586,"url":"https://github.com/elastic/kibana/pull/211586","mergeCommit":{"message":"[Upgrade Assistant][Core] Data stream 8.18 fixes (#211586)\n\n## UA Read-only exclusion list\n\nExlcude certain data streams or backing indices from getting certain\ncorrectiveActions.\nThe key is the data stream pattern and the value is an array of\ncorrective actions to exclude.\n\nExclude readOnly data streams from getting read-only corrective actions.\nThis is needed to avoid breaking certain built-in/system functionality\nthat might rely on writing to these data streams.\n\nExample (excludes read-only corrective actions for 7_17_data_stream):\n\n```yaml\nxpack.upgrade_assistant.dataStreamExclusions:\n    7_17_data_stream: [\"readOnly\"]\n```\n\n### Copy changes\n1. Table Resolution cell copy changes:\nResolution gives you only 1 option instead of 2, tooltip text updated as\nwell\n<img width=\"404\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d49d007f-8d12-4fe9-8551-58bb2fcca54d\"\n/>\n\n2. Flyout copy changes:\nReadonly corrective action removed, reindex is the primary button.\nReaonly option in the deteails is removed.\n<img width=\"512\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69f600e0-fc92-4f5f-b94a-45a43ec59f9f\"\n/>\n\n\n3. For Reindexing\nExclusion works for indices and data streams\n<img width=\"707\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e01f4e13-ddfd-4fc6-acab-37202101d731\"\n/>\n\n\n## UA Other Important fixes\n\n- [x] UA copy updates\nhttps://github.com/elastic/kibana/issues/210332#issuecomment-2656331584\n\t- [x] Read only -> read-only\n\t- [x] remove “all” from mark all as read-only in the first flyout step\n\t- [x] Fix \"Migrate\" to \"Reindex\" button text in the first flyout step.\n<img width=\"508\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b3cc0611-1dc3-4346-b04a-b7d38210773c\"\n/>\n\n- [x] Document in the warnings step that users can modify the data flow\nreindexing speed\n<img width=\"536\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1a7381a1-280e-49a6-8b8a-1d7bbdd8d6e7\"\n/>\n\n- [x] Fixing ES Bugs with data stream flows with an ES error not\npropagating when reindexing (they return it in an `error: string[]`\nwhile complete remains `false` ) currently we only account for errors\nwhen the task status `complete: true`\n\n- [x] Fixed an issue in data stream reindex when there is a cached\n‘completed’ task but there are indices requiring reindexing we should\ndelete the task on ES side. otherwise it shows complete though it is not\ncomplete.\n\n- [x] Fix an issue in data stream when job is started and we refresh the\npage we get this error:\n<img width=\"563\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5d70b56e-2bb9-41a0-a10d-2fec5431447f\"\n/>\n\n- [x] Roll over before setting readonly\nhttps://github.com/elastic/kibana-team/issues/1510\n- [x] Use `primaries.count` instead of `total.count` to count data\nstream docs. https://github.com/elastic/kibana/issues/211866\n\nCloses https://github.com/elastic/kibana-team/issues/1502\nCloses https://github.com/elastic/kibana-team/issues/1510\nCloses https://github.com/elastic/kibana-team/issues/1511\nCloses https://github.com/elastic/kibana-team/issues/1512\nCloses https://github.com/elastic/kibana/issues/211866\nComplets 3/5 tasks in copy issue:\nhttps://github.com/elastic/kibana/issues/210332","sha":"089c5e80bdb3acc1bab158b8fe2a0151bd2d7005"}},"sourceBranch":"8.18","suggestedTargetBranches":["9.0","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211586","number":211586,"mergeCommit":{"message":"[Upgrade Assistant][Core] Data stream 8.18 fixes (#211586)\n\n## UA Read-only exclusion list\n\nExlcude certain data streams or backing indices from getting certain\ncorrectiveActions.\nThe key is the data stream pattern and the value is an array of\ncorrective actions to exclude.\n\nExclude readOnly data streams from getting read-only corrective actions.\nThis is needed to avoid breaking certain built-in/system functionality\nthat might rely on writing to these data streams.\n\nExample (excludes read-only corrective actions for 7_17_data_stream):\n\n```yaml\nxpack.upgrade_assistant.dataStreamExclusions:\n    7_17_data_stream: [\"readOnly\"]\n```\n\n### Copy changes\n1. Table Resolution cell copy changes:\nResolution gives you only 1 option instead of 2, tooltip text updated as\nwell\n<img width=\"404\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/d49d007f-8d12-4fe9-8551-58bb2fcca54d\"\n/>\n\n2. Flyout copy changes:\nReadonly corrective action removed, reindex is the primary button.\nReaonly option in the deteails is removed.\n<img width=\"512\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/69f600e0-fc92-4f5f-b94a-45a43ec59f9f\"\n/>\n\n\n3. For Reindexing\nExclusion works for indices and data streams\n<img width=\"707\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e01f4e13-ddfd-4fc6-acab-37202101d731\"\n/>\n\n\n## UA Other Important fixes\n\n- [x] UA copy updates\nhttps://github.com/elastic/kibana/issues/210332#issuecomment-2656331584\n\t- [x] Read only -> read-only\n\t- [x] remove “all” from mark all as read-only in the first flyout step\n\t- [x] Fix \"Migrate\" to \"Reindex\" button text in the first flyout step.\n<img width=\"508\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b3cc0611-1dc3-4346-b04a-b7d38210773c\"\n/>\n\n- [x] Document in the warnings step that users can modify the data flow\nreindexing speed\n<img width=\"536\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1a7381a1-280e-49a6-8b8a-1d7bbdd8d6e7\"\n/>\n\n- [x] Fixing ES Bugs with data stream flows with an ES error not\npropagating when reindexing (they return it in an `error: string[]`\nwhile complete remains `false` ) currently we only account for errors\nwhen the task status `complete: true`\n\n- [x] Fixed an issue in data stream reindex when there is a cached\n‘completed’ task but there are indices requiring reindexing we should\ndelete the task on ES side. otherwise it shows complete though it is not\ncomplete.\n\n- [x] Fix an issue in data stream when job is started and we refresh the\npage we get this error:\n<img width=\"563\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/5d70b56e-2bb9-41a0-a10d-2fec5431447f\"\n/>\n\n- [x] Roll over before setting readonly\nhttps://github.com/elastic/kibana-team/issues/1510\n- [x] Use `primaries.count` instead of `total.count` to count data\nstream docs. https://github.com/elastic/kibana/issues/211866\n\nCloses https://github.com/elastic/kibana-team/issues/1502\nCloses https://github.com/elastic/kibana-team/issues/1510\nCloses https://github.com/elastic/kibana-team/issues/1511\nCloses https://github.com/elastic/kibana-team/issues/1512\nCloses https://github.com/elastic/kibana/issues/211866\nComplets 3/5 tasks in copy issue:\nhttps://github.com/elastic/kibana/issues/210332","sha":"089c5e80bdb3acc1bab158b8fe2a0151bd2d7005"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->