### PR TITLE
[Observability] [Alert details page] Alert insights v1

### DIFF
--- a/src/platform/packages/shared/kbn-alerting-types/search_strategy_types.ts
+++ b/src/platform/packages/shared/kbn-alerting-types/search_strategy_types.ts
@@ -14,6 +14,7 @@ import type {
   QueryDslQueryContainer,
   SortCombinations,
 } from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import type { Alert } from './alerts_types';
 
 export type RuleRegistrySearchRequest = IEsSearchRequest & {
@@ -24,6 +25,7 @@ export type RuleRegistrySearchRequest = IEsSearchRequest & {
   sort?: SortCombinations[];
   pagination?: RuleRegistrySearchRequestPagination;
   runtimeMappings?: MappingRuntimeFields;
+  aggs?: Record<string, estypes.AggregationsAggregationContainer>;
 };
 
 export interface RuleRegistrySearchRequestPagination {

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/search_alerts/search_alerts.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/apis/search_alerts/search_alerts.ts
@@ -23,6 +23,7 @@ import type {
   QueryDslQueryContainer,
   SortCombinations,
 } from '@elastic/elasticsearch/lib/api/types';
+import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 
 export interface SearchAlertsParams {
   // Dependencies
@@ -68,6 +69,14 @@ export interface SearchAlertsParams {
    * The page size to fetch
    */
   pageSize: number;
+  /**
+   * Aggregate alerts
+   */
+  aggs?: Record<string, estypes.AggregationsAggregationContainer>;
+  /**
+   * Force using the default context, otherwise use the AlertQueryContext
+   */
+  useDefaultContext?: boolean;
 }
 
 export interface SearchAlertsResult {
@@ -92,6 +101,7 @@ export const searchAlerts = ({
   runtimeMappings,
   pageIndex,
   pageSize,
+  aggs,
 }: SearchAlertsParams): Promise<SearchAlertsResult> =>
   lastValueFrom(
     data.search
@@ -104,6 +114,7 @@ export const searchAlerts = ({
           pagination: { pageIndex, pageSize },
           sort,
           runtimeMappings,
+          aggs,
         },
         {
           strategy: 'privateRuleRegistryAlertsSearchStrategy',

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_search_alerts_query.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/use_search_alerts_query.ts
@@ -27,7 +27,11 @@ export const queryKeyPrefix = ['alerts', searchAlerts.name];
  * When testing components that depend on this hook, prefer mocking the {@link searchAlerts} function instead of the hook itself.
  * @external https://tanstack.com/query/v4/docs/framework/react/guides/testing
  */
-export const useSearchAlertsQuery = ({ data, ...params }: UseSearchAlertsQueryParams) => {
+export const useSearchAlertsQuery = ({
+  data,
+  useDefaultContext,
+  ...params
+}: UseSearchAlertsQueryParams) => {
   const {
     ruleTypeIds,
     consumers,
@@ -43,6 +47,7 @@ export const useSearchAlertsQuery = ({ data, ...params }: UseSearchAlertsQueryPa
     runtimeMappings,
     pageIndex = 0,
     pageSize = DEFAULT_ALERTS_PAGE_SIZE,
+    aggs = {},
   } = params;
   return useQuery({
     queryKey: queryKeyPrefix.concat(JSON.stringify(params)),
@@ -58,9 +63,10 @@ export const useSearchAlertsQuery = ({ data, ...params }: UseSearchAlertsQueryPa
         runtimeMappings,
         pageIndex,
         pageSize,
+        aggs,
       }),
     refetchOnWindowFocus: false,
-    context: AlertsQueryContext,
+    context: useDefaultContext === true ? undefined : AlertsQueryContext,
     enabled: ruleTypeIds.length > 0,
     // To avoid flash of empty state with pagination, see https://tanstack.com/query/latest/docs/framework/react/guides/paginated-queries#better-paginated-queries-with-placeholderdata
     keepPreviousData: true,

--- a/x-pack/platform/plugins/shared/rule_registry/server/search_strategy/search_strategy.ts
+++ b/x-pack/platform/plugins/shared/rule_registry/server/search_strategy/search_strategy.ts
@@ -175,6 +175,7 @@ export const ruleRegistrySearchStrategyProvider = (
               from: request.pagination ? request.pagination.pageIndex * size : 0,
               query,
               ...(request.runtimeMappings ? { runtime_mappings: request.runtimeMappings } : {}),
+              aggs: request.aggs,
             },
           };
           return (isAnyRuleTypeESAuthorized ? requestUserEs : internalUserEs).search(

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -19,6 +19,8 @@ import {
   EuiTabbedContentTab,
   useEuiTheme,
   EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlexGrid,
 } from '@elastic/eui';
 import {
   AlertStatus,
@@ -54,6 +56,8 @@ import { AlertOverview } from '../../components/alert_overview/alert_overview';
 import { CustomThresholdRule } from '../../components/custom_threshold/components/types';
 import { AlertDetailContextualInsights } from './alert_details_contextual_insights';
 import { AlertHistoryChart } from './components/alert_history';
+import { AlertsTriggeredAroundSameTime } from './components/alerts_triggered_around_same_time';
+import AlertsActiveAtSameTime from './components/alerts_active_at_the_same_time';
 
 interface AlertDetailsPathParams {
   alertId: string;
@@ -230,6 +234,20 @@ export function AlertDetails() {
         <EuiSpacer size="m" />
         <EuiFlexGroup direction="column" gutterSize="m">
           <SourceBar alert={alertDetail.formatted} sources={sources} />
+          <EuiFlexGrid columns={3} gutterSize="m">
+            <EuiFlexItem>
+              <AlertsTriggeredAroundSameTime
+                alert={alertDetail?.formatted}
+                onViewRelatedAlertsClick={() => handleSetTabId(RELATED_ALERTS_TAB_ID)}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <AlertsActiveAtSameTime
+                alert={alertDetail?.formatted}
+                onViewRelatedAlertsClick={() => handleSetTabId(RELATED_ALERTS_TAB_ID)}
+              />
+            </EuiFlexItem>
+          </EuiFlexGrid>
           <AlertDetailContextualInsights alert={alertDetail} />
           {rule && alertDetail.formatted && (
             <>

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -233,7 +233,6 @@ export function AlertDetails() {
       <>
         <EuiSpacer size="m" />
         <EuiFlexGroup direction="column" gutterSize="m">
-          <SourceBar alert={alertDetail.formatted} sources={sources} />
           <EuiFlexGrid columns={3} gutterSize="m">
             <EuiFlexItem>
               <AlertsTriggeredAroundSameTime
@@ -246,6 +245,9 @@ export function AlertDetails() {
                 alert={alertDetail?.formatted}
                 onViewRelatedAlertsClick={() => handleSetTabId(RELATED_ALERTS_TAB_ID)}
               />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <SourceBar alert={alertDetail.formatted} sources={sources} />
             </EuiFlexItem>
           </EuiFlexGrid>
           <AlertDetailContextualInsights alert={alertDetail} />

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/alerts_active_at_the_same_time.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/alerts_active_at_the_same_time.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiLink, EuiPanel, useEuiTheme } from '@elastic/eui';
+import { ALERT_START, ALERT_STATUS } from '@kbn/rule-data-utils';
+import { useSearchAlertsQuery } from '@kbn/alerts-ui-shared/src/common/hooks/use_search_alerts_query';
+import { Chart, Metric, Settings } from '@elastic/charts';
+import {
+  OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
+  observabilityAlertFeatureIds,
+} from '../../../../common/constants';
+import { useKibana } from '../../../utils/kibana_react';
+import { AlertInsightProps, NUM_OF_ALERTS } from '../types';
+
+export function AlertsActiveAtSameTime({ alert, onViewRelatedAlertsClick }: AlertInsightProps) {
+  const { data, charts } = useKibana().services;
+  const { euiTheme } = useEuiTheme();
+
+  const query = {
+    bool: {
+      must: [{ term: { [ALERT_STATUS]: 'active' } }],
+    },
+  };
+
+  const histogramAgg = {
+    active_alerts: {
+      date_histogram: {
+        field: ALERT_START,
+        fixed_interval: '1h',
+        min_doc_count: 1,
+      },
+    },
+  };
+
+  const { data: alertsData } = useSearchAlertsQuery({
+    data,
+    ruleTypeIds: OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
+    consumers: observabilityAlertFeatureIds,
+    pageIndex: 0,
+    pageSize: NUM_OF_ALERTS,
+    query,
+    aggs: histogramAgg,
+    useDefaultContext: true,
+  });
+
+  const rawResponse = alertsData?.querySnapshot?.response[0] ?? 'null';
+  const aggregationsResponse = JSON.parse(rawResponse)?.aggregations;
+  const activeAlertBuckets = aggregationsResponse?.active_alerts?.buckets;
+
+  const metricChartData = activeAlertBuckets
+    ? activeAlertBuckets.map((bucket: { key: number; doc_count: number }) => ({
+        x: bucket.key,
+        y: bucket.doc_count,
+      }))
+    : [];
+
+  return (
+    <EuiPanel paddingSize="none" onFocus={(e: any) => e.target.blur()}>
+      <Chart size={[, 200]}>
+        <Settings baseTheme={charts.theme.useChartsBaseTheme()} />
+        <Metric
+          id="active_at_the_same_time"
+          data={[
+            [
+              {
+                color: euiTheme.colors.backgroundBaseDanger,
+                title: 'Active at the same time',
+                subtitle: '',
+                extra: (
+                  <EuiLink
+                    data-test-subj="o11yAlertsActiveAtSameTimeViewInRelatedAlertsLink"
+                    onClick={onViewRelatedAlertsClick}
+                  >
+                    {i18n.translate(
+                      'xpack.observability.alertsActiveAtSameTime.viewInRelatedAlertsLinkLabel',
+                      { defaultMessage: 'View in related alerts' }
+                    )}
+                  </EuiLink>
+                ),
+                value: String(alertsData?.alerts.length),
+                trend: metricChartData,
+                trendShape: 'area',
+              },
+            ],
+          ]}
+        />
+      </Chart>
+    </EuiPanel>
+  );
+}
+
+// eslint-disable-next-line import/no-default-export
+export default AlertsActiveAtSameTime;

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/alerts_triggered_around_same_time.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/alerts_triggered_around_same_time.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiLink, EuiPanel } from '@elastic/eui';
+import { ALERT_START, ALERT_STATUS } from '@kbn/rule-data-utils';
+import moment from 'moment';
+import { useSearchAlertsQuery } from '@kbn/alerts-ui-shared/src/common/hooks/use_search_alerts_query';
+import { Chart, Metric, Settings } from '@elastic/charts';
+import {
+  OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
+  observabilityAlertFeatureIds,
+} from '../../../../common/constants';
+import { useKibana } from '../../../utils/kibana_react';
+import { AlertInsightProps, NUM_OF_ALERTS } from '../types';
+
+export function AlertsTriggeredAroundSameTime({
+  alert,
+  onViewRelatedAlertsClick,
+}: AlertInsightProps) {
+  const { data, charts } = useKibana().services;
+
+  const alertStartedAt = moment(alert.fields[ALERT_START]);
+
+  const query = {
+    bool: {
+      filter: [
+        {
+          range: {
+            [ALERT_START]: {
+              gte: alertStartedAt.clone().subtract(20, 'm').toISOString(),
+              lte: alertStartedAt.clone().add(20, 'm').toISOString(),
+            },
+          },
+        },
+      ],
+      should: [{ term: { [ALERT_STATUS]: 'active' } }, { term: { [ALERT_STATUS]: 'recovered' } }],
+      minimum_should_match: 1,
+    },
+  };
+
+  const histogramAgg = {
+    alerts: {
+      date_histogram: {
+        field: ALERT_START,
+        fixed_interval: '1m',
+        min_doc_count: 1,
+      },
+    },
+  };
+
+  const { data: alertsData } = useSearchAlertsQuery({
+    data,
+    ruleTypeIds: OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
+    consumers: observabilityAlertFeatureIds,
+    pageIndex: 0,
+    pageSize: NUM_OF_ALERTS,
+    query,
+    aggs: histogramAgg,
+    useDefaultContext: true,
+  });
+
+  const rawResponse = alertsData?.querySnapshot?.response[0] ?? 'null';
+  const aggregationsResponse = JSON.parse(rawResponse)?.aggregations;
+  const alertBuckets = aggregationsResponse?.alerts?.buckets;
+
+  const metricChartData = alertBuckets
+    ? alertBuckets.map((bucket: { key: number; doc_count: number }) => ({
+        x: bucket.key,
+        y: bucket.doc_count,
+      }))
+    : [];
+
+  return (
+    <EuiPanel paddingSize="none" onFocus={(e: any) => e.target.blur()}>
+      <Chart size={[, 200]}>
+        <Settings baseTheme={charts.theme.useChartsBaseTheme()} />
+        <Metric
+          id="triggered_around_same_time"
+          data={[
+            [
+              {
+                color: '#FFFFFF',
+                title: 'Triggered around the same time',
+                subtitle: '',
+                extra: (
+                  <EuiLink
+                    data-test-subj="o11yAlertsTriggeredAroundSameTimeViewInRelatedAlertsLink"
+                    onClick={onViewRelatedAlertsClick}
+                  >
+                    {i18n.translate(
+                      'xpack.observability.alertsTriggeredAroundSameTime.viewInRelatedAlertsLinkLabel',
+                      { defaultMessage: 'View in related alerts' }
+                    )}
+                  </EuiLink>
+                ),
+                value: String(alertsData?.alerts.length),
+                trend: metricChartData,
+                trendShape: 'area',
+              },
+            ],
+          ]}
+        />
+      </Chart>
+    </EuiPanel>
+  );
+}
+
+// eslint-disable-next-line import/no-default-export
+export default AlertsTriggeredAroundSameTime;

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/source_bar.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/components/source_bar.tsx
@@ -35,7 +35,12 @@ export function SourceBar({ alert, sources = [] }: SourceBarProps) {
   return (
     groups &&
     groups.length > 0 && (
-      <EuiPanel data-test-subj="alert-summary-container" hasShadow={false} hasBorder={true}>
+      <EuiPanel
+        paddingSize="s"
+        data-test-subj="alert-summary-container"
+        hasShadow={false}
+        hasBorder={true}
+      >
         <EuiFlexGroup gutterSize="l" direction="row" wrap>
           <EuiTitle size="xs">
             <h5>

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/types.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/types.ts
@@ -8,7 +8,6 @@
 import { ReactNode } from 'react';
 import { TopAlert } from '../..';
 
-export const NUM_OF_BUCKETS = 1000;
 export const NUM_OF_ALERTS = 10000;
 
 export interface AlertDetailsSource {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/types.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/types.ts
@@ -6,6 +6,10 @@
  */
 
 import { ReactNode } from 'react';
+import { TopAlert } from '../..';
+
+export const NUM_OF_BUCKETS = 1000;
+export const NUM_OF_ALERTS = 10000;
 
 export interface AlertDetailsSource {
   label: ReactNode | string;
@@ -14,4 +18,9 @@ export interface AlertDetailsSource {
 
 export interface AlertDetailsAppSectionProps {
   setSources: React.Dispatch<React.SetStateAction<AlertDetailsSource[] | undefined>>;
+}
+
+export interface AlertInsightProps {
+  alert: TopAlert;
+  onViewRelatedAlertsClick: () => void;
 }


### PR DESCRIPTION
Adds following alert insights to the alert details page:
- Triggered around same time
- Active at the same time

The alert insight includes number of alerts and trend chart of alerts based on alert start time.

<img width="1479" alt="Screenshot 2025-03-21 at 12 39 37 PM" src="https://github.com/user-attachments/assets/dfc8c073-4c6b-4af6-bbf3-804bfdbba4c6" />
