### PR TITLE
Connector usage api testing

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/usage/connector_usage_reporting_task.ts
+++ b/x-pack/platform/plugins/shared/actions/server/usage/connector_usage_reporting_task.ts
@@ -20,7 +20,7 @@ import { ActionsConfig } from '../config';
 import { ConnectorUsageReport } from './types';
 import { ActionsPluginsStart } from '../plugin';
 
-export const CONNECTOR_USAGE_REPORTING_TASK_SCHEDULE: IntervalSchedule = { interval: '1h' };
+export const CONNECTOR_USAGE_REPORTING_TASK_SCHEDULE: IntervalSchedule = { interval: '5m' };
 export const CONNECTOR_USAGE_REPORTING_TASK_ID = 'connector_usage_reporting';
 export const CONNECTOR_USAGE_REPORTING_TASK_TYPE = `actions:${CONNECTOR_USAGE_REPORTING_TASK_ID}`;
 export const CONNECTOR_USAGE_REPORTING_TASK_TIMEOUT = 30000;
@@ -57,8 +57,10 @@ export class ConnectorUsageReportingTask {
     const caCertificatePath = config.ca?.path;
 
     if (caCertificatePath && caCertificatePath.length > 0) {
+      this.logger.info(`caCertificatePath: ${caCertificatePath}`);
       try {
         this.caCertificate = fs.readFileSync(caCertificatePath, 'utf8');
+        this.logger.info(`CA Certificate for the project "${projectId}" read successfully`);
       } catch (e) {
         this.caCertificate = undefined;
         this.logger.error(
@@ -181,7 +183,8 @@ export class ConnectorUsageReportingTask {
     } catch (e) {
       if (attempts < MAX_PUSH_ATTEMPTS) {
         this.logger.error(
-          `Usage data could not be pushed to usage-api. It will be retried (${attempts}). Error:${e.message}`
+          `Usage data could not be pushed to usage-api. It will be retried (${attempts}). Error:${e.message}`,
+          { error: { stack_trace: e.stack } }
         );
 
         return {

--- a/x-pack/platform/plugins/shared/actions/server/usage/connector_usage_reporting_task.ts
+++ b/x-pack/platform/plugins/shared/actions/server/usage/connector_usage_reporting_task.ts
@@ -196,7 +196,8 @@ export class ConnectorUsageReportingTask {
         };
       }
       this.logger.error(
-        `Usage data could not be pushed to usage-api. Stopped retrying after ${attempts} attempts. Error:${e.message}`
+        `Usage data could not be pushed to usage-api. Stopped retrying after ${attempts} attempts. Error:${e.message}`,
+        { error: { stack_trace: e.stack } }
       );
       return {
         state: {

--- a/x-pack/platform/plugins/shared/actions/server/usage/connector_usage_reporting_task.ts
+++ b/x-pack/platform/plugins/shared/actions/server/usage/connector_usage_reporting_task.ts
@@ -26,7 +26,7 @@ export const CONNECTOR_USAGE_REPORTING_TASK_TYPE = `actions:${CONNECTOR_USAGE_RE
 export const CONNECTOR_USAGE_REPORTING_TASK_TIMEOUT = 30000;
 export const CONNECTOR_USAGE_TYPE = `connector_request_body_bytes`;
 export const CONNECTOR_USAGE_REPORTING_SOURCE_ID = `task-connector-usage-report`;
-export const MAX_PUSH_ATTEMPTS = 5;
+export const MAX_PUSH_ATTEMPTS = 1;
 
 export class ConnectorUsageReportingTask {
   private readonly logger: Logger;


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



