### PR TITLE
[8.17] [Obs AI Assistant] Make KB retrieval namespace specific  (#213505)

### DIFF
--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/client/index.ts
@@ -829,7 +829,12 @@ export class ObservabilityAIAssistantClient {
     sortBy: string;
     sortDirection: 'asc' | 'desc';
   }) => {
-    return this.dependencies.knowledgeBaseService.getEntries({ query, sortBy, sortDirection });
+    return this.dependencies.knowledgeBaseService.getEntries({
+      query,
+      sortBy,
+      sortDirection,
+      namespace: this.dependencies.namespace,
+    });
   };
 
   deleteKnowledgeBaseEntry = async (id: string) => {

--- a/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/util/get_space_query.ts
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/server/service/util/get_space_query.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function getSpaceQuery({ namespace }: { namespace?: string }) {
+  return [
+    {
+      bool: {
+        should: [
+          { term: { namespace } },
+          { bool: { must_not: { exists: { field: 'namespace' } } } },
+        ],
+      },
+    },
+  ];
+}

--- a/x-pack/test/observability_ai_assistant_api_integration/common/observability_ai_assistant_api_client.ts
+++ b/x-pack/test/observability_ai_assistant_api_integration/common/observability_ai_assistant_api_client.ts
@@ -34,6 +34,7 @@ export function createObservabilityAIAssistantApiClient(st: supertest.Agent) {
     options: {
       type?: 'form-data';
       endpoint: TEndpoint;
+      spaceId?: string;
     } & ObservabilityAIAssistantAPIClientRequestParamsOf<TEndpoint> & {
         params?: { query?: { _inspect?: boolean } };
       }
@@ -43,7 +44,8 @@ export function createObservabilityAIAssistantApiClient(st: supertest.Agent) {
     const params = 'params' in options ? (options.params as Record<string, any>) : {};
 
     const { method, pathname, version } = formatRequest(endpoint, params.path);
-    const url = format({ pathname, query: params?.query });
+    const pathnameWithSpaceId = options.spaceId ? `/s/${options.spaceId}${pathname}` : pathname;
+    const url = format({ pathname: pathnameWithSpaceId, query: params?.query });
 
     const headers: Record<string, string> = { 'kbn-xsrf': 'foo' };
 

--- a/x-pack/test/observability_ai_assistant_api_integration/tests/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/test/observability_ai_assistant_api_integration/tests/knowledge_base/knowledge_base.spec.ts
@@ -331,44 +331,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         expect(spaceBEntries[1].title).to.equal('Entry in Space B by Admin 4');
       });
     });
-
-    describe('security roles and access privileges', () => {
-      describe('should deny access for users without the ai_assistant privilege', () => {
-        it('POST /internal/observability_ai_assistant/kb/entries/save', async () => {
-          const { status } = await observabilityAIAssistantAPIClient.viewer({
-            endpoint: 'POST /internal/observability_ai_assistant/kb/entries/save',
-            params: {
-              body: {
-                id: 'my-doc-id-1',
-                title: 'My title',
-                text: 'My content',
-              },
-            },
-          });
-          expect(status).to.be(403);
-        });
-
-        it('GET /internal/observability_ai_assistant/kb/entries', async () => {
-          const { status } = await observabilityAIAssistantAPIClient.viewer({
-            endpoint: 'GET /internal/observability_ai_assistant/kb/entries',
-            params: {
-              query: { query: '', sortBy: 'title', sortDirection: 'asc' },
-            },
-          });
-          expect(status).to.be(403);
-        });
-
-        it('DELETE /internal/observability_ai_assistant/kb/entries/{entryId}', async () => {
-          const { status } = await observabilityAIAssistantAPIClient.viewer({
-            endpoint: 'DELETE /internal/observability_ai_assistant/kb/entries/{entryId}',
-            params: {
-              path: { entryId: 'my-doc-id-1' },
-            },
-          });
-          expect(status).to.be(403);
-        });
-      });
-    });
   });
 }
 

--- a/x-pack/test/observability_ai_assistant_api_integration/tests/knowledge_base/knowledge_base.spec.ts
+++ b/x-pack/test/observability_ai_assistant_api_integration/tests/knowledge_base/knowledge_base.spec.ts
@@ -21,7 +21,32 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   const es = getService('es');
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantAPIClient');
 
