### PR TITLE
[Onboarding] Fix console warning in quick stats component

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/public/components/quick_stats/quick_stats.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/quick_stats/quick_stats.tsx
@@ -52,34 +52,57 @@ export const QuickStats: React.FC<QuickStatsProps> = ({
           documentCount={indexDocuments?.results._meta.page.total ?? 0}
           open={open}
           setOpen={setOpen}
+          key="statelessDocumentCountStat"
         />,
         ...(Array.isArray(index.aliases) && index.aliases.length > 0
-          ? [<AliasesStat aliases={index.aliases} open={open} setOpen={setOpen} />]
+          ? [
+              <AliasesStat
+                aliases={index.aliases}
+                open={open}
+                setOpen={setOpen}
+                key="aliasesStat"
+              />,
+            ]
           : []),
         <AISearchQuickStat
           mappingStats={mappingStats}
           vectorFieldCount={vectorFieldCount}
           open={open}
           setOpen={setOpen}
+          key="aISearchQuickStat"
         />,
       ]
     : [
-        <IndexStatusStat index={index} open={open} setOpen={setOpen} />,
-        <StatefulIndexStorageStat index={index} open={open} setOpen={setOpen} />,
+        <IndexStatusStat index={index} open={open} setOpen={setOpen} key="indexStatusStat" />,
+        <StatefulIndexStorageStat
+          index={index}
+          open={open}
+          setOpen={setOpen}
+          key="statefulIndexStorageStat"
+        />,
         <StatefulDocumentCountStat
           open={open}
           setOpen={setOpen}
           index={index}
           mappingStats={mappingStats}
+          key="statefulDocumentCountStat"
         />,
         ...(Array.isArray(index.aliases) && index.aliases.length > 0
-          ? [<AliasesStat aliases={index.aliases} open={open} setOpen={setOpen} />]
+          ? [
+              <AliasesStat
+                aliases={index.aliases}
+                open={open}
+                setOpen={setOpen}
+                key="aliasesStat"
+              />,
+            ]
           : []),
         <AISearchQuickStat
           mappingStats={mappingStats}
           vectorFieldCount={vectorFieldCount}
           open={open}
           setOpen={setOpen}
+          key="aISearchQuickStat"
         />,
       ];
 


### PR DESCRIPTION
## Summary

Added unique key to each react jsx array component in [QuickStats](https://github.com/elastic/kibana/blob/main/x-pack/solutions/search/plugins/search_indices/public/components/quick_stats/quick_stats.tsx#L48-L84), this fixes warning shown in the console.  
Fixes for both Stateful & Stateless

### Screenshot of Warning
<img width="1447" alt="Screenshot 2025-03-12 at 1 18 11 PM" src="https://github.com/user-attachments/assets/b5a566e7-4eda-45d5-ae84-490f8ae3eb0d" />
