### PR TITLE
[8.17][EDR Workflows] Unskip management Jest tests

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
@@ -14,9 +14,9 @@ import {
 } from '../../../../common/mock/endpoint';
 import { ActionsLogUsersFilter } from './actions_log_users_filter';
 import { MANAGEMENT_PATH } from '../../../../../common/constants';
+import { waitFor } from '@testing-library/react';
 
-// FLAKY: https://github.com/elastic/kibana/issues/193092
-describe.skip('Users filter', () => {
+describe('Users filter', () => {
   let render: (
     props?: React.ComponentProps<typeof ActionsLogUsersFilter>
   ) => ReturnType<AppContextTestRender['render']>;
@@ -27,6 +27,7 @@ describe.skip('Users filter', () => {
   const testPrefix = 'test';
   const filterPrefix = 'users-filter';
   let onChangeUsersFilter: jest.Mock;
+  const delay = 100; // ms
 
   beforeEach(() => {
     onChangeUsersFilter = jest.fn();
@@ -51,41 +52,45 @@ describe.skip('Users filter', () => {
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
     expect(searchInput).toBeTruthy();
     expect(searchInput.getAttribute('placeholder')).toEqual('Filter by username');
-  });
+  }, 10000);
 
   it('should search on given search string on enter', async () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, 'usernameX', { delay: 10 });
+    await userEvent.type(searchInput, 'usernameX', { delay });
     await userEvent.keyboard('{enter}');
-    expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']);
-  });
+    await waitFor(() => expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']));
+  }, 10000);
 
   it('should search comma separated strings as multiple users', async () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, 'usernameX,usernameY,usernameZ', { delay: 10 });
+    await userEvent.type(searchInput, 'usernameX,usernameY,usernameZ', { delay });
     await userEvent.keyboard('{enter}');
-    expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY', 'usernameZ']);
-  });
+    await waitFor(() =>
+      expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY', 'usernameZ'])
+    );
+  }, 15000);
 
   it('should ignore white spaces in a given username when updating the API params', async () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, '   usernameX   ', { delay: 10 });
+    await userEvent.type(searchInput, '   usernameX   ', { delay });
     await userEvent.keyboard('{enter}');
-    expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']);
-  });
+    await waitFor(() => expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']));
+  }, 10000);
 
   it('should ignore white spaces in comma separated usernames when updating the API params', async () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, '   , usernameX ,usernameY    ,       ', { delay: 10 });
+    await userEvent.type(searchInput, '   , usernameX ,usernameY    ,       ', { delay });
     await userEvent.keyboard('{enter}');
-    expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY']);
-  });
+    await waitFor(() =>
+      expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY'])
+    );
+  }, 15000);
 });

--- a/x-pack/plugins/security_solution/public/management/hooks/artifacts/use_list_artifact.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/hooks/artifacts/use_list_artifact.test.tsx
@@ -16,8 +16,7 @@ import {
   renderQuery,
 } from '../test_utils';
 
-// FLAKY: https://github.com/elastic/kibana/issues/196724
-describe.skip('List artifact hook', () => {
+describe('List artifact hook', () => {
   let result: ReturnType<typeof useListArtifact>;
   let searchableFields: string[];
   let options:

--- a/x-pack/plugins/security_solution/public/management/hooks/test_utils.tsx
+++ b/x-pack/plugins/security_solution/public/management/hooks/test_utils.tsx
@@ -42,7 +42,7 @@ export const renderQuery = async (
   const { result: resultHook, waitFor } = renderHook(() => hook(), {
     wrapper,
   });
-  await waitFor(() => resultHook.current[waitForHook].toBeTruthy(), { timeout: 5000 });
+  await waitFor(() => resultHook.current[waitForHook], { timeout: 5000 });
   return resultHook.current;
 };
 

--- a/x-pack/plugins/security_solution/public/management/hooks/test_utils.tsx
+++ b/x-pack/plugins/security_solution/public/management/hooks/test_utils.tsx
@@ -42,7 +42,7 @@ export const renderQuery = async (
   const { result: resultHook, waitFor } = renderHook(() => hook(), {
     wrapper,
   });
-  await waitFor(() => resultHook.current[waitForHook].toBeTruthy(), { timeout: 5000} );
+  await waitFor(() => resultHook.current[waitForHook].toBeTruthy(), { timeout: 5000 });
   return resultHook.current;
 };
 

--- a/x-pack/plugins/security_solution/public/management/hooks/test_utils.tsx
+++ b/x-pack/plugins/security_solution/public/management/hooks/test_utils.tsx
@@ -42,7 +42,7 @@ export const renderQuery = async (
   const { result: resultHook, waitFor } = renderHook(() => hook(), {
     wrapper,
   });
-  await waitFor(() => resultHook.current[waitForHook]);
+  await waitFor(() => resultHook.current[waitForHook].toBeTruthy(), { timeout: 5000} );
   return resultHook.current;
 };
 


### PR DESCRIPTION
Part of https://github.com/elastic/security-team/issues/12176

This is a manual backport to version 8.17 of https://github.com/elastic/kibana/pull/215324, including only the tests that were skipped in the 8.17 branch.