### PR TITLE
[8.17] Upgrade xml-crypto 6.0.0 → 6.0.1 (#214792)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1841,7 +1841,7 @@
     "webpack-dev-server": "^5.0.4",
     "webpack-merge": "^6.0.1",
     "webpack-sources": "^3.2.3",
-    "xml-crypto": "^6.0.0",
+    "xml-crypto": "^6.0.1",
     "xmlbuilder": "15.1.1",
     "yargs": "^15.4.1",
     "yarn-deduplicate": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30403,7 +30403,7 @@ string-replace-loader@^3.1.0:
 
 "string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30403,7 +30403,7 @@ string-replace-loader@^3.1.0:
 
 "string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
@@ -33545,10 +33545,10 @@ x-default-browser@^0.4.0:
   optionalDependencies:
     default-browser-id "^1.0.4"
 
-xml-crypto@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/xml-crypto/-/xml-crypto-6.0.0.tgz#9657ce63cbbaacc48b2c74a13d05cf0a9d339d47"
-  integrity sha512-L3RgnkaDrHaYcCnoENv4Idzt1ZRj5U1z1BDH98QdDTQfssScx8adgxhd9qwyYo+E3fXbQZjEQH7aiXHLVgxGvw==
+xml-crypto@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/xml-crypto/-/xml-crypto-6.0.1.tgz#81d224cf9f2cac9f15190bbb4ef93f53e1f8a8e8"
+  integrity sha512-v05aU7NS03z4jlZ0iZGRFeZsuKO1UfEbbYiaeRMiATBFs6Jq9+wqKquEMTn4UTrYZ9iGD8yz3KT4L9o2iF682w==
   dependencies:
     "@xmldom/is-dom-node" "^1.0.1"
     "@xmldom/xmldom" "^0.8.10"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Upgrade xml-crypto 6.0.0 → 6.0.1 (#214792)](https://github.com/elastic/kibana/pull/214792)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2025-03-17T17:57:41Z","message":"Upgrade xml-crypto 6.0.0 → 6.0.1 (#214792)\n\n## Summary\n\nUpgrades `xml-crypto` from v6.0.0 to v6.0.1","sha":"da7e44988d160c55147765959dcc19ff59d1cdb6","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v9.1.0","v9.0.1"],"title":"Upgrade xml-crypto 6.0.0 → 6.0.1","number":214792,"url":"https://github.com/elastic/kibana/pull/214792","mergeCommit":{"message":"Upgrade xml-crypto 6.0.0 → 6.0.1 (#214792)\n\n## Summary\n\nUpgrades `xml-crypto` from v6.0.0 to v6.0.1","sha":"da7e44988d160c55147765959dcc19ff59d1cdb6"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214792","number":214792,"mergeCommit":{"message":"Upgrade xml-crypto 6.0.0 → 6.0.1 (#214792)\n\n## Summary\n\nUpgrades `xml-crypto` from v6.0.0 to v6.0.1","sha":"da7e44988d160c55147765959dcc19ff59d1cdb6"}},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->