### PR TITLE
[Security Solution] Force upgrading to target version for "Reference URLs" when base version is missing

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/calculate_rule_fields_diff.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/diff/calculation/calculate_rule_fields_diff.ts
@@ -227,7 +227,7 @@ const commonFieldsDiffAlgorithms: FieldsDiffAlgorithmsFor<DiffableCommonFields> 
   risk_score: numberDiffAlgorithm,
   risk_score_mapping: simpleDiffAlgorithm,
   references: createScalarArrayDiffAlgorithm({
-    missingBaseVersionStrategy: ScalarArrayDiffMissingBaseVersionStrategy.Merge,
+    missingBaseVersionStrategy: ScalarArrayDiffMissingBaseVersionStrategy.UseTarget,
   }),
   false_positives: simpleDiffAlgorithm,
   threat: simpleDiffAlgorithm,

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/prebuilt_rule_customization/customization_enabled/diffable_rule_fields/common_fields/references.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/prebuilt_rules/prebuilt_rule_customization/customization_enabled/diffable_rule_fields/common_fields/references.ts
@@ -297,11 +297,11 @@ export function referencesField({ getService }: FtrProviderContext): void {
             ruleUpgradeAssets,
             diffableRuleFieldName: 'references',
             expectedDiffOutcome: ThreeWayDiffOutcome.MissingBaseCanUpdate,
-            isMergableField: true,
+            isMergableField: false,
             expectedFieldDiffValues: {
               current: ['http://url-3'],
               target: ['http://url-1', 'http://url-2'],
-              merged: ['http://url-3', 'http://url-1', 'http://url-2'],
+              merged: ['http://url-1', 'http://url-2'],
             },
           },
           getService


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/214171**

## Summary

This PR fixes an issue with "references" field in -AB situations. When the base version is missing we try to merge current and target arrays which leads to old and potentially broken URLs from the current version ending up in the result.

Now the behaviour is changed to always force merged version to be equal to target (which always has correct URLs).

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->