### PR TITLE
[streams][lifecycle] format total docs

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/metadata.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/metadata.tsx
@@ -31,6 +31,7 @@ import {
   EuiPanel,
   EuiPopover,
   EuiText,
+  formatNumber,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { LifecycleEditAction } from './modal';
@@ -203,7 +204,7 @@ export function RetentionMetadata({
           ) : isLoadingStats || !stats ? (
             <EuiLoadingSpinner size="s" />
           ) : (
-            stats.totalDocs
+            formatNumber(stats.totalDocs, '0,0')
           )
         }
       />


### PR DESCRIPTION
Total docs is now readable

![formatnumber](https://github.com/user-attachments/assets/64ba53c7-e574-4540-aac0-dd3da2521d89)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->