### PR TITLE
[8.16] [Threat Hunting Investigations] Fix timeline column width bug (#214178)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -9,7 +9,10 @@ import React, { memo, useMemo, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import type { DataTableRecord } from '@kbn/discover-utils/types';
-import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
+import type {
+  UnifiedDataTableProps,
+  UnifiedDataTableSettingsColumn,
+} from '@kbn/unified-data-table';
 import { UnifiedDataTable, DataLoadingState } from '@kbn/unified-data-table';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type {
@@ -145,9 +148,24 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
 
     const showTimeCol = useMemo(() => !!dataView && !!dataView.timeFieldName, [dataView]);
 
-    const { rowHeight, sampleSize, excludedRowRendererIds } = useSelector((state: State) =>
-      selectTimelineById(state, timelineId)
-    );
+    const {
+      rowHeight,
+      sampleSize,
+      excludedRowRendererIds,
+      columns: timelineColumns,
+    } = useSelector((state: State) => selectTimelineById(state, timelineId));
+
+    const settings: UnifiedDataTableProps['settings'] = useMemo(() => {
+      const _columns: Record<string, UnifiedDataTableSettingsColumn> = {};
+      timelineColumns.forEach((timelineColumn) => {
+        _columns[timelineColumn.id] = {
+          width: timelineColumn.initialWidth ?? undefined,
+        };
+      });
+      return {
+        columns: _columns,
+      };
+    }, [timelineColumns]);
 
     const { tableRows, tableStylesOverride } = useMemo(
       () => transformTimelineItemToUnifiedRows({ events, dataView }),
@@ -190,27 +208,19 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       [tableRows, handleOnEventDetailPanelOpened, closeFlyout]
     );
 
-    const onColumnResize = useCallback(
-      ({ columnId, width }: { columnId: string; width?: number }) => {
-        dispatch(
-          timelineActions.updateColumnWidth({
-            columnId,
-            id: timelineId,
-            width, // initialWidth?
-          })
-        );
-      },
-      [dispatch, timelineId]
-    );
-
     const onResizeDataGrid = useCallback<NonNullable<UnifiedDataTableProps['onResize']>>(
       (colSettings) => {
-        onColumnResize({
-          columnId: colSettings.columnId,
-          ...(colSettings.width ? { width: Math.round(colSettings.width) } : {}),
-        });
+        if (colSettings.width) {
+          dispatch(
+            timelineActions.updateColumnWidth({
+              columnId: colSettings.columnId,
+              id: timelineId,
+              width: Math.round(colSettings.width),
+            })
+          );
+        }
       },
-      [onColumnResize]
+      [dispatch, timelineId]
     );
 
     const onChangeItemsPerPage = useCallback<
@@ -423,6 +433,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
             trailingControlColumns={finalTrailControlColumns}
             externalControlColumns={leadingControlColumns}
             onUpdatePageIndex={onUpdatePageIndex}
+            settings={settings}
           />
         </StyledTimelineUnifiedDataTable>
       </StatefulEventContext.Provider>

--- a/x-pack/plugins/security_solution/public/timelines/store/actions.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/actions.ts
@@ -249,12 +249,6 @@ export const updateItemsPerPageOptions = actionCreator<{
   itemsPerPageOptions: number[];
 }>('UPDATE_ITEMS_PER_PAGE_OPTIONS');
 
-export const applyDeltaToColumnWidth = actionCreator<{
-  id: string;
-  columnId: string;
-  delta: number;
-}>('APPLY_DELTA_TO_COLUMN_WIDTH');
-
 export const clearEventsLoading = actionCreator<{
   id: string;
 }>('CLEAR_TGRID_EVENTS_LOADING');

--- a/x-pack/plugins/security_solution/public/timelines/store/actions.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/actions.ts
@@ -249,6 +249,12 @@ export const updateItemsPerPageOptions = actionCreator<{
   itemsPerPageOptions: number[];
 }>('UPDATE_ITEMS_PER_PAGE_OPTIONS');
 
+export const applyDeltaToColumnWidth = actionCreator<{
+  id: string;
+  columnId: string;
+  delta: number;
+}>('APPLY_DELTA_TO_COLUMN_WIDTH');
+
 export const clearEventsLoading = actionCreator<{
   id: string;
 }>('CLEAR_TGRID_EVENTS_LOADING');

--- a/x-pack/plugins/security_solution/public/timelines/store/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/helpers.test.ts
@@ -19,12 +19,16 @@ import type {
 } from '../components/timeline/data_providers/data_provider';
 import { IS_OPERATOR } from '../components/timeline/data_providers/data_provider';
 import { defaultColumnHeaderType } from '../components/timeline/body/column_headers/default_headers';
-import { DEFAULT_COLUMN_MIN_WIDTH } from '../components/timeline/body/constants';
+import {
+  DEFAULT_COLUMN_MIN_WIDTH,
+  RESIZED_COLUMN_MIN_WITH,
+} from '../components/timeline/body/constants';
 import { defaultHeaders } from '../../common/mock';
 import {
   addNewTimeline,
   addTimelineProviders,
   addTimelineToStore,
+  applyDeltaToTableColumnWidth,
   removeTimelineColumn,
   removeTimelineProvider,
   updateTimelineColumns,
@@ -679,6 +683,87 @@ describe('Timeline', () => {
       const update = removeTimelineColumn({
         id: 'foo',
         columnId: 'does.not.exist',
+        timelineById: mockWithExistingColumns,
+      });
+
+      expect(update.foo.columns).toEqual(expectedColumns);
+    });
+  });
+
+  describe('#applyDeltaToColumnWidth', () => {
+    let mockWithExistingColumns: TimelineById;
+    beforeEach(() => {
+      mockWithExistingColumns = {
+        ...timelineByIdMock,
+        foo: {
+          ...timelineByIdMock.foo,
+          columns: columnsMock,
+        },
+      };
+    });
+    test('should return a new reference and not the same reference', () => {
+      const delta = 50;
+      const update = applyDeltaToTableColumnWidth({
+        id: 'foo',
+        columnId: columnsMock[0].id,
+        delta,
+        timelineById: mockWithExistingColumns,
+      });
+
+      expect(update).not.toBe(timelineByIdMock);
+    });
+
+    test('should update initialWidth with the specified delta when the delta is positive', () => {
+      const aDateColumn = columnsMock[0];
+      const delta = 50;
+      const expectedToHaveNewWidth = {
+        ...aDateColumn,
+        initialWidth: Number(aDateColumn.initialWidth) + 50,
+      };
+      const expectedColumns = [expectedToHaveNewWidth, columnsMock[1], columnsMock[2]];
+
+      const update = applyDeltaToTableColumnWidth({
+        id: 'foo',
+        columnId: aDateColumn.id,
+        delta,
+        timelineById: mockWithExistingColumns,
+      });
+
+      expect(update.foo.columns).toEqual(expectedColumns);
+    });
+
+    test('should update initialWidth with the specified delta when the delta is negative, and the resulting width is greater than the min column width', () => {
+      const aDateColumn = columnsMock[0];
+      const delta = 50 * -1; // the result will still be above the min column size
+      const expectedToHaveNewWidth = {
+        ...aDateColumn,
+        initialWidth: Number(aDateColumn.initialWidth) - 50,
+      };
+      const expectedColumns = [expectedToHaveNewWidth, columnsMock[1], columnsMock[2]];
+
+      const update = applyDeltaToTableColumnWidth({
+        id: 'foo',
+        columnId: aDateColumn.id,
+        delta,
+        timelineById: mockWithExistingColumns,
+      });
+
+      expect(update.foo.columns).toEqual(expectedColumns);
+    });
+
+    test('should set initialWidth to `RESIZED_COLUMN_MIN_WITH` when the requested delta results in a column that is too small ', () => {
+      const aDateColumn = columnsMock[0];
+      const delta = (Number(aDateColumn.initialWidth) - 5) * -1; // the requested delta would result in a width of just 5 pixels, which is too small
+      const expectedToHaveNewWidth = {
+        ...aDateColumn,
+        initialWidth: RESIZED_COLUMN_MIN_WITH, // we expect the minimum
+      };
+      const expectedColumns = [expectedToHaveNewWidth, columnsMock[1], columnsMock[2]];
+
+      const update = applyDeltaToTableColumnWidth({
+        id: 'foo',
+        columnId: aDateColumn.id,
+        delta,
         timelineById: mockWithExistingColumns,
       });
 

--- a/x-pack/plugins/security_solution/public/timelines/store/helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/helpers.test.ts
@@ -19,16 +19,12 @@ import type {
 } from '../components/timeline/data_providers/data_provider';
 import { IS_OPERATOR } from '../components/timeline/data_providers/data_provider';
 import { defaultColumnHeaderType } from '../components/timeline/body/column_headers/default_headers';
-import {
-  DEFAULT_COLUMN_MIN_WIDTH,
-  RESIZED_COLUMN_MIN_WITH,
-} from '../components/timeline/body/constants';
+import { DEFAULT_COLUMN_MIN_WIDTH } from '../components/timeline/body/constants';
 import { defaultHeaders } from '../../common/mock';
 import {
   addNewTimeline,
   addTimelineProviders,
   addTimelineToStore,
-  applyDeltaToTimelineColumnWidth,
   removeTimelineColumn,
   removeTimelineProvider,
   updateTimelineColumns,
@@ -42,15 +38,19 @@ import {
   updateTimelineShowTimeline,
   updateTimelineSort,
   updateTimelineTitleAndDescription,
-  upsertTimelineColumn,
   updateTimelineGraphEventId,
   updateTimelineColumnWidth,
+  upsertTimelineColumn,
 } from './helpers';
 import type { TimelineModel } from './model';
 import { timelineDefaults } from './defaults';
 import type { TimelineById } from './types';
 import { Direction } from '../../../common/search_strategy';
 import { defaultUdtHeaders } from '../components/timeline/unified_components/default_headers';
+import {
+  type LocalStorageColumnSettings,
+  setStoredTimelineColumnsConfig,
+} from './middlewares/timeline_localstorage';
 
 jest.mock('../../common/utils/normalize_time_range');
 jest.mock('../../common/utils/default_date_settings', () => {
@@ -156,6 +156,10 @@ const columnsMock: ColumnHeaderOptions[] = [
 ];
 
 describe('Timeline', () => {
+  beforeEach(() => {
+    setStoredTimelineColumnsConfig(undefined);
+  });
+
   describe('#add saved object Timeline to store ', () => {
     test('should return a timelineModel with default value and not just a timelineResult ', () => {
       const update = addTimelineToStore({
@@ -171,6 +175,47 @@ describe('Timeline', () => {
           ...basicTimeline,
           show: true,
         },
+      });
+    });
+
+    test('should apply the locally stored column config', () => {
+      const initialWidth = 123456789;
+      const storedConfig: LocalStorageColumnSettings = {
+        '@timestamp': {
+          id: '@timestamp',
+          initialWidth,
+        },
+      };
+      setStoredTimelineColumnsConfig(storedConfig);
+      const update = addTimelineToStore({
+        id: 'foo',
+        timeline: {
+          ...basicTimeline,
+          columns: [{ id: '@timestamp', columnHeaderType: 'not-filtered' }],
+        },
+        timelineById: timelineByIdMock,
+      });
+
+      expect(update.foo.columns.find((col) => col.id === '@timestamp')).toEqual(
+        expect.objectContaining({
+          initialWidth,
+        })
+      );
+    });
+
+    test('should not apply changes to the columns when no previous config is stored in localStorage', () => {
+      const update = addTimelineToStore({
+        id: 'foo',
+        timeline: {
+          ...basicTimeline,
+          columns: [{ id: '@timestamp', columnHeaderType: 'not-filtered' }],
+        },
+        timelineById: timelineByIdMock,
+      });
+
+      expect(update.foo.columns.find((col) => col.id === '@timestamp')).toEqual({
+        id: '@timestamp',
+        columnHeaderType: 'not-filtered',
       });
     });
 
@@ -457,6 +502,49 @@ describe('Timeline', () => {
 
       expect(update.foo.columns).toEqual(expectedColumns);
     });
+
+    test('should apply the locally stored column config to new columns', () => {
+      const initialWidth = 123456789;
+      const storedConfig: LocalStorageColumnSettings = {
+        'event.action': {
+          id: 'event.action',
+          initialWidth,
+        },
+      };
+      setStoredTimelineColumnsConfig(storedConfig);
+      const expectedColumns = [{ ...columnToAdd, initialWidth }];
+      const update = upsertTimelineColumn({
+        column: columnToAdd,
+        id: 'foo',
+        index: 0,
+        timelineById,
+      });
+
+      expect(update.foo.columns).toEqual(expectedColumns);
+    });
+
+    test('should apply the locally stored column config to existing columns', () => {
+      const initialWidth = 123456789;
+      const storedConfig: LocalStorageColumnSettings = {
+        '@timestamp': {
+          id: '@timestamp',
+          initialWidth,
+        },
+      };
+      setStoredTimelineColumnsConfig(storedConfig);
+      const update = upsertTimelineColumn({
+        column: columns[0],
+        id: 'foo',
+        index: 0,
+        timelineById: mockWithExistingColumns,
+      });
+
+      expect(update.foo.columns.find((col) => col.id === '@timestamp')).toEqual(
+        expect.objectContaining({
+          initialWidth,
+        })
+      );
+    });
   });
 
   describe('#addTimelineProvider', () => {
@@ -591,87 +679,6 @@ describe('Timeline', () => {
       const update = removeTimelineColumn({
         id: 'foo',
         columnId: 'does.not.exist',
-        timelineById: mockWithExistingColumns,
-      });
-
-      expect(update.foo.columns).toEqual(expectedColumns);
-    });
-  });
-
-  describe('#applyDeltaToColumnWidth', () => {
-    let mockWithExistingColumns: TimelineById;
-    beforeEach(() => {
-      mockWithExistingColumns = {
-        ...timelineByIdMock,
-        foo: {
-          ...timelineByIdMock.foo,
-          columns: columnsMock,
-        },
-      };
-    });
-    test('should return a new reference and not the same reference', () => {
-      const delta = 50;
-      const update = applyDeltaToTimelineColumnWidth({
-        id: 'foo',
-        columnId: columnsMock[0].id,
-        delta,
-        timelineById: mockWithExistingColumns,
-      });
-
-      expect(update).not.toBe(timelineByIdMock);
-    });
-
-    test('should update initialWidth with the specified delta when the delta is positive', () => {
-      const aDateColumn = columnsMock[0];
-      const delta = 50;
-      const expectedToHaveNewWidth = {
-        ...aDateColumn,
-        initialWidth: Number(aDateColumn.initialWidth) + 50,
-      };
-      const expectedColumns = [expectedToHaveNewWidth, columnsMock[1], columnsMock[2]];
-
-      const update = applyDeltaToTimelineColumnWidth({
-        id: 'foo',
-        columnId: aDateColumn.id,
-        delta,
-        timelineById: mockWithExistingColumns,
-      });
-
-      expect(update.foo.columns).toEqual(expectedColumns);
-    });
-
-    test('should update initialWidth with the specified delta when the delta is negative, and the resulting width is greater than the min column width', () => {
-      const aDateColumn = columnsMock[0];
-      const delta = 50 * -1; // the result will still be above the min column size
-      const expectedToHaveNewWidth = {
-        ...aDateColumn,
-        initialWidth: Number(aDateColumn.initialWidth) - 50,
-      };
-      const expectedColumns = [expectedToHaveNewWidth, columnsMock[1], columnsMock[2]];
-
-      const update = applyDeltaToTimelineColumnWidth({
-        id: 'foo',
-        columnId: aDateColumn.id,
-        delta,
-        timelineById: mockWithExistingColumns,
-      });
-
-      expect(update.foo.columns).toEqual(expectedColumns);
-    });
-
-    test('should set initialWidth to `RESIZED_COLUMN_MIN_WITH` when the requested delta results in a column that is too small ', () => {
-      const aDateColumn = columnsMock[0];
-      const delta = (Number(aDateColumn.initialWidth) - 5) * -1; // the requested delta would result in a width of just 5 pixels, which is too small
-      const expectedToHaveNewWidth = {
-        ...aDateColumn,
-        initialWidth: RESIZED_COLUMN_MIN_WITH, // we expect the minimum
-      };
-      const expectedColumns = [expectedToHaveNewWidth, columnsMock[1], columnsMock[2]];
-
-      const update = applyDeltaToTimelineColumnWidth({
-        id: 'foo',
-        columnId: aDateColumn.id,
-        delta,
         timelineById: mockWithExistingColumns,
       });
 
@@ -859,6 +866,28 @@ describe('Timeline', () => {
         timelineById: timelineByIdMock,
       });
       expect(update.foo.columns).toEqual([...columnsMock]);
+    });
+
+    test('should apply the locally stored column config', () => {
+      const initialWidth = 123456789;
+      const storedConfig: LocalStorageColumnSettings = {
+        '@timestamp': {
+          id: '@timestamp',
+          initialWidth,
+        },
+      };
+      setStoredTimelineColumnsConfig(storedConfig);
+      const update = updateTimelineColumns({
+        id: 'foo',
+        columns: columnsMock,
+        timelineById: timelineByIdMock,
+      });
+
+      expect(update.foo.columns.find((col) => col.id === '@timestamp')).toEqual(
+        expect.objectContaining({
+          initialWidth,
+        })
+      );
     });
   });
 

--- a/x-pack/plugins/security_solution/public/timelines/store/middlewares/create_timeline_middlewares.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/middlewares/create_timeline_middlewares.ts
@@ -12,6 +12,7 @@ import { favoriteTimelineMiddleware } from './timeline_favorite';
 import { addNoteToTimelineMiddleware } from './timeline_note';
 import { addPinnedEventToTimelineMiddleware } from './timeline_pinned_event';
 import { saveTimelineMiddleware } from './timeline_save';
+import { timelineLocalStorageMiddleware } from './timeline_localstorage';
 
 export function createTimelineMiddlewares(kibana: CoreStart) {
   return [
@@ -20,5 +21,6 @@ export function createTimelineMiddlewares(kibana: CoreStart) {
     addNoteToTimelineMiddleware(kibana),
     addPinnedEventToTimelineMiddleware(kibana),
     saveTimelineMiddleware(kibana),
+    timelineLocalStorageMiddleware,
   ];
 }

--- a/x-pack/plugins/security_solution/public/timelines/store/middlewares/timeline_localstorage.test.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/middlewares/timeline_localstorage.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createMockStore, kibanaMock } from '../../../common/mock';
+import { TimelineId } from '../../../../common/types/timeline';
+import { updateColumnWidth } from '../actions';
+import {
+  TIMELINE_COLUMNS_CONFIG_KEY,
+  getStoredTimelineColumnsConfig,
+  setStoredTimelineColumnsConfig,
+} from './timeline_localstorage';
+
+const initialWidth = 123456789;
+
+describe('Timeline localStorage middleware', () => {
+  let store = createMockStore(undefined, undefined, kibanaMock);
+
+  beforeEach(() => {
+    store = createMockStore(undefined, undefined, kibanaMock);
+    jest.clearAllMocks();
+    setStoredTimelineColumnsConfig(undefined);
+  });
+
+  it('should write the timeline column settings to localStorage', async () => {
+    await store.dispatch(
+      updateColumnWidth({ id: TimelineId.test, columnId: '@timestamp', width: initialWidth })
+    );
+    const storedConfig = getStoredTimelineColumnsConfig();
+    expect(storedConfig!['@timestamp'].initialWidth).toBe(initialWidth);
+  });
+
+  it('should not fail to read the column config when localStorage contains a malformatted config', () => {
+    localStorage.setItem(TIMELINE_COLUMNS_CONFIG_KEY, '1234');
+    const storedConfig = getStoredTimelineColumnsConfig();
+    expect(storedConfig).toBe(undefined);
+  });
+});

--- a/x-pack/plugins/security_solution/public/timelines/store/middlewares/timeline_localstorage.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/middlewares/timeline_localstorage.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Action, Middleware } from 'redux';
+import { z } from '@kbn/zod';
+
+import { selectTimelineById } from '../selectors';
+import { updateColumnWidth } from '../actions';
+
+const LocalStorageColumnSettingsSchema = z.record(
+  z.string(),
+  z.object({
+    initialWidth: z.number().optional(),
+    id: z.string(),
+  })
+);
+export type LocalStorageColumnSettings = z.infer<typeof LocalStorageColumnSettingsSchema>;
+
+export const TIMELINE_COLUMNS_CONFIG_KEY = 'timeline:columnsConfig';
+
+type UpdateColumnWidthAction = ReturnType<typeof updateColumnWidth>;
+
+function isUpdateColumnWidthAction(action: Action): action is UpdateColumnWidthAction {
+  return action.type === updateColumnWidth.type;
+}
+
+/**
+ * Saves the timeline column settings to localStorage when it changes
+ */
+export const timelineLocalStorageMiddleware: Middleware =
+  ({ getState }) =>
+  (next) =>
+  (action: Action) => {
+    // perform the action
+    const ret = next(action);
+
+    // Store the column config when it changes
+    if (isUpdateColumnWidthAction(action)) {
+      const timeline = selectTimelineById(getState(), action.payload.id);
+      const timelineColumnsConfig = timeline.columns.reduce<LocalStorageColumnSettings>(
+        (columnSettings, { initialWidth, id }) => {
+          columnSettings[id] = { initialWidth, id };
+          return columnSettings;
+        },
+        {}
+      );
+      setStoredTimelineColumnsConfig(timelineColumnsConfig);
+    }
+
+    return ret;
+  };
+
+export function getStoredTimelineColumnsConfig() {
+  const storedConfigStr = localStorage.getItem(TIMELINE_COLUMNS_CONFIG_KEY);
+  if (storedConfigStr) {
+    try {
+      return LocalStorageColumnSettingsSchema.parse(JSON.parse(storedConfigStr));
+    } catch (_) {
+      /* empty */
+    }
+  }
+}
+
+export function setStoredTimelineColumnsConfig(config?: LocalStorageColumnSettings) {
+  localStorage.setItem(TIMELINE_COLUMNS_CONFIG_KEY, JSON.stringify(config));
+}

--- a/x-pack/plugins/security_solution/public/timelines/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/reducer.ts
@@ -53,7 +53,6 @@ import {
   initializeTimelineSettings,
   updateItemsPerPage,
   updateItemsPerPageOptions,
-  applyDeltaToColumnWidth,
   clearEventsDeleted,
   clearEventsLoading,
   updateSavedSearchId,
@@ -94,14 +93,13 @@ import {
   updateFilters,
   updateTimelineSessionViewConfig,
   setLoadingTableEvents,
-  removeTableColumn,
-  upsertTableColumn,
-  updateTableColumns,
-  updateTableSort,
+  removeTimelineColumn,
+  upsertTimelineColumn,
+  updateTimelineColumns,
+  updateTimelineSort,
   setSelectedTableEvents,
   setDeletedTableEvents,
   setInitializeTimelineSettings,
-  applyDeltaToTableColumnWidth,
   updateTimelinePerPageOptions,
   updateTimelineItemsPerPage,
   updateTimelineColumnWidth,
@@ -391,7 +389,7 @@ export const timelineReducer = reducerWithInitialState(initialTimelineState)
   }))
   .case(removeColumn, (state, { id, columnId }) => ({
     ...state,
-    timelineById: removeTableColumn({
+    timelineById: removeTimelineColumn({
       id,
       columnId,
       timelineById: state.timelineById,
@@ -399,11 +397,11 @@ export const timelineReducer = reducerWithInitialState(initialTimelineState)
   }))
   .case(upsertColumn, (state, { column, id, index }) => ({
     ...state,
-    timelineById: upsertTableColumn({ column, id, index, timelineById: state.timelineById }),
+    timelineById: upsertTimelineColumn({ column, id, index, timelineById: state.timelineById }),
   }))
   .case(updateColumns, (state, { id, columns }) => ({
     ...state,
-    timelineById: updateTableColumns({
+    timelineById: updateTimelineColumns({
       id,
       columns,
       timelineById: state.timelineById,
@@ -421,7 +419,7 @@ export const timelineReducer = reducerWithInitialState(initialTimelineState)
   }))
   .case(updateSort, (state, { id, sort }) => ({
     ...state,
-    timelineById: updateTableSort({ id, sort, timelineById: state.timelineById }),
+    timelineById: updateTimelineSort({ id, sort, timelineById: state.timelineById }),
   }))
   .case(setSelected, (state, { id, eventIds, isSelected, isSelectAllChecked }) => ({
     ...state,
@@ -474,15 +472,6 @@ export const timelineReducer = reducerWithInitialState(initialTimelineState)
     timelineById: updateTimelinePerPageOptions({
       id,
       itemsPerPageOptions,
-      timelineById: state.timelineById,
-    }),
-  }))
-  .case(applyDeltaToColumnWidth, (state, { id, columnId, delta }) => ({
-    ...state,
-    timelineById: applyDeltaToTableColumnWidth({
-      id,
-      columnId,
-      delta,
       timelineById: state.timelineById,
     }),
   }))

--- a/x-pack/plugins/security_solution/public/timelines/store/reducer.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/reducer.ts
@@ -53,6 +53,7 @@ import {
   initializeTimelineSettings,
   updateItemsPerPage,
   updateItemsPerPageOptions,
+  applyDeltaToColumnWidth,
   clearEventsDeleted,
   clearEventsLoading,
   updateSavedSearchId,
@@ -100,6 +101,7 @@ import {
   setSelectedTableEvents,
   setDeletedTableEvents,
   setInitializeTimelineSettings,
+  applyDeltaToTableColumnWidth,
   updateTimelinePerPageOptions,
   updateTimelineItemsPerPage,
   updateTimelineColumnWidth,
@@ -472,6 +474,15 @@ export const timelineReducer = reducerWithInitialState(initialTimelineState)
     timelineById: updateTimelinePerPageOptions({
       id,
       itemsPerPageOptions,
+      timelineById: state.timelineById,
+    }),
+  }))
+  .case(applyDeltaToColumnWidth, (state, { id, columnId, delta }) => ({
+    ...state,
+    timelineById: applyDeltaToTableColumnWidth({
+      id,
+      columnId,
+      delta,
       timelineById: state.timelineById,
     }),
   }))


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Threat Hunting Investigations] Fix timeline column width bug (#214178)](https://github.com/elastic/kibana/pull/214178)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jan Monschke","email":"jan.monschke@elastic.co"},"sourceCommit":{"committedDate":"2025-03-13T18:49:16Z","message":"[Threat Hunting Investigations] Fix timeline column width bug (#214178)\n\n## Summary\n\nFixes: https://github.com/elastic/kibana/issues/213754\n\nThe issue above describes a bug in timeline that makes it impossible to\nchange the width of a timeline column. This PR fixes that issue and\nmakes sure that timeline column width settings are saved to\nlocalStorage. This mimics the behaviour of the alerts table elsewhere in\nsecurity solution.\n\n\nhttps://github.com/user-attachments/assets/8b9803a0-406d-4f2d-ada5-4c0b76cd6ab8\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"edbc618321930e358b2e0910f1c5cb5f7606e621","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:Threat Hunting:Investigations","backport:all-open","v8.18.0","v9.1.0","v8.19.0"],"title":"[Threat Hunting Investigations] Fix timeline column width bug","number":214178,"url":"https://github.com/elastic/kibana/pull/214178","mergeCommit":{"message":"[Threat Hunting Investigations] Fix timeline column width bug (#214178)\n\n## Summary\n\nFixes: https://github.com/elastic/kibana/issues/213754\n\nThe issue above describes a bug in timeline that makes it impossible to\nchange the width of a timeline column. This PR fixes that issue and\nmakes sure that timeline column width settings are saved to\nlocalStorage. This mimics the behaviour of the alerts table elsewhere in\nsecurity solution.\n\n\nhttps://github.com/user-attachments/assets/8b9803a0-406d-4f2d-ada5-4c0b76cd6ab8\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"edbc618321930e358b2e0910f1c5cb5f7606e621"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214473","number":214473,"state":"MERGED","mergeCommit":{"sha":"6c1aa0a4d9f5d605ad037ace4515c848af38f6f4","message":"[9.0] [Threat Hunting Investigations] Fix timeline column width bug (#214178) (#214473)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Threat Hunting Investigations] Fix timeline column width bug\n(#214178)](https://github.com/elastic/kibana/pull/214178)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jan Monschke <jan.monschke@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214471","number":214471,"state":"MERGED","mergeCommit":{"sha":"f2c8c4c0ce81a88387e0eb400ae6166aceb751f0","message":"[8.18] [Threat Hunting Investigations] Fix timeline column width bug (#214178) (#214471)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Threat Hunting Investigations] Fix timeline column width bug\n(#214178)](https://github.com/elastic/kibana/pull/214178)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jan Monschke <jan.monschke@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214178","number":214178,"mergeCommit":{"message":"[Threat Hunting Investigations] Fix timeline column width bug (#214178)\n\n## Summary\n\nFixes: https://github.com/elastic/kibana/issues/213754\n\nThe issue above describes a bug in timeline that makes it impossible to\nchange the width of a timeline column. This PR fixes that issue and\nmakes sure that timeline column width settings are saved to\nlocalStorage. This mimics the behaviour of the alerts table elsewhere in\nsecurity solution.\n\n\nhttps://github.com/user-attachments/assets/8b9803a0-406d-4f2d-ada5-4c0b76cd6ab8\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"edbc618321930e358b2e0910f1c5cb5f7606e621"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214472","number":214472,"state":"MERGED","mergeCommit":{"sha":"b578cc110edf15ae10f5a284a4bc110dbbbd5173","message":"[8.x] [Threat Hunting Investigations] Fix timeline column width bug (#214178) (#214472)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Threat Hunting Investigations] Fix timeline column width bug\n(#214178)](https://github.com/elastic/kibana/pull/214178)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jan Monschke <jan.monschke@elastic.co>"}}]}] BACKPORT-->