### PR TITLE
[Obs Onboarding] Add page rendering performance monitoring

### DIFF
--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/measure_interaction/index.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/measure_interaction/index.ts
@@ -36,7 +36,7 @@ export function measureInteraction(pathname: string) {
       let performanceMeta: PerformanceMeta | undefined;
       performance.mark(perfomanceMarkers.endPageReady);
 
-      if (eventData?.meta) {
+      if (eventData?.meta?.rangeFrom && eventData?.meta?.rangeTo) {
         const { rangeFrom, rangeTo, description } = eventData.meta;
 
         // Convert the date range  to epoch timestamps (in milliseconds)

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/measure_interaction/index.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/measure_interaction/index.ts
@@ -17,8 +17,8 @@ import { perfomanceMarkers } from '../../performance_markers';
 import { DescriptionWithPrefix } from '../types';
 
 interface PerformanceMeta {
-  queryRangeSecs: number;
-  queryOffsetSecs: number;
+  queryRangeSecs?: number;
+  queryOffsetSecs?: number;
   isInitialLoad?: boolean;
   description?: DescriptionWithPrefix;
 }
@@ -33,11 +33,11 @@ export function measureInteraction(pathname: string) {
      * @param customMetrics - Custom metrics to be included in the performance measure.
      */
     pageReady(eventData?: EventData) {
-      let performanceMeta: PerformanceMeta | undefined;
+      const performanceMeta: PerformanceMeta = {};
       performance.mark(perfomanceMarkers.endPageReady);
 
       if (eventData?.meta?.rangeFrom && eventData?.meta?.rangeTo) {
-        const { rangeFrom, rangeTo, description } = eventData.meta;
+        const { rangeFrom, rangeTo } = eventData.meta;
 
         // Convert the date range  to epoch timestamps (in milliseconds)
         const dateRangesInEpoch = getDateRange({
@@ -45,12 +45,13 @@ export function measureInteraction(pathname: string) {
           to: rangeTo,
         });
 
-        performanceMeta = {
-          queryRangeSecs: getTimeDifferenceInSeconds(dateRangesInEpoch),
-          queryOffsetSecs:
-            rangeTo === 'now' ? 0 : getOffsetFromNowInSeconds(dateRangesInEpoch.endDate),
-          description,
-        };
+        performanceMeta.queryRangeSecs = getTimeDifferenceInSeconds(dateRangesInEpoch);
+        performanceMeta.queryOffsetSecs =
+          rangeTo === 'now' ? 0 : getOffsetFromNowInSeconds(dateRangesInEpoch.endDate);
+      }
+
+      if (eventData?.meta?.description) {
+        performanceMeta.description = eventData.meta.description;
       }
 
       if (

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/performance_context.tsx
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/performance_context.tsx
@@ -17,8 +17,8 @@ import { DescriptionWithPrefix } from './types';
 export type CustomMetrics = Omit<PerformanceMetricEvent, 'eventName' | 'meta' | 'duration'>;
 
 export interface Meta {
-  rangeFrom: string;
-  rangeTo: string;
+  rangeFrom?: string;
+  rangeTo?: string;
   description?: DescriptionWithPrefix;
 }
 

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
@@ -8,8 +8,9 @@
  */
 
 type ApmPageId = 'services' | 'traces' | 'dependencies';
-type InfraPageId = 'hosts' | 'onboarding';
+type InfraPageId = 'hosts';
+type OnboardingPageId = 'onboarding';
 
-export type Key = `${ApmPageId}` | `${InfraPageId}`;
+export type Key = `${ApmPageId}` | `${InfraPageId}` | `${OnboardingPageId}`;
 
 export type DescriptionWithPrefix = `[ttfmp_${Key}] ${string}`;

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
@@ -8,7 +8,7 @@
  */
 
 type ApmPageId = 'services' | 'traces' | 'dependencies';
-type InfraPageId = 'hosts';
+type InfraPageId = 'hosts' | 'onboarding';
 
 export type Key = `${ApmPageId}` | `${InfraPageId}`;
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/app.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/app.tsx
@@ -8,6 +8,7 @@
 import { EuiErrorBoundary } from '@elastic/eui';
 import { AppMountParameters, APP_WRAPPER_CLASS, CoreStart } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
+import { PerformanceContextProvider } from '@kbn/ebt-tools';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
@@ -71,13 +72,15 @@ export function ObservabilityOnboardingAppRoot({
               }}
             >
               <Router history={history}>
-                <EuiErrorBoundary>
-                  <ObservabilityOnboardingHeaderActionMenu
-                    setHeaderActionMenu={setHeaderActionMenu}
-                    theme$={theme$}
-                  />
-                  <ObservabilityOnboardingFlow />
-                </EuiErrorBoundary>
+                <PerformanceContextProvider>
+                  <EuiErrorBoundary>
+                    <ObservabilityOnboardingHeaderActionMenu
+                      setHeaderActionMenu={setHeaderActionMenu}
+                      theme$={theme$}
+                    />
+                    <ObservabilityOnboardingFlow />
+                  </EuiErrorBoundary>
+                </PerformanceContextProvider>
               </Router>
             </KibanaThemeProvider>
           </KibanaContextProvider>

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
@@ -27,6 +27,7 @@ import { css } from '@emotion/react';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { IntegrationCardItem } from '@kbn/fleet-plugin/public';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { PackageListSearchForm } from '../package_list_search_form/package_list_search_form';
 import { Category } from './types';
 import { useCustomCards } from './use_custom_cards';
@@ -113,6 +114,7 @@ export const OnboardingFlowForm: FunctionComponent = () => {
   const radioGroupId = useGeneratedHtmlId({ prefix: 'onboardingCategory' });
   const categorySelectorTitleId = useGeneratedHtmlId();
   const packageListTitleId = useGeneratedHtmlId();
+  const { onPageReady } = usePerformanceContext();
 
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -147,6 +149,10 @@ export const OnboardingFlowForm: FunctionComponent = () => {
     },
     [] // eslint-disable-line react-hooks/exhaustive-deps
   );
+
+  useEffect(() => {
+    onPageReady();
+  }, [onPageReady]);
 
   const featuredCardsForCategoryMap: Record<Category, string[]> = {
     host: ['auto-detect-logs', 'otel-logs'],

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
@@ -151,7 +151,9 @@ export const OnboardingFlowForm: FunctionComponent = () => {
   );
 
   useEffect(() => {
-    onPageReady();
+    onPageReady({
+      meta: { description: '[ttfmp_onboarding] The UI with onboarding categories is rendered' },
+    });
   }, [onPageReady]);
 
   const featuredCardsForCategoryMap: Record<Category, string[]> = {

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
@@ -46,7 +46,11 @@ export const AutoDetectPanel: FunctionComponent = () => {
 
   useEffect(() => {
     if (data) {
-      onPageReady();
+      onPageReady({
+        meta: {
+          description: `[ttfmp_onboarding] Request to create the onboarding flow succeeded and the flow's UI has rendered`,
+        },
+      });
     }
   }, [data, onPageReady]);
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { type FunctionComponent } from 'react';
+import React, { useEffect, type FunctionComponent } from 'react';
 import { i18n } from '@kbn/i18n';
 import {
   EuiPanel,
@@ -22,6 +22,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { DASHBOARD_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { ASSET_DETAILS_LOCATOR_ID } from '@kbn/observability-shared-plugin/common';
 import { type LogsLocatorParams, LOGS_LOCATOR_ID } from '@kbn/logs-shared-plugin/common';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { getAutoDetectCommand } from './get_auto_detect_command';
 import { DASHBOARDS, useOnboardingFlow } from './use_onboarding_flow';
 import { ProgressIndicator } from '../shared/progress_indicator';
@@ -38,9 +39,16 @@ export const AutoDetectPanel: FunctionComponent = () => {
   const { status, data, error, refetch, installedIntegrations } = useOnboardingFlow();
   const command = data ? getAutoDetectCommand(data) : undefined;
   const accordionId = useGeneratedHtmlId({ prefix: 'accordion' });
+  const { onPageReady } = usePerformanceContext();
   const {
     services: { share },
   } = useKibana<ObservabilityOnboardingContextValue>();
+
+  useEffect(() => {
+    if (data) {
+      onPageReady();
+    }
+  }, [data, onPageReady]);
 
   if (error) {
     return <EmptyPrompt onboardingFlowType="auto-detect" error={error} onRetryClick={refetch} />;

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/firehose/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/firehose/index.tsx
@@ -69,7 +69,11 @@ export function FirehosePanel() {
 
   useEffect(() => {
     if (data) {
-      onPageReady();
+      onPageReady({
+        meta: {
+          description: `[ttfmp_onboarding] Request to create the onboarding flow succeeded and the flow's UI has rendered`,
+        },
+      });
     }
   }, [data, onPageReady]);
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/firehose/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/firehose/index.tsx
@@ -18,8 +18,9 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { OnboardingFlowEventContext } from '../../../../common/telemetry_events';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { EmptyPrompt } from '../shared/empty_prompt';
@@ -64,6 +65,13 @@ export function FirehosePanel() {
   } = useKibana<ObservabilityOnboardingAppServices>();
   const { data, status, error, refetch } = useFirehoseFlow();
   const { data: populatedAWSIndexList } = usePopulatedAWSIndexList();
+  const { onPageReady } = usePerformanceContext();
+
+  useEffect(() => {
+    if (data) {
+      onPageReady();
+    }
+  }, [data, onPageReady]);
 
   const hasExistingData = Array.isArray(populatedAWSIndexList) && populatedAWSIndexList.length > 0;
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/index.tsx
@@ -36,7 +36,11 @@ export const KubernetesPanel: React.FC = () => {
 
   useEffect(() => {
     if (data) {
-      onPageReady();
+      onPageReady({
+        meta: {
+          description: `[ttfmp_onboarding] Request to create the onboarding flow succeeded and the flow's UI has rendered`,
+        },
+      });
     }
   }, [data, onPageReady]);
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   EuiPanel,
   EuiSkeletonRectangle,
@@ -15,6 +15,7 @@ import {
   EuiStepStatus,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { EmptyPrompt } from '../shared/empty_prompt';
 import { CommandSnippet } from './command_snippet';
@@ -25,12 +26,19 @@ import { useWindowBlurDataMonitoringTrigger } from '../shared/use_window_blur_da
 
 export const KubernetesPanel: React.FC = () => {
   const { data, status, error, refetch } = useKubernetesFlow();
+  const { onPageReady } = usePerformanceContext();
 
   const isMonitoringStepActive = useWindowBlurDataMonitoringTrigger({
     isActive: status === FETCH_STATUS.SUCCESS,
     onboardingFlowType: 'kubernetes',
     onboardingId: data?.onboardingId,
   });
+
+  useEffect(() => {
+    if (data) {
+      onPageReady();
+    }
+  }, [data, onPageReady]);
 
   if (error !== undefined) {
     return <EmptyPrompt onboardingFlowType="kubernetes" error={error} onRetryClick={refetch} />;

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   EuiPanel,
   EuiSkeletonText,
@@ -26,6 +26,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { DASHBOARD_APP_LOCATOR } from '@kbn/deeplinks-analytics';
 import { css } from '@emotion/react';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { EmptyPrompt } from '../shared/empty_prompt';
 import { GetStartedPanel } from '../shared/get_started_panel';
 import { FeedbackButtons } from '../shared/feedback_buttons';
@@ -46,6 +47,13 @@ export const OtelKubernetesPanel: React.FC = () => {
   const apmLocator = share.url.locators.get('APM_LOCATOR');
   const dashboardLocator = share.url.locators.get(DASHBOARD_APP_LOCATOR);
   const theme = useEuiTheme();
+  const { onPageReady } = usePerformanceContext();
+
+  useEffect(() => {
+    if (data) {
+      onPageReady();
+    }
+  }, [data, onPageReady]);
 
   if (error) {
     return (

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -51,7 +51,11 @@ export const OtelKubernetesPanel: React.FC = () => {
 
   useEffect(() => {
     if (data) {
-      onPageReady();
+      onPageReady({
+        meta: {
+          description: `[ttfmp_onboarding] Request to create the onboarding flow succeeded and the flow's UI has rendered`,
+        },
+      });
     }
   }, [data, onPageReady]);
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
@@ -66,7 +66,11 @@ export const OtelLogsPanel: React.FC = () => {
 
   useEffect(() => {
     if (apiKeyData && setup) {
-      onPageReady();
+      onPageReady({
+        meta: {
+          description: `[ttfmp_onboarding] Requests to get the environment and to generate API key succeeded and the flow's UI has rendered`,
+        },
+      });
     }
   }, [apiKeyData, onPageReady, setup]);
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
@@ -27,6 +27,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { type LogsLocatorParams, LOGS_LOCATOR_ID } from '@kbn/logs-shared-plugin/common';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { ObservabilityOnboardingAppServices } from '../../..';
 import { useFetcher } from '../../../hooks/use_fetcher';
 import { MultiIntegrationInstallBanner } from './multi_integration_install_banner';
@@ -42,6 +43,7 @@ const HOST_COMMAND = i18n.translate(
 );
 
 export const OtelLogsPanel: React.FC = () => {
+  const { onPageReady } = usePerformanceContext();
   const {
     data: apiKeyData,
     error,
@@ -61,6 +63,12 @@ export const OtelLogsPanel: React.FC = () => {
   const {
     services: { share, http },
   } = useKibana<ObservabilityOnboardingAppServices>();
+
+  useEffect(() => {
+    if (apiKeyData && setup) {
+      onPageReady();
+    }
+  }, [apiKeyData, onPageReady, setup]);
 
   const AGENT_CDN_BASE_URL = 'artifacts.elastic.co/downloads/beats/elastic-agent';
   const agentVersion = setup?.elasticAgentVersionInfo.agentVersion ?? '';

--- a/x-pack/solutions/observability/plugins/observability_onboarding/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/tsconfig.json
@@ -45,7 +45,8 @@
     "@kbn/core-application-browser",
     "@kbn/core-plugins-server",
     "@kbn/logs-shared-plugin",
-    "@kbn/tooling-log"
+    "@kbn/tooling-log",
+    "@kbn/ebt-tools"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
Closes https://github.com/elastic/observability-dev/issues/4238 🔒
Closes https://github.com/elastic/observability-dev/issues/3513 🔒

This change add logic for triggering [the page rendering performance metrics](https://docs.elastic.dev/kibana-dev-docs/tutorial/performance/adding_custom_performance_metrics#report-kibanaplugin_render_time-metric-event) for:
* Onboarding home screen
* Host auto-detect flow
* Host OTel flow
* Host K8S flow
* K8S OTel flow
* Firehose flow

## How to test
1. Run Kibana locally
2. Open browser dev tools
3. Navigate to one of the above mentioned onboarding screens
4. Observe `kibana:plugin_render_time` EBT event emitted in the Network tab of the dev tools

Events emitted from local Kibana end up in the Staging Telemetry cluster, there is a [dedicated rendering performance dashboard](https://telemetry-v2-staging.elastic.dev/s/apm/app/dashboards#/view/f240fff6-fac9-491b-81d1-ac39006c5c94?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-24h%2Fh,to:now))), onboarding events can be filtered using `observabilityOnboarding` application ID. (note that it takes some time for events to be indexed and they appear in the cluster with a significant delay)

<!--ONMERGE {"backportTargets":["8.18","9.0"]} ONMERGE-->