### PR TITLE
Restore files lost during relocation of src/platform/test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,11 +30,11 @@ __tmp__
 /x-pack/examples/*/build
 
 # Ignore certain functional test runner artifacts
-/test/*/failure_debug
-/test/*/screenshots/diff
-/test/*/screenshots/failure
-/test/*/screenshots/session
-/test/*/screenshots/visual_regression_gallery.html
+/src/platform/test/*/failure_debug
+/src/platform/test/*/screenshots/diff
+/src/platform/test/*/screenshots/failure
+/src/platform/test/*/screenshots/session
+/src/platform/test/*/screenshots/visual_regression_gallery.html
 
 # Ignore the same artifacts in x-pack
 /x-pack/test/*/failure_debug
@@ -70,7 +70,7 @@ webpackstats.json
 !/config/serverless.security.search_ai_lake.yml
 !/config/node.options
 coverage
-!/test/common/fixtures/plugins/coverage
+!/src/platform/test/common/fixtures/plugins/coverage
 selenium
 .babel_register_cache.json
 .webpack.babelcache

--- a/src/platform/test/common/fixtures/plugins/coverage/kibana.json
+++ b/src/platform/test/common/fixtures/plugins/coverage/kibana.json
@@ -1,0 +1,7 @@
+{
+  "id": "coverageFixtures",
+  "owner": { "name": "Kibana Operations", "githubTeam": "kibana-operations" },
+  "version": "kibana",
+  "server": false,
+  "ui": true
+}

--- a/src/platform/test/common/fixtures/plugins/coverage/public/index.ts
+++ b/src/platform/test/common/fixtures/plugins/coverage/public/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { CodeCoverageReportingPlugin } from './plugin';
+
+export function plugin() {
+  return new CodeCoverageReportingPlugin();
+}

--- a/src/platform/test/common/fixtures/plugins/coverage/public/plugin.ts
+++ b/src/platform/test/common/fixtures/plugins/coverage/public/plugin.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { Plugin } from '@kbn/core/server';
+
+declare global {
+  interface Window {
+    __coverage__: any;
+    flushCoverageToLog: any;
+  }
+}
+
+export class CodeCoverageReportingPlugin implements Plugin {
+  constructor() {}
+
+  public start() {}
+
+  public setup() {
+    window.flushCoverageToLog = function () {
+      if (window.__coverage__) {
+        // eslint-disable-next-line no-console
+        console.log('coveragejson:' + btoa(JSON.stringify(window.__coverage__)));
+      }
+    };
+    window.addEventListener('beforeunload', window.flushCoverageToLog);
+  }
+}


### PR DESCRIPTION
## Summary

These files were lost (not added during the relocation) due to outdated `.gitignore` config.