### PR TITLE
[DOCS][8.18] New sub-feature priv for case assignees

### DIFF
--- a/docs/management/cases/setup-cases.asciidoc
+++ b/docs/management/cases/setup-cases.asciidoc
@@ -23,8 +23,7 @@ a|
 The *{connectors-feature}* feature privilege is required to create, add,
 delete, and modify case connectors and to send updates to external systems.
 
-By default, `All` for the *Cases* feature includes authority to delete cases
-and comments, edit case settings, add case comments and attachments, and re-open cases unless you customize the sub-feature privileges.
+By default, **All** for the *Cases* feature allows you to have full control over cases, including deleting them, editing case settings, and more. You can customize the sub-feature privileges to limit feature access.
 ====
 
 | Give assignee access to cases


### PR DESCRIPTION
Partially addresses https://github.com/elastic/docs-content/issues/333. Makes minor changes to future-proof docs for giving full access to manage cases and settings.

Preview: [Cases requirements](https://security-docs_bk_6641.docs-preview.app.elstc.co/guide/en/security/8.x/case-permissions.html)

**Related PRs:**

- 9.0 and Serverless docs (all): https://github.com/elastic/docs-content/pull/831
- Security docs: https://github.com/elastic/security-docs/pull/6641
- Observability docs: https://github.com/elastic/observability-docs/pull/4850