### PR TITLE
[OnWeek][ResponseOps][Alerts] Enrich browser fields API with ECS metadata

### DIFF
--- a/src/platform/packages/shared/kbn-alerting-types/alert_fields_type.ts
+++ b/src/platform/packages/shared/kbn-alerting-types/alert_fields_type.ts
@@ -7,24 +7,20 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { SerializedFieldFormat } from '@kbn/field-formats-plugin/common';
-import type { IFieldSubType } from '@kbn/es-query';
-import type { RuntimeField } from '@kbn/data-views-plugin/common';
+import type { FieldDescriptorWithMetadata } from '@kbn/rule-registry-plugin/common/types';
 
-export interface BrowserField {
-  aggregatable: boolean;
+export interface AlertField extends FieldDescriptorWithMetadata {
   category: string;
-  description?: string | null;
-  example?: string | number | null;
-  fields: Readonly<Record<string, Partial<BrowserField>>>;
-  format?: SerializedFieldFormat;
-  indexes: string[];
-  name: string;
-  searchable: boolean;
-  type: string;
-  subType?: IFieldSubType;
-  readFromDocValues: boolean;
-  runtimeField?: RuntimeField;
 }
 
-export type BrowserFields = Record<string, Partial<BrowserField>>;
+export interface AlertFieldCategory {
+  name: string;
+  fields: Record<string, AlertField>;
+  title?: string;
+  description?: string;
+  group?: number;
+  root?: boolean;
+  short?: string;
+}
+
+export type AlertFieldCategoriesMap = Record<string, AlertFieldCategory>;

--- a/src/platform/packages/shared/kbn-alerting-types/tsconfig.json
+++ b/src/platform/packages/shared/kbn-alerting-types/tsconfig.json
@@ -22,9 +22,8 @@
     "@kbn/rrule",
     "@kbn/core",
     "@kbn/es-query",
-    "@kbn/field-formats-plugin",
-    "@kbn/data-views-plugin",
     "@kbn/search-types",
-    "@kbn/utility-types"
+    "@kbn/utility-types",
+    "@kbn/rule-registry-plugin"
   ]
 }

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/fetch_alerts_fields/fetch_alerts_fields.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/fetch_alerts_fields/fetch_alerts_fields.ts
@@ -7,16 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { FieldDescriptor } from '@kbn/data-views-plugin/server';
-import type { BrowserFields } from '@kbn/alerting-types';
+import type { AlertFieldCategoriesMap } from '@kbn/alerting-types';
 import type { FetchAlertsFieldsParams } from './types';
 import { BASE_RAC_ALERTS_API_PATH } from '../../constants';
 
 export const fetchAlertsFields = ({ http, ruleTypeIds }: FetchAlertsFieldsParams) => {
-  return http.get<{ browserFields: BrowserFields; fields: FieldDescriptor[] }>(
-    `${BASE_RAC_ALERTS_API_PATH}/browser_fields`,
-    {
-      query: { ruleTypeIds },
-    }
-  );
+  return http.get<AlertFieldCategoriesMap>(`${BASE_RAC_ALERTS_API_PATH}/browser_fields`, {
+    query: { ruleTypeIds },
+  });
 };

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_alerts_data_view.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_alerts_data_view.ts
@@ -15,7 +15,7 @@ import type { ToastsStart, HttpStart } from '@kbn/core/public';
 
 import { DataViewBase } from '@kbn/es-query';
 import type { FieldDescriptor } from '@kbn/data-views-plugin/server';
-import { BrowserFields } from '@kbn/alerting-types';
+import { AlertFieldCategoriesMap } from '@kbn/alerting-types';
 import { useVirtualDataViewQuery } from './use_virtual_data_view_query';
 import { useFetchAlertsFieldsQuery } from './use_fetch_alerts_fields_query';
 import { useFetchAlertsIndexNamesQuery } from './use_fetch_alerts_index_names_query';
