### PR TITLE
Alerts table in Rule Preview panel fills container width

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_histogram.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/preview_histogram.tsx
@@ -38,8 +38,6 @@ import { INSPECT_ACTION } from '../../../../common/components/visualization_acti
 
 const FullScreenContainer = styled.div<{ $isFullScreen: boolean }>`
   height: ${({ $isFullScreen }) => ($isFullScreen ? '100%' : undefined)};
-  flex: 1 1 auto;
-  display: flex;
   width: 100%;
 `;
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/elastic/kibana/issues/213706.

I suspect that this stopped working when #206523 removed the `FullScreenContainer` from the inner StatefulEventsViewer component; that change combined with the `display:flex` on this parent element caused the table to no longer grow as expected.

Luckily, the fix here was simply not using flexbox on the container. Since the table is the only element within this container, I saw no reason why flexbox was needed here; testing has confirmed this.

### Screenshot (after fix; see bug for "before" image)
<kbd><img width="1709" alt="Screenshot 2025-03-11 at 5 35 43 PM" src="https://github.com/user-attachments/assets/108be815-00e2-48b7-8821-e63566eefa09" /></kbd>



<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->