### PR TITLE
[Security Solution] Avoid showing rules update confirmation modal on basic license

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management/hooks/use_prebuilt_rules_upgrade.tsx
@@ -201,11 +201,21 @@ export function usePrebuiltRulesUpgrade({
         return;
       }
 
-      await upgradeRulesWithDryRun({
-        mode: 'ALL_RULES',
-        pick_version: isRulesCustomizationEnabled ? 'MERGED' : 'TARGET',
-        filter,
-      });
+      if (isRulesCustomizationEnabled) {
+        await upgradeRulesWithDryRun({
+          mode: 'ALL_RULES',
+          pick_version: 'MERGED',
+          filter,
+        });
+      } else {
+        // Upgrading prebuilt rules to TARGET version will erase any rule customizations.
+        // It's unnecessary to run a dry run request since we don't expect skipped rules.
+        await upgradeRulesRequest({
+          mode: 'ALL_RULES',
+          pick_version: 'TARGET',
+          filter,
+        });
+      }
     } catch {
       // Error is handled by the mutation's onError callback, so no need to do anything here
     } finally {
@@ -214,6 +224,7 @@ export function usePrebuiltRulesUpgrade({
   }, [
     upgradeableRules,
     upgradeRulesWithDryRun,
+    upgradeRulesRequest,
     confirmLegacyMLJobs,
     isRulesCustomizationEnabled,
     filter,


### PR DESCRIPTION
**Resolves:** https://github.com/elastic/kibana/issues/214302

## Summary

This PR prevents showing rule upgrade confirmation modal on lower licenses where prebuilt rules customization is not allowed.

## Details

Users may see a rules upgrade confirmation modal when trying to upgrade prebuilt rules even if prebuilt rules customization is disabled due to insufficient license. It happens due to improper response from `upgrade/_perform` which doesn't respect `pick_version`. It's expected rule upgrade goes smoothly when `pick_version` is one of `BASE`, `CURRENT` or `TARGET`.

The fix makes sure dry run request isn't fired and a prebuilt rules upgrade confirmation modal isn't shown when running with insufficient for prebuilt rules customization license.

There is a [ticket](https://github.com/elastic/kibana/issues/214338) to address this issue in the API endpoint.



<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->