### PR TITLE
update retrieve_elastic_doc api test

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
@@ -161,7 +161,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           );
         });
 
-        it('returns the retrieved doc in the final tool message', () => {
+        it('responds with the correct tool message', () => {
           expect(lastMessage?.role).to.be('tool');
           // @ts-expect-error
           expect(lastMessage?.tool_call_id).to.equal(

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
@@ -6,6 +6,9 @@
  */
 
 import expect from '@kbn/expect';
+import { ChatCompletionStreamParams } from 'openai/lib/ChatCompletionStream';
+import { first, last } from 'lodash';
+import { MessageAddEvent, MessageRole } from '@kbn/observability-ai-assistant-plugin/common';
 import {
   LlmProxy,
   createLlmProxy,
@@ -22,7 +25,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     // Fails on MKI: https://github.com/elastic/kibana/issues/205581
     this.tags(['failsOnMKI']);
     const supertest = getService('supertest');
-    const USER_MESSAGE = 'What is Kibana Lens?';
+    const USER_PROMPT = 'What is Kibana Lens?';
 
     describe('POST /internal/observability_ai_assistant/chat/complete without product doc installed', function () {
       let llmProxy: LlmProxy;
@@ -36,7 +39,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         void llmProxy.interceptConversation('Hello from LLM Proxy');
 
         await chatComplete({
-          userPrompt: USER_MESSAGE,
+          userPrompt: USER_PROMPT,
           connectorId,
           observabilityAIAssistantAPIClient,
         });
@@ -70,7 +73,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       it('contains the original user message', () => {
         const everyRequestHasUserMessage = llmProxy.interceptedRequests.every(({ requestBody }) =>
           requestBody.messages.some(
-            (message) => message.role === 'user' && (message.content as string) === USER_MESSAGE
+            (message) => message.role === 'user' && (message.content as string) === USER_PROMPT
           )
         );
         expect(everyRequestHasUserMessage).to.be(true);
@@ -81,6 +84,9 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     describe('POST /internal/observability_ai_assistant/chat/complete', function () {
       let llmProxy: LlmProxy;
       let connectorId: string;
+      let messageAddedEvents: MessageAddEvent[];
+      let firstRequestBody: ChatCompletionStreamParams;
+      let secondRequestBody: ChatCompletionStreamParams;
       before(async () => {
         llmProxy = await createLlmProxy(log);
         connectorId = await observabilityAIAssistantAPIClient.createProxyActionConnector({
@@ -90,18 +96,24 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
 
         void llmProxy.interceptWithFunctionRequest({
           name: 'retrieve_elastic_doc',
-          arguments: () => JSON.stringify({}),
+          arguments: () =>
+            JSON.stringify({
+              query: USER_PROMPT,
+            }),
+          when: () => true,
         });
 
         void llmProxy.interceptConversation('Hello from LLM Proxy');
 
-        await chatComplete({
-          userPrompt: USER_MESSAGE,
+        ({ messageAddedEvents } = await chatComplete({
+          userPrompt: USER_PROMPT,
           connectorId,
           observabilityAIAssistantAPIClient,
-        });
+        }));
 
         await llmProxy.waitForAllInterceptorsToHaveBeenCalled();
+        firstRequestBody = llmProxy.interceptedRequests[0].requestBody;
+        secondRequestBody = llmProxy.interceptedRequests[1].requestBody;
       });
 
       after(async () => {
@@ -112,25 +124,65 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         });
       });
 
-      it('makes 6 requests to the LLM', () => {
-        expect(llmProxy.interceptedRequests.length).to.be(6);
+      it('emits 5 messageAdded events', () => {
+        expect(messageAddedEvents.length).to.be(5);
       });
 
-      it('every request contain retrieve_elastic_doc function', () => {
-        const everyRequestHasRetrieveElasticDoc = llmProxy.interceptedRequests.every(
-          ({ requestBody }) =>
-            requestBody.tools?.some((t) => t.function.name === 'retrieve_elastic_doc')
-        );
-        expect(everyRequestHasRetrieveElasticDoc).to.be(true);
+      describe('The first request', () => {
+        it('contains the correct number of messages', () => {
+          expect(firstRequestBody.messages.length).to.be(4);
+        });
+
+        it('contains the system message as the first message in the request', () => {
+          expect(first(firstRequestBody.messages)?.role === MessageRole.System);
+        });
+
+        it('contain retrieve_elastic_doc function', () => {
+          expect(firstRequestBody.tools?.map((t) => t.function.name)).to.contain(
+            'retrieve_elastic_doc'
+          );
+        });
+
+        it('leaves the LLM to choose the correct tool by leave tool_choice as auto and passes tools', () => {
+          expect(firstRequestBody.tool_choice).to.be('auto');
+          expect(firstRequestBody.tools?.length).to.not.be(0);
+        });
+
+        it('contains the original user message', () => {
+          expect(
+            firstRequestBody.messages.find((message) => message.role === MessageRole.User)?.content
+          ).to.be(USER_PROMPT);
+        });
       });
 
-      it('contains the original user message', () => {
-        const everyRequestHasUserMessage = llmProxy.interceptedRequests.every(({ requestBody }) =>
-          requestBody.messages.some(
-            (message) => message.role === 'user' && (message.content as string) === USER_MESSAGE
-          )
-        );
-        expect(everyRequestHasUserMessage).to.be(true);
+      describe('The second request - Sending the user prompt', () => {
+        it('contains the correct number of messages', () => {
+          expect(secondRequestBody.messages.length).to.be(6);
+        });
+
+        it('contains the system message as the first message in the request', () => {
+          expect(first(secondRequestBody.messages)?.role === MessageRole.System);
+        });
+
+        it('contains the user prompt', () => {
+          expect(secondRequestBody.messages[1].role).to.be(MessageRole.User);
+          expect(secondRequestBody.messages[1].content).to.be(USER_PROMPT);
+        });
+
+        it('contains the tool call for retrieve_elastic_doc and the corresponding response', () => {
+          expect(secondRequestBody.messages[4].role).to.be(MessageRole.Assistant);
+          // @ts-expect-error
+          expect(secondRequestBody.messages[4].tool_calls[0].function.name).to.be(
+            'retrieve_elastic_doc'
+          );
+
+          expect(last(secondRequestBody.messages)?.role).to.be('tool');
+          // @ts-expect-error
+          expect(last(secondRequestBody.messages)?.tool_call_id).to.equal(
+            // @ts-expect-error
+            secondRequestBody.messages[4].tool_calls[0].id
+          );
+        });
       });
     });
   });

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
@@ -154,7 +154,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           );
         });
 
-        it('documents from Elastic docs are sent to the LLM', () => {
+        it('sends Elastic product docs to the LLM', () => {
           const lastMessage = last(secondRequestBody.messages);
           expect(lastMessage?.role).to.be('tool');
           // @ts-expect-error

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/retrieve_elastic_doc.spec.ts
@@ -134,7 +134,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       });
 
       describe('The first request', () => {
-        it('contain retrieve_elastic_doc function', () => {
+        it('contains the retrieve_elastic_doc function', () => {
           expect(firstRequestBody.tools?.map((t) => t.function.name)).to.contain(
             'retrieve_elastic_doc'
           );
@@ -153,7 +153,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
           lastMessage = last(secondRequestBody.messages) as ChatCompletionMessageParam;
           parsedContent = JSON.parse(lastMessage.content as string);
         });
-        it('includes a retrieve_elastic_doc function call', () => {
+        it('includes the retrieve_elastic_doc function call', () => {
           expect(secondRequestBody.messages[4].role).to.be(MessageRole.Assistant);
           // @ts-expect-error
           expect(secondRequestBody.messages[4].tool_calls[0].function.name).to.be(
@@ -169,15 +169,15 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
             secondRequestBody.messages[4].tool_calls[0].id
           );
         });
-        it('retrieve documents from Elastic docs are sent to the LLM', () => {
+        it('sends the retrieved documents from Elastic docs to the LLM', () => {
           expect(lastMessage.content).to.be.a('string');
         });
 
-        it('send 3 documents to the llm', () => {
+        it('should send 3 documents to the llm', () => {
           expect(parsedContent.documents.length).to.be(3);
         });
 
-        it('document content must contain the "lens" word', () => {
+        it('should contain the word "lens" in the document content', () => {
           const document = parsedContent.documents.find(
             (doc) => doc.title === 'Enhancements and bug fixes'
           );


### PR DESCRIPTION
Related: https://github.com/elastic/kibana/issues/180787

- Update test for `retrieve_elastic_doc` function

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->