### PR TITLE
[8.x] [Authz]: added reason for authorization opt-out for search routes (#213879)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/analytics.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/analytics.ts
@@ -51,6 +51,12 @@ export function registerAnalyticsRoutes({
   router.get(
     {
       path: '/internal/elasticsearch/analytics/collections',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           query: schema.maybe(schema.string()),
@@ -76,6 +82,12 @@ export function registerAnalyticsRoutes({
   router.get(
     {
       path: '/internal/elasticsearch/analytics/collections/{name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           name: schema.string(),
@@ -102,6 +114,12 @@ export function registerAnalyticsRoutes({
   router.post(
     {
       path: '/internal/elasticsearch/analytics/collections/{name}/api_key',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           keyName: schema.string(),
@@ -128,6 +146,12 @@ export function registerAnalyticsRoutes({
   router.post(
     {
       path: '/internal/elasticsearch/analytics/collections',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           name: schema.string(),
@@ -173,6 +197,12 @@ export function registerAnalyticsRoutes({
   router.delete(
     {
       path: '/internal/elasticsearch/analytics/collections/{name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           name: schema.string(),
@@ -196,6 +226,12 @@ export function registerAnalyticsRoutes({
   router.get(
     {
       path: '/internal/elasticsearch/analytics/collection/{name}/events/exist',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           name: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/api_keys.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/api_keys.ts
@@ -15,6 +15,12 @@ export function registerApiKeysRoutes({ log, router }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/{indexName}/api_keys',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           keyName: schema.string(),
@@ -44,6 +50,12 @@ export function registerApiKeysRoutes({ log, router }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/api_keys',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
     },
     async (context, request, response) => {
@@ -75,6 +87,12 @@ export function registerApiKeysRoutes({ log, router }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/api_keys/{apiKeyId}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           apiKeyId: schema.string(),
@@ -109,6 +127,12 @@ export function registerApiKeysRoutes({ log, router }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/api_keys',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.any(),
       },

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/config_data.ts
@@ -27,6 +27,12 @@ export function registerConfigDataRoute({
   router.get(
     {
       path: '/internal/enterprise_search/config_data',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: false,
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {
@@ -54,6 +60,12 @@ export function registerConfigDataRoute({
   router.get(
     {
       path: '/internal/enterprise_search/es_config',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: false,
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -61,6 +61,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/connectors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           delete_existing_connector: schema.maybe(schema.boolean()),
@@ -110,6 +116,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/cancel_syncs',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -126,6 +138,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{syncJobId}/cancel_sync',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           syncJobId: schema.string(),
@@ -160,6 +178,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/configuration',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.recordOf(
           schema.string(),
@@ -184,6 +208,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/scheduling',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           access_control: schema.object({ enabled: schema.boolean(), interval: schema.string() }),
@@ -209,6 +239,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/start_sync',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           nextSyncConfig: schema.maybe(schema.string()),
@@ -233,6 +269,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/start_incremental_sync',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -249,6 +291,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/start_access_control_sync',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -283,6 +331,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/sync_jobs',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -310,6 +364,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/pipeline',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           extract_binary_content: schema.boolean(),
@@ -333,6 +393,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/default_pipeline',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           extract_binary_content: schema.boolean(),
@@ -352,6 +418,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/connectors/default_pipeline',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
     },
     elasticsearchErrorHandler(log, async (context, _, response) => {
@@ -364,6 +436,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/service_type',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({ serviceType: schema.string() }),
         params: schema.object({
@@ -385,6 +463,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/status',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({ status: schema.string() }),
         params: schema.object({
@@ -406,6 +490,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/name_and_description',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           description: schema.nullable(schema.string()),
@@ -434,6 +524,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/filtering/draft',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           advanced_snippet: schema.string(),
@@ -472,6 +568,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/filtering',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.maybe(
           schema.object({
@@ -505,6 +607,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/native',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           is_native: schema.boolean(),
@@ -525,6 +633,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/connectors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           fetchCrawlersOnly: schema.maybe(schema.boolean()),
@@ -602,6 +716,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -623,6 +743,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.delete(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -696,6 +822,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.put(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/index_name/{indexName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -737,6 +869,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/connectors/available_indices',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           from: schema.number({ defaultValue: 0, min: 0 }),
@@ -775,6 +913,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/connectors/{connectorId}/generate_config',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           connectorId: schema.string(),
@@ -838,6 +982,12 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/connectors/generate_connector_name',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           connectorName: schema.maybe(schema.string()),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/documents.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/documents.ts
@@ -17,6 +17,12 @@ export function registerDocumentRoute({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/indices/{index_name}/document/{document_id}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           document_id: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -81,7 +81,16 @@ export function registerIndexRoutes({
   ml,
 }: RouteDependencies) {
   router.get(
-    { path: '/internal/enterprise_search/search_indices', validate: false },
+    {
+      path: '/internal/enterprise_search/search_indices',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
+      validate: false,
+    },
     elasticsearchErrorHandler(log, async (context, _, response) => {
       const { client } = (await context.core).elasticsearch;
       const patterns: AlwaysShowPattern = {
@@ -100,6 +109,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/indices',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           from: schema.number({ defaultValue: 0, min: 0 }),
@@ -164,6 +179,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -198,6 +219,12 @@ export function registerIndexRoutes({
   router.delete(
     {
       path: '/internal/enterprise_search/indices/{indexName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -271,6 +298,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/exists',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -309,6 +342,12 @@ export function registerIndexRoutes({
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/api_key',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           is_native: schema.boolean(),
@@ -336,6 +375,12 @@ export function registerIndexRoutes({
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/pipelines',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -358,6 +403,12 @@ export function registerIndexRoutes({
   router.delete(
     {
       path: '/internal/enterprise_search/indices/{indexName}/pipelines',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -379,6 +430,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/pipelines',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -405,6 +462,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/pipeline_parameters',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -425,6 +488,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -457,6 +526,12 @@ export function registerIndexRoutes({
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -538,6 +613,12 @@ export function registerIndexRoutes({
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/attach',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           pipeline_name: schema.string(),
@@ -577,6 +658,12 @@ export function registerIndexRoutes({
   router.post(
     {
       path: '/internal/enterprise_search/indices',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           index_name: schema.string(),
@@ -656,6 +743,12 @@ export function registerIndexRoutes({
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/simulate',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           docs: schema.arrayOf(schema.any()),
@@ -718,6 +811,12 @@ export function registerIndexRoutes({
   router.post(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/simulate/{pipelineName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           docs: schema.arrayOf(schema.any()),
@@ -799,6 +898,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/errors',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -829,6 +934,12 @@ export function registerIndexRoutes({
   router.put(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/{pipelineName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           description: schema.maybe(schema.string()),
@@ -887,6 +998,12 @@ export function registerIndexRoutes({
   router.delete(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/{pipelineName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -946,6 +1063,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/history',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -973,6 +1096,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/pipelines/ml_inference',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {
@@ -996,6 +1125,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/pipelines/{pipelineName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           pipelineName: schema.string(),
@@ -1037,6 +1172,12 @@ export function registerIndexRoutes({
   router.delete(
     {
       path: '/internal/enterprise_search/indices/{indexName}/ml_inference/pipeline_processors/{pipelineName}/detach',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),
@@ -1079,6 +1220,12 @@ export function registerIndexRoutes({
   router.post(
     {
       path: '/internal/enterprise_search/ml/models/{modelName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           modelName: schema.string(),
@@ -1120,6 +1267,12 @@ export function registerIndexRoutes({
   router.post(
     {
       path: '/internal/enterprise_search/ml/models/{modelName}/deploy',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           modelName: schema.string(),
@@ -1161,6 +1314,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/ml/models',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {},
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {
@@ -1183,6 +1342,12 @@ export function registerIndexRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/ml/models/{modelName}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           modelName: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/mapping.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/mapping.ts
@@ -19,6 +19,12 @@ export function registerMappingRoute({ router, log }: RouteDependencies) {
   router.get(
     {
       path: '/internal/enterprise_search/mappings/{index_name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           index_name: schema.string(),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search.ts
@@ -22,6 +22,12 @@ export function registerSearchRoute({ router, log }: RouteDependencies) {
   router.post(
     {
       path: '/internal/enterprise_search/indices/{index_name}/search',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           searchQuery: schema.string({

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/search_applications.ts
@@ -34,6 +34,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.get(
     {
       path: '/internal/enterprise_search/search_applications',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           from: schema.number({ defaultValue: 0, min: 0 }),
@@ -68,6 +74,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.get(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           engine_name: schema.string(),
@@ -99,6 +111,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.put(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           indices: schema.arrayOf(schema.string()),
@@ -198,6 +216,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.delete(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           engine_name: schema.string(),
@@ -217,6 +241,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.post(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}/search',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({}, { unknowns: 'allow' }),
         params: schema.object({
@@ -238,6 +268,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.post(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}/api_key',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           keyName: schema.string(),
@@ -263,6 +299,12 @@ export function registerSearchApplicationsRoutes({ log, router }: RouteDependenc
   router.get(
     {
       path: '/internal/enterprise_search/search_applications/{engine_name}/field_capabilities',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: { params: schema.object({ engine_name: schema.string() }) },
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/stats.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/stats.ts
@@ -19,6 +19,12 @@ export function registerStatsRoutes({
   router.get(
     {
       path: '/internal/enterprise_search/stats/sync_jobs',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         query: schema.object({
           isCrawler: schema.maybe(schema.boolean()),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/telemetry.ts
@@ -24,6 +24,12 @@ export function registerTelemetryRoute({ router, getSavedObjectsService }: Route
   router.put(
     {
       path: '/internal/enterprise_search/stats',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           product: schema.oneOf([

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/documents.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/documents.ts
@@ -17,6 +17,12 @@ export function registerDocumentRoutes(router: IRouter, logger: Logger) {
   router.delete(
     {
       path: INDEX_DOCUMENT_ROUTE,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         params: schema.object({
           indexName: schema.string(),

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/indices.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/indices.ts
@@ -18,6 +18,12 @@ export function registerIndicesRoutes(router: IRouter, logger: Logger) {
   router.post(
     {
       path: POST_CREATE_INDEX_ROUTE,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       validate: {
         body: schema.object({
           indexName: schema.string(),

--- a/x-pack/solutions/search/plugins/search_indices/server/routes/status.ts
+++ b/x-pack/solutions/search/plugins/search_indices/server/routes/status.ts
@@ -16,6 +16,12 @@ export function registerStatusRoutes(router: IRouter, logger: Logger) {
     {
       path: GET_STATUS_ROUTE,
       validate: {},
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       options: {
         access: 'internal',
       },
@@ -36,6 +42,12 @@ export function registerStatusRoutes(router: IRouter, logger: Logger) {
     {
       path: GET_USER_PRIVILEGES_ROUTE,
       validate: {},
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the scoped ES client',
+        },
+      },
       options: {
         access: 'internal',
       },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Authz]: added reason for authorization opt-out for search routes (#213879)](https://github.com/elastic/kibana/pull/213879)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Shostak","email":"165678770+elena-shostak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-12T13:40:47Z","message":"[Authz]: added reason for authorization opt-out for search routes (#213879)\n\n## Summary\n\nAdded justification for opting out of authorization for search routes.\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"fcb15aca8439b0b464c8fc37fa7b5854d9e07be3","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Security/Authorization","v9.0.0","backport:prev-minor","backport:version","Authz: API migration","v9.1.0","v8.19.0"],"title":"[Authz]: added reason for authorization opt-out for search routes","number":213879,"url":"https://github.com/elastic/kibana/pull/213879","mergeCommit":{"message":"[Authz]: added reason for authorization opt-out for search routes (#213879)\n\n## Summary\n\nAdded justification for opting out of authorization for search routes.\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"fcb15aca8439b0b464c8fc37fa7b5854d9e07be3"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214162","number":214162,"state":"MERGED","mergeCommit":{"sha":"873f281cd3c3b507beac56f8490ef96adebc9918","message":"[9.0] [Authz]: added reason for authorization opt-out for search routes (#213879) (#214162)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Authz]: added reason for authorization opt-out for search routes\n(#213879)](https://github.com/elastic/kibana/pull/213879)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Elena Shostak <165678770+elena-shostak@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213879","number":213879,"mergeCommit":{"message":"[Authz]: added reason for authorization opt-out for search routes (#213879)\n\n## Summary\n\nAdded justification for opting out of authorization for search routes.\n\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"fcb15aca8439b0b464c8fc37fa7b5854d9e07be3"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->