### PR TITLE
[Security Solution] Fix example of creating 200 rules

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/scripts/quickstart/README.md
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/quickstart/README.md
@@ -84,15 +84,19 @@ import { buildCreateRuleExceptionListItemsProps } from './modules/exceptions';
 
 // Core logic
 const bodyWithCreatedRule = await createRule(supertest, log, basicRule);
-const ruleCopies = duplicateRuleParams(bodyWithCreatedRule, 200);
-const { body } = await detectionsClient.
-                  .performRulesBulkAction({
-                    query: { dry_run: false },
-                    body: {
-                      ids: ruleCopies.map((rule) => rule.id),
-                      action: 'duplicate',
-                    },
-                  })
+const { body } = await securitySolutionApi
+          .performRulesBulkAction({
+            query: { dry_run: false },
+            body: {
+              ids: Array(200).fill(bodyWithCreatedRule.id),
+              action: 'duplicate',
+              duplicate: {
+                include_exceptions: true,
+                include_expired_exceptions: false,
+              },
+            },
+          })
+          .expect(200);
 const createdRules: RuleResponse[] = body.attributes.results.created;
 
 // This map looks a bit confusing, but the concept is simple: take the rules we just created and

--- a/x-pack/solutions/security/plugins/security_solution/scripts/quickstart/README.md
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/quickstart/README.md
@@ -83,21 +83,19 @@ import { buildCreateRuleExceptionListItemsProps } from './modules/exceptions';
 // ... omitted client setup stuff
 
 // Core logic
-const bodyWithCreatedRule = await createRule(supertest, log, basicRule);
-const { body } = await securitySolutionApi
-          .performRulesBulkAction({
-            query: { dry_run: false },
-            body: {
-              ids: Array(200).fill(bodyWithCreatedRule.id),
-              action: 'duplicate',
-              duplicate: {
-                include_exceptions: true,
-                include_expired_exceptions: false,
-              },
-            },
-          })
-          .expect(200);
-const createdRules: RuleResponse[] = body.attributes.results.created;
+const createRuleResponse = await detectionsClient.createRule({ body: basicRule });
+const bulkActionResponse = await detectionsClient.performRulesBulkAction({
+  query: { dry_run: false },
+  body: {
+    ids: Array(200).fill(createRuleResponse.data.id),
+    action: 'duplicate',
+    duplicate: {
+      include_exceptions: true,
+      include_expired_exceptions: false,
+    },
+  },
+});
+const createdRules: RuleResponse[] = bulkActionResponse.data.attributes.results.created;
 
 // This map looks a bit confusing, but the concept is simple: take the rules we just created and
 // create a *function* per rule to create an exception for that rule. We want a function to call later instead of just


### PR DESCRIPTION
**Resolves: #208329**

## Summary

This is an improvement of an example. The example was reworked in #213244, as part of removing bulk_crud endpoints and replacing it with bulk_action endpoint. However, a [comment](https://github.com/elastic/kibana/pull/213244#discussion_r1995862889) was raised to improve it, and in order not to block that PR, we decided to improve the example later, in a separate PR. And this is it.



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->