### PR TITLE
[ES|QL] Fixes the accessibility issue of the run button

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -62,6 +62,7 @@ import './query_bar.scss';
 
 const isMac = navigator.platform.toLowerCase().indexOf('mac') >= 0;
 const COMMAND_KEY = isMac ? '⌘' : 'CTRL';
+const textBasedRunShortcut = `${COMMAND_KEY} + Enter`;
 
 export const strings = {
   getNeedsUpdatingLabel: () =>
@@ -87,6 +88,10 @@ export const strings = {
   getRunQueryLabel: () =>
     i18n.translate('unifiedSearch.queryBarTopRow.submitButton.run', {
       defaultMessage: 'Run query',
+    }),
+  getRunQueryShortcutLabel: () =>
+    i18n.translate('unifiedSearch.queryBarTopRow.submitButton.shortcutLabel', {
+      defaultMessage: `(shortcut ${textBasedRunShortcut})`,
     }),
   getRunButtonLabel: () =>
     i18n.translate('unifiedSearch.queryBarTopRow.submitButton.runButton', {
@@ -565,9 +570,11 @@ export const QueryBarTopRow = React.memo(
       if (!shouldRenderUpdatebutton() && !shouldRenderDatePicker()) {
         return null;
       }
-      const textBasedRunShortcut = `${COMMAND_KEY} + Enter`;
-      const buttonLabelUpdate = strings.getNeedsUpdatingLabel();
       const buttonLabelRefresh = Boolean(isQueryLangSelected)
+        ? `${strings.getRunQueryLabel()} ${strings.getRunQueryShortcutLabel()}`
+        : strings.getRefreshQueryLabel();
+      const buttonLabelUpdate = strings.getNeedsUpdatingLabel();
+      const tooltipText = Boolean(isQueryLangSelected)
         ? textBasedRunShortcut
         : strings.getRefreshQueryLabel();
       const buttonLabelRun = textBasedRunShortcut;
@@ -598,7 +605,7 @@ export const QueryBarTopRow = React.memo(
               needsUpdate={props.isDirty}
               data-test-subj="querySubmitButton"
               toolTipProps={{
-                content: props.isDirty ? tooltipDirty : buttonLabelRefresh,
+                content: props.isDirty ? tooltipDirty : tooltipText,
                 delay: 'long',
                 position: 'bottom',
               }}

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -91,7 +91,8 @@ export const strings = {
     }),
   getRunQueryShortcutLabel: () =>
     i18n.translate('unifiedSearch.queryBarTopRow.submitButton.shortcutLabel', {
-      defaultMessage: `(shortcut ${textBasedRunShortcut})`,
+      defaultMessage: `(shortcut {textBasedRunShortcut})`,
+      values: { textBasedRunShortcut },
     }),
   getRunButtonLabel: () =>
     i18n.translate('unifiedSearch.queryBarTopRow.submitButton.runButton', {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/214540

Separates the tooltip label with the aria label for accessibility reasons

<img width="428" alt="image" src="https://github.com/user-attachments/assets/7aef7e8f-dc1d-4fce-ae05-cf6e215480af" />







<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->