### PR TITLE
[8.18] [ML] Fixing ML migration help URL (#214400)

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -604,7 +604,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       nlpElser: `${MACHINE_LEARNING_DOCS}ml-nlp-elser.html`,
       nlpE5: `${MACHINE_LEARNING_DOCS}ml-nlp-e5.html`,
       nlpImportModel: `${MACHINE_LEARNING_DOCS}ml-nlp-import-model.html`,
-      anomalyMigrationGuide: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/reference/master/migrating-9.0.html#breaking_90_anomaly_detection_results`,
+      anomalyMigrationGuide: `${ELASTIC_WEBSITE_URL}guide/en/elastic-stack/9.0/upgrading-elastic-stack.html#anomaly-detection-results-migration`,
     },
     transforms: {
       guide: isServerless


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[ML] Fixing ML migration help URL (#214400)](https://github.com/elastic/kibana/pull/214400)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"James Gowdy","email":"jgowdy@elastic.co"},"sourceCommit":{"committedDate":"2025-03-13T16:55:43Z","message":"[ML] Fixing ML migration help URL (#214400)\n\nThe docs path has changed and the upgrade assistant link for ML is\nincorrect.","sha":"aa1c935cdb0d4cba862b27801c7dd3b7a5638ba3","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","backport:version","v8.18.0","v8.19.0"],"title":"[ML] Fixing ML migration help URL","number":214400,"url":"https://github.com/elastic/kibana/pull/214400","mergeCommit":{"message":"[ML] Fixing ML migration help URL (#214400)\n\nThe docs path has changed and the upgrade assistant link for ML is\nincorrect.","sha":"aa1c935cdb0d4cba862b27801c7dd3b7a5638ba3"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->