### PR TITLE
[8.x] [ResponseOps] Some places refer to `xpack.alerting.maxScheduledPerMinute` when it should be `xpack.alerting.rules.maxScheduledPerMinute` (#213487)

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -242,7 +242,7 @@ kibana_vars=(
     xpack.alerting.rules.run.actions.max
     xpack.alerting.rules.run.alerts.max
     xpack.alerting.rules.run.actions.connectorTypeOverrides
-    xpack.alerting.maxScheduledPerMinute
+    xpack.alerting.rules.maxScheduledPerMinute
     xpack.alerts.healthCheck.interval
     xpack.alerts.invalidateApiKeysTask.interval
     xpack.alerts.invalidateApiKeysTask.removalDelay


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ResponseOps] Some places refer to `xpack.alerting.maxScheduledPerMinute` when it should be `xpack.alerting.rules.maxScheduledPerMinute` (#213487)](https://github.com/elastic/kibana/pull/213487)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-10T17:36:53Z","message":"[ResponseOps] Some places refer to `xpack.alerting.maxScheduledPerMinute` when it should be `xpack.alerting.rules.maxScheduledPerMinute` (#213487)\n\nRelated to https://github.com/elastic/response-ops-team/issues/291\n\n## Summary\n\nThis PR updates `xpack.alerting.maxScheduledPerMinute` to be\n`xpack.alerting.rules.maxScheduledPerMinute`.","sha":"1692e9f59af3ee12b26e6bd5e510e0f54f0f3a31","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","v9.1.0","v8.19.0"],"title":"[ResponseOps] Some places refer to `xpack.alerting.maxScheduledPerMinute` when it should be `xpack.alerting.rules.maxScheduledPerMinute`","number":213487,"url":"https://github.com/elastic/kibana/pull/213487","mergeCommit":{"message":"[ResponseOps] Some places refer to `xpack.alerting.maxScheduledPerMinute` when it should be `xpack.alerting.rules.maxScheduledPerMinute` (#213487)\n\nRelated to https://github.com/elastic/response-ops-team/issues/291\n\n## Summary\n\nThis PR updates `xpack.alerting.maxScheduledPerMinute` to be\n`xpack.alerting.rules.maxScheduledPerMinute`.","sha":"1692e9f59af3ee12b26e6bd5e510e0f54f0f3a31"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213487","number":213487,"mergeCommit":{"message":"[ResponseOps] Some places refer to `xpack.alerting.maxScheduledPerMinute` when it should be `xpack.alerting.rules.maxScheduledPerMinute` (#213487)\n\nRelated to https://github.com/elastic/response-ops-team/issues/291\n\n## Summary\n\nThis PR updates `xpack.alerting.maxScheduledPerMinute` to be\n`xpack.alerting.rules.maxScheduledPerMinute`.","sha":"1692e9f59af3ee12b26e6bd5e510e0f54f0f3a31"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->