### PR TITLE
chore(): add Platform Analytics as codeowners of schemas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1892,8 +1892,8 @@ packages/kbn-monaco/src/esql @elastic/kibana-esql
 # Kibana Telemetry
 /.telemetryrc.json @elastic/kibana-core
 /x-pack/.telemetryrc.json @elastic/kibana-core
-/src/platform/plugins/shared/telemetry/schema/ @elastic/kibana-core
-/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/ @elastic/kibana-core
+/src/platform/plugins/shared/telemetry/schema/ @elastic/kibana-core @elastic/platform-analytics
+/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/ @elastic/kibana-core @elastic/platform-analytics
 x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/config.ts @elastic/kibana-core @shahinakmal
 
 # Kibana Localization


### PR DESCRIPTION
## Summary

Adds `@elastic/platform-analytics` as codeowners of the telemetry schemas to raise awareness of any changes implemented in the snapshot telemetry.

The end goal is to remove Kibana Core from owning them.




