### PR TITLE
[8.18] [EDR Workflows] Unskip management Jest tests (#215324)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/mock/endpoint/app_context_render.tsx
@@ -119,7 +119,8 @@ export type ReactQueryHookRenderer<
    * query response state value to be true
    */
   waitForHook?: WaitForReactHookState,
-  options?: RenderHookOptions<TProps>
+  options?: RenderHookOptions<TProps>,
+  timeout?: number
 ) => Promise<TResult>;
 
 export interface UserPrivilegesMockSetter {
@@ -334,12 +335,13 @@ export const createAppRootMockRenderer = (): AppContextTestRender => {
      * If defined (default is `isSuccess`), the renderer will wait for the given react query to be truthy
      */
     waitForHook: WaitForReactHookState = 'isSuccess',
-    options: RenderHookOptions<TProps> = {}
+    options: RenderHookOptions<TProps> = {},
+    timeout = 1000
   ) => {
     const { result: hookResult } = renderHook<TResult, TProps>(hookFn, options);
 
     if (waitForHook) {
-      await waitFor(() => expect(hookResult.current[waitForHook]).toBe(true));
+      await waitFor(() => expect(hookResult.current[waitForHook]).toBe(true), { timeout });
     }
 
     return hookResult.current;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/bad_argument.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/bad_argument.test.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { waitFor } from '@testing-library/react';
 import type { CommandDefinition, ConsoleProps } from '..';
 import type { AppContextTestRender } from '../../../../common/mock/endpoint';
 import type { ConsoleTestSetup } from '../mocks';
@@ -38,20 +39,23 @@ describe('BadArgument component', () => {
     render();
     await enterCommand('cmd1 --foo');
 
-    expect(renderResult.getByTestId('test-badArgument-message').textContent).toEqual(
-      'Argument --foo must have a value'
-    );
-    expect(renderResult.getByTestId('test-badArgument-commandUsage'));
-  });
+    await waitFor(() => {
+      expect(renderResult.getByTestId('test-badArgument-message').textContent).toEqual(
+        'Argument --foo must have a value'
+      );
+      expect(renderResult.getByTestId('test-badArgument-commandUsage')).toBeInTheDocument();
+    });
+  }, 10000);
 
   it('should only display message (no help) if command is hidden from help', async () => {
     command.helpHidden = true;
     render();
     await enterCommand('cmd1 --foo');
-
-    expect(renderResult.getByTestId('test-badArgument-message').textContent).toEqual(
-      'Argument --foo must have a value'
-    );
-    expect(renderResult.queryByTestId('test-badArgument-commandUsage')).toBeNull();
-  });
+    await waitFor(() => {
+      expect(renderResult.getByTestId('test-badArgument-message').textContent).toEqual(
+        'Argument --foo must have a value'
+      );
+      expect(renderResult.queryByTestId('test-badArgument-commandUsage')).toBeNull();
+    });
+  }, 10000);
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx
@@ -14,9 +14,9 @@ import {
 } from '../../../../common/mock/endpoint';
 import { ActionsLogUsersFilter } from './actions_log_users_filter';
 import { MANAGEMENT_PATH } from '../../../../../common/constants';
+import { waitFor } from '@testing-library/react';
 
-// FLAKY: https://github.com/elastic/kibana/issues/193092
-describe.skip('Users filter', () => {
+describe('Users filter', () => {
   let render: (
     props?: React.ComponentProps<typeof ActionsLogUsersFilter>
   ) => ReturnType<AppContextTestRender['render']>;
@@ -26,6 +26,7 @@ describe.skip('Users filter', () => {
 
   const testPrefix = 'test';
   const filterPrefix = 'users-filter';
+  const delay = 100; // ms
   let onChangeUsersFilter: jest.Mock;
 
   beforeEach(() => {
@@ -51,41 +52,45 @@ describe.skip('Users filter', () => {
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
     expect(searchInput).toBeTruthy();
     expect(searchInput.getAttribute('placeholder')).toEqual('Filter by username');
-  });
+  }, 10000);
 
   it('should search on given search string on enter', async () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, 'usernameX', { delay: 10 });
+    await userEvent.type(searchInput, 'usernameX', { delay });
     await userEvent.keyboard('{enter}');
-    expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']);
-  });
+    await waitFor(() => expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']));
+  }, 10000);
 
   it('should search comma separated strings as multiple users', async () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, 'usernameX,usernameY,usernameZ', { delay: 10 });
+    await userEvent.type(searchInput, 'usernameX,usernameY,usernameZ', { delay });
     await userEvent.keyboard('{enter}');
-    expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY', 'usernameZ']);
-  });
+    await waitFor(() =>
+      expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY', 'usernameZ'])
+    );
+  }, 15000);
 
   it('should ignore white spaces in a given username when updating the API params', async () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, '   usernameX   ', { delay: 10 });
+    await userEvent.type(searchInput, '   usernameX   ', { delay });
     await userEvent.keyboard('{enter}');
