### PR TITLE
[Maps][Choropleth Map] Mark fields as required

### DIFF
--- a/x-pack/platform/plugins/shared/maps/public/lens/choropleth_chart/visualization.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/lens/choropleth_chart/visualization.tsx
@@ -93,7 +93,7 @@ export const getVisualization = ({
           supportsMoreColumns: !state.regionAccessor,
           filterOperations: (op: OperationMetadata) => op.isBucketed && op.dataType === 'string',
           enableDimensionEditor: true,
-          required: true,
+          requiredMinDimensionCount: 1,
           dataTestSubj: 'lnsChoropleth_regionKeyDimensionPanel',
         },
         {
@@ -106,7 +106,8 @@ export const getVisualization = ({
           supportsMoreColumns: !state.valueAccessor,
           filterOperations: (op: OperationMetadata) => !op.isBucketed && op.dataType === 'number',
           enableDimensionEditor: true,
-          required: true,
+          isMetricDimension: true,
+          requiredMinDimensionCount: 1,
           dataTestSubj: 'lnsChoropleth_valueDimensionPanel',
         },
       ],


### PR DESCRIPTION
## Summary

Fixes #197904

Configure both dimensions in the choropleth map as required.

<img width="330" alt="Screenshot 2025-03-11 at 14 51 46" src="https://github.com/user-attachments/assets/65a7d3a4-2850-474c-a4e1-db0aca4307d3" />
<img width="371" alt="Screenshot 2025-03-11 at 14 51 28" src="https://github.com/user-attachments/assets/ad6e3aea-6c94-4dec-bd76-d5cc75c07744" />


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->