### PR TITLE
[kbn-grid-layout] Fix bug when bulk moving panels to an empty row

### DIFF
--- a/src/platform/packages/private/kbn-grid-layout/grid/utils/row_management.test.ts
+++ b/src/platform/packages/private/kbn-grid-layout/grid/utils/row_management.test.ts
@@ -10,7 +10,7 @@
 import { omit } from 'lodash';
 import { getSampleLayout } from '../test_utils/sample_layout';
 import { GridLayoutData } from '../types';
-import { movePanelsToRow } from './row_management';
+import { deleteRow, movePanelsToRow } from './row_management';
 
 describe('row management', () => {
   describe('move panels to row', () => {
@@ -70,4 +70,24 @@ describe('row management', () => {
       });
     });
   });
+
+  describe('delete row', () => {
+    it('delete existing row', () => {
+      const originalLayout = getSampleLayout();
+      const newLayout = deleteRow(originalLayout, 'first');
+
+      // modification happens by value and not by reference
+      expect(originalLayout.first).toBeDefined();
+      expect(newLayout.first).not.toBeDefined();
+    });
+
+    it('delete non-existant row', () => {
+      const originalLayout = getSampleLayout();
+      expect(() => {
+        const newLayout = deleteRow(originalLayout, 'fake');
+        expect(newLayout.fake).not.toBeDefined();
+      }).not.toThrow();
+    });
+  });
 });
+s;

--- a/src/platform/packages/private/kbn-grid-layout/grid/utils/row_management.test.ts
+++ b/src/platform/packages/private/kbn-grid-layout/grid/utils/row_management.test.ts
@@ -90,4 +90,3 @@ describe('row management', () => {
     });
   });
 });
-s;

--- a/src/platform/packages/private/kbn-grid-layout/grid/utils/row_management.test.ts
+++ b/src/platform/packages/private/kbn-grid-layout/grid/utils/row_management.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { omit } from 'lodash';
+import { getSampleLayout } from '../test_utils/sample_layout';
+import { GridLayoutData } from '../types';
+import { movePanelsToRow } from './row_management';
+
+describe('row management', () => {
+  describe('move panels to row', () => {
+    const checkPanelCountsAfterMove = (
+      originalLayout: GridLayoutData,
+      newLayout: GridLayoutData,
+      startingRow: string,
+      newRow: string
+    ) => {
+      // panels are removed from the starting row
+      expect(newLayout[startingRow].panels).toEqual({});
+      // and added to the new row
+      expect(Object.keys(newLayout[newRow].panels).length).toEqual(
+        Object.keys(originalLayout[newRow].panels).length +
+          Object.keys(originalLayout[startingRow].panels).length
+      );
+    };
+
+    it('move panels from one row to another populated row', () => {
+      const originalLayout = getSampleLayout();
+      const newLayout = movePanelsToRow(originalLayout, 'third', 'first');
+      checkPanelCountsAfterMove(originalLayout, newLayout, 'third', 'first');
+
+      // existing panels in new row do not move
+      Object.values(originalLayout.first.panels).forEach((panel) => {
+        expect(panel).toEqual(newLayout.first.panels[panel.id]); // deep equal
+      });
+      // only the new panel's row is different, since no compaction was necessary
+      const newPanel = newLayout.first.panels.panel10;
+      expect(newPanel.row).toBe(14);
+      expect(omit(newPanel, 'row')).toEqual(omit(originalLayout.third.panels.panel10, 'row'));
+    });
+
+    it('move panels from one row to another empty row', () => {
+      const originalLayout = {
+        first: {
+          title: 'Large section',
+          isCollapsed: false,
+          id: 'first',
+          order: 0,
+          panels: {},
+        },
+        second: {
+          title: 'Another section',
+          isCollapsed: false,
+          id: 'second',
+          order: 1,
+          panels: getSampleLayout().first.panels,
+        },
+      };
+      const newLayout = movePanelsToRow(originalLayout, 'second', 'first');
+      checkPanelCountsAfterMove(originalLayout, newLayout, 'second', 'first');
+
+      // if no panels in new row, then just send all panels to new row with no changes
+      Object.values(originalLayout.second.panels).forEach((panel) => {
+        expect(panel).toEqual(newLayout.first.panels[panel.id]); // deep equal
+      });
+    });
+  });
+});

--- a/src/platform/packages/private/kbn-grid-layout/grid/utils/row_management.ts
+++ b/src/platform/packages/private/kbn-grid-layout/grid/utils/row_management.ts
@@ -21,9 +21,11 @@ import { resolveGridRow } from './resolve_grid_row';
 export const movePanelsToRow = (layout: GridLayoutData, startingRow: string, newRow: string) => {
   const newLayout = cloneDeep(layout);
   const panelsToMove = newLayout[startingRow].panels;
-  const maxRow = Math.max(
-    ...Object.values(newLayout[newRow].panels).map(({ row, height }) => row + height)
-  );
+  const startingPanels = Object.values(newLayout[newRow].panels);
+  const maxRow =
+    startingPanels.length > 0
+      ? Math.max(...startingPanels.map(({ row, height }) => row + height))
+      : 0;
   Object.keys(panelsToMove).forEach((index) => (panelsToMove[index].row += maxRow));
   newLayout[newRow].panels = { ...newLayout[newRow].panels, ...panelsToMove };
   newLayout[newRow] = resolveGridRow(newLayout[newRow]);


### PR DESCRIPTION
## Summary

We were not accounting for moving panels to an **empty** row in the logic for `movePanelsToRow` - this resulted in a `maxRow` of `Infinity`, which then caused the `grid-row-start` of all the panels to be `Infinity`. This caused the following bug, because CSS grid does not know how to handle `Infinity`: 


https://github.com/user-attachments/assets/671112b9-ab96-4a1d-8589-e79bebd25292



By setting `maxRow` to zero when there are no panels in the destination row, we now get the expected behaviour:



https://github.com/user-attachments/assets/7d4032e3-2699-47b0-847c-77af8f5f03ee



### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

The row feature has not been released to customers, so risk is very low.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->