### PR TITLE
[ES3] Enable inference action type

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -84,7 +84,7 @@ telemetry.labels.serverless: search
 
 # Alerts and LLM config
 xpack.actions.enabledActionTypes:
-  ['.email', '.index', '.slack', '.jira', '.webhook', '.teams', '.gen-ai', '.bedrock', '.gemini']
+  ['.email', '.index', '.slack', '.jira', '.webhook', '.teams', '.gen-ai', '.bedrock', '.gemini', '.inference']
 
 # Customize empty page state for analytics apps
 no_data_page.analyticsNoDataPageFlavor: 'serverless_search'


### PR DESCRIPTION
## Summary

This enables the inference action connector type on ES3.

