### PR TITLE
[ci] Disable chrome forward testing until 2025-03-28

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-chrome-forward-testing.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-chrome-forward-testing.yml
@@ -42,9 +42,10 @@ spec:
           access_level: BUILD_AND_READ
       # Scheduled runs for the pipeline
       schedules:
-        Daily 12 pm UTC:
-          cronline: 0 12 * * *
-          message: Daily Chrome Forward Testing
-          branch: main
+         # Disabled until 2025-03-28 (Chrome will be released @ 2025-04-01)
+#        Daily 12 pm UTC:
+#          cronline: 0 12 * * *
+#          message: Daily Chrome Forward Testing
+#          branch: main
       tags:
         - kibana


### PR DESCRIPTION
## Summary
The chrome forward-testing pipeline highlights upcoming errors in next chrome versions: https://buildkite.com/elastic/kibana-chrome-forward-testing

It's currently broken since chrome-beta was updated to 135. Chrome 135 will drop to main line on [April 1st. ](https://chromiumdash.appspot.com/schedule)

Revert this by 2025-03-28, or if https://github.com/elastic/kibana/issues/213919 is finished.
