### PR TITLE
[Observability] Add Investigation Guide feature to o11y rules

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_definition.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_definition.tsx
@@ -54,6 +54,7 @@ import { getAuthorizedConsumers } from '../utils';
 import { RuleAlertDelay } from './rule_alert_delay';
 import { RuleConsumerSelection } from './rule_consumer_selection';
 import { RuleSchedule } from './rule_schedule';
+import InvestigationManager from './rule_investigation_guide';
 
 export const RuleDefinition = () => {
   const {
@@ -190,6 +191,7 @@ export const RuleDefinition = () => {
     [dispatch]
   );
 
+  console.log('params', params);
   return (
     <EuiSplitPanel.Outer hasBorder hasShadow={false} data-test-subj="ruleDefinition">
       <EuiSplitPanel.Inner color="subdued">
@@ -255,6 +257,15 @@ export const RuleDefinition = () => {
                 </EuiErrorBoundary>
               </EuiFlexItem>
             </EuiFlexGroup>
+            <Suspense fallback={null}>
+              <EuiFlexItem>
+                <EuiSpacer size="l" />
+                <InvestigationManager
+                  setRuleParams={onSetRuleParams}
+                  value={params?.investigationGuide ?? ''}
+                />
+              </EuiFlexItem>
+            </Suspense>
           </Suspense>
         )}
       </EuiSplitPanel.Inner>

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_definition.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_definition.tsx
@@ -191,7 +191,6 @@ export const RuleDefinition = () => {
     [dispatch]
   );
 
-  console.log('params', params);
   return (
     <EuiSplitPanel.Outer hasBorder hasShadow={false} data-test-subj="ruleDefinition">
       <EuiSplitPanel.Inner color="subdued">

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_investigation_guide.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_investigation_guide.tsx
@@ -73,9 +73,9 @@ export function InvestigationManager<T extends RuleTypeParams>({
   setRuleParams: RuleTypeParamsExpressionProps<T>['setRuleParams'];
   value: string;
 }) {
-  const [messages, setMessages] = useState<string[]>([]);
+  const [messages, setMessages] = useState<string[] | undefined>(undefined);
   const onParse = useCallback((error: any, { messages: msg, astVal }: any) => {
-    setMessages(error ? [error] : [msg]);
+    setMessages(error ? [error] : undefined);
   }, []);
   return (
     <div>

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_investigation_guide.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_investigation_guide.tsx
@@ -1,8 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 import {
@@ -64,7 +66,6 @@ import React, { useCallback, useState } from 'react';
 //     }),
 //   };
 // }
-
 export function InvestigationManager<T extends RuleTypeParams>({
   setRuleParams,
   value,
@@ -81,12 +82,12 @@ export function InvestigationManager<T extends RuleTypeParams>({
       <EuiFlexGroup gutterSize="xs" alignItems="center">
         <EuiFlexItem grow={false}>
           <EuiText>
-            <h3>
+            <strong>
               <FormattedMessage
                 id="xpack.observability.investigationManager.title"
                 defaultMessage="Investigation Guide"
               />
-            </h3>
+            </strong>
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/src/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status/v1.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/synthetics_monitor_status/v1.ts
@@ -63,6 +63,7 @@ export const syntheticsMonitorStatusRuleParamsSchema = schema.object(
     tags: schema.maybe(schema.arrayOf(schema.string())),
     monitorTypes: schema.maybe(schema.arrayOf(schema.string())),
     projects: schema.maybe(schema.arrayOf(schema.string())),
+    investigationGuide: schema.maybe(schema.string()),
     kqlQuery: schema.maybe(schema.string()),
   },
   {

--- a/src/platform/packages/shared/response-ops/rule_params/synthetics_tls/v1.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/synthetics_tls/v1.ts
@@ -15,6 +15,7 @@ export const tlsRuleParamsSchema = schema.object(
     search: schema.maybe(schema.string()),
     certExpirationThreshold: schema.maybe(schema.number()),
     certAgeThreshold: schema.maybe(schema.number()),
+    investigationGuide: schema.maybe(schema.string()),
   },
   {
     meta: { description: 'The parameters for the rule.' },

--- a/x-pack/solutions/observability/plugins/observability/public/components/investigation_manager/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/investigation_manager/index.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  // EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIconTip,
+  EuiMarkdownEditor,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+// import type { EuiMarkdownEditorUiPluginEditorProps } from '@elastic/eui/src/components/markdown_editor/markdown_types';
+import { RuleTypeParams, RuleTypeParamsExpressionProps } from '@kbn/alerts-ui-shared';
+import { i18n } from '@kbn/i18n';
+import React, { useCallback, useState } from 'react';
+
+// const dropHandlers = [
+//   {
+//     supportedFiles: ['.jpg', '.jpeg'],
+//     accepts: (itemType) => itemType === 'image/jpeg',
+//     getFormattingForItem: (item) => {
+//       // fake an upload
+//       return new Promise((resolve) => {
+//         setTimeout(() => {
+//           const url = URL.createObjectURL(item);
+//           resolve({
+//             text: `![${item.name}](${url})`,
+//             config: { block: true },
+//           });
+//         }, 1000);
+//       });
+//     },
+//   },
+// ];
+
+// function plugin() {
+//   return {
+//     name: 'test-plugin',
+//     button: {
+//       label: 'Test',
+//       iconType: 'observabilityApp',
+//       isDisabled: false,
+//     },
+//     helpText: (
+//       <div>
+//         <p>Test plugin</p>
+//       </div>
+//     ),
+//     editor: React.memo(function TestPlugin(props: EuiMarkdownEditorUiPluginEditorProps) {
+//       const { onCancel } = props;
+//       console.log('props', props);
+//       return (
+//         <div>
+//           I am a test editor <EuiButton onClick={onCancel}>Close</EuiButton>
+//         </div>
+//       );
+//     }),
+//   };
+// }
+
+export function InvestigationManager<T extends RuleTypeParams>({
+  setRuleParams,
+  value,
+}: {
+  setRuleParams: RuleTypeParamsExpressionProps<T>['setRuleParams'];
+  value: string;
+}) {
+  const [messages, setMessages] = useState<string[]>([]);
+  const onParse = useCallback((error: any, { messages: msg, astVal }: any) => {
+    setMessages(error ? [error] : [msg]);
+  }, []);
+  return (
+    <div>
+      <EuiFlexGroup gutterSize="xs" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="s">
+            <h3>
+              <FormattedMessage
+                id="xpack.observability.investigationManager.title"
+                defaultMessage="Investigation Guide"
+              />
+            </h3>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiIconTip content="Include a guide or useful information for addressing alerts created by this rule" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="xs" />
+      <EuiMarkdownEditor
+        aria-label={i18n.translate('xpack.observability.investigationManager.editor.ariaLabel', {
+          defaultMessage: 'Add guidelines for addressing alerts created by this rule',
+        })}
+        placeholder={i18n.translate('xpack.observability.investigationManager.editor.placeholder', {
+          defaultMessage: 'Add guidelines for addressing alerts created by this rule',
+        })}
+        value={value}
+        onChange={(v) => {
+          setRuleParams('investigationGuide', v);
+        }}
+        errors={messages}
+        height={400}
+        onParse={onParse}
+        // uiPlugins={[plugin()]}
+        initialViewMode="editing"
+        // dropHandlers={dropHandlers}
+        // isReadonly={false}
+      />
+    </div>
+  );
+}
+
+// eslint-disable-next-line import/no-default-export
+export default InvestigationManager;

--- a/x-pack/solutions/observability/plugins/observability/public/index.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/index.ts
@@ -58,6 +58,7 @@ export { ObservabilityAlertSearchBar } from './components/alert_search_bar/get_a
 export { DatePicker } from './pages/overview/components/date_picker';
 
 export const LazyAlertsFlyout = lazy(() => import('./components/alerts_flyout/alerts_flyout'));
+export const LazyInvestigationManager = lazy(() => import('./components/investigation_manager'));
 
 export type {
   Stat,

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -19,6 +19,7 @@ import {
   EuiTabbedContentTab,
   useEuiTheme,
   EuiFlexGroup,
+  EuiMarkdownFormat,
 } from '@elastic/eui';
 import {
   AlertStatus,
@@ -282,6 +283,30 @@ export function AlertDetails() {
       }),
       'data-test-subj': 'metadataTab',
       content: metadataTab,
+    },
+    {
+      id: 'investigationguide',
+      name: (
+        <>
+          <FormattedMessage
+            id="xpack.observability.alertDetails.tab.investigationGuideLabel"
+            defaultMessage="Investigation Guide"
+          />
+          &nbsp;
+          <BetaBadge size="s" iconType="beta" style={{ verticalAlign: 'middle' }} />
+        </>
+      ),
+      'data-test-subj': 'investigationGuideTab',
+      disabled: !alertDetail?.formatted?.fields['kibana.alert.rule.parameters']?.investigationGuide,
+      content: (
+        <>
+          <EuiSpacer size="m" />
+          <EuiMarkdownFormat>
+            {(alertDetail?.formatted?.fields['kibana.alert.rule.parameters']
+              ?.investigationGuide as string) ?? ''}
+          </EuiMarkdownFormat>
+        </>
+      ),
     },
     {
       id: RELATED_ALERTS_TAB_ID,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_ui.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_ui.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, Suspense } from 'react';
+import { LazyInvestigationManager } from '@kbn/observability-plugin/public';
 import { RuleTypeParamsExpressionProps } from '@kbn/triggers-actions-ui-plugin/public';
 import { Filter } from '@kbn/es-query';
 import { EuiSpacer } from '@elastic/eui';
@@ -36,6 +37,12 @@ export const StatusRuleComponent: React.FC<{
       <StatusRuleViz ruleParams={ruleParams} />
       <EuiSpacer size="m" />
       <StatusRuleExpression ruleParams={ruleParams} setRuleParams={setRuleParams} />
+      <Suspense fallback={null}>
+        <LazyInvestigationManager
+          setRuleParams={setRuleParams}
+          value={ruleParams?.investigationGuide ?? ''}
+        />
+      </Suspense>
     </>
   );
 };


### PR DESCRIPTION
## Summary

Resolves #213024.

Adds capability to include a markdown text investigation guide to observability rules. When alerts fire from a rule with a guide defined, it will be viewable on the alert details page.

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/67901e3a-b72c-428b-92f3-ac8b58868d19" />

<img width="1538" alt="image" src="https://github.com/user-attachments/assets/80898309-b2b5-4d17-b178-077495618ee9" />
