### PR TITLE
[Obs AI Assistant] Fix auth in the evaluation framework

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/cli.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/cli.ts
@@ -26,7 +26,10 @@ export const elasticsearchOption = {
   string: true as const,
   default: format({
     ...parse(config.elasticsearch.hosts || 'http://localhost:9200'),
-    auth: `${config.elasticsearch.username}:${config.elasticsearch.password}`,
+    auth:
+      config.elasticsearch.username && config.elasticsearch.password
+        ? `${config.elasticsearch.username}:${config.elasticsearch.password}`
+        : '',
   }),
 };
 

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/get_service_urls.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/get_service_urls.ts
@@ -121,7 +121,7 @@ export async function getServiceUrls({
 
   let auth = parsedTarget.auth;
 
-  if (!parsedTarget.auth || parsedTarget.auth.includes('undefined')) {
+  if (!parsedTarget.auth) {
     auth = await discoverAuth(parsedTarget, log);
   }
 

--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/get_service_urls.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/scripts/evaluation/get_service_urls.ts
@@ -121,7 +121,7 @@ export async function getServiceUrls({
 
   let auth = parsedTarget.auth;
 
-  if (!parsedTarget.auth) {
+  if (!parsedTarget.auth || parsedTarget.auth.includes('undefined')) {
     auth = await discoverAuth(parsedTarget, log);
   }
 


### PR DESCRIPTION
## Summary

### Problem

`parsedTarget.auth` returns `undefined:undefined` instead of an empty value.

### Solution

Check whether username and password exists before building the URL. 


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



