### PR TITLE
[UA] Increase polling interval for reindexing and data stream migration

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/use_migration_state.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/use_migration_state.tsx
@@ -20,7 +20,7 @@ import { CancelLoadingState, LoadingState } from '../../../types';
 import { ApiService } from '../../../../lib/api';
 import { readOnlyExecute } from './readonly_state';
 
-const POLL_INTERVAL = 1000;
+const POLL_INTERVAL = 3000;
 
 export interface MigrationState {
   loadingState: LoadingState;

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/use_reindex.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/use_reindex.tsx
@@ -16,7 +16,7 @@ import {
 import { CancelLoadingState, LoadingState } from '../../../types';
 import { ApiService } from '../../../../lib/api';
 
-const POLL_INTERVAL = 1000;
+const POLL_INTERVAL = 3000;
 
 export interface ReindexState {
   loadingState: LoadingState;


### PR DESCRIPTION
Part of: https://github.com/elastic/kibana/issues/214076

## Summary

This PR increases the polling interval at the client for reindexing and migrating data streams. The previous interval was 1s. After some testing, 3s seems to be a good balance between reducing the number of requests and keeping the UI up to date.


