### PR TITLE
[Uptime] Unskip flaky Overview Page tests

### DIFF
--- a/x-pack/test/functional/apps/uptime/overview.ts
+++ b/x-pack/test/functional/apps/uptime/overview.ts
@@ -9,6 +9,7 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export const UPTIME_HEARTBEAT_DATA = 'x-pack/test/functional/es_archives/uptime/full_heartbeat';
+const DEFAULT_NAVIGATION_SEARCH = `dateRangeEnd=2019-09-11T19:40:08.078Z&dateRangeStart=2019-09-10T12:40:08.078Z`;
 
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const { uptime, common } = getPageObjects(['uptime', 'common']);
@@ -24,7 +25,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     beforeEach(async () => {
       await common.navigateToApp('uptime', {
-        search: `dateRangeEnd=2019-09-11T19:40:08.078Z&dateRangeStart=2019-09-10T12:40:08.078Z`,
+        search: DEFAULT_NAVIGATION_SEARCH,
       });
 
       await uptime.resetFilters();
@@ -55,7 +56,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     it('pagination is cleared when filter criteria changes', async () => {
       await common.navigateToApp('uptime', {
-        search: `dateRangeEnd=2019-09-11T19:40:08.078Z&dateRangeStart=2019-09-10T12:40:08.078Z&pagination={"cursorDirection":"AFTER","sortOrder":"ASC","cursorKey":{"monitor_id":"0009-up"}}`,
+        search: `${DEFAULT_NAVIGATION_SEARCH}&pagination={"cursorDirection":"AFTER","sortOrder":"ASC","cursorKey":{"monitor_id":"0009-up"}}`,
       });
       await uptime.pageHasExpectedIds([
         '0010-down',


### PR DESCRIPTION
## Summary

Resolves #57737.
Resolves [#89072](https://github.com/elastic/kibana/issues/89072).

40/40 ✅  [run](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8051) on Flaky Test Runner.

- [Example #57737 success](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8051#0195a4d4-f2d0-4be4-a91d-6b0d4b6ba84d/240-1226)
- [Example #89072 success](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8051#0195a4d4-f2d0-4be4-a91d-6b0d4b6ba84d/240-1231)

Using the page elements manually on the test server version of Kibana, I can click through and execute all these tests by hand. However, for some reason web driver does not click the elements and make the desired things happen.

All of the behaviors we are testing are configurable via the URL params, so I'm relying on the URL to set the app state to the expected conditions to verify the app is working. These page elements are also tested via unit-level tests, so I don't think we are losing any practical coverage for this soon-to-be-deprecated code.

Additionally, I removed the code in the `beforeEach` hook that utilizes the date picker to set the default start/end range fields. This takes _forever_, and our tests don't need to test that `SuperDatePicker` is doing its job (again, our implementation has unit tests to verify the correct callbacks are provided and that they handle the input criteria). Instead we simply `navigateToApp` with the default parameters specified in the URL search.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->