### PR TITLE
add API title_conversation tests

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/operators/get_generated_title.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/operators/get_generated_title.ts
@@ -13,7 +13,8 @@ import { Message, MessageRole } from '../../../../common';
 import { LangTracer } from '../instrumentation/lang_tracer';
 
 export const TITLE_CONVERSATION_FUNCTION_NAME = 'title_conversation';
-
+export const TITLE_SYSTEM_MESSAGE =
+  'You are a helpful assistant for Elastic Observability. Assume the following message is the start of a conversation between you and a user; give this conversation a title based on the content below. DO NOT UNDER ANY CIRCUMSTANCES wrap this title in single or double quotes. This title is shown in a list of conversations to the user, so title it for the user, not for you.';
 type ChatFunctionWithoutConnectorAndTokenCount = (
   name: string,
   params: Omit<
@@ -35,8 +36,7 @@ export function getGeneratedTitle({
 }): Observable<string> {
   return from(
     chat('generate_title', {
-      systemMessage:
-        'You are a helpful assistant for Elastic Observability. Assume the following message is the start of a conversation between you and a user; give this conversation a title based on the content below. DO NOT UNDER ANY CIRCUMSTANCES wrap this title in single or double quotes. This title is shown in a list of conversations to the user, so title it for the user, not for you.',
+      systemMessage: TITLE_SYSTEM_MESSAGE,
       messages: [
         {
           '@timestamp': new Date().toISOString(),

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MessageAddEvent } from '@kbn/observability-ai-assistant-plugin/common';
+import expect from '@kbn/expect';
+import { ChatCompletionStreamParams } from 'openai/lib/ChatCompletionStream';
+import {
+  TITLE_CONVERSATION_FUNCTION_NAME,
+  TITLE_SYSTEM_MESSAGE,
+} from '@kbn/observability-ai-assistant-plugin/server/service/client/operators/get_generated_title';
+import {
+  LlmProxy,
+  createLlmProxy,
+} from '../../../../../../../observability_ai_assistant_api_integration/common/create_llm_proxy';
+import { chatComplete, getMessageAddedEvents } from './helpers';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../../../ftr_provider_context';
+
+export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const log = getService('log');
+  const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
+
+  describe('when calling the title_conversation function', function () {
+    // Fails on MKI: https://github.com/elastic/kibana/issues/205581
+    this.tags(['failsOnMKI']);
+    let llmProxy: LlmProxy;
+    let connectorId: string;
+
+    before(async () => {
+      llmProxy = await createLlmProxy(log);
+      connectorId = await observabilityAIAssistantAPIClient.createProxyActionConnector({
+        port: llmProxy.getPort(),
+      });
+    });
+
+    after(async () => {
+      llmProxy.close();
+      await observabilityAIAssistantAPIClient.deleteActionConnector({
+        actionId: connectorId,
+      });
+    });
+
+    // Calling `title_conversation` via the chat/complete endpoint
+    describe('POST /internal/observability_ai_assistant/chat/complete', function () {
+      let messageAddedEvents: MessageAddEvent[];
+      let titleRequestBody: ChatCompletionStreamParams;
+
+      const USER_MESSAGE = 'Why the sky is blue?';
+
+      before(async () => {
+        void llmProxy.interceptTitle('title');
+        void llmProxy.interceptConversation(`The sky is blue because of Rayleigh scattering.`);
+
+        const response = await chatComplete({
+          userPrompt: USER_MESSAGE,
+          connectorId,
+          persist: true,
+          observabilityAIAssistantAPIClient,
+        });
+
+        await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+        messageAddedEvents = getMessageAddedEvents(response.body);
+
+        titleRequestBody = llmProxy.interceptedRequests[0].requestBody;
+      });
+
+      it('makes 2 requests to the LLM', () => {
+        expect(llmProxy.interceptedRequests.length).to.be(2);
+      });
+
+      it('sends the correct system message to the LLM for the title', () => {
+        expect(
+          titleRequestBody.messages.find((message) => message.role === 'system')?.content
+        ).to.be(TITLE_SYSTEM_MESSAGE);
+      });
+
+      it('sends the correct user message to the LLM for the title', () => {
+        expect(
+          titleRequestBody.messages.find((message) => message.role === 'user')?.content
+        ).to.contain('Why the sky is blue?');
+      });
+
+      it('sends the correct function call to the LLM for the title', () => {
+        expect(titleRequestBody.tools?.[0].function.name).to.be(TITLE_CONVERSATION_FUNCTION_NAME);
+      });
+    });
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
@@ -46,7 +46,6 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     describe('POST /internal/observability_ai_assistant/chat/complete', function () {
       let titleRequestBody: ChatCompletionStreamParams;
 
-      const USER_MESSAGE = 'Why the sky is blue?';
       const TITLE = 'Question about color of the sky';
       let conversationId: string;
 
@@ -55,7 +54,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         void llmProxy.interceptConversation('The sky is blue because of Rayleigh scattering.');
 
         const res = await chatComplete({
-          userPrompt: USER_MESSAGE,
+          userPrompt: 'Why the sky is blue?',
           connectorId,
           persist: true,
           observabilityAIAssistantAPIClient,

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
@@ -51,7 +51,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       const USER_MESSAGE = 'Why the sky is blue?';
 
       before(async () => {
-        void llmProxy.interceptTitle('title');
+        void llmProxy.interceptTitle('Question about color of the sky');
         void llmProxy.interceptConversation(`The sky is blue because of Rayleigh scattering.`);
 
         const response = await chatComplete({

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
@@ -15,7 +15,7 @@ import {
   LlmProxy,
   createLlmProxy,
 } from '../../../../../../../observability_ai_assistant_api_integration/common/create_llm_proxy';
-import { chatComplete } from './helpers';
+import { chatComplete } from '../../utils/conversation';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { MessageAddEvent } from '@kbn/observability-ai-assistant-plugin/common';
 import expect from '@kbn/expect';
 import { ChatCompletionStreamParams } from 'openai/lib/ChatCompletionStream';
 import {
@@ -16,7 +15,7 @@ import {
   LlmProxy,
   createLlmProxy,
 } from '../../../../../../../observability_ai_assistant_api_integration/common/create_llm_proxy';
-import { chatComplete, getMessageAddedEvents } from './helpers';
+import { chatComplete } from './helpers';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
@@ -45,7 +44,6 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
     // Calling `title_conversation` via the chat/complete endpoint
     describe('POST /internal/observability_ai_assistant/chat/complete', function () {
-      let messageAddedEvents: MessageAddEvent[];
       let titleRequestBody: ChatCompletionStreamParams;
 
       const USER_MESSAGE = 'Why the sky is blue?';
@@ -54,7 +52,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         void llmProxy.interceptTitle('Question about color of the sky');
         void llmProxy.interceptConversation(`The sky is blue because of Rayleigh scattering.`);
 
-        const response = await chatComplete({
+        await chatComplete({
           userPrompt: USER_MESSAGE,
           connectorId,
           persist: true,
@@ -62,7 +60,6 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         });
 
         await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
-        messageAddedEvents = getMessageAddedEvents(response.body);
 
         titleRequestBody = llmProxy.interceptedRequests[0].requestBody;
       });

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/title_conversation.spec.ts
@@ -59,7 +59,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           persist: true,
           observabilityAIAssistantAPIClient,
         });
-        conversationId = res.conversation?.conversation.id || '';
+        conversationId = res.conversationCreateEvent?.conversation.id || '';
 
         await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
 

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/index.ts
@@ -24,6 +24,7 @@ export default function aiAssistantApiIntegrationTests({
     loadTestFile(require.resolve('./complete/functions/summarize.spec.ts'));
     loadTestFile(require.resolve('./complete/functions/recall.spec.ts'));
     loadTestFile(require.resolve('./complete/functions/context.spec.ts'));
+    loadTestFile(require.resolve('./complete/functions/title_conversation.spec.ts'));
     loadTestFile(require.resolve('./public_complete/public_complete.spec.ts'));
     loadTestFile(require.resolve('./knowledge_base/knowledge_base_setup.spec.ts'));
     loadTestFile(

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/conversation.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/conversation.ts
@@ -84,11 +84,13 @@ export async function chatComplete({
   userPrompt,
   screenContexts = [],
   connectorId,
+  persist = false,
   observabilityAIAssistantAPIClient,
 }: {
   userPrompt: string;
   screenContexts?: ObservabilityAIAssistantScreenContextRequest[];
   connectorId: string;
+  persist?: boolean;
   observabilityAIAssistantAPIClient: ObservabilityAIAssistantApiClient;
 }) {
   const { status, body } = await observabilityAIAssistantAPIClient.editor({
@@ -105,7 +107,7 @@ export async function chatComplete({
           },
         ],
         connectorId,
-        persist: false,
+        persist,
         screenContexts,
         scopes: ['observability' as const],
       },

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/conversation.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/conversation.ts
@@ -11,7 +11,6 @@ import {
   ConversationUpdateEvent,
   Message,
   MessageAddEvent,
-  ConversationCreateEvent,
   MessageRole,
   StreamingChatResponseEvent,
   StreamingChatResponseEventType,
@@ -33,12 +32,6 @@ export function decodeEvents(body: Readable | string) {
 export function getMessageAddedEvents(body: Readable | string) {
   return decodeEvents(body).filter(
     (event): event is MessageAddEvent => event.type === 'messageAdd'
-  );
-}
-
-export function getConversationCreateEvent(body: Readable | string) {
-  return decodeEvents(body).find(
-    (event): event is ConversationCreateEvent => event.type === 'conversationCreate'
   );
 }
 
@@ -124,8 +117,8 @@ export async function chatComplete({
   expect(status).to.be(200);
   const messageEvents = decodeEvents(body);
   const messageAddedEvents = getMessageAddedEvents(body);
-  const conversation = getConversationCreateEvent(body);
-  return { messageAddedEvents, conversation, messageEvents, status };
+  const conversationCreateEvent = getConversationCreatedEvent(body);
+  return { messageAddedEvents, conversationCreateEvent, messageEvents, status };
 }
 
 // order of instructions can vary, so we sort to compare them

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/conversation.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/conversation.ts
@@ -30,12 +30,14 @@ export function decodeEvents(body: Readable | string) {
     .map((line) => JSON.parse(line) as StreamingChatResponseEvent);
 }
 
-export function getMessageAddedEvents(body: StreamingChatResponseEvent[]) {
-  return body.filter((event): event is MessageAddEvent => event.type === 'messageAdd');
+export function getMessageAddedEvents(body: Readable | string) {
+  return decodeEvents(body).filter(
+    (event): event is MessageAddEvent => event.type === 'messageAdd'
+  );
 }
 
-export function getConversationCreateEvent(body: StreamingChatResponseEvent[]) {
-  return body.find(
+export function getConversationCreateEvent(body: Readable | string) {
+  return decodeEvents(body).find(
     (event): event is ConversationCreateEvent => event.type === 'conversationCreate'
   );
 }
@@ -120,10 +122,10 @@ export async function chatComplete({
   });
 
   expect(status).to.be(200);
-  const decodedBody = decodeEvents(body);
-  const messageAddedEvents = getMessageAddedEvents(decodedBody);
-  const conversation = getConversationCreateEvent(decodedBody);
-  return { messageAddedEvents, conversation, body: decodedBody, status };
+  const messageEvents = decodeEvents(body);
+  const messageAddedEvents = getMessageAddedEvents(body);
+  const conversation = getConversationCreateEvent(body);
+  return { messageAddedEvents, conversation, messageEvents, status };
 }
 
 // order of instructions can vary, so we sort to compare them

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/conversation.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/conversation.ts
@@ -163,12 +163,6 @@ export function getConversationCreatedEvent(body: Readable | string) {
     (event) => event.type === StreamingChatResponseEventType.ConversationCreate
   ) as ConversationCreateEvent;
 
-  if (!conversationCreatedEvent) {
-    throw new Error(
-      `No conversation created event found: ${JSON.stringify(decodedEvents, null, 2)}`
-    );
-  }
-
   return conversationCreatedEvent;
 }
 


### PR DESCRIPTION
Related: https://github.com/elastic/kibana/issues/180787

- Adds test for `title_conversation` function

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->