### PR TITLE
[8.16] [Synthetics] Use range filter instead of timespan !! (#209281)

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/queries/query_monitor_status_alert.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/queries/query_monitor_status_alert.ts
@@ -12,7 +12,7 @@ import { intersection } from 'lodash';
 import { AlertStatusMetaData } from '../../../../common/runtime_types/alert_rules/common';
 import {
   FINAL_SUMMARY_FILTER,
-  getTimespanFilter,
+  getRangeFilter,
   SUMMARY_FILTER,
 } from '../../../../common/constants/client_defaults';
 import { OverviewPing } from '../../../../common/runtime_types';
@@ -75,7 +75,7 @@ export async function queryMonitorStatusAlert({
             bool: {
               filter: [
                 ...(includeRetests ? [SUMMARY_FILTER] : [FINAL_SUMMARY_FILTER]),
-                getTimespanFilter({ from: range.from, to: range.to }),
+                getRangeFilter({ from: range.from, to: range.to }),
                 {
                   terms: {
                     'monitor.id': idsToQuery,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Synthetics] Monitor status rule, show to which monitors rule applies !! (#209281)](https://github.com/elastic/kibana/pull/209281)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2025-02-06T16:07:22Z","message":"[Synthetics] Monitor status rule, show to which monitors rule applies !! (#209281)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/198688\r\n\r\nMonitor status rule, show to which monitors rule applies !!\r\n\r\nWith filters shows to which monitors the rule applies \r\n<img width=\"1728\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/5536ad12-d0ed-4394-a511-8dd826bf3b56\"\r\n/>\r\n\r\n\r\nAlso showing an inspect flyout with query details\r\n\r\n<img width=\"1728\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/d441e4f9-8f0c-4fac-a2ca-5f214f8d2709\"\r\n/>","sha":"ac89e472a6156d44e098d06f3665d90f892dbdba","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Synthetics] Monitor status rule, show to which monitors rule applies !!","number":209281,"url":"https://github.com/elastic/kibana/pull/209281","mergeCommit":{"message":"[Synthetics] Monitor status rule, show to which monitors rule applies !! (#209281)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/198688\r\n\r\nMonitor status rule, show to which monitors rule applies !!\r\n\r\nWith filters shows to which monitors the rule applies \r\n<img width=\"1728\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/5536ad12-d0ed-4394-a511-8dd826bf3b56\"\r\n/>\r\n\r\n\r\nAlso showing an inspect flyout with query details\r\n\r\n<img width=\"1728\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/d441e4f9-8f0c-4fac-a2ca-5f214f8d2709\"\r\n/>","sha":"ac89e472a6156d44e098d06f3665d90f892dbdba"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210061","number":210061,"state":"MERGED","mergeCommit":{"sha":"67b17c8bbb945e918be2a44a9e44cbfe7f513815","message":"[9.0] [Synthetics] Monitor status rule, show to which monitors rule applies !! (#209281) (#210061)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Synthetics] Monitor status rule, show to which monitors rule applies\n!! (#209281)](https://github.com/elastic/kibana/pull/209281)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209281","number":209281,"mergeCommit":{"message":"[Synthetics] Monitor status rule, show to which monitors rule applies !! (#209281)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/198688\r\n\r\nMonitor status rule, show to which monitors rule applies !!\r\n\r\nWith filters shows to which monitors the rule applies \r\n<img width=\"1728\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/5536ad12-d0ed-4394-a511-8dd826bf3b56\"\r\n/>\r\n\r\n\r\nAlso showing an inspect flyout with query details\r\n\r\n<img width=\"1728\" alt=\"image\"\r\nsrc=\"https://github.com/user-attachments/assets/d441e4f9-8f0c-4fac-a2ca-5f214f8d2709\"\r\n/>","sha":"ac89e472a6156d44e098d06f3665d90f892dbdba"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215097","number":215097,"state":"OPEN"}]}] BACKPORT-->