### PR TITLE
[EDR Workflows] Rename Endpoint Insights to Automatic Troubleshooting

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_workflow_insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_workflow_insights.ts
@@ -165,7 +165,7 @@ const generateWorkflowInsightsDoc = ({
           list_id: 'endpoint_trusted_apps',
           name: `${antivirus}`,
           os_types: [os],
-          description: 'Suggested by Security Workflow Insights',
+          description: 'Suggested by Automatic Troubleshooting',
           tags: ['policy:all'],
         },
       ],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
@@ -186,7 +186,7 @@ export const stubWorkflowInsightsApiResponse = (endpointId: string) => {
                 list_id: 'endpoint_trusted_apps',
                 name: 'ClamAV',
                 os_types: ['linux'],
-                description: 'Suggested by Security Workflow Insights',
+                description: 'Suggested by Automatic Troubleshooting',
                 tags: ['policy:all'],
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/translations.ts
@@ -13,7 +13,7 @@ export const OVERVIEW = i18n.translate('xpack.securitySolution.endpointDetails.o
 
 export const WORKFLOW_INSIGHTS = {
   title: i18n.translate('xpack.securitySolution.endpointDetails.workflowInsights.sectionTitle', {
-    defaultMessage: 'Endpoint Insights',
+    defaultMessage: 'Automatic Troubleshooting',
   }),
   titleRight: i18n.translate(
     'xpack.securitySolution.endpointDetails.workflowInsights.extraAction',
@@ -23,7 +23,7 @@ export const WORKFLOW_INSIGHTS = {
   ),
   scan: {
     title: i18n.translate('xpack.securitySolution.endpointDetails.workflowInsights.scan.title', {
-      defaultMessage: 'Endpoint Insights scan',
+      defaultMessage: 'Automatic Troubleshooting',
     }),
     button: i18n.translate('xpack.securitySolution.endpointDetails.workflowInsights.scan.button', {
       defaultMessage: 'Scan',

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
@@ -106,7 +106,7 @@ describe('buildIncompatibleAntivirusWorkflowInsights', () => {
           {
             list_id: ENDPOINT_ARTIFACT_LISTS.trustedApps.id,
             name: 'AVGAntivirus',
-            description: 'Suggested by Security Workflow Insights',
+            description: 'Suggested by Automatic Troubleshooting',
             entries: [
               {
                 field: 'process.executable.caseless',

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
@@ -113,7 +113,7 @@ export async function buildIncompatibleAntivirusWorkflowInsights(
               {
                 list_id: ENDPOINT_ARTIFACT_LISTS.trustedApps.id,
                 name: defendInsight.group,
-                description: 'Suggested by Security Workflow Insights',
+                description: 'Suggested by Automatic Troubleshooting',
                 entries: [
                   {
                     field: 'process.executable.caseless',


### PR DESCRIPTION
Updated Endpoint Insight UI label to Automatic Troubleshooting.
![Screenshot 2025-03-11 at 10 05 23](https://github.com/user-attachments/assets/2981c1dc-525c-4c85-8e02-8977d3efad32)
![Screenshot 2025-03-11 at 10 05 35](https://github.com/user-attachments/assets/6f2d3b50-9178-4e99-8dad-d524a2dc5722)
![Screenshot 2025-03-11 at 10 13 12](https://github.com/user-attachments/assets/201aa773-5ad9-4450-85fb-e1f90bfd88bd)


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->