### PR TITLE
[Docs] Add link to dependencies page - 8.15 backport

### DIFF
--- a/docs/developer/dependencies-versions.asciidoc
+++ b/docs/developer/dependencies-versions.asciidoc
@@ -1,0 +1,4 @@
+[[dependencies-versions]]
+== List of dependencies
+
+Refer to https://artifacts.elastic.co/reports/dependencies/dependencies-current.html[Elastic Stack third-party dependencies] for the complete list of dependencies.

--- a/docs/developer/index.asciidoc
+++ b/docs/developer/index.asciidoc
@@ -15,6 +15,7 @@ running in no time. If you have any problems, file an issue in the https://githu
 * <<kibana-architecture>>
 * <<advanced>>
 * <<plugin-list>>
+* <<dependencies-versions>>
 * <<development-telemetry>>
 
 --
@@ -32,6 +33,8 @@ include::plugin/index.asciidoc[]
 include::advanced/index.asciidoc[]
 
 include::plugin-list.asciidoc[]
+
+include::dependencies-versions.asciidoc[]
 
 include::telemetry.asciidoc[]
 


### PR DESCRIPTION
## Summary

This PR backports https://github.com/elastic/kibana/pull/214667 to 8.15.