### PR TITLE
[ci] remove diskSize definition in scout_tests.yml

### DIFF
--- a/.buildkite/pipelines/pull_request/scout_tests.yml
+++ b/.buildkite/pipelines/pull_request/scout_tests.yml
@@ -3,7 +3,6 @@ steps:
     label: 'Scout Test Run Builder'
     agents:
       machineType: n2-standard-2
-      diskSizeGb: 75
     timeout_in_minutes: 10
     env:
       SCOUT_CONFIGS_SCRIPT: '.buildkite/scripts/steps/test/scout_configs.sh'


### PR DESCRIPTION
## Summary

Trying to fix pipeline failure due to not enough disk space:

```

  | 2025-03-12 10:47:33 UTC | Copying cached snapshots from /opt/buildkite-agent/.es-snapshot-cache/cache to .es/cache
  | 2025-03-12 10:47:48 UTC | cp: error writing '.es/cache/elasticsearch-9.0.0-SNAPSHOT-linux-x86_64.tar.gz': No space left on device
  | 2025-03-12 10:47:48 UTC | cp: error writing '.es/cache/elasticsearch-9.0.0-SNAPSHOT-linux-x86_64.tar.gz.meta': No space left on device
  | 2025-03-12 10:47:48 UTC | cp: error writing '.es/cache/elasticsearch-9.1.0-SNAPSHOT-linux-x86_64.tar.gz': No space left on device
  | 2025-03-12 10:47:48 UTC | cp: error writing '.es/cache/elasticsearch-9.1.0-SNAPSHOT-linux-x86_64.tar.gz.meta': No space left on device
```