### PR TITLE
[UA] Use `reindex_required` metadata to drive corrective actions

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/__fixtures__/fake_deprecations.json
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/__fixtures__/fake_deprecations.json
@@ -69,7 +69,10 @@
         "message": "Index created before 7.0",
         "url": "https: //www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html",
         "details": "This index was created using version: 6.8.13",
-        "resolve_during_rolling_upgrade": false
+        "resolve_during_rolling_upgrade": false,
+        "_meta": {
+          "reindex_required": true
+        }
       }
     ],
     "frozen_index": [
@@ -97,7 +100,10 @@
         "message": "Index created before 7.0",
         "url": "https: //www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html",
         "details": "This index was created using version: 6.8.13",
-        "resolve_during_rolling_upgrade": false
+        "resolve_during_rolling_upgrade": false,
+        "_meta": {
+          "reindex_required": true
+        }
       }
     ],
     "deprecated_settings": [
@@ -183,7 +189,10 @@
         "message": "Old index with a compatibility version < 8.0",
         "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-9.0.html",
         "details": "This index has version: 7.17.25",
-        "resolve_during_rolling_upgrade": false
+        "resolve_during_rolling_upgrade": false,
+        "_meta": {
+          "reindex_required": true
+        }
       }
     ],
     ".ent-search-1": [

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/index.test.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/index.test.ts
@@ -219,6 +219,9 @@ describe('getESUpgradeStatus', () => {
           details: 'This index was created using version: 6.8.13',
           // @ts-ignore
           resolve_during_rolling_upgrade: false,
+          _meta: {
+            reindex_required: true,
+          },
         },
         {
           level: 'critical',
@@ -227,6 +230,9 @@ describe('getESUpgradeStatus', () => {
           details: 'This index was created using version: 6.8.13',
           // @ts-ignore
           resolve_during_rolling_upgrade: false,
+          _meta: {
+            reindex_required: true,
+          },
         },
       ],
       ml_settings: [],
@@ -394,6 +400,9 @@ describe('getESUpgradeStatus', () => {
           details: 'This index was created using version: 6.8.13',
           // @ts-ignore
           resolve_during_rolling_upgrade: false,
+          _meta: {
+            reindex_required: true,
+          },
         },
       ],
       ml_settings: [],

--- a/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
+++ b/x-pack/test/upgrade_assistant_integration/upgrade_assistant/api_deprecations.ts
@@ -207,7 +207,7 @@ export default function ({ getService }: FtrProviderContext) {
         );
       });
     });
-    it('GET /api/upgrade_assistant/status does not return { readyForUpgrade: false } if there are only critical API deprecations', async () => {
+    it('Readiness status excludes critical deprecations based on Kibana API usage', async () => {
       /** Throw in another critical deprecation... */
       await supertest.get(`/api/routing_example/d/removed_route`).expect(200);
       // sleep a little until the usage counter is synced into ES
@@ -225,7 +225,8 @@ export default function ({ getService }: FtrProviderContext) {
       );
       const { body } = await supertest.get(`/api/upgrade_assistant/status`).expect(200);
 
-      // There are critical deprecations, but we expect none of them to be related to Kibana
+      // There are critical deprecations for Kibana API usage, but we do not
+      // surface them in readiness status
       expect(body.readyForUpgrade).to.be(false);
       expect(body.details?.length > 0).to.be(true);
       expect(/Kibana/gi.test(body.details)).to.be(false);


### PR DESCRIPTION
## Summary

Tested locally and critical old data deprecations are still surfaced as expected

<img width="586" alt="Screenshot 2025-03-14 at 10 12 50" src="https://github.com/user-attachments/assets/25d87fbd-7c98-45e0-a86a-d513ea455571" />
