### PR TITLE
[Synthetics] Fix lat test run timestamp !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/ping/ping.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/ping/ping.ts
@@ -159,7 +159,6 @@ export type TestSummary = t.TypeOf<typeof SummaryCodec>;
 
 export const PingType = t.intersection([
   t.type({
-    timestamp: t.string,
     monitor: MonitorType,
     docId: t.string,
     observer: ObserverCodec,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_details_panel.tsx
@@ -111,8 +111,8 @@ export const MonitorDetailsPanel = ({
         </EuiDescriptionListDescription>
         <EuiDescriptionListTitle>{LAST_RUN_LABEL}</EuiDescriptionListTitle>
         <EuiDescriptionListDescription>
-          {latestPing?.timestamp ? (
-            <Time timestamp={latestPing?.timestamp} />
+          {latestPing?.['@timestamp'] ? (
+            <Time timestamp={latestPing?.['@timestamp']} />
           ) : (
             <EuiText color="subdued">
               {i18n.translate('xpack.synthetics.monitorDetailsPanel.TextLabel', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/view_document.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/view_document.tsx
@@ -20,7 +20,7 @@ export const ViewDocument = ({ ping }: { ping: Ping }) => {
 
   const dataView = useSyntheticsDataView();
   const formatter = useDateFormat();
-  const formattedTimestamp = formatter(ping.timestamp);
+  const formattedTimestamp = formatter(ping['@timestamp']);
 
   const [, hit] = useEsDocSearch({ id: ping.docId, index: SYNTHETICS_INDEX_PATTERN, dataView });
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/components/error_duration.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/components/error_duration.tsx
@@ -19,7 +19,7 @@ export const ErrorDuration: React.FC = () => {
 
   const { killerState } = useFindMyKillerState();
 
-  const endsAt = killerState?.timestamp ? moment(killerState?.timestamp) : moment();
+  const endsAt = killerState?.['@timestamp'] ? moment(killerState?.['@timestamp']) : moment();
   const startedAt = moment(state?.started_at);
 
   const duration = state ? getErrorDuration(startedAt, endsAt) : 0;

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/components/error_timeline.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/components/error_timeline.tsx
@@ -26,7 +26,7 @@ export const ErrorTimeline = ({ lastTestRun }: { lastTestRun?: Ping }) => {
         from: moment(startedAt)
           .subtract(diff / 2, 'minutes')
           .toISOString(),
-        to: moment(lastTestRun.timestamp)
+        to: moment(lastTestRun['@timestamp'])
           .add(diff / 2, 'minutes')
           .toISOString(),
       }}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/components/resolved_at.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/error_details/components/resolved_at.tsx
@@ -15,7 +15,7 @@ export const ResolvedAt: React.FC = () => {
   const { killerState } = useFindMyKillerState();
 
   const formatter = useDateFormat();
-  let endsAt: string | ReactElement = formatter(killerState?.timestamp ?? '');
+  let endsAt: string | ReactElement = formatter(killerState?.['@timestamp'] ?? '');
 
   if (!endsAt) {
     endsAt = 'N/A';

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_last_run.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_last_run.tsx
@@ -14,7 +14,7 @@ import { useMonitorLatestPing } from './hooks/use_monitor_latest_ping';
 export const MonitorDetailsLastRun: React.FC = () => {
   const { latestPing, loading: pingsLoading } = useMonitorLatestPing();
   let description: string | ReactElement = latestPing
-    ? moment(latestPing.timestamp).fromNow()
+    ? moment(latestPing['@timestamp']).fromNow()
     : '--';
 
   if (!latestPing && pingsLoading) {
@@ -27,7 +27,10 @@ export const MonitorDetailsLastRun: React.FC = () => {
         {
           title: LAST_RUN_LABEL,
           description: (
-            <EuiToolTip content={moment(latestPing?.timestamp).format('LLL')} position="bottom">
+            <EuiToolTip
+              content={moment(latestPing?.['@timestamp']).format('LLL')}
+              position="bottom"
+            >
               <>{description}</>
             </EuiToolTip>
           ),

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/last_test_run.tsx
@@ -156,7 +156,7 @@ const PanelHeader = ({
   const { monitorId } = useParams<{ monitorId: string }>();
 
   const formatter = useDateFormat();
-  const lastRunTimestamp = formatter(latestPing?.timestamp);
+  const lastRunTimestamp = formatter(latestPing?.['@timestamp']);
 
   const isBrowserMonitor = monitor?.[ConfigKey.MONITOR_TYPE] === MonitorTypeEnum.BROWSER;
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
@@ -135,7 +135,7 @@ export const TestRunsTable = ({
                   <JourneyLastScreenshot
                     checkGroupId={item.monitor.check_group}
                     size={THUMBNAIL_SCREENSHOT_SIZE_MOBILE}
-                    timestamp={item.timestamp}
+                    timestamp={item['@timestamp']}
                   />
                 </EuiFlexGroup>
               ),
@@ -332,7 +332,11 @@ export const MobileRowDetails = ({
 }) => {
   return (
     <EuiFlexGroup direction="column" gutterSize="m">
-      <TestDetailsLink isBrowserMonitor={isBrowserMonitor} timestamp={ping.timestamp} ping={ping} />
+      <TestDetailsLink
+        isBrowserMonitor={isBrowserMonitor}
+        timestamp={ping['@timestamp']}
+        ping={ping}
+      />
       <EuiFlexGroup
         justifyContent="spaceBetween"
         alignItems="center"

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
@@ -37,7 +37,6 @@ describe('Monitor Detail Flyout', () => {
     jest.spyOn(monitorDetail, 'useMonitorDetail').mockReturnValue({
       data: {
         docId: 'docId',
-        timestamp: '2013-03-01 12:54:23',
         monitor: {
           name: 'test monitor',
           id: 'test-id',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/simple/ping_list/columns/ping_status.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/simple/ping_list/columns/ping_status.tsx
@@ -26,7 +26,7 @@ const getPingStatusLabel = (status: string) => {
 };
 
 export const PingStatusColumn = ({ pingStatus, item }: Props) => {
-  const timeStamp = moment(item.timestamp);
+  const timeStamp = moment(item['@timestamp']);
 
   let checkedTime = '';
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_detail.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/hooks/use_monitor_detail.ts
@@ -50,7 +50,7 @@ export const useMonitorDetail = (
 
   if (!result || result.hits.hits.length !== 1) return { data: undefined, loading };
   return {
-    data: { ...result.hits.hits[0]._source, timestamp: result.hits.hits[0]._source['@timestamp'] },
+    data: result.hits.hits[0]._source,
     loading,
   };
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/monitor_details/effects.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/monitor_details/effects.ts
@@ -65,7 +65,7 @@ export function* fetchSyntheticsMonitorEffect() {
         recentPingFromList?.[ConfigKey.CONFIG_ID] &&
         lastRunPing?.[ConfigKey.CONFIG_ID] === recentPingFromList?.[ConfigKey.CONFIG_ID] &&
         lastRunPing?.observer?.geo?.name === recentPingFromList?.observer?.geo?.name &&
-        new Date(lastRunPing?.timestamp) < new Date(recentPingFromList?.timestamp)
+        new Date(lastRunPing?.['@timestamp']) < new Date(recentPingFromList?.['@timestamp'])
       ) {
         yield put(updateMonitorLastRunAction({ data: recentPingFromList }));
       }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
@@ -345,7 +345,7 @@ function getMonitorDetailsMockSlice() {
             version: '8.3.0',
           },
           synthetics: {
-            journey: { name: 'inline', id: 'inline', tags: null },
+            journey: { name: 'inline', id: 'inline' },
             type: 'heartbeat/summary',
           },
           monitor: {
@@ -380,7 +380,6 @@ function getMonitorDetailsMockSlice() {
           ecs: { version: '8.0.0' },
           config_id: '4afd3980-0b72-11ed-9c10-b57918ea89d6',
           data_stream: { namespace: 'default', type: 'synthetics', dataset: 'browser' },
-          timestamp: '2022-07-24T17:04:03.769Z',
           docId: 'mkYqMYIBqL6WCtughFUq',
         },
         {
@@ -436,7 +435,6 @@ function getMonitorDetailsMockSlice() {
           ecs: { version: '8.0.0' },
           config_id: '4afd3980-0b72-11ed-9c10-b57918ea89d6',
           data_stream: { namespace: 'default', type: 'synthetics', dataset: 'browser' },
-          timestamp: '2022-07-24T17:01:48.326Z',
           docId: 'kUYoMYIBqL6WCtugc1We',
         },
       ],

--- a/x-pack/solutions/observability/plugins/synthetics/server/queries/get_last_successful_check.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/queries/get_last_successful_check.ts
@@ -100,11 +100,10 @@ export const getLastSuccessfulCheck = async ({
     return null;
   }
 
-  const check = result.hits.hits[0]._source as Ping & { '@timestamp': string };
+  const check = result.hits.hits[0]._source as Ping;
 
   return {
     ...check,
-    timestamp: check['@timestamp'],
     docId: result.hits.hits[0]._id!,
   };
 };


### PR DESCRIPTION
## Summary

 Fix lat test run timestamp !!

Issue was because of using timestamp abstraction on the ping document.

### Changes
removed the unnecessary timestamp field from ping and use `@timestamp`  which is natively present on the document. it was causing unnecessary confusion.

Fixes https://github.com/elastic/kibana/issues/213742 !!


### Before
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/ce03e52d-2287-4b30-b984-07a1a8690dff" />


### After
<img width="1478" alt="image" src="https://github.com/user-attachments/assets/149694d8-8f49-4444-bf3b-edf8fe914741" />





<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->