### PR TITLE
[Security Solution] Fix issue with alert grouping re-render

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -34,6 +34,7 @@ import { ALERTS_QUERY_NAMES } from '../../containers/detection_engine/alerts/con
 import { getAlertsGroupingQuery, useGroupTakeActionsItems } from './grouping_settings';
 
 const ALERTS_GROUPING_ID = 'alerts-grouping';
+const DEFAULT_FILTERS: Filter[] = [];
 
 interface OwnProps {
   currentAlertStatusFilterValue?: Status[];
@@ -66,7 +67,7 @@ export type AlertsTableComponentProps = OwnProps;
 
 export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
   currentAlertStatusFilterValue,
-  defaultFilters = [],
+  defaultFilters = DEFAULT_FILTERS,
   from,
   getGrouping,
   globalFilters,


### PR DESCRIPTION
## Summary

While doing a POC trying to implement the grouping component with the UnifiedDataTable, I discovered a rendering issue that caused some sort of infinite loop rerendering after selecting a group.

This PR fixes that issue but making sure we do not have a new instance of an empty array every time the component is rendered.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->