### PR TITLE
only transform legend if present

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/saved_objects/inventory_view/inventory_view_saved_object.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/saved_objects/inventory_view/inventory_view_saved_object.test.ts
@@ -57,5 +57,24 @@ describe('invetoryViewSavedObject model version transformation', () => {
       });
       expect(migrated.attributes).toEqual(inventoryViewV2.attributes);
     });
+
+    it('should return unaltered document if legend is not defined when converting from v1 to v2', () => {
+      const { legend, ...inventoryViewV2bAttributes } = inventoryViewV2.attributes;
+      const inventoryViewV1b = JSON.parse(
+        JSON.stringify({ ...inventoryViewV2, attributes: inventoryViewV2bAttributes })
+      );
+      delete inventoryViewV1b.attributes.legend;
+      const migrated = migrator.migrate({
+        document: {
+          ...inventoryViewV1b,
+          attributes: {
+            ...inventoryViewV1b.attributes,
+          },
+        },
+        fromVersion: 1,
+        toVersion: 2,
+      });
+      expect(migrated.attributes).toEqual(inventoryViewV2bAttributes);
+    });
   });
 });

--- a/x-pack/solutions/observability/plugins/infra/server/saved_objects/inventory_view/inventory_view_saved_object.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/saved_objects/inventory_view/inventory_view_saved_object.ts
@@ -59,9 +59,9 @@ export const inventoryViewSavedObjectType: SavedObjectsType = {
         {
           type: 'unsafe_transform',
           transformFn: (document) => {
-            if (document.attributes.legend.steps > 18) {
+            if (document.attributes.legend?.steps > 18) {
               document.attributes.legend.steps = 18;
-            } else if (document.attributes.legend.steps < 2) {
+            } else if (document.attributes.legend?.steps < 2) {
               document.attributes.legend.steps = 2;
             }
             return { document };


### PR DESCRIPTION
The inventory_view saved object allows the legend attribute to be optional and limits and/or sets the number of steps during an upgrade between model version 1 and 2. The transform function needs to handle cases where legend is not set to prevent migration failures.

Related to https://github.com/elastic/kibana/pull/207007

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.17","8.18","8.x","9.0"]} ONMERGE-->