### PR TITLE
[Security solution] Fix assistant `apiConfig` set by Security getting started page

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -87,6 +87,7 @@ const AssistantComponent: React.FC<Props> = ({
   const {
     assistantAvailability: { isAssistantEnabled },
     assistantTelemetry,
+    currentAppId,
     augmentMessageCodeBlocks,
     getComments,
     getLastConversation,
@@ -94,6 +95,7 @@ const AssistantComponent: React.FC<Props> = ({
     promptContexts,
     currentUserAvatar,
     setLastConversation,
+    spaceId,
     contentReferencesVisible,
     showAnonymizedValues,
     setContentReferencesVisible,
@@ -143,8 +145,11 @@ const AssistantComponent: React.FC<Props> = ({
     setCurrentSystemPromptId,
   } = useCurrentConversation({
     allSystemPrompts,
+    currentAppId,
+    connectors,
     conversations,
     defaultConnector,
+    spaceId,
     refetchCurrentUserConversations,
     lastConversation: lastConversation ?? getLastConversation(lastConversation),
     mayUpdateConversations:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_current_conversation/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_current_conversation/index.test.tsx
@@ -9,14 +9,32 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { useCurrentConversation, Props } from '.';
 import { useConversation } from '../use_conversation';
 import deepEqual from 'fast-deep-equal';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { Conversation } from '../../..';
 import { find } from 'lodash';
+import { AIConnector } from '../../connectorland/connector_selector';
 
 // Mock dependencies
+jest.mock('react-use/lib/useLocalStorage', () => jest.fn());
 jest.mock('../use_conversation');
 jest.mock('../helpers');
 jest.mock('fast-deep-equal');
 jest.mock('lodash');
+const defaultConnector: AIConnector = {
+  actionTypeId: '.gen-ai',
+  isPreconfigured: false,
+  isDeprecated: false,
+  referencedByCount: 0,
+  isMissingSecrets: false,
+  isSystemAction: false,
+  secrets: {},
+  id: 'c5f91dc0-2197-11ee-aded-897192c5d6f5',
+  name: 'OpenAI',
+  config: {
+    apiProvider: 'OpenAI',
+    apiUrl: 'https://api.openai.com/v1/chat/completions',
+  },
+};
 const mockData = {
   welcome_id: {
     id: 'welcome_id',
@@ -52,6 +70,7 @@ describe('useCurrentConversation', () => {
     (useConversation as jest.Mock).mockReturnValue(mockUseConversation);
     (deepEqual as jest.Mock).mockReturnValue(false);
     (find as jest.Mock).mockReturnValue(undefined);
+    (useLocalStorage as jest.Mock).mockReturnValue([undefined, jest.fn()]);
   });
 
   afterEach(() => {
@@ -66,6 +85,7 @@ describe('useCurrentConversation', () => {
     mayUpdateConversations: true,
     refetchCurrentUserConversations: jest.fn().mockResolvedValue({ data: mockData }),
     setLastConversation,
+    spaceId: 'default',
   };
 
   const setupHook = (props: Partial<Props> = {}) => {
@@ -74,6 +94,79 @@ describe('useCurrentConversation', () => {
 
   it('should initialize with correct default values', () => {
     const { result } = setupHook();
+
+    expect(result.current.currentConversation).toEqual({
+      category: 'assistant',
+      id: '',
+      messages: [],
+      replacements: {},
+      title: '',
+    });
+    expect(result.current.currentSystemPrompt).toBeUndefined();
+  });
+
+  it('should initialize with apiConfig if defaultConnector is provided', () => {
+    (useLocalStorage as jest.Mock).mockReturnValue(['456', jest.fn()]);
+    const { result } = setupHook({
+      defaultConnector,
+    });
+
+    expect(result.current.currentConversation).toEqual({
+      category: 'assistant',
+      id: '',
+      messages: [],
+      replacements: {},
+      title: '',
+      apiConfig: {
+        actionTypeId: defaultConnector.actionTypeId,
+        connectorId: defaultConnector.id,
+      },
+    });
+    expect(result.current.currentSystemPrompt).toBeUndefined();
+  });
+
+  it('should initialize with local storage connectorId if app is security solution and local storage connectorId exists', () => {
+    (useLocalStorage as jest.Mock).mockReturnValue(['456', jest.fn()]);
+    const { result } = setupHook({
+      currentAppId: 'securitySolutionUI',
+      connectors: [
+        defaultConnector,
+        {
+          ...defaultConnector,
+          id: '456',
+          actionTypeId: '.bedrock',
+          name: 'My Bedrock',
+        },
+      ],
+    });
+
+    expect(result.current.currentConversation).toEqual({
+      category: 'assistant',
+      id: '',
+      messages: [],
+      replacements: {},
+      title: '',
+      apiConfig: {
+        actionTypeId: '.bedrock',
+        connectorId: '456',
+      },
+    });
+    expect(result.current.currentSystemPrompt).toBeUndefined();
+  });
+
+  it('should initialize without apiConfig if app is security solution and local storage connectorId does not exist', () => {
+    const { result } = setupHook({
+      currentAppId: 'securitySolutionUI',
+      connectors: [
+        defaultConnector,
+        {
+          ...defaultConnector,
+          id: '456',
+          actionTypeId: '.bedrock',
+          name: 'My Bedrock',
+        },
+      ],
+    });
 
     expect(result.current.currentConversation).toEqual({
       category: 'assistant',

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_current_conversation/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/use_current_conversation/index.tsx
@@ -199,7 +199,7 @@ export const useCurrentConversation = ({
   );
 
   const [localSecuritySolutionAssistantConnectorId] = useLocalStorage<string | undefined>(
-    `securitySolution.onboarding.assistantCard.connectorId.default`
+    `securitySolution.onboarding.assistantCard.connectorId.${spaceId}`
   );
 
   const handleOnConversationSelected = useCallback(

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -87,6 +87,7 @@ export interface AssistantProviderProps {
   title?: string;
   toasts?: IToasts;
   currentAppId: string;
+  spaceId: string;
   productDocBase: ProductDocBasePluginStart;
   userProfileService: UserProfileService;
   chrome: ChromeStart;
@@ -137,6 +138,7 @@ export interface UseAssistantContext {
     langSmithProject: string;
     langSmithApiKey: string;
   }) => void;
+  spaceId: string;
   title: string;
   toasts: IToasts | undefined;
   traceOptions: TraceOptions;
@@ -167,6 +169,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
   navigateToApp,
   nameSpace = DEFAULT_ASSISTANT_NAMESPACE,
   productDocBase,
+  spaceId,
   title = DEFAULT_ASSISTANT_TITLE,
   toasts,
   currentAppId,
@@ -385,6 +388,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       setShowAssistantOverlay,
       setTraceOptions: setSessionStorageTraceOptions,
       showAssistantOverlay,
+      spaceId,
       title,
       toasts,
       traceOptions: sessionStorageTraceOptions,
@@ -426,6 +430,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       setContentReferencesVisible,
       setSessionStorageTraceOptions,
       showAssistantOverlay,
+      spaceId,
       title,
       toasts,
       sessionStorageTraceOptions,

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/mock/test_providers/test_providers.tsx
@@ -92,6 +92,7 @@ export const TestProvidersComponent: React.FC<Props> = ({
             }}
             userProfileService={jest.fn() as unknown as UserProfileService}
             chrome={chrome}
+            spaceId="default"
           >
             {children}
           </AssistantProvider>

--- a/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
+++ b/x-pack/solutions/security/packages/ecs-data-quality-dashboard/impl/data_quality_panel/mock/test_providers/test_providers.tsx
@@ -93,6 +93,7 @@ const TestExternalProvidersComponent: React.FC<TestExternalProvidersProps> = ({ 
               currentAppId={'securitySolutionUI'}
               userProfileService={jest.fn() as unknown as UserProfileService}
               chrome={chrome}
+              spaceId="default"
             >
               {children}
             </AssistantProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/assistant/provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/assistant/provider.tsx
@@ -24,6 +24,7 @@ import type { HttpSetup } from '@kbn/core-http-browser';
 import type { Message } from '@kbn/elastic-assistant-common';
 import { loadAllActions as loadConnectors } from '@kbn/triggers-actions-ui-plugin/public/common/constants';
 import useObservable from 'react-use/lib/useObservable';
+import { useSpaceId } from '../common/hooks/use_space_id';
 import { APP_ID } from '../../common';
 import { useBasePath, useKibana } from '../common/lib/kibana';
 import { useAssistantTelemetry } from './use_assistant_telemetry';
@@ -145,6 +146,7 @@ export const AssistantProvider: FC<PropsWithChildren<unknown>> = ({ children }) 
     chrome,
     productDocBase,
   } = useKibana().services;
+  const spaceId = useSpaceId();
 
   let inferenceEnabled = false;
   try {
@@ -234,6 +236,7 @@ export const AssistantProvider: FC<PropsWithChildren<unknown>> = ({ children }) 
       inferenceEnabled={inferenceEnabled}
       navigateToApp={navigateToApp}
       productDocBase={productDocBase}
+      spaceId={spaceId ?? 'default'}
       title={ASSISTANT_TITLE}
       toasts={toasts}
       currentAppId={currentAppId ?? 'securitySolutionUI'}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/mock_assistant_provider.tsx
@@ -64,6 +64,7 @@ export const MockAssistantProviderComponent: React.FC<Props> = ({
       }}
       userProfileService={mockUserProfileService}
       chrome={chrome}
+      spaceId="default"
     >
       {children}
     </AssistantProvider>

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/assistant/assistant_card.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/assistant/assistant_card.tsx
@@ -76,6 +76,7 @@ export const AssistantCard: OnboardingCardComponent<AssistantCardMetadata> = ({
     allSystemPrompts,
     conversations,
     defaultConnector,
+    spaceId,
     refetchCurrentUserConversations,
     lastConversation: getLastConversation(),
     mayUpdateConversations:
@@ -102,7 +103,6 @@ export const AssistantCard: OnboardingCardComponent<AssistantCardMetadata> = ({
       const config = getGenAiConfig(connector);
       const apiProvider = config?.apiProvider;
       const model = config?.defaultModel;
-
       if (currentConversation != null) {
         const conversation = await setApiConfig({
           conversation: currentConversation,
@@ -121,17 +121,11 @@ export const AssistantCard: OnboardingCardComponent<AssistantCardMetadata> = ({
         }
       }
 
-      if (selectedConnectorId != null) {
+      if (connector) {
         setSelectedConnectorId(connectorId);
       }
     },
-    [
-      currentConversation,
-      selectedConnectorId,
-      setApiConfig,
-      onConversationChange,
-      setSelectedConnectorId,
-    ]
+    [currentConversation, setApiConfig, onConversationChange, setSelectedConnectorId]
   );
 
   if (!checkCompleteMetadata) {


### PR DESCRIPTION
## Summary


Resolves partially https://github.com/elastic/kibana/issues/213872. Resolves the issue for 8.19/9.1. 

The changes in the [Conversation pagination refactor](https://github.com/elastic/kibana/pull/211831) broke some functionality of the security solution getting started page. The functionality allows the user to select a connector, and assigns that `connectorId` to local storage and assigns it to the current conversation. Since we no longer have default conversations, there was no current conversation to assign the `connectorId` to. Therefore, I added a check in `useCurrentConversation` that will look for the local storage value if the currentAppId is `securitySolutionUI` when initializing with an empty conversation. This resolves the issue.

Thanks to @agusruidiazgd for pairing to help resolve the issue.

There was still an issue in 8.18/9.0 unrelated to the refactor.
Resolves 8.18: https://github.com/elastic/kibana/pull/213969
Resolves 9.0: https://github.com/elastic/kibana/pull/213971

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->