### PR TITLE
[Onboarding] Fix languages not being cut off from language selector drop down

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_code_view.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_code_view.tsx
@@ -110,7 +110,7 @@ export const CreateIndexCodeView = ({
         </>
       )}
       <EuiFlexGroup>
-        <EuiFlexItem grow={false} css={{ maxWidth: '300px' }}>
+        <EuiFlexItem grow={false} css={{ minWidth: '150px' }}>
           <LanguageSelector
             options={LanguageOptions}
             selectedLanguage={selectedLanguage}


### PR DESCRIPTION
## Summary

Replace `maxWidth: '300px'` with` minWidth: '150px'` in LanguageSelector parent FlexGroup.  This would help dropdown languages not being cut off. 

With this change, LanguageSelector rendered  from [add documents code example](https://github.com/elastic/kibana/blob/main/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/add_documents_code_example.tsx#L104) is not changed. 

Fixes in both Serverless & Stateful 

### Screenshot of problem
<img width="965" alt="Screenshot 2025-03-12 at 3 51 17 PM" src="https://github.com/user-attachments/assets/0d6c9a3d-b75a-40e9-8fe0-950924213423" />

### Screen recording with Solution

https://github.com/user-attachments/assets/ae45197c-4784-475f-99cb-346f9f61c7db