-  describe('Knowledge base', () => {
+  async function getEntries({
+    query = '',
+    sortBy = 'title',
+    sortDirection = 'asc',
+    spaceId,
+    user = 'editor',
+  }: {
+    query?: string;
+    sortBy?: string;
+    sortDirection?: 'asc' | 'desc';
+    spaceId?: string;
+    user?: 'admin' | 'editor' | 'viewer';
+  } = {}): Promise<KnowledgeBaseEntry[]> {
+    const res = await observabilityAIAssistantAPIClient[user]({
+      endpoint: 'GET /internal/observability_ai_assistant/kb/entries',
+      params: {
+        query: { query, sortBy, sortDirection },
+      },
+      spaceId,
+    });
+    expect(res.status).to.be(200);
+
+    return omitCategories(res.body.entries);
+  }
+
+  describe('Knowledge base', function () {
     before(async () => {
       await createKnowledgeBaseModel(ml);
 
@@ -133,23 +158,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
 
     describe('when managing multiple entries', () => {
-      async function getEntries({
-        query = '',
-        sortBy = 'title',
-        sortDirection = 'asc',
-      }: { query?: string; sortBy?: string; sortDirection?: 'asc' | 'desc' } = {}) {
-        const res = await observabilityAIAssistantAPIClient
-          .editor({
-            endpoint: 'GET /internal/observability_ai_assistant/kb/entries',
-            params: {
-              query: { query, sortBy, sortDirection },
-            },
-          })
-          .expect(200);
-
-        return omitCategories(res.body.entries);
-      }
-
       beforeEach(async () => {
         await clearKnowledgeBase(es);
 
@@ -208,6 +216,157 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         const entries = await getEntries({ query: 'b' });
         expect(entries.length).to.eql(1);
         expect(entries[0].title).to.eql('My title b');
+      });
+    });
+
+    describe('when managing multiple entries across spaces', () => {
+      const SPACE_A_ID = 'space_a';
+      const SPACE_B_ID = 'space_b';
+
+      before(async () => {
+        await clearKnowledgeBase(es);
+
+        const { status: importStatusForSpaceA } = await observabilityAIAssistantAPIClient.admin({
+          endpoint: 'POST /internal/observability_ai_assistant/kb/entries/import',
+          params: {
+            body: {
+              entries: [
+                {
+                  id: 'my-doc-1',
+                  title: `Entry in Space A by Admin 1`,
+                  text: `This is a public entry in Space A created by Admin`,
+                  public: true,
+                },
+                {
+                  id: 'my-doc-2',
+                  title: `Entry in Space A by Admin 2`,
+                  text: `This is a private entry in Space A created by Admin`,
+                  public: false,
+                },
+              ],
+            },
+          },
+          spaceId: SPACE_A_ID,
+        });
+        expect(importStatusForSpaceA).to.be(200);
+
+        const { status: importStatusForSpaceB } = await observabilityAIAssistantAPIClient.admin({
+          endpoint: 'POST /internal/observability_ai_assistant/kb/entries/import',
+          params: {
+            body: {
+              entries: [
+                {
+                  id: 'my-doc-3',
+                  title: `Entry in Space B by Admin 3`,
+                  text: `This is a public entry in Space B created by Admin`,
+                  public: true,
+                },
+                {
+                  id: 'my-doc-4',
+                  title: `Entry in Space B by Admin 4`,
+                  text: `This is a private entry in Space B created by Admin`,
+                  public: false,
+                },
+              ],
+            },
+          },
+          spaceId: SPACE_B_ID,
+        });
+        expect(importStatusForSpaceB).to.be(200);
+      });
+
+      after(async () => {
+        await clearKnowledgeBase(es);
+      });
+
+      it('ensures users can only access entries relevant to their namespace', async () => {
+        // User (admin) in space A should only see entries in space A
+        const spaceAEntries = await getEntries({
+          user: 'admin',
+          spaceId: SPACE_A_ID,
+        });
+
+        expect(spaceAEntries.length).to.be(2);
+
+        expect(spaceAEntries[0].id).to.equal('my-doc-1');
+        expect(spaceAEntries[0].public).to.be(true);
+        expect(spaceAEntries[0].title).to.equal('Entry in Space A by Admin 1');
+
+        expect(spaceAEntries[1].id).to.equal('my-doc-2');
+        expect(spaceAEntries[1].public).to.be(false);
+        expect(spaceAEntries[1].title).to.equal('Entry in Space A by Admin 2');
+
+        // User (admin) in space B should only see entries in space B
+        const spaceBEntries = await getEntries({
+          user: 'admin',
+          spaceId: SPACE_B_ID,
+        });
+
+        expect(spaceBEntries.length).to.be(2);
+
+        expect(spaceBEntries[0].id).to.equal('my-doc-3');
+        expect(spaceBEntries[0].public).to.be(true);
+        expect(spaceBEntries[0].title).to.equal('Entry in Space B by Admin 3');
+
+        expect(spaceBEntries[1].id).to.equal('my-doc-4');
+        expect(spaceBEntries[1].public).to.be(false);
+        expect(spaceBEntries[1].title).to.equal('Entry in Space B by Admin 4');
+      });
+
+      it('should allow a user who is not the owner of the entries to access entries relevant to their namespace', async () => {
+        // User (editor) in space B should only see entries in space B
+        const spaceBEntries = await getEntries({
+          user: 'editor',
+          spaceId: SPACE_B_ID,
+        });
+
+        expect(spaceBEntries.length).to.be(2);
+
+        expect(spaceBEntries[0].id).to.equal('my-doc-3');
+        expect(spaceBEntries[0].public).to.be(true);
+        expect(spaceBEntries[0].title).to.equal('Entry in Space B by Admin 3');
+
+        expect(spaceBEntries[1].id).to.equal('my-doc-4');
+        expect(spaceBEntries[1].public).to.be(false);
+        expect(spaceBEntries[1].title).to.equal('Entry in Space B by Admin 4');
+      });
+    });
+
+    describe('security roles and access privileges', () => {
+      describe('should deny access for users without the ai_assistant privilege', () => {
+        it('POST /internal/observability_ai_assistant/kb/entries/save', async () => {
+          const { status } = await observabilityAIAssistantAPIClient.viewer({
+            endpoint: 'POST /internal/observability_ai_assistant/kb/entries/save',
+            params: {
+              body: {
+                id: 'my-doc-id-1',
+                title: 'My title',
+                text: 'My content',
+              },
+            },
+          });
+          expect(status).to.be(403);
+        });
+
+        it('GET /internal/observability_ai_assistant/kb/entries', async () => {
+          const { status } = await observabilityAIAssistantAPIClient.viewer({
+            endpoint: 'GET /internal/observability_ai_assistant/kb/entries',
+            params: {
+              query: { query: '', sortBy: 'title', sortDirection: 'asc' },
+            },
+          });
+          expect(status).to.be(403);
+        });
+
+        it('DELETE /internal/observability_ai_assistant/kb/entries/{entryId}', async () => {
+          const { status } = await observabilityAIAssistantAPIClient.viewer({
+            endpoint: 'DELETE /internal/observability_ai_assistant/kb/entries/{entryId}',
+            params: {
+              path: { entryId: 'my-doc-id-1' },
+            },
+          });
+          expect(status).to.be(403);
+        });
       });
     });
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Obs AI Assistant] Make KB retrieval namespace specific  (#213505)](https://github.com/elastic/kibana/pull/213505)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-03-11T17:44:28Z","message":"[Obs AI Assistant] Make KB retrieval namespace specific  (#213505)\n\nCloses https://github.com/elastic/kibana/issues/213504\n\n## Summary\n\n### Problem\n\nKB retrievals are not space specific at present. Therefore, users are\nable to view entries across spaces.\n\n###  Solution\n\nFilter by `namespace` when retrieving KB entries.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"9b1455c7f7beeddd70d2ecefaa58bd6f5ff8cb0e","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v8.18.0","v9.1.0","v8.19.0","v8.17.4"],"title":"[Obs AI Assistant] Make KB retrieval namespace specific ","number":213505,"url":"https://github.com/elastic/kibana/pull/213505","mergeCommit":{"message":"[Obs AI Assistant] Make KB retrieval namespace specific  (#213505)\n\nCloses https://github.com/elastic/kibana/issues/213504\n\n## Summary\n\n### Problem\n\nKB retrievals are not space specific at present. Therefore, users are\nable to view entries across spaces.\n\n###  Solution\n\nFilter by `namespace` when retrieving KB entries.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"9b1455c7f7beeddd70d2ecefaa58bd6f5ff8cb0e"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213986","number":213986,"state":"MERGED","mergeCommit":{"sha":"f1e9a5f631849800a41fdc3f979aea86a3f7d50c","message":"[9.0] [Obs AI Assistant] Make KB retrieval namespace specific  (#213505) (#213986)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Obs AI Assistant] Make KB retrieval namespace specific\n(#213505)](https://github.com/elastic/kibana/pull/213505)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Viduni Wickramarachchi <viduni.wickramarachchi@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213984","number":213984,"state":"MERGED","mergeCommit":{"sha":"f8e55ed7354017e6f1a76c5b86eaf6ddc370679e","message":"[8.18] [Obs AI Assistant] Make KB retrieval namespace specific  (#213505) (#213984)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Obs AI Assistant] Make KB retrieval namespace specific\n(#213505)](https://github.com/elastic/kibana/pull/213505)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Viduni Wickramarachchi <viduni.wickramarachchi@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213505","number":213505,"mergeCommit":{"message":"[Obs AI Assistant] Make KB retrieval namespace specific  (#213505)\n\nCloses https://github.com/elastic/kibana/issues/213504\n\n## Summary\n\n### Problem\n\nKB retrievals are not space specific at present. Therefore, users are\nable to view entries across spaces.\n\n###  Solution\n\nFilter by `namespace` when retrieving KB entries.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"9b1455c7f7beeddd70d2ecefaa58bd6f5ff8cb0e"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213985","number":213985,"state":"MERGED","mergeCommit":{"sha":"7c36cedfe62da1d9a7e6930ad708c63596fba60c","message":"[8.x] [Obs AI Assistant] Make KB retrieval namespace specific  (#213505) (#213985)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Obs AI Assistant] Make KB retrieval namespace specific\n(#213505)](https://github.com/elastic/kibana/pull/213505)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Viduni Wickramarachchi <viduni.wickramarachchi@elastic.co>"}},{"branch":"8.17","label":"v8.17.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->