### PR TITLE
[8.x] [Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/__snapshots__/risk_score_configuration_section.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/__snapshots__/risk_score_configuration_section.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`RiskScoreConfigurationSection renders correctly 1`] = `
         end="now"
         onTimeChange={[Function]}
         showUpdateButton={false}
-        start="now-30m"
+        start="now-30d"
         width="auto"
       />
     </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.test.tsx
@@ -23,7 +23,7 @@ describe('RiskScoreConfigurationSection', () => {
   const defaultProps = {
     includeClosedAlerts: false,
     setIncludeClosedAlerts: jest.fn(),
-    from: 'now-30m',
+    from: 'now-30d',
     to: 'now',
     onDateChange: jest.fn(),
   };
@@ -55,8 +55,8 @@ describe('RiskScoreConfigurationSection', () => {
 
   it('calls onDateChange on date change', () => {
     const wrapper = mount(<RiskScoreConfigurationSection {...defaultProps} />);
-    wrapper.find(EuiSuperDatePicker).props().onTimeChange({ start: 'now-30m', end: 'now' });
-    expect(defaultProps.onDateChange).toHaveBeenCalledWith({ start: 'now-30m', end: 'now' });
+    wrapper.find(EuiSuperDatePicker).props().onTimeChange({ start: 'now-30d', end: 'now' });
+    expect(defaultProps.onDateChange).toHaveBeenCalledWith({ start: 'now-30d', end: 'now' });
   });
 
   it('shows bottom bar when changes are made', async () => {
@@ -88,7 +88,7 @@ describe('RiskScoreConfigurationSection', () => {
     const callArgs = mockMutate.mock.calls[0][0];
     expect(callArgs).toEqual({
       includeClosedAlerts: true,
-      range: { start: 'now-30m', end: 'now' },
+      range: { start: 'now-30d', end: 'now' },
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/risk_score_configuration_section.tsx
@@ -76,9 +76,10 @@ export const RiskScoreConfigurationSection = ({
 
   const onRefresh = ({ start: newStart, end: newEnd }: { start: string; end: string }) => {
     setFrom(newStart);
-    setTo(newEnd);
-    onDateChange({ start: newStart, end: newEnd });
-    checkForChanges(newStart, newEnd, includeClosedAlerts);
+    const adjustedEnd = newStart === newEnd ? 'now' : newEnd;
+    setTo(adjustedEnd);
+    onDateChange({ start: newStart, end: adjustedEnd });
+    checkForChanges(newStart, adjustedEnd, includeClosedAlerts);
   };
 
   const handleToggle = () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
@@ -36,7 +36,7 @@ export const EntityAnalyticsManagementPage = () => {
   const styles = getEntityAnalyticsRiskScorePageStyles(euiTheme);
   const privileges = useMissingRiskEnginePrivileges();
   const [includeClosedAlerts, setIncludeClosedAlerts] = useState(false);
-  const [from, setFrom] = useState(localStorage.getItem('dateStart') || 'now-30m');
+  const [from, setFrom] = useState(localStorage.getItem('dateStart') || 'now-30d');
   const [to, setTo] = useState(localStorage.getItem('dateEnd') || 'now');
   const { data: riskEngineStatus } = useRiskEngineStatus({
     refetchInterval: TEN_SECONDS,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)](https://github.com/elastic/kibana/pull/215093)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abhishek Bhatia","email":"117628830+abhishekbhatia1710@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-19T11:46:24Z","message":"[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)\n\n## Summary\n\nThe PR updates the code to extend the lookback period for Risk scoring\ncalculations from `now-30m` to `now-30d`.\n\nThis change impacts:  \n- Risk score UI (date picker)\n- The preview API  \n- The enable API (for Risk Score Saved Object configuration)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\nScreenshots : \n\n## UI and Preview API payload\n\n\n![image](https://github.com/user-attachments/assets/9a074dc4-328f-405b-8ffe-5ce8a7def3d6)\n\n## Risk Engine configuration SO\n\n\n![image](https://github.com/user-attachments/assets/bfd4f6f8-3f1c-4f83-8247-66b9e93a71c2)\n\n\n## Testing Steps:\n\n1. Navigate to the Entity Analytics management page (Entity Risk Score\nwebpage).\n2. Ensure the default text in the date picker displays **\"Last 30\ndays\"**.\n3. Open the **Network** tab in Developer Tools and verify that the\n**\"preview\"** API request reflects a 30-day difference between the\n`from` and `to` values.\n4. If the **Risk Engine** is enabled, disable it and open a window\ndisplaying Kibana logs.\n5. Re-enable the **Risk Engine** and check the logs for the\nconfiguration message: **\"Risk engine running with configuration\"**. The\nexpected range should be:\n   ```json\n   \"range\": {\n     \"start\": \"now/M\",\n     \"end\": \"now\"\n   }\n   ```\n\n\n## Advanced Testing Steps  \n\n1. The date picker should default to **\"Last 30 days\"**. If you change\nit to **\"Yesterday\"** without clicking **Save changes**, the **Preview\nAPI** should reflect \"Yesterday,\" but the **Saved Object (SO)** should\n**not** update its range.\n2. Upon refreshing the page without saving the changes, the date picker\nshould reset to its default value, **\"Last 30 days\"**.","sha":"90dd368e71f3fce950607df3ec486289b408a6af","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","v9.0.0","Team:Entity Analytics","backport:version","v8.17.0","v8.18.0","v9.1.0"],"title":"[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period","number":215093,"url":"https://github.com/elastic/kibana/pull/215093","mergeCommit":{"message":"[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)\n\n## Summary\n\nThe PR updates the code to extend the lookback period for Risk scoring\ncalculations from `now-30m` to `now-30d`.\n\nThis change impacts:  \n- Risk score UI (date picker)\n- The preview API  \n- The enable API (for Risk Score Saved Object configuration)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\nScreenshots : \n\n## UI and Preview API payload\n\n\n![image](https://github.com/user-attachments/assets/9a074dc4-328f-405b-8ffe-5ce8a7def3d6)\n\n## Risk Engine configuration SO\n\n\n![image](https://github.com/user-attachments/assets/bfd4f6f8-3f1c-4f83-8247-66b9e93a71c2)\n\n\n## Testing Steps:\n\n1. Navigate to the Entity Analytics management page (Entity Risk Score\nwebpage).\n2. Ensure the default text in the date picker displays **\"Last 30\ndays\"**.\n3. Open the **Network** tab in Developer Tools and verify that the\n**\"preview\"** API request reflects a 30-day difference between the\n`from` and `to` values.\n4. If the **Risk Engine** is enabled, disable it and open a window\ndisplaying Kibana logs.\n5. Re-enable the **Risk Engine** and check the logs for the\nconfiguration message: **\"Risk engine running with configuration\"**. The\nexpected range should be:\n   ```json\n   \"range\": {\n     \"start\": \"now/M\",\n     \"end\": \"now\"\n   }\n   ```\n\n\n## Advanced Testing Steps  \n\n1. The date picker should default to **\"Last 30 days\"**. If you change\nit to **\"Yesterday\"** without clicking **Save changes**, the **Preview\nAPI** should reflect \"Yesterday,\" but the **Saved Object (SO)** should\n**not** update its range.\n2. Upon refreshing the page without saving the changes, the date picker\nshould reset to its default value, **\"Last 30 days\"**.","sha":"90dd368e71f3fce950607df3ec486289b408a6af"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215147","number":215147,"state":"MERGED","mergeCommit":{"sha":"d6aebc956109cb43eec521506ca25543aea37fbc","message":"[9.0] [Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093) (#215147)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution][Entity Analytics][Bug][Risk Score]Changes to\nreplace 30m to 30d for Risk score lookback period\n(#215093)](https://github.com/elastic/kibana/pull/215093)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Abhishek Bhatia <117628830+abhishekbhatia1710@users.noreply.github.com>"}},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215150","number":215150,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215146","number":215146,"state":"MERGED","mergeCommit":{"sha":"064682e29a6fe95a5cb973691082455745b5e02c","message":"[8.18] [Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093) (#215146)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Security Solution][Entity Analytics][Bug][Risk Score]Changes to\nreplace 30m to 30d for Risk score lookback period\n(#215093)](https://github.com/elastic/kibana/pull/215093)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Abhishek Bhatia <117628830+abhishekbhatia1710@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215093","number":215093,"mergeCommit":{"message":"[Security Solution][Entity Analytics][Bug][Risk Score]Changes to replace 30m to 30d for Risk score lookback period (#215093)\n\n## Summary\n\nThe PR updates the code to extend the lookback period for Risk scoring\ncalculations from `now-30m` to `now-30d`.\n\nThis change impacts:  \n- Risk score UI (date picker)\n- The preview API  \n- The enable API (for Risk Score Saved Object configuration)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\nScreenshots : \n\n## UI and Preview API payload\n\n\n![image](https://github.com/user-attachments/assets/9a074dc4-328f-405b-8ffe-5ce8a7def3d6)\n\n## Risk Engine configuration SO\n\n\n![image](https://github.com/user-attachments/assets/bfd4f6f8-3f1c-4f83-8247-66b9e93a71c2)\n\n\n## Testing Steps:\n\n1. Navigate to the Entity Analytics management page (Entity Risk Score\nwebpage).\n2. Ensure the default text in the date picker displays **\"Last 30\ndays\"**.\n3. Open the **Network** tab in Developer Tools and verify that the\n**\"preview\"** API request reflects a 30-day difference between the\n`from` and `to` values.\n4. If the **Risk Engine** is enabled, disable it and open a window\ndisplaying Kibana logs.\n5. Re-enable the **Risk Engine** and check the logs for the\nconfiguration message: **\"Risk engine running with configuration\"**. The\nexpected range should be:\n   ```json\n   \"range\": {\n     \"start\": \"now/M\",\n     \"end\": \"now\"\n   }\n   ```\n\n\n## Advanced Testing Steps  \n\n1. The date picker should default to **\"Last 30 days\"**. If you change\nit to **\"Yesterday\"** without clicking **Save changes**, the **Preview\nAPI** should reflect \"Yesterday,\" but the **Saved Object (SO)** should\n**not** update its range.\n2. Upon refreshing the page without saving the changes, the date picker\nshould reset to its default value, **\"Last 30 days\"**.","sha":"90dd368e71f3fce950607df3ec486289b408a6af"}}]}] BACKPORT-->