### PR TITLE
chore/slo: add cursor based pagination fields to slo schema, show slo definition api

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -40792,6 +40792,16 @@ paths:
           name: kqlQuery
           schema:
             type: string
+        - description: Size provided for cursor based pagination
+          example: 25
+          in: query
+          name: size
+          schema:
+            type: integer
+        - in: query
+          name: searchAfter
+          schema:
+            type: string
         - description: The page to use for pagination, must be greater or equal than 1
           example: 1
           in: query
@@ -41215,6 +41225,69 @@ paths:
                 $ref: '#/components/schemas/SLOs_404_response'
           description: Not found response
       summary: Enable an SLO
+      tags:
+        - slo
+      x-beta: true
+  /s/{spaceId}/internal/observability/slos/_definitions:
+    get:
+      description: |
+        You must have the `read` privileges for the **SLOs** feature in the **Observability** section of the Kibana feature privileges.
+      operationId: getDefinitionsOp
+      parameters:
+        - $ref: '#/components/parameters/SLOs_kbn_xsrf'
+        - $ref: '#/components/parameters/SLOs_space_id'
+        - description: Indicates if the API returns only outdated SLO or all SLO definitions
+          example: true
+          in: query
+          name: includeOutdatedOnly
+          schema:
+            type: boolean
+        - description: Filters the SLOs by name
+          example: my service availability
+          in: query
+          name: search
+          schema:
+            type: string
+        - description: The page to use for pagination, must be greater or equal than 1
+          example: 1
+          in: query
+          name: page
+          schema:
+            type: number
+        - description: Number of SLOs returned by page
+          example: 100
+          in: query
+          name: perPage
+          schema:
+            default: 100
+            maximum: 1000
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_find_slo_definitions_response'
+          description: Successful request
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_400_response'
+          description: Bad request
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_401_response'
+          description: Unauthorized response
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_403_response'
+          description: Unauthorized response
+      summary: Get the SLO definitions
       tags:
         - slo
       x-beta: true
@@ -56614,6 +56687,25 @@ components:
           type: string
       title: FilterMeta
       type: object
+    SLOs_find_slo_definitions_response:
+      description: |
+        A paginated response of SLO definitions matching the query.
+      properties:
+        page:
+          example: 2
+          type: number
+        perPage:
+          example: 100
+          type: number
+        results:
+          items:
+            $ref: '#/components/schemas/SLOs_slo_definition_response'
+          type: array
+        total:
+          example: 123
+          type: number
+      title: Find SLO definitions response
+      type: object
     SLOs_find_slo_response:
       description: |
         A paginated response of SLOs matching the query.
@@ -56628,6 +56720,12 @@ components:
           items:
             $ref: '#/components/schemas/SLOs_slo_with_summary_response'
           type: array
+        searchAfter:
+          type: string
+        size:
+          description: Size provided for cursor based pagination
+          example: 25
+          type: number
         total:
           example: 34
           type: number

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -43656,6 +43656,16 @@ paths:
           name: kqlQuery
           schema:
             type: string
+        - description: Size provided for cursor based pagination
+          example: 25
+          in: query
+          name: size
+          schema:
+            type: integer
+        - in: query
+          name: searchAfter
+          schema:
+            type: string
         - description: The page to use for pagination, must be greater or equal than 1
           example: 1
           in: query
@@ -44071,6 +44081,68 @@ paths:
                 $ref: '#/components/schemas/SLOs_404_response'
           description: Not found response
       summary: Enable an SLO
+      tags:
+        - slo
+  /s/{spaceId}/internal/observability/slos/_definitions:
+    get:
+      description: |
+        You must have the `read` privileges for the **SLOs** feature in the **Observability** section of the Kibana feature privileges.
+      operationId: getDefinitionsOp
+      parameters:
+        - $ref: '#/components/parameters/SLOs_kbn_xsrf'
+        - $ref: '#/components/parameters/SLOs_space_id'
+        - description: Indicates if the API returns only outdated SLO or all SLO definitions
+          example: true
+          in: query
+          name: includeOutdatedOnly
+          schema:
+            type: boolean
+        - description: Filters the SLOs by name
+          example: my service availability
+          in: query
+          name: search
+          schema:
+            type: string
+        - description: The page to use for pagination, must be greater or equal than 1
+          example: 1
+          in: query
+          name: page
+          schema:
+            type: number
+        - description: Number of SLOs returned by page
+          example: 100
+          in: query
+          name: perPage
+          schema:
+            default: 100
+            maximum: 1000
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_find_slo_definitions_response'
+          description: Successful request
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_400_response'
+          description: Bad request
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_401_response'
+          description: Unauthorized response
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_403_response'
+          description: Unauthorized response
+      summary: Get the SLO definitions
       tags:
         - slo
 components:
