### PR TITLE
[MKI][FTR] Improve feedback in test for debugging

### DIFF
--- a/x-pack/test/functional/page_objects/index_management_page.ts
+++ b/x-pack/test/functional/page_objects/index_management_page.ts
@@ -247,7 +247,8 @@ export function IndexManagementPageProvider({ getService }: FtrProviderContext) 
           return await (await row.findByTestSubject('indexTableIndexNameLink')).getVisibleText();
         })
       );
-      expect(indexNames.some((i) => i === indexName)).to.be(true);
+      const indexFound = indexNames.some((i) => i === indexName);
+      expect(indexFound).to.equal(true, `Looked for ${indexName}, but only found: ${indexNames}`);
     },
 
     async confirmDeleteModalIsVisible() {


### PR DESCRIPTION
## Summary

For now, trying to get more information on the failure that's been occurring against MKI for:
   `x-pack/test_serverless/functional/test_suites/search/index_management.ts`
   
The index names are suffixed by `Math.random()`, so I've changed the assertion to additionally print out what it found and what it was looking for regarding index names.

The test is flaky from my local and in the serverless pipeline.

\cc @saikatsarkar056 