### PR TITLE
[8.x] [Fleet] Fix source mode synthetics when handling experimental datastream features (#210195)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.test.ts
@@ -271,7 +271,11 @@ describe('experimental_datastream_features', () => {
         expect.objectContaining({
           body: expect.objectContaining({
             template: expect.objectContaining({
-              mappings: expect.objectContaining({ _source: { mode: 'synthetic' } }),
+              settings: expect.objectContaining({
+                index: expect.objectContaining({
+                  mapping: expect.objectContaining({ source: { mode: 'synthetic' } }),
+                }),
+              }),
             }),
           }),
           _meta: { has_experimental_data_stream_indexing_features: true },
@@ -483,7 +487,11 @@ describe('experimental_datastream_features', () => {
           expect.objectContaining({
             body: expect.objectContaining({
               template: expect.objectContaining({
-                mappings: expect.objectContaining({ _source: { mode: 'synthetic' } }),
+                settings: expect.objectContaining({
+                  index: expect.objectContaining({
+                    mapping: expect.objectContaining({ source: { mode: 'synthetic' } }),
+                  }),
+                }),
               }),
             }),
             _meta: { has_experimental_data_stream_indexing_features: true },

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policies/experimental_datastream_features.ts
@@ -155,21 +155,32 @@ export async function handleExperimentalDatastreamFeatureOptIn({
     });
 
     if (isSyntheticSourceOptInChanged) {
-      sourceModeSettings = {
-        _source: {
-          ...(featureMapEntry.features.synthetic_source ? { mode: 'synthetic' } : {}),
-        },
-      };
+      sourceModeSettings = featureMapEntry.features.synthetic_source
+        ? {
+            source: {
+              mode: 'synthetic',
+            },
+          }
+        : {};
     }
 
     if (componentTemplateChanged) {
       const body = {
         template: {
           ...componentTemplate.template,
+          settings: {
+            ...componentTemplate.template?.settings,
+            index: {
+              ...componentTemplate.template?.settings?.index,
+              mapping: {
+                ...componentTemplate.template?.settings?.index?.mapping,
+                ...sourceModeSettings,
+              },
+            },
+          },
           mappings: {
             ...mappings,
             properties: mappingsProperties ?? {},
-            ...sourceModeSettings,
           },
         },
       };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Fleet] Fix source mode synthetics when handling experimental datastream features (#210195)](https://github.com/elastic/kibana/pull/210195)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2025-02-10T13:00:59Z","message":"[Fleet] Fix source mode synthetics when handling experimental datastream features (#210195)","sha":"d2070ca7242a832c158d9a8dd4edcc8bd806649a","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","backport:prev-minor","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Fleet] Fix source mode synthetics when handling experimental datastream features","number":210195,"url":"https://github.com/elastic/kibana/pull/210195","mergeCommit":{"message":"[Fleet] Fix source mode synthetics when handling experimental datastream features (#210195)","sha":"d2070ca7242a832c158d9a8dd4edcc8bd806649a"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210370","number":210370,"state":"MERGED","mergeCommit":{"sha":"a407b262aaecc2f7f212280c95c011061a1bae38","message":"[9.0] [Fleet] Fix source mode synthetics when handling experimental datastream features (#210195) (#210370)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Fleet] Fix source mode synthetics when handling experimental\ndatastream features\n(#210195)](https://github.com/elastic/kibana/pull/210195)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210376","number":210376,"state":"MERGED","mergeCommit":{"sha":"6b79455363bfdcf314d8aa9b9d6d31f6c90f05bd","message":"[8.18] [Fleet] Fix source mode synthetics when handling experimental datastream features (#210195) (#210376)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Fleet] Fix source mode synthetics when handling experimental\ndatastream features\n(#210195)](https://github.com/elastic/kibana/pull/210195)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Nicolas Chaulet <nicolas.chaulet@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210195","number":210195,"mergeCommit":{"message":"[Fleet] Fix source mode synthetics when handling experimental datastream features (#210195)","sha":"d2070ca7242a832c158d9a8dd4edcc8bd806649a"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->