### PR TITLE
[8.16] [Uptime] Fix skipped a11y tests (#214396)

### DIFF
--- a/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/components/common/charts/__snapshots__/chart_wrapper.test.tsx.snap
+++ b/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/components/common/charts/__snapshots__/chart_wrapper.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ChartWrapper component renders the component with loading false 1`] = `
 <EuiErrorBoundary>
-  <div
+  <figure
     intl={
       Object {
         "$t": [Function],
@@ -133,13 +133,13 @@ exports[`ChartWrapper component renders the component with loading false 1`] = `
       height={144}
       up={4}
     />
-  </div>
+  </figure>
 </EuiErrorBoundary>
 `;
 
 exports[`ChartWrapper component renders the component with loading true 1`] = `
 <EuiErrorBoundary>
-  <div
+  <figure
     intl={
       Object {
         "$t": [Function],
@@ -270,7 +270,7 @@ exports[`ChartWrapper component renders the component with loading true 1`] = `
       height={144}
       up={4}
     />
-  </div>
+  </figure>
   <EuiFlexGroup
     alignItems="center"
     justifyContent="spaceAround"

--- a/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/components/common/charts/chart_wrapper/chart_wrapper.tsx
+++ b/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/components/common/charts/chart_wrapper/chart_wrapper.tsx
@@ -33,7 +33,7 @@ export const ChartWrapper: FC<PropsWithChildren<Props>> = ({
 
   return (
     <EuiErrorBoundary>
-      <div
+      <figure
         style={{
           height,
           opacity,
@@ -42,7 +42,7 @@ export const ChartWrapper: FC<PropsWithChildren<Props>> = ({
         {...(rest as HTMLAttributes<HTMLDivElement>)}
       >
         {children}
-      </div>
+      </figure>
       {loading === true && (
         <EuiFlexGroup
           justifyContent="spaceAround"

--- a/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/components/common/charts/duration_charts.test.tsx
+++ b/x-pack/plugins/observability_solution/uptime/public/legacy_uptime/components/common/charts/duration_charts.test.tsx
@@ -48,7 +48,7 @@ describe('MonitorCharts component', () => {
   };
 
   it('renders the component without errors', () => {
-    const { getByLabelText } = render(
+    const { getByRole } = render(
       <DurationChartComponent
         loading={false}
         anomalies={null}
@@ -72,7 +72,11 @@ describe('MonitorCharts component', () => {
         },
       }
     );
-    expect(getByLabelText(`A chart displaying the monitor's ping duration, grouped by location.`));
+    const figureElement = getByRole('figure');
+    expect(figureElement).toHaveAttribute(
+      'aria-label',
+      "A chart displaying the monitor's ping duration, grouped by location."
+    );
   });
 
   it('renders an empty state when no monitor data is present', () => {

--- a/x-pack/test/accessibility/apps/group1/uptime.ts
+++ b/x-pack/test/accessibility/apps/group1/uptime.ts
@@ -19,8 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const es = getService('es');
   const toasts = getService('toasts');
 
-  // github.com/elastic/kibana/issues/153601
-  describe.skip('uptime Accessibility', () => {
+  describe('uptime Accessibility', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/uptime/blank');
       await makeChecks(es, A11Y_TEST_MONITOR_ID, 150, 1, 1000, {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [[Uptime] Fix skipped a11y tests (#214396)](https://github.com/elastic/kibana/pull/214396)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Justin Kambic","email":"jk@elastic.co"},"sourceCommit":{"committedDate":"2025-03-14T17:01:45Z","message":"[Uptime] Fix skipped a11y tests (#214396)\n\n## Summary\n\nResolves #204152.\n\nAttempt to fix the mislabeled element by adding the `figure` role to it.","sha":"631a840db44a26553acca83182ab0071e9db3abb","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["skipped-test","release_note:skip","v9.0.0","backport:prev-minor","backport:prev-major","Team:obs-ux-management","v9.1.0"],"title":"[Uptime] Fix skipped a11y tests","number":214396,"url":"https://github.com/elastic/kibana/pull/214396","mergeCommit":{"message":"[Uptime] Fix skipped a11y tests (#214396)\n\n## Summary\n\nResolves #204152.\n\nAttempt to fix the mislabeled element by adding the `figure` role to it.","sha":"631a840db44a26553acca83182ab0071e9db3abb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214621","number":214621,"state":"MERGED","mergeCommit":{"sha":"36986a89e7cc06dcaf21e7f91db6fb1e0edc84a0","message":"[9.0] [Uptime] Fix skipped a11y tests (#214396) (#214621)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Uptime] Fix skipped a11y tests\n(#214396)](https://github.com/elastic/kibana/pull/214396)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Justin Kambic <jk@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214396","number":214396,"mergeCommit":{"message":"[Uptime] Fix skipped a11y tests (#214396)\n\n## Summary\n\nResolves #204152.\n\nAttempt to fix the mislabeled element by adding the `figure` role to it.","sha":"631a840db44a26553acca83182ab0071e9db3abb"}},{"url":"https://github.com/elastic/kibana/pull/215563","number":215563,"branch":"8.x","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/215564","number":215564,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/215565","number":215565,"branch":"8.17","state":"OPEN"}]}] BACKPORT-->