### PR TITLE
[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/__snapshots__/risk_score_configuration_section.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/__snapshots__/risk_score_configuration_section.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`RiskScoreConfigurationSection renders correctly 1`] = `
         end="now"
         onTimeChange={[Function]}
         showUpdateButton={false}
-        start="now-30m"
+        start="now-30d"
         width="auto"
       />
     </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.test.tsx
@@ -23,7 +23,7 @@ describe('RiskScoreConfigurationSection', () => {
   const defaultProps = {
     includeClosedAlerts: false,
     setIncludeClosedAlerts: jest.fn(),
-    from: 'now-30m',
+    from: 'now-30d',
     to: 'now',
     onDateChange: jest.fn(),
   };
@@ -55,8 +55,8 @@ describe('RiskScoreConfigurationSection', () => {
 
   it('calls onDateChange on date change', () => {
     const wrapper = mount(<RiskScoreConfigurationSection {...defaultProps} />);
-    wrapper.find(EuiSuperDatePicker).props().onTimeChange({ start: 'now-30m', end: 'now' });
-    expect(defaultProps.onDateChange).toHaveBeenCalledWith({ start: 'now-30m', end: 'now' });
+    wrapper.find(EuiSuperDatePicker).props().onTimeChange({ start: 'now-30d', end: 'now' });
+    expect(defaultProps.onDateChange).toHaveBeenCalledWith({ start: 'now-30d', end: 'now' });
   });
 
   it('shows bottom bar when changes are made', async () => {
@@ -88,7 +88,7 @@ describe('RiskScoreConfigurationSection', () => {
     const callArgs = mockMutate.mock.calls[0][0];
     expect(callArgs).toEqual({
       includeClosedAlerts: true,
-      range: { start: 'now-30m', end: 'now' },
+      range: { start: 'now-30d', end: 'now' },
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.tsx
@@ -76,9 +76,10 @@ export const RiskScoreConfigurationSection = ({
 
   const onRefresh = ({ start: newStart, end: newEnd }: { start: string; end: string }) => {
     setFrom(newStart);
-    setTo(newEnd);
-    onDateChange({ start: newStart, end: newEnd });
-    checkForChanges(newStart, newEnd, includeClosedAlerts);
+    const adjustedEnd = newStart === newEnd ? 'now' : newEnd;
+    setTo(adjustedEnd);
+    onDateChange({ start: newStart, end: adjustedEnd });
+    checkForChanges(newStart, adjustedEnd, includeClosedAlerts);
   };
 
   const handleToggle = () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
@@ -36,7 +36,7 @@ export const EntityAnalyticsManagementPage = () => {
   const styles = getEntityAnalyticsRiskScorePageStyles(euiTheme);
   const privileges = useMissingRiskEnginePrivileges();
   const [includeClosedAlerts, setIncludeClosedAlerts] = useState(false);
-  const [from, setFrom] = useState(localStorage.getItem('dateStart') || 'now-30m');
+  const [from, setFrom] = useState(localStorage.getItem('dateStart') || 'now-30d');
   const [to, setTo] = useState(localStorage.getItem('dateEnd') || 'now');
   const { data: riskEngineStatus } = useRiskEngineStatus({
     refetchInterval: TEN_SECONDS,


### PR DESCRIPTION
## Summary

The PR updates the code to extend the lookback period for Risk scoring calculations from `now-30m` to `now-30d`.  

This change impacts:  
- Risk score UI (date picker)
- The preview API  
- The enable API (for Risk Score Saved Object configuration)


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

Screenshots : 

## UI and Preview API payload

![image](https://github.com/user-attachments/assets/9a074dc4-328f-405b-8ffe-5ce8a7def3d6)

## Risk Engine configuration SO

![image](https://github.com/user-attachments/assets/bfd4f6f8-3f1c-4f83-8247-66b9e93a71c2)


## Testing Steps:

1. Navigate to the Entity Analytics management page (Entity Risk Score webpage).  
2. Ensure the default text in the date picker displays **"Last 30 days"**.  
3. Open the **Network** tab in Developer Tools and verify that the **"preview"** API request reflects a 30-day difference between the `from` and `to` values.  
4. If the **Risk Engine** is enabled, disable it and open a window displaying Kibana logs.  
5. Re-enable the **Risk Engine** and check the logs for the configuration message: **"Risk engine running with configuration"**. The expected range should be:  
   ```json
   "range": {
     "start": "now/M",
     "end": "now"
   }
   ```


## Advanced Testing Steps  

1. The date picker should default to **"Last 30 days"**. If you change it to **"Yesterday"** without clicking **Save changes**, the **Preview API** should reflect "Yesterday," but the **Saved Object (SO)** should **not** update its range.  
2. Upon refreshing the page without saving the changes, the date picker should reset to its default value, **"Last 30 days"**.



<!--ONMERGE {"backportTargets":["8.17","8.18","9.0"]} ONMERGE-->