### PR TITLE
[Synthetics] Fix UI issue on Last test run panel and changed breadcrumb string when creating a monitor

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
@@ -25,7 +25,6 @@ import {
   EuiTextProps,
   EuiTitle,
   useEuiTheme,
-  useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import { EuiThemeComputed } from '@elastic/eui/src/services/theme/types';
 
@@ -105,7 +104,6 @@ export const BrowserStepsList = ({
   const { euiTheme } = useEuiTheme();
   const [expandedMap, setExpandedMap] = useState<Record<string, ReactElement>>(defaultExpanded);
   const [stepIds, setStepIds] = useState<string>(mapStepIds(stepEnds));
-  const isTabletOrGreater = useIsWithinMinBreakpoint('s');
 
   useEffect(() => {
     /**
@@ -284,35 +282,32 @@ export const BrowserStepsList = ({
   ];
 
   return (
-    <>
-      <EuiBasicTable
-        css={{ overflowX: isTabletOrGreater ? 'auto' : undefined }}
-        cellProps={(row) => {
-          if (expandedMap[row._id]) {
-            return {
-              style: { verticalAlign: 'top' },
-            };
-          }
-        }}
-        compressed={compressed}
-        loading={loading}
-        columns={columns}
-        error={error?.message}
-        items={stepEnds}
-        noItemsMessage={
-          loading
-            ? i18n.translate('xpack.synthetics.monitor.step.loading', {
-                defaultMessage: 'Loading steps...',
-              })
-            : i18n.translate('xpack.synthetics.monitor.step.noDataFound', {
-                defaultMessage: 'No data found',
-              })
+    <EuiBasicTable
+      cellProps={(row) => {
+        if (expandedMap[row._id]) {
+          return {
+            style: { verticalAlign: 'top' },
+          };
         }
-        tableLayout="auto"
-        itemId="_id"
-        itemIdToExpandedRowMap={testNowMode || showExpand ? expandedMap : undefined}
-      />
-    </>
+      }}
+      compressed={compressed}
+      loading={loading}
+      columns={columns}
+      error={error?.message}
+      items={stepEnds}
+      noItemsMessage={
+        loading
+          ? i18n.translate('xpack.synthetics.monitor.step.loading', {
+              defaultMessage: 'Loading steps...',
+            })
+          : i18n.translate('xpack.synthetics.monitor.step.noDataFound', {
+              defaultMessage: 'No data found',
+            })
+      }
+      tableLayout="auto"
+      itemId="_id"
+      itemIdToExpandedRowMap={testNowMode || showExpand ? expandedMap : undefined}
+    />
   );
 };
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details.tsx
@@ -31,8 +31,8 @@ export const ResultDetails = ({
 }) => {
   return (
     <div>
+      <StatusBadge status={parseBadgeStatus(pingStatus)} />
       <EuiText size="s">
-        <StatusBadge status={parseBadgeStatus(pingStatus)} />{' '}
         {!testNowMode
           ? i18n.translate('xpack.synthetics.step.duration.label', {
               defaultMessage: 'after {value}',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details.tsx
@@ -31,7 +31,7 @@ export const ResultDetails = ({
 }) => {
   return (
     <div>
-      <EuiText className="eui-textNoWrap" size="s">
+      <EuiText size="s">
         <StatusBadge status={parseBadgeStatus(pingStatus)} />{' '}
         {!testNowMode
           ? i18n.translate('xpack.synthetics.step.duration.label', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.ts
@@ -30,7 +30,7 @@ export const useMonitorAddEditBreadcrumbs = (isEdit?: boolean) => {
 export const ADD_MONITOR_CRUMB = i18n.translate(
   'xpack.synthetics.monitorManagement.addMonitorCrumb',
   {
-    defaultMessage: 'Add monitor',
+    defaultMessage: 'Create monitor',
   }
 );
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -67,13 +67,13 @@ export const MonitorSummary = () => {
       />
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="m" wrap={true}>
-        <EuiFlexItem css={{ minWidth: 500, maxWidth: 500 }}>
+        <EuiFlexItem css={{ minWidth: 430 }}>
           <LastTestRun />
         </EuiFlexItem>
         <EuiFlexItem css={{ minWidth: 260 }}>
           <MonitorAlerts dateLabel={dateLabel} from={from} to={to} />
           <EuiSpacer size="m" />
-          <StepDurationPanel />
+          <StepDurationPanel legendPosition="bottom" />
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -10,7 +10,6 @@ import { EuiTitle, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiSpacer } fro
 import { i18n } from '@kbn/i18n';
 import { LoadWhenInView } from '@kbn/observability-shared-plugin/public';
 import { SummaryPanel } from './summary_panel';
-import { useTestFlyoutOpen } from '../../test_now_mode/hooks/use_test_flyout_open';
 
 import { useMonitorDetailsPage } from '../use_monitor_details_page';
 import { useMonitorRangeFrom } from '../hooks/use_monitor_range_from';
@@ -25,8 +24,6 @@ import { MonitorPendingWrapper } from '../monitor_pending_wrapper';
 
 export const MonitorSummary = () => {
   const { from, to } = useMonitorRangeFrom();
-
-  const isFlyoutOpen = !!useTestFlyoutOpen();
 
   const dateLabel = from === 'now-30d/d' ? LAST_30_DAYS_LABEL : TO_DATE_LABEL;
 
@@ -70,7 +67,7 @@ export const MonitorSummary = () => {
       />
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="m" wrap={true}>
-        <EuiFlexItem css={isFlyoutOpen ? { minWidth: 260, maxWidth: 500 } : { maxWidth: 500 }}>
+        <EuiFlexItem css={{ minWidth: 500, maxWidth: 500 }}>
           <LastTestRun />
         </EuiFlexItem>
         <EuiFlexItem css={{ minWidth: 260 }}>


### PR DESCRIPTION
This PR fixes #200921.

This is the final result, where the step details button is correctly shown.
<img width="511" alt="Screenshot 2025-03-11 at 09 57 33" src="https://github.com/user-attachments/assets/c6017848-635a-4af5-aebc-68979ae115f9" />

This PR also fixes #212246.
<img width="1143" alt="Screenshot 2025-03-11 at 11 09 55" src="https://github.com/user-attachments/assets/20b75ba4-ce99-4cc9-a827-11e5cb03a6da" />





<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->