### PR TITLE
[8.17] [Security Solution] Add retrieve results to security solution search strategy (#207307)

### DIFF
--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.test.ts
@@ -10,6 +10,7 @@ import {
   buildEventEnrichmentRawResponseMock,
 } from '../../../../../../common/search_strategy/security_solution/cti/index.mock';
 import { parseEventEnrichmentResponse } from './response';
+import type { IEsSearchResponse } from '@kbn/search-types';
 
 describe('parseEventEnrichmentResponse', () => {
   it('includes an accurate inspect response', async () => {
@@ -100,5 +101,17 @@ describe('parseEventEnrichmentResponse', () => {
         'matched.index': ['filebeat-8.0.0-2021.05.28-000001'],
       }),
     ]);
+  });
+
+  it('returns an empty array when no hits', async () => {
+    const options = buildEventEnrichmentRequestOptionsMock();
+    const response = {
+      rawResponse: {
+        hits: {},
+      },
+    } as IEsSearchResponse;
+    const parsedResponse = await parseEventEnrichmentResponse(options, response);
+
+    expect(parsedResponse.enrichments).toEqual([]);
   });
 });

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/factory/cti/event_enrichment/response.ts
@@ -6,6 +6,8 @@
  */
 
 import type { IEsSearchResponse } from '@kbn/search-types';
+import { getOr } from 'lodash/fp';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import type { EventEnrichmentRequestOptions } from '../../../../../../common/api/search_strategy';
 import { inspectStringifyObject } from '../../../../../utils/build_query';
 import { buildIndicatorEnrichments, getTotalCount } from './helpers';
@@ -19,7 +21,8 @@ export const parseEventEnrichmentResponse = async (
     dsl: [inspectStringifyObject(buildEventEnrichmentQuery(options))],
   };
   const totalCount = getTotalCount(response.rawResponse.hits.total);
-  const enrichments = buildIndicatorEnrichments(response.rawResponse.hits.hits);
+  const hits: SearchHit[] = getOr([], 'rawResponse.hits.hits', response);
+  const enrichments = buildIndicatorEnrichments(hits);
 
   return {
     ...response,

--- a/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/security_solution/index.ts
@@ -27,8 +27,9 @@ export const securitySolutionSearchStrategyProvider = (
 
   return {
     search: (request, options, deps) => {
+      // NOTE: without this parameter, .hits.hits can be empty
+      options.retrieveResults = true;
       const parsedRequest = searchStrategyRequestSchema.parse(request);
-
       const queryFactory = securitySolutionFactory[parsedRequest.factoryQueryType];
 
       const dsl = queryFactory.buildDsl(parsedRequest);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Security Solution] Add retrieve results to security solution search strategy (#207307)](https://github.com/elastic/kibana/pull/207307)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Angela Chuang","email":"6295984+angorayc@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-21T13:19:49Z","message":"[Security Solution] Add retrieve results to security solution search strategy (#207307)\n\n## Summary\r\n\r\nhttps://github.com/elastic/kibana/pull/189031\r\n\r\nhttps://p.elstc.co/paste/pCGQy1nV#B7fBRtGiDq-QN14qT/eE8zPOPWgXP88672NIcbSblaD\r\nWithout `options.retrieveResults = true` parameter,\r\n`response.rawResponse.hits.hits` from search strategy can be undefined\r\n\r\n### Checklist\r\n\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"91eefe437a0ef68de34cd6f50f2a1e9cb93f6fc2","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","v9.0.0","v8.18.0"],"title":"[Security Solution] Add retrieve results to security solution search strategy","number":207307,"url":"https://github.com/elastic/kibana/pull/207307","mergeCommit":{"message":"[Security Solution] Add retrieve results to security solution search strategy (#207307)\n\n## Summary\r\n\r\nhttps://github.com/elastic/kibana/pull/189031\r\n\r\nhttps://p.elstc.co/paste/pCGQy1nV#B7fBRtGiDq-QN14qT/eE8zPOPWgXP88672NIcbSblaD\r\nWithout `options.retrieveResults = true` parameter,\r\n`response.rawResponse.hits.hits` from search strategy can be undefined\r\n\r\n### Checklist\r\n\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"91eefe437a0ef68de34cd6f50f2a1e9cb93f6fc2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.0.0","branchLabelMappingKey":"^v9.0.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/207307","number":207307,"mergeCommit":{"message":"[Security Solution] Add retrieve results to security solution search strategy (#207307)\n\n## Summary\r\n\r\nhttps://github.com/elastic/kibana/pull/189031\r\n\r\nhttps://p.elstc.co/paste/pCGQy1nV#B7fBRtGiDq-QN14qT/eE8zPOPWgXP88672NIcbSblaD\r\nWithout `options.retrieveResults = true` parameter,\r\n`response.rawResponse.hits.hits` from search strategy can be undefined\r\n\r\n### Checklist\r\n\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"91eefe437a0ef68de34cd6f50f2a1e9cb93f6fc2"}},{"branch":"8.x","label":"v8.18.0","branchLabelMappingKey":"^v8.18.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/207353","number":207353,"state":"MERGED","mergeCommit":{"sha":"ad38e9b0a80d5417e4d3d31fe96694677fe927c7","message":"[8.x] [Security Solution] Add retrieve results to security solution search strategy (#207307) (#207353)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Security Solution] Add retrieve results to security solution search\nstrategy (#207307)](https://github.com/elastic/kibana/pull/207307)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Angela Chuang <6295984+angorayc@users.noreply.github.com>"}}]}] BACKPORT-->