### PR TITLE
[UA] Small cosmetic fixes

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecation_logs/es_deprecation_logs.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecation_logs/es_deprecation_logs.tsx
@@ -39,7 +39,7 @@ export const EsDeprecationLogs: FunctionComponent = () => {
   }, [breadcrumbs]);
 
   return (
-    <EuiPageBody restrictWidth={true} data-test-subj="esDeprecationLogs">
+    <EuiPageBody restrictWidth data-test-subj="esDeprecationLogs" css={{ width: '100%' }}>
       <EuiPageSection color="transparent" paddingSize="none">
         <EuiPageHeader
           bottomBorder

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/common/_step_progress.scss
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/common/_step_progress.scss
@@ -1,13 +1,18 @@
 .upgStepProgress__step {
   display: flex;
   align-items: center;
-  margin-top: $euiSize;
+  margin-top: $euiSizeS;
   margin-bottom: $euiSizeS;
   line-height: $euiSize;
+
+  &:first-child {
+    margin-top: $euiSize;
+  }
 }
 
 .upgStepProgress__status {
   @include size($euiSize);
+  min-width: $euiSize;
   margin-right: $euiSizeM;
 }
 
@@ -33,6 +38,8 @@ $stepStatusToCallOutColor: (
 }
 
 .upgStepProgress__title {
+  line-height: $euiSizeL;
+
   &--currentStep {
     font-weight: $euiFontWeightBold;
   }

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/warning/warning_step_checkbox.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/warning/warning_step_checkbox.tsx
@@ -144,14 +144,17 @@ export const ReplaceIndexWithAliasWarningCheckbox: React.FunctionComponent<
         />
       }
       description={
-        <FormattedMessage
-          id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.warningsStep.replaceIndexWithAliasWarningDetail"
-          defaultMessage="You can search {indexName} as before. To delete the data you'll have to delete {reindexName}"
-          values={{
-            indexName: <EuiCode>{meta?.indexName}</EuiCode>,
-            reindexName: <EuiCode>{meta?.reindexName}</EuiCode>,
-          }}
-        />
+        <>
+          <EuiSpacer />
+          <FormattedMessage
+            id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.warningsStep.replaceIndexWithAliasWarningDetail"
+            defaultMessage="You can search {indexName} as before. To delete the data you'll have to delete {reindexName}"
+            values={{
+              indexName: <EuiCode>{meta?.indexName}</EuiCode>,
+                reindexName: <EuiCode>{meta?.reindexName}</EuiCode>,
+            }}
+          />
+        </>
       }
     />
   );

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/warning/warning_step_checkbox.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/warning/warning_step_checkbox.tsx
@@ -151,7 +151,7 @@ export const ReplaceIndexWithAliasWarningCheckbox: React.FunctionComponent<
             defaultMessage="You can search {indexName} as before. To delete the data you'll have to delete {reindexName}"
             values={{
               indexName: <EuiCode>{meta?.indexName}</EuiCode>,
-                reindexName: <EuiCode>{meta?.reindexName}</EuiCode>,
+              reindexName: <EuiCode>{meta?.reindexName}</EuiCode>,
             }}
           />
         </>


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/214865 and https://github.com/elastic/kibana/issues/212517

## Summary

This PR has a few visual fixes for UA.

// Adds a bit of spacing in accept changes checkbox
![Screenshot 2025-03-18 at 14 36 39](https://github.com/user-attachments/assets/a92b1540-cd9b-4d4c-9051-7777b0f1da70)

// Prevents wrapping of step numbers and added lineheight to prevent collision of lines
![Screenshot 2025-03-18 at 14 04 50](https://github.com/user-attachments/assets/d479bc4d-c7e7-4652-9ec9-fd39a296d3e3)

// When toggling icons/loading state line remains intact
https://github.com/user-attachments/assets/98b806ca-7db8-42ed-b699-f9f7c6e3ced0

// Fixed page wrapping when toggle is disabled
![Screenshot 2025-03-18 at 14 21 57](https://github.com/user-attachments/assets/3ac6dbb0-8d19-4736-b521-ade79b9e0ea7)

// There was already a close button for the read-only step
![Screenshot 2025-03-18 at 14 06 24](https://github.com/user-attachments/assets/5004f6cd-8701-4b0d-a5c9-18b5b18492da)




