### PR TITLE
[8.16] [ResponseOps][Connectors] Fix bug with OAuth form in the ServiceNow connector (#213658)

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/api.test.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/api.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { httpServiceMock } from '@kbn/core/public/mocks';
-import { getChoices, getAppInfo } from './api';
+import { getChoices, getAppInfo, getOAuthToken } from './api';
 import { ServiceNowActionConnector } from './types';
 
 const choicesResponse = {
@@ -123,6 +123,7 @@ describe('ServiceNow API', () => {
       expect(res).toEqual(applicationInfoData.result);
 
       expect(http.post).toHaveBeenCalledWith('/internal/actions/connector/_oauth_access_token', {
+        signal: abortCtrl.signal,
         body: JSON.stringify({
           type: 'jwt',
           options: {
@@ -160,6 +161,7 @@ describe('ServiceNow API', () => {
 
       expect(res).toEqual(applicationInfoData.result);
       expect(http.post).toHaveBeenCalledWith('/internal/actions/connector/_oauth_access_token', {
+        signal: abortCtrl.signal,
         body: JSON.stringify({
           type: 'jwt',
           options: {
@@ -245,6 +247,71 @@ describe('ServiceNow API', () => {
           http,
         })
       ).rejects.toThrow('bad');
+    });
+  });
+
+  describe('getOAuthToken', () => {
+    it('should call the API correctly', async () => {
+      const abortCtrl = new AbortController();
+      http.post.mockResolvedValueOnce(oAuthResponse);
+
+      const res = await getOAuthToken({
+        signal: abortCtrl.signal,
+        connector: oAuthConnector,
+        http,
+      });
+
+      expect(res).toEqual(oAuthResponse);
+
+      expect(http.post).toHaveBeenCalledWith('/internal/actions/connector/_oauth_access_token', {
+        signal: abortCtrl.signal,
+        body: JSON.stringify({
+          type: 'jwt',
+          options: {
+            tokenUrl: 'https://example.com/oauth_token.do',
+            config: {
+              clientId: 'clientId',
+              userIdentifierValue: 'userIdentifierValue',
+              jwtKeyId: 'jwtKeyId',
+            },
+            secrets: { clientSecret: 'test', privateKey: 'test' },
+          },
+        }),
+      });
+    });
+
+    it('should construct the error correctly when body is defined', async () => {
+      expect.assertions(1);
+      const abortCtrl = new AbortController();
+      const error = new Error('my error message');
+      // @ts-expect-error
+      error.body = { statusCode: 400, error: 'body error', message: 'body error message' };
+
+      http.post.mockRejectedValueOnce(error);
+
+      await expect(() =>
+        getOAuthToken({
+          signal: abortCtrl.signal,
+          connector: basicAuthConnector,
+          http,
+        })
+      ).rejects.toThrow('400 body error: body error message');
+    });
+
+    it('should construct the error correctly when body is undefined', async () => {
+      expect.assertions(1);
+      const abortCtrl = new AbortController();
+      const error = new Error('my error message');
+
+      http.post.mockRejectedValueOnce(error);
+
+      await expect(() =>
+        getOAuthToken({
+          signal: abortCtrl.signal,
+          connector: basicAuthConnector,
+          http,
+        })
+      ).rejects.toThrow('my error message');
     });
   });
 });

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/auth_types/oauth.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/auth_types/oauth.tsx
@@ -38,6 +38,7 @@ const OAuthComponent: React.FC<Props> = ({ isLoading, readOnly, pathPrefix = '' 
           ],
         }}
         componentProps={{
+          id: 'clientId',
           euiFieldProps: {
             'data-test-subj': 'connector-servicenow-client-id-form-input',
             readOnly,
@@ -58,6 +59,7 @@ const OAuthComponent: React.FC<Props> = ({ isLoading, readOnly, pathPrefix = '' 
           ],
         }}
         componentProps={{
+          id: 'userIdentifierValue',
           euiFieldProps: {
             'data-test-subj': 'connector-servicenow-user-identifier-form-input',
             readOnly,
@@ -78,6 +80,7 @@ const OAuthComponent: React.FC<Props> = ({ isLoading, readOnly, pathPrefix = '' 
           ],
         }}
         componentProps={{
+          id: 'jwtKeyId',
           euiFieldProps: {
             'data-test-subj': 'connector-servicenow-jwt-key-id-form-input',
             readOnly,
@@ -98,6 +101,7 @@ const OAuthComponent: React.FC<Props> = ({ isLoading, readOnly, pathPrefix = '' 
         }}
         component={PasswordField}
         componentProps={{
+          id: 'clientSecret',
           euiFieldProps: {
             'data-test-subj': 'connector-servicenow-client-secret-form-input',
             isLoading,
@@ -118,6 +122,7 @@ const OAuthComponent: React.FC<Props> = ({ isLoading, readOnly, pathPrefix = '' 
           ],
         }}
         componentProps={{
+          id: 'privateKey',
           euiFieldProps: {
             readOnly,
             'data-test-subj': 'connector-servicenow-private-key-form-input',
@@ -134,6 +139,7 @@ const OAuthComponent: React.FC<Props> = ({ isLoading, readOnly, pathPrefix = '' 
         }}
         component={PasswordField}
         componentProps={{
+          id: 'privateKeyPassword',
           euiFieldProps: {
             'data-test-subj': 'connector-servicenow-private-key-password-form-input',
             isLoading,

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/cors_error.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/cors_error.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export class CORSError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CORSError';
+  }
+}

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/credentials.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/credentials.tsx
@@ -48,6 +48,7 @@ const CredentialsComponent: React.FC<Props> = ({ readOnly, isLoading, isOAuth })
           euiFieldProps: {
             label: i18n.IS_OAUTH,
             disabled: readOnly,
+            'data-test-subj': 'use-oauth-switch',
           },
         }}
       />

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/error_callout.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/error_callout.test.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ErrorCallout } from './error_callout';
+
+describe('ErrorCallout', () => {
+  it('renders the callout', () => {
+    render(<ErrorCallout message={'My error message'} />);
+
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText('My error message')).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/error_callout.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/error_callout.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo } from 'react';
+import { EuiSpacer, EuiCallOut } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+const ERROR_MESSAGE = i18n.translate(
+  'xpack.stackConnectors.components.serviceNow.errorCallout.errorTitle',
+  {
+    defaultMessage: 'Error',
+  }
+);
+
+interface Props {
+  message: string | null;
+}
+
+const ErrorCalloutComponent: React.FC<Props> = ({ message }) => {
+  return (
+    <>
+      <EuiSpacer size="s" />
+      <EuiCallOut
+        size="m"
+        iconType="warning"
+        data-test-subj="errorCallout"
+        color="danger"
+        title={ERROR_MESSAGE}
+      >
+        <p>{message}</p>
+      </EuiCallOut>
+      <EuiSpacer size="m" />
+    </>
+  );
+};
+
+export const ErrorCallout = memo(ErrorCalloutComponent);

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/helpers.test.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/helpers.test.ts
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
+import { CORSError } from './cors_error';
 import {
   isRESTApiError,
   isFieldInvalid,
   getConnectorDescriptiveTitle,
   getSelectedConnectorIcon,
+  isCORSError,
 } from './helpers';
 import { ActionConnector } from '@kbn/triggers-actions-ui-plugin/public/types';
 
@@ -48,6 +50,17 @@ describe('helpers', () => {
     test('should return false if there is no error', async () => {
       // @ts-expect-error
       expect(isRESTApiError({ whatever: 'test' })).toBeFalsy();
+    });
+  });
+
+  describe('isCORSError', () => {
+    test('should return true if the error is CORSError', () => {
+      const error = new CORSError('cors error');
+      expect(isCORSError(error)).toBeTruthy();
+    });
+
+    test('should return false if there is no error', () => {
+      expect(isCORSError(new Error())).toBeFalsy();
     });
   });
 

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/helpers.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/helpers.ts
@@ -13,6 +13,7 @@ import {
   IErrorObject,
 } from '@kbn/triggers-actions-ui-plugin/public';
 import { AppInfo, Choice, RESTApiError } from './types';
+import { CORSError } from './cors_error';
 
 export const DEFAULT_CORRELATION_ID = '{{rule.id}}:{{alert.id}}';
 
@@ -24,6 +25,8 @@ export const choicesToEuiOptions = (choices: Choice[]): EuiSelectOption[] =>
 export const isRESTApiError = (res: AppInfo | RESTApiError | undefined): res is RESTApiError =>
   res != null &&
   ((res as RESTApiError).error != null || (res as RESTApiError).status === 'failure');
+
+export const isCORSError = (error: unknown): error is CORSError => error instanceof CORSError;
 
 export const isFieldInvalid = (
   field: string | undefined | null,

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/servicenow_connectors.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/servicenow_connectors.test.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { act, within, render, screen, waitFor } from '@testing-library/react';
 
 import { ConnectorValidationFunc } from '@kbn/triggers-actions-ui-plugin/public/types';
@@ -23,6 +23,13 @@ jest.mock('./api');
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 const getAppInfoMock = getAppInfo as jest.Mock;
 const updateActionConnectorMock = updateActionConnector as jest.Mock;
+
+type PreSubmitValidatorRes =
+  | {
+      message: ReactNode;
+    }
+  | undefined
+  | void;
 
 describe('ServiceNowActionConnectorFields renders', () => {
   const usesTableApiConnector = {
@@ -302,7 +309,11 @@ describe('ServiceNowActionConnectorFields renders', () => {
         </ConnectorFormTestProvider>
       );
 
-      const res = await act(async () => preSubmitValidator());
+      let res: PreSubmitValidatorRes;
+
+      await act(async () => {
+        res = await preSubmitValidator();
+      });
 
       expect(getAppInfoMock).toHaveBeenCalledTimes(1);
 
@@ -326,7 +337,11 @@ describe('ServiceNowActionConnectorFields renders', () => {
         </ConnectorFormTestProvider>
       );
 
-      const res = await act(async () => preSubmitValidator());
+      let res: PreSubmitValidatorRes;
+
+      await act(async () => {
+        res = await preSubmitValidator();
+      });
 
       expect(getAppInfoMock).toHaveBeenCalledTimes(1);
 
@@ -352,7 +367,11 @@ describe('ServiceNowActionConnectorFields renders', () => {
         </ConnectorFormTestProvider>
       );
 
-      const res = await act(async () => preSubmitValidator());
+      let res: PreSubmitValidatorRes;
+
+      await act(async () => {
+        res = await preSubmitValidator();
+      });
 
       expect(getAppInfoMock).toHaveBeenCalledTimes(1);
 

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/use_get_app_info.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/use_get_app_info.test.tsx
@@ -11,6 +11,7 @@ import { useGetAppInfo, UseGetAppInfo, UseGetAppInfoProps } from './use_get_app_
 import { getAppInfo } from './api';
 import { ServiceNowActionConnector } from './types';
 import { httpServiceMock } from '@kbn/core/public/mocks';
+import { CORSError } from './cors_error';
 
 jest.mock('./api');
 jest.mock('@kbn/triggers-actions-ui-plugin/public/common/lib/kibana');
@@ -100,8 +101,8 @@ describe('useGetAppInfo', () => {
     ).rejects.toThrow('An error occurred');
   });
 
-  it('it throws an error when fetch fails', async () => {
-    expect.assertions(1);
+  it('it throws a CORS error on CORS errors', async () => {
+    expect.assertions(2);
     getAppInfoMock.mockImplementation(() => {
       const error = new Error('An error occurred');
       error.name = 'TypeError';
@@ -115,12 +116,15 @@ describe('useGetAppInfo', () => {
       })
     );
 
-    await expect(() =>
-      act(async () => {
+    try {
+      await act(async () => {
         await result.current.fetchAppInfo(actionConnector);
-      })
-    ).rejects.toThrow(
-      'Failed to fetch. Check the URL or the CORS configuration of your ServiceNow instance.'
-    );
+      });
+    } catch (e) {
+      expect(e).toBeInstanceOf(CORSError);
+      expect(e.message).toBe(
+        'Failed to fetch. Check the URL or the CORS configuration of your ServiceNow instance.'
+      );
+    }
   });
 });

--- a/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/use_get_app_info.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/lib/servicenow/use_get_app_info.tsx
@@ -11,6 +11,7 @@ import { HttpStart } from '@kbn/core/public';
 import { getAppInfo } from './api';
 import { AppInfo, RESTApiError, ServiceNowActionConnector } from './types';
 import { FETCH_ERROR } from './translations';
+import { CORSError } from './cors_error';
 
 export interface UseGetAppInfoProps {
   actionTypeId?: string;
@@ -66,7 +67,7 @@ export const useGetAppInfo = ({ actionTypeId, http }: UseGetAppInfoProps): UseGe
          * in the ServiceNow instance is needed by our ServiceNow applications.
          */
         if (error.name === 'TypeError') {
-          throw new Error(FETCH_ERROR);
+          throw new CORSError(FETCH_ERROR);
         }
 
         throw error;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[ResponseOps][Connectors] Fix bug with OAuth form in the ServiceNow connector (#213658)](https://github.com/elastic/kibana/pull/213658)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Christos Nasikas","email":"christos.nasikas@elastic.co"},"sourceCommit":{"committedDate":"2025-03-10T18:53:48Z","message":"[ResponseOps][Connectors] Fix bug with OAuth form in the ServiceNow connector (#213658)\n\n## Summary\n\nThis PR fixes a bug where users could not create a ServiceNow connector\nwith OAuth configuration. In addition to the fix, I decided to improve\nthe error messages and show the callout to install our SN applications\nonly on CORS errors. The rest of the errors will be shown on a generic\nerror callout.\n\n<img width=\"1246\" alt=\"Screenshot 2025-03-08 at 1 54 56 PM\"\nsrc=\"https://github.com/user-attachments/assets/5dac9662-be9b-474a-a0ca-d6d1a14baa53\"\n/>\n<img width=\"1248\" alt=\"Screenshot 2025-03-08 at 1 55 16 PM\"\nsrc=\"https://github.com/user-attachments/assets/fc548263-ebd3-4ce6-aac1-725236b626b5\"\n/>\n\n\nFixes: https://github.com/elastic/kibana/issues/212790\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n## Release notes\nFix a bug with ServiceNow where users could not create the connector\nfrom the UI form using OAuth.","sha":"2839562b8a7c8016582cbb0d5fc35e2a71cdaccf","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:ResponseOps","v9.0.0","Feature:Actions/ConnectorTypes","backport:version","v8.18.0","v9.1.0","v8.19.0","v8.16.6","v8.17.4"],"title":"[ResponseOps][Connectors] Fix bug with OAuth form in the ServiceNow connector","number":213658,"url":"https://github.com/elastic/kibana/pull/213658","mergeCommit":{"message":"[ResponseOps][Connectors] Fix bug with OAuth form in the ServiceNow connector (#213658)\n\n## Summary\n\nThis PR fixes a bug where users could not create a ServiceNow connector\nwith OAuth configuration. In addition to the fix, I decided to improve\nthe error messages and show the callout to install our SN applications\nonly on CORS errors. The rest of the errors will be shown on a generic\nerror callout.\n\n<img width=\"1246\" alt=\"Screenshot 2025-03-08 at 1 54 56 PM\"\nsrc=\"https://github.com/user-attachments/assets/5dac9662-be9b-474a-a0ca-d6d1a14baa53\"\n/>\n<img width=\"1248\" alt=\"Screenshot 2025-03-08 at 1 55 16 PM\"\nsrc=\"https://github.com/user-attachments/assets/fc548263-ebd3-4ce6-aac1-725236b626b5\"\n/>\n\n\nFixes: https://github.com/elastic/kibana/issues/212790\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n## Release notes\nFix a bug with ServiceNow where users could not create the connector\nfrom the UI form using OAuth.","sha":"2839562b8a7c8016582cbb0d5fc35e2a71cdaccf"}},"sourceBranch":"main","suggestedTargetBranches":["8.16","8.17"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213818","number":213818,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213816","number":213816,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213658","number":213658,"mergeCommit":{"message":"[ResponseOps][Connectors] Fix bug with OAuth form in the ServiceNow connector (#213658)\n\n## Summary\n\nThis PR fixes a bug where users could not create a ServiceNow connector\nwith OAuth configuration. In addition to the fix, I decided to improve\nthe error messages and show the callout to install our SN applications\nonly on CORS errors. The rest of the errors will be shown on a generic\nerror callout.\n\n<img width=\"1246\" alt=\"Screenshot 2025-03-08 at 1 54 56 PM\"\nsrc=\"https://github.com/user-attachments/assets/5dac9662-be9b-474a-a0ca-d6d1a14baa53\"\n/>\n<img width=\"1248\" alt=\"Screenshot 2025-03-08 at 1 55 16 PM\"\nsrc=\"https://github.com/user-attachments/assets/fc548263-ebd3-4ce6-aac1-725236b626b5\"\n/>\n\n\nFixes: https://github.com/elastic/kibana/issues/212790\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n## Release notes\nFix a bug with ServiceNow where users could not create the connector\nfrom the UI form using OAuth.","sha":"2839562b8a7c8016582cbb0d5fc35e2a71cdaccf"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213817","number":213817,"state":"OPEN"},{"branch":"8.16","label":"v8.16.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->