### PR TITLE
[SecuritySolution] Custom onboarding navigation in fleet to de-dup app information in `navigateToApp`

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -432,7 +432,7 @@ export function Detail() {
       }
 
       const navigateOptions: InstallPkgRouteOptions =
-        onboardingAppId && fixedOnboardingLink
+        onboardingAppId && onboardingLink && fixedOnboardingLink
           ? [
               defaultNavigateOptions[0],
               {
@@ -440,6 +440,7 @@ export function Detail() {
                 state: {
                   ...(defaultNavigateOptions[1]?.state ?? {}),
                   onCancelNavigateTo: [onboardingAppId, { path: fixedOnboardingLink }],
+                  onCancelUrl: onboardingLink,
                   onSaveNavigateTo: [onboardingAppId, { path: fixedOnboardingLink }],
                 },
               },

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -421,17 +421,26 @@ export function Detail() {
       /** Users from Security Solution onboarding page will have onboardingLink and onboardingAppId in the query params
        ** to redirect back to the onboarding page after adding an integration
        */
+
+      // if link already contains the application, remove it
+      let fixedOnboardingLink = onboardingLink;
+      if (onboardingAppId) {
+        const appBaseUrl = services.application.getUrlForApp(onboardingAppId);
+        if (onboardingLink?.startsWith(appBaseUrl)) {
+          fixedOnboardingLink = onboardingLink.slice(appBaseUrl.length);
+        }
+      }
+
       const navigateOptions: InstallPkgRouteOptions =
-        onboardingAppId && onboardingLink
+        onboardingAppId && fixedOnboardingLink
           ? [
               defaultNavigateOptions[0],
               {
                 ...defaultNavigateOptions[1],
                 state: {
                   ...(defaultNavigateOptions[1]?.state ?? {}),
-                  onCancelNavigateTo: [onboardingAppId, { path: onboardingLink }],
-                  onCancelUrl: onboardingLink,
-                  onSaveNavigateTo: [onboardingAppId, { path: onboardingLink }],
+                  onCancelNavigateTo: [onboardingAppId, { path: fixedOnboardingLink }],
+                  onSaveNavigateTo: [onboardingAppId, { path: fixedOnboardingLink }],
                 },
               },
             ]


### PR DESCRIPTION
## Summary

Fixes the custom fleet onboarding navigation logic to de-duplicate the application details from the assembled link.

## Overview

When looking into utilizing this logic for the AI4DSOC slimmed down integrations page, I noticed that for the custom onboarding redirects, we are double accounting for the appId in the function calls, and essentially building an invalid link. It seems like it only worked because the default page for the security solution was the page we were trying to navigate to. 

### Reproduce

To test this out locally, simply change [this line](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/integrations/use_integration_card_list.ts#L83) 
from
```
  const onboardingLink = getAppUrl({ appId: SECURITY_UI_APP_ID, path: ONBOARDING_PATH });
```
to
```
  const onboardingLink = getAppUrl({ appId: SECURITY_UI_APP_ID, path: RULES });
```

To verify, make sure **both** the `Back to selection` button on the integrations overview page, and the `Cancel`/`Save and continue` buttons on the integration policy create page, navigate you to the `Rules` page.

### Screen recordings before and after

Before (pointed to the rules page as my `onboardingLink`)

https://github.com/user-attachments/assets/04618d69-7d14-445a-bc9f-7c4f98ae29a3

After (still pointed to the rules page as my `onboardingLink`)

https://github.com/user-attachments/assets/c28fbb60-8bf2-4b82-a430-cc328f11d0ab


Relates: https://github.com/elastic/kibana/pull/194028

