### PR TITLE
[Uptime] Fix skipped a11y tests

### DIFF
--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/__snapshots__/chart_wrapper.test.tsx.snap
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/__snapshots__/chart_wrapper.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ChartWrapper component renders the component with loading false 1`] = `
 <EuiErrorBoundary>
-  <div
+  <figure
     intl={
       Object {
         "$t": [Function],
@@ -133,13 +133,13 @@ exports[`ChartWrapper component renders the component with loading false 1`] = `
       height={144}
       up={4}
     />
-  </div>
+  </figure>
 </EuiErrorBoundary>
 `;
 
 exports[`ChartWrapper component renders the component with loading true 1`] = `
 <EuiErrorBoundary>
-  <div
+  <figure
     intl={
       Object {
         "$t": [Function],
@@ -270,7 +270,7 @@ exports[`ChartWrapper component renders the component with loading true 1`] = `
       height={144}
       up={4}
     />
-  </div>
+  </figure>
   <EuiFlexGroup
     alignItems="center"
     justifyContent="spaceAround"

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/chart_wrapper/chart_wrapper.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/chart_wrapper/chart_wrapper.tsx
@@ -40,6 +40,7 @@ export const ChartWrapper: FC<PropsWithChildren<Props>> = ({
           transition: 'opacity 0.2s',
         }}
         {...(rest as HTMLAttributes<HTMLDivElement>)}
+        role="figure"
       >
         {children}
       </div>

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/chart_wrapper/chart_wrapper.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/chart_wrapper/chart_wrapper.tsx
@@ -33,17 +33,16 @@ export const ChartWrapper: FC<PropsWithChildren<Props>> = ({
 
   return (
     <EuiErrorBoundary>
-      <div
+      <figure
         style={{
           height,
           opacity,
           transition: 'opacity 0.2s',
         }}
         {...(rest as HTMLAttributes<HTMLDivElement>)}
-        role="figure"
       >
         {children}
-      </div>
+      </figure>
       {loading === true && (
         <EuiFlexGroup
           justifyContent="spaceAround"

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/duration_charts.test.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/duration_charts.test.tsx
@@ -48,7 +48,7 @@ describe('MonitorCharts component', () => {
   };
 
   it('renders the component without errors', () => {
-    const { getByLabelText } = render(
+    const { getByLabelText, getByRole } = render(
       <DurationChartComponent
         loading={false}
         anomalies={null}
@@ -73,6 +73,7 @@ describe('MonitorCharts component', () => {
       }
     );
     expect(getByLabelText(`A chart displaying the monitor's ping duration, grouped by location.`));
+    expect(getByRole('figure'));
   });
 
   it('renders an empty state when no monitor data is present', () => {

--- a/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/duration_charts.test.tsx
+++ b/x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/duration_charts.test.tsx
@@ -48,7 +48,7 @@ describe('MonitorCharts component', () => {
   };
 
   it('renders the component without errors', () => {
-    const { getByLabelText, getByRole } = render(
+    const { getByRole } = render(
       <DurationChartComponent
         loading={false}
         anomalies={null}
@@ -72,8 +72,11 @@ describe('MonitorCharts component', () => {
         },
       }
     );
-    expect(getByLabelText(`A chart displaying the monitor's ping duration, grouped by location.`));
-    expect(getByRole('figure'));
+    const figureElement = getByRole('figure');
+    expect(figureElement).toHaveAttribute(
+      'aria-label',
+      "A chart displaying the monitor's ping duration, grouped by location."
+    );
   });
 
   it('renders an empty state when no monitor data is present', () => {

--- a/x-pack/test/accessibility/apps/group1/uptime.ts
+++ b/x-pack/test/accessibility/apps/group1/uptime.ts
@@ -19,8 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const es = getService('es');
   const toasts = getService('toasts');
 
-  // Failing: See https://github.com/elastic/kibana/issues/210245
-  describe.skip('uptime Accessibility', () => {
+  describe('uptime Accessibility', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/uptime/blank');
       await makeChecks(es, A11Y_TEST_MONITOR_ID, 150, 1, 1000, {


### PR DESCRIPTION
## Summary

Resolves [#210245](https://github.com/elastic/kibana/issues/210245).

Attempt to fix the mislabeled element by adding the `figure` role to it.

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->