### PR TITLE
Update SLO custom metric bundle

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -59933,31 +59933,52 @@ components:
                 metrics:
                   description: List of metrics with their name, aggregation type, and field.
                   items:
-                    type: object
-                    properties:
-                      aggregation:
-                        description: The aggregation type of the metric.
-                        enum:
-                          - sum
-                          - doc_count
-                        example: sum
-                        type: string
-                      field:
-                        description: The field of the metric.
-                        example: processor.processed
-                        type: string
-                      filter:
-                        description: The filter to apply to the metric.
-                        example: 'processor.outcome: "success"'
-                        type: string
-                      name:
-                        description: The name of the metric. Only valid options are A-Z
-                        example: A
-                        pattern: ^[A-Z]$
-                        type: string
-                    required:
-                      - name
-                      - aggregation
+                    oneOf:
+                      - type: object
+                        properties:
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            enum:
+                              - sum
+                            example: sum
+                            type: string
+                          field:
+                            description: The field of the metric.
+                            example: processor.processed
+                            type: string
+                          filter:
+                            description: The filter to apply to the metric.
+                            example: 'processor.outcome: *'
+                            type: string
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            example: A
+                            pattern: ^[A-Z]$
+                            type: string
+                        required:
+                          - name
+                          - aggregation
+                          - field
+                      - type: object
+                        properties:
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            enum:
+                              - doc_count
+                            example: doc_count
+                            type: string
+                          filter:
+                            description: The filter to apply to the metric.
+                            example: 'processor.outcome: *'
+                            type: string
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            example: A
+                            pattern: ^[A-Z]$
+                            type: string
+                        required:
+                          - name
+                          - aggregation
                   type: array
               required:
                 - metrics
@@ -59983,31 +60004,52 @@ components:
                 metrics:
                   description: List of metrics with their name, aggregation type, and field.
                   items:
-                    type: object
-                    properties:
-                      aggregation:
-                        description: The aggregation type of the metric.
-                        enum:
-                          - sum
-                          - doc_count
-                        example: sum
-                        type: string
-                      field:
-                        description: The field of the metric.
-                        example: processor.processed
-                        type: string
-                      filter:
-                        description: The filter to apply to the metric.
-                        example: 'processor.outcome: *'
-                        type: string
-                      name:
-                        description: The name of the metric. Only valid options are A-Z
-                        example: A
-                        pattern: ^[A-Z]$
-                        type: string
-                    required:
-                      - name
-                      - aggregation
+                    oneOf:
+                      - type: object
+                        properties:
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            enum:
+                              - sum
+                            example: sum
+                            type: string
+                          field:
+                            description: The field of the metric.
+                            example: processor.processed
+                            type: string
+                          filter:
+                            description: The filter to apply to the metric.
+                            example: 'processor.outcome: *'
+                            type: string
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            example: A
+                            pattern: ^[A-Z]$
+                            type: string
+                        required:
+                          - name
+                          - aggregation
+                          - field
+                      - type: object
+                        properties:
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            enum:
+                              - doc_count
+                            example: doc_count
+                            type: string
+                          filter:
+                            description: The filter to apply to the metric.
+                            example: 'processor.outcome: *'
+                            type: string
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            example: A
+                            pattern: ^[A-Z]$
+                            type: string
+                        required:
+                          - name
+                          - aggregation
                   type: array
               required:
                 - metrics

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -44363,16 +44363,20 @@ paths:
           name: kqlQuery
           schema:
             type: string
-        - description: Size provided for cursor based pagination
-          example: 25
+        - description: The page size to use for cursor-based pagination, must be greater or equal than 1
+          example: 1
           in: query
           name: size
           schema:
+            default: 1
             type: integer
-        - in: query
+        - description: The cursor to use for fetching the results from, when using a cursor-base pagination.
+          in: query
           name: searchAfter
           schema:
-            type: string
+            items:
+              type: string
+            type: array
         - description: The page to use for pagination, must be greater or equal than 1
           example: 1
           in: query
@@ -59676,20 +59680,50 @@ components:
     SLOs_find_slo_definitions_response:
       description: |
         A paginated response of SLO definitions matching the query.
