### PR TITLE
[8.18] [EDR Workflows] Fix event filters cannot be saved bug (#213805)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/event_filters/view/components/form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/event_filters/view/components/form.tsx
@@ -197,9 +197,7 @@ export const EventFiltersForm: React.FC<ArtifactFormComponentProps & { allowSele
       [exception]
     );
 
-    const [areConditionsValid, setAreConditionsValid] = useState(
-      !!exception.entries.length || false
-    );
+    const [areConditionsValid, setAreConditionsValid] = useState(!!exception.entries.length);
     // compute this for initial render only
     const existingComments = useMemo<ExceptionListItemSchema['comments']>(
       () => (exception as ExceptionListItemSchema)?.comments,
@@ -236,7 +234,7 @@ export const EventFiltersForm: React.FC<ArtifactFormComponentProps & { allowSele
         cleanupEntries(item);
         onChange({
           item,
-          isValid: isFormValid && areConditionsValid,
+          isValid: isFormValid && areConditionsValid && hasFormChanged,
           confirmModalLabels: hasWildcardWithWrongOperator
             ? CONFIRM_WARNING_MODAL_LABELS(
                 i18n.translate('xpack.securitySolution.eventFilter.flyoutForm.confirmModal.name', {
@@ -246,7 +244,14 @@ export const EventFiltersForm: React.FC<ArtifactFormComponentProps & { allowSele
             : undefined,
         });
       },
-      [areConditionsValid, exception, isFormValid, onChange, hasWildcardWithWrongOperator]
+      [
+        areConditionsValid,
+        exception,
+        hasFormChanged,
+        isFormValid,
+        onChange,
+        hasWildcardWithWrongOperator,
+      ]
     );
 
     // set initial state of `wasByPolicy` that checks
@@ -550,11 +555,11 @@ export const EventFiltersForm: React.FC<ArtifactFormComponentProps & { allowSele
     // conditions and handler
     const handleOnBuilderChange = useCallback(
       (arg: OnChangeProps) => {
-        const hasDuplicates =
+        const isCalledWithoutChanges =
           (!hasFormChanged && arg.exceptionItems[0] === undefined) ||
           isEqual(arg.exceptionItems[0]?.entries, exception?.entries);
 
-        if (hasDuplicates) {
+        if (isCalledWithoutChanges) {
           const addedFields = arg.exceptionItems[0]?.entries.map((e) => e.field) || [''];
 
           if (isFilterProcessDescendantsFeatureEnabled && isFilterProcessDescendantsSelected) {
@@ -562,7 +567,6 @@ export const EventFiltersForm: React.FC<ArtifactFormComponentProps & { allowSele
           }
 
           setHasDuplicateFields(computeHasDuplicateFields(getAddedFieldsCounts(addedFields)));
-          if (!hasFormChanged) setHasFormChanged(true);
           return;
         } else {
           setHasDuplicateFields(false);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[EDR Workflows] Fix event filters cannot be saved bug (#213805)](https://github.com/elastic/kibana/pull/213805)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gergő Ábrahám","email":"gergo.abraham@elastic.co"},"sourceCommit":{"committedDate":"2025-03-11T18:49:42Z","message":"[EDR Workflows] Fix event filters cannot be saved bug (#213805)\n\n## Summary\n\nThis PR fixes the bug when the Save button on the flyout of the edited\nEvent Filter won't turn into enabled state, when the user edits the\ninput fields.\n\n\n## Screen recordings\nAdded some screen recordings to help the reviews.\n\n### Editing\nThis had the original issue, here how it works:\n\n\nhttps://github.com/user-attachments/assets/ff270cad-ca9b-431c-a789-d24cffe2f526\n\n### Adding new event filter\nJust regression.\n\n\nhttps://github.com/user-attachments/assets/7d0c0722-6e8e-4518-8505-c137a50c8cb7\n\n### Adding from Security / Explore\nJust to see that it still works, as I needed to modify its unit tests.\n\n\nhttps://github.com/user-attachments/assets/ec204b34-d528-4937-aabc-1aa808a3b3d8\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"91e8ac4f87c458b2f27b28f1842298985586b5ca","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Defend Workflows","backport:prev-minor","backport:prev-major","v9.1.0"],"title":"[EDR Workflows] Fix event filters cannot be saved bug","number":213805,"url":"https://github.com/elastic/kibana/pull/213805","mergeCommit":{"message":"[EDR Workflows] Fix event filters cannot be saved bug (#213805)\n\n## Summary\n\nThis PR fixes the bug when the Save button on the flyout of the edited\nEvent Filter won't turn into enabled state, when the user edits the\ninput fields.\n\n\n## Screen recordings\nAdded some screen recordings to help the reviews.\n\n### Editing\nThis had the original issue, here how it works:\n\n\nhttps://github.com/user-attachments/assets/ff270cad-ca9b-431c-a789-d24cffe2f526\n\n### Adding new event filter\nJust regression.\n\n\nhttps://github.com/user-attachments/assets/7d0c0722-6e8e-4518-8505-c137a50c8cb7\n\n### Adding from Security / Explore\nJust to see that it still works, as I needed to modify its unit tests.\n\n\nhttps://github.com/user-attachments/assets/ec204b34-d528-4937-aabc-1aa808a3b3d8\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"91e8ac4f87c458b2f27b28f1842298985586b5ca"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213805","number":213805,"mergeCommit":{"message":"[EDR Workflows] Fix event filters cannot be saved bug (#213805)\n\n## Summary\n\nThis PR fixes the bug when the Save button on the flyout of the edited\nEvent Filter won't turn into enabled state, when the user edits the\ninput fields.\n\n\n## Screen recordings\nAdded some screen recordings to help the reviews.\n\n### Editing\nThis had the original issue, here how it works:\n\n\nhttps://github.com/user-attachments/assets/ff270cad-ca9b-431c-a789-d24cffe2f526\n\n### Adding new event filter\nJust regression.\n\n\nhttps://github.com/user-attachments/assets/7d0c0722-6e8e-4518-8505-c137a50c8cb7\n\n### Adding from Security / Explore\nJust to see that it still works, as I needed to modify its unit tests.\n\n\nhttps://github.com/user-attachments/assets/ec204b34-d528-4937-aabc-1aa808a3b3d8\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"91e8ac4f87c458b2f27b28f1842298985586b5ca"}},{"url":"https://github.com/elastic/kibana/pull/213994","number":213994,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->