### PR TITLE
[Fleet] fix UI bug displaying default agent binary source

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.test.tsx
@@ -682,6 +682,11 @@ describe('useFleetServerHostsOptions', () => {
           "value": "@@##DEFAULT_SELECT##@@",
         },
         Object {
+          "disabled": false,
+          "inputDisplay": "Default",
+          "value": "default-host",
+        },
+        Object {
           "disabled": true,
           "inputDisplay": "Internal",
           "value": "internal-output",

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
@@ -16,10 +16,7 @@ import {
   useGetDownloadSources,
   useGetFleetServerHosts,
 } from '../../../../hooks';
-import {
-  DEFAULT_DOWNLOAD_SOURCE_ID,
-  LICENCE_FOR_PER_POLICY_OUTPUT,
-} from '../../../../../../../common/constants';
+import { LICENCE_FOR_PER_POLICY_OUTPUT } from '../../../../../../../common/constants';
 import {
   getAllowedOutputTypesForAgentPolicy,
   policyHasFleetServer,
@@ -172,14 +169,12 @@ export function useDownloadSourcesOptions() {
 
     return [
       getDefaultDownloadSource(defaultDownloadSourceName),
-      ...downloadSourcesRequest.data.items
-        .filter((item) => !item.is_default)
-        .map((item) => {
-          return {
-            value: item.id,
-            inputDisplay: item.name,
-          };
-        }),
+      ...downloadSourcesRequest.data.items.map((item) => {
+        return {
+          value: item.id,
+          inputDisplay: item.name,
+        };
+      }),
     ];
   }, [downloadSourcesRequest]);
 
@@ -205,7 +200,7 @@ function getDefaultDownloadSource(
       }),
       defaultDownloadSourceDisabledMessage
     ),
-    value: DEFAULT_DOWNLOAD_SOURCE_ID,
+    value: DEFAULT_SELECT_VALUE,
     disabled: defaultDownloadSourceDisabled,
   };
 }
@@ -225,17 +220,15 @@ export function useFleetServerHostsOptions(agentPolicy: Partial<NewAgentPolicy |
 
     return [
       getDefaultFleetServerHosts(defaultFleetServerHostsName),
-      ...fleetServerHostsRequest.data.items
-        .filter((item) => !item.is_default)
-        .map((item) => {
-          const isInternalFleetServerHost = !!item.is_internal;
+      ...fleetServerHostsRequest.data.items.map((item) => {
+        const isInternalFleetServerHost = !!item.is_internal;
 
-          return {
-            value: item.id,
-            inputDisplay: item.name,
-            disabled: isInternalFleetServerHost,
-          };
-        }),
+        return {
+          value: item.id,
+          inputDisplay: item.name,
+          disabled: isInternalFleetServerHost,
+        };
+      }),
     ];
   }, [fleetServerHostsRequest]);
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/hooks.tsx
@@ -16,7 +16,10 @@ import {
   useGetDownloadSources,
   useGetFleetServerHosts,
 } from '../../../../hooks';
-import { LICENCE_FOR_PER_POLICY_OUTPUT } from '../../../../../../../common/constants';
+import {
+  DEFAULT_DOWNLOAD_SOURCE_ID,
+  LICENCE_FOR_PER_POLICY_OUTPUT,
+} from '../../../../../../../common/constants';
 import {
   getAllowedOutputTypesForAgentPolicy,
   policyHasFleetServer,
@@ -156,7 +159,7 @@ export function useOutputOptions(agentPolicy: Partial<NewAgentPolicy | AgentPoli
   );
 }
 
-export function useDownloadSourcesOptions(agentPolicy: Partial<NewAgentPolicy | AgentPolicy>) {
+export function useDownloadSourcesOptions() {
   const downloadSourcesRequest = useGetDownloadSources();
 
   const dataDownloadSourceOptions = useMemo(() => {
@@ -202,7 +205,7 @@ function getDefaultDownloadSource(
       }),
       defaultDownloadSourceDisabledMessage
     ),
-    value: DEFAULT_SELECT_VALUE,
+    value: DEFAULT_DOWNLOAD_SOURCE_ID,
     disabled: defaultDownloadSourceDisabled,
   };
 }

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -112,7 +112,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
     maxAgentPoliciesWithInactivityTimeout !== undefined &&
     totalAgentPoliciesWithInactivityTimeout > (maxAgentPoliciesWithInactivityTimeout ?? 0);
   const { dataDownloadSourceOptions, isLoading: isLoadingDownloadSources } =
-    useDownloadSourcesOptions(agentPolicy);
+    useDownloadSourcesOptions();
 
   const { fleetServerHostsOptions, isLoading: isLoadingFleetServerHostsOption } =
     useFleetServerHostsOptions(agentPolicy);


### PR DESCRIPTION
## Summary

Fix UI bug when an agent policy uses the default download source explicitly. The Agent binary download UI select was empty.

To verify:
- create a new agent binary download source
- create an agent policy with using the default download source
- check on Agent policy details UI that the Agent binary download UI select is populated correctly

```
POST kbn:/api/fleet/agent_policies
{
  "name": "demo-policy-5",
  "description": "",
  "namespace": "default",
  "monitoring_enabled": [
    "logs",
    "metrics",
    "traces"
  ],
  "inactivity_timeout": 1209600,
  "is_protected": false,
  "download_source_id": "fleet-default-download-source"
}
```

Before:

![image](https://github.com/user-attachments/assets/6bde2652-bbf2-42af-8a2a-c893c5e80d27)

After:

<img width="1517" alt="image" src="https://github.com/user-attachments/assets/f5d19520-317e-4df8-aaed-0e367a2e6d9b" />


<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->