### PR TITLE
[8.17] [EDR Workflows] Update description on data reduction advanced options (#213970)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -2091,7 +2091,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.alerts.hash.md5',
       {
         defaultMessage:
-          'Compute and include MD5 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: true',
+          'Compute and include MD5 hashes for processes and libraries in alerts? This will increase CPU usage and alert sizes. If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2102,7 +2102,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.alerts.hash.sha1',
       {
         defaultMessage:
-          'Compute and include SHA-1 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: true',
+          'Compute and include SHA-1 hashes for processes and libraries in alerts? This will increase CPU usage and alert sizes. If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2113,7 +2113,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.hash.md5',
       {
         defaultMessage:
-          'Compute and include MD5 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: true',
+          'Compute and include MD5 hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2124,7 +2124,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.hash.sha1',
       {
         defaultMessage:
-          'Compute and include SHA-1 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: true',
+          'Compute and include SHA-1 hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2135,7 +2135,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.hash.sha256',
       {
         defaultMessage:
-          'Compute and include SHA-256 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: true',
+          'Compute and include SHA-256 hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2146,7 +2146,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.alerts.hash.md5',
       {
         defaultMessage:
-          'Compute and include MD5 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: true',
+          'Compute and include MD5 hashes for processes and libraries in alerts? This will increase CPU usage and alert sizes. If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2157,7 +2157,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.alerts.hash.sha1',
       {
         defaultMessage:
-          'Compute and include SHA-1 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: true',
+          'Compute and include SHA-1 hashes for processes and libraries in alerts? This will increase CPU usage and alert sizes. If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2168,7 +2168,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.events.hash.md5',
       {
         defaultMessage:
-          'Compute and include MD5 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: true',
+          'Compute and include MD5 hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2179,7 +2179,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.events.hash.sha1',
       {
         defaultMessage:
-          'Compute and include SHA-1 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: true',
+          'Compute and include SHA-1 hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2190,7 +2190,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.events.hash.sha256',
       {
         defaultMessage:
-          'Compute and include SHA-256 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: true',
+          'Compute and include SHA-256 hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2201,7 +2201,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.alerts.hash.md5',
       {
         defaultMessage:
-          'Compute and include MD5 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: true',
+          'Compute and include MD5 hashes for processes and libraries in alerts? This will increase CPU usage and alert sizes. If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2212,7 +2212,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.alerts.hash.sha1',
       {
         defaultMessage:
-          'Compute and include SHA-1 hashes in alerts?  This will increase CPU usage and alert sizes.  If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.  Default: true',
+          'Compute and include SHA-1 hashes for processes and libraries in alerts? This will increase CPU usage and alert sizes. If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2223,7 +2223,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.events.hash.md5',
       {
         defaultMessage:
-          'Compute and include MD5 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: true',
+          'Compute and include MD5 hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2234,7 +2234,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.events.hash.sha1',
       {
         defaultMessage:
-          'Compute and include SHA-1 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: true',
+          'Compute and include SHA-1 hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },
@@ -2245,7 +2245,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.events.hash.sha256',
       {
         defaultMessage:
-          'Compute and include SHA-256 hashes for processes and libraries in events?  This will increase CPU usage and event sizes.  Default: true',
+          'Compute and include SHA-256 hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type. Default: true',
       }
     ),
   },


### PR DESCRIPTION
# Backport

> [!IMPORTANT]
> This is only a partial backport: only description refinements are backported for 15 advanced options:
> - `(win|mac|linux).advanced.events.hash.(md5|sha1|sha256)`
>    *Compute and include (MD5|SHA-1|SHA-256) hashes for processes and libraries in events? This will increase CPU usage and event sizes. If any user event filter or trustlists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.*
> - `(win|mac|linux).advanced.alerts.hash.(md5|sha1)`
>   *Compute and include (MD5|SHA-1) hashes for processes and libraries in alerts? This will increase CPU usage and alert sizes. If any user exceptionlist, trustlist, or blocklists reference this hash type, Endpoint will ignore this setting and automatically enable this hash type.*

This will backport the following commits from `main` to `8.17`:
 - [[EDR Workflows] Update description on data reduction advanced options (#213970)](https://github.com/elastic/kibana/pull/213970)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gergő Ábrahám","email":"gergo.abraham@elastic.co"},"sourceCommit":{"committedDate":"2025-03-12T15:42:27Z","message":"[EDR Workflows] Update description on data reduction advanced options (#213970)\n\n## Summary\n\n- refines description for\n- 9 `(win|mac|linux).advanced.events.hash.(md5|sha1|sha256)`:\n9e7bbcf767a47795ef1e791ba4f88045526ac90d\n> Compute and include (MD5|SHA-1|SHA-256) hashes for processes and\nlibraries in events? This will increase CPU usage and event sizes. If\nany user event filter or trustlists reference this hash type, Endpoint\nwill ignore this setting and automatically enable this hash type.\n- 6 `(win|mac|linux).advanced.alerts.hash.(md5|sha1)`:\n8fc0f51ab45ffc2430683f0b05773a91e0a63717\n> Compute and include (MD5|SHA-1) hashes for processes and libraries in\nalerts? This will increase CPU usage and alert sizes. If any user\nexceptionlist, trustlist, or blocklists reference this hash type,\nEndpoint will ignore this setting and automatically enable this hash\ntype.\n- provides a 'history' for default behavior changes (e.g. `<=8.17\ndefault: true, >=8.18 default: false`) for\n- 12 `(win|mac|linux).advanced.(events|alerts).hash.(md5|sha1)`:\n05b0ebe8eab1a5f010f8a995454ffb05dfd502d8\n  (note that events sha256 is not changed)\n    >  <=8.17 default: true, >=8.18 default: false\n- 3 `(win|mac|linux).advanced.events.aggregate_process`:\n5984d8e90a43127c93c367286d727c489612c90e\n    > <=8.17 default: false, >=8.18 default: true\n- 3 `(win|mac|linux).advanced.events.set_extended_host_information`:\n5da25a3592409b5bfbc7b7256312f2b3f67fe1b5\n    >  <=8.17 default: true, >=8.18 default: false\n\n> [!IMPORTANT]\n> The plan is to backport this PR to all open branches:\n> - `8.18`/`8.x`/`9.0`/`main` will contain all modifications,\n> - but `8.16`/`8.17` manual backports will only contain the description\nrefinement\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)","sha":"ad3b7fce112d8dc0e28c847937458bf2d455fba2","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","backport:prev-minor","backport:prev-major","v9.1.0"],"title":"[EDR Workflows] Update description on data reduction advanced options","number":213970,"url":"https://github.com/elastic/kibana/pull/213970","mergeCommit":{"message":"[EDR Workflows] Update description on data reduction advanced options (#213970)\n\n## Summary\n\n- refines description for\n- 9 `(win|mac|linux).advanced.events.hash.(md5|sha1|sha256)`:\n9e7bbcf767a47795ef1e791ba4f88045526ac90d\n> Compute and include (MD5|SHA-1|SHA-256) hashes for processes and\nlibraries in events? This will increase CPU usage and event sizes. If\nany user event filter or trustlists reference this hash type, Endpoint\nwill ignore this setting and automatically enable this hash type.\n- 6 `(win|mac|linux).advanced.alerts.hash.(md5|sha1)`:\n8fc0f51ab45ffc2430683f0b05773a91e0a63717\n> Compute and include (MD5|SHA-1) hashes for processes and libraries in\nalerts? This will increase CPU usage and alert sizes. If any user\nexceptionlist, trustlist, or blocklists reference this hash type,\nEndpoint will ignore this setting and automatically enable this hash\ntype.\n- provides a 'history' for default behavior changes (e.g. `<=8.17\ndefault: true, >=8.18 default: false`) for\n- 12 `(win|mac|linux).advanced.(events|alerts).hash.(md5|sha1)`:\n05b0ebe8eab1a5f010f8a995454ffb05dfd502d8\n  (note that events sha256 is not changed)\n    >  <=8.17 default: true, >=8.18 default: false\n- 3 `(win|mac|linux).advanced.events.aggregate_process`:\n5984d8e90a43127c93c367286d727c489612c90e\n    > <=8.17 default: false, >=8.18 default: true\n- 3 `(win|mac|linux).advanced.events.set_extended_host_information`:\n5da25a3592409b5bfbc7b7256312f2b3f67fe1b5\n    >  <=8.17 default: true, >=8.18 default: false\n\n> [!IMPORTANT]\n> The plan is to backport this PR to all open branches:\n> - `8.18`/`8.x`/`9.0`/`main` will contain all modifications,\n> - but `8.16`/`8.17` manual backports will only contain the description\nrefinement\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)","sha":"ad3b7fce112d8dc0e28c847937458bf2d455fba2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213970","number":213970,"mergeCommit":{"message":"[EDR Workflows] Update description on data reduction advanced options (#213970)\n\n## Summary\n\n- refines description for\n- 9 `(win|mac|linux).advanced.events.hash.(md5|sha1|sha256)`:\n9e7bbcf767a47795ef1e791ba4f88045526ac90d\n> Compute and include (MD5|SHA-1|SHA-256) hashes for processes and\nlibraries in events? This will increase CPU usage and event sizes. If\nany user event filter or trustlists reference this hash type, Endpoint\nwill ignore this setting and automatically enable this hash type.\n- 6 `(win|mac|linux).advanced.alerts.hash.(md5|sha1)`:\n8fc0f51ab45ffc2430683f0b05773a91e0a63717\n> Compute and include (MD5|SHA-1) hashes for processes and libraries in\nalerts? This will increase CPU usage and alert sizes. If any user\nexceptionlist, trustlist, or blocklists reference this hash type,\nEndpoint will ignore this setting and automatically enable this hash\ntype.\n- provides a 'history' for default behavior changes (e.g. `<=8.17\ndefault: true, >=8.18 default: false`) for\n- 12 `(win|mac|linux).advanced.(events|alerts).hash.(md5|sha1)`:\n05b0ebe8eab1a5f010f8a995454ffb05dfd502d8\n  (note that events sha256 is not changed)\n    >  <=8.17 default: true, >=8.18 default: false\n- 3 `(win|mac|linux).advanced.events.aggregate_process`:\n5984d8e90a43127c93c367286d727c489612c90e\n    > <=8.17 default: false, >=8.18 default: true\n- 3 `(win|mac|linux).advanced.events.set_extended_host_information`:\n5da25a3592409b5bfbc7b7256312f2b3f67fe1b5\n    >  <=8.17 default: true, >=8.18 default: false\n\n> [!IMPORTANT]\n> The plan is to backport this PR to all open branches:\n> - `8.18`/`8.x`/`9.0`/`main` will contain all modifications,\n> - but `8.16`/`8.17` manual backports will only contain the description\nrefinement\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)","sha":"ad3b7fce112d8dc0e28c847937458bf2d455fba2"}},{"url":"https://github.com/elastic/kibana/pull/214206","number":214206,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/214207","number":214207,"branch":"8.x","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/214208","number":214208,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->