### PR TITLE
[8.18] [APM] Fix: Add missing user_agent version field and show it on the trace summary (#215403)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
@@ -34,6 +34,7 @@ Object {
       "http.response.status_code",
       "http.request.method",
       "user_agent.name",
+      "user_agent.version",
     ],
     "query": Object {
       "bool": Object {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/transactions/get_transaction/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/transactions/get_transaction/index.ts
@@ -30,6 +30,7 @@ import {
   HTTP_RESPONSE_STATUS_CODE,
   TRANSACTION_PAGE_URL,
   USER_AGENT_NAME,
+  USER_AGENT_VERSION,
 } from '../../../../common/es_fields/apm';
 import { asMutableArray } from '../../../../common/utils/as_mutable_array';
 import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
@@ -71,6 +72,7 @@ export async function getTransaction({
     HTTP_RESPONSE_STATUS_CODE,
     HTTP_REQUEST_METHOD,
     USER_AGENT_NAME,
+    USER_AGENT_VERSION,
   ] as const);
 
   const resp = await apmEventClient.search('get_transaction', {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[APM] Fix: Add missing user_agent version field and show it on the trace summary (#215403)](https://github.com/elastic/kibana/pull/215403)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-03-21T17:33:01Z","message":"[APM] Fix: Add missing user_agent version field and show it on the trace summary (#215403)\n\nCloses #215229 \n\n## Summary\n\nThis PR adds the `USER_AGENT_VERSION` missing field to the\n`optionalFields` query fields\n\n## Testing\n\n- Find a trace with user agent version (on the edge oblt we have it for\n`elastic-co-frontend` for example)\n- Go to the transaction tab (in case of `elastic-co-frontend` click on\n`/blog/:id`)\nIf the user agent version is available it should be visible in the trace\nsummary:\n\n<img width=\"1155\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/75b7e331-44d0-4d1c-8060-815c269e23c9\"\n/>","sha":"42a66131c529ff3f48a037abd40fef118a09d248","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","backport:prev-major","Team:obs-ux-infra_services","v9.1.0"],"title":"[APM] Fix: Add missing user_agent version field and show it on the trace summary","number":215403,"url":"https://github.com/elastic/kibana/pull/215403","mergeCommit":{"message":"[APM] Fix: Add missing user_agent version field and show it on the trace summary (#215403)\n\nCloses #215229 \n\n## Summary\n\nThis PR adds the `USER_AGENT_VERSION` missing field to the\n`optionalFields` query fields\n\n## Testing\n\n- Find a trace with user agent version (on the edge oblt we have it for\n`elastic-co-frontend` for example)\n- Go to the transaction tab (in case of `elastic-co-frontend` click on\n`/blog/:id`)\nIf the user agent version is available it should be visible in the trace\nsummary:\n\n<img width=\"1155\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/75b7e331-44d0-4d1c-8060-815c269e23c9\"\n/>","sha":"42a66131c529ff3f48a037abd40fef118a09d248"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215403","number":215403,"mergeCommit":{"message":"[APM] Fix: Add missing user_agent version field and show it on the trace summary (#215403)\n\nCloses #215229 \n\n## Summary\n\nThis PR adds the `USER_AGENT_VERSION` missing field to the\n`optionalFields` query fields\n\n## Testing\n\n- Find a trace with user agent version (on the edge oblt we have it for\n`elastic-co-frontend` for example)\n- Go to the transaction tab (in case of `elastic-co-frontend` click on\n`/blog/:id`)\nIf the user agent version is available it should be visible in the trace\nsummary:\n\n<img width=\"1155\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/75b7e331-44d0-4d1c-8060-815c269e23c9\"\n/>","sha":"42a66131c529ff3f48a037abd40fef118a09d248"}}]}] BACKPORT-->