### PR TITLE
[Security Solution] Hide conflict badges when rule customization is not enabled

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/upgrade_prebuilt_rules_table/use_upgrade_prebuilt_rules_table_columns.tsx
@@ -246,7 +246,7 @@ export const useUpgradePrebuiltRulesTableColumns = (): TableColumn[] => {
     () => [
       RULE_NAME_COLUMN,
       MODIFIED_COLUMN,
-      CONFLICT_COLUMN,
+      ...(isRulesCustomizationEnabled ? [CONFLICT_COLUMN] : []),
       ...(showRelatedIntegrations ? [INTEGRATIONS_COLUMN] : []),
       TAGS_COLUMN,
       {


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/214301**

## Summary

This PR removes conflict badges from the Rule Updates table for users with license that is insufficient for prebuilt rule customization.

**Before (on Basic license)**
<img width="1014" alt="Scherm­afbeelding 2025-03-13 om 13 44 07" src="https://github.com/user-attachments/assets/fd830253-80d0-4250-861c-88b0a11d6786" />


**After (on Basic license)**
<img width="1014" alt="Scherm­afbeelding 2025-03-13 om 13 39 01" src="https://github.com/user-attachments/assets/f8b00964-72bf-4d0a-9f03-9e47231c5227" />

Since users on Basic license can't customize rules, it doesn't make sense to show these badges - they are not actionable anyways.

Users will still see a callout mentioning that their modifications will be erased if they open a flyout for a customized rule.

<img width="953" alt="Scherm­afbeelding 2025-03-13 om 13 41 21" src="https://github.com/user-attachments/assets/b2a2514e-2b19-4653-9076-d742130b30b6" />


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->