-      properties:
-        page:
-          example: 2
-          type: number
-        perPage:
-          example: 100
-          type: number
-        results:
-          items:
-            $ref: '#/components/schemas/SLOs_slo_definition_response'
-          type: array
-        total:
-          example: 123
-          type: number
+      oneOf:
+        - type: object
+          properties:
+            page:
+              example: 1
+              type: number
+            perPage:
+              example: 25
+              type: number
+            results:
+              items:
+                $ref: '#/components/schemas/SLOs_slo_with_summary_response'
+              type: array
+            total:
+              example: 34
+              type: number
+        - type: object
+          properties:
+            page:
+              default: 1
+              description: for backward compability
+              type: number
+            perPage:
+              description: for backward compability
+              example: 25
+              type: number
+            results:
+              items:
+                $ref: '#/components/schemas/SLOs_slo_with_summary_response'
+              type: array
+            searchAfter:
+              description: the cursor to provide to get the next paged results
+              example:
+                - some-slo-id
+                - other-cursor-id
+              items:
+                type: string
+              type: array
+            size:
+              example: 25
+              type: number
+            total:
+              example: 34
+              type: number
       title: Find SLO definitions response
       type: object
     SLOs_find_slo_response:
@@ -59902,9 +59936,10 @@ components:
                     type: object
                     properties:
                       aggregation:
-                        description: The aggregation type of the metric. Only valid option is "sum"
+                        description: The aggregation type of the metric.
                         enum:
                           - sum
+                          - doc_count
                         example: sum
                         type: string
                       field:
@@ -59923,7 +59958,6 @@ components:
                     required:
                       - name
                       - aggregation
-                      - field
                   type: array
               required:
                 - metrics
@@ -59952,9 +59986,10 @@ components:
                     type: object
                     properties:
                       aggregation:
-                        description: The aggregation type of the metric. Only valid option is "sum"
+                        description: The aggregation type of the metric.
                         enum:
                           - sum
+                          - doc_count
                         example: sum
                         type: string
                       field:
@@ -59973,7 +60008,6 @@ components:
                     required:
                       - name
                       - aggregation
-                      - field
                   type: array
               required:
                 - metrics

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -67525,31 +67525,52 @@ components:
                 metrics:
                   description: List of metrics with their name, aggregation type, and field.
                   items:
-                    type: object
-                    properties:
-                      aggregation:
-                        description: The aggregation type of the metric.
-                        enum:
-                          - sum
-                          - doc_count
-                        example: sum
-                        type: string
-                      field:
-                        description: The field of the metric.
-                        example: processor.processed
-                        type: string
-                      filter:
-                        description: The filter to apply to the metric.
-                        example: 'processor.outcome: "success"'
-                        type: string
-                      name:
-                        description: The name of the metric. Only valid options are A-Z
-                        example: A
-                        pattern: ^[A-Z]$
-                        type: string
-                    required:
-                      - name
-                      - aggregation
+                    oneOf:
+                      - type: object
+                        properties:
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            enum:
+                              - sum
+                            example: sum
+                            type: string
+                          field:
+                            description: The field of the metric.
+                            example: processor.processed
+                            type: string
+                          filter:
+                            description: The filter to apply to the metric.
+                            example: 'processor.outcome: *'
+                            type: string
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            example: A
+                            pattern: ^[A-Z]$
+                            type: string
+                        required:
+                          - name
+                          - aggregation
+                          - field
+                      - type: object
+                        properties:
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            enum:
+                              - doc_count
+                            example: doc_count
+                            type: string
+                          filter:
+                            description: The filter to apply to the metric.
+                            example: 'processor.outcome: *'
+                            type: string
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            example: A
+                            pattern: ^[A-Z]$
+                            type: string
+                        required:
+                          - name
+                          - aggregation
                   type: array
               required:
                 - metrics
@@ -67575,31 +67596,52 @@ components:
                 metrics:
                   description: List of metrics with their name, aggregation type, and field.
                   items:
-                    type: object
-                    properties:
-                      aggregation:
-                        description: The aggregation type of the metric.
-                        enum:
-                          - sum
-                          - doc_count
-                        example: sum
-                        type: string
-                      field:
-                        description: The field of the metric.
-                        example: processor.processed
-                        type: string
-                      filter:
-                        description: The filter to apply to the metric.
-                        example: 'processor.outcome: *'
-                        type: string
-                      name:
-                        description: The name of the metric. Only valid options are A-Z
-                        example: A
-                        pattern: ^[A-Z]$
-                        type: string
-                    required:
-                      - name
-                      - aggregation
+                    oneOf:
+                      - type: object
+                        properties:
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            enum:
+                              - sum
+                            example: sum
+                            type: string
+                          field:
+                            description: The field of the metric.
+                            example: processor.processed
+                            type: string
+                          filter:
+                            description: The filter to apply to the metric.
+                            example: 'processor.outcome: *'
+                            type: string
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            example: A
+                            pattern: ^[A-Z]$
+                            type: string
+                        required:
+                          - name
+                          - aggregation
+                          - field
+                      - type: object
+                        properties:
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            enum:
+                              - doc_count
+                            example: doc_count
+                            type: string
+                          filter:
+                            description: The filter to apply to the metric.
+                            example: 'processor.outcome: *'
+                            type: string
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            example: A
+                            pattern: ^[A-Z]$
+                            type: string
+                        required:
+                          - name
+                          - aggregation
                   type: array
               required:
                 - metrics

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -48042,16 +48042,20 @@ paths:
           name: kqlQuery
           schema:
             type: string
