### PR TITLE
[Fleet] Update serverless readme

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/developing_kibana_in_serverless.md
+++ b/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/developing_kibana_in_serverless.md
@@ -122,3 +122,45 @@ rm -rf .es/stateless
 ## Release
 
 Serverless Kibana is periodically released from `main` following a deployment workflow composed of four environments (CI, QA, Staging, Production). It is therefore important to be aware of the release schedule and ensure timely communication with our QA team prior to merging.
+
+## Serverless local setup with agent VM
+
+To enroll an agent from a multipass VM with a local serverless stack, some changes are needed to the setup:
+
+Start ES with the `host` parameter:
+
+```bash
+# Start Elasticsearch in serverless mode as a security|oblt projectType
+yarn es serverless --projectType=security --kill --host=<local_ip>
+
+# Run Kibana as a security|oblt projectType
+yarn serverless-security
+```
+
+Add to `kibana.dev.yml` config:
+
+```yaml
+xpack.fleet.fleetServerHosts:
+  - id: default-fleet-server
+    name: Default Fleet server
+    is_default: true
+    host_urls: ['http://<local_ip>:8220']
+xpack.fleet.outputs:
+  - id: es-default-output
+    name: Default output
+    type: elasticsearch
+    is_default: true
+    is_default_monitoring: true
+    is_internal: false
+    hosts: ['https://<local_ip>:9200']
+    ca_trusted_fingerprint: F71F73085975FD977339A1909EBFE2DF40DB255E0D5BB56FC37246BF383FFC84
+    config: 
+      ssl:
+        verification_mode: none
+```
+
+Enroll agent in a multipass VM with the `insecure` flag:
+
+```
+sudo ./elastic-agent install --url=http://<local_ip>:8220 --enrollment-token=<token> --insecure
+```


### PR DESCRIPTION
Document setup to start local stack in serverless mode and enroll an agent from a multipass VM.