### PR TITLE
[Security Solution] Fix session view error from alerts tab

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/left/components/session_view.tsx
@@ -60,7 +60,7 @@ export const SessionView: FC = memo(() => {
   const isEnabled = sessionViewConfig && isEnterprisePlus;
 
   const { selectedPatterns } = useSourcererDataView(SourcererScopeName.detections);
-  const eventDetailsIndex = useMemo(() => selectedPatterns.join(','), [selectedPatterns]);
+  const alertsIndex = useMemo(() => selectedPatterns.join(','), [selectedPatterns]);
 
   const { openPreviewPanel, closePreviewPanel } = useExpandableFlyoutApi();
   const openAlertDetailsPreview = useCallback(
@@ -75,7 +75,7 @@ export const SessionView: FC = memo(() => {
           id: DocumentDetailsPreviewPanelKey,
           params: {
             id: evtId,
-            indexName: eventDetailsIndex,
+            indexName: alertsIndex,
             scopeId,
             banner: ALERT_PREVIEW_BANNER,
             isPreviewMode: true,
@@ -87,7 +87,7 @@ export const SessionView: FC = memo(() => {
         panel: 'preview',
       });
     },
-    [openPreviewPanel, eventDetailsIndex, scopeId, telemetry]
+    [openPreviewPanel, alertsIndex, scopeId, telemetry]
   );
 
   const openDetailsInPreview = useCallback(

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/tabs/alerts_tab.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/session_view/tabs/alerts_tab.tsx
@@ -18,7 +18,8 @@ import {
 } from '../../shared/constants/panel_keys';
 import { ALERT_PREVIEW_BANNER } from '../../preview/constants';
 import { useSessionViewPanelContext } from '../context';
-
+import { SourcererScopeName } from '../../../../sourcerer/store/model';
+import { useSourcererDataView } from '../../../../sourcerer/containers';
 /**
  * Tab displayed in the SessionView preview panel, shows alerts related to the session.
  */
@@ -32,6 +33,9 @@ export const AlertsTab = memo(() => {
     isFetching: isFetchingAlerts,
     hasNextPage: hasNextPageAlerts,
   } = useFetchSessionViewAlerts(sessionEntityId, sessionStartTime, investigatedAlertId);
+
+  const { selectedPatterns } = useSourcererDataView(SourcererScopeName.detections);
+  const alertsIndex = useMemo(() => selectedPatterns.join(','), [selectedPatterns]);
 
   // this code mimics what is being done in the x-pack/plugins/session_view/public/components/session_view/index.tsx file
   const alerts = useMemo(() => {
@@ -53,14 +57,14 @@ export const AlertsTab = memo(() => {
         id: DocumentDetailsPreviewPanelKey,
         params: {
           id: evtId,
-          indexName,
+          indexName: alertsIndex,
           scopeId,
           banner: ALERT_PREVIEW_BANNER,
           isPreviewMode: true,
         },
       });
     },
-    [openPreviewPanel, indexName, scopeId]
+    [openPreviewPanel, scopeId, alertsIndex]
   );
 
   // this code mimics what is being done in the x-pack/plugins/session_view/public/components/session_view/index.tsx file


### PR DESCRIPTION
## Summary

Related: https://github.com/elastic/kibana/issues/130641

When session view is opened on non-alert pages, if alert index is not passed, an error shows up when opening alert flyout. https://github.com/elastic/kibana/pull/196422 addressed this by passing an `alertsIndex` to the index name. However, it only addressed the alerts from the canvas area, when clicking view alerts from the alert panel, the error still occurs. This PR fixed that by passing alerts index in the panel as well.

The bug only applies to alerts opened from alerts tab, and when `visualizationinFlyout` is enabled. This video shows the alerts flyout is showing correctly with the advanced setting on and off.

https://github.com/user-attachments/assets/8dca4568-4645-4718-9605-17baa0691ed0

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.18","9.0"]} ONMERGE-->