### PR TITLE
[8.18] [Security Assistant] Fix inference rollover (#214718)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/use_knowledge_base_table.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings_management/use_knowledge_base_table.tsx
@@ -46,7 +46,7 @@ const useUserProfile = ({ username, enabled = true }: { username: string; enable
     },
     select: (profile) => {
       return {
-        username: profile?.[0]?.user.username ?? 'Unknown',
+        username: profile?.[0]?.user.username ?? username ?? 'Unknown',
         avatar: profile?.[0]?.data.avatar,
       };
     },

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_data_clients/knowledge_base/create_knowledge_base_entry.ts
@@ -120,7 +120,7 @@ export const transformToUpdateSchema = ({
   const base = {
     id: entry.id,
     updated_at: updatedAt,
-    updated_by: user.profile_uid ?? 'unknown',
+    updated_by: user.profile_uid ?? user.username ?? 'unknown',
     name: entry.name,
     type: entry.type,
     global: entry.global,
@@ -186,9 +186,9 @@ export const transformToCreateSchema = ({
   const base = {
     '@timestamp': createdAt,
     created_at: createdAt,
-    created_by: user.profile_uid ?? 'unknown',
+    created_by: user.profile_uid ?? user.username ?? 'unknown',
     updated_at: createdAt,
-    updated_by: user.profile_uid ?? 'unknown',
+    updated_by: user.profile_uid ?? user.username ?? 'unknown',
     name: entry.name,
     namespace: spaceId,
     type: entry.type,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.ts
@@ -224,7 +224,7 @@ export class AIAssistantService {
   private async rolloverDataStream(
     initialInferenceEndpointId: string,
     targetInferenceEndpointId: string
-  ): Promise<void> {
+  ): Promise<DataStreamSpacesAdapter> {
     const esClient = await this.options.elasticsearchClientPromise;
 
     const currentDataStream = this.createDataStream({
@@ -289,6 +289,8 @@ export class AIAssistantService {
     } catch (e) {
       /* empty */
     }
+
+    return newDS;
   }
 
   private async initializeResources(): Promise<InitializationPromise> {
@@ -340,12 +342,12 @@ export class AIAssistantService {
 
       // Used only for testing purposes
       if (this.modelIdOverride && !isUsingDedicatedInferenceEndpoint) {
-        await this.rolloverDataStream(
+        this.knowledgeBaseDataStream = await this.rolloverDataStream(
           ELASTICSEARCH_ELSER_INFERENCE_ID,
           ASSISTANT_ELSER_INFERENCE_ID
         );
       } else if (isUsingDedicatedInferenceEndpoint) {
-        await this.rolloverDataStream(
+        this.knowledgeBaseDataStream = await this.rolloverDataStream(
           ASSISTANT_ELSER_INFERENCE_ID,
           ELASTICSEARCH_ELSER_INFERENCE_ID
         );
@@ -362,7 +364,7 @@ export class AIAssistantService {
             `Deleted existing inference endpoint ${ASSISTANT_ELSER_INFERENCE_ID} for ELSER model '${elserId}'`
           );
         } catch (error) {
-          this.options.logger.error(
+          this.options.logger.debug(
             `Error deleting inference endpoint ${ASSISTANT_ELSER_INFERENCE_ID} for ELSER model '${elserId}':\n${error}`
           );
         }
@@ -385,12 +387,13 @@ export class AIAssistantService {
           },
           writeIndexOnly: true,
         });
-        await this.knowledgeBaseDataStream.install({
-          esClient,
-          logger: this.options.logger,
-          pluginStop$: this.options.pluginStop$,
-        });
       }
+
+      await this.knowledgeBaseDataStream.install({
+        esClient,
+        logger: this.options.logger,
+        pluginStop$: this.options.pluginStop$,
+      });
 
       await this.promptsDataStream.install({
         esClient,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/data_stream/documents_data_writer.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/data_stream/documents_data_writer.ts
@@ -136,13 +136,15 @@ export class DocumentsDataWriter implements DocumentsDataWriter {
               path: 'users',
               query: {
                 bool: {
-                  must: [
-                    {
-                      match: authenticatedUser.profile_uid
-                        ? { 'users.id': authenticatedUser.profile_uid }
-                        : { 'users.name': authenticatedUser.username },
-                    },
+                  should: [
+                    // Match on users.id if profile_uid exists
+                    ...(authenticatedUser.profile_uid
+                      ? [{ term: { 'users.id': authenticatedUser.profile_uid } }]
+                      : []),
+                    // Always try to match on users.name
+                    { term: { 'users.name': authenticatedUser.username } },
                   ],
+                  minimum_should_match: 1,
                 },
               },
             },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Security Assistant] Fix inference rollover (#214718)](https://github.com/elastic/kibana/pull/214718)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Patryk Kopyciński","email":"contact@patrykkopycinski.com"},"sourceCommit":{"committedDate":"2025-03-18T17:47:45Z","message":"[Security Assistant] Fix inference rollover (#214718)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/214709#event-16799922233\n\nThe issue was caused by the rollover of the Knowledge Base Data stream\nto use default inference endpoint.\nDuring the rollover it first got to this branch\nhttps://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.ts#L347-L369\nwhere it went through all the steps and continued, but it didn't\noverride `this.knowledgeBaseStream`, so the next time someone hit API it\nwas going through this path calling `getInitializedResources` to make\nsure all data streams were configured properly, but because we didn't\nupdate `this.knowledgeBaseStream` it was failing, because the original\nconfiguration that was created in service constructor was not called,\nthat's why it was returning an error","sha":"be777cf44f8313c995379a5bc4485ab1e26b14ac","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","v9.0.0","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Security Assistant] Fix inference rollover","number":214718,"url":"https://github.com/elastic/kibana/pull/214718","mergeCommit":{"message":"[Security Assistant] Fix inference rollover (#214718)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/214709#event-16799922233\n\nThe issue was caused by the rollover of the Knowledge Base Data stream\nto use default inference endpoint.\nDuring the rollover it first got to this branch\nhttps://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.ts#L347-L369\nwhere it went through all the steps and continued, but it didn't\noverride `this.knowledgeBaseStream`, so the next time someone hit API it\nwas going through this path calling `getInitializedResources` to make\nsure all data streams were configured properly, but because we didn't\nupdate `this.knowledgeBaseStream` it was failing, because the original\nconfiguration that was created in service constructor was not called,\nthat's why it was returning an error","sha":"be777cf44f8313c995379a5bc4485ab1e26b14ac"}},"sourceBranch":"main","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215043","number":215043,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214718","number":214718,"mergeCommit":{"message":"[Security Assistant] Fix inference rollover (#214718)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/214709#event-16799922233\n\nThe issue was caused by the rollover of the Knowledge Base Data stream\nto use default inference endpoint.\nDuring the rollover it first got to this branch\nhttps://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/elastic_assistant/server/ai_assistant_service/index.ts#L347-L369\nwhere it went through all the steps and continued, but it didn't\noverride `this.knowledgeBaseStream`, so the next time someone hit API it\nwas going through this path calling `getInitializedResources` to make\nsure all data streams were configured properly, but because we didn't\nupdate `this.knowledgeBaseStream` it was failing, because the original\nconfiguration that was created in service constructor was not called,\nthat's why it was returning an error","sha":"be777cf44f8313c995379a5bc4485ab1e26b14ac"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215042","number":215042,"state":"OPEN"}]}] BACKPORT-->