### PR TITLE
[8.18] [8.x] [Enterprise Search] Don't Show Deprecation of Config Setting enterpriseSearch.appsDisabled if on Cloud (#215017)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.test.ts
@@ -45,6 +45,7 @@ describe('Enterprise Search node deprecation', () => {
     expect(steps).toHaveLength(6);
     const stepsStr = steps.join(', ');
     expect(stepsStr).toMatch('Go to cloud.elastic.co');
+    expect(stepsStr).not.toMatch("Edit 'kibana.yml'");
     expect(stepsStr).toMatch('You should no longer see any Enterprise Search capacity');
   });
 
@@ -53,10 +54,11 @@ describe('Enterprise Search node deprecation', () => {
     const deprecations = getEnterpriseSearchNodeDeprecation(config, notCloud, docsUrl);
     expect(deprecations).toHaveLength(1);
     const steps = deprecations[0].correctiveActions.manualSteps;
-    expect(steps).toHaveLength(5);
+    expect(steps).toHaveLength(6);
     const stepsStr = steps.join(', ');
     expect(stepsStr).toMatch("remove 'enterpriseSearch.host'");
     expect(stepsStr).toMatch("remove 'enterpriseSearch.customHeaders'");
+    expect(stepsStr).toMatch("remove 'enterpriseSearch.appsDisabled'");
     expect(stepsStr).toMatch('Stop all your Enterprise Search nodes');
   });
 
@@ -65,10 +67,11 @@ describe('Enterprise Search node deprecation', () => {
     const deprecations = getEnterpriseSearchNodeDeprecation(config, notCloud, docsUrl);
     expect(deprecations).toHaveLength(1);
     const steps = deprecations[0].correctiveActions.manualSteps;
-    expect(steps).toHaveLength(5);
+    expect(steps).toHaveLength(6);
     const stepsStr = steps.join(', ');
     expect(stepsStr).toMatch("remove 'enterpriseSearch.host'");
     expect(stepsStr).toMatch("remove 'enterpriseSearch.customHeaders'");
+    expect(stepsStr).toMatch("remove 'enterpriseSearch.appsDisabled'");
     expect(stepsStr).toMatch('Stop all your Enterprise Search nodes');
   });
 

--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
@@ -91,6 +91,10 @@ export function getEnterpriseSearchNodeDeprecation(
             defaultMessage:
               "Edit 'kibana.yml' to remove 'enterpriseSearch.customHeaders' if it exists",
           }),
+          i18n.translate('xpack.enterpriseSearch.deprecations.entsearchhost.removeappsdisabled', {
+            defaultMessage:
+              "Edit 'kibana.yml' to remove 'enterpriseSearch.appsDisabled' if it exists",
+          }),
           i18n.translate('xpack.enterpriseSearch.deprecations.entsearchhost.restart', {
             defaultMessage: 'Restart Kibana',
           }),

--- a/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/index.ts
@@ -70,9 +70,6 @@ export const config: PluginConfigDescriptor<ConfigType> = {
         deprecate('ui', '9.0.0', {
           level: 'critical',
         }),
-        deprecate('appsDisabled', '9.0.0', {
-          level: 'critical',
-        }),
       ].forEach((deprecation) => deprecation(deprecationConfig, fromPath, addDeprecation, context));
     },
   ],


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[8.x] [Enterprise Search] Don't Show Deprecation of Config Setting enterpriseSearch.appsDisabled if on Cloud (#215017)](https://github.com/elastic/kibana/pull/215017)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mark J. Hoy","email":"mark.hoy@elastic.co"},"sourceCommit":{"committedDate":"2025-03-18T21:41:07Z","message":"[8.x] [Enterprise Search] Don't Show Deprecation of Config Setting enterpriseSearch.appsDisabled if on Cloud (#215017)\n\n## Summary\n\nIf a user is upgrading from 8.x to 9.x on Cloud, the Kibana UA will show\na critical deprecation warning asking them to remove the\n`enterpriseSearch.appsDisabled` config value - which they cannot. This\nshould be conditional based on if the user is using Cloud or not.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-","sha":"ab5072721b0a507519d34e6181fd5420e351563e","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Upgrade Assistant","Team:EnterpriseSearch","v8.18.0","v8.19.0","backport:8.18","v8.18.1"],"title":"[8.x] [Enterprise Search] Don't Show Deprecation of Config Setting enterpriseSearch.appsDisabled if on Cloud","number":215017,"url":"https://github.com/elastic/kibana/pull/215017","mergeCommit":{"message":"[8.x] [Enterprise Search] Don't Show Deprecation of Config Setting enterpriseSearch.appsDisabled if on Cloud (#215017)\n\n## Summary\n\nIf a user is upgrading from 8.x to 9.x on Cloud, the Kibana UA will show\na critical deprecation warning asking them to remove the\n`enterpriseSearch.appsDisabled` config value - which they cannot. This\nshould be conditional based on if the user is using Cloud or not.\n\n### Checklist\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-","sha":"ab5072721b0a507519d34e6181fd5420e351563e"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->