### PR TITLE
update package testing script after /test was moved to src/platform/test

### DIFF
--- a/.buildkite/scripts/steps/package_testing/test.sh
+++ b/.buildkite/scripts/steps/package_testing/test.sh
@@ -25,7 +25,7 @@ elif [[ "$TEST_PACKAGE" == "docker" ]]; then
 fi
 cd ..
 
-export VAGRANT_CWD=$PWD/test/package
+export VAGRANT_CWD=$PWD/src/platform/test/package
 vagrant up "$TEST_PACKAGE" --no-provision
 
 node scripts/es snapshot \

--- a/docs/extend/development-tests.md
+++ b/docs/extend/development-tests.md
@@ -786,7 +786,7 @@ Packaging tests use Vagrant virtual machines as hosts and Ansible for provisioni
 # Build distributions
 node scripts/build --all-platforms --debug
 
-cd test/package
+cd src/platform/test/package
 
 # Setup virtual machine and networking
 vagrant up <hostname> --no-provision


### PR DESCRIPTION
## Summary
After https://github.com/elastic/kibana/pull/210956 - the artifact snapshot testing code is broken because a path reference wasn't updated. This PR updates that.

Fixes: https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/5745

The checks started (https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/5764) but it failed for a different reason. Probably some real errors?

<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->