### PR TITLE
feat(slo): add saved query

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/query_search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/query_search_bar.tsx
@@ -158,6 +158,8 @@ export const QuerySearchBar = memo(
                   disableQueryLanguageSwitcher={true}
                   onClearSavedQuery={() => {}}
                   filters={kqlQuerySchema.is(field.value) ? [] : field.value?.filters ?? []}
+                  allowSavingQueries={true}
+                  showSavedQueryControls={true}
                 />
               </div>
             </EuiFormRow>


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/214478

## Summary

Add options to save query and load saved query to the various QueryBuilder used in the SLO form.


https://github.com/user-attachments/assets/dbc614a9-add1-4781-b577-e5abc2b8ea24



<!--ONMERGE {"backportTargets":["8.17","8.18","8.x","9.0"]} ONMERGE-->