### PR TITLE
[SLOs] Fix path for slo e2e test scope !!

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -156,7 +156,7 @@ const getPipeline = (filename: string, removeSteps = true) => {
 
     if (
       (await doAnyChangesMatch([
-        /^x-pack\/plugins\/observability_solution/,
+        /^x-pack\/solutions\/observability\/plugins/,
         /^package.json/,
         /^yarn.lock/,
       ])) ||


### PR DESCRIPTION
## Summary

Since observability plugins have been moved, needed to fix the path to scope tests !!

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->