### PR TITLE
[8.x] [Synthetics] Fix UI issue on Last test run panel and changed breadcrumb string when creating a monitor (#213874)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/result_details.tsx
@@ -31,8 +31,8 @@ export const ResultDetails = ({
 }) => {
   return (
     <div>
-      <EuiText className="eui-textNoWrap" size="s">
-        <StatusBadge status={parseBadgeStatus(pingStatus)} />{' '}
+      <StatusBadge status={parseBadgeStatus(pingStatus)} />
+      <EuiText size="s">
         {!testNowMode
           ? i18n.translate('xpack.synthetics.step.duration.label', {
               defaultMessage: 'after {value}',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/use_breadcrumbs.ts
@@ -30,7 +30,7 @@ export const useMonitorAddEditBreadcrumbs = (isEdit?: boolean) => {
 export const ADD_MONITOR_CRUMB = i18n.translate(
   'xpack.synthetics.monitorManagement.addMonitorCrumb',
   {
-    defaultMessage: 'Add monitor',
+    defaultMessage: 'Create monitor',
   }
 );
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { EuiTitle, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiText, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { LoadWhenInView } from '@kbn/observability-shared-plugin/public';
-import { useTestFlyoutOpen } from '../../test_now_mode/hooks/use_test_flyout_open';
 
 import { useMonitorDetailsPage } from '../use_monitor_details_page';
 import { useMonitorRangeFrom } from '../hooks/use_monitor_range_from';
@@ -30,8 +29,6 @@ import { MonitorPendingWrapper } from '../monitor_pending_wrapper';
 
 export const MonitorSummary = () => {
   const { from, to } = useMonitorRangeFrom();
-
-  const isFlyoutOpen = !!useTestFlyoutOpen();
 
   const dateLabel = from === 'now-30d/d' ? LAST_30_DAYS_LABEL : TO_DATE_LABEL;
 
@@ -118,13 +115,13 @@ export const MonitorSummary = () => {
       />
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="m" wrap={true}>
-        <EuiFlexItem css={isFlyoutOpen ? { minWidth: 260, maxWidth: 500 } : { maxWidth: 500 }}>
+        <EuiFlexItem css={{ minWidth: 430 }}>
           <LastTestRun />
         </EuiFlexItem>
         <EuiFlexItem css={{ minWidth: 260 }}>
           <MonitorAlerts dateLabel={dateLabel} from={from} to={to} />
           <EuiSpacer size="m" />
-          <StepDurationPanel />
+          <StepDurationPanel legendPosition="bottom" />
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Synthetics] Fix UI issue on Last test run panel and changed breadcrumb string when creating a monitor (#213874)](https://github.com/elastic/kibana/pull/213874)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-03-12T13:21:06Z","message":"[Synthetics] Fix UI issue on Last test run panel and changed breadcrumb string when creating a monitor (#213874)\n\nThis PR fixes #200921.\n\nThis is the final result, where the step details button is correctly\nshown.\n<img width=\"511\" alt=\"Screenshot 2025-03-11 at 09 57 33\"\nsrc=\"https://github.com/user-attachments/assets/c6017848-635a-4af5-aebc-68979ae115f9\"\n/>\n\nThis PR also fixes #212246.\n<img width=\"1143\" alt=\"Screenshot 2025-03-11 at 11 09 55\"\nsrc=\"https://github.com/user-attachments/assets/20b75ba4-ce99-4cc9-a827-11e5cb03a6da\"\n/>","sha":"1b8fcd21e31963425153c34d4ca1be73d9bd7dcf","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Synthetics] Fix UI issue on Last test run panel and changed breadcrumb string when creating a monitor","number":213874,"url":"https://github.com/elastic/kibana/pull/213874","mergeCommit":{"message":"[Synthetics] Fix UI issue on Last test run panel and changed breadcrumb string when creating a monitor (#213874)\n\nThis PR fixes #200921.\n\nThis is the final result, where the step details button is correctly\nshown.\n<img width=\"511\" alt=\"Screenshot 2025-03-11 at 09 57 33\"\nsrc=\"https://github.com/user-attachments/assets/c6017848-635a-4af5-aebc-68979ae115f9\"\n/>\n\nThis PR also fixes #212246.\n<img width=\"1143\" alt=\"Screenshot 2025-03-11 at 11 09 55\"\nsrc=\"https://github.com/user-attachments/assets/20b75ba4-ce99-4cc9-a827-11e5cb03a6da\"\n/>","sha":"1b8fcd21e31963425153c34d4ca1be73d9bd7dcf"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214158","number":214158,"state":"MERGED","mergeCommit":{"sha":"6536b6598de4698571cc6c5b1ff7d7283d6bd193","message":"[9.0] [Synthetics] Fix UI issue on Last test run panel and changed breadcrumb string when creating a monitor (#213874) (#214158)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Synthetics] Fix UI issue on Last test run panel and changed\nbreadcrumb string when creating a monitor\n(#213874)](https://github.com/elastic/kibana/pull/213874)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Francesco Fagnani <fagnani.francesco@gmail.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213874","number":213874,"mergeCommit":{"message":"[Synthetics] Fix UI issue on Last test run panel and changed breadcrumb string when creating a monitor (#213874)\n\nThis PR fixes #200921.\n\nThis is the final result, where the step details button is correctly\nshown.\n<img width=\"511\" alt=\"Screenshot 2025-03-11 at 09 57 33\"\nsrc=\"https://github.com/user-attachments/assets/c6017848-635a-4af5-aebc-68979ae115f9\"\n/>\n\nThis PR also fixes #212246.\n<img width=\"1143\" alt=\"Screenshot 2025-03-11 at 11 09 55\"\nsrc=\"https://github.com/user-attachments/assets/20b75ba4-ce99-4cc9-a827-11e5cb03a6da\"\n/>","sha":"1b8fcd21e31963425153c34d4ca1be73d9bd7dcf"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->