@@ -63363,6 +63435,25 @@ components:
           type: string
       title: FilterMeta
       type: object
+    SLOs_find_slo_definitions_response:
+      description: |
+        A paginated response of SLO definitions matching the query.
+      properties:
+        page:
+          example: 2
+          type: number
+        perPage:
+          example: 100
+          type: number
+        results:
+          items:
+            $ref: '#/components/schemas/SLOs_slo_definition_response'
+          type: array
+        total:
+          example: 123
+          type: number
+      title: Find SLO definitions response
+      type: object
     SLOs_find_slo_response:
       description: |
         A paginated response of SLOs matching the query.
@@ -63377,6 +63468,12 @@ components:
           items:
             $ref: '#/components/schemas/SLOs_slo_with_summary_response'
           type: array
+        searchAfter:
+          type: string
+        size:
+          description: Size provided for cursor based pagination
+          example: 25
+          type: number
         total:
           example: 34
           type: number

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.json
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "SLOs",
     "description": "OpenAPI schema for SLOs endpoints",
-    "version": "1.0",
+    "version": "1.1",
     "contact": {
       "name": "Actionable Observability Team"
     },
@@ -130,6 +130,22 @@
               "type": "string"
             },
             "example": "slo.name:latency* and slo.tags : \"prod\""
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "example": 25,
+            "description": "Size provided for cursor based pagination"
+          },
+          {
+            "name": "searchAfter",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "page",
@@ -670,6 +686,104 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/404_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/s/{spaceId}/internal/observability/slos/_definitions": {
+      "get": {
+        "summary": "Get the SLO definitions",
+        "operationId": "getDefinitionsOp",
+        "description": "You must have the `read` privileges for the **SLOs** feature in the **Observability** section of the Kibana feature privileges.\n",
+        "tags": [
+          "slo"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          },
+          {
+            "$ref": "#/components/parameters/space_id"
+          },
+          {
+            "name": "includeOutdatedOnly",
+            "in": "query",
+            "description": "Indicates if the API returns only outdated SLO or all SLO definitions",
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Filters the SLOs by name",
+            "schema": {
+              "type": "string"
+            },
+            "example": "my service availability"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "The page to use for pagination, must be greater or equal than 1",
+            "schema": {
+              "type": "number"
+            },
+            "example": 1
+          },
+          {
+            "name": "perPage",
+            "in": "query",
+            "description": "Number of SLOs returned by page",
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 1000
+            },
+            "example": 100
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/find_slo_definitions_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/400_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/401_response"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Unauthorized response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/403_response"
                 }
               }
             }
@@ -1895,6 +2009,14 @@
         "description": "A paginated response of SLOs matching the query.\n",
         "type": "object",
         "properties": {
+          "size": {
+            "type": "number",
+            "example": 25,
+            "description": "Size provided for cursor based pagination"
+          },
+          "searchAfter": {
+            "type": "string"
+          },
           "page": {
             "type": "number",
             "example": 1
@@ -2289,6 +2411,31 @@
             "description": "The internal SLO version",
             "type": "number",
             "example": 2
+          }
+        }
+      },
+      "find_slo_definitions_response": {
+        "title": "Find SLO definitions response",
+        "description": "A paginated response of SLO definitions matching the query.\n",
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "example": 2
+          },
+          "perPage": {
+            "type": "number",
+            "example": 100
+          },
+          "total": {
+            "type": "number",
+            "example": 123
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/slo_definition_response"
+            }
           }
         }
       },

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: SLOs
   description: OpenAPI schema for SLOs endpoints
-  version: '1.0'
+  version: '1.1'
   contact:
     name: Actionable Observability Team
   license:
@@ -81,6 +81,16 @@ paths:
           schema:
             type: string
           example: 'slo.name:latency* and slo.tags : "prod"'
+        - name: size
+          in: query
+          schema:
+            type: integer
+          example: 25
+          description: Size provided for cursor based pagination
+        - name: searchAfter
+          in: query
+          schema:
+            type: string
         - name: page
           in: query
           description: The page to use for pagination, must be greater or equal than 1
