### PR TITLE
fix(NA): retrieve_elastic_doc tests helpers import

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
@@ -10,7 +10,7 @@ import {
   LlmProxy,
   createLlmProxy,
 } from '../../../../../../../observability_ai_assistant_api_integration/common/create_llm_proxy';
-import { chatComplete } from './helpers';
+import { chatComplete } from '../../utils/conversation';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../../../ftr_provider_context';
 import { installProductDoc, uninstallProductDoc } from '../../utils/product_doc_base';
 


### PR DESCRIPTION
This PR fixes https://github.com/elastic/kibana/pull/214880 as it included a non existent import

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->