### PR TITLE
[Security Solution] Prevent undesired rule upgrade failures

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/perform_rule_upgrade/perform_rule_upgrade_route.ts
@@ -144,12 +144,16 @@ export type RuleUpToDateSkipReason = z.infer<typeof RuleUpToDateSkipReason>;
 export const RuleUpToDateSkipReason = z.object({
   reason: z.literal(SkipRuleUpgradeReasonEnum.RULE_UP_TO_DATE),
   rule_id: z.string(),
+  version: RuleVersion,
+  revision: z.number(),
 });
 
 export type UpgradeConflictSkipReason = z.infer<typeof UpgradeConflictSkipReason>;
 export const UpgradeConflictSkipReason = z.object({
   reason: z.literal(SkipRuleUpgradeReasonEnum.CONFLICT),
   rule_id: z.string(),
+  version: RuleVersion,
+  revision: z.number(),
   conflict: z.nativeEnum(ThreeWayDiffConflict),
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_handler.ts
@@ -141,6 +141,8 @@ export const performRuleUpgradeHandler = async (
         if (!targetVersion || targetVersion.version <= currentVersion.version) {
           skippedRules.push({
             rule_id: targetRule.rule_id,
+            version: currentVersion.version,
+            revision: currentVersion.revision,
             reason: SkipRuleUpgradeReasonEnum.RULE_UP_TO_DATE,
           });
           return;
@@ -169,6 +171,8 @@ export const performRuleUpgradeHandler = async (
           if (conflict !== ThreeWayDiffConflict.NONE) {
             skippedRules.push({
               rule_id: targetRule.rule_id,
+              version: currentVersion.version,
+              revision: currentVersion.revision,
               reason: SkipRuleUpgradeReasonEnum.CONFLICT,
               conflict,
             });


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/214292**

## Summary

This PR makes sure users don't see unexpected rule upgrade failure or skipped errors in a toast message.

## Details

Rule upgrade workflow has multiple paths. In case users wanna upgrade multiple rules and some of them have conflicts we display a modal to let users choose upgrading conflict-free rules or upgrade conflict-free and auto-resolved conflict rules. By picking any option users expect to see desired number of rules upgraded successfully.

Current implementation requests upgrading all rules users selected without filtering our based on their choice. `upgrade/_perform` makes a decision on each rule based on `on_conflict` parameter value and may return errors. For example errors always appear when some rules to upgrade have unresolved conflicts. It results in a toast message rule upgrade failure while users didn't expect upgrading rules with unresolved conflicts.

This PR fixes this problem by crafting rule upgrade specifiers list users confirmed via rules upgrade confirmation modal. In that case any returned failures will legit errors.

## Screenshots:

_Before:_

https://github.com/user-attachments/assets/3d088e9e-efb4-4826-a707-b7e8d9064f5c

https://github.com/user-attachments/assets/b44c9bb8-99f5-46b8-a38f-d12e3945e8c4

_After:_

https://github.com/user-attachments/assets/afaf9f21-6e21-4a08-ad8c-00966d1f7a40

