### PR TITLE
[fleet] fix overlay in integrations on mobile

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
@@ -19,6 +19,7 @@ import {
   EuiPopover,
   EuiContextMenuPanel,
   EuiContextMenuItem,
+  useEuiTheme,
 } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -103,6 +104,7 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
   spacer = true,
   scrollElementId,
 }) => {
+  const euiTheme = useEuiTheme();
   const localSearch = useLocalSearch(list, !!isLoading);
 
   const [isPopoverOpen, setPopover] = useState(false);
@@ -196,7 +198,15 @@ export const PackageListGrid: FunctionComponent<PackageListGridProps> = ({
         </StickySidebar>
       )}
 
-      <EuiFlexItem grow={5} data-test-subj="epmList.mainColumn" style={{ alignSelf: 'stretch' }}>
+      <EuiFlexItem
+        grow={5}
+        data-test-subj="epmList.mainColumn"
+        style={{
+          position: 'relative',
+          backgroundColor: euiTheme.euiTheme.colors.backgroundBasePlain,
+          alignSelf: 'stretch',
+        }}
+      >
         {showSearchTools && (
           <EuiFlexItem grow={false}>
             <SearchBox


### PR DESCRIPTION
## Summary

This PR resolves [Integrations overlay mobile-view](https://github.com/elastic/kibana/issues/214146) issue.


Before:

https://github.com/user-attachments/assets/47142abc-60b6-4639-b21d-566bcf3a0573

After:

https://github.com/user-attachments/assets/e1044db2-ada1-4a9f-b068-418cf42c20a2






<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->