### PR TITLE
[8.18] [Infra] Inventory-view saved object schema fix (#210023)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/saved_objects/inventory_view/inventory_view_saved_object.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/saved_objects/inventory_view/inventory_view_saved_object.ts
@@ -23,9 +23,14 @@ const getInventoryViewTitle = (savedObject: SavedObject<unknown>) =>
   );
 
 const schemaV1 = schema.object({}, { unknowns: 'allow' });
-const schemaV2 = schema.object({
-  legend: schema.object({ steps: schema.number({ max: 18, min: 2 }) }),
-});
+const schemaV2 = schema.object(
+  {
+    legend: schema.maybe(
+      schema.object({ steps: schema.number({ max: 18, min: 2 }) }, { unknowns: 'allow' })
+    ),
+  },
+  { unknowns: 'allow' }
+);
 
 export const inventoryViewSavedObjectType: SavedObjectsType = {
   name: inventoryViewSavedObjectName,
@@ -64,7 +69,7 @@ export const inventoryViewSavedObjectType: SavedObjectsType = {
         },
       ],
       schemas: {
-        forwardCompatibility: schemaV2.extends({}, { unknowns: 'ignore' }),
+        forwardCompatibility: schemaV2,
         create: schemaV2,
       },
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Infra] Inventory-view saved object schema fix (#210023)](https://github.com/elastic/kibana/pull/210023)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-07T14:00:17Z","message":"[Infra] Inventory-view saved object schema fix (#210023)\n\nfixes [#209996](https://github.com/elastic/kibana/issues/209996) \r\n\r\n## Summary\r\n\r\nFix the `inventory-view` schema. The wrong schema was causing an error\r\nwhen trying to create/update a saved view on Infra Inventory UI\r\n\r\n\r\n![inventory-saved-view](https://github.com/user-attachments/assets/682533c0-1893-47a6-9f87-99a2390bb19a)\r\n\r\n### How to test\r\n\r\n- Run on dev tools the request below, it should return a 400 containing\r\nthe message: `\"[attributes.legend.steps]: Value must be equal to or\r\nlower than [18].: Bad Request\"`\r\n```\r\nPOST kbn:/api/saved_objects/inventory-view\r\n{\r\n  \"attributes\": {\r\n    \"metric\": {\r\n      \"type\": \"cpuV2\"\r\n    },\r\n    \"sort\": {\r\n      \"by\": \"name\",\r\n      \"direction\": \"desc\"\r\n    },\r\n    \"groupBy\": [],\r\n    \"nodeType\": \"host\",\r\n    \"view\": \"map\",\r\n    \"customOptions\": [],\r\n    \"customMetrics\": [],\r\n    \"boundsOverride\": {\r\n      \"max\": 1,\r\n      \"min\": 0\r\n    },\r\n    \"autoBounds\": true,\r\n    \"accountId\": \"\",\r\n    \"region\": \"\",\r\n    \"time\": 1738848614746,\r\n    \"autoReload\": false,\r\n    \"filterQuery\": {\r\n      \"expression\": \"\",\r\n      \"kind\": \"kuery\"\r\n    },\r\n    \"legend\": {\r\n      \"palette\": \"cool\",\r\n      \"steps\": 20,\r\n      \"reverseColors\": false\r\n    },\r\n    \"timelineOpen\": false,\r\n    \"name\": \"sss\"\r\n  }\r\n}\r\n```\r\n- Navigate to Infra > Inventory\r\n- Create a new saved view","sha":"e21e7482e71540eb889c883a79f0390277bd12f5","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","backport:prev-minor","Team:obs-ux-infra_services","v9.1.0"],"title":"[Infra] Inventory-view saved object schema fix","number":210023,"url":"https://github.com/elastic/kibana/pull/210023","mergeCommit":{"message":"[Infra] Inventory-view saved object schema fix (#210023)\n\nfixes [#209996](https://github.com/elastic/kibana/issues/209996) \r\n\r\n## Summary\r\n\r\nFix the `inventory-view` schema. The wrong schema was causing an error\r\nwhen trying to create/update a saved view on Infra Inventory UI\r\n\r\n\r\n![inventory-saved-view](https://github.com/user-attachments/assets/682533c0-1893-47a6-9f87-99a2390bb19a)\r\n\r\n### How to test\r\n\r\n- Run on dev tools the request below, it should return a 400 containing\r\nthe message: `\"[attributes.legend.steps]: Value must be equal to or\r\nlower than [18].: Bad Request\"`\r\n```\r\nPOST kbn:/api/saved_objects/inventory-view\r\n{\r\n  \"attributes\": {\r\n    \"metric\": {\r\n      \"type\": \"cpuV2\"\r\n    },\r\n    \"sort\": {\r\n      \"by\": \"name\",\r\n      \"direction\": \"desc\"\r\n    },\r\n    \"groupBy\": [],\r\n    \"nodeType\": \"host\",\r\n    \"view\": \"map\",\r\n    \"customOptions\": [],\r\n    \"customMetrics\": [],\r\n    \"boundsOverride\": {\r\n      \"max\": 1,\r\n      \"min\": 0\r\n    },\r\n    \"autoBounds\": true,\r\n    \"accountId\": \"\",\r\n    \"region\": \"\",\r\n    \"time\": 1738848614746,\r\n    \"autoReload\": false,\r\n    \"filterQuery\": {\r\n      \"expression\": \"\",\r\n      \"kind\": \"kuery\"\r\n    },\r\n    \"legend\": {\r\n      \"palette\": \"cool\",\r\n      \"steps\": 20,\r\n      \"reverseColors\": false\r\n    },\r\n    \"timelineOpen\": false,\r\n    \"name\": \"sss\"\r\n  }\r\n}\r\n```\r\n- Navigate to Infra > Inventory\r\n- Create a new saved view","sha":"e21e7482e71540eb889c883a79f0390277bd12f5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/211620","number":211620,"state":"MERGED","mergeCommit":{"sha":"f8106291e9786c7f6915bdf30d6b552bbc3917b4","message":"[9.0] [Infra] Inventory-view saved object schema fix (#210023) (#211620)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Infra] Inventory-view saved object schema fix\n(#210023)](https://github.com/elastic/kibana/pull/210023)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210023","number":210023,"mergeCommit":{"message":"[Infra] Inventory-view saved object schema fix (#210023)\n\nfixes [#209996](https://github.com/elastic/kibana/issues/209996) \r\n\r\n## Summary\r\n\r\nFix the `inventory-view` schema. The wrong schema was causing an error\r\nwhen trying to create/update a saved view on Infra Inventory UI\r\n\r\n\r\n![inventory-saved-view](https://github.com/user-attachments/assets/682533c0-1893-47a6-9f87-99a2390bb19a)\r\n\r\n### How to test\r\n\r\n- Run on dev tools the request below, it should return a 400 containing\r\nthe message: `\"[attributes.legend.steps]: Value must be equal to or\r\nlower than [18].: Bad Request\"`\r\n```\r\nPOST kbn:/api/saved_objects/inventory-view\r\n{\r\n  \"attributes\": {\r\n    \"metric\": {\r\n      \"type\": \"cpuV2\"\r\n    },\r\n    \"sort\": {\r\n      \"by\": \"name\",\r\n      \"direction\": \"desc\"\r\n    },\r\n    \"groupBy\": [],\r\n    \"nodeType\": \"host\",\r\n    \"view\": \"map\",\r\n    \"customOptions\": [],\r\n    \"customMetrics\": [],\r\n    \"boundsOverride\": {\r\n      \"max\": 1,\r\n      \"min\": 0\r\n    },\r\n    \"autoBounds\": true,\r\n    \"accountId\": \"\",\r\n    \"region\": \"\",\r\n    \"time\": 1738848614746,\r\n    \"autoReload\": false,\r\n    \"filterQuery\": {\r\n      \"expression\": \"\",\r\n      \"kind\": \"kuery\"\r\n    },\r\n    \"legend\": {\r\n      \"palette\": \"cool\",\r\n      \"steps\": 20,\r\n      \"reverseColors\": false\r\n    },\r\n    \"timelineOpen\": false,\r\n    \"name\": \"sss\"\r\n  }\r\n}\r\n```\r\n- Navigate to Infra > Inventory\r\n- Create a new saved view","sha":"e21e7482e71540eb889c883a79f0390277bd12f5"}}]}] BACKPORT-->