### PR TITLE
[8.17] [Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/__snapshots__/risk_score_configuration_section.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/__snapshots__/risk_score_configuration_section.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RiskScoreConfigurationSection renders correctly 1`] = `
+<Fragment>
+  <EuiFlexGroup
+    alignItems="center"
+  >
+    <div>
+      <EuiSwitch
+        checked={false}
+        data-test-subj="includeClosedAlertsSwitch"
+        label="Include closed alerts for risk scoring"
+        onChange={[Function]}
+      />
+    </div>
+    <Styled(div) />
+    <div>
+      <EuiSuperDatePicker
+        compressed={false}
+        end="now"
+        onTimeChange={[Function]}
+        showUpdateButton={false}
+        start="now-30d"
+        width="auto"
+      />
+    </div>
+  </EuiFlexGroup>
+  <EuiSpacer
+    size="m"
+  />
+  <EuiText
+    size="s"
+  >
+    <p>
+      Enable this option to factor both open and closed alerts into the risk engine
+            calculations. Including closed alerts helps provide a more comprehensive risk assessment
+            based on past incidents, leading to more accurate scoring and insights.
+    </p>
+  </EuiText>
+</Fragment>
+`;

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { RiskScoreConfigurationSection } from './risk_score_configuration_section';
+import { shallow, mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+import { EuiSuperDatePicker, EuiSwitch } from '@elastic/eui';
+import * as i18n from '../translations';
+import { useAppToasts } from '../../common/hooks/use_app_toasts';
+import { useConfigureSORiskEngineMutation } from '../api/hooks/use_configure_risk_engine_saved_object';
+
+jest.mock('../../common/lib/kibana');
+jest.mock('../../common/hooks/use_app_toasts');
+jest.mock('../api/hooks/use_configure_risk_engine_saved_object');
+
+describe('RiskScoreConfigurationSection', () => {
+  const mockConfigureSO = useConfigureSORiskEngineMutation as jest.Mock;
+  const defaultProps = {
+    includeClosedAlerts: false,
+    setIncludeClosedAlerts: jest.fn(),
+    from: 'now-30d',
+    to: 'now',
+    onDateChange: jest.fn(),
+  };
+
+  const mockAddSuccess = jest.fn();
+  const mockMutate = jest.fn();
+
+  beforeEach(() => {
+    (useAppToasts as jest.Mock).mockReturnValue({ addSuccess: mockAddSuccess });
+    mockConfigureSO.mockReturnValue({ mutate: mockMutate });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const wrapper = shallow(<RiskScoreConfigurationSection {...defaultProps} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('toggles includeClosedAlerts', () => {
+    const wrapper = mount(
+      <RiskScoreConfigurationSection {...defaultProps} includeClosedAlerts={true} />
+    );
+    wrapper.find(EuiSwitch).simulate('click');
+    expect(defaultProps.setIncludeClosedAlerts).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onDateChange on date change', () => {
+    const wrapper = mount(<RiskScoreConfigurationSection {...defaultProps} />);
+    wrapper.find(EuiSuperDatePicker).props().onTimeChange({ start: 'now-30d', end: 'now' });
+    expect(defaultProps.onDateChange).toHaveBeenCalledWith({ start: 'now-30d', end: 'now' });
+  });
+
+  it('shows bottom bar when changes are made', async () => {
+    const wrapper = mount(
+      <RiskScoreConfigurationSection {...defaultProps} includeClosedAlerts={false} />
+    );
+    wrapper.find(EuiSwitch).simulate('click');
+    wrapper.find(EuiSuperDatePicker).props().onTimeChange({ start: 'now-14m', end: 'now' });
+    wrapper.update();
+    await new Promise((resolve) => setTimeout(resolve, 0)); // wait for the component to update
+    expect(wrapper.find('EuiBottomBar').exists()).toBe(true);
+  });
+
+  it('saves changes', () => {
+    const wrapper = mount(
+      <RiskScoreConfigurationSection {...defaultProps} includeClosedAlerts={true} />
+    );
+
+    // Simulate clicking the switch
+    const closedAlertsToggle = wrapper.find('button[data-test-subj="includeClosedAlertsSwitch"]');
+    expect(closedAlertsToggle.exists()).toBe(true);
+    closedAlertsToggle.simulate('click');
+
+    wrapper.update();
+
+    const saveChangesButton = wrapper.find('button[data-test-subj="riskScoreSaveButton"]');
+    expect(saveChangesButton.exists()).toBe(true);
+    saveChangesButton.simulate('click');
+    const callArgs = mockMutate.mock.calls[0][0];
+    expect(callArgs).toEqual({
+      includeClosedAlerts: true,
+      range: { start: 'now-30d', end: 'now' },
+    });
+  });
+
+  it('shows success toast on save', () => {
+    const wrapper = mount(
+      <RiskScoreConfigurationSection {...defaultProps} includeClosedAlerts={true} />
+    );
+
+    act(() => {
+      wrapper.find('button[data-test-subj="includeClosedAlertsSwitch"]').simulate('click');
+    });
+    wrapper.update();
+
+    act(() => {
+      wrapper.find('button[data-test-subj="riskScoreSaveButton"]').simulate('click');
+    });
+
+    act(() => {
+      mockMutate.mock.calls[0][1].onSuccess();
+    });
+
+    expect(mockAddSuccess).toHaveBeenCalledWith(
+      i18n.RISK_ENGINE_SAVED_OBJECT_CONFIGURATION_SUCCESS,
+      {
+        toastLifeTimeMs: 5000,
+      }
+    );
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  EuiSuperDatePicker,
+  EuiButton,
+  EuiText,
+  EuiFlexGroup,
+  EuiSwitch,
+  EuiFlexItem,
+  EuiBottomBar,
+  EuiButtonEmpty,
+  EuiSpacer,
+  useEuiTheme,
+} from '@elastic/eui';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { useAppToasts } from '../../common/hooks/use_app_toasts';
+import * as i18n from '../translations';
+import { useConfigureSORiskEngineMutation } from '../api/hooks/use_configure_risk_engine_saved_object';
+import { getEntityAnalyticsRiskScorePageStyles } from './risk_score_page_styles';
+
+export const RiskScoreConfigurationSection = ({
+  includeClosedAlerts,
+  setIncludeClosedAlerts,
+  from,
+  to,
+  onDateChange,
+}: {
+  includeClosedAlerts: boolean;
+  setIncludeClosedAlerts: (value: boolean) => void;
+  from: string;
+  to: string;
+  onDateChange: ({ start, end }: { start: string; end: string }) => void;
+}) => {
+  const { euiTheme } = useEuiTheme();
+  const styles = getEntityAnalyticsRiskScorePageStyles(euiTheme);
+  const [start, setFrom] = useState(from);
+  const [end, setTo] = useState(to);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showBar, setShowBar] = useState(false);
+  const { addSuccess } = useAppToasts();
+  const initialIncludeClosedAlerts = useRef(includeClosedAlerts);
+  const initialStart = useRef(from);
+  const initialEnd = useRef(to);
+
+  const [savedIncludeClosedAlerts, setSavedIncludeClosedAlerts] = useLocalStorage(
+    'includeClosedAlerts',
+    includeClosedAlerts ?? false
+  );
+  const [savedStart, setSavedStart] = useLocalStorage(
+    'entityAnalytics:riskScoreConfiguration:fromDate',
+    from
+  );
+  const [savedEnd, setSavedEnd] = useLocalStorage(
+    'entityAnalytics:riskScoreConfiguration:toDate',
+    to
+  );
+
+  useEffect(() => {
+    if (savedIncludeClosedAlerts !== null && savedIncludeClosedAlerts !== undefined) {
+      initialIncludeClosedAlerts.current = savedIncludeClosedAlerts;
+      setIncludeClosedAlerts(savedIncludeClosedAlerts);
+    }
+    if (savedStart && savedEnd) {
+      initialStart.current = savedStart;
+      initialEnd.current = savedEnd;
+      setFrom(savedStart);
+      setTo(savedEnd);
+    }
+  }, [savedIncludeClosedAlerts, savedStart, savedEnd, setIncludeClosedAlerts]);
+
+  const onRefresh = ({ start: newStart, end: newEnd }: { start: string; end: string }) => {
+    setFrom(newStart);
+    const adjustedEnd = newStart === newEnd ? 'now' : newEnd;
+    setTo(adjustedEnd);
+    onDateChange({ start: newStart, end: adjustedEnd });
+    checkForChanges(newStart, adjustedEnd, includeClosedAlerts);
+  };
+
+  const handleToggle = () => {
+    const newValue = !includeClosedAlerts;
+    setIncludeClosedAlerts(newValue);
+    checkForChanges(start, end, newValue);
+  };
+
+  const checkForChanges = (newStart: string, newEnd: string, newIncludeClosedAlerts: boolean) => {
+    if (
+      newStart !== initialStart.current ||
+      newEnd !== initialEnd.current ||
+      newIncludeClosedAlerts !== initialIncludeClosedAlerts.current
+    ) {
+      setShowBar(true);
+    } else {
+      setShowBar(false);
+    }
+  };
+
+  const { mutate } = useConfigureSORiskEngineMutation();
+
+  const handleSave = () => {
+    setIsLoading(true);
+    mutate(
+      {
+        includeClosedAlerts,
+        range: { start, end },
+      },
+      {
+        onSuccess: () => {
+          setShowBar(false);
+          addSuccess(i18n.RISK_ENGINE_SAVED_OBJECT_CONFIGURATION_SUCCESS, {
+            toastLifeTimeMs: 5000,
+          });
+          setIsLoading(false);
+
+          initialStart.current = start;
+          initialEnd.current = end;
+          initialIncludeClosedAlerts.current = includeClosedAlerts;
+
+          setSavedIncludeClosedAlerts(includeClosedAlerts);
+          setSavedStart(start);
+          setSavedEnd(end);
+        },
+        onError: () => {
+          setIsLoading(false);
+        },
+      }
+    );
+  };
+
+  return (
+    <>
+      <EuiFlexGroup alignItems="center">
+        <div>
+          <EuiSwitch
+            label={i18n.INCLUDE_CLOSED_ALERTS_LABEL}
+            checked={includeClosedAlerts}
+            onChange={handleToggle}
+            data-test-subj="includeClosedAlertsSwitch"
+          />
+        </div>
+        <styles.VerticalSeparator />
+        <div>
+          <EuiSuperDatePicker
+            start={start}
+            end={end}
+            onTimeChange={onRefresh}
+            width={'auto'}
+            compressed={false}
+            showUpdateButton={false}
+          />
+        </div>
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
+      <EuiText size="s">
+        <p>{i18n.RISK_ENGINE_INCLUDE_CLOSED_ALERTS_DESCRIPTION}</p>
+      </EuiText>
+      {showBar && (
+        <EuiBottomBar paddingSize="s" position="fixed">
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  color="text"
+                  size="s"
+                  iconType="cross"
+                  onClick={() => {
+                    setShowBar(false);
+                    setFrom(initialStart.current);
+                    setTo(initialEnd.current);
+                    setIncludeClosedAlerts(initialIncludeClosedAlerts.current);
+                  }}
+                >
+                  {i18n.DISCARD_CHANGES}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  color="primary"
+                  fill
+                  size="s"
+                  iconType="check"
+                  onClick={handleSave}
+                  isLoading={isLoading}
+                  data-test-subj="riskScoreSaveButton"
+                >
+                  {i18n.SAVE_CHANGES}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexGroup>
+        </EuiBottomBar>
+      )}
+    </>
+  );
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, useCallback } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPageHeader,
+  EuiHorizontalRule,
+  EuiButton,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import moment from 'moment';
+import { RiskScorePreviewSection } from '../components/risk_score_preview_section';
+import { RiskScoreEnableSection } from '../components/risk_score_enable_section';
+import { ENTITY_ANALYTICS_RISK_SCORE } from '../../app/translations';
+import { RiskEnginePrivilegesCallOut } from '../components/risk_engine_privileges_callout';
+import { useMissingRiskEnginePrivileges } from '../hooks/use_missing_risk_engine_privileges';
+import { RiskScoreUsefulLinksSection } from '../components/risk_score_useful_links_section';
+import { RiskScoreConfigurationSection } from '../components/risk_score_configuration_section';
+import { useRiskEngineStatus } from '../api/hooks/use_risk_engine_status';
+import { useScheduleNowRiskEngineMutation } from '../api/hooks/use_schedule_now_risk_engine_mutation';
+import { useAppToasts } from '../../common/hooks/use_app_toasts';
+import * as i18n from '../translations';
+import { getEntityAnalyticsRiskScorePageStyles } from '../components/risk_score_page_styles';
+
+const TEN_SECONDS = 10000;
+
+export const EntityAnalyticsManagementPage = () => {
+  const { euiTheme } = useEuiTheme();
+  const styles = getEntityAnalyticsRiskScorePageStyles(euiTheme);
+  const privileges = useMissingRiskEnginePrivileges();
+  const [includeClosedAlerts, setIncludeClosedAlerts] = useState(false);
+  const [from, setFrom] = useState(localStorage.getItem('dateStart') || 'now-30d');
+  const [to, setTo] = useState(localStorage.getItem('dateEnd') || 'now');
+  const { data: riskEngineStatus } = useRiskEngineStatus({
+    refetchInterval: TEN_SECONDS,
+    structuralSharing: false, // Force the component to rerender after every Risk Engine Status API call
+  });
+  const currentRiskEngineStatus = riskEngineStatus?.risk_engine_status;
+  const runEngineEnabled = currentRiskEngineStatus === 'ENABLED';
+  const [isLoading, setIsLoading] = useState(false);
+  const { mutate: scheduleNowRiskEngine } = useScheduleNowRiskEngineMutation();
+  const { addSuccess, addError } = useAppToasts();
+
+  const handleRunEngineClick = async () => {
+    setIsLoading(true);
+    try {
+      scheduleNowRiskEngine();
+
+      if (!isLoading) {
+        addSuccess(i18n.RISK_SCORE_ENGINE_RUN_SUCCESS, { toastLifeTimeMs: 5000 });
+      }
+    } catch (error) {
+      addError(error, {
+        title: i18n.RISK_SCORE_ENGINE_RUN_FAILURE,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleIncludeClosedAlertsToggle = useCallback(
+    (value: boolean) => {
+      setIncludeClosedAlerts(value);
+    },
+    [setIncludeClosedAlerts]
+  );
+
+  const handleDateChange = ({ start, end }: { start: string; end: string }) => {
+    setFrom(start);
+    setTo(end);
+    localStorage.setItem('dateStart', start);
+    localStorage.setItem('dateEnd', end);
+  };
+
+  const { status, runAt } = riskEngineStatus?.risk_engine_task_status || {};
+
+  const isRunning = status === 'running' || (!!runAt && new Date(runAt) < new Date());
+
+  const formatTimeFromNow = (time: string | undefined): string => {
+    if (!time) {
+      return '';
+    }
+    return i18n.RISK_ENGINE_NEXT_RUN_TIME(moment(time).fromNow(true));
+  };
+
+  const countDownText = isRunning
+    ? 'Now running'
+    : formatTimeFromNow(riskEngineStatus?.risk_engine_task_status?.runAt);
+
+  return (
+    <>
+      <RiskEnginePrivilegesCallOut privileges={privileges} />
+      <EuiPageHeader
+        pageTitle={
+          <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+            {/* Page Title */}
+            <EuiFlexItem data-test-subj="entityAnalyticsManagementPageTitle" grow={false}>
+              {ENTITY_ANALYTICS_RISK_SCORE}
+            </EuiFlexItem>
+
+            {/* Controls Section */}
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup alignItems="center" gutterSize="m">
+                {/* Run Engine Section */}
+                {runEngineEnabled && (
+                  <>
+                    {/* Run Engine Button */}
+                    <EuiButton
+                      size="s"
+                      iconType="play"
+                      isLoading={isLoading}
+                      onClick={handleRunEngineClick}
+                    >
+                      {i18n.RUN_RISK_SCORE_ENGINE}
+                    </EuiButton>
+
+                    {/* Vertical Line */}
+                    <styles.VerticalSeparator />
+
+                    {/* Countdown Text */}
+                    <div>
+                      <EuiText size="s" color="subdued">
+                        {countDownText}
+                      </EuiText>
+                    </div>
+                  </>
+                )}
+
+                {/* Risk Score Enable Section */}
+                <div>
+                  <RiskScoreEnableSection privileges={privileges} />
+                </div>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+      />
+
+      <EuiHorizontalRule />
+      <EuiFlexGroup gutterSize="xl" alignItems="flexStart">
+        <EuiFlexItem grow={2}>
+          <RiskScoreConfigurationSection
+            includeClosedAlerts={includeClosedAlerts}
+            setIncludeClosedAlerts={handleIncludeClosedAlertsToggle}
+            from={from}
+            to={to}
+            onDateChange={handleDateChange}
+          />
+          <EuiHorizontalRule />
+          <RiskScoreUsefulLinksSection />
+        </EuiFlexItem>
+        <EuiFlexItem grow={2}>
+          <RiskScorePreviewSection
+            privileges={privileges}
+            includeClosedAlerts={includeClosedAlerts}
+            from={from}
+            to={to}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};
+
+EntityAnalyticsManagementPage.displayName = 'EntityAnalyticsManagementPage';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)](https://github.com/elastic/kibana/pull/215093)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abhishek Bhatia","email":"117628830+abhishekbhatia1710@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-19T11:46:24Z","message":"[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)\n\n## Summary\n\nThe PR updates the code to extend the lookback period for Risk scoring\ncalculations from `now-30m` to `now-30d`.\n\nThis change impacts:  \n- Risk score UI (date picker)\n- The preview API  \n- The enable API (for Risk Score Saved Object configuration)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\nScreenshots : \n\n## UI and Preview API payload\n\n\n![image](https://github.com/user-attachments/assets/9a074dc4-328f-405b-8ffe-5ce8a7def3d6)\n\n## Risk Engine configuration SO\n\n\n![image](https://github.com/user-attachments/assets/bfd4f6f8-3f1c-4f83-8247-66b9e93a71c2)\n\n\n## Testing Steps:\n\n1. Navigate to the Entity Analytics management page (Entity Risk Score\nwebpage).\n2. Ensure the default text in the date picker displays **\"Last 30\ndays\"**.\n3. Open the **Network** tab in Developer Tools and verify that the\n**\"preview\"** API request reflects a 30-day difference between the\n`from` and `to` values.\n4. If the **Risk Engine** is enabled, disable it and open a window\ndisplaying Kibana logs.\n5. Re-enable the **Risk Engine** and check the logs for the\nconfiguration message: **\"Risk engine running with configuration\"**. The\nexpected range should be:\n   ```json\n   \"range\": {\n     \"start\": \"now/M\",\n     \"end\": \"now\"\n   }\n   ```\n\n\n## Advanced Testing Steps  \n\n1. The date picker should default to **\"Last 30 days\"**. If you change\nit to **\"Yesterday\"** without clicking **Save changes**, the **Preview\nAPI** should reflect \"Yesterday,\" but the **Saved Object (SO)** should\n**not** update its range.\n2. Upon refreshing the page without saving the changes, the date picker\nshould reset to its default value, **\"Last 30 days\"**.","sha":"90dd368e71f3fce950607df3ec486289b408a6af","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","v9.0.0","Team:Entity Analytics","backport:version","v8.17.0","v8.18.0","v9.1.0"],"title":"[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period","number":215093,"url":"https://github.com/elastic/kibana/pull/215093","mergeCommit":{"message":"[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)\n\n## Summary\n\nThe PR updates the code to extend the lookback period for Risk scoring\ncalculations from `now-30m` to `now-30d`.\n\nThis change impacts:  \n- Risk score UI (date picker)\n- The preview API  \n- The enable API (for Risk Score Saved Object configuration)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\nScreenshots : \n\n## UI and Preview API payload\n\n\n![image](https://github.com/user-attachments/assets/9a074dc4-328f-405b-8ffe-5ce8a7def3d6)\n\n## Risk Engine configuration SO\n\n\n![image](https://github.com/user-attachments/assets/bfd4f6f8-3f1c-4f83-8247-66b9e93a71c2)\n\n\n## Testing Steps:\n\n1. Navigate to the Entity Analytics management page (Entity Risk Score\nwebpage).\n2. Ensure the default text in the date picker displays **\"Last 30\ndays\"**.\n3. Open the **Network** tab in Developer Tools and verify that the\n**\"preview\"** API request reflects a 30-day difference between the\n`from` and `to` values.\n4. If the **Risk Engine** is enabled, disable it and open a window\ndisplaying Kibana logs.\n5. Re-enable the **Risk Engine** and check the logs for the\nconfiguration message: **\"Risk engine running with configuration\"**. The\nexpected range should be:\n   ```json\n   \"range\": {\n     \"start\": \"now/M\",\n     \"end\": \"now\"\n   }\n   ```\n\n\n## Advanced Testing Steps  \n\n1. The date picker should default to **\"Last 30 days\"**. If you change\nit to **\"Yesterday\"** without clicking **Save changes**, the **Preview\nAPI** should reflect \"Yesterday,\" but the **Saved Object (SO)** should\n**not** update its range.\n2. Upon refreshing the page without saving the changes, the date picker\nshould reset to its default value, **\"Last 30 days\"**.","sha":"90dd368e71f3fce950607df3ec486289b408a6af"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215147","number":215147,"state":"OPEN"},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215146","number":215146,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215093","number":215093,"mergeCommit":{"message":"[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)\n\n## Summary\n\nThe PR updates the code to extend the lookback period for Risk scoring\ncalculations from `now-30m` to `now-30d`.\n\nThis change impacts:  \n- Risk score UI (date picker)\n- The preview API  \n- The enable API (for Risk Score Saved Object configuration)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\nScreenshots : \n\n## UI and Preview API payload\n\n\n![image](https://github.com/user-attachments/assets/9a074dc4-328f-405b-8ffe-5ce8a7def3d6)\n\n## Risk Engine configuration SO\n\n\n![image](https://github.com/user-attachments/assets/bfd4f6f8-3f1c-4f83-8247-66b9e93a71c2)\n\n\n## Testing Steps:\n\n1. Navigate to the Entity Analytics management page (Entity Risk Score\nwebpage).\n2. Ensure the default text in the date picker displays **\"Last 30\ndays\"**.\n3. Open the **Network** tab in Developer Tools and verify that the\n**\"preview\"** API request reflects a 30-day difference between the\n`from` and `to` values.\n4. If the **Risk Engine** is enabled, disable it and open a window\ndisplaying Kibana logs.\n5. Re-enable the **Risk Engine** and check the logs for the\nconfiguration message: **\"Risk engine running with configuration\"**. The\nexpected range should be:\n   ```json\n   \"range\": {\n     \"start\": \"now/M\",\n     \"end\": \"now\"\n   }\n   ```\n\n\n## Advanced Testing Steps  \n\n1. The date picker should default to **\"Last 30 days\"**. If you change\nit to **\"Yesterday\"** without clicking **Save changes**, the **Preview\nAPI** should reflect \"Yesterday,\" but the **Saved Object (SO)** should\n**not** update its range.\n2. Upon refreshing the page without saving the changes, the date picker\nshould reset to its default value, **\"Last 30 days\"**.","sha":"90dd368e71f3fce950607df3ec486289b408a6af"}}]}] BACKPORT-->