### PR TITLE
[Authz]: added reason for authorization opt-out for search routes

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/analytics.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/analytics.ts
@@ -51,6 +51,12 @@ export function registerAnalyticsRoutes({
   router.get(
     {
       path: '/internal/elasticsearch/analytics/collections',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           query: schema.maybe(schema.string()),
@@ -76,6 +82,12 @@ export function registerAnalyticsRoutes({
   router.get(
     {
       path: '/internal/elasticsearch/analytics/collections/{name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           name: schema.string(),
@@ -102,6 +114,12 @@ export function registerAnalyticsRoutes({
   router.post(
     {
       path: '/internal/elasticsearch/analytics/collections/{name}/api_key',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           keyName: schema.string(),
@@ -128,6 +146,12 @@ export function registerAnalyticsRoutes({
   router.post(
     {
       path: '/internal/elasticsearch/analytics/collections',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           name: schema.string(),
@@ -173,6 +197,12 @@ export function registerAnalyticsRoutes({
   router.delete(
     {
       path: '/internal/elasticsearch/analytics/collections/{name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           name: schema.string(),
@@ -196,6 +226,12 @@ export function registerAnalyticsRoutes({
   router.get(
     {
       path: '/internal/elasticsearch/analytics/collection/{name}/events/exist',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           name: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/api_keys.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/api_keys.ts
@@ -15,6 +15,12 @@ export function registerApiKeysRoutes({ log, router }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/{indexName}/api_keys',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           keyName: schema.string(),
@@ -44,6 +50,12 @@ export function registerApiKeysRoutes({ log, router }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/api_keys',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
     },
     async (context, request, response) => {
@@ -75,6 +87,12 @@ export function registerApiKeysRoutes({ log, router }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/api_keys/{apiKeyId}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           apiKeyId: schema.string(),
@@ -109,6 +127,12 @@ export function registerApiKeysRoutes({ log, router }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/api_keys',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.any(),
       },

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
@@ -21,6 +21,12 @@ export function registerConfigDataRoute({
   router.get(
     {
       path: '/internal/enterprise_search/config_data',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: false,
     },
     elasticsearchErrorHandler(log, async (context, _request, response) => {
@@ -48,6 +54,12 @@ export function registerConfigDataRoute({
   router.get(
     {
       path: '/internal/enterprise_search/es_config',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: false,
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -64,6 +64,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.post(
     {
       path: '/internal/enterprise_search/connectors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           delete_existing_connector: schema.maybe(schema.boolean()),
@@ -113,6 +119,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/cancel_syncs',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -129,6 +141,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{syncJobId}/cancel_sync',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           syncJobId: schema.string(),
@@ -163,6 +181,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/configuration',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.recordOf(
           schema.string(),
@@ -187,6 +211,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/scheduling',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           access_control: schema.object({ enabled: schema.boolean(), interval: schema.string() }),
@@ -212,6 +242,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/start_sync',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -228,6 +264,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/start_incremental_sync',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -244,6 +286,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/start_access_control_sync',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -278,6 +326,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.get(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/sync_jobs',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -305,6 +359,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/pipeline',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           extract_binary_content: schema.boolean(),
@@ -328,6 +388,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/default_pipeline',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           extract_binary_content: schema.boolean(),
@@ -347,6 +413,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.get(
     {
       path: '/internal/enterprise_search/connectors/default_pipeline',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
     },
     elasticsearchErrorHandler(log, async (context, _, response) => {
@@ -359,6 +431,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/service_type',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({ serviceType: schema.string() }),
         params: schema.object({
@@ -380,6 +458,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/status',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({ status: schema.string() }),
         params: schema.object({
@@ -401,6 +485,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/name_and_description',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           description: schema.nullable(schema.string()),
@@ -429,6 +519,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/filtering/draft',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           advanced_snippet: schema.string(),
@@ -467,6 +563,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/filtering',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.maybe(
           schema.object({
@@ -500,6 +602,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/native',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           is_native: schema.boolean(),
@@ -520,6 +628,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.get(
     {
       path: '/internal/enterprise_search/connectors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           fetchCrawlersOnly: schema.maybe(schema.boolean()),
@@ -597,6 +711,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.get(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -618,6 +738,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.delete(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -691,6 +817,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/index_name/{indexName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -732,6 +864,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.get(
     {
       path: '/internal/enterprise_search/connectors/available_indices',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           from: schema.number({ defaultValue: 0, min: 0 }),
@@ -770,6 +908,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/generate_config',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -833,6 +977,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.post(
     {
       path: '/internal/enterprise_search/connectors/generate_connector_name',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           connectorName: schema.maybe(schema.string()),
@@ -878,6 +1028,12 @@ export function registerConnectorRoutes({ router, log, getStartServices }: Route
   router.get(
     {
       path: '/internal/enterprise_search/{connectorId}/agentless_policy',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/documents.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/documents.ts
@@ -17,6 +17,12 @@ export function registerDocumentRoute({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{index_name}/document/{document_id}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           document_id: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -73,7 +73,16 @@ import { getPrefixedInferencePipelineProcessorName } from '../../utils/ml_infere
 
 export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
-    { path: '/internal/enterprise_search/search_indices', validate: false },
+    {
+      path: '/internal/enterprise_search/search_indices',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
+      validate: false,
+    },
     elasticsearchErrorHandler(log, async (context, _, response) => {
       const { client } = (await context.core).elasticsearch;
       const patterns: AlwaysShowPattern = {
@@ -92,6 +101,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           from: schema.number({ defaultValue: 0, min: 0 }),
@@ -151,6 +166,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -185,6 +206,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.delete(
     {
       path: '/internal/enterprise_search/indices/{indexName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -246,6 +273,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/exists',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -284,6 +317,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/api_key',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           is_native: schema.boolean(),
@@ -311,6 +350,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/pipelines',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -333,6 +378,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.delete(
     {
       path: '/internal/enterprise_search/indices/{indexName}/pipelines',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -354,6 +405,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/pipelines',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -380,6 +437,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/pipeline_parameters',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -400,6 +463,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -432,6 +501,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -513,6 +588,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/attach',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           pipeline_name: schema.string(),
@@ -552,6 +633,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/indices',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           index_name: schema.string(),
@@ -614,6 +701,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/simulate',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           docs: schema.arrayOf(schema.any()),
@@ -676,6 +769,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/simulate/{pipelineName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           docs: schema.arrayOf(schema.any()),
@@ -757,6 +856,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/errors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -787,6 +892,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/{pipelineName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           description: schema.maybe(schema.string()),
@@ -845,6 +956,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.delete(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/{pipelineName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -904,6 +1021,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/history',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -931,6 +1054,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/pipelines/ml_inference',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {
@@ -954,6 +1083,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/pipelines/{pipelineName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           pipelineName: schema.string(),
@@ -995,6 +1130,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.delete(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/{pipelineName}/detach',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -1037,6 +1178,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/ml/models/{modelName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           modelName: schema.string(),
@@ -1078,6 +1225,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/ml/models/{modelName}/deploy',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           modelName: schema.string(),
@@ -1119,6 +1272,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/ml/models',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {
@@ -1141,6 +1300,12 @@ export function registerIndexRoutes({ router, log, ml }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/ml/models/{modelName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           modelName: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/mapping.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/mapping.ts
@@ -19,6 +19,12 @@ export function registerMappingRoute({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/mappings/{index_name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           index_name: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search.ts
@@ -22,6 +22,12 @@ export function registerSearchRoute({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/indices/{index_name}/search',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           searchQuery: schema.string({

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
@@ -34,6 +34,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.get(
     {
       path: '/internal/enterprise_search/search_applications',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           from: schema.number({ defaultValue: 0, min: 0 }),
@@ -68,6 +74,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.get(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           engine_name: schema.string(),
@@ -99,6 +111,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.put(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           indices: schema.arrayOf(schema.string()),
@@ -199,6 +217,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.delete(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           engine_name: schema.string(),
@@ -218,6 +242,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.post(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}/search',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({}, { unknowns: 'allow' }),
         params: schema.object({
@@ -239,6 +269,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.post(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}/api_key',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           keyName: schema.string(),
@@ -264,6 +300,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.get(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}/field_capabilities',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: { params: schema.object({ engine_name: schema.string() }) },
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/stats.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/stats.ts
@@ -15,6 +15,12 @@ export function registerStatsRoutes({ log, router }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/stats/sync_jobs',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           isCrawler: schema.maybe(schema.boolean()),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
@@ -20,6 +20,12 @@ export function registerTelemetryRoute({ router, getSavedObjectsService }: Route
   router.put(
     {
       path: '/internal/enterprise_search/stats',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           product: schema.oneOf([schema.literal('enterprise_search')]),

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/documents.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/documents.ts
@@ -17,6 +17,12 @@ export function registerDocumentRoutes(router: IRouter, logger: Logger) {
   router.delete(
     {
       path: INDEX_DOCUMENT_ROUTE,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/indices.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/indices.ts
@@ -20,6 +20,12 @@ export function registerIndicesRoutes(router: IRouter, logger: Logger) {
   router.post(
     {
       path: POST_CREATE_INDEX_ROUTE,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           indexName: schema.string(),
@@ -68,6 +74,12 @@ export function registerIndicesRoutes(router: IRouter, logger: Logger) {
   router.post(
     {
       path: SEARCH_DOCUMENTS_ROUTE,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           searchQuery: schema.string({

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/onboarding.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/onboarding.ts
@@ -15,6 +15,12 @@ export function registerOnboardingRoutes(router: IRouter, logger: Logger) {
   router.get(
     {
       path: GET_ONBOARDING_TOKEN_ROUTE,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
       options: {
         access: 'internal',

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/status.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/status.ts
@@ -16,6 +16,12 @@ export function registerStatusRoutes(router: IRouter, logger: Logger) {
   router.get(
     {
       path: GET_STATUS_ROUTE,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
       options: {
         access: 'internal',
@@ -36,6 +42,12 @@ export function registerStatusRoutes(router: IRouter, logger: Logger) {
   router.get(
     {
       path: GET_USER_PRIVILEGES_ROUTE,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),


### PR DESCRIPTION
## Summary

Added justification for opting out of authorization for search routes.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->