### PR TITLE
[Security Solution] Fix inconsistent rule's modified status after applying bulk actions

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx
@@ -229,7 +229,7 @@ const INTEGRATIONS_COLUMN: TableColumn = {
 
     return <IntegrationsPopover relatedIntegrations={integrations} />;
   },
-  width: '143px',
+  width: '70px',
   truncateText: true,
 };
 
@@ -258,7 +258,7 @@ const MODIFIED_COLUMN: TableColumn = {
       </EuiToolTip>
     );
   },
-  width: '70px',
+  width: '90px',
   truncateText: true,
 };
 


### PR DESCRIPTION
## Summary

Fixes a problem [`Bulk adding tags to rules marks some rules as customized and doesn't mark other rules as customized. It looks like it depends on the existence of the base version.`](https://github.com/elastic/kibana/pull/212761#pullrequestreview-2675994950) discovered while smoke testing after enabling Prebuilt Rules Customization FF.

## Details

The problems manifests as some rules have `Modified` badge missing after modifying tags via bulk actions.

The root cause is that current bulk actions implementation expects unmodified rule's data in `paramsModifier()` callback. But Alerting Framework's Rules Client invokes `paramsModifier()` providing already modified rule. Alerting Framework managed fields like `rule.tags` have modified values.

The fix makes sure rule customizartion state is calculated by using unmodified rule data.

## Screenshots

Before:

https://github.com/user-attachments/assets/eeb65b18-c51f-4c5e-b0e6-6552e442994e

After:

https://github.com/user-attachments/assets/d18d8765-4f40-4513-95a1-2cd84ac2a0a9



<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->