### PR TITLE
[SecuritySolution] Security Entity Store Fix Data view refresh does not support the indexPattern parameter

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/entity_store_data_client.ts
@@ -88,6 +88,7 @@ import {
   getEntitiesIndexName,
   isPromiseFulfilled,
   isPromiseRejected,
+  mergeEntityStoreIndices,
 } from './utils';
 import { EntityEngineActions } from './auditing/actions';
 import { AUDIT_CATEGORY, AUDIT_OUTCOME, AUDIT_TYPE } from '../audit';
@@ -803,30 +804,11 @@ export class EntityStoreDataClient {
       };
     }
 
-    const indexPatterns = await buildIndexPatterns(
+    const defaultIndexPatterns = await buildIndexPatterns(
       this.options.namespace,
       this.options.appClient,
       this.options.dataViewsService
     );
-
-    const privileges = await getEntityStoreSourceIndicesPrivileges(
-      this.options.request,
-      this.options.security,
-      indexPatterns
-    );
-
-    if (!privileges.has_all_required) {
-      const missingPrivilegesMsg = getAllMissingPrivileges(privileges).elasticsearch.index.map(
-        ({ indexName, privileges: missingPrivileges }) =>
-          `Missing [${missingPrivileges.join(', ')}] privileges for index '${indexName}'.`
-      );
-
-      throw new Error(
-        `The current user does not have the required indices privileges.\n${missingPrivilegesMsg.join(
-          '\n'
-        )}`
-      );
-    }
 
     const updateDefinitionPromises: Array<Promise<EngineDataviewUpdateResult>> = engines.map(
       async (engine) => {
@@ -843,6 +825,8 @@ export class EntityStoreDataClient {
           );
         }
 
+        const indexPatterns = mergeEntityStoreIndices(defaultIndexPatterns, engine.indexPattern);
+
         // Skip update if index patterns are the same
         if (isEqual(definition.indexPatterns, indexPatterns)) {
           logger.debug(
@@ -852,6 +836,25 @@ export class EntityStoreDataClient {
         } else {
           logger.info(
             `In namespace ${this.options.namespace}: Data view index changes detected, applying changes to entity definition.`
+          );
+        }
+
+        const privileges = await getEntityStoreSourceIndicesPrivileges(
+          this.options.request,
+          this.options.security,
+          indexPatterns
+        );
+
+        if (!privileges.has_all_required) {
+          const missingPrivilegesMsg = getAllMissingPrivileges(privileges).elasticsearch.index.map(
+            ({ indexName, privileges: missingPrivileges }) =>
+              `Missing [${missingPrivileges.join(', ')}] privileges for index '${indexName}'.`
+          );
+
+          throw new Error(
+            `The current user does not have the required indices privileges for updating the '${
+              engine.type
+            }' entity store.\n${missingPrivilegesMsg.join('\n')}`
           );
         }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/engine_description.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/installation/engine_description.ts
@@ -17,7 +17,7 @@ import {
   serviceEntityEngineDescription,
 } from '../entity_definitions/entity_descriptions';
 import type { EntityStoreConfig } from '../types';
-import { buildEntityDefinitionId } from '../utils';
+import { buildEntityDefinitionId, mergeEntityStoreIndices } from '../utils';
 import type { EntityDescription } from '../entity_definitions/types';
 import type { EntityEngineInstallationDescriptor } from './types';
 import { merge } from '../../../../../common/utils/objects/merge';
@@ -46,9 +46,7 @@ export const createEngineDescription = (params: EngineDescriptionParams) => {
   };
   const options = merge(defaultOptions, merge(fileConfig, requestParams));
 
-  const indexPatterns = options.indexPattern
-    ? defaultIndexPatterns.concat(options.indexPattern.split(','))
-    : defaultIndexPatterns;
+  const indexPatterns = mergeEntityStoreIndices(defaultIndexPatterns, options.indexPattern);
 
   const description = engineDescriptionRegistry[entityType];
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
@@ -52,9 +52,9 @@ export const applyDataViewIndicesEntityEngineRoute = (
           if (successes.length === 0 && errors.length > 0) {
             return siemResponse.error({
               statusCode: 500,
-              body: `Error in ApplyEntityEngineDataViewIndices. Errors: [${errorMessages.join(
-                ', '
-              )}]`,
+              body: `Errors applying data view changes to the entity store. Errors: \n${errorMessages.join(
+                '\n\n'
+              )}`,
             });
           }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/utils/entity_utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/utils/entity_utils.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mergeEntityStoreIndices } from './entity_utils';
+
+describe('mergeEntityStoreIndices', () => {
+  it('returns the original indices if indexPattern is empty', () => {
+    const indices = ['index1', 'index2'];
+    const result = mergeEntityStoreIndices(indices, '');
+    expect(result).toEqual(indices);
+  });
+
+  it('merges indices with indexPattern when indexPattern is provided', () => {
+    const indices = ['index1', 'index2'];
+    const indexPattern = 'index3,index4';
+    const result = mergeEntityStoreIndices(indices, indexPattern);
+    expect(result).toEqual(['index1', 'index2', 'index3', 'index4']);
+  });
+
+  it('deduplicate indices', () => {
+    const indices = ['index1', 'index2'];
+    const indexPattern = 'index2,index3';
+    const result = mergeEntityStoreIndices(indices, indexPattern);
+    expect(result).toEqual(['index1', 'index2', 'index3']);
+  });
+
+  it('returns an empty array if both indices and indexPattern are empty', () => {
+    const indices: string[] = [];
+    const indexPattern = '';
+    const result = mergeEntityStoreIndices(indices, indexPattern);
+    expect(result).toEqual([]);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/utils/entity_utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/utils/entity_utils.ts
@@ -11,6 +11,7 @@ import {
   entitiesIndexPattern,
 } from '@kbn/entities-schema';
 import type { DataViewsService, DataView } from '@kbn/data-views-plugin/common';
+import { uniq } from 'lodash/fp';
 import type { AppClient } from '../../../../types';
 import { getRiskScoreLatestIndex } from '../../../../../common/entity_analytics/risk_engine';
 import { getAssetCriticalityIndex } from '../../../../../common/entity_analytics/asset_criticality';
@@ -77,3 +78,6 @@ export const isPromiseFulfilled = <T>(
 export const isPromiseRejected = <T>(
   result: PromiseSettledResult<T>
 ): result is PromiseRejectedResult => result.status === 'rejected';
+
+export const mergeEntityStoreIndices = (indices: string[], indexPattern: string | undefined) =>
+  indexPattern ? uniq(indices.concat(indexPattern.split(','))) : indices;


### PR DESCRIPTION
## Summary

When the data view refresh API or task was executed, it was overwriting the engine's additional `indexPattern`.

This PR updates the code to support `indexPattern` and ensures the user has privileges for all indices.

I extracted the merge function to add deduplicate logic.

### How to reproduce it?
* Create an entity store using the indexPatterns param
* Call refresh dataview API (`POST kbn:api/entity_store/engines/apply_dataview_indices`)
* It will apply the dataview and ignore the indexPatterns param

After the fix, we should be able to update the indexPatterns param, and the task that refreshes the index pattern should pick up the change properly.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->