### PR TITLE
[Obs AI Assistant] Update test to intercept API request to fix flakiness

### DIFF
--- a/x-pack/test/observability_ai_assistant_functional/common/intercept_request.ts
+++ b/x-pack/test/observability_ai_assistant_functional/common/intercept_request.ts
@@ -9,6 +9,7 @@ import { WebDriver } from 'selenium-webdriver';
 
 interface ResponseFactory {
   fail: (reason?: string) => ['Fetch.failRequest', { requestId: string }];
+  continue: () => ['Fetch.continueRequest', { requestId: string }];
 }
 
 export async function interceptRequest(
@@ -31,6 +32,7 @@ export async function interceptRequest(
                 'Fetch.failRequest',
                 { requestId: parsed.params.requestId, errorReason: 'Failed' },
               ],
+              continue: () => ['Fetch.continueRequest', { requestId: parsed.params.requestId }],
             }),
             innerResolve
           )

--- a/x-pack/test/observability_ai_assistant_functional/tests/conversations/sharing.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/conversations/sharing.spec.ts
@@ -13,6 +13,7 @@ import {
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { createConnector, deleteConnectors } from '../../common/connectors';
 import { deleteConversations } from '../../common/conversations';
+import { interceptRequest } from '../../common/intercept_request';
 
 export default function ApiTest({ getService, getPageObjects }: FtrProviderContext) {
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantAPIClient');
@@ -21,6 +22,7 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
   const supertest = getService('supertest');
   const log = getService('log');
   const retry = getService('retry');
+  const driver = getService('__webdriver__');
 
   const { header } = getPageObjects(['header', 'security']);
   const PageObjects = getPageObjects(['common', 'error', 'navigationalSearch', 'security']);
@@ -77,9 +79,16 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
 
       describe('when changing access to Shared', () => {
         before(async () => {
-          await testSubjects.click(ui.pages.conversations.access.sharedOption);
-          await testSubjects.existOrFail(ui.pages.conversations.access.loadingBadge);
-          await testSubjects.missingOrFail(ui.pages.conversations.access.loadingBadge);
+          await interceptRequest(
+            driver.driver,
+            '*observability_ai_assistant\\/conversation\\/*',
+            (responseFactory) => {
+              return responseFactory.continue();
+            },
+            async () => {
+              await testSubjects.click(ui.pages.conversations.access.sharedOption);
+            }
+          );
         });
 
         it('should update the badge to "Shared"', async () => {
@@ -104,10 +113,17 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
 
       describe('when changing access to Private', () => {
         before(async () => {
-          await testSubjects.click(ui.pages.conversations.access.shareButton);
-          await testSubjects.click(ui.pages.conversations.access.privateOption);
-          await testSubjects.existOrFail(ui.pages.conversations.access.loadingBadge);
-          await testSubjects.missingOrFail(ui.pages.conversations.access.loadingBadge);
+          await interceptRequest(
+            driver.driver,
+            '*observability_ai_assistant\\/conversation\\/*',
+            (responseFactory) => {
+              return responseFactory.continue();
+            },
+            async () => {
+              await testSubjects.click(ui.pages.conversations.access.shareButton);
+              await testSubjects.click(ui.pages.conversations.access.privateOption);
+            }
+          );
         });
 
         it('should update the badge to "Private"', async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/214455

## Summary

Fixes flaky test by intercepting the API request.

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->