### PR TITLE
[ML] Fixes chart in single metric anomaly detection wizard

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/common/results_loader/results_loader.ts
+++ b/x-pack/platform/plugins/shared/ml/public/application/jobs/new_job/common/results_loader/results_loader.ts
@@ -209,9 +209,7 @@ export class ResultsLoader {
       // set the _lastModelTimeStamp to be 5 buckets behind so we load the correct
       // section of results next time.
       this._lastModelTimeStamp = model[model.length - 5].time;
-      for (let i = 0; i < 5; i++) {
-        this._results.model[dtrIndex].pop();
-      }
+      this._results.model[dtrIndex] = this._results.model[dtrIndex].slice(0, -5);
     }
 
     // return a new array from the old and new model


### PR DESCRIPTION
Fixes an issue with the single metric wizard chart where an error is thrown when attempting to adjust the buckets of the previous batch of loaded results.

**Before**

![image](https://github.com/user-attachments/assets/ac9feef5-f354-4423-b34d-39afc029f024)
![image](https://github.com/user-attachments/assets/7d62db99-e7d9-4a08-a823-fa4a4a5e79af)



**After**
![image](https://github.com/user-attachments/assets/a3d9c3fd-3eac-4b82-b9d6-319735258661)



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->