### PR TITLE
[8.x] [ES|QL] Separate `RENAME` autocomplete routine (#213641)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.rename.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/autocomplete.command.rename.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getFieldNamesByType, setup } from './helpers';
+
+describe('autocomplete.suggest', () => {
+  describe('RENAME', () => {
+    it('suggests fields', async () => {
+      const { assertSuggestions } = await setup();
+      await assertSuggestions(
+        'from a | rename /',
+        getFieldNamesByType('any').map((field) => field + ' ')
+      );
+      await assertSuggestions(
+        'from a | rename fie/',
+        getFieldNamesByType('any').map((field) => field + ' ')
+      );
+      await assertSuggestions(
+        'from a | rename field AS foo, /',
+        getFieldNamesByType('any').map((field) => field + ' ')
+      );
+      await assertSuggestions(
+        'from a | rename field AS foo, fie/',
+        getFieldNamesByType('any').map((field) => field + ' ')
+      );
+    });
+
+    it('suggests AS after field', async () => {
+      const { assertSuggestions } = await setup();
+      await assertSuggestions('from a | rename field /', ['AS ']);
+      await assertSuggestions('from a | rename field A/', ['AS ']);
+      await assertSuggestions('from a | rename field AS foo, field2 /', ['AS ']);
+      await assertSuggestions('from a | rename field as foo , field2 /', ['AS ']);
+      await assertSuggestions('from a | rename field AS foo, field2 A/', ['AS ']);
+    });
+
+    it('suggests nothing after AS', async () => {
+      const { assertSuggestions } = await setup();
+      await assertSuggestions('from a | rename field AS /', []);
+    });
+
+    it('suggests pipe and comma after complete expression', async () => {
+      const { assertSuggestions } = await setup();
+      await assertSuggestions('from a | rename field AS foo /', ['| ', ', ']);
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.test.ts
@@ -112,12 +112,6 @@ describe('autocomplete', () => {
     testSuggestions('from a metadata _id | eval var0 = a | /', commands);
   });
 
-  describe('rename', () => {
-    testSuggestions('from a | rename /', getFieldNamesByType('any'));
-    testSuggestions('from a | rename keywordField /', ['AS $0'], ' ');
-    testSuggestions('from a | rename keywordField as /', ['var0']);
-  });
-
   for (const command of ['keep', 'drop']) {
     describe(command, () => {
       testSuggestions(`from a | ${command} /`, getFieldNamesByType('any'));
@@ -405,13 +399,13 @@ describe('autocomplete', () => {
     );
 
     // RENAME field
-    testSuggestions('FROM index1 | RENAME f/', getFieldNamesByType('any'));
+    testSuggestions(
+      'FROM index1 | RENAME f/',
+      getFieldNamesByType('any').map((name) => `${name} `)
+    );
 
     // RENAME field AS
-    testSuggestions('FROM index1 | RENAME field A/', ['AS $0']);
-
-    // RENAME field AS var0
-    testSuggestions('FROM index1 | RENAME field AS v/', ['var0']);
+    testSuggestions('FROM index1 | RENAME field A/', ['AS ']);
 
     // STATS argument
     testSuggestions('FROM index1 | STATS f/', [

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/rename/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/rename/index.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import { CommandSuggestParams } from '../../../definitions/types';
+
+import type { SuggestionRawDefinition } from '../../types';
+import { commaCompleteItem, pipeCompleteItem } from '../../complete_items';
+
+export async function suggest({
+  getColumnsByType,
+  innerText,
+}: CommandSuggestParams<'rename'>): Promise<SuggestionRawDefinition[]> {
+  if (/(?:rename|,)\s+\S+\s+a?$/i.test(innerText)) {
+    return [asCompletionItem];
+  }
+
+  if (/rename(?:\s+\S+\s+as\s+\S+\s*,)*\s+\S+\s+as\s+[^\s,]+\s+$/i.test(innerText)) {
+    return [pipeCompleteItem, { ...commaCompleteItem, text: ', ' }];
+  }
+
+  if (/as\s+$/i.test(innerText)) {
+    return [];
+  }
+
+  return getColumnsByType('any', [], { advanceCursor: true, openSuggestions: true });
+}
+
+const asCompletionItem: SuggestionRawDefinition = {
+  detail: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.asDoc', {
+    defaultMessage: 'As',
+  }),
+  kind: 'Reference',
+  label: 'AS',
+  sortText: '1',
+  text: 'AS ',
+};

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -42,6 +42,7 @@ import { suggest as suggestForShow } from '../autocomplete/commands/show';
 import { suggest as suggestForGrok } from '../autocomplete/commands/grok';
 import { suggest as suggestForDissect } from '../autocomplete/commands/dissect';
 import { suggest as suggestForEnrich } from '../autocomplete/commands/enrich';
+import { suggest as suggestForRename } from '../autocomplete/commands/rename';
 import { suggest as suggestForLimit } from '../autocomplete/commands/limit';
 import { suggest as suggestForMvExpand } from '../autocomplete/commands/mv_expand';
 
@@ -275,6 +276,7 @@ export const commandDefinitions: Array<CommandDefinition<any>> = [
     },
     options: [asOption],
     modes: [],
+    suggest: suggestForRename,
   },
   {
     name: 'limit',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ES|QL] Separate `RENAME` autocomplete routine (#213641)](https://github.com/elastic/kibana/pull/213641)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2025-03-11T15:02:40Z","message":"[ES|QL] Separate `RENAME` autocomplete routine (#213641)\n\n## Summary\n\nPart of https://github.com/elastic/kibana/issues/195418\n\nGives `RENAME` autocomplete logic its own home 🏡\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### Identify risks\n\n- [ ] As with any refactor, there's a possibility this will introduce a\nregression in the behavior of commands. However, all automated tests are\npassing and I have tested the behavior manually and can detect no\nregression.","sha":"63d33648176204151610db0966f7b79f811396c2","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:ES|QL","Team:ESQL","backport:version","v9.1.0","v8.19.0"],"title":"[ES|QL] Separate `RENAME` autocomplete routine","number":213641,"url":"https://github.com/elastic/kibana/pull/213641","mergeCommit":{"message":"[ES|QL] Separate `RENAME` autocomplete routine (#213641)\n\n## Summary\n\nPart of https://github.com/elastic/kibana/issues/195418\n\nGives `RENAME` autocomplete logic its own home 🏡\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### Identify risks\n\n- [ ] As with any refactor, there's a possibility this will introduce a\nregression in the behavior of commands. However, all automated tests are\npassing and I have tested the behavior manually and can detect no\nregression.","sha":"63d33648176204151610db0966f7b79f811396c2"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213641","number":213641,"mergeCommit":{"message":"[ES|QL] Separate `RENAME` autocomplete routine (#213641)\n\n## Summary\n\nPart of https://github.com/elastic/kibana/issues/195418\n\nGives `RENAME` autocomplete logic its own home 🏡\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n### Identify risks\n\n- [ ] As with any refactor, there's a possibility this will introduce a\nregression in the behavior of commands. However, all automated tests are\npassing and I have tested the behavior manually and can detect no\nregression.","sha":"63d33648176204151610db0966f7b79f811396c2"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->