### PR TITLE
[7.17] Hide the chrome popup about leaked passwords (#215414)

### DIFF
--- a/test/functional/services/remote/webdriver.ts
+++ b/test/functional/services/remote/webdriver.ts
@@ -45,6 +45,7 @@ const downloadDir = resolve(REPO_ROOT, 'target/functional-tests/downloads');
 const chromiumUserPrefs = {
   'download.default_directory': downloadDir,
   'download.prompt_for_download': false,
+  'profile.password_manager_leak_detection': false,
   'profile.content_settings.exceptions.clipboard': {
     '[*.],*': {
       last_modified: Date.now(),
@@ -52,7 +53,6 @@ const chromiumUserPrefs = {
     },
   },
 };
-
 const sleep$ = (ms: number) => Rx.timer(ms).pipe(ignoreElements());
 
 /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Hide the chrome popup about leaked passwords (#215414)](https://github.com/elastic/kibana/pull/215414)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-21T12:04:25Z","message":"Hide the chrome popup about leaked passwords (#215414)\n\n## Summary\nCloses https://github.com/elastic/kibana/issues/214355\n\nTesting with Chrome 135.x.x.x resulted in a pop up that was breaking the\nflow of tests:\n\n<img width=\"470\" alt=\"Screenshot 2025-03-20 at 4 25 17 PM\"\nsrc=\"https://github.com/user-attachments/assets/df908294-1881-4b6d-b9a2-3027b37b06ad\"\n/>\n\nThis isn't captured by the screenshotting plugin, but is visible if you\nrun `headless=0`\n\nThis adds the config to disable that popup since our generic testing\npasswords are very common and therefor flagged","sha":"f5cebe2c23dff4454ec948358cc0a938400d5ede","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v9.1.0"],"title":"Hide the chrome popup about leaked passwords","number":215414,"url":"https://github.com/elastic/kibana/pull/215414","mergeCommit":{"message":"Hide the chrome popup about leaked passwords (#215414)\n\n## Summary\nCloses https://github.com/elastic/kibana/issues/214355\n\nTesting with Chrome 135.x.x.x resulted in a pop up that was breaking the\nflow of tests:\n\n<img width=\"470\" alt=\"Screenshot 2025-03-20 at 4 25 17 PM\"\nsrc=\"https://github.com/user-attachments/assets/df908294-1881-4b6d-b9a2-3027b37b06ad\"\n/>\n\nThis isn't captured by the screenshotting plugin, but is visible if you\nrun `headless=0`\n\nThis adds the config to disable that popup since our generic testing\npasswords are very common and therefor flagged","sha":"f5cebe2c23dff4454ec948358cc0a938400d5ede"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215414","number":215414,"mergeCommit":{"message":"Hide the chrome popup about leaked passwords (#215414)\n\n## Summary\nCloses https://github.com/elastic/kibana/issues/214355\n\nTesting with Chrome 135.x.x.x resulted in a pop up that was breaking the\nflow of tests:\n\n<img width=\"470\" alt=\"Screenshot 2025-03-20 at 4 25 17 PM\"\nsrc=\"https://github.com/user-attachments/assets/df908294-1881-4b6d-b9a2-3027b37b06ad\"\n/>\n\nThis isn't captured by the screenshotting plugin, but is visible if you\nrun `headless=0`\n\nThis adds the config to disable that popup since our generic testing\npasswords are very common and therefor flagged","sha":"f5cebe2c23dff4454ec948358cc0a938400d5ede"}},{"url":"https://github.com/elastic/kibana/pull/215477","number":215477,"branch":"8.16","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/215478","number":215478,"branch":"8.17","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/215479","number":215479,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/215480","number":215480,"branch":"8.x","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/215481","number":215481,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->