@@ -410,6 +420,68 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+  /s/{spaceId}/internal/observability/slos/_definitions:
+    get:
+      summary: Get the SLO definitions
+      operationId: getDefinitionsOp
+      description: |
+        You must have the `read` privileges for the **SLOs** feature in the **Observability** section of the Kibana feature privileges.
+      tags:
+        - slo
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+        - $ref: '#/components/parameters/space_id'
+        - name: includeOutdatedOnly
+          in: query
+          description: Indicates if the API returns only outdated SLO or all SLO definitions
+          schema:
+            type: boolean
+          example: true
+        - name: search
+          in: query
+          description: Filters the SLOs by name
+          schema:
+            type: string
+          example: my service availability
+        - name: page
+          in: query
+          description: The page to use for pagination, must be greater or equal than 1
+          schema:
+            type: number
+          example: 1
+        - name: perPage
+          in: query
+          description: Number of SLOs returned by page
+          schema:
+            type: integer
+            default: 100
+            maximum: 1000
+          example: 100
+      responses:
+        '200':
+          description: Successful request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/find_slo_definitions_response'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400_response'
+        '401':
+          description: Unauthorized response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401_response'
+        '403':
+          description: Unauthorized response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/403_response'
   /s/{spaceId}/api/observability/slos/_delete_instances:
     post:
       summary: Batch delete rollup and summary data
@@ -1317,6 +1389,12 @@ components:
         A paginated response of SLOs matching the query.
       type: object
       properties:
+        size:
+          type: number
+          example: 25
+          description: Size provided for cursor based pagination
+        searchAfter:
+          type: string
         page:
           type: number
           example: 1
@@ -1589,6 +1667,25 @@ components:
           description: The internal SLO version
           type: number
           example: 2
+    find_slo_definitions_response:
+      title: Find SLO definitions response
+      description: |
+        A paginated response of SLO definitions matching the query.
+      type: object
+      properties:
+        page:
+          type: number
+          example: 2
+        perPage:
+          type: number
+          example: 100
+        total:
+          type: number
+          example: 123
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/slo_definition_response'
     delete_slo_instances_request:
       title: Delete SLO instances request
       description: |

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/find_slo_definitions_response.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/find_slo_definitions_response.yaml
@@ -2,17 +2,45 @@ title: Find SLO definitions response
 description: >
   A paginated response of SLO definitions matching the query.
 type: object
-properties:
-  page:
-    type: number
-    example: 2
-  perPage:
-    type: number
-    example: 100
-  total:
-    type: number
-    example: 123
-  results:
-    type: array
-    items:
-      $ref: 'slo_definition_response.yaml'
+oneOf:
+  - type: object
+    properties:
+      page:
+        type: number
+        example: 1
+      perPage:
+        type: number
+        example: 25
+      total:
+        type: number
+        example: 34
+      results:
+        type: array
+        items:
+          $ref: 'slo_with_summary_response.yaml'
+  - type: object
+    properties:
+      page:
+        type: number
+        default: 1
+        description: for backward compability
+      perPage:
+        type: number
+        example: 25
+        description: for backward compability
+      size:
+        type: number
+        example: 25
+      searchAfter:
+        type: array
+        items:
+          type: string
+        example: ['some-slo-id', 'other-cursor-id']
+        description: the cursor to provide to get the next paged results
+      total:
+        type: number
+        example: 34
+      results:
+        type: array
+        items:
+          $ref: 'slo_with_summary_response.yaml'

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/find_slo_response.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/find_slo_response.yaml
@@ -3,6 +3,12 @@ description: >
   A paginated response of SLOs matching the query.
 type: object
 properties:
+  size:
+    type: number
+    example: 25
+    description: Size provided for cursor based pagination
+  searchAfter:
+    type: string
   page:
     type: number
     example: 1

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/entrypoint.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/entrypoint.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: SLOs
   description: OpenAPI schema for SLOs endpoints
-  version: "1.0"
+  version: '1.1'
   contact:
     name: Actionable Observability Team
   license:
@@ -17,19 +17,19 @@ servers:
       kibana_url:
         default: localhost:5601
 paths:
