### PR TITLE
[Fleet] update disabled inputs

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/constants/agentless.ts
@@ -46,4 +46,6 @@ export const AGENTLESS_DISABLED_INPUTS = [
   'gcp-pubsub',
   'azure-eventhub',
   'logfile',
+  'aws-s3',
+  'streaming',
 ];


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/215411

Disable `aws-s3` and `streaming` as an input type for agentless

<img width="2540" alt="image" src="https://github.com/user-attachments/assets/9ee96838-919c-4be3-851b-51afad6b6e06" />
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/a6f702cf-6885-4512-ae04-7074cbfa0a40" />



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->