### PR TITLE
[ci] More info to test annotation failure logging

### DIFF
--- a/.buildkite/scripts/lifecycle/annotate_test_failures.ts
+++ b/.buildkite/scripts/lifecycle/annotate_test_failures.ts
@@ -13,10 +13,17 @@ import { TestFailures } from '#pipeline-utils';
   try {
     await TestFailures.annotateTestFailures();
   } catch (ex) {
-    console.error('Annotate test failures error', ex.message);
+    console.error(
+      'Annotate test failures error',
+      ex.message,
+      ex?.stack || 'no stacktrace information'
+    );
     if (ex.response) {
-      console.error('HTTP Error Response Status', ex.response.status);
-      console.error('HTTP Error Response Body', ex.response.data);
+      const requestUrl = ex.response?.url || ex.response?.config?.url || '';
+      console.error(
+        `HTTP Error ${ex.response.status}/${ex.response.statusText} (${requestUrl})`,
+        ex.response.data
+      );
     }
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
While annotating test failures, we're seeing increased amount of errors like this:
```
2025-03-21 13:52:32 INFO   Artifact uploads completed successfully
--
  | Annotate test failures error Request failed with status code 404
  | HTTP Error Response Status 404
  | HTTP Error Response Body { message: 'Not Found' }
  | user command error: exit status 10
```

It would be nicer to show a bit more from the error to help debugging.

<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->