-  "/s/{spaceId}/api/observability/slos":
-    $ref: "paths/s@{spaceid}@api@slos.yaml"
-  "/s/{spaceId}/api/observability/slos/{sloId}":
-    $ref: "paths/s@{spaceid}@api@slos@{sloid}.yaml"
-  "/s/{spaceId}/api/observability/slos/{sloId}/enable":
-    $ref: "paths/s@{spaceid}@api@slos@{sloid}@enable.yaml"
-  "/s/{spaceId}/api/observability/slos/{sloId}/disable":
-    $ref: "paths/s@{spaceid}@api@slos@{sloid}@disable.yaml"
-  "/s/{spaceId}/api/observability/slos/{sloId}/_reset":
-    $ref: "paths/s@{spaceid}@api@slos@{sloid}@_reset.yaml"
+  '/s/{spaceId}/api/observability/slos':
+    $ref: 'paths/s@{spaceid}@api@slos.yaml'
+  '/s/{spaceId}/api/observability/slos/{sloId}':
+    $ref: 'paths/s@{spaceid}@api@slos@{sloid}.yaml'
+  '/s/{spaceId}/api/observability/slos/{sloId}/enable':
+    $ref: 'paths/s@{spaceid}@api@slos@{sloid}@enable.yaml'
+  '/s/{spaceId}/api/observability/slos/{sloId}/disable':
+    $ref: 'paths/s@{spaceid}@api@slos@{sloid}@disable.yaml'
+  '/s/{spaceId}/api/observability/slos/{sloId}/_reset':
+    $ref: 'paths/s@{spaceid}@api@slos@{sloid}@_reset.yaml'
   # "/s/{spaceId}/internal/observability/slos/_historical_summary":
   #   $ref: "paths/s@{spaceid}@api@slos@_historical_summary.yaml"
-  # "/s/{spaceId}/internal/observability/slos/_definitions":
-  #   $ref: "paths/s@{spaceid}@api@slos@_definitions.yaml"
-  "/s/{spaceId}/api/observability/slos/_delete_instances":
-    $ref: "paths/s@{spaceid}@api@slos@_delete_instances.yaml"
+  '/s/{spaceId}/internal/observability/slos/_definitions':
+    $ref: 'paths/s@{spaceid}@api@slos@_definitions.yaml'
+  '/s/{spaceId}/api/observability/slos/_delete_instances':
+    $ref: 'paths/s@{spaceid}@api@slos@_delete_instances.yaml'

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
@@ -65,12 +65,14 @@ get:
       example: 'slo.name:latency* and slo.tags : "prod"'
     - name: size
       in: query
-      type: number
+      schema:
+        type: integer
       example: 25
       description: Size provided for cursor based pagination
     - name: searchAfter
       in: query
-      type: string
+      schema:
+        type: string
     - name: page
       in: query
       description: The page to use for pagination, must be greater or equal than 1

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
@@ -63,7 +63,7 @@ get:
       schema:
         type: string
       example: 'slo.name:latency* and slo.tags : "prod"'
-  - name: size
+    - name: size
       in: query
       description: The page size to use for cursor-based pagination, must be greater or equal than 1
       schema:

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
@@ -63,16 +63,20 @@ get:
       schema:
         type: string
       example: 'slo.name:latency* and slo.tags : "prod"'
-    - name: size
+  - name: size
       in: query
+      description: The page size to use for cursor-based pagination, must be greater or equal than 1
       schema:
         type: integer
-      example: 25
-      description: Size provided for cursor based pagination
+        default: 1
+      example: 1
     - name: searchAfter
       in: query
+      description: The cursor to use for fetching the results from, when using a cursor-base pagination.
       schema:
-        type: string
+        type: array
+        items:
+          type: string
     - name: page
       in: query
       description: The page to use for pagination, must be greater or equal than 1

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
@@ -63,6 +63,14 @@ get:
       schema:
         type: string
       example: 'slo.name:latency* and slo.tags : "prod"'
+    - name: size
+      in: query
+      type: number
+      example: 25
+      description: Size provided for cursor based pagination
+    - name: searchAfter
+      in: query
+      type: string
     - name: page
       in: query
       description: The page to use for pagination, must be greater or equal than 1


### PR DESCRIPTION
## Summary

Resolves #213238 

- Adds SLO definition API doc
- Adds fields for cursor based pagination to Find SLO docs

[bundled.json](https://github.com/user-attachments/files/19186322/bundled.json)


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->