### PR TITLE
[9.0] [Automatic Import] Fixes the CSV header bug (#212513)

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/server/graphs/csv/csv.test.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/graphs/csv/csv.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { IScopedClusterClient } from '@kbn/core/server';
+import { handleCSV } from './csv';
+import { ESProcessorItem } from '../../../common';
+import { DocTemplate } from '../../util/pipeline';
+
+interface SimpleCSVPipelineSimulationParams {
+  pipeline: { processors: ESProcessorItem[] };
+  docs: DocTemplate[];
+}
+
+/**
+ * Simulates processing a list of documents with a defined pipeline of processors,
+ * specifically handling 'csv' and 'drop' processors in the way they are used in our CSV processing.
+ *
+ * @param params - An object containing the pipeline of processors and the documents to be transformed.
+ * @returns An object containing the processed list of documents after all processors in the pipeline have been applied.
+ */
+export const simpleCSVPipelineSimulation = (
+  params: SimpleCSVPipelineSimulationParams
+): { docs: Array<{ doc: DocTemplate }> } => {
+  const { pipeline, docs } = params;
+  for (const processor of pipeline.processors) {
+    if ('remove' in processor) {
+      // do nothing
+    } else if ('csv' in processor) {
+      // Not a real CSV parser, of course. It only handles the "json.*" field names.
+      const fields = processor.csv.target_fields as string[];
+      for (const doc of docs) {
+        const message = doc._source.message;
+        const values = message.split(',');
+        const unpacked: Record<string, unknown> = {};
+        for (let i = 0; i < fields.length; i++) {
+          const field = fields[i].startsWith('json.') ? fields[i].slice(5) : fields[i];
+          // The only error it handles is: CSV value starts with " and does not end with ".
+          if (values[i].startsWith('"') && !values[i].endsWith('"')) {
+            throw new Error('Mismatched quote');
+          }
+          unpacked[field] = values[i].startsWith('"') ? values[i].slice(1, -1) : values[i];
+        }
+        // eslint-disable-next-line dot-notation
+        doc._source['json'] = unpacked;
+      }
+    } else if ('drop' in processor) {
+      docs.shift();
+    } else {
+      throw new Error('Unknown processor');
+    }
+  }
+  return { docs: docs.map((doc) => ({ doc })) };
+};
+
+describe('handleCSV', () => {
+  const mockClient = {
+    asCurrentUser: {
+      ingest: {
+        simulate: simpleCSVPipelineSimulation,
+      },
+    },
+  } as unknown as IScopedClusterClient;
+
+  it('should successfully parse valid CSV logs without header', async () => {
+    const mockParams = {
+      state: {
+        packageName: 'testPackage',
+        dataStreamName: 'testDataStream',
+        logSamples: ['123,"string",456', '"123",Some Value,"456"'],
+        samplesFormat: {
+          columns: [],
+          header: false,
+        },
+        additionalProcessors: [],
+      },
+      client: mockClient,
+    };
+
+    const result = await handleCSV(mockParams);
+    expect(result.jsonSamples).toBeDefined();
+    expect(result.additionalProcessors).toHaveLength(1); // Must be CSV and drop processor
+    if (!result.additionalProcessors) {
+      fail('additionalProcessors is undefined, logic error after expectation');
+    }
+
+    const csvProcessor = result.additionalProcessors[0].csv;
+    expect(csvProcessor).toBeDefined();
+    expect(csvProcessor.target_fields).toEqual([
+      'testPackage.testDataStream.column1',
+      'testPackage.testDataStream.column2',
+      'testPackage.testDataStream.column3',
+    ]);
+    expect(result.jsonSamples).toEqual([
+      '{"column1":"123","column2":"string","column3":"456"}',
+      '{"column1":"123","column2":"Some Value","column3":"456"}',
+    ]);
+    expect(result.lastExecutedChain).toBe('handleCSV');
+  });
+
+  it('should successfully parse valid CSV logs with header', async () => {
+    const mockParams = {
+      state: {
+        packageName: 'testPackage',
+        dataStreamName: 'testDataStream',
+        logSamples: ['header1,header2,header3', 'value1,value2,value3'],
+        samplesFormat: {
+          columns: ['first column', 'second column'],
+          header: true,
+        },
+        additionalProcessors: [],
+      },
+      client: mockClient,
+    };
+
+    const result = await handleCSV(mockParams);
+    expect(result.jsonSamples).toBeDefined();
+    expect(result.additionalProcessors).toHaveLength(2); // Must be CSV and drop processor
+    if (!result.additionalProcessors) {
+      fail('additionalProcessors is undefined, logic error after expectation');
+    }
+    const csvProcessor = result.additionalProcessors[0].csv;
+    expect(csvProcessor).toBeDefined();
+    expect(csvProcessor.target_fields).toEqual([
+      'testPackage.testDataStream.first_column',
+      'testPackage.testDataStream.second_column',
+      'testPackage.testDataStream.header3',
+    ]);
+    const dropProcessor = result.additionalProcessors[1].drop;
+    expect(dropProcessor).toBeDefined();
+    expect(dropProcessor.if).toContain('header1'); // column value, not column name!
+    expect(result.lastExecutedChain).toBe('handleCSV');
+  });
+
+  it('should throw UnparseableCSVFormatError when CSV parsing fails', async () => {
+    const mockParams = {
+      state: {
+        packageName: 'testPackage',
+        dataStreamName: 'testDataStream',
+        // Intentionally malformed according to our simple CSV parser
+        logSamples: ['header1,header2', '"values...'],
+        samplesFormat: {
+          columns: ['col1', 'col2'],
+          header: true,
+        },
+        additionalProcessors: [],
+      },
+      client: mockClient,
+    };
+    await expect(handleCSV(mockParams)).rejects.toThrow('unparseable-csv-data');
+  });
+});

--- a/x-pack/platform/plugins/shared/automatic_import/server/graphs/log_type_detection/graph.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/graphs/log_type_detection/graph.ts
@@ -126,7 +126,7 @@ export async function getLogFormatDetectionGraph({ model, client }: LogDetection
       'handleUnstructuredGraph',
       (await getUnstructuredGraph({ model, client })).withConfig({ runName: 'Unstructured' })
     )
-    .addNode('handleCSV', (state: LogFormatDetectionState) => handleCSV({ state, model, client }))
+    .addNode('handleCSV', (state: LogFormatDetectionState) => handleCSV({ state, client }))
     .addEdge(START, 'modelInput')
     .addEdge('modelInput', 'handleLogFormatDetection')
     .addEdge('handleKVGraph', 'modelOutput')

--- a/x-pack/platform/plugins/shared/automatic_import/server/util/fields.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/util/fields.ts
@@ -23,3 +23,13 @@ export type FieldPath = string[];
 export function fieldPathToProcessorString(fieldPath: FieldPath): string {
   return fieldPath.join('.');
 }
+
+/**
+ * Converts a string representing a processor's path into a field path array.
+ *
+ * @param processorString - The dotted string to convert
+ * @returns An array of path segments representing the field path
+ */
+export function processorStringToFieldPath(processorString: string): FieldPath {
+  return processorString.split('.');
+}

--- a/x-pack/platform/plugins/shared/automatic_import/server/util/pipeline.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/util/pipeline.ts
@@ -8,11 +8,12 @@ import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import { ESProcessorItem } from '../../common';
 import { createPassthroughFailureProcessor, createRemoveProcessor } from './processors';
 
-interface DocTemplate {
+export interface DocTemplate {
   _index: string;
   _id: string;
   _source: {
     message: string;
+    [key: string]: unknown;
   };
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Automatic Import] Fixes the CSV header bug (#212513)](https://github.com/elastic/kibana/pull/212513)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ilya Nikokoshev","email":"ilya.nikokoshev@elastic.co"},"sourceCommit":{"committedDate":"2025-02-28T14:31:56Z","message":"[Automatic Import] Fixes the CSV header bug (#212513)\n\nFixes https://github.com/elastic/kibana/issues/211911\n\nThe CSV processing is now a three-stage process: \n\n1. Parse the samples with the temporary column names of the form\n`column1`.\n2. Test parsing with the actual pipeline that parses into\n`package.dataStream.columnName`.\n3. Convert the samples into JSON form `{\"columnName\": \"value\", ...}` for\nfurther processing.\n\nNow the pipeline works as expected:\n\n```yaml\n  - csv:\n      tag: parse_csv\n      field: message\n      target_fields:\n        - ai_202502211453.logs._timestamp\n        - ai_202502211453.logs.message\n      description: Parse CSV input\n  - drop:\n      ignore_failure: true\n      if: >-\n        ctx.ai_202502211453?.logs?._timestamp == '@timestamp' &&\n        ctx.ai_202502211453?.logs?.message == 'message'\n      tag: remove_csv_header\n      description: Remove the CSV header line by comparing the values\n```\n\nThere are unit tests tests for the CSV functionality that include a mock\nCSV processing pipeline.","sha":"ab46ddeef239eceed26ef6777e77f58a365c6f6c","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","backport:prev-major","v9.1.0"],"title":"[Automatic Import] Fixes the CSV header bug","number":212513,"url":"https://github.com/elastic/kibana/pull/212513","mergeCommit":{"message":"[Automatic Import] Fixes the CSV header bug (#212513)\n\nFixes https://github.com/elastic/kibana/issues/211911\n\nThe CSV processing is now a three-stage process: \n\n1. Parse the samples with the temporary column names of the form\n`column1`.\n2. Test parsing with the actual pipeline that parses into\n`package.dataStream.columnName`.\n3. Convert the samples into JSON form `{\"columnName\": \"value\", ...}` for\nfurther processing.\n\nNow the pipeline works as expected:\n\n```yaml\n  - csv:\n      tag: parse_csv\n      field: message\n      target_fields:\n        - ai_202502211453.logs._timestamp\n        - ai_202502211453.logs.message\n      description: Parse CSV input\n  - drop:\n      ignore_failure: true\n      if: >-\n        ctx.ai_202502211453?.logs?._timestamp == '@timestamp' &&\n        ctx.ai_202502211453?.logs?.message == 'message'\n      tag: remove_csv_header\n      description: Remove the CSV header line by comparing the values\n```\n\nThere are unit tests tests for the CSV functionality that include a mock\nCSV processing pipeline.","sha":"ab46ddeef239eceed26ef6777e77f58a365c6f6c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212513","number":212513,"mergeCommit":{"message":"[Automatic Import] Fixes the CSV header bug (#212513)\n\nFixes https://github.com/elastic/kibana/issues/211911\n\nThe CSV processing is now a three-stage process: \n\n1. Parse the samples with the temporary column names of the form\n`column1`.\n2. Test parsing with the actual pipeline that parses into\n`package.dataStream.columnName`.\n3. Convert the samples into JSON form `{\"columnName\": \"value\", ...}` for\nfurther processing.\n\nNow the pipeline works as expected:\n\n```yaml\n  - csv:\n      tag: parse_csv\n      field: message\n      target_fields:\n        - ai_202502211453.logs._timestamp\n        - ai_202502211453.logs.message\n      description: Parse CSV input\n  - drop:\n      ignore_failure: true\n      if: >-\n        ctx.ai_202502211453?.logs?._timestamp == '@timestamp' &&\n        ctx.ai_202502211453?.logs?.message == 'message'\n      tag: remove_csv_header\n      description: Remove the CSV header line by comparing the values\n```\n\nThere are unit tests tests for the CSV functionality that include a mock\nCSV processing pipeline.","sha":"ab46ddeef239eceed26ef6777e77f58a365c6f6c"}}]}] BACKPORT-->