### PR TITLE
[APM] Fix: Add missing user_agent version field and show it on the trace summary

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
@@ -33,6 +33,7 @@ Object {
     "http.response.status_code",
     "http.request.method",
     "user_agent.name",
+    "user_agent.version",
   ],
   "query": Object {
     "bool": Object {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/transactions/get_transaction/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/transactions/get_transaction/index.ts
@@ -30,6 +30,7 @@ import {
   HTTP_RESPONSE_STATUS_CODE,
   TRANSACTION_PAGE_URL,
   USER_AGENT_NAME,
+  USER_AGENT_VERSION,
 } from '../../../../common/es_fields/apm';
 import { asMutableArray } from '../../../../common/utils/as_mutable_array';
 import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
@@ -71,6 +72,7 @@ export async function getTransaction({
     HTTP_RESPONSE_STATUS_CODE,
     HTTP_REQUEST_METHOD,
     USER_AGENT_NAME,
+    USER_AGENT_VERSION,
   ] as const);
 
   const resp = await apmEventClient.search('get_transaction', {


### PR DESCRIPTION
Closes #215229 

## Summary

This PR adds the `USER_AGENT_VERSION` missing field to the `optionalFields` query fields 

## Testing

- Find a trace with user agent version (on the edge oblt we have it for `elastic-co-frontend`  for example)
- Go to the transaction tab (in case of `elastic-co-frontend` click on  `/blog/:id`)
If the user agent version is available it should be visible in the trace summary: 

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/75b7e331-44d0-4d1c-8060-815c269e23c9" />



<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->