-        - description: Size provided for cursor based pagination
-          example: 25
+        - description: The page size to use for cursor-based pagination, must be greater or equal than 1
+          example: 1
           in: query
           name: size
           schema:
+            default: 1
             type: integer
-        - in: query
+        - description: The cursor to use for fetching the results from, when using a cursor-base pagination.
+          in: query
           name: searchAfter
           schema:
-            type: string
+            items:
+              type: string
+            type: array
         - description: The page to use for pagination, must be greater or equal than 1
           example: 1
           in: query
@@ -67268,20 +67272,50 @@ components:
     SLOs_find_slo_definitions_response:
       description: |
         A paginated response of SLO definitions matching the query.
-      properties:
-        page:
-          example: 2
-          type: number
-        perPage:
-          example: 100
-          type: number
-        results:
-          items:
-            $ref: '#/components/schemas/SLOs_slo_definition_response'
-          type: array
-        total:
-          example: 123
-          type: number
+      oneOf:
+        - type: object
+          properties:
+            page:
+              example: 1
+              type: number
+            perPage:
+              example: 25
+              type: number
+            results:
+              items:
+                $ref: '#/components/schemas/SLOs_slo_with_summary_response'
+              type: array
+            total:
+              example: 34
+              type: number
+        - type: object
+          properties:
+            page:
+              default: 1
+              description: for backward compability
+              type: number
+            perPage:
+              description: for backward compability
+              example: 25
+              type: number
+            results:
+              items:
+                $ref: '#/components/schemas/SLOs_slo_with_summary_response'
+              type: array
+            searchAfter:
+              description: the cursor to provide to get the next paged results
+              example:
+                - some-slo-id
+                - other-cursor-id
+              items:
+                type: string
+              type: array
+            size:
+              example: 25
+              type: number
+            total:
+              example: 34
+              type: number
       title: Find SLO definitions response
       type: object
     SLOs_find_slo_response:
@@ -67494,9 +67528,10 @@ components:
                     type: object
                     properties:
                       aggregation:
-                        description: The aggregation type of the metric. Only valid option is "sum"
+                        description: The aggregation type of the metric.
                         enum:
                           - sum
+                          - doc_count
                         example: sum
                         type: string
                       field:
@@ -67515,7 +67550,6 @@ components:
                     required:
                       - name
                       - aggregation
-                      - field
                   type: array
               required:
                 - metrics
@@ -67544,9 +67578,10 @@ components:
                     type: object
                     properties:
                       aggregation:
-                        description: The aggregation type of the metric. Only valid option is "sum"
+                        description: The aggregation type of the metric.
                         enum:
                           - sum
+                          - doc_count
                         example: sum
                         type: string
                       field:
@@ -67565,7 +67600,6 @@ components:
                     required:
                       - name
                       - aggregation
-                      - field
                   type: array
               required:
                 - metrics

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.json
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.json
@@ -1256,38 +1256,70 @@
                     "description": "List of metrics with their name, aggregation type, and field.",
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "required": [
-                        "name",
-                        "aggregation"
-                      ],
-                      "properties": {
-                        "name": {
-                          "description": "The name of the metric. Only valid options are A-Z",
-                          "type": "string",
-                          "example": "A",
-                          "pattern": "^[A-Z]$"
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "aggregation",
+                            "field"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "The name of the metric. Only valid options are A-Z",
+                              "type": "string",
+                              "example": "A",
+                              "pattern": "^[A-Z]$"
+                            },
+                            "aggregation": {
+                              "description": "The aggregation type of the metric.",
+                              "type": "string",
+                              "example": "sum",
+                              "enum": [
+                                "sum"
+                              ]
+                            },
+                            "field": {
+                              "description": "The field of the metric.",
+                              "type": "string",
+                              "example": "processor.processed"
+                            },
+                            "filter": {
+                              "description": "The filter to apply to the metric.",
+                              "type": "string",
+                              "example": "processor.outcome: *"
+                            }
+                          }
                         },
