### PR TITLE
[Lens][Embeddable] Fix unnecessary rerender on view mode change

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.test.ts
@@ -240,7 +240,14 @@ describe('Data Loader', () => {
         attributes: getLensAttributesMock(),
         enhancements: {
           dynamicActions: {
-            events: [],
+            events: [
+              // make sure there's at least one event
+              {
+                eventId: 'test',
+                triggers: [],
+                action: { factoryId: 'test', name: 'testAction', config: {} },
+              },
+            ],
           },
         },
       });
@@ -252,6 +259,24 @@ describe('Data Loader', () => {
   });
 
   it('should not re-render when dashboard view/edit mode changes if dynamic actions are not set', async () => {
+    await expectRerenderOnDataLoader(async ({ api, getState }) => {
+      getState.mockReturnValue({
+        attributes: getLensAttributesMock(),
+        enhancements: {
+          dynamicActions: {
+            // empty list should not trigger
+            events: [],
+          },
+        },
+      });
+      // trigger a change by changing the title in the attributes
+      (api.viewMode$ as BehaviorSubject<ViewMode | undefined>).next('view');
+
+      return false;
+    });
+  });
+
+  it('should not re-render when dashboard view/edit mode changes if dynamic actions are not available', async () => {
     await expectRerenderOnDataLoader(async ({ api }) => {
       // the default get state does not have dynamic actions
       // trigger a change by changing the title in the attributes

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/data_loader.ts
@@ -304,7 +304,7 @@ export function loadEmbeddableData(
     // make sure to reload on viewMode change
     api.viewMode$.subscribe(() => {
       // only reload if drilldowns are set
-      if (getState().enhancements?.dynamicActions) {
+      if (getState().enhancements?.dynamicActions?.events.length) {
         reload('viewMode');
       }
     }),


### PR DESCRIPTION
## Summary

Fixes #203020 

Improve drill down check before triggering a rerender.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.17","8.18","8.x","9.0"]} ONMERGE-->