### PR TITLE
[Dashboards] Type is not required if the panel is a by-reference (has `panelRefName`)

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -7336,8 +7336,35 @@
                                     "type": "string"
                                   },
                                   "type": {
+                                    "anyOf": [
+                                      {
+                                        "items": {},
+                                        "type": "array"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "object"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
                                     "description": "The embeddable type",
-                                    "type": "string"
+                                    "nullable": true,
+                                    "oneOf": [
+                                      {
+                                        "type": "string",
+                                        "x-oas-optional": true
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ]
                                   },
                                   "version": {
                                     "deprecated": true,
@@ -7991,8 +8018,35 @@
                               "type": "string"
                             },
                             "type": {
+                              "anyOf": [
+                                {
+                                  "items": {},
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
                               "description": "The embeddable type",
-                              "type": "string"
+                              "nullable": true,
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "x-oas-optional": true
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ]
                             },
                             "version": {
                               "deprecated": true,
@@ -8528,8 +8582,35 @@
                                     "type": "string"
                                   },
                                   "type": {
+                                    "anyOf": [
+                                      {
+                                        "items": {},
+                                        "type": "array"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "object"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
                                     "description": "The embeddable type",
-                                    "type": "string"
+                                    "nullable": true,
+                                    "oneOf": [
+                                      {
+                                        "type": "string",
+                                        "x-oas-optional": true
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ]
                                   },
                                   "version": {
                                     "deprecated": true,
@@ -9155,8 +9236,35 @@
                               "type": "string"
                             },
                             "type": {
+                              "anyOf": [
+                                {
+                                  "items": {},
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
                               "description": "The embeddable type",
-                              "type": "string"
+                              "nullable": true,
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "x-oas-optional": true
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ]
                             },
                             "version": {
                               "deprecated": true,
@@ -9686,8 +9794,35 @@
                                     "type": "string"
                                   },
                                   "type": {
+                                    "anyOf": [
+                                      {
+                                        "items": {},
+                                        "type": "array"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "object"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
                                     "description": "The embeddable type",
-                                    "type": "string"
+                                    "nullable": true,
+                                    "oneOf": [
+                                      {
+                                        "type": "string",
+                                        "x-oas-optional": true
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ]
                                   },
                                   "version": {
                                     "deprecated": true,

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -7336,8 +7336,35 @@
                                     "type": "string"
                                   },
                                   "type": {
+                                    "anyOf": [
+                                      {
+                                        "items": {},
+                                        "type": "array"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "object"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
                                     "description": "The embeddable type",
-                                    "type": "string"
+                                    "nullable": true,
+                                    "oneOf": [
+                                      {
+                                        "type": "string",
+                                        "x-oas-optional": true
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ]
                                   },
                                   "version": {
                                     "deprecated": true,
@@ -7991,8 +8018,35 @@
                               "type": "string"
                             },
                             "type": {
+                              "anyOf": [
+                                {
+                                  "items": {},
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
                               "description": "The embeddable type",
-                              "type": "string"
+                              "nullable": true,
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "x-oas-optional": true
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ]
                             },
                             "version": {
                               "deprecated": true,
@@ -8528,8 +8582,35 @@
                                     "type": "string"
                                   },
                                   "type": {
+                                    "anyOf": [
+                                      {
+                                        "items": {},
+                                        "type": "array"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "object"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
                                     "description": "The embeddable type",
-                                    "type": "string"
+                                    "nullable": true,
+                                    "oneOf": [
+                                      {
+                                        "type": "string",
+                                        "x-oas-optional": true
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ]
                                   },
                                   "version": {
                                     "deprecated": true,
@@ -9155,8 +9236,35 @@
                               "type": "string"
                             },
                             "type": {
+                              "anyOf": [
+                                {
+                                  "items": {},
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
                               "description": "The embeddable type",
-                              "type": "string"
+                              "nullable": true,
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "x-oas-optional": true
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ]
                             },
                             "version": {
                               "deprecated": true,
@@ -9686,8 +9794,35 @@
                                     "type": "string"
                                   },
                                   "type": {
+                                    "anyOf": [
+                                      {
+                                        "items": {},
+                                        "type": "array"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "object"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
                                     "description": "The embeddable type",
-                                    "type": "string"
+                                    "nullable": true,
+                                    "oneOf": [
+                                      {
+                                        "type": "string",
+                                        "x-oas-optional": true
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ]
                                   },
                                   "version": {
                                     "deprecated": true,

--- a/src/platform/plugins/shared/dashboard/server/content_management/v3/cm_services.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v3/cm_services.ts
@@ -282,7 +282,14 @@ export const panelSchema = schema.object({
   id: schema.maybe(
     schema.string({ meta: { description: 'The saved object id for by reference panels' } })
   ),
-  type: schema.string({ meta: { description: 'The embeddable type' } }),
+  // Type is not required if the panel is a by-reference (has `panelRefName`)
+  type: schema.conditional(
+    schema.siblingRef('panelRefName'),
+    schema.string(),
+    schema.maybe(schema.string()),
+    schema.string(),
+    { meta: { description: 'The embeddable type' } }
+  ),
   panelRefName: schema.maybe(schema.string()),
   gridData: gridDataSchema,
   panelIndex: schema.maybe(


### PR DESCRIPTION
## Summary

Adds validation support for dashboards with by-reference panels that do not include panel type.

This bug is not surfaced in production builds of Kibana due to relaxed validation.

Instructions for testing.
1. Start Kibana from source (such as with `yarn start`).
2. From Stack Management - Saved Objects, import the lens and tsvb dashboards in `x-pack/test/functional/apps/dashboard/group2/migration_smoke_tests`
3. Open the "TSVB Index Pattern Smoke Test" and "Lens by Reference With Various Filters" dashboards.

Both dashboards should open without issues. They will fail to open in `main` when running Kibana in development.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



