### PR TITLE
[ES|QL] Fixes the comment autocomplete when there is a space

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/suggestions_in_comments.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/suggestions_in_comments.test.ts
@@ -13,6 +13,7 @@ describe('suggestions in comments', () => {
   it('does not suggest in single-line comments', async () => {
     const { assertSuggestions } = await setup('^');
     await assertSuggestions('FROM index | EVAL // hey there ^', []);
+    await assertSuggestions('FROM index // I^', [], { triggerCharacter: ' ' });
   });
 
   it('does not suggest in multi-line comments', async () => {
@@ -29,7 +30,7 @@ describe('suggestions in comments', () => {
   test('suggests next to comments', async () => {
     const { suggest } = await setup('^');
     expect((await suggest('FROM index | EVAL ^/* */')).length).toBeGreaterThan(0);
-    expect((await suggest('FROM index | EVAL /* */^')).length).toBeGreaterThan(0);
+    expect((await suggest('FROM index | EVAL /* */ ^')).length).toBeGreaterThan(0);
     expect((await suggest('FROM index | EVAL ^// a comment')).length).toBeGreaterThan(0);
     expect((await suggest('FROM index | EVAL // a comment\n^')).length).toBeGreaterThan(0);
   });

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/context.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/context.ts
@@ -151,7 +151,7 @@ export function getAstContext(queryString: string, ast: ESQLAst, offset: number)
   let inComment = false;
 
   Walker.visitComments(ast, (node) => {
-    if (node.location && node.location.min <= offset && node.location.max > offset) {
+    if (node.location && node.location.min <= offset && node.location.max >= offset) {
       inComment = true;
     }
   });


### PR DESCRIPTION
## Summary

Fixes the problem with autocomplete been triggered in comments

**Before**
![meow](https://github.com/user-attachments/assets/a201a429-1280-47d9-8874-f12335d59f55)

**Now**
![meow](https://github.com/user-attachments/assets/365d2252-95a9-419e-9de8-319eaa208d3b)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->