### PR TITLE
[CI] Disable docs actions on forks

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   docs-preview:
+    if: github.event.repository.fork == false
     uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
     with:
       path-pattern: docs/**

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   docs-preview:
+    if: github.event.repository.fork == false
     uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml@main
     permissions:
       contents: none


### PR DESCRIPTION
## Summary

The docs actions are running against forks and don't need to be

https://github.com/Ikuni17/kibana/actions/runs/13910741250


