### PR TITLE
[8.18] [UA] Do not allow reindexing data_stream backing indices (and other enhancements) (#213755)

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/mocked_responses.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/mocked_responses.ts
@@ -35,6 +35,11 @@ export const MOCK_REINDEX_DEPRECATION: EnrichedDeprecationInfo = {
   index: 'reindex_index',
   correctiveAction: {
     type: 'reindex',
+    metadata: {
+      isClosedIndex: false,
+      isFrozenIndex: false,
+      isInDataStream: false,
+    },
   },
 };
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/reindex_deprecation_flyout.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/reindex_deprecation_flyout.test.ts
@@ -23,6 +23,7 @@ const defaultReindexStatusMeta: ReindexStatusResponse['meta'] = {
   aliases: [],
   isFrozen: false,
   isReadonly: false,
+  isInDataStream: false,
 };
 
 describe('Reindex deprecation flyout', () => {

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/details/warnings_callout.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/details/warnings_callout.tsx
@@ -29,6 +29,12 @@ export const DurationClarificationCallOut: React.FunctionComponent<Props> = ({
         <br />
         <br />
         <FormattedMessage
+          id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.backingIndicesUnfrozen"
+          defaultMessage="If any of the backing indices of the data stream are frozen, they will be converted to non-frozen indices during the update process."
+        />
+        <br />
+        <br />
+        <FormattedMessage
           id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.suggestReadOnly"
           defaultMessage="Depending on size and resources, reindexing may take extended time and your data will be in a read-only state until the job has completed. {learnMoreHtml}"
           values={{

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/context.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/context.tsx
@@ -10,7 +10,7 @@ import React, { createContext, useContext } from 'react';
 import { ApiService } from '../../../../lib/api';
 import { useReindex, ReindexState } from './use_reindex';
 import { UpdateIndexState, useUpdateIndex } from './use_update_index';
-import { EnrichedDeprecationInfo } from '../../../../../../common/types';
+import { EnrichedDeprecationInfo, IndexAction } from '../../../../../../common/types';
 
 export interface IndexStateContext {
   deprecation: EnrichedDeprecationInfo;
@@ -43,9 +43,13 @@ export const IndexStatusProvider: React.FunctionComponent<Props> = ({
   children,
 }) => {
   const indexName = deprecation.index!;
+  const indexAction = deprecation.correctiveAction as IndexAction;
   const { reindexState, startReindex, cancelReindex } = useReindex({
     indexName,
     api,
+    isInDataStream: Boolean(indexAction?.metadata.isInDataStream),
+    isFrozen: Boolean(indexAction?.metadata.isFrozenIndex),
+    isClosedIndex: Boolean(indexAction?.metadata.isClosedIndex),
   });
 
   const { updateIndexState, updateIndex } = useUpdateIndex({

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/container.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/container.tsx
@@ -126,8 +126,6 @@ export const IndexFlyout: React.FunctionComponent<IndexFlyoutProps> = ({
     switch (flyoutStep) {
       case 'details':
         return correctiveAction?.type === 'unfreeze' ? (
-          // we will show specific unfreeze details/flow for:
-          // A) 7.x indices that are frozen AND read-only (should be an edge case)
           <UnfreezeDetailsFlyoutStep
             closeFlyout={closeFlyout}
             startReindex={() => {
@@ -141,11 +139,6 @@ export const IndexFlyout: React.FunctionComponent<IndexFlyoutProps> = ({
             reindexState={reindexState}
           />
         ) : (
-          // we will show specific reindex details/flow for:
-          // B) 7.x indices that are frozen AND NOT read-only (should be the most common scenario)
-          // C) 7.x indices that are not frozen
-          //    C.1) if they are read-only => this will be a WARNING deprecation
-          //    C.2) if they are NOT read-only => this will be a CRITICAL deprecation
           <ReindexDetailsFlyoutStep
             closeFlyout={closeFlyout}
             startReindex={() => {

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/messages.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/messages.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiLink } from '@elastic/eui';
+import { EuiLink, EuiSpacer } from '@elastic/eui';
 import { EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ReindexStatus } from '../../../../../../../../../common/types';
+import { IndexClosedParagraph } from '../index_closed_paragraph';
 
 export const getReindexButtonLabel = (status?: ReindexStatus) => {
   switch (status) {
@@ -47,11 +48,13 @@ export const getReindexButtonLabel = (status?: ReindexStatus) => {
 };
 
 export const getDefaultGuideanceText = ({
+  isClosedIndex,
   readOnlyExcluded,
   reindexExcluded,
   indexBlockUrl,
   indexManagementUrl,
 }: {
+  isClosedIndex: boolean;
   readOnlyExcluded: boolean;
   reindexExcluded: boolean;
   indexBlockUrl: string;
@@ -73,6 +76,12 @@ export const getDefaultGuideanceText = ({
             id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindex.option1.description"
             defaultMessage="The reindex operation allows transforming an index into a new, compatible one. It will copy all of the existing documents into a new index and remove the old one. Depending on size and resources, reindexing may take extended time and your data will be in a read-only state until the job has completed."
           />
+          {isClosedIndex && (
+            <Fragment>
+              <EuiSpacer size="xs" />
+              <IndexClosedParagraph />
+            </Fragment>
+          )}
         </EuiText>
       ),
     });

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.test.tsx
@@ -49,10 +49,12 @@ describe('ReindexDetailsFlyoutStep', () => {
     loadingState: LoadingState.Success,
     meta: {
       indexName: 'some_index',
+      reindexName: 'some_index-reindexed-for-9',
       aliases: [],
+      isInDataStream: false,
       isFrozen: false,
       isReadonly: false,
-      reindexName: 'some_index-reindexed-for-9',
+      isClosedIndex: false,
     },
     hasRequiredPrivileges: true,
     reindexTaskPercComplete: null,
@@ -226,7 +228,15 @@ describe('ReindexDetailsFlyoutStep', () => {
         updateIndexState={defaultUpdateIndexState()}
         deprecation={{
           ...defaultDeprecation(),
-          correctiveAction: { type: 'reindex', transformIds: ['abc', 'def'] },
+          correctiveAction: {
+            type: 'reindex',
+            transformIds: ['abc', 'def'],
+            metadata: {
+              isFrozenIndex: false,
+              isInDataStream: false,
+              isClosedIndex: false,
+            },
+          },
         }}
       />
     );
@@ -238,6 +248,11 @@ describe('ReindexDetailsFlyoutStep', () => {
               deprecation={
                 Object {
                   "correctiveAction": Object {
+                    "metadata": Object {
+                      "isClosedIndex": false,
+                      "isFrozenIndex": false,
+                      "isInDataStream": false,
+                    },
                     "transformIds": Array [
                       "abc",
                       "def",

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/reindex_details_step.tsx
@@ -36,6 +36,7 @@ import { FetchFailedCallOut } from '../fetch_failed_callout';
 import { ReindexingFailedCallOut } from '../reindexing_failed_callout';
 import { MlAnomalyGuidance } from './ml_anomaly_guidance';
 import { ESTransformsTargetGuidance } from './es_transform_target_guidance';
+import { IndexClosedParagraph } from '../index_closed_paragraph';
 
 const ML_ANOMALIES_PREFIX = '.ml-anomalies-';
 
@@ -66,7 +67,7 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
 
   const { loadingState, status: reindexStatus, hasRequiredPrivileges, meta } = reindexState;
   const { status: updateIndexStatus } = updateIndexState;
-  const { indexName } = meta;
+  const { indexName, isFrozen, isClosedIndex, isReadonly } = meta;
   const loading = loadingState === LoadingState.Loading;
   const isCompleted = reindexStatus === ReindexStatus.completed || updateIndexStatus === 'complete';
   const hasFetchFailed = reindexStatus === ReindexStatus.fetchFailed;
@@ -87,7 +88,7 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
 
   if (isESTransformTarget) {
     showEsTransformsGuidance = true;
-  } else if (meta.isReadonly) {
+  } else if (isReadonly) {
     showReadOnlyGuidance = true;
   } else if (isMLAnomalyIndex) {
     showMlAnomalyReindexingGuidance = true;
@@ -161,7 +162,7 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
           <ReindexingFailedCallOut errorMessage={reindexState.errorMessage!} />
         )}
 
-        {meta.isFrozen && <FrozenCallOut />}
+        {isFrozen && <FrozenCallOut />}
 
         <EuiText>
           {showEsTransformsGuidance && <ESTransformsTargetGuidance deprecation={deprecation} />}
@@ -180,6 +181,11 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
                   defaultMessage="The reindex operation allows transforming an index into a new, compatible one. It will copy all of the existing documents into a new index and remove the old one. Depending on size and resources, reindexing may take extended time and your data will be in a read-only state until the job has completed."
                 />
               </p>
+              {isClosedIndex && (
+                <p>
+                  <IndexClosedParagraph />
+                </p>
+              )}
             </Fragment>
           )}
           {showDefaultGuidance && (
@@ -193,6 +199,7 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
               <EuiDescriptionList
                 rowGutterSize="m"
                 listItems={getDefaultGuideanceText({
+                  isClosedIndex,
                   readOnlyExcluded,
                   reindexExcluded,
                   indexManagementUrl: `${http.basePath.prepend(
@@ -218,7 +225,7 @@ export const ReindexDetailsFlyoutStep: React.FunctionComponent<{
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="s">
-              {!meta.isReadonly &&
+              {!isReadonly &&
                 !hasFetchFailed &&
                 !isCompleted &&
                 hasRequiredPrivileges &&

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/unfreeze_details_step.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/details/unfreeze_details_step.test.tsx
@@ -44,6 +44,8 @@ describe('UnfreezeDetailsFlyoutStep', () => {
       aliases: [],
       isFrozen: true,
       isReadonly: true,
+      isInDataStream: false,
+      isClosedIndex: false,
       reindexName: 'some_index-reindexed-for-9',
     },
     hasRequiredPrivileges: true,
@@ -56,7 +58,7 @@ describe('UnfreezeDetailsFlyoutStep', () => {
     failedBefore: false,
   };
 
-  it('renders', () => {
+  it('renders all options for regular indices', () => {
     const wrapper = shallow(
       <UnfreezeDetailsFlyoutStep
         closeFlyout={jest.fn()}
@@ -67,132 +69,30 @@ describe('UnfreezeDetailsFlyoutStep', () => {
       />
     );
 
-    expect(wrapper).toMatchInlineSnapshot(`
-      <Fragment>
-        <EuiFlyoutBody>
-          <EuiText>
-            <p>
-              <MemoizedFormattedMessage
-                defaultMessage="This index is frozen. Frozen indices will no longer be supported after the upgrade. Choose one of the following options:"
-                id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.frozenIndexText"
-              />
-            </p>
-            <EuiDescriptionList
-              listItems={
-                Array [
-                  Object {
-                    "description": <EuiText
-                      size="m"
-                    >
-                      <Memo(MemoizedFormattedMessage)
-                        defaultMessage="Unfreeze this index and make it read-only. This ensures that the index will remain compatible with the next major version."
-                        id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.unfreeze.option1.description"
-                      />
-                    </EuiText>,
-                    "title": "Option 1: Unfreeze index",
-                  },
-                  Object {
-                    "description": <EuiText
-                      size="m"
-                    >
-                      <Memo(MemoizedFormattedMessage)
-                        defaultMessage="Alternatively, you can reindex the data into a new, compatible index. All existing documents will be copied over to a new index, and the old index will be removed. Depending on the size of the index and the available resources, the reindexing operation can take some time. Your data will be in read-only mode until the reindexing has completed."
-                        id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.unfreeze.option2.description"
-                      />
-                    </EuiText>,
-                    "title": "Option 2: Reindex data",
-                  },
-                  Object {
-                    "description": <EuiText
-                      size="m"
-                    >
-                      <Memo(MemoizedFormattedMessage)
-                        defaultMessage="If you no longer need it, you can also delete the index from {indexManagementLinkHtml}."
-                        id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.unfreeze.option3.description"
-                        values={
-                          Object {
-                            "indexManagementLinkHtml": <EuiLink
-                              href="undefined"
-                            >
-                              <Memo(MemoizedFormattedMessage)
-                                defaultMessage="Index Management"
-                                id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.indexMgmtLink"
-                              />
-                            </EuiLink>,
-                          }
-                        }
-                      />
-                    </EuiText>,
-                    "title": "Option 3: Delete index",
-                  },
-                ]
-              }
-              rowGutterSize="m"
-            />
-          </EuiText>
-          <EuiSpacer />
-        </EuiFlyoutBody>
-        <EuiFlyoutFooter>
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <EuiButtonEmpty
-                flush="left"
-                iconType="cross"
-                onClick={[MockFunction]}
-              >
-                <MemoizedFormattedMessage
-                  defaultMessage="Close"
-                  id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.closeButtonLabel"
-                />
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <EuiFlexGroup
-                gutterSize="s"
-              >
-                <EuiFlexItem
-                  grow={false}
-                >
-                  <EuiButton
-                    color="primary"
-                    data-test-subj="startReindexingButton"
-                    disabled={false}
-                    isLoading={false}
-                    onClick={[MockFunction]}
-                  >
-                    <MemoizedFormattedMessage
-                      defaultMessage="Start reindexing"
-                      id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindexButton.runReindexLabel"
-                    />
-                  </EuiButton>
-                </EuiFlexItem>
-                <EuiFlexItem
-                  grow={false}
-                >
-                  <EuiButton
-                    data-test-subj="startIndexReadonlyButton"
-                    disabled={false}
-                    fill={true}
-                    onClick={[MockFunction]}
-                  >
-                    <MemoizedFormattedMessage
-                      data-test-subj="startIndexReadonlyButton"
-                      defaultMessage="Unfreeze"
-                      id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.unfreezeIndexButton"
-                    />
-                  </EuiButton>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiFlyoutFooter>
-      </Fragment>
-    `);
+    expect(wrapper.find('EuiButton[data-test-subj="startReindexingButton"]')).toHaveLength(1);
+    expect(wrapper.find('EuiButton[data-test-subj="startUnfreezeButton"]')).toHaveLength(1);
+  });
+
+  it('does NOT render Reindex option for data stream backing indices', () => {
+    const backingIndexReindexState = {
+      ...defaultReindexState,
+      meta: {
+        ...defaultReindexState.meta,
+        isInDataStream: true,
+      },
+    };
+
+    const wrapper = shallow(
+      <UnfreezeDetailsFlyoutStep
+        closeFlyout={jest.fn()}
+        startReindex={jest.fn()}
+        unfreeze={jest.fn()}
+        reindexState={backingIndexReindexState}
+        updateIndexState={defaultUpdateIndexState}
+      />
+    );
+
+    expect(wrapper.find('EuiButton[data-test-subj="startReindexingButton"]')).toHaveLength(0);
+    expect(wrapper.find('EuiButton[data-test-subj="startUnfreezeButton"]')).toHaveLength(1);
   });
 });

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/index_closed_paragraph.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/index_closed_paragraph.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiLink } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import { useAppContext } from '../../../../../../app_context';
+
+export const IndexClosedParagraph: React.FunctionComponent = () => {
+  const {
+    services: {
+      core: { docLinks },
+    },
+  } = useAppContext();
+
+  return (
+    <FormattedMessage
+      id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.indexClosed"
+      defaultMessage="This index is currently closed. The Upgrade Assistant will open, reindex and then close the index. {reindexingMayTakeLongerEmph}. {learnMore}"
+      values={{
+        learnMore: (
+          <EuiLink target="_blank" href={docLinks.links.apis.openIndex}>
+            {i18n.translate(
+              'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.learnMoreLinkLabel',
+              {
+                defaultMessage: 'Learn more',
+              }
+            )}
+          </EuiLink>
+        ),
+        reindexingMayTakeLongerEmph: (
+          <b>
+            {i18n.translate(
+              'xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.detailsStep.reindexTakesLonger',
+              { defaultMessage: 'Reindexing may take longer than usual' }
+            )}
+          </b>
+        ),
+      }}
+    />
+  );
+};

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/__snapshots__/reindex_step.test.tsx.snap
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/__snapshots__/reindex_step.test.tsx.snap
@@ -39,7 +39,9 @@ exports[`ReindexStep renders 1`] = `
           "meta": Object {
             "aliases": Array [],
             "indexName": "myIndex",
+            "isClosedIndex": false,
             "isFrozen": false,
+            "isInDataStream": false,
             "isReadonly": false,
             "reindexName": "reindexed-myIndex",
           },
@@ -130,7 +132,9 @@ exports[`ReindexStep renders for frozen indices 1`] = `
           "meta": Object {
             "aliases": Array [],
             "indexName": "myIndex",
+            "isClosedIndex": false,
             "isFrozen": true,
+            "isInDataStream": false,
             "isReadonly": false,
             "reindexName": "reindexed-myIndex",
           },

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/progress.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/progress.test.tsx
@@ -30,6 +30,8 @@ describe('ReindexProgress', () => {
               aliases: [],
               isFrozen: false,
               isReadonly: false,
+              isInDataStream: false,
+              isClosedIndex: false,
             },
           } as ReindexState
         }
@@ -98,7 +100,9 @@ describe('ReindexProgress', () => {
                       "meta": Object {
                         "aliases": Array [],
                         "indexName": "foo",
+                        "isClosedIndex": false,
                         "isFrozen": false,
+                        "isInDataStream": false,
                         "isReadonly": false,
                         "reindexName": "reindexed-foo",
                       },
@@ -179,6 +183,8 @@ describe('ReindexProgress', () => {
               aliases: [],
               isFrozen: true,
               isReadonly: false,
+              isInDataStream: false,
+              isClosedIndex: false,
             },
           } as ReindexState
         }

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/reindex_step.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/reindex_step.test.tsx
@@ -61,6 +61,8 @@ describe('ReindexStep', () => {
         aliases: [],
         isReadonly: false,
         isFrozen: false,
+        isInDataStream: false,
+        isClosedIndex: false,
       },
     } as ReindexState,
   };

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/update/update_step.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/update/update_step.test.tsx
@@ -15,8 +15,10 @@ describe('UpdateIndexFlyoutStep', () => {
   const meta: ReindexState['meta'] = {
     indexName: 'some_index',
     aliases: [],
+    isInDataStream: false,
     isFrozen: false,
     isReadonly: false,
+    isClosedIndex: false,
     reindexName: 'some_index-reindexed-for-9',
   };
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/warning/warning_step.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/warning/warning_step.test.tsx
@@ -43,6 +43,7 @@ describe('WarningFlyoutStep', () => {
       aliases: [],
       isFrozen: false,
       isReadonly: false,
+      isInDataStream: false,
     },
   };
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/use_reindex.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/use_reindex.tsx
@@ -33,14 +33,16 @@ export interface ReindexState {
     aliases: string[];
     isFrozen: boolean;
     isReadonly: boolean;
+    isInDataStream: boolean;
+    isClosedIndex: boolean;
   };
 }
 
 const getReindexState = (
   reindexState: ReindexState,
   { reindexOp, warnings, hasRequiredPrivileges, meta: updatedMeta }: ReindexStatusResponse
-) => {
-  const meta = { ...(updatedMeta ?? reindexState.meta) };
+): ReindexState => {
+  const meta = { ...reindexState.meta, ...updatedMeta };
   // Once we have received an array of existing aliases, we won't update the meta value anymore because
   // when we'll delete the original alias during the reindex process there won't be any aliases pointing
   // to it anymore and the last reindex step (Update existing aliases) would be suddenly removed.
@@ -108,7 +110,19 @@ const getReindexState = (
   return newReindexState;
 };
 
-export const useReindex = ({ indexName, api }: { indexName: string; api: ApiService }) => {
+export const useReindex = ({
+  indexName,
+  isFrozen,
+  isInDataStream,
+  isClosedIndex,
+  api,
+}: {
+  indexName: string;
+  isFrozen: boolean;
+  isInDataStream: boolean;
+  isClosedIndex: boolean;
+  api: ApiService;
+}) => {
   const [reindexState, setReindexState] = useState<ReindexState>({
     loadingState: LoadingState.Loading,
     errorMessage: null,
@@ -118,8 +132,10 @@ export const useReindex = ({ indexName, api }: { indexName: string; api: ApiServ
       // these properties will be known after fetching the reindexStatus
       reindexName: '',
       aliases: [],
-      isFrozen: false,
-      isReadonly: false,
+      isFrozen,
+      isInDataStream,
+      isClosedIndex,
+      isReadonly: false, // we don't have this information in the deprecation list
     },
   });
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/use_update_index.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/use_update_index.tsx
@@ -7,7 +7,7 @@
 
 import { useCallback, useState } from 'react';
 import type { UpdateIndexOperation } from '../../../../../../common/update_index';
-import type { EnrichedDeprecationInfo } from '../../../../../../common/types';
+import type { CorrectiveAction } from '../../../../../../common/types';
 import type { ApiService } from '../../../../lib/api';
 
 export interface UpdateIndexState {
@@ -19,7 +19,7 @@ export interface UpdateIndexState {
 export interface UseUpdateIndexParams {
   indexName: string;
   api: ApiService;
-  correctiveAction: EnrichedDeprecationInfo['correctiveAction'];
+  correctiveAction?: CorrectiveAction;
 }
 
 export const useUpdateIndex = ({ indexName, api, correctiveAction }: UseUpdateIndexParams) => {

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/__snapshots__/index.test.ts.snap
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/__snapshots__/index.test.ts.snap
@@ -80,8 +80,12 @@ Object {
     },
     Object {
       "correctiveAction": Object {
-        "blockerForReindexing": undefined,
         "excludedActions": Array [],
+        "metadata": Object {
+          "isClosedIndex": false,
+          "isFrozenIndex": false,
+          "isInDataStream": false,
+        },
         "type": "reindex",
       },
       "details": "This index was created using version: 6.8.13",
@@ -94,22 +98,29 @@ Object {
     },
     Object {
       "correctiveAction": Object {
-        "blockerForReindexing": undefined,
-        "excludedActions": Array [],
-        "type": "reindex",
+        "metadata": Object {
+          "isClosedIndex": false,
+          "isFrozenIndex": true,
+          "isInDataStream": false,
+        },
+        "type": "unfreeze",
       },
-      "details": "This index has version: 7.17.28-8.0.0",
+      "details": "Frozen indices must be unfrozen before upgrading to version 9.0. (The legacy frozen indices feature no longer offers any advantages. You may consider cold or frozen tiers in place of frozen indices.)",
       "index": "frozen_index",
       "isCritical": true,
-      "message": "Old index with a compatibility version < 8.0",
+      "message": "Index [frozen_index] is a frozen index. The frozen indices feature is deprecated and will be removed in version 9.0.",
       "resolveDuringUpgrade": false,
       "type": "index_settings",
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#breaking-changes-8.0",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/frozen-indices.html",
     },
     Object {
       "correctiveAction": Object {
-        "blockerForReindexing": "index-closed",
         "excludedActions": Array [],
+        "metadata": Object {
+          "isClosedIndex": true,
+          "isFrozenIndex": false,
+          "isInDataStream": false,
+        },
         "type": "reindex",
       },
       "details": "This index was created using version: 6.8.13",
@@ -177,8 +188,12 @@ Object {
     },
     Object {
       "correctiveAction": Object {
-        "blockerForReindexing": undefined,
         "excludedActions": Array [],
+        "metadata": Object {
+          "isClosedIndex": false,
+          "isFrozenIndex": false,
+          "isInDataStream": false,
+        },
         "transformIds": Array [
           "abc",
         ],
@@ -194,8 +209,12 @@ Object {
     },
     Object {
       "correctiveAction": Object {
-        "blockerForReindexing": undefined,
         "excludedActions": Array [],
+        "metadata": Object {
+          "isClosedIndex": false,
+          "isFrozenIndex": false,
+          "isInDataStream": false,
+        },
         "type": "reindex",
       },
       "details": "This index has version: 7.17.25",

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/get_corrective_actions.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/get_corrective_actions.ts
@@ -5,32 +5,30 @@
  * 2.0.
  */
 
-import { EnrichedDeprecationInfo } from '../../../common/types';
+import type { CorrectiveAction } from '../../../common/types';
+import type { BaseDeprecation } from './migrations';
 
 interface Action {
   action_type: 'remove_settings';
   objects: string[];
 }
 
-interface Actions {
+interface CommonActionMetadata {
   actions?: Action[];
 }
 
-interface MlActionMetadata {
-  actions?: Action[];
+interface MlActionMetadata extends CommonActionMetadata {
   snapshot_id: string;
   job_id: string;
 }
 
-interface IndexActionMetadata {
-  actions?: Action[];
+interface IndexActionMetadata extends CommonActionMetadata {
   reindex_required: boolean;
   transform_ids: string[];
+  is_in_data_stream?: boolean;
 }
 
-interface DataStreamActionMetadata {
-  actions?: Action[];
-
+interface DataStreamActionMetadata extends CommonActionMetadata {
   excludedActions?: Array<'readOnly' | 'reindex'>;
   total_backing_indices: number;
   reindex_required: boolean;
@@ -44,7 +42,7 @@ interface DataStreamActionMetadata {
   ignored_indices_requiring_upgrade_count?: number;
 }
 
-export type EsMetadata = Actions | MlActionMetadata | DataStreamActionMetadata;
+export type EsMetadata = IndexActionMetadata | MlActionMetadata | DataStreamActionMetadata;
 
 // TODO(jloleysens): Replace these regexes once this issue is addressed https://github.com/elastic/elasticsearch/issues/118062
 const ES_INDEX_MESSAGES_REQUIRING_REINDEX = [
@@ -55,26 +53,23 @@ const ES_INDEX_MESSAGES_REQUIRING_REINDEX = [
 export const isFrozenDeprecation = (message: string, indexName?: string): boolean =>
   Boolean(indexName) && message.includes(`Index [${indexName}] is a frozen index`);
 
-export const getCorrectiveAction = (
-  deprecationType: EnrichedDeprecationInfo['type'],
-  message: string,
-  metadata: EsMetadata,
-  indexName?: string
-): EnrichedDeprecationInfo['correctiveAction'] => {
+export const getCorrectiveAction = (deprecation: BaseDeprecation): CorrectiveAction | undefined => {
+  const { index, type, message, metadata } = deprecation;
+
   const indexSettingDeprecation = metadata?.actions?.find(
-    (action) => action.action_type === 'remove_settings' && indexName
+    (action) => action.action_type === 'remove_settings' && index
   );
   const clusterSettingDeprecation = metadata?.actions?.find(
-    (action) => action.action_type === 'remove_settings' && typeof indexName === 'undefined'
+    (action) => action.action_type === 'remove_settings' && typeof index === 'undefined'
   );
   const requiresReindexAction = ES_INDEX_MESSAGES_REQUIRING_REINDEX.some((regexp) =>
     regexp.test(message)
   );
-  const requiresUnfreezeAction = isFrozenDeprecation(message, indexName);
+  const requiresUnfreezeAction = isFrozenDeprecation(message, index);
   const requiresIndexSettingsAction = Boolean(indexSettingDeprecation);
   const requiresClusterSettingsAction = Boolean(clusterSettingDeprecation);
   const requiresMlAction = /[Mm]odel snapshot/.test(message);
-  const requiresDataStreamsAction = deprecationType === 'data_streams';
+  const requiresDataStreamsAction = type === 'data_streams';
 
   if (requiresDataStreamsAction) {
     const {
@@ -114,12 +109,22 @@ export const getCorrectiveAction = (
     return {
       type: 'reindex',
       ...(transformIds?.length ? { transformIds } : {}),
+      metadata: {
+        isClosedIndex: Boolean(deprecation.isClosedIndex),
+        isFrozenIndex: Boolean(deprecation.isFrozenIndex),
+        isInDataStream: Boolean((deprecation.metadata as IndexActionMetadata)?.is_in_data_stream),
+      },
     };
   }
 
   if (requiresUnfreezeAction) {
     return {
       type: 'unfreeze',
+      metadata: {
+        isClosedIndex: Boolean(deprecation.isClosedIndex),
+        isFrozenIndex: Boolean(deprecation.isFrozenIndex),
+        isInDataStream: Boolean((deprecation.metadata as IndexActionMetadata)?.is_in_data_stream),
+      },
     };
   }
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/health_indicators.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/health_indicators.test.ts
@@ -5,18 +5,18 @@
  * 2.0.
  */
 
-import { elasticsearchServiceMock, ScopedClusterClientMock } from '@kbn/core/server/mocks';
+import { elasticsearchServiceMock, type ElasticsearchClientMock } from '@kbn/core/server/mocks';
 import { getHealthIndicators } from './health_indicators';
 import * as healthIndicatorsMock from '../__fixtures__/health_indicators';
 
 describe('getHealthIndicators', () => {
-  let esClient: ScopedClusterClientMock;
+  let esClient: ElasticsearchClientMock;
   beforeEach(() => {
-    esClient = elasticsearchServiceMock.createScopedClusterClient();
+    esClient = elasticsearchServiceMock.createScopedClusterClient().asCurrentUser;
   });
 
   it('returns empty array on green indicators', async () => {
-    esClient.asCurrentUser.healthReport.mockResponse({
+    esClient.healthReport.mockResponse({
       cluster_name: 'mock',
       indicators: {
         disk: healthIndicatorsMock.diskIndicatorGreen,
@@ -30,7 +30,7 @@ describe('getHealthIndicators', () => {
   });
 
   it('returns unknown indicators', async () => {
-    esClient.asCurrentUser.healthReport.mockResponse({
+    esClient.healthReport.mockResponse({
       cluster_name: 'mock',
       indicators: {
         disk: healthIndicatorsMock.diskIndicatorUnknown,
@@ -48,7 +48,7 @@ describe('getHealthIndicators', () => {
   });
 
   it('returns unhealthy shards_capacity indicator', async () => {
-    esClient.asCurrentUser.healthReport.mockResponse({
+    esClient.healthReport.mockResponse({
       cluster_name: 'mock',
       indicators: {
         disk: healthIndicatorsMock.diskIndicatorGreen,
@@ -92,7 +92,7 @@ describe('getHealthIndicators', () => {
   });
 
   it('returns unhealthy disk indicator', async () => {
-    esClient.asCurrentUser.healthReport.mockResponse({
+    esClient.healthReport.mockResponse({
       cluster_name: 'mock',
       indicators: {
         disk: healthIndicatorsMock.diskIndicatorRed,

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/health_indicators.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/health_indicators.ts
@@ -7,13 +7,13 @@
 
 import { i18n } from '@kbn/i18n';
 import type * as estypes from '@elastic/elasticsearch/lib/api/types';
-import { IScopedClusterClient } from '@kbn/core/server';
-import { EnrichedDeprecationInfo } from '../../../common/types';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { EnrichedDeprecationInfo } from '../../../common/types';
 
 export async function getHealthIndicators(
-  dataClient: IScopedClusterClient
+  dataClient: ElasticsearchClient
 ): Promise<EnrichedDeprecationInfo[]> {
-  const healthIndicators = await dataClient.asCurrentUser.healthReport();
+  const healthIndicators = await dataClient.healthReport();
   const isStatusNotGreen = (indicator?: estypes.HealthReportBaseIndicator): boolean => {
     return !!(indicator?.status && indicator?.status !== 'green');
   };

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/index.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { IScopedClusterClient } from '@kbn/core/server';
+import { ElasticsearchClient } from '@kbn/core/server';
 import {
   EnrichedDeprecationInfo,
   ESUpgradeStatus,
@@ -19,7 +19,7 @@ import { getHealthIndicators } from './health_indicators';
 import { matchExclusionPattern } from '../data_source_exclusions';
 
 export async function getESUpgradeStatus(
-  dataClient: IScopedClusterClient,
+  dataClient: ElasticsearchClient,
   {
     featureSet,
     dataSourceExclusions,

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_indices_state_check.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_indices_state_check.ts
@@ -12,19 +12,16 @@ import { ResolveIndexResponseFromES } from '../../common/types';
 type StatusCheckResult = Record<string, 'open' | 'closed'>;
 
 export const esIndicesStateCheck = async (
-  asCurrentUser: ElasticsearchClient,
+  esClient: ElasticsearchClient,
   indices: string[]
 ): Promise<StatusCheckResult> => {
-  const response = await asCurrentUser.indices.resolveIndex({
+  const response = await esClient.indices.resolveIndex({
     name: '*',
     expand_wildcards: 'all',
   });
 
-  const result: StatusCheckResult = {};
-
-  indices.forEach((index) => {
-    result[index] = getIndexState(index, response as ResolveIndexResponseFromES);
-  });
-
-  return result;
+  return indices.reduce<StatusCheckResult>((acc, index) => {
+    acc[index] = getIndexState(index, response as ResolveIndexResponseFromES);
+    return acc;
+  }, {});
 };

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/reindexing/reindex_service.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/reindexing/reindex_service.ts
@@ -116,9 +116,11 @@ export interface ReindexService {
    * Obtain metadata about the index, including aliases and settings
    * @param indexName
    */
-  getIndexInfo(
-    indexName: string
-  ): Promise<{ aliases: Record<string, IndicesAlias>; settings?: IndicesIndexSettings }>;
+  getIndexInfo(indexName: string): Promise<{
+    aliases: Record<string, IndicesAlias>;
+    settings?: IndicesIndexSettings;
+    isInDataStream: boolean;
+  }>;
 }
 
 export const reindexServiceFactory = (
@@ -356,7 +358,8 @@ export const reindexServiceFactory = (
 
     const aliases = response[indexName]?.aliases ?? {};
     const settings = response[indexName]?.settings?.index ?? {};
-    return { aliases, settings };
+    const isInDataStream = Boolean(response[indexName]?.data_stream);
+    return { aliases, settings, isInDataStream };
   };
 
   const isIndexHidden = async (indexName: string) => {

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/es_deprecations.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/es_deprecations.test.ts
@@ -43,6 +43,7 @@ describe('ES deprecations API', () => {
       },
       router: mockRouter,
       lib: { handleEsError },
+      log: { error: jest.fn() },
     };
     registerESDeprecationRoutes(routeDependencies);
   });

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/es_deprecations.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/es_deprecations.ts
@@ -8,7 +8,7 @@
 import { API_BASE_PATH } from '../../common/constants';
 import { getESUpgradeStatus } from '../lib/es_deprecations_status';
 import { versionCheckHandlerWrapper } from '../lib/es_version_precheck';
-import { RouteDependencies } from '../types';
+import type { RouteDependencies } from '../types';
 import { reindexActionsFactory } from '../lib/reindexing/reindex_actions';
 import { reindexServiceFactory } from '../lib/reindexing';
 
@@ -36,8 +36,10 @@ export function registerESDeprecationRoutes({
           savedObjects: { client: savedObjectsClient },
           elasticsearch: { client },
         } = await core;
-        const status = await getESUpgradeStatus(client, { featureSet, dataSourceExclusions });
-
+        const status = await getESUpgradeStatus(client.asCurrentUser, {
+          featureSet,
+          dataSourceExclusions,
+        });
         const asCurrentUser = client.asCurrentUser;
         const reindexActions = reindexActionsFactory(savedObjectsClient, asCurrentUser);
         const reindexService = reindexServiceFactory(asCurrentUser, reindexActions, log, licensing);
@@ -51,6 +53,7 @@ export function registerESDeprecationRoutes({
           body: status,
         });
       } catch (error) {
+        log.error(error);
         return handleEsError({ error, response });
       }
     })

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/reindex_indices.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/reindex_indices/reindex_indices.ts
@@ -120,7 +120,7 @@ export function registerReindexIndicesRoutes(
           : [];
 
         const isTruthy = (value?: string | boolean): boolean => value === true || value === 'true';
-        const { aliases, settings } = await reindexService.getIndexInfo(indexName);
+        const { aliases, settings, isInDataStream } = await reindexService.getIndexInfo(indexName);
 
         const body: ReindexStatusResponse = {
           reindexOp: reindexOp ? reindexOp.attributes : undefined,
@@ -132,6 +132,7 @@ export function registerReindexIndicesRoutes(
             aliases: Object.keys(aliases),
             isFrozen: isTruthy(settings?.frozen),
             isReadonly: isTruthy(settings?.verified_read_only),
+            isInDataStream,
           },
         };
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.test.ts
@@ -118,6 +118,7 @@ describe('Status API', () => {
         lib: { handleEsError },
         current: currentVersion,
         defaultTarget: nextMajor,
+        log: { error: jest.fn() },
       };
 
       registerUpgradeStatusRoute(routeDependencies);
@@ -278,6 +279,7 @@ describe('Status API', () => {
         lib: { handleEsError },
         current: currentVersion,
         defaultTarget: nextMajor,
+        log: { error: jest.fn() },
       };
 
       registerUpgradeStatusRoute(routeDependencies);

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/routes/status.ts
@@ -23,6 +23,7 @@ export function registerUpgradeStatusRoute({
   lib: { handleEsError },
   current,
   defaultTarget,
+  log,
 }: RouteDependencies) {
   router.get(
     {
@@ -57,7 +58,7 @@ export function registerUpgradeStatusRoute({
         const {
           totalCriticalDeprecations, // critical deprecations
           totalCriticalHealthIssues, // critical health issues
-        } = await getESUpgradeStatus(esClient, { featureSet, dataSourceExclusions });
+        } = await getESUpgradeStatus(esClient.asCurrentUser, { featureSet, dataSourceExclusions });
 
         const getSystemIndicesMigrationStatus = async () => {
           /**
@@ -159,6 +160,7 @@ export function registerUpgradeStatusRoute({
           },
         });
       } catch (error) {
+        log.error(error);
         return handleEsError({ error, response });
       }
     })


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[UA] Do not allow reindexing data_stream backing indices (and other enhancements) (#213755)](https://github.com/elastic/kibana/pull/213755)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gerard Soldevila","email":"gerard.soldevila@elastic.co"},"sourceCommit":{"committedDate":"2025-03-13T13:34:47Z","message":"[UA] Do not allow reindexing data_stream backing indices (and other enhancements) (#213755)\n\n## Summary\n\nThe PR brings the following improvements to the UA ES deprecations\nflows:\n\n* Remove the \"Reindex\" option for _Frozen index_ deprecations that are\nrelated to a data stream's backing index (backing indices cannot be\nalias-based, see\n[thread](https://elastic.slack.com/archives/C08A04N8XHV/p1741017934359239)).\n* Propagate `\"isClosedIndex\"` information to the UI side, so that we can\nshow a warning message in the reindex flows flyouts. The [original\nfunctionality](https://github.com/elastic/kibana/pull/58890) got lost in\nthe woods.\n* Propagate `\"isClosedIndex\", \"isFrozenIndex\", \"isReadonly\"` properties\nas part of the `correctiveAction` details ONLY for _index_settings\nmigrations_, instead of doing it as top level properties for all\nmigrations. These properties did not make for most migration types.\n* Big refactor in `migrations.ts` file (server side). The logic for\nobtaining, filtering and enriching ES deprecations had become quite\nfragmented and hard to read. @Bamieh @jloleysens please take a close\nlook at this one.\n* Improve existing type definitions.","sha":"f2ae05909dd81e3cc368173b350b331587a99d8d","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:version","v8.18.0","v8.19.0"],"title":"[UA] Do not allow reindexing data_stream backing indices (and other enhancements)","number":213755,"url":"https://github.com/elastic/kibana/pull/213755","mergeCommit":{"message":"[UA] Do not allow reindexing data_stream backing indices (and other enhancements) (#213755)\n\n## Summary\n\nThe PR brings the following improvements to the UA ES deprecations\nflows:\n\n* Remove the \"Reindex\" option for _Frozen index_ deprecations that are\nrelated to a data stream's backing index (backing indices cannot be\nalias-based, see\n[thread](https://elastic.slack.com/archives/C08A04N8XHV/p1741017934359239)).\n* Propagate `\"isClosedIndex\"` information to the UI side, so that we can\nshow a warning message in the reindex flows flyouts. The [original\nfunctionality](https://github.com/elastic/kibana/pull/58890) got lost in\nthe woods.\n* Propagate `\"isClosedIndex\", \"isFrozenIndex\", \"isReadonly\"` properties\nas part of the `correctiveAction` details ONLY for _index_settings\nmigrations_, instead of doing it as top level properties for all\nmigrations. These properties did not make for most migration types.\n* Big refactor in `migrations.ts` file (server side). The logic for\nobtaining, filtering and enriching ES deprecations had become quite\nfragmented and hard to read. @Bamieh @jloleysens please take a close\nlook at this one.\n* Improve existing type definitions.","sha":"f2ae05909dd81e3cc368173b350b331587a99d8d"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->