-                        "aggregation": {
-                          "description": "The aggregation type of the metric.",
-                          "type": "string",
-                          "example": "sum",
-                          "enum": [
-                            "sum",
-                            "doc_count"
-                          ]
-                        },
-                        "field": {
-                          "description": "The field of the metric.",
-                          "type": "string",
-                          "example": "processor.processed"
-                        },
-                        "filter": {
-                          "description": "The filter to apply to the metric.",
-                          "type": "string",
-                          "example": "processor.outcome: \"success\""
+                        {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "aggregation"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "The name of the metric. Only valid options are A-Z",
+                              "type": "string",
+                              "example": "A",
+                              "pattern": "^[A-Z]$"
+                            },
+                            "aggregation": {
+                              "description": "The aggregation type of the metric.",
+                              "type": "string",
+                              "example": "doc_count",
+                              "enum": [
+                                "doc_count"
+                              ]
+                            },
+                            "filter": {
+                              "description": "The filter to apply to the metric.",
+                              "type": "string",
+                              "example": "processor.outcome: *"
+                            }
+                          }
                         }
-                      }
+                      ]
                     }
                   },
                   "equation": {
@@ -1309,38 +1341,70 @@
                     "description": "List of metrics with their name, aggregation type, and field.",
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "required": [
-                        "name",
-                        "aggregation"
-                      ],
-                      "properties": {
-                        "name": {
-                          "description": "The name of the metric. Only valid options are A-Z",
-                          "type": "string",
-                          "example": "A",
-                          "pattern": "^[A-Z]$"
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "aggregation",
+                            "field"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "The name of the metric. Only valid options are A-Z",
+                              "type": "string",
+                              "example": "A",
+                              "pattern": "^[A-Z]$"
+                            },
+                            "aggregation": {
+                              "description": "The aggregation type of the metric.",
+                              "type": "string",
+                              "example": "sum",
+                              "enum": [
+                                "sum"
+                              ]
+                            },
+                            "field": {
+                              "description": "The field of the metric.",
+                              "type": "string",
+                              "example": "processor.processed"
+                            },
+                            "filter": {
+                              "description": "The filter to apply to the metric.",
+                              "type": "string",
+                              "example": "processor.outcome: *"
+                            }
+                          }
                         },
-                        "aggregation": {
-                          "description": "The aggregation type of the metric.",
-                          "type": "string",
-                          "example": "sum",
-                          "enum": [
-                            "sum",
-                            "doc_count"
-                          ]
-                        },
-                        "field": {
-                          "description": "The field of the metric.",
-                          "type": "string",
-                          "example": "processor.processed"
-                        },
-                        "filter": {
-                          "description": "The filter to apply to the metric.",
-                          "type": "string",
-                          "example": "processor.outcome: *"
+                        {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "aggregation"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "The name of the metric. Only valid options are A-Z",
+                              "type": "string",
+                              "example": "A",
+                              "pattern": "^[A-Z]$"
+                            },
+                            "aggregation": {
+                              "description": "The aggregation type of the metric.",
+                              "type": "string",
+                              "example": "doc_count",
+                              "enum": [
+                                "doc_count"
+                              ]
+                            },
+                            "filter": {
+                              "description": "The filter to apply to the metric.",
+                              "type": "string",
+                              "example": "processor.outcome: *"
+                            }
+                          }
                         }
-                      }
+                      ]
                     }
                   },
                   "equation": {

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.json
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.json
@@ -134,17 +134,22 @@
           {
             "name": "size",
             "in": "query",
+            "description": "The page size to use for cursor-based pagination, must be greater or equal than 1",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 1
             },
-            "example": 25,
-            "description": "Size provided for cursor based pagination"
+            "example": 1
           },
           {
             "name": "searchAfter",
             "in": "query",
+            "description": "The cursor to use for fetching the results from, when using a cursor-base pagination.",
             "schema": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           {
@@ -1254,8 +1259,7 @@
                       "type": "object",
                       "required": [
                         "name",
-                        "aggregation",
-                        "field"
+                        "aggregation"
                       ],
                       "properties": {
                         "name": {
@@ -1265,11 +1269,12 @@
                           "pattern": "^[A-Z]$"
                         },
                         "aggregation": {
-                          "description": "The aggregation type of the metric. Only valid option is \"sum\"",
+                          "description": "The aggregation type of the metric.",
                           "type": "string",
                           "example": "sum",
                           "enum": [
-                            "sum"
+                            "sum",
+                            "doc_count"
                           ]
                         },
                         "field": {
@@ -1307,8 +1312,7 @@
                       "type": "object",
                       "required": [
                         "name",
-                        "aggregation",
-                        "field"
+                        "aggregation"
                       ],
                       "properties": {
                         "name": {
@@ -1318,11 +1322,12 @@
                           "pattern": "^[A-Z]$"
                         },
                         "aggregation": {
-                          "description": "The aggregation type of the metric. Only valid option is \"sum\"",
+                          "description": "The aggregation type of the metric.",
                           "type": "string",
                           "example": "sum",
                           "enum": [
-                            "sum"
+                            "sum",
+                            "doc_count"
                           ]
                         },
                         "field": {
@@ -2418,26 +2423,71 @@
         "title": "Find SLO definitions response",
         "description": "A paginated response of SLO definitions matching the query.\n",
         "type": "object",
-        "properties": {
-          "page": {
-            "type": "number",
-            "example": 2
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number",
+                "example": 1
+              },
+              "perPage": {
+                "type": "number",
+                "example": 25
+              },
+              "total": {
+                "type": "number",
+                "example": 34
+              },
+              "results": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/slo_with_summary_response"
+                }
+              }
+            }
           },
-          "perPage": {
-            "type": "number",
-            "example": 100
-          },
-          "total": {
-            "type": "number",
-            "example": 123
-          },
-          "results": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/slo_definition_response"
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number",
+                "default": 1,
+                "description": "for backward compability"
+              },
+              "perPage": {
+                "type": "number",
+                "example": 25,
+                "description": "for backward compability"
+              },
+              "size": {
+                "type": "number",
+                "example": 25
+              },
+              "searchAfter": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "example": [
+                  "some-slo-id",
+                  "other-cursor-id"
+                ],
+                "description": "the cursor to provide to get the next paged results"
+              },
+              "total": {
+                "type": "number",
+                "example": 34
+              },
+              "results": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/slo_with_summary_response"
+                }
+              }
             }
           }
