### PR TITLE
[8.x] Use `inferenceChatModel` for playground (#210756)

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/search_playground/kibana.jsonc
@@ -26,7 +26,8 @@
       "security",
       "stackConnectors",
       "triggersActionsUi",
-      "uiActions"
+      "uiActions",
+      "inference"
     ],
     "optionalPlugins": [
       "cloud",

--- a/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/lib/get_chat_params.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { getChatParams } from './get_chat_params';
-import { ActionsClientChatOpenAI, ActionsClientSimpleChatModel } from '@kbn/langchain/server';
 import {
   OPENAI_CONNECTOR_ID,
   BEDROCK_CONNECTOR_ID,
@@ -14,8 +13,10 @@ import {
   INFERENCE_CONNECTOR_ID,
 } from '@kbn/stack-connectors-plugin/public/common';
 import { Prompt, QuestionRewritePrompt } from '../../common/prompt';
-import { KibanaRequest, Logger } from '@kbn/core/server';
+import { loggerMock, MockedLogger } from '@kbn/logging-mocks';
+import { httpServerMock } from '@kbn/core/server/mocks';
 import { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
+import { inferenceMock } from '@kbn/inference-plugin/server/mocks';
 
 jest.mock('@kbn/langchain/server', () => {
   const original = jest.requireActual('@kbn/langchain/server');
@@ -43,11 +44,15 @@ describe('getChatParams', () => {
     getActionsClientWithRequest: jest.fn(() => Promise.resolve(mockActionsClient)),
   } as unknown as ActionsPluginStartContract;
 
-  const logger = jest.fn() as unknown as Logger;
-  const request = jest.fn() as unknown as KibanaRequest;
+  let logger: MockedLogger;
+  let request: ReturnType<typeof httpServerMock.createKibanaRequest>;
+  let inference: ReturnType<typeof inferenceMock.createStartContract>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    logger = loggerMock.create();
+    request = httpServerMock.createKibanaRequest();
+    inference = inferenceMock.createStartContract();
   });
 
   it('returns the correct chat model and prompt for OPENAI_CONNECTOR_ID', async () => {
@@ -60,7 +65,7 @@ describe('getChatParams', () => {
         prompt: 'Hello, world!',
         citations: true,
       },
-      { actions, request, logger }
+      { actions, request, logger, inference }
     );
     expect(Prompt).toHaveBeenCalledWith('Hello, world!', {
       citations: true,
@@ -70,7 +75,14 @@ describe('getChatParams', () => {
     expect(QuestionRewritePrompt).toHaveBeenCalledWith({
       type: 'openai',
     });
-    expect(ActionsClientChatOpenAI).toHaveBeenCalledWith(expect.anything());
+    expect(inference.getChatModel).toHaveBeenCalledWith({
+      request,
+      connectorId: '1',
+      chatModelOptions: expect.objectContaining({
+        model: 'text-davinci-003',
+        maxRetries: 0,
+      }),
+    });
     expect(result.chatPrompt).toContain('Hello, world!');
   });
 
@@ -84,7 +96,7 @@ describe('getChatParams', () => {
         prompt: 'Hello, world!',
         citations: true,
       },
-      { actions, request, logger }
+      { actions, request, logger, inference }
     );
     expect(Prompt).toHaveBeenCalledWith('Hello, world!', {
       citations: true,
@@ -94,14 +106,14 @@ describe('getChatParams', () => {
     expect(QuestionRewritePrompt).toHaveBeenCalledWith({
       type: 'gemini',
     });
-    expect(ActionsClientSimpleChatModel).toHaveBeenCalledWith({
-      temperature: 0,
-      llmType: 'gemini',
-      logger: expect.anything(),
-      model: 'gemini-1.5-pro',
+    expect(inference.getChatModel).toHaveBeenCalledWith({
+      request,
       connectorId: '1',
-      actionsClient: expect.anything(),
-      streaming: true,
+      chatModelOptions: expect.objectContaining({
+        model: 'gemini-1.5-pro',
+        temperature: 0,
+        maxRetries: 0,
+      }),
     });
     expect(result.chatPrompt).toContain('Hello, world!');
   });
@@ -116,7 +128,7 @@ describe('getChatParams', () => {
         prompt: 'How does it work?',
         citations: false,
       },
-      { actions, request, logger }
+      { actions, request, logger, inference }
     );
 
     expect(Prompt).toHaveBeenCalledWith('How does it work?', {
@@ -127,19 +139,19 @@ describe('getChatParams', () => {
     expect(QuestionRewritePrompt).toHaveBeenCalledWith({
       type: 'anthropic',
     });
-    expect(ActionsClientSimpleChatModel).toHaveBeenCalledWith({
-      temperature: 0,
-      llmType: 'bedrock',
-      logger: expect.anything(),
-      model: 'custom-model',
+    expect(inference.getChatModel).toHaveBeenCalledWith({
+      request,
       connectorId: '2',
-      actionsClient: expect.anything(),
-      streaming: true,
+      chatModelOptions: expect.objectContaining({
+        model: 'custom-model',
+        temperature: 0,
+        maxRetries: 0,
+      }),
     });
     expect(result.chatPrompt).toContain('How does it work?');
   });
 
-  it('throws an error for invalid connector id', async () => {
+  it('throws an error for invalid connector type', async () => {
     mockActionsClient.get.mockResolvedValue({ id: '3', actionTypeId: 'unknown' });
 
     await expect(
@@ -149,9 +161,9 @@ describe('getChatParams', () => {
           prompt: 'This should fail.',
           citations: false,
         },
-        { actions, request, logger }
+        { actions, request, logger, inference }
       )
-    ).rejects.toThrow('Invalid connector id');
+    ).rejects.toThrow('Invalid connector type: unknown');
   });
 
   it('returns the correct chat model and uses the default model when not specified in the params', async () => {
@@ -167,7 +179,7 @@ describe('getChatParams', () => {
         prompt: 'How does it work?',
         citations: false,
       },
-      { actions, request, logger }
+      { actions, request, logger, inference }
     );
 
     expect(Prompt).toHaveBeenCalledWith('How does it work?', {
@@ -178,15 +190,14 @@ describe('getChatParams', () => {
     expect(QuestionRewritePrompt).toHaveBeenCalledWith({
       type: 'openai',
     });
-    expect(ActionsClientChatOpenAI).toHaveBeenCalledWith({
-      logger: expect.anything(),
-      model: 'local',
+    expect(inference.getChatModel).toHaveBeenCalledWith({
+      request,
       connectorId: '2',
-      actionsClient: expect.anything(),
-      signal: expect.anything(),
-      traceId: 'test-uuid',
-      temperature: 0.2,
-      maxRetries: 0,
+      chatModelOptions: expect.objectContaining({
+        model: 'local',
+        temperature: 0.2,
+        maxRetries: 0,
+      }),
     });
     expect(result.chatPrompt).toContain('How does it work?');
   });
@@ -204,7 +215,7 @@ describe('getChatParams', () => {
         prompt: 'How does it work?',
         citations: false,
       },
-      { actions, request, logger }
+      { actions, request, logger, inference }
     );
 
     expect(Prompt).toHaveBeenCalledWith('How does it work?', {
@@ -215,14 +226,13 @@ describe('getChatParams', () => {
     expect(QuestionRewritePrompt).toHaveBeenCalledWith({
       type: 'openai',
     });
-    expect(ActionsClientChatOpenAI).toHaveBeenCalledWith({
-      logger: expect.anything(),
-      model: 'local',
+    expect(inference.getChatModel).toHaveBeenCalledWith({
+      request,
       connectorId: '2',
-      actionsClient: expect.anything(),
-      temperature: 0.2,
-      maxRetries: 0,
-      llmType: 'inference',
+      chatModelOptions: expect.objectContaining({
+        model: 'local',
+        maxRetries: 0,
+      }),
     });
     expect(result.chatPrompt).toContain('How does it work?');
   });

--- a/x-pack/solutions/search/plugins/search_playground/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/routes.ts
@@ -108,7 +108,7 @@ export function defineRoutes({
       },
     },
     errorHandler(logger)(async (context, request, response) => {
-      const [{ analytics }, { actions, cloud }] = await getStartServices();
+      const [{ analytics }, { actions, cloud, inference }] = await getStartServices();
 
       const { client } = (await context.core).elasticsearch;
       const aiClient = Assist({
@@ -122,7 +122,7 @@ export function defineRoutes({
           citations: data.citations,
           prompt: data.prompt,
         },
-        { actions, logger, request }
+        { actions, inference, logger, request }
       );
 
       let sourceFields = {};

--- a/x-pack/solutions/search/plugins/search_playground/server/types.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/types.ts
@@ -8,6 +8,7 @@
 import type { PluginStartContract as ActionsPluginStartContract } from '@kbn/actions-plugin/server';
 import type { CloudSetup, CloudStart } from '@kbn/cloud-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { InferenceServerStart } from '@kbn/inference-plugin/server';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchPlaygroundPluginSetup {}
@@ -22,6 +23,7 @@ export interface SearchPlaygroundPluginSetupDependencies {
 
 export interface SearchPlaygroundPluginStartDependencies {
   actions: ActionsPluginStartContract;
+  inference: InferenceServerStart;
   cloud?: CloudStart;
 }
 

--- a/x-pack/solutions/search/plugins/search_playground/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_playground/tsconfig.json
@@ -51,6 +51,8 @@
     "@kbn/alerts-ui-shared",
     "@kbn/ui-actions-plugin",
     "@kbn/file-upload-common",
+    "@kbn/logging-mocks",
+    "@kbn/inference-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Use `inferenceChatModel` for playground (#210756)](https://github.com/elastic/kibana/pull/210756)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2025-03-12T08:18:18Z","message":"Use `inferenceChatModel` for playground (#210756)\n\n## Summary\n\nPart of https://github.com/elastic/kibana/issues/206710\n\nWire the new `InferenceChatModel` into playground. Please refer to\nhttps://github.com/elastic/kibana/pull/210756 for the reasons behind\nthat change.\n\n### testing\n\nTested with all 4 supported connectors:\n\n<img width=\"1673\" alt=\"Screenshot 2025-02-12 at 10 32 43\"\nsrc=\"https://github.com/user-attachments/assets/45d76fc1-79c5-4e17-bc4d-4f7aa173f892\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ed7178674c183459c03eb427fc163e94db94606e","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","Team:AI Infra","v9.1.0","v8.19.0"],"title":"Use `inferenceChatModel` for playground","number":210756,"url":"https://github.com/elastic/kibana/pull/210756","mergeCommit":{"message":"Use `inferenceChatModel` for playground (#210756)\n\n## Summary\n\nPart of https://github.com/elastic/kibana/issues/206710\n\nWire the new `InferenceChatModel` into playground. Please refer to\nhttps://github.com/elastic/kibana/pull/210756 for the reasons behind\nthat change.\n\n### testing\n\nTested with all 4 supported connectors:\n\n<img width=\"1673\" alt=\"Screenshot 2025-02-12 at 10 32 43\"\nsrc=\"https://github.com/user-attachments/assets/45d76fc1-79c5-4e17-bc4d-4f7aa173f892\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ed7178674c183459c03eb427fc163e94db94606e"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210756","number":210756,"mergeCommit":{"message":"Use `inferenceChatModel` for playground (#210756)\n\n## Summary\n\nPart of https://github.com/elastic/kibana/issues/206710\n\nWire the new `InferenceChatModel` into playground. Please refer to\nhttps://github.com/elastic/kibana/pull/210756 for the reasons behind\nthat change.\n\n### testing\n\nTested with all 4 supported connectors:\n\n<img width=\"1673\" alt=\"Screenshot 2025-02-12 at 10 32 43\"\nsrc=\"https://github.com/user-attachments/assets/45d76fc1-79c5-4e17-bc4d-4f7aa173f892\"\n/>\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ed7178674c183459c03eb427fc163e94db94606e"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->