### PR TITLE
[Response Ops][Connectors] Adding `allowPartialTrustChain` for connector usage reporting task

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/usage/connector_usage_reporting_task.ts
+++ b/x-pack/platform/plugins/shared/actions/server/usage/connector_usage_reporting_task.ts
@@ -298,6 +298,8 @@ export class ConnectorUsageReportingTask {
       headers: { 'Content-Type': 'application/json' },
       timeout: CONNECTOR_USAGE_REPORTING_TASK_TIMEOUT,
       httpsAgent: new https.Agent({
+        // @ts-expect-error option added to node 20.18.0 but @types/node has not been updated to reflect this
+        allowPartialTrustChain: true,
         ca: this.caCertificate,
       }),
     });


### PR DESCRIPTION
## Summary

We need to pass this option to allow the CA certificate to be used for pushing to the usage API.