### PR TITLE
[9.0] [EDR Workflows] Rename Endpoint Insights to Automatic Troubleshooting (#213876)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_workflow_insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/data_loaders/index_workflow_insights.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/insights.ts
@@ -186,7 +186,7 @@ export const stubWorkflowInsightsApiResponse = (endpointId: string) => {
                 list_id: 'endpoint_trusted_apps',
                 name: 'ClamAV',
                 os_types: ['linux'],
-                description: 'Suggested by Security Workflow Insights',
+                description: 'Suggested by Automatic Troubleshooting',
                 tags: ['policy:all'],
               },
             ],

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/endpoint_hosts/view/translations.ts
@@ -13,7 +13,7 @@ export const OVERVIEW = i18n.translate('xpack.securitySolution.endpointDetails.o
 
 export const WORKFLOW_INSIGHTS = {
   title: i18n.translate('xpack.securitySolution.endpointDetails.workflowInsights.sectionTitle', {
-    defaultMessage: 'Endpoint Insights',
+    defaultMessage: 'Automatic Troubleshooting',
   }),
   titleRight: i18n.translate(
     'xpack.securitySolution.endpointDetails.workflowInsights.extraAction',
@@ -23,7 +23,7 @@ export const WORKFLOW_INSIGHTS = {
   ),
   scan: {
     title: i18n.translate('xpack.securitySolution.endpointDetails.workflowInsights.scan.title', {
-      defaultMessage: 'Endpoint Insights scan',
+      defaultMessage: 'Automatic Troubleshooting',
     }),
     button: i18n.translate('xpack.securitySolution.endpointDetails.workflowInsights.scan.button', {
       defaultMessage: 'Scan',

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
@@ -106,7 +106,7 @@ describe('buildIncompatibleAntivirusWorkflowInsights', () => {
           {
             list_id: ENDPOINT_ARTIFACT_LISTS.trustedApps.id,
             name: 'AVGAntivirus',
-            description: 'Suggested by Security Workflow Insights',
+            description: 'Suggested by Automatic Troubleshooting',
             entries: [
               {
                 field: 'process.executable.caseless',

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
@@ -113,7 +113,7 @@ export async function buildIncompatibleAntivirusWorkflowInsights(
               {
                 list_id: ENDPOINT_ARTIFACT_LISTS.trustedApps.id,
                 name: defendInsight.group,
-                description: 'Suggested by Security Workflow Insights',
+                description: 'Suggested by Automatic Troubleshooting',
                 entries: [
                   {
                     field: 'process.executable.caseless',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[EDR Workflows] Rename Endpoint Insights to Automatic Troubleshooting (#213876)](https://github.com/elastic/kibana/pull/213876)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Szwarc","email":"konrad.szwarc@elastic.co"},"sourceCommit":{"committedDate":"2025-03-11T14:09:19Z","message":"[EDR Workflows] Rename Endpoint Insights to Automatic Troubleshooting (#213876)\n\nUpdated Endpoint Insight UI label to Automatic Troubleshooting.\n![Screenshot 2025-03-11 at 10 05\n23](https://github.com/user-attachments/assets/2981c1dc-525c-4c85-8e02-8977d3efad32)\n![Screenshot 2025-03-11 at 10 05\n35](https://github.com/user-attachments/assets/6f2d3b50-9178-4e99-8dad-d524a2dc5722)\n![Screenshot 2025-03-11 at 10 13\n12](https://github.com/user-attachments/assets/201aa773-5ad9-4450-85fb-e1f90bfd88bd)","sha":"e0bf98e45a6c2b4e138cac601c6082ca68fb8301","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Defend Workflows","backport:prev-minor","v9.1.0"],"title":"[EDR Workflows] Rename Endpoint Insights to Automatic Troubleshooting","number":213876,"url":"https://github.com/elastic/kibana/pull/213876","mergeCommit":{"message":"[EDR Workflows] Rename Endpoint Insights to Automatic Troubleshooting (#213876)\n\nUpdated Endpoint Insight UI label to Automatic Troubleshooting.\n![Screenshot 2025-03-11 at 10 05\n23](https://github.com/user-attachments/assets/2981c1dc-525c-4c85-8e02-8977d3efad32)\n![Screenshot 2025-03-11 at 10 05\n35](https://github.com/user-attachments/assets/6f2d3b50-9178-4e99-8dad-d524a2dc5722)\n![Screenshot 2025-03-11 at 10 13\n12](https://github.com/user-attachments/assets/201aa773-5ad9-4450-85fb-e1f90bfd88bd)","sha":"e0bf98e45a6c2b4e138cac601c6082ca68fb8301"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213876","number":213876,"mergeCommit":{"message":"[EDR Workflows] Rename Endpoint Insights to Automatic Troubleshooting (#213876)\n\nUpdated Endpoint Insight UI label to Automatic Troubleshooting.\n![Screenshot 2025-03-11 at 10 05\n23](https://github.com/user-attachments/assets/2981c1dc-525c-4c85-8e02-8977d3efad32)\n![Screenshot 2025-03-11 at 10 05\n35](https://github.com/user-attachments/assets/6f2d3b50-9178-4e99-8dad-d524a2dc5722)\n![Screenshot 2025-03-11 at 10 13\n12](https://github.com/user-attachments/assets/201aa773-5ad9-4450-85fb-e1f90bfd88bd)","sha":"e0bf98e45a6c2b4e138cac601c6082ca68fb8301"}}]}] BACKPORT-->