### PR TITLE
make OTEL config fit current semconv for resource attributes

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/otel_agent.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/onboarding/instructions/otel_agent.tsx
@@ -193,7 +193,7 @@ export function OpenTelemetryInstructions({
     {
       setting: 'OTEL_RESOURCE_ATTRIBUTES',
       value:
-        'service.name=<app-name>,service.version=<app-version>,deployment.environment=production',
+        'service.name=<app-name>,service.version=<app-version>,deployment.environment.name=production',
     },
   ];
 

--- a/x-pack/solutions/observability/plugins/apm/public/tutorial/config_agent/opentelemetry_instructions.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/tutorial/config_agent/opentelemetry_instructions.tsx
@@ -47,7 +47,7 @@ export function OpenTelemetryInstructions({ apmServerUrl, secretToken }: Props) 
     {
       setting: 'OTEL_RESOURCE_ATTRIBUTES',
       value:
-        'service.name=<app-name>,service.version=<app-version>,deployment.environment=production',
+        'service.name=<app-name>,service.version=<app-version>,deployment.environment.name=production',
     },
   ];
 


### PR DESCRIPTION
## Summary

The OTel semconv resource attributes for providing the environment name changed some time ago in semconv 1.27.0, the latest version is 1.31.0.

We need to update the instructions to use the newer resource attribute name, which is replacing `deployment.environment` with `deployment.environment.name` with an extra `.name` suffix.

This change has already been documented in documentation https://github.com/elastic/opentelemetry/pull/109

This changes only the environment variables values in the install instructions, so there is no risk involved in kibana behavior.