### PR TITLE
[ci] use default worker in on-merge-unsupported-ftrs scout step

### DIFF
--- a/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
+++ b/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
@@ -71,8 +71,12 @@ steps:
   - command: .buildkite/scripts/steps/test/scout_test_run_builder.sh
     label: 'Scout Test Run Builder'
     agents:
+      image: family/kibana-ubuntu-2004
+      imageProject: elastic-images-prod
+      provider: gcp
       machineType: n2-standard-2
-      diskSizeGb: 75
+      preemptible: true
+    depends_on: build
     timeout_in_minutes: 10
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'

--- a/.buildkite/scripts/steps/test/scout_test_run_builder.sh
+++ b/.buildkite/scripts/steps/test/scout_test_run_builder.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
+.buildkite/scripts/download_build_artifacts.sh
+.buildkite/scripts/copy_es_snapshot_cache.sh
 
 echo '--- Discover Playwright Configs and upload to Buildkite artifacts'
 node scripts/scout discover-playwright-configs --save


### PR DESCRIPTION
## Summary

related to https://github.com/elastic/kibana/pull/211797

Fixing bootstrap failure in https://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34167

```
yarn install and bootstrap, attempt 2
2025-03-11 18:13:27 UTC	yarn run v1.22.22
2025-03-11 18:13:27 UTC	$ node scripts/kbn bootstrap --force-install
2025-03-11 18:13:27 UTC	Kibana should not be run as root.  Use --allow-root to continue.
2025-03-11 18:13:27 UTC	error Command failed with exit code 1.
2025-03-11 18:13:27 UTC	info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2025-03-11 18:13:28 UTC	🚨 Error: The command exited with status 1
```



