### PR TITLE
[APM] Fix entry item in waterfall shouldn't be orphan

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
@@ -749,7 +749,39 @@ describe('waterfall_helpers', () => {
           parentId: 'myTransactionId1',
         } as IWaterfallSpan,
       ];
-      expect(getOrphanItemsIds(traceItems).length).toBe(0);
+      expect(getOrphanItemsIds(traceItems, traceItems[0].id).length).toBe(0);
+    });
+
+    it('should return missing items count: 0 if first item is orphan', () => {
+      const traceItems: IWaterfallSpanOrTransaction[] = [
+        {
+          doc: {
+            processor: { event: 'transaction' },
+            trace: { id: 'myTrace' },
+            transaction: {
+              id: 'myTransactionId1',
+            },
+          } as WaterfallTransaction,
+          docType: 'transaction',
+          id: 'myTransactionId1',
+          parentId: 'myNotExistingTransactionId0',
+        } as IWaterfallTransaction,
+        {
+          doc: {
+            processor: { event: 'span' },
+            span: {
+              id: 'myOrphanSpanId',
+            },
+            parent: {
+              id: 'myTransactionId1',
+            },
+          } as WaterfallSpan,
+          docType: 'span',
+          id: 'myOrphanSpanId',
+          parentId: 'myTransactionId1',
+        } as IWaterfallSpan,
+      ];
+      expect(getOrphanItemsIds(traceItems, traceItems[0].id).length).toBe(0);
     });
 
     it('should return missing items count if there are orphan items', () => {
@@ -770,7 +802,7 @@ describe('waterfall_helpers', () => {
           parentId: 'myNotExistingTransactionId1',
         } as IWaterfallSpan,
       ];
-      expect(getOrphanItemsIds(traceItems).length).toBe(1);
+      expect(getOrphanItemsIds(traceItems, traceItems[0].id).length).toBe(1);
     });
   });
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -413,7 +413,7 @@ export function getOrphanItemsIds(
   return waterfall
     .filter(
       (item) =>
-        // the first item should never be orphan
+        // the root transaction should never be orphan
         entryWaterfallTransactionId !== item.id &&
         item.parentId &&
         !waterfallItemsIds.has(item.parentId)

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -342,7 +342,7 @@ function reparentSpans(waterfallItems: IWaterfallSpanOrTransaction[]) {
 }
 
 const getChildrenGroupedByParentId = (waterfallItems: IWaterfallSpanOrTransaction[]) =>
-  groupBy(waterfallItems, (item) => (item.parentId ? item.parentId : ROOT_ID));
+  groupBy(waterfallItems, (item) => item.parentId ?? ROOT_ID);
 
 const getEntryWaterfallTransaction = (
   entryTransactionId: string,
@@ -405,10 +405,19 @@ function getErrorCountByParentId(errorDocs: TraceAPIResponse['traceItems']['erro
   }, {});
 }
 
-export function getOrphanItemsIds(waterfall: IWaterfallSpanOrTransaction[]) {
+export function getOrphanItemsIds(
+  waterfall: IWaterfallSpanOrTransaction[],
+  entryWaterfallTransactionId?: string
+) {
   const waterfallItemsIds = new Set(waterfall.map((item) => item.id));
   return waterfall
-    .filter((item) => item.parentId && !waterfallItemsIds.has(item.parentId))
+    .filter(
+      (item) =>
+        // the first item should never be orphan
+        entryWaterfallTransactionId !== item.id &&
+        item.parentId &&
+        !waterfallItemsIds.has(item.parentId)
+    )
     .map((item) => item.id);
 }
 
@@ -457,7 +466,7 @@ export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
     waterfallItems
   );
 
-  const orphanItemsIds = getOrphanItemsIds(waterfallItems);
+  const orphanItemsIds = getOrphanItemsIds(waterfallItems, entryWaterfallTransaction?.id);
   const childrenByParentId = getChildrenGroupedByParentId(
     reparentOrphanItems(
       orphanItemsIds,


### PR DESCRIPTION
## Summary

Closes #213074

This PR fixes the scenario where the entry waterfall transaction is treated as an orphan, causing it to reparent itself and be duplicated multiple times.




<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->