### PR TITLE
[Security Solution] [Detections] skip individual EQL shard failure test instead of entire suite

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/eql/trial_license_complete_tier/eql.ts
@@ -82,8 +82,7 @@ export default ({ getService }: FtrProviderContext) => {
   const auditPath = dataPathBuilder.getPath('auditbeat/hosts');
   const packetBeatPath = dataPathBuilder.getPath('packetbeat/default');
 
-  // Failing: See https://github.com/elastic/kibana/issues/209024
-  describe.skip('@ess @serverless @serverlessQA EQL type rules', () => {
+  describe('@ess @serverless @serverlessQA EQL type rules', () => {
     const { indexListOfDocuments } = dataGeneratorFactory({
       es,
       index: 'ecs_compliant',
@@ -248,7 +247,8 @@ export default ({ getService }: FtrProviderContext) => {
       ).eql(1);
     });
 
-    it('parses shard failures for EQL event query', async () => {
+    // Failing: See https://github.com/elastic/kibana/issues/209024
+    it.skip('parses shard failures for EQL event query', async () => {
       await esArchiver.load(packetBeatPath);
       const rule: EqlRuleCreateProps = {
         ...getEqlRuleForAlertTesting(['auditbeat-*', 'packetbeat-*']),


### PR DESCRIPTION
skips individual failing test instead of entire test suite




<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->