### PR TITLE
add API retrieve_elastic_doc tests

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import {
+  LlmProxy,
+  createLlmProxy,
+} from '../../../../../../../observability_ai_assistant_api_integration/common/create_llm_proxy';
+import { chatComplete } from './helpers';
+import type { DeploymentAgnosticFtrProviderContext } from '../../../../../ftr_provider_context';
+
+export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const log = getService('log');
+  const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
+
+  describe('retrieve_elastic_doc', function () {
+    // Fails on MKI: https://github.com/elastic/kibana/issues/205581
+    this.tags(['failsOnMKI']);
+    const USER_MESSAGE = 'What is Kibana Lens?';
+
+    describe('POST /internal/observability_ai_assistant/chat/complete without product doc installed', function () {
+      let llmProxy: LlmProxy;
+      let connectorId: string;
+
+      before(async () => {
+        llmProxy = await createLlmProxy(log);
+        connectorId = await observabilityAIAssistantAPIClient.createProxyActionConnector({
+          port: llmProxy.getPort(),
+        });
+        void llmProxy.interceptConversation('Hello from LLM Proxy');
+
+        await chatComplete({
+          userPrompt: USER_MESSAGE,
+          connectorId,
+          observabilityAIAssistantAPIClient,
+        });
+
+        await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+      });
+
+      after(async () => {
+        llmProxy.close();
+        await observabilityAIAssistantAPIClient.deleteActionConnector({
+          actionId: connectorId,
+        });
+      });
+
+      it('makes 1 requests to the LLM', () => {
+        expect(llmProxy.interceptedRequests.length).to.be(1);
+      });
+
+      it('not contain retrieve_elastic_doc function when product doc is not installed', () => {
+        expect(
+          llmProxy.interceptedRequests.flatMap(({ requestBody }) =>
+            requestBody.tools?.map((t) => t.function.name)
+          )
+        ).to.not.contain('retrieve_elastic_doc');
+      });
+
+      it('contains the original user message', () => {
+        const everyRequestHasUserMessage = llmProxy.interceptedRequests.every(({ requestBody }) =>
+          requestBody.messages.some(
+            (message) => message.role === 'user' && (message.content as string) === USER_MESSAGE
+          )
+        );
+        expect(everyRequestHasUserMessage).to.be(true);
+      });
+    });
+
+    // Calling `retrieve_elastic_doc` via the chat/complete endpoint
+    describe('POST /internal/observability_ai_assistant/chat/complete', function () {
+      let llmProxy: LlmProxy;
+      let connectorId: string;
+      before(async () => {
+        llmProxy = await createLlmProxy(log);
+        connectorId = await observabilityAIAssistantAPIClient.createProxyActionConnector({
+          port: llmProxy.getPort(),
+        });
+        await observabilityAIAssistantAPIClient.installProductDoc();
+
+        void llmProxy.interceptWithFunctionRequest({
+          name: 'retrieve_elastic_doc',
+          arguments: () => JSON.stringify({}),
+          when: () => true,
+        });
+
+        void llmProxy.interceptConversation('Hello from LLM Proxy');
+
+        await chatComplete({
+          userPrompt: USER_MESSAGE,
+          connectorId,
+          observabilityAIAssistantAPIClient,
+        });
+
+        await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+      });
+
+      after(async () => {
+        await observabilityAIAssistantAPIClient.uninstallProductDoc();
+        llmProxy.close();
+        await observabilityAIAssistantAPIClient.deleteActionConnector({
+          actionId: connectorId,
+        });
+      });
+
+      it('makes 6 requests to the LLM', () => {
+        expect(llmProxy.interceptedRequests.length).to.be(6);
+      });
+
+      it('every request contain retrieve_elastic_doc function', () => {
+        const everyRequestHasRetrieveElasticDoc = llmProxy.interceptedRequests.every(
+          ({ requestBody }) =>
+            requestBody.tools?.some((t) => t.function.name === 'retrieve_elastic_doc')
+        );
+        expect(everyRequestHasRetrieveElasticDoc).to.be(true);
+      });
+
+      it('contains the original user message', () => {
+        const everyRequestHasUserMessage = llmProxy.interceptedRequests.every(({ requestBody }) =>
+          requestBody.messages.some(
+            (message) => message.role === 'user' && (message.content as string) === USER_MESSAGE
+          )
+        );
+        expect(everyRequestHasUserMessage).to.be(true);
+      });
+    });
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../../../../../observability_ai_assistant_api_integration/common/create_llm_proxy';
 import { chatComplete } from './helpers';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../../../ftr_provider_context';
+import { installProductDoc, uninstallProductDoc } from '../../utils/product_doc_base';
 
 export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
   const log = getService('log');
@@ -20,6 +21,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   describe('retrieve_elastic_doc', function () {
     // Fails on MKI: https://github.com/elastic/kibana/issues/205581
     this.tags(['failsOnMKI']);
+    const supertest = getService('supertest');
     const USER_MESSAGE = 'What is Kibana Lens?';
 
     describe('POST /internal/observability_ai_assistant/chat/complete without product doc installed', function () {
@@ -80,7 +82,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         connectorId = await observabilityAIAssistantAPIClient.createProxyActionConnector({
           port: llmProxy.getPort(),
         });
-        await observabilityAIAssistantAPIClient.installProductDoc();
+        await installProductDoc(supertest);
 
         void llmProxy.interceptWithFunctionRequest({
           name: 'retrieve_elastic_doc',
@@ -100,7 +102,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
 
       after(async () => {
-        await observabilityAIAssistantAPIClient.uninstallProductDoc();
+        await uninstallProductDoc(supertest);
         llmProxy.close();
         await observabilityAIAssistantAPIClient.deleteActionConnector({
           actionId: connectorId,

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/index.ts
@@ -20,6 +20,7 @@ export default function aiAssistantApiIntegrationTests({
     loadTestFile(require.resolve('./complete/functions/get_dataset_info.spec.ts'));
     loadTestFile(require.resolve('./complete/functions/execute_query.spec.ts'));
     loadTestFile(require.resolve('./complete/functions/elasticsearch.spec.ts'));
+    loadTestFile(require.resolve('./complete/functions/retrieve_elastic_doc.spec.ts'));
     loadTestFile(require.resolve('./complete/functions/summarize.spec.ts'));
     loadTestFile(require.resolve('./complete/functions/recall.spec.ts'));
     loadTestFile(require.resolve('./public_complete/public_complete.spec.ts'));

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/product_doc_base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/product_doc_base.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ELASTIC_HTTP_VERSION_HEADER,
+  X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
+} from '@kbn/core-http-common';
+
+import type SuperTest from 'supertest';
+
+export async function installProductDoc(supertest: SuperTest.Agent) {
+  return supertest
+    .post('/internal/product_doc_base/install')
+    .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+    .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+    .set('kbn-xsrf', 'foo')
+    .expect(200);
+}
+
+export async function uninstallProductDoc(supertest: SuperTest.Agent) {
+  return supertest
+    .post('/internal/product_doc_base/uninstall')
+    .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+    .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana')
+    .set('kbn-xsrf', 'foo')
+    .expect(200);
+}

--- a/x-pack/test/api_integration/deployment_agnostic/services/observability_ai_assistant_api.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/services/observability_ai_assistant_api.ts
@@ -140,51 +140,11 @@ function createObservabilityAIAssistantApiClient({
     }
   }
 
-  async function installProductDoc() {
-    const internalReqHeader = samlAuth.getInternalRequestHeader();
-    const roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('editor');
-    try {
-      const res = await supertestWithoutAuth
-        .post('/internal/product_doc_base/install')
-        .set(roleAuthc.apiKeyHeader)
-        .set(internalReqHeader)
-        .set('kbn-xsrf', 'foo')
-        .expect(200);
-
-      const connectorId = res.body.id as string;
-      return connectorId;
-    } catch (e) {
-      logger.error(`Failed to create action connector due to: ${e}`);
-      throw e;
-    }
-  }
-
-  async function uninstallProductDoc() {
-    const internalReqHeader = samlAuth.getInternalRequestHeader();
-    const roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('editor');
-    try {
-      const res = await supertestWithoutAuth
-        .post('/internal/product_doc_base/uninstall')
-        .set(roleAuthc.apiKeyHeader)
-        .set(internalReqHeader)
-        .set('kbn-xsrf', 'foo')
-        .expect(200);
-
-      const connectorId = res.body.id as string;
-      return connectorId;
-    } catch (e) {
-      logger.error(`Failed to create action connector due to: ${e}`);
-      throw e;
-    }
-  }
-
   return {
     makeApiRequest,
     deleteAllActionConnectors,
     deleteActionConnector,
     createProxyActionConnector,
-    installProductDoc,
-    uninstallProductDoc,
   };
 }
 
@@ -214,8 +174,6 @@ export function ObservabilityAIAssistantApiProvider(context: DeploymentAgnosticF
     deleteAllActionConnectors: observabilityAIAssistantApiClient.deleteAllActionConnectors,
     createProxyActionConnector: observabilityAIAssistantApiClient.createProxyActionConnector,
     deleteActionConnector: observabilityAIAssistantApiClient.deleteActionConnector,
-    installProductDoc: observabilityAIAssistantApiClient.installProductDoc,
-    uninstallProductDoc: observabilityAIAssistantApiClient.uninstallProductDoc,
   };
 }
 

--- a/x-pack/test/api_integration/deployment_agnostic/services/observability_ai_assistant_api.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/services/observability_ai_assistant_api.ts
@@ -140,11 +140,51 @@ function createObservabilityAIAssistantApiClient({
     }
   }
 
+  async function installProductDoc() {
+    const internalReqHeader = samlAuth.getInternalRequestHeader();
+    const roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('editor');
+    try {
+      const res = await supertestWithoutAuth
+        .post('/internal/product_doc_base/install')
+        .set(roleAuthc.apiKeyHeader)
+        .set(internalReqHeader)
+        .set('kbn-xsrf', 'foo')
+        .expect(200);
+
+      const connectorId = res.body.id as string;
+      return connectorId;
+    } catch (e) {
+      logger.error(`Failed to create action connector due to: ${e}`);
+      throw e;
+    }
+  }
+
+  async function uninstallProductDoc() {
+    const internalReqHeader = samlAuth.getInternalRequestHeader();
+    const roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('editor');
+    try {
+      const res = await supertestWithoutAuth
+        .post('/internal/product_doc_base/uninstall')
+        .set(roleAuthc.apiKeyHeader)
+        .set(internalReqHeader)
+        .set('kbn-xsrf', 'foo')
+        .expect(200);
+
+      const connectorId = res.body.id as string;
+      return connectorId;
+    } catch (e) {
+      logger.error(`Failed to create action connector due to: ${e}`);
+      throw e;
+    }
+  }
+
   return {
     makeApiRequest,
     deleteAllActionConnectors,
     deleteActionConnector,
     createProxyActionConnector,
+    installProductDoc,
+    uninstallProductDoc,
   };
 }
 
@@ -174,6 +214,8 @@ export function ObservabilityAIAssistantApiProvider(context: DeploymentAgnosticF
     deleteAllActionConnectors: observabilityAIAssistantApiClient.deleteAllActionConnectors,
     createProxyActionConnector: observabilityAIAssistantApiClient.createProxyActionConnector,
     deleteActionConnector: observabilityAIAssistantApiClient.deleteActionConnector,
+    installProductDoc: observabilityAIAssistantApiClient.installProductDoc,
+    uninstallProductDoc: observabilityAIAssistantApiClient.uninstallProductDoc,
   };
 }
 


### PR DESCRIPTION
Related: https://github.com/elastic/kibana/issues/180787

- Adds test for `retrieve_elastic_doc` function

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->