### PR TITLE
🌊 Streams: Fix success rate calculation

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/internal/streams/processing/simulation_handler.ts
@@ -396,7 +396,9 @@ const computePipelineSimulationResult = (
       const procId = error.processor_id;
 
       processorsMap[procId].errors.push(error);
-      processorsMap[procId].failure_rate++;
+      if (error.type !== 'non_additive_processor_failure') {
+        processorsMap[procId].failure_rate++;
+      }
     });
 
     return {

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/processing_simulate.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/processing_simulate.ts
@@ -406,6 +406,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
               'The processor is not additive to the documents. It might update fields [log.level,message]',
           },
         ]);
+        // Non-additive changes are not counted as error
+        expect(grokMetrics.success_rate).to.be(1);
+        expect(grokMetrics.failure_rate).to.be(0);
       });
 
       it('should return the is_non_additive_simulation simulation flag', async () => {


### PR DESCRIPTION
We decided to allow non-additive changes. However, the simulation endpoint was still counting parsing steps which would make non-additive changes as errors.

This PR makes sure that additive changes are not counted towards the error rate, but are still reported to the UI and shown as a warning.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->