### PR TITLE
[Security Solution] Adds check for license level for rule editing callout message

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/pages/rule_editing/index.tsx
@@ -562,7 +562,7 @@ const EditRulePageComponent: FC<{ rule: RuleResponse }> = ({ rule }) => {
                         setIsRulePreviewVisible={setIsRulePreviewVisible}
                         togglePanel={togglePanel}
                       />
-                      {upgradeCallout}
+                      {isRulesCustomizationEnabled && upgradeCallout}
                       {invalidSteps.length > 0 && (
                         <EuiCallOut title={i18n.SORRY_ERRORS} color="danger" iconType="warning">
                           <FormattedMessage


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/213983

Adds gating logic to only display the rule upgrade related warning callout on the rule editing page if the user has the appropriate license level, otherwise the message is irrelevant as the user wouldn't be able to edit a prebuilt rule in the way the message refers to

### Testing

**Steps to reproduce:**

1. Use a Platinum license or any tier that does not allow prebuilt rule updates.
2. Navigate to the Rule Management page and select a prebuilt rule with an available update.
3. Open Rule Details page -> Edit rule settings
4. Observe the callout message is not displayed at the top of the page

NOTE: When using the enterprise license, the callout should still be displayed





<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->