### PR TITLE
[8.16] [CI] Only emit .d.ts when running typecheck (#209259)

### DIFF
--- a/packages/kbn-ts-type-check-cli/run_type_check_cli.ts
+++ b/packages/kbn-ts-type-check-cli/run_type_check_cli.ts
@@ -47,6 +47,8 @@ async function createTypeCheckConfigs(log: SomeDevLog, projects: TsProject[]) {
         ...config.compilerOptions,
         composite: true,
         rootDir: '.',
+        noEmit: false,
+        emitDeclarationOnly: true,
         paths: project.repoRel === 'tsconfig.base.json' ? config.compilerOptions?.paths : undefined,
       },
       kbn_references: undefined,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[CI] Only emit .d.ts when running typecheck (#209259)](https://github.com/elastic/kibana/pull/209259)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2025-03-18T10:48:14Z","message":"[CI] Only emit .d.ts when running typecheck (#209259)\n\n## Summary\nStop emitting any `.js` files during typechecking. We only depend on the\ndeclarations, not the emitted, compiled javascript files.\n\nAn added benefit, is making some bad import errors more obvious.  \nWe'll no longer try to build javascript files in place if a poor\nimport/require is made, rather the error of importing outside projects\n(in the forest of a bunch of errors possibly) will be visible in the\ntypescript logs:\n```\n# instead of:\nproc [tsc] error TS5055: Cannot write file '/opt/buildkite-agent/builds/bk-agent-prod-gcp-1741789017236110254/elastic/kibana-pull-request/kibana/src/platform/packages/shared/kbn-babel-register/cache/no_cache_cache.js' because it would overwrite input file.\n\n# we'll see:\n... several others like this\n proc [tsc] src/platform/packages/shared/kbn-grok-ui/scripts/generate_patterns.js:10:9 - error TS6307: File '/Users/alex/Git/elastic-kibana/src/setup_node_env/index.js' is not listed within the file list of project '/Users/alex/Git/elastic-kibana/src/platform/packages/shared/kbn-grok-ui/tsconfig.type_check.json'. Projects must list all files or use an 'include' pattern.\n proc [tsc] \n proc [tsc] 10 require('../../../../../setup_node_env');\n... several others like this\n```","sha":"702c9c49dcbc9036af80ba5473c961cf96573030","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","v9.0.0","backport:all-open","v8.18.0","v9.1.0","v8.19.0"],"title":"[CI] Only emit .d.ts when running typecheck","number":209259,"url":"https://github.com/elastic/kibana/pull/209259","mergeCommit":{"message":"[CI] Only emit .d.ts when running typecheck (#209259)\n\n## Summary\nStop emitting any `.js` files during typechecking. We only depend on the\ndeclarations, not the emitted, compiled javascript files.\n\nAn added benefit, is making some bad import errors more obvious.  \nWe'll no longer try to build javascript files in place if a poor\nimport/require is made, rather the error of importing outside projects\n(in the forest of a bunch of errors possibly) will be visible in the\ntypescript logs:\n```\n# instead of:\nproc [tsc] error TS5055: Cannot write file '/opt/buildkite-agent/builds/bk-agent-prod-gcp-1741789017236110254/elastic/kibana-pull-request/kibana/src/platform/packages/shared/kbn-babel-register/cache/no_cache_cache.js' because it would overwrite input file.\n\n# we'll see:\n... several others like this\n proc [tsc] src/platform/packages/shared/kbn-grok-ui/scripts/generate_patterns.js:10:9 - error TS6307: File '/Users/alex/Git/elastic-kibana/src/setup_node_env/index.js' is not listed within the file list of project '/Users/alex/Git/elastic-kibana/src/platform/packages/shared/kbn-grok-ui/tsconfig.type_check.json'. Projects must list all files or use an 'include' pattern.\n proc [tsc] \n proc [tsc] 10 require('../../../../../setup_node_env');\n... several others like this\n```","sha":"702c9c49dcbc9036af80ba5473c961cf96573030"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214944","number":214944,"state":"MERGED","mergeCommit":{"sha":"bc32304513a6315a89cb0644ad1f41343199e9c1","message":"[9.0] [CI] Only emit .d.ts when running typecheck (#209259) (#214944)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[CI] Only emit .d.ts when running typecheck\n(#209259)](https://github.com/elastic/kibana/pull/209259)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214942","number":214942,"state":"MERGED","mergeCommit":{"sha":"3f9d5f4d210fb38a72e1b9cc3ba1af53e354504a","message":"[8.18] [CI] Only emit .d.ts when running typecheck (#209259) (#214942)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[CI] Only emit .d.ts when running typecheck\n(#209259)](https://github.com/elastic/kibana/pull/209259)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209259","number":209259,"mergeCommit":{"message":"[CI] Only emit .d.ts when running typecheck (#209259)\n\n## Summary\nStop emitting any `.js` files during typechecking. We only depend on the\ndeclarations, not the emitted, compiled javascript files.\n\nAn added benefit, is making some bad import errors more obvious.  \nWe'll no longer try to build javascript files in place if a poor\nimport/require is made, rather the error of importing outside projects\n(in the forest of a bunch of errors possibly) will be visible in the\ntypescript logs:\n```\n# instead of:\nproc [tsc] error TS5055: Cannot write file '/opt/buildkite-agent/builds/bk-agent-prod-gcp-1741789017236110254/elastic/kibana-pull-request/kibana/src/platform/packages/shared/kbn-babel-register/cache/no_cache_cache.js' because it would overwrite input file.\n\n# we'll see:\n... several others like this\n proc [tsc] src/platform/packages/shared/kbn-grok-ui/scripts/generate_patterns.js:10:9 - error TS6307: File '/Users/alex/Git/elastic-kibana/src/setup_node_env/index.js' is not listed within the file list of project '/Users/alex/Git/elastic-kibana/src/platform/packages/shared/kbn-grok-ui/tsconfig.type_check.json'. Projects must list all files or use an 'include' pattern.\n proc [tsc] \n proc [tsc] 10 require('../../../../../setup_node_env');\n... several others like this\n```","sha":"702c9c49dcbc9036af80ba5473c961cf96573030"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214943","number":214943,"state":"MERGED","mergeCommit":{"sha":"cc35bc14b0fd76dc3c7a8d9338743c4d209706a6","message":"[8.x] [CI] Only emit .d.ts when running typecheck (#209259) (#214943)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[CI] Only emit .d.ts when running typecheck\n(#209259)](https://github.com/elastic/kibana/pull/209259)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Alex Szabo <alex.szabo@elastic.co>"}}]}] BACKPORT-->