### PR TITLE
[Security solution] Destructure `telemetryMetadata` from `subActionParams` in order not to pass to OpenAI

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
@@ -284,7 +284,7 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
     body: InvokeAIActionParams,
     connectorUsageCollector: ConnectorUsageCollector
   ): Promise<PassThrough> {
-    const { signal, timeout, ...rest } = body;
+    const { signal, timeout, telemetryMetadata, ...rest } = body;
 
     const res = (await this.streamApi(
       {
@@ -316,7 +316,7 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
     tokenCountStream: Stream<ChatCompletionChunk>;
   }> {
     try {
-      const { signal, timeout, ...rest } = body;
+      const { signal, timeout, telemetryMetadata, ...rest } = body;
       const messages = rest.messages as unknown as ChatCompletionMessageParam[];
       const requestBody: ChatCompletionCreateParamsStreaming = {
         ...rest,
@@ -354,9 +354,9 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
     body: InvokeAIActionParams,
     connectorUsageCollector: ConnectorUsageCollector
   ): Promise<InvokeAIActionResponse> {
-    const { signal, timeout, ...rest } = body;
+    const { signal, timeout, telemetryMetadata, ...rest } = body;
     const res = await this.runApi(
-      { body: JSON.stringify(rest), signal, timeout },
+      { body: JSON.stringify(rest), signal, timeout, telemetryMetadata },
       connectorUsageCollector
     );
 

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/openai/openai.ts
@@ -284,7 +284,7 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
     body: InvokeAIActionParams,
     connectorUsageCollector: ConnectorUsageCollector
   ): Promise<PassThrough> {
-    const { signal, timeout, telemetryMetadata, ...rest } = body;
+    const { signal, timeout, telemetryMetadata: _telemetryMetadata, ...rest } = body;
 
     const res = (await this.streamApi(
       {
@@ -316,7 +316,7 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
     tokenCountStream: Stream<ChatCompletionChunk>;
   }> {
     try {
-      const { signal, timeout, telemetryMetadata, ...rest } = body;
+      const { signal, timeout, telemetryMetadata: _telemetryMetadata, ...rest } = body;
       const messages = rest.messages as unknown as ChatCompletionMessageParam[];
       const requestBody: ChatCompletionCreateParamsStreaming = {
         ...rest,
@@ -354,9 +354,9 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
     body: InvokeAIActionParams,
     connectorUsageCollector: ConnectorUsageCollector
   ): Promise<InvokeAIActionResponse> {
-    const { signal, timeout, telemetryMetadata, ...rest } = body;
+    const { signal, timeout, telemetryMetadata: _telemetryMetadata, ...rest } = body;
     const res = await this.runApi(
-      { body: JSON.stringify(rest), signal, timeout, telemetryMetadata },
+      { body: JSON.stringify(rest), signal, timeout },
       connectorUsageCollector
     );
 


### PR DESCRIPTION
## Summary

In some of the OpenAI connector subActions, `telemetryMetadata` was not properly destructured from `subActionParams`, causing it to get passed to OpenAI resulting in this error:

```
Status code: 400. Message: API Error: model_error - Unrecognized request argument supplied: telemetryMetadata,
```

Properly destructure `telemetryMetadata` in order to clear the error and track telemetry.

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->