### PR TITLE
[8.18] [ci] Trigger VM image rebuild for cache rebuild only (#213497)

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/promote.sh
+++ b/.buildkite/scripts/steps/es_snapshots/promote.sh
@@ -25,6 +25,7 @@ steps:
     async: true
     build:
       env:
-        IMAGES_CONFIG: "kibana/images.yml"
+        IMAGES_CONFIG: 'kibana/image_cache.yml'
+        BASE_IMAGES_CONFIG: 'core/images.yml,kibana/base_image.yml'
         RETRY: "1"
 EOF


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ci] Trigger VM image rebuild for cache rebuild only (#213497)](https://github.com/elastic/kibana/pull/213497)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2025-03-10T09:56:15Z","message":"[ci] Trigger VM image rebuild for cache rebuild only (#213497)\n\n## Summary\nWhen VM image rebuild is triggered after ES promotion, only the cache\nwarmup should be built.\n\nThis PR also separates the daily full build to a daily base + cache\nbuild (in case ES promotions are failing for some reason, we should\nstill have a daily cache refresh).\n\nRequires: https://github.com/elastic/ci-agent-images/pull/1295\n\nWith this, we'd run a daily base image build and cache build (~40m +\n25m) + cache warmups for every promotion (~4x 25m) instead of a full\nbuild and promotion per build (~4x 55m). Ultimately not that much of a\ngain 🤷 (4*55=220m => 40+5x25=165m)","sha":"830dbd4ed72cb05829dbc1ee383dee9f9cbcdac8","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","skip-ci","backport:prev-minor","backport:prev-major","v9.1.0"],"title":"[ci] Trigger VM image rebuild for cache rebuild only","number":213497,"url":"https://github.com/elastic/kibana/pull/213497","mergeCommit":{"message":"[ci] Trigger VM image rebuild for cache rebuild only (#213497)\n\n## Summary\nWhen VM image rebuild is triggered after ES promotion, only the cache\nwarmup should be built.\n\nThis PR also separates the daily full build to a daily base + cache\nbuild (in case ES promotions are failing for some reason, we should\nstill have a daily cache refresh).\n\nRequires: https://github.com/elastic/ci-agent-images/pull/1295\n\nWith this, we'd run a daily base image build and cache build (~40m +\n25m) + cache warmups for every promotion (~4x 25m) instead of a full\nbuild and promotion per build (~4x 55m). Ultimately not that much of a\ngain 🤷 (4*55=220m => 40+5x25=165m)","sha":"830dbd4ed72cb05829dbc1ee383dee9f9cbcdac8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213697","number":213697,"state":"MERGED","mergeCommit":{"sha":"e3b7db6f446a8daedb965cbe0f6823c91747c10c","message":"[9.0] [ci] Trigger VM image rebuild for cache rebuild only (#213497) (#213697)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[ci] Trigger VM image rebuild for cache rebuild only\n(#213497)](https://github.com/elastic/kibana/pull/213497)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213497","number":213497,"mergeCommit":{"message":"[ci] Trigger VM image rebuild for cache rebuild only (#213497)\n\n## Summary\nWhen VM image rebuild is triggered after ES promotion, only the cache\nwarmup should be built.\n\nThis PR also separates the daily full build to a daily base + cache\nbuild (in case ES promotions are failing for some reason, we should\nstill have a daily cache refresh).\n\nRequires: https://github.com/elastic/ci-agent-images/pull/1295\n\nWith this, we'd run a daily base image build and cache build (~40m +\n25m) + cache warmups for every promotion (~4x 25m) instead of a full\nbuild and promotion per build (~4x 55m). Ultimately not that much of a\ngain 🤷 (4*55=220m => 40+5x25=165m)","sha":"830dbd4ed72cb05829dbc1ee383dee9f9cbcdac8"}}]}] BACKPORT-->