### PR TITLE
[APM][OTel] Fix: Pass telemetry.sdk* data when loading a dashboard

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/metrics/index.tsx
@@ -60,6 +60,8 @@ export function Metrics() {
     return (
       <JsonMetricsDashboard
         agentName={agentName}
+        telemetrySdkName={telemetrySdkName}
+        telemetrySdkLanguage={telemetrySdkLanguage}
         runtimeName={runtimeName}
         serverlessType={serverlessType}
         dataView={dataView}


### PR DESCRIPTION
Closes #214328 

## Summary

This PR fixes the issue with loading an otel native dashboard

## Testing
- Run ` node scripts/synthtrace otel_edot_simple_trace.ts`
  - ⚠️ As our test data has only a java service there is a small manual step needed (it will be listed below **^**)
- Open the metrics tab for the service (currently we don't have a dashboard): 

![image](https://github.com/user-attachments/assets/e5f1461c-be6f-4d18-9185-7cb25698764b)


- **^** Go to the `dashboard_catalog.ts` and add mapping for otel native java case: 
  - first: `'otel_native-edot-java',`

   ![image](https://github.com/user-attachments/assets/a3463f5b-6db9-466e-95fc-3ccd44a4a016)
  - second: 
      ```js   
     case 'otel_native-edot-java': {
      return import(
        /* webpackChunkName: "lazyJavaOtelNativeDashboard" */
        './opentelemetry_java.json'
      );
    }
   ``

    - ![image](https://github.com/user-attachments/assets/34c12147-db1e-4494-8ea6-95dffc5975d4)

- Check the same page after refresh
![image](https://github.com/user-attachments/assets/e12b7046-9868-421b-9f9e-df004f82ddfc)




<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->