### PR TITLE
Fix custom threshold preview test failure due to the upgrade to Chrome 135

### DIFF
--- a/.buildkite/pipelines/flaky_tests/pipeline.ts
+++ b/.buildkite/pipelines/flaky_tests/pipeline.ts
@@ -139,6 +139,7 @@ for (const testSuite of testSuites) {
       command: `.buildkite/scripts/steps/test/ftr_configs.sh`,
       env: {
         FTR_CONFIG: testSuite.ftrConfig,
+        USE_CHROME_BETA: 'true',
       },
       key: `ftr-suite-${suiteIndex++}`,
       label: `${testSuite.ftrConfig}`,

--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/custom_threshold_preview_chart.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/custom_threshold_preview_chart.ts
@@ -17,6 +17,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
   const logger = getService('log');
   const retry = getService('retry');
   const pageObjects = getPageObjects(['common', 'header']);
+  const RENDER_COMPLETE_SELECTOR = '[data-render-complete="true"]';
 
   describe('Custom threshold preview chart', () => {
     const observability = getService('observability');
@@ -48,6 +49,9 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       await observability.alerts.rulesPage.clickOnObservabilityCategory();
       await observability.alerts.rulesPage.clickOnCustomThresholdRule();
       await pageObjects.common.sleep(1000);
+      const renderedPreview = await find.allByCssSelector(RENDER_COMPLETE_SELECTOR);
+      const renderingCount = Number(await renderedPreview[0].getAttribute('data-rendering-count'));
+      logger.info(`renderingCount: ${renderingCount}`);
       expect(await find.existsByCssSelector('[data-rendering-count="2"]')).toBe(true);
     });
 


### PR DESCRIPTION
Fixes #214924

## Summary

This PR fixes custom threshold preview test failure due to the upgrade to Chrome 135. (Example failure: [Mon](https://buildkite.com/elastic/kibana-chrome-forward-testing/builds/167))


