### PR TITLE
[Security Solution] Fix flaky test for delete rules bulk legacy and unskip it

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/basic_license_essentials_tier/delete_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/basic_license_essentials_tier/delete_rules_bulk.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
+import expect from 'expect';
 
 import { FtrProviderContext } from '../../../../../ftr_provider_context';
 import {
@@ -58,7 +58,7 @@ export default ({ getService }: FtrProviderContext): void => {
           await utils.getUsername()
         );
 
-        expect(bodyToCompare).to.eql(expectedRule);
+        expect(bodyToCompare).toEqual(expectedRule);
       });
 
       it('should return an error if the id does not exist when trying to delete an id', async () => {
@@ -69,7 +69,7 @@ export default ({ getService }: FtrProviderContext): void => {
           })
           .expect(500);
 
-        expect(body).to.eql({
+        expect(body).toEqual({
           statusCode: 500,
           error: 'Internal Server Error',
           message: 'Bulk edit failed',

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
+import expect from 'expect';
 import { Rule } from '@kbn/alerting-plugin/common';
 import { BaseRuleParams } from '@kbn/security-solution-plugin/server/lib/detection_engine/rule_schema';
 import { RuleResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
@@ -63,7 +63,7 @@ export default ({ getService }: FtrProviderContext): void => {
           await utils.getUsername()
         );
 
-        expect(bodyToCompare).to.eql(expectedRule);
+        expect(bodyToCompare).toEqual(expectedRule);
       });
 
       it('should return an error if the id does not exist when trying to delete an id', async () => {
@@ -74,7 +74,7 @@ export default ({ getService }: FtrProviderContext): void => {
           })
           .expect(500);
 
-        expect(body).to.eql({
+        expect(body).toEqual({
           statusCode: 500,
           error: 'Internal Server Error',
           message: 'Bulk edit failed',
@@ -144,14 +144,14 @@ export default ({ getService }: FtrProviderContext): void => {
           })
           .expect(200);
 
-        expect(body.success).to.be(true);
-        expect(body.rules_count).to.be(2);
+        expect(body.success).toBe(true);
+        expect(body.rules_count).toBe(2);
 
         const investigationFields = body.attributes.results.deleted
           .map((rule: RuleResponse) => rule.investigation_fields)
           .sort();
 
-        expect(investigationFields).to.eql([
+        expect(investigationFields).toEqual([
           { field_names: ['client.address', 'agent.name'] },
           undefined,
         ]);

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk_legacy.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_delete/trial_license_complete_tier/delete_rules_bulk_legacy.ts
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
+import expect from 'expect';
 import { BASE_ALERTING_API_PATH } from '@kbn/alerting-plugin/common';
+import { RuleResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
 import {
   createLegacyRuleAction,
   getSimpleRule,
@@ -28,9 +29,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const log = getService('log');
   const es = getService('es');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/214633
-  // Failing: See https://github.com/elastic/kibana/issues/214633
-  describe.skip('@ess delete_rules_bulk_legacy', () => {
+  describe('@ess delete_rules_bulk_legacy', () => {
     describe('deleting rules bulk using bulk_action endpoint', () => {
       beforeEach(async () => {
         await createAlertsIndex(supertest, log);
@@ -69,9 +68,9 @@ export default ({ getService }: FtrProviderContext): void => {
           })
           .expect(200);
 
-        expect(body.attributes.results.deleted.length).to.eql(1);
+        expect(body.attributes.results.deleted.length).toEqual(1);
         // ensure that its actions equal what we expect
-        expect(body.attributes.results.deleted[0].actions).to.eql([
+        expect(body.attributes.results.deleted[0].actions).toEqual([
           {
             id: hookAction.id,
             action_type_id: hookAction.connector_type_id,
@@ -121,33 +120,31 @@ export default ({ getService }: FtrProviderContext): void => {
           .expect(200);
 
         // ensure we only get two bodies back
-        expect(body.attributes.results.deleted.length).to.eql(2);
+        expect(body.attributes.results.deleted.length).toEqual(2);
+
+        const actions = body.attributes.results.deleted.map(
+          (rule: RuleResponse) => rule.actions[0]
+        );
 
         // ensure that its actions equal what we expect for both responses
-        expect(body.attributes.results.deleted[0].actions).to.eql([
-          {
-            id: hookAction1.id,
-            action_type_id: hookAction1.connector_type_id,
-            group: 'default',
-            params: {
-              message:
-                'Hourly\nRule {{context.rule.name}} generated {{state.signals_count}} alerts',
-            },
-            frequency: { summary: true, throttle: '1h', notifyWhen: 'onThrottleInterval' },
+        expect(actions).toContainEqual({
+          id: hookAction1.id,
+          action_type_id: hookAction1.connector_type_id,
+          group: 'default',
+          params: {
+            message: 'Hourly\nRule {{context.rule.name}} generated {{state.signals_count}} alerts',
           },
-        ]);
-        expect(body.attributes.results.deleted[1].actions).to.eql([
-          {
-            id: hookAction2.id,
-            action_type_id: hookAction2.connector_type_id,
-            group: 'default',
-            params: {
-              message:
-                'Hourly\nRule {{context.rule.name}} generated {{state.signals_count}} alerts',
-            },
-            frequency: { summary: true, throttle: '1h', notifyWhen: 'onThrottleInterval' },
+          frequency: { summary: true, throttle: '1h', notifyWhen: 'onThrottleInterval' },
+        });
+        expect(actions).toContainEqual({
+          id: hookAction2.id,
+          action_type_id: hookAction2.connector_type_id,
+          group: 'default',
+          params: {
+            message: 'Hourly\nRule {{context.rule.name}} generated {{state.signals_count}} alerts',
           },
-        ]);
+          frequency: { summary: true, throttle: '1h', notifyWhen: 'onThrottleInterval' },
+        });
       });
 
       /**
@@ -169,8 +166,8 @@ export default ({ getService }: FtrProviderContext): void => {
 
         // check for legacy sidecar action
         const sidecarActionsResults = await getLegacyActionSO(es);
-        expect(sidecarActionsResults.hits.hits.length).to.eql(1);
-        expect(sidecarActionsResults.hits.hits[0]?._source?.references[0].id).to.eql(
+        expect(sidecarActionsResults.hits.hits.length).toEqual(1);
+        expect(sidecarActionsResults.hits.hits[0]?._source?.references[0].id).toEqual(
           createRuleBody.id
         );
 
@@ -200,11 +197,11 @@ export default ({ getService }: FtrProviderContext): void => {
           .send();
 
         // Expect that we have exactly 0 legacy rules after the deletion
-        expect(bodyAfterDelete.total).to.eql(0);
+        expect(bodyAfterDelete.total).toEqual(0);
 
         // legacy sidecar action should be gone
         const sidecarActionsPostResults = await getLegacyActionSO(es);
-        expect(sidecarActionsPostResults.hits.hits.length).to.eql(0);
+        expect(sidecarActionsPostResults.hits.hits.length).toEqual(0);
       });
     });
   });


### PR DESCRIPTION
**Resolves: #214633**

## Summary

I am fixing a flaky test in the `delete_rules_bulk_legacy.ts` file introduced in the #213244.

Also, in two other files I am changing using expect from kbn to jest.




<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->