-        }
+        ]
       },
       "delete_slo_instances_request": {
         "title": "Delete SLO instances request",

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.yaml
@@ -821,31 +821,52 @@ components:
                   description: List of metrics with their name, aggregation type, and field.
                   type: array
                   items:
-                    type: object
-                    required:
-                      - name
-                      - aggregation
-                    properties:
-                      name:
-                        description: The name of the metric. Only valid options are A-Z
-                        type: string
-                        example: A
-                        pattern: ^[A-Z]$
-                      aggregation:
-                        description: The aggregation type of the metric.
-                        type: string
-                        example: sum
-                        enum:
-                          - sum
-                          - doc_count
-                      field:
-                        description: The field of the metric.
-                        type: string
-                        example: processor.processed
-                      filter:
-                        description: The filter to apply to the metric.
-                        type: string
-                        example: 'processor.outcome: "success"'
+                    oneOf:
+                      - type: object
+                        required:
+                          - name
+                          - aggregation
+                          - field
+                        properties:
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            type: string
+                            example: A
+                            pattern: ^[A-Z]$
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            type: string
+                            example: sum
+                            enum:
+                              - sum
+                          field:
+                            description: The field of the metric.
+                            type: string
+                            example: processor.processed
+                          filter:
+                            description: The filter to apply to the metric.
+                            type: string
+                            example: 'processor.outcome: *'
+                      - type: object
+                        required:
+                          - name
+                          - aggregation
+                        properties:
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            type: string
+                            example: A
+                            pattern: ^[A-Z]$
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            type: string
+                            example: doc_count
+                            enum:
+                              - doc_count
+                          filter:
+                            description: The filter to apply to the metric.
+                            type: string
+                            example: 'processor.outcome: *'
                 equation:
                   description: The equation to calculate the "good" metric.
                   type: string
@@ -862,31 +883,52 @@ components:
                   description: List of metrics with their name, aggregation type, and field.
                   type: array
                   items:
-                    type: object
-                    required:
-                      - name
-                      - aggregation
-                    properties:
-                      name:
-                        description: The name of the metric. Only valid options are A-Z
-                        type: string
-                        example: A
-                        pattern: ^[A-Z]$
-                      aggregation:
-                        description: The aggregation type of the metric.
-                        type: string
-                        example: sum
-                        enum:
-                          - sum
-                          - doc_count
-                      field:
-                        description: The field of the metric.
-                        type: string
-                        example: processor.processed
-                      filter:
-                        description: The filter to apply to the metric.
-                        type: string
-                        example: 'processor.outcome: *'
+                    oneOf:
+                      - type: object
+                        required:
+                          - name
+                          - aggregation
+                          - field
+                        properties:
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            type: string
+                            example: A
+                            pattern: ^[A-Z]$
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            type: string
+                            example: sum
+                            enum:
+                              - sum
+                          field:
+                            description: The field of the metric.
+                            type: string
+                            example: processor.processed
+                          filter:
+                            description: The filter to apply to the metric.
+                            type: string
+                            example: 'processor.outcome: *'
+                      - type: object
+                        required:
+                          - name
+                          - aggregation
+                        properties:
+                          name:
+                            description: The name of the metric. Only valid options are A-Z
+                            type: string
+                            example: A
+                            pattern: ^[A-Z]$
+                          aggregation:
+                            description: The aggregation type of the metric.
+                            type: string
+                            example: doc_count
+                            enum:
+                              - doc_count
+                          filter:
+                            description: The filter to apply to the metric.
+                            type: string
+                            example: 'processor.outcome: *'
                 equation:
                   description: The equation to calculate the "total" metric.
                   type: string

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.yaml
@@ -83,14 +83,18 @@ paths:
           example: 'slo.name:latency* and slo.tags : "prod"'
         - name: size
           in: query
+          description: The page size to use for cursor-based pagination, must be greater or equal than 1
           schema:
             type: integer
-          example: 25
-          description: Size provided for cursor based pagination
+            default: 1
+          example: 1
         - name: searchAfter
           in: query
+          description: The cursor to use for fetching the results from, when using a cursor-base pagination.
           schema:
-            type: string
+            type: array
+            items:
+              type: string
         - name: page
           in: query
           description: The page to use for pagination, must be greater or equal than 1
@@ -821,7 +825,6 @@ components:
                     required:
                       - name
                       - aggregation
-                      - field
                     properties:
                       name:
                         description: The name of the metric. Only valid options are A-Z
@@ -829,11 +832,12 @@ components:
                         example: A
                         pattern: ^[A-Z]$
                       aggregation:
-                        description: The aggregation type of the metric. Only valid option is "sum"
+                        description: The aggregation type of the metric.
                         type: string
                         example: sum
                         enum:
                           - sum
+                          - doc_count
                       field:
                         description: The field of the metric.
                         type: string
@@ -862,7 +866,6 @@ components:
                     required:
                       - name
                       - aggregation
-                      - field
                     properties:
                       name:
                         description: The name of the metric. Only valid options are A-Z
@@ -870,11 +873,12 @@ components:
                         example: A
                         pattern: ^[A-Z]$
                       aggregation:
-                        description: The aggregation type of the metric. Only valid option is "sum"
+                        description: The aggregation type of the metric.
                         type: string
                         example: sum
                         enum:
                           - sum
+                          - doc_count
                       field:
                         description: The field of the metric.
                         type: string
@@ -1672,20 +1676,50 @@ components:
       description: |
         A paginated response of SLO definitions matching the query.
       type: object
-      properties:
-        page:
-          type: number
-          example: 2
-        perPage:
-          type: number
-          example: 100
-        total:
-          type: number
-          example: 123
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/slo_definition_response'
+      oneOf:
+        - type: object
+          properties:
+            page:
+              type: number
+              example: 1
+            perPage:
+              type: number
+              example: 25
+            total:
+              type: number
+              example: 34
+            results:
+              type: array
+              items:
+                $ref: '#/components/schemas/slo_with_summary_response'
+        - type: object
+          properties:
+            page:
+              type: number
+              default: 1
+              description: for backward compability
+            perPage:
+              type: number
+              example: 25
+              description: for backward compability
+            size:
+              type: number
+              example: 25
+            searchAfter:
+              type: array
+              items:
+                type: string
+              example:
+                - some-slo-id
+                - other-cursor-id
+              description: the cursor to provide to get the next paged results
+            total:
+              type: number
+              example: 34
+            results:
+              type: array
+              items:
+                $ref: '#/components/schemas/slo_with_summary_response'
     delete_slo_instances_request:
       title: Delete SLO instances request
       description: |

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/indicator_properties_custom_metric.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/indicator_properties_custom_metric.yaml
@@ -45,31 +45,52 @@ properties:
             description: List of metrics with their name, aggregation type, and field.
             type: array
             items:
-              type: object
-              required:
-                - name
-                - aggregation
-              properties:
-                name:
-                  description: The name of the metric. Only valid options are A-Z
-                  type: string
-                  example: A
-                  pattern: "^[A-Z]$"
-                aggregation:
-                  description: The aggregation type of the metric.
-                  type: string
-                  example: sum
-                  enum:
-                    - sum
-                    - doc_count
-                field:
-                  description: The field of the metric.
-                  type: string
-                  example: processor.processed
-                filter:
-                  description: The filter to apply to the metric.
-                  type: string
-                  example: 'processor.outcome: "success"'
+              oneOf:
+                - type: object
+                  required:
+                    - name
+                    - aggregation
+                    - field
+                  properties:
+                    name:
+                      description: The name of the metric. Only valid options are A-Z
+                      type: string
+                      example: A
+                      pattern: "^[A-Z]$"
+                    aggregation:
+                      description: The aggregation type of the metric.
+                      type: string
+                      example: sum
+                      enum:
+                        - sum
+                    field:
+                      description: The field of the metric.
+                      type: string
+                      example: processor.processed
+                    filter:
+                      description: The filter to apply to the metric.
+                      type: string
+                      example: "processor.outcome: *"
+                - type: object
+                  required:
+                    - name
+                    - aggregation
+                  properties:
+                    name:
+                      description: The name of the metric. Only valid options are A-Z
+                      type: string
+                      example: A
+                      pattern: "^[A-Z]$"
+                    aggregation:
+                      description: The aggregation type of the metric.
+                      type: string
+                      example: doc_count
+                      enum:
+                        - doc_count
+                    filter:
+                      description: The filter to apply to the metric.
+                      type: string
+                      example: "processor.outcome: *"
           equation:
             description: The equation to calculate the "good" metric.
             type: string
@@ -86,31 +107,52 @@ properties:
             description: List of metrics with their name, aggregation type, and field.
             type: array
             items:
-              type: object
-              required:
-                - name
-                - aggregation
-              properties:
-                name:
-                  description: The name of the metric. Only valid options are A-Z
-                  type: string
-                  example: A
-                  pattern: "^[A-Z]$"
-                aggregation:
-                  description: The aggregation type of the metric.
-                  type: string
-                  example: sum
-                  enum:
-                    - sum
-                    - doc_count
-                field:
-                  description: The field of the metric.
-                  type: string
-                  example: processor.processed
-                filter:
-                  description: The filter to apply to the metric.
-                  type: string
-                  example: "processor.outcome: *"
+              oneOf:
+                - type: object
+                  required:
+                    - name
+                    - aggregation
+                    - field
+                  properties:
+                    name:
+                      description: The name of the metric. Only valid options are A-Z
+                      type: string
+                      example: A
+                      pattern: "^[A-Z]$"
+                    aggregation:
+                      description: The aggregation type of the metric.
+                      type: string
+                      example: sum
+                      enum:
+                        - sum
+                    field:
+                      description: The field of the metric.
+                      type: string
+                      example: processor.processed
+                    filter:
+                      description: The filter to apply to the metric.
+                      type: string
+                      example: "processor.outcome: *"
+                - type: object
+                  required:
+                    - name
+                    - aggregation
+                  properties:
+                    name:
+                      description: The name of the metric. Only valid options are A-Z
+                      type: string
+                      example: A
+                      pattern: "^[A-Z]$"
+                    aggregation:
+                      description: The aggregation type of the metric.
+                      type: string
+                      example: doc_count
+                      enum:
+                        - doc_count
+                    filter:
+                      description: The filter to apply to the metric.
+                      type: string
+                      example: "processor.outcome: *"
           equation:
             description: The equation to calculate the "total" metric.
             type: string

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/indicator_properties_custom_metric.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/indicator_properties_custom_metric.yaml
@@ -49,7 +49,6 @@ properties:
               required:
                 - name
                 - aggregation
-                - field
               properties:
                 name:
                   description: The name of the metric. Only valid options are A-Z
@@ -57,10 +56,12 @@ properties:
                   example: A
                   pattern: "^[A-Z]$"
                 aggregation:
-                  description: The aggregation type of the metric. Only valid option is "sum"
+                  description: The aggregation type of the metric.
                   type: string
                   example: sum
-                  enum: [sum]
+                  enum:
+                    - sum
+                    - doc_count
                 field:
                   description: The field of the metric.
                   type: string
@@ -89,7 +90,6 @@ properties:
               required:
                 - name
                 - aggregation
-                - field
               properties:
                 name:
                   description: The name of the metric. Only valid options are A-Z
@@ -97,10 +97,12 @@ properties:
                   example: A
                   pattern: "^[A-Z]$"
                 aggregation:
-                  description: The aggregation type of the metric. Only valid option is "sum"
+                  description: The aggregation type of the metric.
                   type: string
                   example: sum
-                  enum: [sum]
+                  enum:
+                    - sum
+                    - doc_count
                 field:
                   description: The field of the metric.
                   type: string


### PR DESCRIPTION
## Summary

This PR updates `properties.params.properties.good.properties.metrics` and `properties.params.properties.total.properties.metrics` to include the `doc_count` enum as well as make the `field` property optional (since it is only required for `sum`). 

The bundle update includes some additions ostensibly from other changes in the tree, but I have included them anyway since it looks like it needed an update. 

I also encountered the following errors when running `make bundle` in `x-pack/solutions/observability/plugins/slo/docs/openapi/slo`. I'm unsure if they can be safely ignored or not, but thought I would flag it anyway.

```
❯ make bundle
entrypoint.yaml is valid
bundling entrypoint.yaml...
📦 Created a bundle for entrypoint.yaml at bundled.yaml 27ms.
bundling entrypoint.yaml...
📦 Created a bundle for entrypoint.yaml at bundled.json 23ms.
make[1]: Entering directory '/Users/nick/work/kibana/x-pack/solutions/observability/plugins/slo/docs/openapi/slo'
No configurations were provided -- using built in recommended configuration by default.

validating bundled.json...
[1] bundled.json:111:7 at #/paths/~1s~1{spaceId}~1api~1observability~1slos/get

Every operation should have security defined on it or on the root level.

109 |   }
110 | },
111 | "get": {
112 |   "summary": "Get a paginated list of SLOs",
113 |   "operationId": "findSlosOp",

Error was generated by the security-defined rule.


[2] bundled.json:33:7 at #/paths/~1s~1{spaceId}~1api~1observability~1slos/post

Every operation should have security defined on it or on the root level.

31 | "paths": {
32 |   "/s/{spaceId}/api/observability/slos": {
33 |     "post": {
34 |       "summary": "Create an SLO",
35 |       "operationId": "createSloOp",

Error was generated by the security-defined rule.


[3] bundled.json:270:7 at #/paths/~1s~1{spaceId}~1api~1observability~1slos~1{sloId}/get

Every operation should have security defined on it or on the root level.

268 | },
269 | "/s/{spaceId}/api/observability/slos/{sloId}": {
270 |   "get": {
271 |     "summary": "Get an SLO",
272 |     "operationId": "getSloOp",

Error was generated by the security-defined rule.


[4] bundled.json:350:7 at #/paths/~1s~1{spaceId}~1api~1observability~1slos~1{sloId}/put

Every operation should have security defined on it or on the root level.

348 |   }
349 | },
350 | "put": {
351 |   "summary": "Update an SLO",
352 |   "operationId": "updateSloOp",

Error was generated by the security-defined rule.


[5] bundled.json:431:7 at #/paths/~1s~1{spaceId}~1api~1observability~1slos~1{sloId}/delete

Every operation should have security defined on it or on the root level.

429 |   }
430 | },
431 | "delete": {
432 |   "summary": "Delete an SLO",
433 |   "operationId": "deleteSloOp",

Error was generated by the security-defined rule.


[6] bundled.json:497:7 at #/paths/~1s~1{spaceId}~1api~1observability~1slos~1{sloId}~1enable/post

Every operation should have security defined on it or on the root level.

495 | },
496 | "/s/{spaceId}/api/observability/slos/{sloId}/enable": {
497 |   "post": {
498 |     "summary": "Enable an SLO",
499 |     "operationId": "enableSloOp",

Error was generated by the security-defined rule.


[7] bundled.json:563:7 at #/paths/~1s~1{spaceId}~1api~1observability~1slos~1{sloId}~1disable/post

Every operation should have security defined on it or on the root level.

561 | },
562 | "/s/{spaceId}/api/observability/slos/{sloId}/disable": {
563 |   "post": {
564 |     "summary": "Disable an SLO",
565 |     "operationId": "disableSloOp",

Error was generated by the security-defined rule.


[8] bundled.json:629:7 at #/paths/~1s~1{spaceId}~1api~1observability~1slos~1{sloId}~1_reset/post

Every operation should have security defined on it or on the root level.

627 | },
628 | "/s/{spaceId}/api/observability/slos/{sloId}/_reset": {
629 |   "post": {
630 |     "summary": "Reset an SLO",
631 |     "operationId": "resetSloOp",

Error was generated by the security-defined rule.


[9] bundled.json:702:7 at #/paths/~1s~1{spaceId}~1internal~1observability~1slos~1_definitions/get

Every operation should have security defined on it or on the root level.

700 | },
701 | "/s/{spaceId}/internal/observability/slos/_definitions": {
702 |   "get": {
703 |     "summary": "Get the SLO definitions",
704 |     "operationId": "getDefinitionsOp",

Error was generated by the security-defined rule.


[10] bundled.json:800:7 at #/paths/~1s~1{spaceId}~1api~1observability~1slos~1_delete_instances/post

Every operation should have security defined on it or on the root level.

798 | },
799 | "/s/{spaceId}/api/observability/slos/_delete_instances": {
800 |   "post": {
801 |     "summary": "Batch delete rollup and summary data",
802 |     "operationId": "deleteSloInstancesOp",

Error was generated by the security-defined rule.


bundled.json: validated in 31ms

❌ Validation failed with 10 errors.
run `redocly lint --generate-ignore-file` to add all problems to the ignore file.

make[1]: *** [makefile:15: lint] Error 1
make[1]: Leaving directory '/Users/nick/work/kibana/x-pack/solutions/observability/plugins/slo/docs/openapi/slo'
make: *** [makefile:11: bundle] Error 2

```