-    expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']);
-  });
+    await waitFor(() => expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX']));
+  }, 10000);
 
   it('should ignore white spaces in comma separated usernames when updating the API params', async () => {
     render();
 
     const searchInput = renderResult.getByTestId(`${testPrefix}-${filterPrefix}-search`);
-    await userEvent.type(searchInput, '   , usernameX ,usernameY    ,       ', { delay: 10 });
+    await userEvent.type(searchInput, '   , usernameX ,usernameY    ,       ', { delay });
     await userEvent.keyboard('{enter}');
-    expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY']);
-  });
+    await waitFor(() =>
+      expect(onChangeUsersFilter).toHaveBeenCalledWith(['usernameX', 'usernameY'])
+    );
+  }, 15000);
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/management/hooks/artifacts/use_list_artifact.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/hooks/artifacts/use_list_artifact.test.tsx
@@ -16,8 +16,7 @@ import {
   renderQuery,
 } from '../test_utils';
 
-// FLAKY: https://github.com/elastic/kibana/issues/196724
-describe.skip('List artifact hook', () => {
+describe('List artifact hook', () => {
   let result: ReturnType<typeof useListArtifact>;
   let searchableFields: string[];
   let options:

--- a/x-pack/solutions/security/plugins/security_solution/public/management/hooks/endpoint/use_get_endpoint_details.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/hooks/endpoint/use_get_endpoint_details.test.ts
@@ -42,7 +42,7 @@ describe('useGetEndpointDetails hook', () => {
   });
 
   it('should call the proper API', async () => {
-    await renderReactQueryHook(() => useGetEndpointDetails('123'));
+    await renderReactQueryHook(() => useGetEndpointDetails('123'), 'isSuccess', {}, 5000);
 
     expect(apiMocks.responseProvider.metadataDetails).toHaveBeenCalledWith({
       path: resolvePathVariables(HOST_METADATA_GET_ROUTE, { id: '123' }),
@@ -51,7 +51,7 @@ describe('useGetEndpointDetails hook', () => {
   });
 
   it('should call api with `undefined` for endpoint id if it was not defined on input', async () => {
-    await renderReactQueryHook(() => useGetEndpointDetails(''));
+    await renderReactQueryHook(() => useGetEndpointDetails(''), 'isSuccess', {}, 5000);
 
     expect(apiMocks.responseProvider.metadataDetails).toHaveBeenCalledWith({
       path: resolvePathVariables(HOST_METADATA_GET_ROUTE, {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/hooks/test_utils.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/hooks/test_utils.tsx
@@ -42,7 +42,7 @@ export const renderQuery = async (
   const { result: resultHook } = renderHook(() => hook(), {
     wrapper,
   });
-  await waitFor(() => expect(resultHook.current[waitForHook]).toBeTruthy());
+  await waitFor(() => expect(resultHook.current[waitForHook]).toBeTruthy(), { timeout: 5000 });
   return resultHook.current;
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[EDR Workflows] Unskip management Jest tests (#215324)](https://github.com/elastic/kibana/pull/215324)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Szwarc","email":"konrad.szwarc@elastic.co"},"sourceCommit":{"committedDate":"2025-03-21T12:26:30Z","message":"[EDR Workflows] Unskip management Jest tests (#215324)\n\n8.17 PR - https://github.com/elastic/kibana/pull/215474\nPart of https://github.com/elastic/security-team/issues/12176\n\nUnskiped: \n### `use_list_artifact.test.tsx`\nPath\n`.../plugins/security_solution/public/management/hooks/artifacts/use_list_artifact.test.tsx`\nCloses https://github.com/elastic/kibana/issues/196724\nCommit 438553a1d167d97cc730405783e21963b6a790a7\nReason for unskipping: Couldn't recreate failure locally. Increased\ntimeout from 1000 to 5000 ms.\n\n\n### `actions_log_users_filter.test.tsx`\nPath\n`.../plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx`\nCloses https://github.com/elastic/kibana/issues/193554\nhttps://github.com/elastic/kibana/issues/193092\nCommit ca7b97168318ca39eedb5afa6f67fe5e0ea304ed\nde03fd5448740e5d3b7059fedbd2cd511bec110f\nfb3910e738fab4e158852f60f4f5471732a5b191\nReason for unskipping: wrapped expects in waitFor since they are\nawaiting for state change. Increased the delay between keystrokes when\ntyping. Increased the timeout of tests since locally they are bordering\n5s executions.\n\n### `bad_argument.test.tsx`\nPath\n`.../plugins/security_solution/public/management/components/console/components/bad_argument.test.tsx`\nCloses https://github.com/elastic/kibana/issues/193093\nCommit 6959cd2e3fb53fb4c13d482456cf9ce76682f332\nReason for unskipping: wrapped expects in waitFor since they are\nawaiting for state change. Increased timeout to 10s.\n\n### `use_get_endpoint_details.test.ts`\nPath\n`.../plugins/security_solution/public/management/hooks/endpoint/use_get_endpoint_details.test.ts`\nCloses https://github.com/elastic/kibana/issues/192435\nCommit 3ba10029b62cc63db2c2565de2a2e9ec5b913539\nReason for unskipping: increased timeout of waitFor for\nrenderReactQueryHook to 5s since locally it was bordering 3 seconds","sha":"f09945bb1b5d4e00a953da8a8cd8d677f3d21ecc","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Defend Workflows","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[EDR Workflows] Unskip management Jest tests","number":215324,"url":"https://github.com/elastic/kibana/pull/215324","mergeCommit":{"message":"[EDR Workflows] Unskip management Jest tests (#215324)\n\n8.17 PR - https://github.com/elastic/kibana/pull/215474\nPart of https://github.com/elastic/security-team/issues/12176\n\nUnskiped: \n### `use_list_artifact.test.tsx`\nPath\n`.../plugins/security_solution/public/management/hooks/artifacts/use_list_artifact.test.tsx`\nCloses https://github.com/elastic/kibana/issues/196724\nCommit 438553a1d167d97cc730405783e21963b6a790a7\nReason for unskipping: Couldn't recreate failure locally. Increased\ntimeout from 1000 to 5000 ms.\n\n\n### `actions_log_users_filter.test.tsx`\nPath\n`.../plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx`\nCloses https://github.com/elastic/kibana/issues/193554\nhttps://github.com/elastic/kibana/issues/193092\nCommit ca7b97168318ca39eedb5afa6f67fe5e0ea304ed\nde03fd5448740e5d3b7059fedbd2cd511bec110f\nfb3910e738fab4e158852f60f4f5471732a5b191\nReason for unskipping: wrapped expects in waitFor since they are\nawaiting for state change. Increased the delay between keystrokes when\ntyping. Increased the timeout of tests since locally they are bordering\n5s executions.\n\n### `bad_argument.test.tsx`\nPath\n`.../plugins/security_solution/public/management/components/console/components/bad_argument.test.tsx`\nCloses https://github.com/elastic/kibana/issues/193093\nCommit 6959cd2e3fb53fb4c13d482456cf9ce76682f332\nReason for unskipping: wrapped expects in waitFor since they are\nawaiting for state change. Increased timeout to 10s.\n\n### `use_get_endpoint_details.test.ts`\nPath\n`.../plugins/security_solution/public/management/hooks/endpoint/use_get_endpoint_details.test.ts`\nCloses https://github.com/elastic/kibana/issues/192435\nCommit 3ba10029b62cc63db2c2565de2a2e9ec5b913539\nReason for unskipping: increased timeout of waitFor for\nrenderReactQueryHook to 5s since locally it was bordering 3 seconds","sha":"f09945bb1b5d4e00a953da8a8cd8d677f3d21ecc"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215485","number":215485,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215324","number":215324,"mergeCommit":{"message":"[EDR Workflows] Unskip management Jest tests (#215324)\n\n8.17 PR - https://github.com/elastic/kibana/pull/215474\nPart of https://github.com/elastic/security-team/issues/12176\n\nUnskiped: \n### `use_list_artifact.test.tsx`\nPath\n`.../plugins/security_solution/public/management/hooks/artifacts/use_list_artifact.test.tsx`\nCloses https://github.com/elastic/kibana/issues/196724\nCommit 438553a1d167d97cc730405783e21963b6a790a7\nReason for unskipping: Couldn't recreate failure locally. Increased\ntimeout from 1000 to 5000 ms.\n\n\n### `actions_log_users_filter.test.tsx`\nPath\n`.../plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_users_filter.test.tsx`\nCloses https://github.com/elastic/kibana/issues/193554\nhttps://github.com/elastic/kibana/issues/193092\nCommit ca7b97168318ca39eedb5afa6f67fe5e0ea304ed\nde03fd5448740e5d3b7059fedbd2cd511bec110f\nfb3910e738fab4e158852f60f4f5471732a5b191\nReason for unskipping: wrapped expects in waitFor since they are\nawaiting for state change. Increased the delay between keystrokes when\ntyping. Increased the timeout of tests since locally they are bordering\n5s executions.\n\n### `bad_argument.test.tsx`\nPath\n`.../plugins/security_solution/public/management/components/console/components/bad_argument.test.tsx`\nCloses https://github.com/elastic/kibana/issues/193093\nCommit 6959cd2e3fb53fb4c13d482456cf9ce76682f332\nReason for unskipping: wrapped expects in waitFor since they are\nawaiting for state change. Increased timeout to 10s.\n\n### `use_get_endpoint_details.test.ts`\nPath\n`.../plugins/security_solution/public/management/hooks/endpoint/use_get_endpoint_details.test.ts`\nCloses https://github.com/elastic/kibana/issues/192435\nCommit 3ba10029b62cc63db2c2565de2a2e9ec5b913539\nReason for unskipping: increased timeout of waitFor for\nrenderReactQueryHook to 5s since locally it was bordering 3 seconds","sha":"f09945bb1b5d4e00a953da8a8cd8d677f3d21ecc"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->