### PR TITLE
[8.18] [Security Assistant] Fix timeout during Knowledge Base setup (#213738)

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/index.ts
@@ -178,11 +178,11 @@ export class AIAssistantKnowledgeBaseDataClient extends AIAssistantDataClient {
       if (elasticsearchInference) {
         return ASSISTANT_ELSER_INFERENCE_ID;
       }
-    } catch (error) {
+    } catch (_) {
       /* empty */
     }
 
-    // Fallback to the dedicated inference endpoint
+    // Fallback to the default inference endpoint
     return ELASTICSEARCH_ELSER_INFERENCE_ID;
   };
 
@@ -409,7 +409,7 @@ export class AIAssistantKnowledgeBaseDataClient extends AIAssistantDataClient {
             (await this.isModelInstalled())
               ? Promise.resolve()
               : Promise.reject(new Error('Model not installed')),
-          { minTimeout: 30000, maxTimeout: 30000, retries: 10 }
+          { minTimeout: 30000, maxTimeout: 30000, retries: 20 }
         );
         this.options.logger.debug(`ELSER model '${elserId}' successfully installed!`);
       } else {
@@ -453,7 +453,10 @@ export class AIAssistantKnowledgeBaseDataClient extends AIAssistantDataClient {
           }
 
           this.options.logger.debug(`Loading Security Labs KB docs...`);
-          void loadSecurityLabs(this, this.options.logger);
+
+          void loadSecurityLabs(this, this.options.logger)?.then(() => {
+            this.options.setIsKBSetupInProgress(this.spaceId, false);
+          });
         } else {
           this.options.logger.debug(`Security Labs Knowledge Base docs already loaded!`);
         }

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/knowledge_base/post_knowledge_base.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/knowledge_base/post_knowledge_base.ts
@@ -19,7 +19,7 @@ import { ElasticAssistantPluginRouter } from '../../types';
 
 // Since we're awaiting on ELSER setup, this could take a bit (especially if ML needs to autoscale)
 // Consider just returning if attempt was successful, and switch to client polling
-const ROUTE_HANDLER_TIMEOUT = 10 * 60 * 1000; // 10 * 60 seconds = 10 minutes
+const ROUTE_HANDLER_TIMEOUT = 20 * 60 * 1000; // 20 * 60 seconds = 20 minutes
 
 /**
  * Load Knowledge Base index, pipeline, and resources (collection of documents)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security Assistant] Fix timeout during Knowledge Base setup (#213738)](https://github.com/elastic/kibana/pull/213738)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patryk Kopyciński","email":"contact@patrykkopycinski.com"},"sourceCommit":{"committedDate":"2025-03-11T01:30:44Z","message":"[Security Assistant] Fix timeout during Knowledge Base setup (#213738)\n\n## Summary\n\nCluster with autoscaling for ML nodes can take couple minutes to\nproperly allocate ML node on Cloud, so increasing timeout by 10min\nshould improve the UX and make the process more streamlined.\n\nHowever it's still just arbitrary value, so in the future we should\nthink about more reliable solution","sha":"0b77522dc1db45c1fd43f83165407a5cd0899ad4","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","v9.0.0","ci:cloud-deploy","ci:project-deploy-security","ci:cloud-deploy-elser","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Security Assistant] Fix timeout during Knowledge Base setup","number":213738,"url":"https://github.com/elastic/kibana/pull/213738","mergeCommit":{"message":"[Security Assistant] Fix timeout during Knowledge Base setup (#213738)\n\n## Summary\n\nCluster with autoscaling for ML nodes can take couple minutes to\nproperly allocate ML node on Cloud, so increasing timeout by 10min\nshould improve the UX and make the process more streamlined.\n\nHowever it's still just arbitrary value, so in the future we should\nthink about more reliable solution","sha":"0b77522dc1db45c1fd43f83165407a5cd0899ad4"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213738","number":213738,"mergeCommit":{"message":"[Security Assistant] Fix timeout during Knowledge Base setup (#213738)\n\n## Summary\n\nCluster with autoscaling for ML nodes can take couple minutes to\nproperly allocate ML node on Cloud, so increasing timeout by 10min\nshould improve the UX and make the process more streamlined.\n\nHowever it's still just arbitrary value, so in the future we should\nthink about more reliable solution","sha":"0b77522dc1db45c1fd43f83165407a5cd0899ad4"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213853","number":213853,"state":"OPEN"}]}] BACKPORT-->