### PR TITLE
Fix warning in @kbn/grouping's GroupSelector component

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/group_selector/index.tsx
@@ -150,7 +150,7 @@ const GroupSelectorComponent = ({
         data-test-subj="groupByContextMenu"
         initialPanelId="firstPanel"
         panels={panels}
-        euiTheme={euiTheme}
+        border={euiTheme.border}
       />
     </EuiPopover>
   );

--- a/src/platform/packages/shared/kbn-grouping/src/components/styles.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/styles.tsx
@@ -75,14 +75,14 @@ export const groupingContainerCssLevel = (euiTheme: EuiThemeComputed<{}>) => css
   }
 `;
 
-export const StyledContextMenu = euiStyled(EuiContextMenu)<{ euiTheme: EuiThemeComputed }>`
+export const StyledContextMenu = euiStyled(EuiContextMenu)<{ border: EuiThemeComputed['border'] }>`
   width: 250px;
   & .euiContextMenuItem__text {
     overflow: hidden;
     text-overflow: ellipsis;
   }
   .euiContextMenuItem {
-    border-bottom: ${(props) => props.euiTheme.border.thin};
+    border-bottom: ${(props) => props.border.thin};
   }
   .euiContextMenuItem:last-child {
     border: none;


### PR DESCRIPTION
## Summary

When a user clicks on the grouping's menu trigger to show all available grouping options, React throws this warning:

```
React does not recognize the `euiTheme` prop on a DOM element.
```

Reason is the `<StyledContextMenu>` component is a mere `<div>` element wrapped by `@emotion` to inject some styling. The rendered `<div>` that results from it can only receive HTML-compliant attributes as props. However, the `euiTheme` is an object that contains many fields, and some of them are not valid. And so, React throws a warning to address it.

Solution was to propagate just the border styling instead of the whole `euiTheme` object.

### Screenshot

<img width="312" alt="Screenshot 2025-03-19 at 18 37 18" src="https://github.com/user-attachments/assets/bf4c25d3-ed95-41de-8204-0341662aa470" />

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Very minor risk of not applying the correct border styling to the grouping's menu trigger.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->