### PR TITLE
[Fleet] Never delete @custom component templates

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/remove_legacy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/elasticsearch/template/remove_legacy.ts
@@ -11,6 +11,7 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 
+import { USER_SETTINGS_TEMPLATE_SUFFIX } from '../../../../../common/constants';
 import type { InstallablePackage, RegistryDataStream } from '../../../../types';
 import { getRegistryDataStreamAssetBaseName } from '../../../../../common/services';
 const LEGACY_TEMPLATE_SUFFIXES = ['@mappings', '@settings'];
@@ -108,6 +109,9 @@ export const _filterComponentTemplatesInUse = ({
   const usedByLookup = _getIndexTemplatesToUsedByMap(indexTemplates);
 
   return componentTemplateNames.filter((componentTemplateName) => {
+    if (componentTemplateName.endsWith(USER_SETTINGS_TEMPLATE_SUFFIX)) {
+      return false;
+    }
     const indexTemplatesUsingComponentTemplate = usedByLookup.get(componentTemplateName);
 
     if (indexTemplatesUsingComponentTemplate?.length) {

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/remove.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/remove.test.ts
@@ -4,13 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 
-import { PACKAGES_SAVED_OBJECT_TYPE } from '../../../../common';
+import { ElasticsearchAssetType, PACKAGES_SAVED_OBJECT_TYPE } from '../../../../common';
 
 import { packagePolicyService } from '../..';
 import { auditLoggingService } from '../../audit_logging';
 
-import { removeInstallation } from './remove';
+import { deleteESAsset, removeInstallation } from './remove';
 
 jest.mock('../..', () => {
   return {
@@ -109,5 +110,36 @@ describe('removeInstallation', () => {
       id: 'system',
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
+  });
+});
+
+describe('deleteESAsset', () => {
+  it('should not delete @custom components template', async () => {
+    const esClient = elasticsearchServiceMock.createInternalClient();
+    await deleteESAsset(
+      {
+        id: 'logs@custom',
+        type: ElasticsearchAssetType.componentTemplate,
+      },
+      esClient
+    );
+
+    expect(esClient.cluster.deleteComponentTemplate).not.toBeCalled();
+  });
+
+  it('should delete @package components template', async () => {
+    const esClient = elasticsearchServiceMock.createInternalClient();
+    await deleteESAsset(
+      {
+        id: 'logs-nginx.access@package',
+        type: ElasticsearchAssetType.componentTemplate,
+      },
+      esClient
+    );
+
+    expect(esClient.cluster.deleteComponentTemplate).toBeCalledWith(
+      { name: 'logs-nginx.access@package' },
+      expect.anything()
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/remove.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/remove.ts
@@ -26,6 +26,7 @@ import {
   PACKAGE_POLICY_SAVED_OBJECT_TYPE,
   PACKAGES_SAVED_OBJECT_TYPE,
   SO_SEARCH_LIMIT,
+  USER_SETTINGS_TEMPLATE_SUFFIX,
 } from '../../../constants';
 import { ElasticsearchAssetType } from '../../../types';
 import type {
@@ -386,7 +387,7 @@ async function deleteIndexTemplate(esClient: ElasticsearchClient, name: string):
 
 async function deleteComponentTemplate(esClient: ElasticsearchClient, name: string): Promise<void> {
   // '*' shouldn't ever appear here, but it still would delete all templates
-  if (name && name !== '*') {
+  if (name && name !== '*' && !name.endsWith(USER_SETTINGS_TEMPLATE_SUFFIX)) {
     try {
       await esClient.cluster.deleteComponentTemplate({ name }, { ignore: [404] });
     } catch (error) {


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/212518 

That PR update the code that delete component template on package removal to make sure we never delete user custom component template ( template ending with `@custom)

## Test

You can create some `@custom` component template for your package and check they are not deleted.
I added some unit tests.

I think we should backport this to 8.18 and 9.0 as it seems a really weird behaviour to delete user component templates, especially global ones likes `logs@custom`

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","9.0"]} ONMERGE-->