### PR TITLE
[Authz]: added authorization opt-out reason for monitoring routes

### DIFF
--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/_health/index.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/_health/index.ts
@@ -27,6 +27,12 @@ export function registerV1HealthRoute(server: MonitoringCore) {
   server.route({
     method: 'get',
     path: '/api/monitoring/v1/_health',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       query: validateQuery,
     },

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/alerts/enable.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/alerts/enable.ts
@@ -18,6 +18,12 @@ export function enableAlertsRoute(server: MonitoringCore, npRoute: RouteDependen
   npRoute.router.post(
     {
       path: '/api/monitoring/v1/alerts/enable',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES cluster client',
+        },
+      },
       validate: false,
       options: {
         access: 'internal',

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/alerts/status.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/alerts/status.ts
@@ -28,6 +28,12 @@ export function alertStatusRoute(npRoute: RouteDependencies) {
           }),
         }),
       },
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES cluster client',
+        },
+      },
       options: {
         access: 'internal',
       },

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/apm/instance.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/apm/instance.ts
@@ -25,6 +25,12 @@ export function apmInstanceRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/apm/{apmUuid}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/apm/instances.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/apm/instances.ts
@@ -23,6 +23,12 @@ export function apmInstancesRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/apm/instances',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/apm/overview.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/apm/overview.ts
@@ -24,6 +24,12 @@ export function apmOverviewRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/apm',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/beats/beat_detail.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/beats/beat_detail.ts
@@ -25,6 +25,12 @@ export function beatsDetailRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/beats/beat/{beatUuid}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/beats/beats.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/beats/beats.ts
@@ -23,6 +23,12 @@ export function beatsListingRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/beats/beats',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/beats/overview.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/beats/overview.ts
@@ -25,6 +25,12 @@ export function beatsOverviewRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/beats',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/check_access/check_access.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/check_access/check_access.ts
@@ -20,6 +20,12 @@ export function checkAccessRoute(server: MonitoringCore) {
   server.route({
     method: 'get',
     path: '/api/monitoring/v1/check_access',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {},
     options: {
       access: 'internal',

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/cluster/cluster.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/cluster/cluster.ts
@@ -26,6 +26,12 @@ export function clusterRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/cluster/clusters.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/cluster/clusters.ts
@@ -27,6 +27,12 @@ export function clustersRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       body: validateBody,
     },

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/ccr.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/ccr.ts
@@ -265,6 +265,12 @@ export function ccrRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/elasticsearch/ccr',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/ccr_shard.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/ccr_shard.ts
@@ -89,6 +89,12 @@ export function ccrShardRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/elasticsearch/ccr/{index}/shard/{shardId}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/index_detail.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/index_detail.ts
@@ -32,6 +32,12 @@ export function esIndexRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/elasticsearch/indices/{id}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/indices.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/indices.ts
@@ -27,6 +27,12 @@ export function esIndicesRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/elasticsearch/indices',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       query: validateQuery,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/ml_jobs.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/ml_jobs.ts
@@ -25,6 +25,12 @@ export function mlJobRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/elasticsearch/ml_jobs',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/node_detail.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/node_detail.ts
@@ -37,6 +37,12 @@ export function esNodeRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/elasticsearch/nodes/{nodeUuid}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/nodes.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/nodes.ts
@@ -28,6 +28,12 @@ export function esNodesRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/elasticsearch/nodes',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/overview.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch/overview.ts
@@ -30,6 +30,12 @@ export function esOverviewRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/elasticsearch',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/check/cluster.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/check/cluster.ts
@@ -17,6 +17,12 @@ export function clusterSettingsCheckRoute(server: MonitoringCore) {
   server.route({
     method: 'get',
     path: '/api/monitoring/v1/elasticsearch_settings/check/cluster',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {},
     options: {
       access: 'internal',

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/check/internal_monitoring.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/check/internal_monitoring.ts
@@ -83,6 +83,12 @@ export function internalMonitoringCheckRoute(server: MonitoringCore, npRoute: Ro
       validate: {
         body: validateBody,
       },
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES cluster client',
+        },
+      },
       options: {
         access: 'internal',
       },

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/check/nodes.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/check/nodes.ts
@@ -17,6 +17,12 @@ export function nodesSettingsCheckRoute(server: MonitoringCore) {
   server.route({
     method: 'get',
     path: '/api/monitoring/v1/elasticsearch_settings/check/nodes',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {},
     options: {
       access: 'internal',

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/set/collection_enabled.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/set/collection_enabled.ts
@@ -17,6 +17,12 @@ export function setCollectionEnabledRoute(server: MonitoringCore) {
   server.route({
     method: 'put',
     path: '/api/monitoring/v1/elasticsearch_settings/set/collection_enabled',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {},
     options: {
       access: 'internal',

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/set/collection_interval.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/elasticsearch_settings/set/collection_interval.ts
@@ -17,6 +17,12 @@ export function setCollectionIntervalRoute(server: MonitoringCore) {
   server.route({
     method: 'put',
     path: '/api/monitoring/v1/elasticsearch_settings/set/collection_interval',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {},
     options: {
       access: 'internal',

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/enterprise_search/overview.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/enterprise_search/overview.ts
@@ -24,6 +24,12 @@ export function entSearchOverviewRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/enterprise_search',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/kibana/instance.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/kibana/instance.ts
@@ -25,6 +25,12 @@ export function kibanaInstanceRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/kibana/{kibanaUuid}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/kibana/instances.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/kibana/instances.ts
@@ -23,6 +23,12 @@ export function kibanaInstancesRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/kibana/instances',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/kibana/overview.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/kibana/overview.ts
@@ -25,6 +25,12 @@ export function kibanaOverviewRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/kibana',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/node.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/node.ts
@@ -30,6 +30,12 @@ export function logstashNodeRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/logstash/node/{logstashUuid}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/nodes.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/nodes.ts
@@ -22,6 +22,12 @@ export function logstashNodesRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/logstash/nodes',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/overview.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/overview.ts
@@ -24,6 +24,12 @@ export function logstashOverviewRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/logstash',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/pipeline.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/pipeline.ts
@@ -30,6 +30,12 @@ export function logstashPipelineRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/logstash/pipeline/{pipelineId}/{pipelineHash?}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/pipelines/cluster_pipeline_ids.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/pipelines/cluster_pipeline_ids.ts
@@ -21,6 +21,12 @@ export function logstashClusterPipelineIdsRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/logstash/pipeline_ids',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/pipelines/cluster_pipelines.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/pipelines/cluster_pipelines.ts
@@ -31,6 +31,12 @@ export function logstashClusterPipelinesRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/logstash/pipelines',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/pipelines/node_pipelines.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/logstash/pipelines/node_pipelines.ts
@@ -30,6 +30,12 @@ export function logstashNodePipelinesRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/clusters/{clusterUuid}/logstash/node/{logstashUuid}/pipelines',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       body: validateBody,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/setup/cluster_setup_status.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/setup/cluster_setup_status.ts
@@ -30,6 +30,12 @@ export function clusterSetupStatusRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/setup/collection/cluster/{clusterUuid?}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       query: validateQuery,

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/setup/disable_elasticsearch_internal_collection.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/setup/disable_elasticsearch_internal_collection.ts
@@ -16,6 +16,12 @@ export function disableElasticsearchInternalCollectionRoute(server: MonitoringCo
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/setup/collection/{clusterUuid}/disable_internal_collection',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: createValidationFunction(postDisableInternalCollectionRequestParamsRT),
     },

--- a/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/setup/node_setup_status.ts
+++ b/x-pack/platform/plugins/private/monitoring/server/routes/api/v1/setup/node_setup_status.ts
@@ -30,6 +30,12 @@ export function nodeSetupStatusRoute(server: MonitoringCore) {
   server.route({
     method: 'post',
     path: '/api/monitoring/v1/setup/collection/node/{nodeUuid}',
+    security: {
+      authz: {
+        enabled: false,
+        reason: 'This route delegates authorization to the scoped ES cluster client',
+      },
+    },
     validate: {
       params: validateParams,
       query: validateQuery,


### PR DESCRIPTION
## Summary

 Added authorization opt-out reason for monitoring routes.


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)






<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->