@@ -55,7 +55,7 @@ const resolveDataView = ({
   isError: boolean;
   virtualDataView?: DataView;
   indexNames?: string[];
-  fields?: { browserFields: BrowserFields; fields: FieldDescriptor[] };
+  fields?: { browserFields: AlertFieldCategoriesMap; fields: FieldDescriptor[] };
 }) => {
   if (isError) {
     return;

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/components/categories_selector/categories_selector.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/components/categories_selector/categories_selector.tsx
@@ -20,7 +20,7 @@ import {
   EuiSelectable,
   FilterChecked,
 } from '@elastic/eui';
-import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import type { AlertFieldCategoriesMap } from '@kbn/rule-registry-plugin/common';
 import * as i18n from '../../translations';
 import { getFieldCount, isEscape } from '../../helpers';
 import { styles } from './categories_selector.styles';
@@ -31,7 +31,7 @@ interface CategoriesSelectorProps {
    * filtered such that the name of every field in the category includes
    * the filter input (as a substring).
    */
-  filteredBrowserFields: BrowserFields;
+  filteredBrowserFields: AlertFieldCategoriesMap;
   /**
    * Invoked when the user clicks on the name of a category in the left-hand
    * side of the field browser

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_browser/field_browser.test.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_browser/field_browser.test.tsx
@@ -16,7 +16,7 @@ import { FieldBrowserComponent } from './field_browser';
 import type { FieldBrowserProps } from '../../types';
 
 const defaultProps: FieldBrowserProps = {
-  browserFields: mockBrowserFields,
+  alertFields: mockBrowserFields,
   columnIds: [],
   onToggleColumn: jest.fn(),
   onResetColumns: jest.fn(),

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_browser/field_browser.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_browser/field_browser.tsx
@@ -11,10 +11,10 @@ import { EuiButtonEmpty, EuiToolTip } from '@elastic/eui';
 import { debounce } from 'lodash';
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 
-import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import type { AlertFieldCategoriesMap } from '@kbn/alerting-types';
 import type { FieldBrowserProps } from '../../types';
 import { FieldBrowserModal } from '../field_browser_modal/field_browser_modal';
-import { filterBrowserFieldsByFieldName, filterSelectedBrowserFields } from '../../helpers';
+import { filterBrowserFieldsByFieldName, filterSelectedAlertFields } from '../../helpers';
 import * as i18n from '../../translations';
 import { styles } from './field_browser.styles';
 
@@ -28,7 +28,7 @@ export const INPUT_TIMEOUT = 250;
  */
 export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
   columnIds,
-  browserFields,
+  alertFields,
   onResetColumns,
   onToggleColumn,
   options,
@@ -45,7 +45,8 @@ export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
   /** debounced filterInput, the one that is applied to the filteredBrowserFields */
   const [appliedFilterInput, setAppliedFilterInput] = useState('');
   /** all fields in this collection have field names that match the filterInput */
-  const [filteredBrowserFields, setFilteredBrowserFields] = useState<BrowserFields | null>(null);
+  const [filteredBrowserFields, setFilteredBrowserFields] =
+    useState<AlertFieldCategoriesMap | null>(null);
   /** when true, show only the the selected field */
   const [filterSelectedEnabled, setFilterSelectedEnabled] = useState(false);
   /** when true, show a spinner in the input to indicate the field browser is searching for matching field names */
@@ -71,12 +72,10 @@ export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
     };
   }, [debouncedApplyFilterInput]);
 
