### PR TITLE
[9.0] [Lens][Embeddable] fix can edit check (#213887)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
@@ -7,9 +7,8 @@
 
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 import React, { useEffect } from 'react';
-import { LensApi } from '../..';
 import { ExpressionWrapper } from '../expression_wrapper';
-import { LensInternalApi } from '../types';
+import { LensInternalApi, LensApi } from '../types';
 import { UserMessages } from '../user_messages/container';
 import { useMessages, useDispatcher } from './hooks';
 import { getViewMode } from '../helper';
@@ -34,8 +33,6 @@ export function LensEmbeddableComponent({
     blockingErrors,
     // has the render completed?
     hasRendered,
-    // has view mode changed?
-    latestViewMode,
   ] = useBatchedPublishingSubjects(
     internalApi.expressionParams$,
     internalApi.renderCount$,
@@ -43,7 +40,7 @@ export function LensEmbeddableComponent({
     api.rendered$,
     api.viewMode$
   );
-  const canEdit = Boolean(api.isEditingEnabled?.() && getViewMode(latestViewMode) === 'edit');
+  const canEdit = Boolean(api.isEditingEnabled?.() && getViewMode(api) === 'edit');
 
   const [warningOrErrors, infoMessages] = useMessages(internalApi);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Lens][Embeddable] fix can edit check (#213887)](https://github.com/elastic/kibana/pull/213887)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Liberati","email":"dej611@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-19T11:50:04Z","message":"[Lens][Embeddable] fix can edit check (#213887)\n\n## Summary\n\nThis PR fixes a regression introduced for user messages.\nThe `viewMode` check moved from observable to its raw value but still\nperforming the observable check.\n\nThe fix is to check both the panel `viewMode` AND as fallback the\nembeddable hierarchy viewMode until the `edit` mode is met.\n\n---------\n\nCo-authored-by: Nick Partridge <nick.ryan.partridge@gmail.com>","sha":"cc52db1474298bc25906294978c3eeef56df364a","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","Feature:Embeddables","backport:version","v9.1.0","v8.19.0","v8.18.1","v8.17.4","v9.0.1"],"title":"[Lens][Embeddable] fix can edit check","number":213887,"url":"https://github.com/elastic/kibana/pull/213887","mergeCommit":{"message":"[Lens][Embeddable] fix can edit check (#213887)\n\n## Summary\n\nThis PR fixes a regression introduced for user messages.\nThe `viewMode` check moved from observable to its raw value but still\nperforming the observable check.\n\nThe fix is to check both the panel `viewMode` AND as fallback the\nembeddable hierarchy viewMode until the `edit` mode is met.\n\n---------\n\nCo-authored-by: Nick Partridge <nick.ryan.partridge@gmail.com>","sha":"cc52db1474298bc25906294978c3eeef56df364a"}},"sourceBranch":"main","suggestedTargetBranches":["8.x","8.18","8.17","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213887","number":213887,"mergeCommit":{"message":"[Lens][Embeddable] fix can edit check (#213887)\n\n## Summary\n\nThis PR fixes a regression introduced for user messages.\nThe `viewMode` check moved from observable to its raw value but still\nperforming the observable check.\n\nThe fix is to check both the panel `viewMode` AND as fallback the\nembeddable hierarchy viewMode until the `edit` mode is met.\n\n---------\n\nCo-authored-by: Nick Partridge <nick.ryan.partridge@gmail.com>","sha":"cc52db1474298bc25906294978c3eeef56df364a"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->