### PR TITLE
[Security Solution] remove group from AV workflow insight value

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.test.ts
@@ -98,7 +98,7 @@ describe('buildIncompatibleAntivirusWorkflowInsights', () => {
         type: ActionType.Refreshed,
         timestamp: expect.any(moment),
       },
-      value: `AVGAntivirus /Applications/AVGAntivirus.app/Contents/Backend/services/com.avg.activity${
+      value: `/Applications/AVGAntivirus.app/Contents/Backend/services/com.avg.activity${
         signerValue ? ` ${signerValue}` : ''
       }`,
       remediation: {

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/services/workflow_insights/builders/incompatible_antivirus.ts
@@ -101,7 +101,7 @@ export async function buildIncompatibleAntivirusWorkflowInsights(
             type: ActionType.Refreshed,
             timestamp: currentTime,
           },
-          value: `${defendInsight.group} ${filePath}${signatureValue ? ` ${signatureValue}` : ''}`,
+          value: `${filePath}${signatureValue ? ` ${signatureValue}` : ''}`,
           metadata: {
             notes: {
               llm_model: apiConfig.model ?? '',


### PR DESCRIPTION
## Summary

Removes group from the incompatible antivirus workflow insight type value.

Resolves:
- https://github.com/elastic/kibana/issues/213681


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->