### PR TITLE
[8.17] [Controls] Fix data view ID injection (#214492)

### DIFF
--- a/src/plugins/controls/public/control_group/utils/serialization_utils.ts
+++ b/src/plugins/controls/public/control_group/utils/serialization_utils.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { omit } from 'lodash';
+import { cloneDeep, omit } from 'lodash';
 
 import { SerializedPanelState } from '@kbn/presentation-containers';
 import type { ControlGroupRuntimeState, ControlGroupSerializedState } from '../../../common';
@@ -17,7 +17,9 @@ export const deserializeControlGroup = (
   state: SerializedPanelState<ControlGroupSerializedState>
 ): ControlGroupRuntimeState => {
   const { controls } = state.rawState;
-  const controlsMap = Object.fromEntries(controls.map(({ id, ...rest }) => [id, rest]));
+
+  // we must cloneDeep `rest` because otherwise controlConfig gets copied by reference and not by value
+  const controlsMap = Object.fromEntries(controls.map(({ id, ...rest }) => [id, cloneDeep(rest)]));
 
   /** Inject data view references into each individual control */
   const references = state.references ?? [];
@@ -25,7 +27,7 @@ export const deserializeControlGroup = (
     const referenceName = reference.name;
     const { controlId } = parseReferenceName(referenceName);
     if (controlsMap[controlId]) {
-      controlsMap[controlId].dataViewId = reference.id;
+      controlsMap[controlId].controlConfig.dataViewId = reference.id;
     }
   });
 
@@ -35,7 +37,10 @@ export const deserializeControlGroup = (
     const currentControlExplicitInput = controlsMap[controlId].controlConfig;
     return {
       ...prev,
-      [controlId]: { ...omit(currentControl, 'controlConfig'), ...currentControlExplicitInput },
+      [controlId]: {
+        ...omit(currentControl, 'controlConfig'),
+        ...currentControlExplicitInput,
+      },
     };
   }, {});
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.18` to `8.17`:
 - [[Controls] Fix data view ID injection (#214492)](https://github.com/elastic/kibana/pull/214492)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Mudge","email":"Heenawter@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-14T15:47:09Z","message":"[Controls] Fix data view ID injection (#214492)\n\nCloses https://github.com/elastic/kibana/issues/214265\n\n## Summary\n\nhttps://github.com/elastic/kibana/pull/193067 introduced a bug where the\nvalid injected dataview ID was getting overwritten by the invalid\nreference ID in `controlConfig`.\n\n![Screenshot 2025-03-13 at 3 23\n35 PM](https://github.com/user-attachments/assets/6523b942-cd0f-4d67-a338-cf1d5d2218b8)\n\nThis was unknowingly fixed in\nhttps://github.com/elastic/kibana/pull/211851 when we rewrote the\ninjection logic - however, this PR was not backported to all the same\nversions that the bug existed on. To keep backporting simple, I have\nopted to simply fix the original broken injection logic rather than\nbackporting that entire PR.","sha":"bf928ce52ba05e2b8fd70ddd0493d4d29ffa293c","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","release_note:fix","Feature:Input Control","Team:Presentation","loe:small","impact:high","backport:version","v8.18.0","v8.17.4"],"title":"[Controls] Fix data view ID injection","number":214492,"url":"https://github.com/elastic/kibana/pull/214492","mergeCommit":{"message":"[Controls] Fix data view ID injection (#214492)\n\nCloses https://github.com/elastic/kibana/issues/214265\n\n## Summary\n\nhttps://github.com/elastic/kibana/pull/193067 introduced a bug where the\nvalid injected dataview ID was getting overwritten by the invalid\nreference ID in `controlConfig`.\n\n![Screenshot 2025-03-13 at 3 23\n35 PM](https://github.com/user-attachments/assets/6523b942-cd0f-4d67-a338-cf1d5d2218b8)\n\nThis was unknowingly fixed in\nhttps://github.com/elastic/kibana/pull/211851 when we rewrote the\ninjection logic - however, this PR was not backported to all the same\nversions that the bug existed on. To keep backporting simple, I have\nopted to simply fix the original broken injection logic rather than\nbackporting that entire PR.","sha":"bf928ce52ba05e2b8fd70ddd0493d4d29ffa293c"}},"sourceBranch":"8.18","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214492","number":214492,"mergeCommit":{"message":"[Controls] Fix data view ID injection (#214492)\n\nCloses https://github.com/elastic/kibana/issues/214265\n\n## Summary\n\nhttps://github.com/elastic/kibana/pull/193067 introduced a bug where the\nvalid injected dataview ID was getting overwritten by the invalid\nreference ID in `controlConfig`.\n\n![Screenshot 2025-03-13 at 3 23\n35 PM](https://github.com/user-attachments/assets/6523b942-cd0f-4d67-a338-cf1d5d2218b8)\n\nThis was unknowingly fixed in\nhttps://github.com/elastic/kibana/pull/211851 when we rewrote the\ninjection logic - however, this PR was not backported to all the same\nversions that the bug existed on. To keep backporting simple, I have\nopted to simply fix the original broken injection logic rather than\nbackporting that entire PR.","sha":"bf928ce52ba05e2b8fd70ddd0493d4d29ffa293c"}},{"branch":"8.17","label":"v8.17.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->