### PR TITLE
[Security Solution] Fix - Extra timeline space because of Borealis changes

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/header/index.tsx
@@ -48,7 +48,7 @@ const useStyles = (shouldShowQueryBuilder: boolean) => {
     display: block;
     max-height: ${shouldShowQueryBuilder ? '300px' : '0'};
     visibility: ${shouldShowQueryBuilder ? 'visible' : 'hidden'};
-    margin-block-start: ${shouldShowQueryBuilder ? '0' : -euiTheme.size.s};
+    margin-block-start: ${shouldShowQueryBuilder ? '0' : `calc(-1 * ${euiTheme.size.s})`};
 
     . ${IS_DRAGGING_CLASS_NAME} & {
       display: block;


### PR DESCRIPTION
## Summary

This very small PR fixes an extra space below querybar in timeline. This was issue because of what `euiThemeVars` v/s`euiTheme` returns as a size i.e.  `8` v/s `8px`

### Before
![image](https://github.com/user-attachments/assets/ee767778-741b-4430-aac2-543a08b50822)


### After
![image](https://github.com/user-attachments/assets/cf9eca1c-8c99-43ef-96f4-914e68fcc233)



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->