-  const selectionFilteredBrowserFields = useMemo<BrowserFields>(
+  const selectionFilteredBrowserFields = useMemo<AlertFieldCategoriesMap>(
     () =>
-      filterSelectedEnabled
-        ? filterSelectedBrowserFields({ browserFields, columnIds })
-        : browserFields,
-    [browserFields, columnIds, filterSelectedEnabled]
+      filterSelectedEnabled ? filterSelectedAlertFields({ alertFields, columnIds }) : alertFields,
+    [alertFields, columnIds, filterSelectedEnabled]
   );
 
   useEffect(() => {
@@ -144,7 +143,7 @@ export const FieldBrowserComponent: React.FC<FieldBrowserProps> = ({
         <FieldBrowserModal
           columnIds={columnIds}
           filteredBrowserFields={
-            filteredBrowserFields != null ? filteredBrowserFields : browserFields
+            filteredBrowserFields != null ? filteredBrowserFields : alertFields
           }
           filterSelectedEnabled={filterSelectedEnabled}
           isSearching={isSearching}

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_browser_modal/field_browser_modal.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_browser_modal/field_browser_modal.tsx
@@ -21,7 +21,7 @@ import {
 } from '@elastic/eui';
 import React, { useCallback } from 'react';
 
-import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import type { AlertFieldCategoriesMap } from '@kbn/rule-registry-plugin/common';
 import type { FieldBrowserProps } from '../../types';
 import { Search } from '../search';
 
@@ -49,7 +49,7 @@ export type FieldBrowserModalProps = Pick<
    * filtered such that the name of every field in the category includes
    * the filter input (as a substring).
    */
-  filteredBrowserFields: BrowserFields;
+  filteredBrowserFields: AlertFieldCategoriesMap;
   /** when true, show only the the selected field */
   filterSelectedEnabled: boolean;
   onFilterSelectedChange: (enabled: boolean) => void;

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_items/field_items.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_items/field_items.tsx
@@ -10,29 +10,22 @@
 import React from 'react';
 import {
   EuiCheckbox,
-  EuiIcon,
   EuiToolTip,
   EuiFlexGroup,
   EuiFlexItem,
   EuiBadge,
   EuiScreenReaderOnly,
 } from '@elastic/eui';
-import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
-import { EcsFlat } from '@elastic/ecs';
-import { EcsMetadata } from '@kbn/alerts-as-data-utils/src/field_maps/types';
+import type { AlertFieldCategoriesMap } from '@kbn/rule-registry-plugin/common';
 
 import { ALERT_CASE_IDS, ALERT_MAINTENANCE_WINDOW_IDS } from '@kbn/rule-data-utils';
+import { FieldIcon, getFieldIconType } from '@kbn/field-utils';
+import { css } from '@emotion/react';
 import type { BrowserFieldItem, FieldTableColumns, GetFieldTableColumns } from '../../types';
 import { FieldName } from '../field_name';
 import * as i18n from '../../translations';
 import { styles } from './field_items.style';
-import {
-  getCategory,
-  getDescription,
-  getEmptyValue,
-  getExampleText,
-  getIconFromType,
-} from '../../helpers';
+import { getCategory, getEmptyValue, getExampleText } from '../../helpers';
 
 /**
  * For the Cases field we want to change the
@@ -58,7 +51,7 @@ export const getFieldItemsData = ({
   selectedCategoryIds,
   columnIds,
 }: {
-  browserFields: BrowserFields;
+  browserFields: AlertFieldCategoriesMap;
   selectedCategoryIds: string[];
   columnIds: string[];
 }): { fieldItems: BrowserFieldItem[] } => {
@@ -87,11 +80,9 @@ export const getFieldItemsData = ({
           const categoryFieldItem = {
             name,
             type: field.type,
-            description: getDescription(name, EcsFlat as Record<string, EcsMetadata>),
-            example: field.example?.toString(),
-            category: getCategory(name),
-            selected: selectedFieldIds.has(name),
-            isRuntime: !!field.runtimeField,
+            description: field.metadata?.description,
+              category: getCategory(name),
+              selected: selectedFieldIds.has(name),
           };
           fieldItemsAcc.push(categoryFieldItem);
         }
@@ -107,16 +98,19 @@ const getDefaultFieldTableColumns = ({ highlight }: { highlight: string }): Fiel
   const nameColumn = {
     field: 'name',
     name: i18n.NAME,
-    render: (name: string, { type }: BrowserFieldItem) => {
+    render: (name: string, field: BrowserFieldItem) => {
       return (
-        <EuiFlexGroup alignItems="center" gutterSize="none">
+        <EuiFlexGroup alignItems="center" gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiToolTip content={type}>
-              <EuiIcon
-                data-test-subj={`field-${name}-icon`}
-                css={styles.icon}
-                type={getIconFromType(type ?? null)}
-              />
+            <EuiToolTip
+              content={field.type}
+              anchorProps={{
+                css: css`
+                  display: flex;
+                `,
+              }}
+            >
+              <FieldIcon type={getFieldIconType(field)} />
             </EuiToolTip>
           </EuiFlexItem>
 

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_items/field_items.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_items/field_items.tsx
@@ -81,8 +81,8 @@ export const getFieldItemsData = ({
             name,
             type: field.type,
             description: field.metadata?.description,
-              category: getCategory(name),
-              selected: selectedFieldIds.has(name),
+            category: getCategory(name),
+            selected: selectedFieldIds.has(name),
           };
           fieldItemsAcc.push(categoryFieldItem);
         }

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_table/field_table.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/components/field_table/field_table.tsx
@@ -15,7 +15,7 @@ import {
   useEuiTheme,
   CriteriaWithPagination,
 } from '@elastic/eui';
-import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import type { AlertFieldCategoriesMap } from '@kbn/rule-registry-plugin/common';
 import { getFieldColumns, getFieldItemsData } from '../field_items';
 import { CATEGORY_TABLE_CLASS_NAME, TABLE_HEIGHT } from '../../helpers';
 import type { BrowserFieldItem, FieldBrowserProps, GetFieldTableColumns } from '../../types';
@@ -33,7 +33,7 @@ export interface FieldTableProps extends Pick<FieldBrowserProps, 'columnIds' | '
    * filtered such that the name of every field in the category includes
    * the filter input (as a substring).
    */
-  filteredBrowserFields: BrowserFields;
+  filteredBrowserFields: AlertFieldCategoriesMap;
   /** when true, show only the the selected field */
   filterSelectedEnabled: boolean;
   onFilterSelectedChange: (enabled: boolean) => void;

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/helpers.test.ts
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/helpers.test.ts
@@ -15,9 +15,9 @@ import {
   getDescription,
   getFieldCount,
   filterBrowserFieldsByFieldName,
-  filterSelectedBrowserFields,
+  filterSelectedAlertFields,
 } from './helpers';
-import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import type { AlertFieldCategoriesMap } from '@kbn/rule-registry-plugin/common';
 import { EcsFlat } from '@elastic/ecs';
 
 describe('helpers', () => {
@@ -198,7 +198,7 @@ describe('helpers', () => {
     });
 
     test('it returns (only) non-empty categories, where each category contains only the fields matching the substring', () => {
-      const filtered: BrowserFields = {
+      const filtered: AlertFieldCategoriesMap = {
         agent: {
           fields: {
             'agent.ephemeral_id': {
@@ -324,24 +324,24 @@ describe('helpers', () => {
     const columnIds = ['agent.ephemeral_id', 'agent.id', 'container.id'];
 
     test('it returns an empty collection when browserFields is empty', () => {
-      expect(filterSelectedBrowserFields({ browserFields: {}, columnIds: [] })).toEqual({});
+      expect(filterSelectedAlertFields({ alertFields: {}, columnIds: [] })).toEqual({});
     });
 
     test('it returns an empty collection when browserFields is empty and columnIds is non empty', () => {
-      expect(filterSelectedBrowserFields({ browserFields: {}, columnIds })).toEqual({});
+      expect(filterSelectedAlertFields({ alertFields: {}, columnIds })).toEqual({});
     });
 
     test('it returns an empty collection when browserFields is NOT empty and columnIds is empty', () => {
       expect(
-        filterSelectedBrowserFields({
-          browserFields: mockBrowserFields,
+        filterSelectedAlertFields({
+          alertFields: mockBrowserFields,
           columnIds: [],
         })
       ).toEqual({});
     });
 
     test('it returns (only) non-empty categories, where each category contains only the fields matching the substring', () => {
-      const filtered: BrowserFields = {
+      const filtered: AlertFieldCategoriesMap = {
         agent: {
           fields: {
             'agent.ephemeral_id': {
@@ -385,8 +385,8 @@ describe('helpers', () => {
       };
 
       expect(
-        filterSelectedBrowserFields({
-          browserFields: mockBrowserFields,
+        filterSelectedAlertFields({
+          alertFields: mockBrowserFields,
           columnIds,
         })
       ).toEqual(filtered);

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/helpers.ts
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/helpers.ts
@@ -10,7 +10,7 @@
 import type { EcsMetadata } from '@kbn/alerts-as-data-utils/src/field_maps/types';
 import type { DefaultAlertFieldName } from '@kbn/rule-data-utils';
 import { ALERT_CASE_IDS, ALERT_MAINTENANCE_WINDOW_IDS } from '@kbn/rule-data-utils';
-import type { BrowserField, BrowserFields } from '@kbn/rule-registry-plugin/common';
+import type { AlertFieldCategory, AlertFieldCategoriesMap } from '@kbn/rule-registry-plugin/common';
 import { isEmpty } from 'lodash/fp';
 import { CASES, MAINTENANCE_WINDOWS } from './translations';
 
@@ -18,11 +18,11 @@ export const FIELD_BROWSER_WIDTH = 925;
 export const TABLE_HEIGHT = 260;
 
 /** Returns true if the specified category has at least one field */
-export const categoryHasFields = (category: Partial<BrowserField>): boolean =>
+export const categoryHasFields = (category: Partial<AlertFieldCategory>): boolean =>
   category.fields != null && Object.keys(category.fields).length > 0;
 
 /** Returns the count of fields in the specified category */
-export const getFieldCount = (category: Partial<BrowserField> | undefined): number =>
+export const getFieldCount = (category: Partial<AlertFieldCategory> | undefined): number =>
   category != null && category.fields != null ? Object.keys(category.fields).length : 0;
 
 const matchesSystemField = (field: string, searchTerm: string): boolean => {
@@ -51,15 +51,15 @@ export function filterBrowserFieldsByFieldName({
   browserFields,
   substring,
 }: {
-  browserFields: BrowserFields;
+  browserFields: AlertFieldCategoriesMap;
   substring: string;
-}): BrowserFields {
+}): AlertFieldCategoriesMap {
   const trimmedSubstring = substring.trim();
   // an empty search param will match everything, so return the original browserFields
   if (trimmedSubstring === '') {
     return browserFields;
   }
-  const result: Record<string, Partial<BrowserField>> = {};
+  const result: AlertFieldCategoriesMap = {};
   for (const [categoryName, categoryDescriptor] of Object.entries(browserFields)) {
     if (!categoryDescriptor.fields) {
       // ignore any category that is missing fields. This is not expected to happen.
@@ -70,7 +70,7 @@ export function filterBrowserFieldsByFieldName({
     let hadAMatch = false;
 
     // The fields that matched, for this `categoryName`
-    const filteredFields: Record<string, Partial<BrowserField>> = {};
+    const filteredFields: AlertFieldCategory['fields'] = {};
 
     for (const [fieldName, fieldDescriptor] of Object.entries(categoryDescriptor.fields)) {
       // For historical reasons, we consider the name as it appears on the field descriptor, not the `fieldName` (attribute name) itself.
@@ -108,21 +108,21 @@ export function filterBrowserFieldsByFieldName({
 }
 
 /**
- * Filters the selected `BrowserFields` to return a new collection where every
+ * Filters the selected `AlertFieldsByCategory` to return a new collection where every
  * category contains at least one field that is present in the `columnIds`.
  */
-export const filterSelectedBrowserFields = ({
-  browserFields,
+export const filterSelectedAlertFields = ({
+  alertFields,
   columnIds,
 }: {
-  browserFields: BrowserFields;
+  alertFields: AlertFieldCategoriesMap;
   columnIds: string[];
-}): BrowserFields => {
+}): AlertFieldCategoriesMap => {
   const selectedFieldIds = new Set(columnIds);
 
-  const result: Record<string, Partial<BrowserField>> = {};
+  const result: Record<string, AlertFieldCategory> = {};
 
-  for (const [categoryName, categoryDescriptor] of Object.entries(browserFields)) {
+  for (const [categoryName, categoryDescriptor] of Object.entries(alertFields)) {
     if (!categoryDescriptor.fields) {
       // ignore any category that is missing fields. This is not expected to happen.
       continue;
@@ -132,7 +132,7 @@ export const filterSelectedBrowserFields = ({
     let hadSelected = false;
 
     // The selected fields for this `categoryName`
-    const selectedFields: Record<string, Partial<BrowserField>> = {};
+    const selectedFields: AlertFieldCategory['fields'] = {};
 
     for (const [fieldName, fieldDescriptor] of Object.entries(categoryDescriptor.fields)) {
       // For historical reasons, we consider the name as it appears on the field descriptor, not the `fieldName` (attribute name) itself.
@@ -152,7 +152,7 @@ export const filterSelectedBrowserFields = ({
 
     if (hadSelected) {
       result[categoryName] = {
-        ...browserFields[categoryName],
+        ...alertFields[categoryName],
         fields: selectedFields,
       };
     }

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/mock.ts
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/mock.ts
@@ -8,7 +8,7 @@
  */
 
 import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
-import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import type { AlertFieldCategoriesMap } from '@kbn/rule-registry-plugin/common';
 
 const DEFAULT_INDEX_PATTERN = [
   'apm-*-transaction*',
@@ -21,7 +21,7 @@ const DEFAULT_INDEX_PATTERN = [
   'winlogbeat-*',
 ];
 
-export const mockBrowserFields: BrowserFields = {
+export const mockBrowserFields: AlertFieldCategoriesMap = {
   agent: {
     fields: {
       'agent.ephemeral_id': {

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/tsconfig.json
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/tsconfig.json
@@ -20,5 +20,7 @@
     "@kbn/rule-registry-plugin",
     "@kbn/alerts-as-data-utils",
     "@kbn/rule-data-utils",
+    "@kbn/alerting-types",
+    "@kbn/field-utils",
   ]
 }

--- a/src/platform/packages/shared/response-ops/alerts-fields-browser/types.ts
+++ b/src/platform/packages/shared/response-ops/alerts-fields-browser/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type { EuiBasicTableColumn } from '@elastic/eui';
-import type { BrowserFields } from '@kbn/rule-registry-plugin/common';
+import type { AlertFieldCategoriesMap } from '@kbn/rule-registry-plugin/common';
 
 /**
  * An item rendered in the table
@@ -20,7 +20,7 @@ export interface BrowserFieldItem {
   example?: string;
   category: string;
   selected: boolean;
-  isRuntime: boolean;
+  isRuntime?: boolean;
 }
 
 export type OnFieldSelected = (fieldId: string) => void;
@@ -46,7 +46,7 @@ export interface FieldBrowserProps {
   /** The timeline's current column headers */
   columnIds: string[];
   /** A map of categoryId -> metadata about the fields in that category */
-  browserFields: BrowserFields;
+  alertFields: AlertFieldCategoriesMap;
   /** When true, this Fields Browser is being used as an "events viewer" */
   isEventViewer?: boolean;
   /** Callback to reset the default columns */

--- a/src/platform/packages/shared/response-ops/alerts-table/hooks/use_columns.test.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-table/hooks/use_columns.test.tsx
@@ -12,7 +12,7 @@ import { EuiDataGridColumn } from '@elastic/eui';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { act, waitFor, renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserFields } from '@kbn/alerting-types';
+import { AlertFieldCategoriesMap } from '@kbn/alerting-types';
 import { testQueryClientConfig } from '@kbn/alerts-ui-shared/src/common/test_utils/test_query_client_config';
 import { fetchAlertsFields } from '@kbn/alerts-ui-shared/src/common/apis/fetch_alerts_fields';
 import { useColumns } from './use_columns';
@@ -41,7 +41,7 @@ const wrapper: FunctionComponent<React.PropsWithChildren<{}>> = ({ children }) =
 );
 
 const mockFetchAlertsFields = jest.mocked(fetchAlertsFields);
-const browserFields: BrowserFields = {
+const browserFields: AlertFieldCategoriesMap = {
   kibana: {
     fields: {
       ['event.action']: {

--- a/src/platform/packages/shared/response-ops/alerts-table/hooks/use_toolbar_visibility.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-table/hooks/use_toolbar_visibility.tsx
@@ -12,7 +12,7 @@ import {
   EuiDataGridToolBarVisibilityOptions,
 } from '@elastic/eui';
 import React, { lazy, memo, ReactNode, Suspense, useMemo } from 'react';
-import { Alert, BrowserFields, EsQuerySnapshot } from '@kbn/alerting-types';
+import { Alert, AlertFieldCategoriesMap, EsQuerySnapshot } from '@kbn/alerting-types';
 import { FieldBrowser, FieldBrowserOptions } from '@kbn/response-ops-alerts-fields-browser';
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 import { AlertsCount } from '../components/alerts_count';
@@ -69,7 +69,7 @@ const LeftAppendControl = memo(
     controls?: EuiDataGridToolBarAdditionalControlsOptions;
     fieldsBrowserOptions?: FieldBrowserOptions;
     hasBrowserFields: boolean;
-    browserFields: BrowserFields;
+    browserFields: AlertFieldCategoriesMap;
   }) => {
     return (
       <>
@@ -77,7 +77,7 @@ const LeftAppendControl = memo(
         {hasBrowserFields && (
           <FieldBrowser
             columnIds={columnIds}
-            browserFields={browserFields}
+            alertFields={browserFields}
             onResetColumns={onResetColumns}
             onToggleColumn={onToggleColumn}
             options={fieldsBrowserOptions}
@@ -104,7 +104,7 @@ const useGetDefaultVisibility = ({
   columnIds: string[];
   onToggleColumn: (columnId: string) => void;
   onResetColumns: () => void;
-  browserFields: BrowserFields;
+  browserFields: AlertFieldCategoriesMap;
   additionalToolbarControls?: ReactNode;
   fieldsBrowserOptions?: FieldBrowserOptions;
   alertsQuerySnapshot?: EsQuerySnapshot;

--- a/src/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-table/mocks/context.mock.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Alert, BrowserFields, LegacyField } from '@kbn/alerting-types';
+import { Alert, AlertFieldCategoriesMap, LegacyField } from '@kbn/alerting-types';
 import { AlertsField, RowSelectionState } from '../types';
 import { AdditionalContext, RenderContext } from '../types';
 import { createCasesServiceMock, getCasesMapMock } from './cases.mock';
@@ -39,7 +39,7 @@ export const mockFieldFormatsRegistry = {
   })),
 } as unknown as FieldFormatsRegistry;
 
-export const mockBrowserFields: BrowserFields = {
+export const mockBrowserFields: AlertFieldCategoriesMap = {
   kibana: {
     fields: {
       [AlertsField.uuid]: {

--- a/src/platform/packages/shared/response-ops/alerts-table/types.ts
+++ b/src/platform/packages/shared/response-ops/alerts-table/types.ts
@@ -43,7 +43,7 @@ import type {
   QueryDslQueryContainer,
   SortCombinations,
 } from '@elastic/elasticsearch/lib/api/types';
-import type { BrowserFields } from '@kbn/alerting-types';
+import type { AlertFieldCategoriesMap } from '@kbn/alerting-types';
 import type { SetRequired } from 'type-fest';
 import type { MaintenanceWindow } from '@kbn/alerting-plugin/common';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
@@ -158,7 +158,7 @@ export interface AlertsTableProps<AC extends AdditionalContext = AdditionalConte
    * If provided, the table will not fetch fields from the alerts index and
    * use these instead.
    */
-  browserFields?: BrowserFields;
+  browserFields?: AlertFieldCategoriesMap;
   /**
    * Update callback fired when any render context prop is changed
    *
@@ -312,7 +312,7 @@ export type RenderContext<AC extends AdditionalContext> = {
    */
   ecsAlertsData: any[];
   alertsCount: number;
-  browserFields: BrowserFields;
+  browserFields: AlertFieldCategoriesMap;
 
   isLoadingMutedAlerts: boolean;
   mutedAlerts?: MutedAlerts;

--- a/x-pack/platform/plugins/shared/rule_registry/common/index.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/common/index.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-export type { BrowserFields, BrowserField } from '@kbn/alerting-types';
+export type { AlertFieldCategoriesMap, AlertFieldCategory } from '@kbn/alerting-types';
 export { parseTechnicalFields, type ParsedTechnicalFields } from './parse_technical_fields';
 export type {
   RuleRegistrySearchRequest,

--- a/x-pack/platform/plugins/shared/rule_registry/common/types.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/common/types.ts
@@ -8,6 +8,8 @@
 import type { estypes } from '@elastic/elasticsearch';
 import * as t from 'io-ts';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import { FieldMetadataPlain } from '@kbn/fields-metadata-plugin/common';
+import type { FieldDescriptor } from '@kbn/data-views-plugin/server';
 
 // note: these schemas are not exhaustive. See the `Sort` type of `@elastic/elasticsearch` if you need to enhance it.
 const fieldSchema = t.string;
@@ -412,4 +414,8 @@ export interface ClusterPutComponentTemplateBody {
     };
     mappings: estypes.MappingTypeMapping;
   };
+}
+
+export interface FieldDescriptorWithMetadata extends FieldDescriptor {
+  metadata?: FieldMetadataPlain;
 }

--- a/x-pack/platform/plugins/shared/rule_registry/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/rule_registry/kibana.jsonc
@@ -18,6 +18,7 @@
     "requiredPlugins": [
       "alerting",
       "data",
+      "fieldsMetadata",
       "triggersActionsUi"
     ],
     "optionalPlugins": [

--- a/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/alerts_client.mock.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/alerts_client.mock.ts
@@ -20,7 +20,7 @@ const createAlertsClientMock = () => {
     bulkUpdateCases: jest.fn(),
     find: jest.fn(),
     getGroupAggregations: jest.fn(),
-    getBrowserFields: jest.fn(),
+    getAlertsFieldsByCategory: jest.fn(),
     getAlertSummary: jest.fn(),
     ensureAllAlertsAuthorizedRead: jest.fn(),
     removeCaseIdFromAlerts: jest.fn(),

--- a/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/alerts_client_factory.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/alert_data_client/alerts_client_factory.ts
@@ -10,6 +10,7 @@ import { ElasticsearchClient, KibanaRequest, Logger } from '@kbn/core/server';
 import type { RuleTypeRegistry } from '@kbn/alerting-plugin/server/types';
 import { AlertingAuthorization, AlertingServerStart } from '@kbn/alerting-plugin/server';
 import { SecurityPluginSetup } from '@kbn/security-plugin/server';
+import { FieldsMetadataServerStart } from '@kbn/fields-metadata-plugin/server';
 import { IRuleDataService } from '../rule_data_plugin_service';
 import { AlertsClient } from './alerts_client';
 
@@ -19,11 +20,12 @@ export interface AlertsClientFactoryProps {
   getAlertingAuthorization: (
     request: KibanaRequest
   ) => Promise<PublicMethodsOf<AlertingAuthorization>>;
-  securityPluginSetup: SecurityPluginSetup | undefined;
+  securityPluginSetup?: SecurityPluginSetup;
   ruleDataService: IRuleDataService | null;
   getRuleType: RuleTypeRegistry['get'];
   getRuleList: RuleTypeRegistry['list'];
   getAlertIndicesAlias: AlertingServerStart['getAlertIndicesAlias'];
+  fieldsMetadata: FieldsMetadataServerStart;
 }
 
 export class AlertsClientFactory {
@@ -38,6 +40,7 @@ export class AlertsClientFactory {
   private getRuleType!: RuleTypeRegistry['get'];
   private getRuleList!: RuleTypeRegistry['list'];
   private getAlertIndicesAlias!: AlertingServerStart['getAlertIndicesAlias'];
+  private fieldsMetadata!: FieldsMetadataServerStart;
 
   public initialize(options: AlertsClientFactoryProps) {
     /**
@@ -56,6 +59,7 @@ export class AlertsClientFactory {
     this.getRuleType = options.getRuleType;
     this.getRuleList = options.getRuleList;
     this.getAlertIndicesAlias = options.getAlertIndicesAlias;
+    this.fieldsMetadata = options.fieldsMetadata;
   }
 
   public async create(request: KibanaRequest): Promise<AlertsClient> {
@@ -71,6 +75,7 @@ export class AlertsClientFactory {
       getRuleType: this.getRuleType,
       getRuleList: this.getRuleList,
       getAlertIndicesAlias: this.getAlertIndicesAlias,
+      fieldsMetadataClient: await this.fieldsMetadata.getClient(request),
     });
   }
 }

--- a/x-pack/platform/plugins/shared/rule_registry/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/plugin.ts
@@ -26,6 +26,7 @@ import type {
   PluginSetup as DataPluginSetup,
 } from '@kbn/data-plugin/server';
 
+import { FieldsMetadataServerStart } from '@kbn/fields-metadata-plugin/server';
 import type { RuleRegistryPluginConfig } from './config';
 import { type IRuleDataService, RuleDataService, Dataset } from './rule_data_plugin_service';
 import { AlertsClientFactory } from './alert_data_client/alerts_client_factory';
@@ -35,7 +36,7 @@ import { defineRoutes } from './routes';
 import { ruleRegistrySearchStrategyProvider, RULE_SEARCH_STRATEGY_NAME } from './search_strategy';
 
 export interface RuleRegistryPluginSetupDependencies {
-  security?: SecurityPluginSetup;
+  security: SecurityPluginSetup;
   data: DataPluginSetup;
   alerting: AlertingServerSetup;
 }
@@ -44,6 +45,7 @@ export interface RuleRegistryPluginStartDependencies {
   alerting: AlertingServerStart;
   data: DataPluginStart;
   spaces?: SpacesPluginStart;
+  fieldsMetadata: FieldsMetadataServerStart;
 }
 
 export interface RuleRegistryPluginSetupContract {
@@ -70,7 +72,7 @@ export class RuleRegistryPlugin
   private readonly kibanaVersion: string;
   private readonly alertsClientFactory: AlertsClientFactory;
   private ruleDataService: IRuleDataService | null;
-  private security: SecurityPluginSetup | undefined;
+  private security!: SecurityPluginSetup;
   private pluginStop$: Subject<void>;
 
   constructor(initContext: PluginInitializerContext) {
@@ -170,6 +172,7 @@ export class RuleRegistryPlugin
       getRuleType: plugins.alerting.getType,
       getRuleList: plugins.alerting.listTypes,
       getAlertIndicesAlias: plugins.alerting.getAlertIndicesAlias,
+      fieldsMetadata: plugins.fieldsMetadata,
     });
 
     const getRacClientWithRequest = async (request: KibanaRequest) => {

--- a/x-pack/platform/plugins/shared/rule_registry/server/routes/get_browser_fields_by_rule_type_ids.test.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/routes/get_browser_fields_by_rule_type_ids.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { BASE_RAC_ALERTS_API_PATH } from '../../common/constants';
-import { getBrowserFieldsByFeatureId } from './get_browser_fields_by_rule_type_ids';
+import { getAlertsFieldsByRuleTypeIds } from './get_browser_fields_by_rule_type_ids';
 import { requestContextMock } from './__mocks__/request_context';
 import { getO11yBrowserFields } from './__mocks__/request_responses';
 import { requestMock, serverMock } from './__mocks__/server';
@@ -24,9 +24,9 @@ describe('getBrowserFieldsByFeatureId', () => {
       '.alerts-observability.logs.alerts-default',
     ]);
 
-    clients.rac.getBrowserFields.mockResolvedValue({ browserFields: {}, fields: [] });
+    clients.rac.getAlertsFieldsByCategory.mockResolvedValue({ browserFields: {}, fields: [] });
 
-    getBrowserFieldsByFeatureId(server.router);
+    getAlertsFieldsByRuleTypeIds(server.router);
   });
 
   test('route registered', async () => {

--- a/x-pack/platform/plugins/shared/rule_registry/server/routes/get_browser_fields_by_rule_type_ids.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/routes/get_browser_fields_by_rule_type_ids.ts
@@ -14,7 +14,7 @@ import { RacRequestHandlerContext } from '../types';
 import { BASE_RAC_ALERTS_API_PATH } from '../../common/constants';
 import { buildRouteValidation } from './utils/route_validation';
 
-export const getBrowserFieldsByFeatureId = (router: IRouter<RacRequestHandlerContext>) => {
+export const getAlertsFieldsByRuleTypeIds = (router: IRouter<RacRequestHandlerContext>) => {
   router.get(
     {
       path: `${BASE_RAC_ALERTS_API_PATH}/browser_fields`,
@@ -60,7 +60,7 @@ export const getBrowserFieldsByFeatureId = (router: IRouter<RacRequestHandlerCon
           });
         }
 
-        const fields = await alertsClient.getBrowserFields({
+        const fields = await alertsClient.getAlertsFieldsByCategory({
           indices: o11yIndices,
           ruleTypeIds: onlyO11yRuleTypeIds,
           metaFields: ['_id', '_index'],

--- a/x-pack/platform/plugins/shared/rule_registry/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/routes/index.ts
@@ -13,7 +13,7 @@ import { updateAlertByIdRoute } from './update_alert_by_id';
 import { getAlertsIndexRoute } from './get_alert_index';
 import { bulkUpdateAlertsRoute } from './bulk_update_alerts';
 import { findAlertsByQueryRoute } from './find';
-import { getBrowserFieldsByFeatureId } from './get_browser_fields_by_rule_type_ids';
+import { getAlertsFieldsByRuleTypeIds } from './get_browser_fields_by_rule_type_ids';
 import { getAlertSummaryRoute } from './get_alert_summary';
 import { getAADFieldsByRuleType } from './get_aad_fields_by_rule_type';
 
@@ -24,7 +24,7 @@ export function defineRoutes(router: IRouter<RacRequestHandlerContext>) {
   bulkUpdateAlertsRoute(router);
   findAlertsByQueryRoute(router);
   getAlertsGroupAggregations(router);
-  getBrowserFieldsByFeatureId(router);
+  getAlertsFieldsByRuleTypeIds(router);
   getAlertSummaryRoute(router);
   getAADFieldsByRuleType(router);
 }

--- a/x-pack/platform/plugins/shared/rule_registry/tsconfig.json
+++ b/x-pack/platform/plugins/shared/rule_registry/tsconfig.json
@@ -33,7 +33,8 @@
     "@kbn/alerts-as-data-utils",
     "@kbn/core-http-router-server-mocks",
     "@kbn/core-http-server",
-    "@kbn/alerting-types"
+    "@kbn/alerting-types",
+    "@kbn/fields-metadata-plugin"
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/solutions/security/packages/data-table/components/data_table/index.tsx
+++ b/x-pack/solutions/security/packages/data-table/components/data_table/index.tsx
@@ -230,7 +230,7 @@ export const DataTableComponent = React.memo<DataTableProps>(
                 <UnitCount data-test-subj="server-side-event-count">{unitCountText}</UnitCount>
                 {additionalControls ?? null}
                 <FieldsBrowserComponent
-                  browserFields={browserFields}
+                  alertFields={browserFields}
                   options={fieldBrowserOptions}
                   columnIds={columnHeaders.map(({ id: columnId }) => columnId)}
                   onResetColumns={onResetColumns}

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/table/field_browser.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/components/table/field_browser.tsx
@@ -6,11 +6,11 @@
  */
 
 import React, { VFC } from 'react';
-import { BrowserField } from '@kbn/rule-registry-plugin/common';
+import { AlertFieldCategory } from '@kbn/rule-registry-plugin/common';
 import { FieldBrowser } from '@kbn/response-ops-alerts-fields-browser';
 
 export interface IndicatorsFieldBrowserProps {
-  browserFields: Readonly<Record<string, Partial<BrowserField>>>;
+  browserFields: Readonly<Record<string, Partial<AlertFieldCategory>>>;
   columnIds: string[];
   onResetColumns: () => void;
   onToggleColumn: (columnId: string) => void;
@@ -24,7 +24,7 @@ export const IndicatorsFieldBrowser: VFC<IndicatorsFieldBrowserProps> = ({
 }) => {
   return (
     <FieldBrowser
-      browserFields={browserFields}
+      alertFields={browserFields}
       columnIds={columnIds}
       onResetColumns={onResetColumns}
       onToggleColumn={onToggleColumn}

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_toolbar_options.tsx
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/modules/indicators/hooks/use_toolbar_options.tsx
@@ -7,7 +7,7 @@
 
 import React, { useMemo } from 'react';
 import { EuiButtonIcon, EuiDataGridColumn, EuiText } from '@elastic/eui';
-import { BrowserField } from '@kbn/rule-registry-plugin/common';
+import { AlertFieldCategory } from '@kbn/rule-registry-plugin/common';
 import { useInspector } from '../../../hooks/use_inspector';
 import { IndicatorsFieldBrowser } from '../components/table/field_browser';
 import { INSPECT_BUTTON_TEST_ID } from './test_ids';
@@ -22,7 +22,7 @@ export const useToolbarOptions = ({
   onResetColumns,
   onToggleColumn,
 }: {
-  browserFields: Readonly<Record<string, Partial<BrowserField>>>;
+  browserFields: Readonly<Record<string, Partial<AlertFieldCategory>>>;
   start: number;
   end: number;
   indicatorCount: number;

--- a/x-pack/solutions/security/plugins/threat_intelligence/public/types.ts
+++ b/x-pack/solutions/security/plugins/threat_intelligence/public/types.ts
@@ -13,7 +13,7 @@ import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { TimelinesUIStart } from '@kbn/timelines-plugin/public';
 import type { TriggersAndActionsUIPublicPluginStart as TriggersActionsStart } from '@kbn/triggers-actions-ui-plugin/public';
 import { Filter, Query, TimeRange } from '@kbn/es-query';
-import { BrowserField } from '@kbn/rule-registry-plugin/common';
+import { AlertFieldCategory } from '@kbn/rule-registry-plugin/common';
 import { Store } from 'redux';
 import { DataProvider } from '@kbn/timelines-plugin/common';
 import { Start as InspectorPluginStart } from '@kbn/inspector-plugin/public';
@@ -53,7 +53,7 @@ export interface LicenseAware {
   isPlatinumPlus(): boolean;
 }
 
-export type BrowserFields = Readonly<Record<string, Partial<BrowserField>>>;
+export type BrowserFields = Readonly<Record<string, Partial<AlertFieldCategory>>>;
 
 export interface SelectedDataView {
   sourcererDataView: DataViewSpec;


### PR DESCRIPTION
## Summary

🚧 PoC for integrating ECS metadata in the `browser_fields` (alert fields) API.

