### PR TITLE
[package testing] Skip FTR

### DIFF
--- a/.buildkite/scripts/steps/package_testing/test.sh
+++ b/.buildkite/scripts/steps/package_testing/test.sh
@@ -56,5 +56,6 @@ export TEST_ES_URL="http://elastic:changeme@192.168.56.1:9200"
 
 cd x-pack
 
-echo "--- FTR - Reporting"
-node scripts/functional_test_runner.js --config src/platform/test/functional/apps/visualize/config.ts --include-tag=smoke --quiet
+# Re-enable after finding suitable suites, --include-tag=smoke does not currently have any matches
+# echo "--- FTR - Reporting"
+# node scripts/functional_test_runner.js --config src/platform/test/functional/apps/visualize/config.ts --include-tag=smoke --quiet


### PR DESCRIPTION
The functional test run during package testing is currently erroring post folder migration, but after fixing the path it's still not going to match on any tests.

This temporarily disables the step while alternatives are considered.

Related to https://github.com/elastic/kibana/pull/214730 and https://github.com/elastic/kibana/pull/210956

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->