### PR TITLE
[8.x] Fix field values not visible in borealis theme (#212886)

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/common/translations.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/common/translations.ts
@@ -715,3 +715,17 @@ export const failedDocsErrorsColumnName = i18n.translate(
     defaultMessage: 'Error messages',
   }
 );
+
+export const readMore = i18n.translate(
+  'xpack.datasetQuality.details.qualityIssue.flyout.message.readMore',
+  {
+    defaultMessage: 'Read more',
+  }
+);
+
+export const readLess = i18n.translate(
+  'xpack.datasetQuality.details.qualityIssue.flyout.message.readLess',
+  {
+    defaultMessage: 'Read less',
+  }
+);

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/field_info.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/degraded_field/field_info.tsx
@@ -12,7 +12,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
-  EuiTextColor,
   EuiTitle,
   EuiToolTip,
 } from '@elastic/eui';
@@ -23,6 +22,7 @@ import {
   degradedFieldPotentialCauseColumnName,
   degradedFieldValuesColumnName,
 } from '../../../../../common/translations';
+import { ExpandableTruncatedText } from '../expandable_truncated_text';
 
 export const DegradedFieldInfo = () => {
   const {
@@ -113,13 +113,13 @@ export const DegradedFieldInfo = () => {
                 grow={2}
               >
                 <EuiBadgeGroup gutterSize="s">
-                  {degradedFieldValues?.values.map((value, idx) => (
-                    <EuiBadge color="hollow" key={idx}>
-                      <EuiTextColor color="#765B96">
-                        <strong>{value}</strong>
-                      </EuiTextColor>
-                    </EuiBadge>
-                  ))}
+                  {degradedFieldValues?.values.map((value, idx) => {
+                    return (
+                      <div key={idx} css={{ lineHeight: '1.6', width: '100%' }}>
+                        <ExpandableTruncatedText text={value} />
+                      </div>
+                    );
+                  })}
                 </EuiBadgeGroup>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/expandable_truncated_text.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/expandable_truncated_text.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { EuiCode, EuiFlexGroup } from '@elastic/eui';
+import { readLess, readMore } from '../../../../common/translations';
+
+interface TruncatedTextWithToggleProps {
+  text: string;
+  maxCharLength?: number;
+  truncatedTextLength?: number;
+  codeLanguage?: string;
+}
+
+export const ExpandableTruncatedText = ({
+  text,
+  maxCharLength = 150,
+  truncatedTextLength = 35,
+  codeLanguage,
+}: TruncatedTextWithToggleProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const shouldTruncate = text.length > maxCharLength;
+  const displayText =
+    shouldTruncate && !isExpanded ? `${text.slice(0, truncatedTextLength)}...` : text;
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="none" style={{ width: '100%' }}>
+      <EuiCode language={codeLanguage} style={{ fontWeight: 'normal' }}>
+        {displayText}
+      </EuiCode>
+      {shouldTruncate && (
+        <EuiCode>
+          <button
+            data-test-subj="truncatedTextToggle"
+            onClick={() => setIsExpanded(!isExpanded)}
+            color="primary"
+            css={{ fontWeight: 'bold', textDecoration: 'underline' }}
+          >
+            {isExpanded ? readLess : readMore}
+          </button>
+        </EuiCode>
+      )}
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/failed_docs/error_message.tsx
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/quality_issue_flyout/failed_docs/error_message.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { ExpandableTruncatedText } from '../expandable_truncated_text';
+
+const MAX_CHAR_LENGTH = 200;
+
+export const ErrorMessage = ({ errorMessage }: { errorMessage: string }) => {
+  return (
+    <ExpandableTruncatedText
+      text={errorMessage}
+      maxCharLength={MAX_CHAR_LENGTH}
+      truncatedTextLength={MAX_CHAR_LENGTH}
+      codeLanguage="js"
+    />
+  );
+};

--- a/x-pack/test/functional/apps/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/test/functional/apps/dataset_quality/degraded_field_flyout.ts
@@ -567,6 +567,15 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
             expandedDegradedField: 'test_field',
           });
 
+          await testSubjects.existOrFail(
+            'datasetQualityDetailsDegradedFieldFlyoutFieldValue-values'
+          );
+
+          const expandButtons = await testSubjects.findAll('truncatedTextToggle');
+          for (const button of expandButtons) {
+            await button.click();
+          }
+
           await retry.tryForTime(5000, async () => {
             const testFieldValue1Exists = await PageObjects.datasetQuality.doesTextExist(
               'datasetQualityDetailsDegradedFieldFlyoutFieldValue-values',

--- a/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/degraded_field_flyout.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/degraded_field_flyout.ts
@@ -574,6 +574,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
           await PageObjects.header.waitUntilLoadingHasFinished();
 
+          await testSubjects.existOrFail(
+            'datasetQualityDetailsDegradedFieldFlyoutFieldValue-values'
+          );
+          const expandButtons = await testSubjects.findAll('truncatedTextToggle');
+
+          for (const button of expandButtons) {
+            await button.click();
+          }
+
           await retry.tryForTime(5000, async () => {
             const testFieldValue1Exists = await PageObjects.datasetQuality.doesTextExist(
               'datasetQualityDetailsDegradedFieldFlyoutFieldValue-values',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix field values not visible in borealis theme (#212886)](https://github.com/elastic/kibana/pull/212886)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Robert Stelmach","email":"60304951+rStelmach@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-14T12:17:11Z","message":"Fix field values not visible in borealis theme (#212886)\n\nFIx for the text for values in the Fix It Flow Flyout on Dataset Quality\nnot being visible post Borealis upgrade in 9.1-Snapshot\n\n\n![image](https://github.com/user-attachments/assets/8dba368b-8508-44c2-95a6-8a21ef2ada48)","sha":"21ab897e17d1397ed094f9a75790011bdbe666b6","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport missing","Team:obs-ux-logs","Feature:Dataset Health","backport:version","v9.1.0","v8.19.0"],"title":"Fix field values not visible in borealis theme","number":212886,"url":"https://github.com/elastic/kibana/pull/212886","mergeCommit":{"message":"Fix field values not visible in borealis theme (#212886)\n\nFIx for the text for values in the Fix It Flow Flyout on Dataset Quality\nnot being visible post Borealis upgrade in 9.1-Snapshot\n\n\n![image](https://github.com/user-attachments/assets/8dba368b-8508-44c2-95a6-8a21ef2ada48)","sha":"21ab897e17d1397ed094f9a75790011bdbe666b6"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212886","number":212886,"mergeCommit":{"message":"Fix field values not visible in borealis theme (#212886)\n\nFIx for the text for values in the Fix It Flow Flyout on Dataset Quality\nnot being visible post Borealis upgrade in 9.1-Snapshot\n\n\n![image](https://github.com/user-attachments/assets/8dba368b-8508-44c2-95a6-8a21ef2ada48)","sha":"21ab897e17d1397ed094f9a75790011bdbe666b6"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->