### PR TITLE
[Synthetics] Fix location filter in status rule executor

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_viz.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_viz.tsx
@@ -69,17 +69,19 @@ export const StatusRuleViz = ({
             isOpen={isPopoverOpen}
             closePopover={() => setIsPopoverOpen(false)}
             button={
-              <EuiButtonEmpty
-                data-test-subj="syntheticsStatusRuleVizMonitorQueryIDsButton"
-                size="xs"
-                onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-              >
-                {i18n.translate('xpack.synthetics.statusRuleViz.monitorQueryIdsPopoverButton', {
-                  defaultMessage:
-                    '{total} existing {total, plural, one {monitor} other {monitors}}',
-                  values: { total: loading ? '...' : data?.monitors.length },
-                })}
-              </EuiButtonEmpty>
+              loading ? undefined : (
+                <EuiButtonEmpty
+                  data-test-subj="syntheticsStatusRuleVizMonitorQueryIDsButton"
+                  size="xs"
+                  onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                >
+                  {i18n.translate('xpack.synthetics.statusRuleViz.monitorQueryIdsPopoverButton', {
+                    defaultMessage:
+                      '{total} existing {total, plural, one {monitor} other {monitors}}',
+                    values: { total: data?.monitors.length },
+                  })}
+                </EuiButtonEmpty>
+              )
             }
           >
             <EuiPopoverTitle>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_viz.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/status_rule_viz.tsx
@@ -11,6 +11,7 @@ import {
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLoadingSpinner,
   EuiPopover,
   EuiPopoverTitle,
   EuiSpacer,
@@ -31,7 +32,7 @@ export const StatusRuleViz = ({
 }: {
   ruleParams: StatusRuleParamsProps['ruleParams'];
 }) => {
-  const { data } = useSelector(selectInspectStatusRule);
+  const { data, loading } = useSelector(selectInspectStatusRule);
   const dispatch = useDispatch();
   const {
     services: { inspector },
@@ -57,7 +58,7 @@ export const StatusRuleViz = ({
 
   return (
     <EuiCallOut iconType="search" size="s">
-      <EuiFlexGroup alignItems="center" gutterSize="none">
+      <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
           {i18n.translate('xpack.synthetics.statusRuleViz.ruleAppliesToFlexItemLabel', {
             defaultMessage: 'Rule applies to ',
@@ -76,7 +77,7 @@ export const StatusRuleViz = ({
                 {i18n.translate('xpack.synthetics.statusRuleViz.monitorQueryIdsPopoverButton', {
                   defaultMessage:
                     '{total} existing {total, plural, one {monitor} other {monitors}}',
-                  values: { total: data?.monitors.length },
+                  values: { total: loading ? '...' : data?.monitors.length },
                 })}
               </EuiButtonEmpty>
             }
@@ -93,6 +94,11 @@ export const StatusRuleViz = ({
             <RuleMonitorsTable />
           </EuiPopover>
         </EuiFlexItem>
+        {loading && (
+          <EuiFlexItem grow={false}>
+            <EuiLoadingSpinner size="s" />
+          </EuiFlexItem>
+        )}
         {/* to push detail button to end*/}
         <EuiFlexItem />
         <EuiFlexItem grow={false}>

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
@@ -118,7 +118,7 @@ export class StatusRuleExecutor {
       return processMonitors([]);
     }
 
-    const locationFilter = await parseLocationFilter(
+    const locationIds = await parseLocationFilter(
       {
         savedObjectsClient: this.soClient,
         server: this.server,
@@ -131,7 +131,7 @@ export class StatusRuleExecutor {
       configIds,
       filter: baseFilter,
       tags: this.params.tags,
-      locationFilter,
+      locations: locationIds,
       monitorTypes: this.params.monitorTypes,
       monitorQueryIds: this.params.monitorIds,
       projects: this.params.projects,
@@ -141,7 +141,11 @@ export class StatusRuleExecutor {
       filter: filtersStr,
     });
 
-    this.debug(`Found ${this.monitors.length} monitors for params ${JSON.stringify(this.params)}`);
+    this.debug(
+      `Found ${this.monitors.length} monitors for params ${JSON.stringify(
+        this.params
+      )} | parsed location filter is ${JSON.stringify(locationIds)} `
+    );
     return processMonitors(this.monitors);
   }
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
@@ -36,7 +36,7 @@ import {
   getUngroupedReasonMessage,
 } from './message_utils';
 import { queryMonitorStatusAlert } from './queries/query_monitor_status_alert';
-import { parseArrayFilters } from '../../routes/common';
+import { parseArrayFilters, parseLocationFilter } from '../../routes/common';
 import { SyntheticsServerSetup } from '../../types';
 import { SyntheticsEsClient } from '../../lib';
 import { processMonitors } from '../../saved_objects/synthetics_monitor/get_all_monitors';
@@ -118,14 +118,23 @@ export class StatusRuleExecutor {
       return processMonitors([]);
     }
 
+    const locationFilter = await parseLocationFilter(
+      {
+        savedObjectsClient: this.soClient,
+        server: this.server,
+        syntheticsMonitorClient: this.syntheticsMonitorClient,
+      },
+      this.params.locations
+    );
+
     const { filtersStr } = parseArrayFilters({
       configIds,
       filter: baseFilter,
-      tags: this.params?.tags,
-      locations: this.params?.locations,
-      monitorTypes: this.params?.monitorTypes,
-      monitorQueryIds: this.params?.monitorIds,
-      projects: this.params?.projects,
+      tags: this.params.tags,
+      locationFilter,
+      monitorTypes: this.params.monitorTypes,
+      monitorQueryIds: this.params.monitorIds,
+      projects: this.params.projects,
     });
 
     this.monitors = await this.monitorConfigRepository.getAll({

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/common.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/common.test.ts
@@ -30,7 +30,7 @@ describe('common utils', () => {
     const filters = parseArrayFilters({
       configIds: ['1', '2'],
       tags: ['tag1', 'tag2'],
-      locationFilter: ['loc1', 'loc2'],
+      locations: ['loc1', 'loc2'],
       monitorTypes: ['type1', 'type2'],
       projects: ['project1', 'project2'],
       monitorQueryIds: ['query1', 'query2'],

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/common.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/common.test.ts
@@ -30,14 +30,14 @@ describe('common utils', () => {
     const filters = parseArrayFilters({
       configIds: ['1', '2'],
       tags: ['tag1', 'tag2'],
-      locations: ['loc1', 'loc2'],
+      locationFilter: ['loc1', 'loc2'],
       monitorTypes: ['type1', 'type2'],
       projects: ['project1', 'project2'],
       monitorQueryIds: ['query1', 'query2'],
       schedules: ['schedule1', 'schedule2'],
     });
     expect(filters.filtersStr).toMatchInlineSnapshot(
-      `"synthetics-monitor.attributes.tags:(\\"tag1\\" OR \\"tag2\\") AND synthetics-monitor.attributes.project_id:(\\"project1\\" OR \\"project2\\") AND synthetics-monitor.attributes.type:(\\"type1\\" OR \\"type2\\") AND synthetics-monitor.attributes.schedule.number:(\\"schedule1\\" OR \\"schedule2\\") AND synthetics-monitor.attributes.id:(\\"query1\\" OR \\"query2\\") AND synthetics-monitor.attributes.config_id:(\\"1\\" OR \\"2\\")"`
+      `"synthetics-monitor.attributes.tags:(\\"tag1\\" OR \\"tag2\\") AND synthetics-monitor.attributes.project_id:(\\"project1\\" OR \\"project2\\") AND synthetics-monitor.attributes.type:(\\"type1\\" OR \\"type2\\") AND synthetics-monitor.attributes.locations.id:(\\"loc1\\" OR \\"loc2\\") AND synthetics-monitor.attributes.schedule.number:(\\"schedule1\\" OR \\"schedule2\\") AND synthetics-monitor.attributes.id:(\\"query1\\" OR \\"query2\\") AND synthetics-monitor.attributes.config_id:(\\"1\\" OR \\"2\\")"`
     );
   });
 });

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/common.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/common.ts
@@ -128,7 +128,6 @@ export const getMonitorFilters = async (context: RouteContext) => {
     filter,
     tags,
     monitorTypes,
-    locations,
     projects,
     schedules,
     monitorQueryIds,
@@ -145,7 +144,7 @@ export const parseArrayFilters = ({
   schedules,
   monitorQueryIds,
   locationFilter,
-}: Filters & {
+}: Omit<Filters, 'locations'> & {
   locationFilter?: string | string[];
   configIds?: string[];
 }) => {
@@ -199,12 +198,23 @@ export const getSavedObjectKqlFilter = ({
   return `${fieldKey}:"${escapeQuotes(values)}"`;
 };
 
-const parseLocationFilter = async (context: RouteContext, locations?: string | string[]) => {
+export const parseLocationFilter = async (
+  {
+    syntheticsMonitorClient,
+    savedObjectsClient,
+    server,
+  }: Pick<RouteContext, 'syntheticsMonitorClient' | 'savedObjectsClient' | 'server'>,
+  locations?: string | string[]
+) => {
   if (!locations || locations?.length === 0) {
     return;
   }
 
-  const { allLocations } = await getAllLocations(context);
+  const { allLocations } = await getAllLocations({
+    syntheticsMonitorClient,
+    savedObjectsClient,
+    server,
+  });
 
   if (Array.isArray(locations)) {
     return locations

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.ts
@@ -36,7 +36,7 @@ export const SUMMARIES_PAGE_SIZE = 5000;
 
 export class OverviewStatusService {
   filterData: {
-    locationFilter?: string[] | string;
+    locationIds?: string[] | string;
     filtersStr?: string;
   } = {};
   constructor(
@@ -61,7 +61,7 @@ export class OverviewStatusService {
       disabledCount,
       disabledMonitorsCount,
       projectMonitorsCount,
-    } = processMonitors(allConfigs, this.filterData?.locationFilter);
+    } = processMonitors(allConfigs, this.filterData?.locationIds);
 
     return {
       allIds,
@@ -91,7 +91,7 @@ export class OverviewStatusService {
       projects,
       showFromAllSpaces,
     } = params;
-    const { locationFilter } = this.filterData;
+    const { locationIds } = this.filterData;
     const getTermFilter = (field: string, value: string | string[] | undefined) => {
       if (!value || isEmpty(value)) {
         return [];
@@ -120,10 +120,10 @@ export class OverviewStatusService {
       ...getTermFilter('monitor.project.id', projects),
     ];
 
-    if (scopeStatusByLocation && !isEmpty(locationFilter) && locationFilter) {
+    if (scopeStatusByLocation && !isEmpty(locationIds) && locationIds) {
       filters.push({
         terms: {
-          'observer.name': locationFilter,
+          'observer.name': locationIds,
         },
       });
     }
@@ -231,7 +231,7 @@ export class OverviewStatusService {
     const enabledMonitors = monitors.filter((monitor) => monitor.attributes[ConfigKey.ENABLED]);
     const disabledMonitors = monitors.filter((monitor) => !monitor.attributes[ConfigKey.ENABLED]);
 
-    const queryLocIds = this.filterData?.locationFilter;
+    const queryLocIds = this.filterData?.locationIds;
 
     disabledMonitors.forEach((monitor) => {
       const monitorQueryId = monitor.attributes[ConfigKey.MONITOR_QUERY_ID];


### PR DESCRIPTION
This PR closes #215505 by fixing the location filter when creating a custom status rule for monitors.


https://github.com/user-attachments/assets/623b21fb-af45-42ae-a120-e38562451062






<!--ONMERGE {"backportTargets":["8.17","8.18","8.x","9.0"]} ONMERGE-->