### PR TITLE
[AI4DSOC] Alert summary KPI charts

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/alerts_progress_bar_by_host_name_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/alerts_progress_bar_by_host_name_panel.test.tsx
@@ -12,15 +12,15 @@ import {
   ALERTS_BY_HOST_PANEL,
   ALERTS_BY_HOST_PROGRESS_BAR,
   ALERTS_BY_HOST_ROW,
-  AlertsProgressBarPanel,
-} from './alerts_progress_bar_panel';
+  AlertsProgressBarByHostNamePanel,
+} from './alerts_progress_bar_by_host_name_panel';
 import { TestProviders } from '../../../../common/mock';
 import { useSummaryChartData } from '../../alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data';
 import { parsedAlerts } from '../../alerts_kpis/alerts_progress_bar_panel/mock_data';
 
 jest.mock('../../alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data');
 
-describe('<AlertsProgressBarPanel />', () => {
+describe('<AlertsProgressBarByHostNamePanel />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -33,7 +33,7 @@ describe('<AlertsProgressBarPanel />', () => {
 
     const { getByTestId, queryByTestId } = render(
       <TestProviders>
-        <AlertsProgressBarPanel signalIndexName={''} />
+        <AlertsProgressBarByHostNamePanel signalIndexName={''} />
       </TestProviders>
     );
 
@@ -64,7 +64,7 @@ describe('<AlertsProgressBarPanel />', () => {
 
     const { getByTestId } = render(
       <TestProviders>
-        <AlertsProgressBarPanel signalIndexName={''} />
+        <AlertsProgressBarByHostNamePanel signalIndexName={''} />
       </TestProviders>
     );
 
@@ -79,7 +79,7 @@ describe('<AlertsProgressBarPanel />', () => {
 
     const { getByTestId, queryByTestId } = render(
       <TestProviders>
-        <AlertsProgressBarPanel signalIndexName={''} />
+        <AlertsProgressBarByHostNamePanel signalIndexName={''} />
       </TestProviders>
     );
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/alerts_progress_bar_by_host_name_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/alerts_progress_bar_by_host_name_panel.tsx
@@ -49,7 +49,7 @@ const HEIGHT = 160; // px
  * Renders a list showing the percentages of alerts grouped by host.name .
  * The component is used in the alerts page in the AI for SOC alert summary page.
  */
-export const AlertsProgressBarPanel: React.FC<ChartsPanelProps> = ({
+export const AlertsProgressBarByHostNamePanel: React.FC<ChartsPanelProps> = ({
   filters,
   query,
   signalIndexName,
@@ -128,4 +128,4 @@ export const AlertsProgressBarPanel: React.FC<ChartsPanelProps> = ({
   );
 };
 
-AlertsProgressBarPanel.displayName = 'AlertsProgressBarPanel';
+AlertsProgressBarByHostNamePanel.displayName = 'AlertsProgressBarByHostNamePanel';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/alerts_progress_bar_panel.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/alerts_progress_bar_panel.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  ALERTS_BY_HOST_NO_DATA,
+  ALERTS_BY_HOST_PANEL,
+  ALERTS_BY_HOST_PROGRESS_BAR,
+  ALERTS_BY_HOST_ROW,
+  AlertsProgressBarPanel,
+} from './alerts_progress_bar_panel';
+import { TestProviders } from '../../../../common/mock';
+import { useSummaryChartData } from '../../alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data';
+import { parsedAlerts } from '../../alerts_kpis/alerts_progress_bar_panel/mock_data';
+
+jest.mock('../../alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data');
+
+describe('<AlertsProgressBarPanel />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render all components', () => {
+    (useSummaryChartData as jest.Mock).mockReturnValue({
+      items: parsedAlerts,
+      isLoading: false,
+    });
+
+    const { getByTestId, queryByTestId } = render(
+      <TestProviders>
+        <AlertsProgressBarPanel signalIndexName={''} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('header-section')).toHaveTextContent('Alert distribution by host');
+    expect(getByTestId(ALERTS_BY_HOST_PANEL)).toHaveTextContent('Host name');
+
+    expect(queryByTestId(ALERTS_BY_HOST_PROGRESS_BAR)).not.toBeInTheDocument();
+    expect(queryByTestId(ALERTS_BY_HOST_NO_DATA)).not.toBeInTheDocument();
+
+    parsedAlerts
+      .filter((value) => value.key !== '-')
+      .forEach((alert, i) => {
+        expect(getByTestId(`${ALERTS_BY_HOST_ROW}${alert.key}`)).toBeInTheDocument();
+        expect(getByTestId(`${ALERTS_BY_HOST_ROW}${alert.key}`).textContent).toContain(
+          parsedAlerts[i].label
+        );
+        expect(getByTestId(`${ALERTS_BY_HOST_ROW}${alert.key}`).textContent).toContain(
+          parsedAlerts[i].percentageLabel
+        );
+      });
+  });
+
+  it('should render loading', () => {
+    (useSummaryChartData as jest.Mock).mockReturnValue({
+      items: [],
+      isLoading: true,
+    });
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsProgressBarPanel signalIndexName={''} />
+      </TestProviders>
+    );
+
+    expect(getByTestId(ALERTS_BY_HOST_PROGRESS_BAR)).toBeInTheDocument();
+  });
+
+  it('should render no data', () => {
+    (useSummaryChartData as jest.Mock).mockReturnValue({
+      items: [],
+      isLoading: false,
+    });
+
+    const { getByTestId, queryByTestId } = render(
+      <TestProviders>
+        <AlertsProgressBarPanel signalIndexName={''} />
+      </TestProviders>
+    );
+
+    expect(getByTestId(ALERTS_BY_HOST_NO_DATA)).toBeInTheDocument();
+    expect(queryByTestId(ALERTS_BY_HOST_PROGRESS_BAR)).not.toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/alerts_progress_bar_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/alerts_progress_bar_panel.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import {
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiProgress,
+  EuiSpacer,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { v4 as uuid } from 'uuid';
+import { css } from '@emotion/react';
+import { i18n } from '@kbn/i18n';
+import { ProgressBarRow } from '../../alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar_row';
+import { EMPTY_DATA_MESSAGE } from '../../alerts_kpis/alerts_progress_bar_panel/translations';
+import type { ChartsPanelProps } from '../../alerts_kpis/alerts_summary_charts_panel/types';
+import { HeaderSection } from '../../../../common/components/header_section';
+import { InspectButtonContainer } from '../../../../common/components/inspect';
+import { useSummaryChartData } from '../../alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data';
+import { alertsGroupingAggregations } from '../../alerts_kpis/alerts_summary_charts_panel/aggregations';
+import {
+  getAggregateData,
+  getIsAlertsProgressBarData,
+} from '../../alerts_kpis/alerts_progress_bar_panel/helpers';
+
+export const ALERTS_BY_HOST_PANEL = 'alert-summary-alerts-by-host-panel';
+export const ALERTS_BY_HOST_PROGRESS_BAR = 'alert-summary-alerts-by-host-progress-bar';
+export const ALERTS_BY_HOST_ROW = 'alert-summary-alerts-by-host-row-';
+export const ALERTS_BY_HOST_NO_DATA = 'alert-summary-alerts-by-host-no-data';
+
+const ALERT_BY_HOST_NAME_TITLE = i18n.translate(
+  'xpack.securitySolution.alertSummary.kpiSection.alertByHostNameTitle',
+  {
+    defaultMessage: 'Alert distribution by host',
+  }
+);
+
+const AGGREGATION_FIELD = 'host.name';
+const AGGREGATION_NAME = 'Host name';
+const TOP_ALERTS_CHART_ID = 'alerts-summary-top-alerts';
+const HEIGHT = 160; // px
+
+/**
+ * Renders a list showing the percentages of alerts grouped by host.name .
+ * The component is used in the alerts page in the AI for SOC alert summary page.
+ */
+export const AlertsProgressBarPanel: React.FC<ChartsPanelProps> = ({
+  filters,
+  query,
+  signalIndexName,
+  runtimeMappings,
+  skip = false,
+}) => {
+  const { euiTheme } = useEuiTheme();
+
+  const uniqueQueryId = useMemo(() => `${TOP_ALERTS_CHART_ID}-${uuid()}`, []);
+  const aggregations = useMemo(() => alertsGroupingAggregations(AGGREGATION_FIELD), []);
+  const { items, isLoading } = useSummaryChartData({
+    aggregations,
+    filters,
+    query,
+    signalIndexName,
+    runtimeMappings,
+    skip,
+    uniqueQueryId,
+  });
+  const data = useMemo(() => (getIsAlertsProgressBarData(items) ? items : []), [items]);
+  const [nonEmpty] = useMemo(() => getAggregateData(data), [data]);
+  const noData: boolean = useMemo(() => nonEmpty === 0, [nonEmpty]);
+
+  return (
+    <InspectButtonContainer>
+      <EuiPanel data-test-subj={ALERTS_BY_HOST_PANEL} hasBorder hasShadow={false}>
+        <HeaderSection
+          id={uniqueQueryId}
+          inspectTitle={ALERT_BY_HOST_NAME_TITLE}
+          outerDirection="row"
+          title={ALERT_BY_HOST_NAME_TITLE}
+          titleSize="xs"
+          hideSubtitle
+        />
+        <EuiText
+          size="xs"
+          css={css`
+            font-weight: ${euiTheme.font.weight.semiBold};
+          `}
+        >
+          {AGGREGATION_NAME}
+        </EuiText>
+        {isLoading ? (
+          <>
+            <EuiSpacer size="s" />
+            <EuiProgress data-test-subj={ALERTS_BY_HOST_PROGRESS_BAR} color="primary" size="xs" />
+          </>
+        ) : (
+          <>
+            <EuiHorizontalRule margin="xs" />
+            {noData ? (
+              <EuiText data-test-subj={ALERTS_BY_HOST_NO_DATA} size="s" textAlign="center">
+                {EMPTY_DATA_MESSAGE}
+              </EuiText>
+            ) : (
+              <div
+                className="eui-yScroll"
+                css={css`
+                  height: ${HEIGHT}px !important;
+                `}
+              >
+                {data
+                  .filter((item) => item.key !== '-')
+                  .map((item) => (
+                    <div data-test-subj={`${ALERTS_BY_HOST_ROW}${item.key}`} key={`${item.key}`}>
+                      <ProgressBarRow item={item} />
+                      <EuiSpacer size="s" />
+                    </div>
+                  ))}
+              </div>
+            )}
+          </>
+        )}
+      </EuiPanel>
+    </InspectButtonContainer>
+  );
+};
+
+AlertsProgressBarPanel.displayName = 'AlertsProgressBarPanel';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 import { KPIsSection } from './kpis_section';
-import { ALERTS_BY_HOST_PANEL } from './alerts_progress_bar_panel';
+import { ALERTS_BY_HOST_PANEL } from './alerts_progress_bar_by_host_name_panel';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 import { TestProviders } from '../../../../common/mock';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { KPIsSection } from './kpis_section';
+import { ALERTS_BY_HOST_PANEL } from './alerts_progress_bar_panel';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import { TestProviders } from '../../../../common/mock';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+
+jest.mock('../../../../common/hooks/use_selector');
+
+const dataView: DataView = createStubDataView({ spec: {} });
+
+describe('<KPIsSection />', () => {
+  it('should render all components', async () => {
+    (useDeepEqualSelector as jest.Mock).mockReturnValue({
+      meta: {},
+    });
+
+    await act(async () => {
+      const { getByTestId } = render(
+        <TestProviders>
+          <KPIsSection dataView={dataView} />
+        </TestProviders>
+      );
+
+      expect(getByTestId('severty-level-panel')).toBeInTheDocument();
+      expect(getByTestId('alerts-by-rule-panel')).toBeInTheDocument();
+      expect(getByTestId(ALERTS_BY_HOST_PANEL)).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useMemo } from 'react';
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { inputsSelectors } from '../../../../common/store';
+import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { SeverityLevelPanel } from '../../alerts_kpis/severity_level_panel';
+import { AlertsByRulePanel } from '../../alerts_kpis/alerts_by_rule_panel';
+import { AlertsProgressBarPanel } from './alerts_progress_bar_panel';
+
+export const KPIS_SECTION = 'alert-summary-kpis-section';
+
+export interface KPIsSectionProps {
+  /**
+   * DataView created for the alert summary page
+   */
+  dataView: DataView;
+}
+
+/**
+ * Section rendering 3 charts in the alert summary page.
+ * The component leverages existing chart components from the alerts page but is making a few tweaks:
+ * - the SeverityLevelPanel and AlertsByRulePanel are used directly from the alerts page
+ * - the UI differences on the AlertsProgressBarPanel were significant enough that a separate component was created
+ */
+export const KPIsSection = memo(({ dataView }: KPIsSectionProps) => {
+  const signalIndexName = dataView.getIndexPattern();
+
+  const getGlobalQuerySelector = useMemo(() => inputsSelectors.globalQuerySelector(), []);
+  const query = useDeepEqualSelector(getGlobalQuerySelector);
+
+  return (
+    <EuiFlexGroup data-test-subj={KPIS_SECTION}>
+      <EuiFlexItem>
+        <SeverityLevelPanel
+          signalIndexName={signalIndexName}
+          query={query}
+          showCellActions={false}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <AlertsByRulePanel
+          signalIndexName={signalIndexName}
+          query={query}
+          showCellActions={false}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <AlertsProgressBarPanel signalIndexName={signalIndexName} query={query} />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+});
+
+KPIsSection.displayName = 'KPIsSection';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.tsx
@@ -12,7 +12,7 @@ import { inputsSelectors } from '../../../../common/store';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { SeverityLevelPanel } from '../../alerts_kpis/severity_level_panel';
 import { AlertsByRulePanel } from '../../alerts_kpis/alerts_by_rule_panel';
-import { AlertsProgressBarPanel } from './alerts_progress_bar_panel';
+import { AlertsProgressBarByHostNamePanel } from './alerts_progress_bar_by_host_name_panel';
 
 export const KPIS_SECTION = 'alert-summary-kpis-section';
 
@@ -52,7 +52,7 @@ export const KPIsSection = memo(({ dataView }: KPIsSectionProps) => {
         />
       </EuiFlexItem>
       <EuiFlexItem>
-        <AlertsProgressBarPanel signalIndexName={signalIndexName} query={query} />
+        <AlertsProgressBarByHostNamePanel signalIndexName={signalIndexName} query={query} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.test.tsx
@@ -19,6 +19,7 @@ import {
 import { useKibana } from '../../../common/lib/kibana';
 import { TestProviders } from '../../../common/mock';
 import { SEARCH_BAR_TEST_ID } from './search_bar/search_bar_section';
+import { KPIS_SECTION } from './kpis/kpis_section';
 
 jest.mock('../../../common/components/search_bar', () => ({
   // The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables so we can't use SEARCH_BAR_TEST_ID
@@ -89,7 +90,9 @@ describe('<Wrapper />', () => {
       services: {
         data: {
           dataViews: {
-            create: jest.fn().mockReturnValue({ id: 'id', toSpec: jest.fn() }),
+            create: jest
+              .fn()
+              .mockReturnValue({ getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() }),
             clearInstanceCache: jest.fn(),
           },
           query: { filterManager: { getFilters: jest.fn() } },
@@ -114,6 +117,7 @@ describe('<Wrapper />', () => {
       expect(getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
       expect(getByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
       expect(getByTestId(SEARCH_BAR_TEST_ID)).toBeInTheDocument();
+      expect(getByTestId(KPIS_SECTION)).toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
@@ -17,6 +17,7 @@ import { i18n } from '@kbn/i18n';
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import { useKibana } from '../../../common/lib/kibana';
+import { KPIsSection } from './kpis/kpis_section';
 import { SearchBarSection } from './search_bar/search_bar_section';
 
 const DATAVIEW_ERROR = i18n.translate('xpack.securitySolution.alertSummary.dataViewError', {
@@ -92,6 +93,8 @@ export const Wrapper = memo(({ packages }: WrapperProps) => {
           ) : (
             <div data-test-subj={CONTENT_TEST_ID}>
               <SearchBarSection dataView={dataView} packages={packages} />
+              <EuiSpacer />
+              <KPIsSection dataView={dataView} />
             </div>
           )}
         </>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.test.tsx
@@ -18,29 +18,24 @@ jest.mock('react-router-dom', () => {
 });
 
 describe('Alert by rule chart', () => {
-  const defaultProps = {
-    data: [],
-    isLoading: false,
-  };
-
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  test('renders table correctly without data', () => {
+  test('should render the table correctly without data', () => {
     const { getByTestId } = render(
       <TestProviders>
-        <AlertsByRule {...defaultProps} />
+        <AlertsByRule data={[]} isLoading={false} showCellActions={true} />
       </TestProviders>
     );
     expect(getByTestId('alerts-by-rule-table')).toBeInTheDocument();
     expect(getByTestId('alerts-by-rule-table')).toHaveTextContent('No items found');
   });
 
-  test('renders table correctly with data', () => {
+  test('should render the table correctly with data', () => {
     const { queryAllByRole } = render(
       <TestProviders>
-        <AlertsByRule data={parsedAlerts} isLoading={false} />
+        <AlertsByRule data={parsedAlerts} isLoading={false} showCellActions={true} />
       </TestProviders>
     );
 
@@ -48,6 +43,18 @@ describe('Alert by rule chart', () => {
       expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].rule);
       expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].value.toString());
       expect(queryAllByRole('row')[i + 1].children).toHaveLength(3);
+    });
+  });
+
+  test('should render the table without the third columns (for cell actions)', () => {
+    const { queryAllByRole } = render(
+      <TestProviders>
+        <AlertsByRule data={parsedAlerts} isLoading={false} showCellActions={false} />
+      </TestProviders>
+    );
+
+    parsedAlerts.forEach((_, i) => {
+      expect(queryAllByRole('row')[i + 1].children).toHaveLength(2);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/alerts_by_rule.tsx
@@ -5,24 +5,12 @@
  * 2.0.
  */
 
-import type { EuiBasicTableColumn } from '@elastic/eui';
-import { EuiInMemoryTable, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiInMemoryTable, EuiSpacer } from '@elastic/eui';
 import React from 'react';
 import styled from 'styled-components';
 import type { SortOrder } from '@elastic/elasticsearch/lib/api/types';
-import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
-import { TableId } from '@kbn/securitysolution-data-table';
+import { useGetAlertsByRuleColumns } from './columns';
 import type { AlertsByRuleData } from './types';
-import { FormattedCount } from '../../../../common/components/formatted_number';
-import { ALERTS_HEADERS_RULE_NAME } from '../../alerts_table/translations';
-import { COUNT_TABLE_TITLE } from '../alerts_count_panel/translations';
-import {
-  CellActionsMode,
-  SecurityCellActionsTrigger,
-  SecurityCellActions,
-  SecurityCellActionType,
-} from '../../../../common/components/cell_actions';
-import { getSourcererScopeId } from '../../../../helpers';
 
 const Wrapper = styled.div`
   margin-top: -${({ theme }) => theme.eui.euiSizeM};
@@ -30,57 +18,6 @@ const Wrapper = styled.div`
 const TableWrapper = styled.div`
   height: 210px;
 `;
-
-export interface AlertsByRuleProps {
-  data: AlertsByRuleData[];
-  isLoading: boolean;
-}
-
-const COLUMNS: Array<EuiBasicTableColumn<AlertsByRuleData>> = [
-  {
-    field: 'rule',
-    name: ALERTS_HEADERS_RULE_NAME,
-    'data-test-subj': 'alert-by-rule-table-rule-name',
-    truncateText: true,
-    render: (rule: string) => (
-      <EuiText size="xs" className="eui-textTruncate">
-        {rule}
-      </EuiText>
-    ),
-  },
-  {
-    field: 'value',
-    name: COUNT_TABLE_TITLE,
-    dataType: 'number',
-    sortable: true,
-    'data-test-subj': 'alert-by-rule-table-count',
-    render: (count: number) => (
-      <EuiText grow={false} size="xs">
-        <FormattedCount count={count} />
-      </EuiText>
-    ),
-    width: '22%',
-  },
-  {
-    field: 'rule',
-    name: '',
-    'data-test-subj': 'alert-by-rule-table-actions',
-    width: '10%',
-    render: (rule: string) => (
-      <SecurityCellActions
-        mode={CellActionsMode.INLINE}
-        visibleCellActions={0}
-        triggerId={SecurityCellActionsTrigger.DEFAULT}
-        data={{ field: ALERT_RULE_NAME, value: rule }}
-        sourcererScopeId={getSourcererScopeId(TableId.alertsOnAlertsPage)}
-        disabledActionTypes={[SecurityCellActionType.SHOW_TOP_N]}
-        metadata={{ scopeId: TableId.alertsOnAlertsPage }}
-        extraActionsIconType="boxesVertical"
-        extraActionsColor="text"
-      />
-    ),
-  },
-];
 
 const SORTING: { sort: { field: keyof AlertsByRuleData; direction: SortOrder } } = {
   sort: {
@@ -94,14 +31,31 @@ const PAGINATION: {} = {
   showPerPageOptions: false,
 };
 
-export const AlertsByRule: React.FC<AlertsByRuleProps> = ({ data, isLoading }) => {
+export interface AlertsByRuleProps {
+  /**
+   * Chart data
+   */
+  data: AlertsByRuleData[];
+  /**
+   * If true, renders the UIInMemoryTable loading state
+   */
+  isLoading: boolean;
+  /**
+   * If true, render the last column for cell actions (like filter for, out, add to timeline, copy...)
+   */
+  showCellActions: boolean;
+}
+
+export const AlertsByRule: React.FC<AlertsByRuleProps> = ({ data, isLoading, showCellActions }) => {
+  const columns = useGetAlertsByRuleColumns(showCellActions);
+
   return (
     <Wrapper data-test-subj="alerts-by-rule">
       <EuiSpacer size="xs" />
       <TableWrapper className="eui-yScroll">
         <EuiInMemoryTable
           data-test-subj="alerts-by-rule-table"
-          columns={COLUMNS}
+          columns={columns}
           items={data}
           loading={isLoading}
           sorting={SORTING}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/columns.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/columns.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useGetAlertsByRuleColumns } from './columns';
+import { renderHook } from '@testing-library/react';
+
+describe('useGetAlertsByRuleColumns', () => {
+  it('should return base columns (2)', () => {
+    const { result } = renderHook(() => useGetAlertsByRuleColumns(false));
+    expect(result.current).toHaveLength(2);
+  });
+
+  it('should return all columns (3)', () => {
+    const { result } = renderHook(() => useGetAlertsByRuleColumns(true));
+    expect(result.current).toHaveLength(3);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/columns.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useMemo } from 'react';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import { EuiText } from '@elastic/eui';
+import { ALERT_RULE_NAME } from '@kbn/rule-data-utils';
+import { TableId } from '@kbn/securitysolution-data-table';
+import { FormattedCount } from '../../../../common/components/formatted_number';
+import { COUNT_TABLE_TITLE } from '../alerts_count_panel/translations';
+import {
+  CellActionsMode,
+  SecurityCellActions,
+  SecurityCellActionsTrigger,
+  SecurityCellActionType,
+} from '../../../../common/components/cell_actions';
+import { getSourcererScopeId } from '../../../../helpers';
+import { ALERTS_HEADERS_RULE_NAME } from '../../alerts_table/translations';
+import type { AlertsByRuleData } from './types';
+
+const BASE_COLUMNS: Array<EuiBasicTableColumn<AlertsByRuleData>> = [
+  {
+    field: 'rule',
+    name: ALERTS_HEADERS_RULE_NAME,
+    'data-test-subj': 'alert-by-rule-table-rule-name',
+    truncateText: true,
+    render: (rule: string) => (
+      <EuiText size="xs" className="eui-textTruncate">
+        {rule}
+      </EuiText>
+    ),
+  },
+  {
+    field: 'value',
+    name: COUNT_TABLE_TITLE,
+    dataType: 'number',
+    sortable: true,
+    'data-test-subj': 'alert-by-rule-table-count',
+    render: (count: number) => (
+      <EuiText grow={false} size="xs">
+        <FormattedCount count={count} />
+      </EuiText>
+    ),
+    width: '22%',
+  },
+];
+
+const CELL_ACTIONS_COLUMN: EuiBasicTableColumn<AlertsByRuleData> = {
+  field: 'rule',
+  name: '',
+  'data-test-subj': 'alert-by-rule-table-actions',
+  width: '10%',
+  render: (rule: string) => (
+    <SecurityCellActions
+      mode={CellActionsMode.INLINE}
+      visibleCellActions={0}
+      triggerId={SecurityCellActionsTrigger.DEFAULT}
+      data={{ field: ALERT_RULE_NAME, value: rule }}
+      sourcererScopeId={getSourcererScopeId(TableId.alertsOnAlertsPage)}
+      disabledActionTypes={[SecurityCellActionType.SHOW_TOP_N]}
+      metadata={{ scopeId: TableId.alertsOnAlertsPage }}
+      extraActionsIconType="boxesVertical"
+      extraActionsColor="text"
+    />
+  ),
+};
+
+const ALL_COLUMNS = [...BASE_COLUMNS, CELL_ACTIONS_COLUMN];
+
+/**
+ * Returns the list of columns for the severity table for the KPI charts
+ * @param showCellActions if true, add a third column for cell actions
+ */
+export const useGetAlertsByRuleColumns = (
+  showCellActions: boolean
+): Array<EuiBasicTableColumn<AlertsByRuleData>> => {
+  return useMemo(() => (showCellActions ? ALL_COLUMNS : BASE_COLUMNS), [showCellActions]);
+};

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/index.tsx
@@ -19,12 +19,17 @@ import * as i18n from './translations';
 
 const ALERTS_BY_TYPE_CHART_ID = 'alerts-summary-alert_by_type';
 
+/**
+ * Renders a table showing alerts grouped by rule names.
+ * The component is used in the alerts page as well as in the AI for SOC alert summary page.
+ */
 export const AlertsByRulePanel: React.FC<ChartsPanelProps> = ({
   filters,
   query,
   signalIndexName,
   runtimeMappings,
   skip,
+  showCellActions = true,
 }) => {
   const uniqueQueryId = useMemo(() => `${ALERTS_BY_TYPE_CHART_ID}-${uuid()}`, []);
 
@@ -50,7 +55,7 @@ export const AlertsByRulePanel: React.FC<ChartsPanelProps> = ({
           titleSize="xs"
           hideSubtitle
         />
-        <AlertsByRule data={data} isLoading={isLoading} />
+        <AlertsByRule data={data} isLoading={isLoading} showCellActions={showCellActions} />
       </EuiPanel>
     </InspectButtonContainer>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.tsx
@@ -15,20 +15,20 @@ import {
   EuiProgress,
   EuiSpacer,
   EuiText,
-  useEuiTheme,
 } from '@elastic/eui';
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { ProgressBarRow } from './alerts_progress_bar_row';
 import type { AlertsProgressBarData, GroupBySelection } from './types';
 import type { AddFilterProps } from '../common/types';
 import { getAggregateData } from './helpers';
 import * as i18n from './translations';
 import {
-  SecurityCellActionType,
   CellActionsMode,
-  SecurityCellActionsTrigger,
   SecurityCellActions,
+  SecurityCellActionsTrigger,
+  SecurityCellActionType,
 } from '../../../../common/components/cell_actions';
 import { getSourcererScopeId } from '../../../../helpers';
 
@@ -57,47 +57,22 @@ const EmptyAction = styled.div`
   padding-left: ${({ theme }) => theme.eui.euiSizeL};
 `;
 
-/**
- * Individual progress bar per row
- */
-const ProgressBarRow: React.FC<{ item: AlertsProgressBarData }> = ({ item }) => {
-  const { euiTheme } = useEuiTheme();
-  const color = useMemo(
-    () =>
-      euiTheme.themeName === 'EUI_THEME_BOREALIS'
-        ? euiTheme.colors.vis.euiColorVis6
-        : euiTheme.colors.vis.euiColorVis9,
-    [euiTheme]
-  );
-
-  return (
-    <EuiProgress
-      valueText={
-        <EuiText size="xs" color="default">
-          <strong>{item.percentageLabel}</strong>
-        </EuiText>
-      }
-      max={1}
-      color={color}
-      size="s"
-      value={item.percentage}
-      label={
-        item.key === 'Other' ? (
-          item.label
-        ) : (
-          <EuiText size="xs" className="eui-textTruncate">
-            {item.key}
-          </EuiText>
-        )
-      }
-    />
-  );
-};
-
 export interface AlertsProcessBarProps {
+  /**
+   * Alerts data
+   */
   data: AlertsProgressBarData[];
+  /**
+   * If true, component renders an EuiProgressBar
+   */
   isLoading: boolean;
+  /**
+   * Callback to allow the charts to add filters to the SiemSearchBar
+   */
   addFilter?: ({ field, value, negate }: AddFilterProps) => void;
+  /**
+   * Field the alerts data is grouped by
+   */
   groupBySelection: GroupBySelection;
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar_row.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar_row.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ProgressBarRow } from './alerts_progress_bar_row';
+import type { AlertsProgressBarData } from './types';
+
+describe('ProgressBarRow', () => {
+  it('should render label value when key is Other', () => {
+    const item: AlertsProgressBarData = {
+      key: 'Other',
+      value: 1,
+      percentage: 50,
+      percentageLabel: 'percentageLabel',
+      label: 'label',
+    };
+
+    const { getByText } = render(<ProgressBarRow item={item} />);
+
+    expect(getByText('percentageLabel')).toBeInTheDocument();
+    expect(getByText('label')).toBeInTheDocument();
+  });
+
+  it('should render key value when key is not Other', () => {
+    const item: AlertsProgressBarData = {
+      key: 'key',
+      value: 1,
+      percentage: 50,
+      percentageLabel: 'percentageLabel',
+      label: 'label',
+    };
+
+    const { getByText } = render(<ProgressBarRow item={item} />);
+
+    expect(getByText('percentageLabel')).toBeInTheDocument();
+    expect(getByText('key')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar_row.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar_row.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiProgress, EuiText, useEuiTheme } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import type { AlertsProgressBarData } from './types';
+
+/**
+ * Renders a EuiProgress, used in the KPI chart for the alerts page as well as the AI for SOC alert summary page.
+ */
+export const ProgressBarRow: React.FC<{ item: AlertsProgressBarData }> = ({ item }) => {
+  const { euiTheme } = useEuiTheme();
+  const color = useMemo(
+    () =>
+      euiTheme.themeName === 'EUI_THEME_BOREALIS'
+        ? euiTheme.colors.vis.euiColorVis6
+        : euiTheme.colors.vis.euiColorVis9,
+    [euiTheme]
+  );
+
+  return (
+    <EuiProgress
+      valueText={
+        <EuiText size="xs" color="default">
+          <strong>{item.percentageLabel}</strong>
+        </EuiText>
+      }
+      max={1}
+      color={color}
+      size="s"
+      value={item.percentage}
+      label={
+        item.key === 'Other' ? (
+          item.label
+        ) : (
+          <EuiText size="xs" className="eui-textTruncate">
+            {item.key}
+          </EuiText>
+        )
+      }
+    />
+  );
+};
+
+ProgressBarRow.displayName = 'ProgressBarRow';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.tsx
@@ -7,8 +7,7 @@
 import { EuiPanel } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 import { v4 as uuid } from 'uuid';
-import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
-import type { Filter, Query } from '@kbn/es-query';
+import type { ChartsPanelProps } from '../alerts_summary_charts_panel/types';
 import { HeaderSection } from '../../../../common/components/header_section';
 import { InspectButtonContainer } from '../../../../common/components/inspect';
 import { StackByComboBox } from '../common/components';
@@ -18,23 +17,28 @@ import { alertsGroupingAggregations } from '../alerts_summary_charts_panel/aggre
 import { getIsAlertsProgressBarData } from './helpers';
 import * as i18n from './translations';
 import type { GroupBySelection } from './types';
-import type { AddFilterProps } from '../common/types';
 
 const TOP_ALERTS_CHART_ID = 'alerts-summary-top-alerts';
 const DEFAULT_COMBOBOX_WIDTH = 150;
 const DEFAULT_OPTIONS = ['host.name', 'user.name', 'source.ip', 'destination.ip'];
 
-interface Props {
-  filters?: Filter[];
-  query?: Query;
-  signalIndexName: string | null;
-  runtimeMappings?: MappingRuntimeFields;
-  skip?: boolean;
+interface AlertsProgressBarPanelProps extends ChartsPanelProps {
+  /**
+   * Field to group the alerts by
+   */
   groupBySelection: GroupBySelection;
+  /**
+   * Callback to set which field to group the alerts by
+   */
   setGroupBySelection: (groupBySelection: GroupBySelection) => void;
-  addFilter?: ({ field, value, negate }: AddFilterProps) => void;
 }
-export const AlertsProgressBarPanel: React.FC<Props> = ({
+
+/**
+ * Renders a list showing the percentages of alerts grouped by a property.
+ * The component is used in the alerts page, where users can select what fields they want the alerts to be grouped by,
+ * and in the AI for SOC alert summary page where the alerts are automatically grouped by host.
+ */
+export const AlertsProgressBarPanel: React.FC<AlertsProgressBarPanelProps> = ({
   filters,
   query,
   signalIndexName,
@@ -70,12 +74,17 @@ export const AlertsProgressBarPanel: React.FC<Props> = ({
   });
   const data = useMemo(() => (getIsAlertsProgressBarData(items) ? items : []), [items]);
 
+  const inspectTitle = useMemo(
+    () => `${i18n.ALERT_BY_TITLE} ${groupBySelection}`,
+    [groupBySelection]
+  );
+
   return (
     <InspectButtonContainer>
       <EuiPanel hasBorder hasShadow={false} data-test-subj="alerts-progress-bar-panel">
         <HeaderSection
           id={uniqueQueryId}
-          inspectTitle={`${i18n.ALERT_BY_TITLE} ${groupBySelection}`}
+          inspectTitle={inspectTitle}
           outerDirection="row"
           title={i18n.ALERT_BY_TITLE}
           titleSize="xs"

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/types.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import type { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/types';
 import type { Filter, Query } from '@kbn/es-query';
 import type { SeverityBuckets as SeverityData } from '../../../../overview/components/detection_response/alerts_by_status/types';
@@ -14,6 +15,7 @@ import type {
   AlertsProgressBarData,
 } from '../alerts_progress_bar_panel/types';
 import type { ChartCollapseAgg, ChartCollapseData } from '../chart_panels/chart_collapse/types';
+import type { AddFilterProps } from '../common/types';
 
 export type SummaryChartsAgg = Partial<
   AlertsBySeverityAgg | AlertsByRuleAgg | AlertsByGroupingAgg | ChartCollapseAgg
@@ -26,10 +28,32 @@ export type SummaryChartsData =
   | ChartCollapseData;
 
 export interface ChartsPanelProps {
+  /**
+   * Filters to use when fetching the chart data
+   */
   filters?: Filter[];
+  /**
+   * Query to use when fetching the chart data (comes from Redux when used in combination with the SiemSearchBar)
+   */
   query?: Query;
+  /**
+   * Indices to use when fetching the chart data
+   */
   signalIndexName: string | null;
+  /**
+   * Runtime mappings to use when fetching the chart data
+   */
   runtimeMappings?: MappingRuntimeFields;
+  /**
+   * If true, prevents the data from being fetched
+   */
   skip?: boolean;
-  addFilter?: ({ field, value }: { field: string; value: string | number }) => void;
+  /**
+   * Callback to allow the charts to add filters to the SiemSearchBar
+   */
+  addFilter?: ({ field, value, negate }: AddFilterProps) => void;
+  /**
+   * If true, make the cell action interactions visible (filter for, filter out, add to timeline, copy...)
+   */
+  showCellActions?: boolean;
 }

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/columns.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/columns.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useGetSeverityTableColumns } from './columns';
+import { renderHook } from '@testing-library/react';
+
+describe('useGetSeverityTableColumns', () => {
+  it('should return base columns (2)', () => {
+    const { result } = renderHook(() => useGetSeverityTableColumns(false));
+    expect(result.current).toHaveLength(2);
+  });
+
+  it('should return all columns (3)', () => {
+    const { result } = renderHook(() => useGetSeverityTableColumns(true));
+    expect(result.current).toHaveLength(3);
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/columns.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/columns.tsx
@@ -4,11 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React, { useMemo } from 'react';
+import type { EuiBasicTableColumn } from '@elastic/eui';
 import { EuiHealth, EuiText } from '@elastic/eui';
 import { capitalize } from 'lodash';
 import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
-import type { EuiBasicTableColumn } from '@elastic/eui';
 import type { Severity } from '@kbn/securitysolution-io-ts-alerting-types';
 import { TableId } from '@kbn/securitysolution-data-table';
 import type { SeverityBuckets as SeverityData } from '../../../../overview/components/detection_response/alerts_by_status/types';
@@ -18,16 +19,22 @@ import * as i18n from './translations';
 import { useRiskSeverityColors } from '../../../../common/utils/risk_color_palette';
 import {
   CellActionsMode,
-  SecurityCellActionsTrigger,
   SecurityCellActions,
+  SecurityCellActionsTrigger,
   SecurityCellActionType,
 } from '../../../../common/components/cell_actions';
 import { getSourcererScopeId } from '../../../../helpers';
 
-export const useGetSeverityTableColumns = (): Array<EuiBasicTableColumn<SeverityData>> => {
+/**
+ * Returns the list of columns for the severity table for the KPI charts
+ * @param showCellActions if true, add a third column for cell actions
+ */
+export const useGetSeverityTableColumns = (
+  showCellActions: boolean
+): Array<EuiBasicTableColumn<SeverityData>> => {
   const severityColors = useRiskSeverityColors();
-  return useMemo(
-    () => [
+  return useMemo(() => {
+    const baseColumns: Array<EuiBasicTableColumn<SeverityData>> = [
       {
         field: 'key',
         name: i18n.SEVERITY_LEVEL_COLUMN_TITLE,
@@ -50,7 +57,9 @@ export const useGetSeverityTableColumns = (): Array<EuiBasicTableColumn<Severity
           </EuiText>
         ),
       },
-      {
+    ];
+    if (showCellActions) {
+      baseColumns.push({
         field: 'key',
         name: '',
         'data-test-subj': 'severityTable-actions',
@@ -68,8 +77,8 @@ export const useGetSeverityTableColumns = (): Array<EuiBasicTableColumn<Severity
             extraActionsColor="text"
           />
         ),
-      },
-    ],
-    [severityColors]
-  );
+      });
+    }
+    return baseColumns;
+  }, [severityColors, showCellActions]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/index.tsx
@@ -19,6 +19,10 @@ import * as i18n from './translations';
 
 const SEVERITY_DONUT_CHART_ID = 'alerts-summary-severity-donut';
 
+/**
+ * Renders a table and a donut chart showing alerts grouped by severity levels.
+ * The component is used in the alerts page as well as in the AI for SOC alert summary page.
+ */
 export const SeverityLevelPanel: React.FC<ChartsPanelProps> = ({
   filters,
   query,
@@ -26,6 +30,7 @@ export const SeverityLevelPanel: React.FC<ChartsPanelProps> = ({
   runtimeMappings,
   addFilter,
   skip,
+  showCellActions = true,
 }) => {
   const uniqueQueryId = useMemo(() => `${SEVERITY_DONUT_CHART_ID}-${uuid()}`, []);
 
@@ -50,7 +55,12 @@ export const SeverityLevelPanel: React.FC<ChartsPanelProps> = ({
           titleSize="xs"
           hideSubtitle
         />
-        <SeverityLevelChart data={data} isLoading={isLoading} addFilter={addFilter} />
+        <SeverityLevelChart
+          data={data}
+          isLoading={isLoading}
+          addFilter={addFilter}
+          showCellActions={showCellActions}
+        />
       </EuiPanel>
     </InspectButtonContainer>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.test.tsx
@@ -7,6 +7,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
+import type { SeverityLevelProps } from './severity_level_chart';
 import { SeverityLevelChart } from './severity_level_chart';
 import { parsedAlerts } from './mock_data';
 
@@ -18,16 +19,17 @@ jest.mock('react-router-dom', () => {
 });
 
 describe('Severity level chart', () => {
-  const defaultProps = {
+  const defaultProps: SeverityLevelProps = {
     data: [],
     isLoading: false,
+    showCellActions: true,
   };
 
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  test('renders severity table correctly', () => {
+  it('should render the severity table correctly', () => {
     const { getByTestId } = render(
       <TestProviders>
         <SeverityLevelChart {...defaultProps} />
@@ -37,7 +39,7 @@ describe('Severity level chart', () => {
     expect(getByTestId('severity-level-table')).toHaveTextContent('No items found');
   });
 
-  test('renders severity donut correctly', () => {
+  it('should render the severity donut correctly', () => {
     const { getByTestId } = render(
       <TestProviders>
         <SeverityLevelChart {...defaultProps} />
@@ -46,10 +48,10 @@ describe('Severity level chart', () => {
     expect(getByTestId('severity-level-donut')).toBeInTheDocument();
   });
 
-  test('renders table correctly with data', () => {
+  it('should render the table correctly with data', () => {
     const { queryAllByRole, getByTestId } = render(
       <TestProviders>
-        <SeverityLevelChart data={parsedAlerts} isLoading={false} />
+        <SeverityLevelChart data={parsedAlerts} isLoading={false} showCellActions={true} />
       </TestProviders>
     );
     expect(getByTestId('severity-level-table')).toBeInTheDocument();
@@ -57,6 +59,18 @@ describe('Severity level chart', () => {
       expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].label);
       expect(queryAllByRole('row')[i + 1].textContent).toContain(parsedAlerts[i].value.toString());
       expect(queryAllByRole('row')[i + 1].children).toHaveLength(3);
+    });
+  });
+
+  it('should render the table without the third columns (cell actions)', () => {
+    const { queryAllByRole, getByTestId } = render(
+      <TestProviders>
+        <SeverityLevelChart data={parsedAlerts} isLoading={false} showCellActions={false} />
+      </TestProviders>
+    );
+    expect(getByTestId('severity-level-table')).toBeInTheDocument();
+    parsedAlerts.forEach((_, i) => {
+      expect(queryAllByRole('row')[i + 1].children).toHaveLength(2);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/severity_level_chart.tsx
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React, { useCallback, useMemo } from 'react';
 import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
 import styled from 'styled-components';
@@ -27,19 +28,34 @@ const DONUT_HEIGHT = 150;
 const StyledEuiLoadingSpinner = styled(EuiLoadingSpinner)`
   margin: auto;
 `;
+
 export interface SeverityLevelProps {
+  /**
+   * Chart data
+   */
   data: SeverityData[];
+  /**
+   * If true, shows a EuiSpinner
+   */
   isLoading: boolean;
+  /**
+   * Callback to allow the charts to add filters to the SiemSearchBar
+   */
   addFilter?: ({ field, value }: { field: string; value: string | number }) => void;
+  /**
+   * If true, render the last column for cell actions (like filter for, out, add to timeline, copy...)
+   */
+  showCellActions: boolean;
 }
 
 export const SeverityLevelChart: React.FC<SeverityLevelProps> = ({
   data,
   isLoading,
   addFilter,
+  showCellActions,
 }) => {
   const { euiTheme } = useEuiTheme();
-  const columns = useGetSeverityTableColumns();
+  const columns = useGetSeverityTableColumns(showCellActions);
 
   const count = useMemo(() => {
     return data


### PR DESCRIPTION
## Summary

This PR adds the KPI charts section to the alert summary page. The 3 charts are similar to the ones in the alerts page, but there are some subtle differences, which lead to one of them being a separate component, while the other 2 I was able to reuse the existing components and just add a property to handle the different logic.

Here are the differences:
- in the AI for SOC we do not (currently) have cell actions, so a property was added to the charts to be able to hide the cell actions entirely
- the title of the right chart as well as the fact that it does not have a dropdown to select the field to group the alerts by meant that a new component (still using existing child components) was created

![Screenshot 2025-03-26 at 3 02 33 PM](https://github.com/user-attachments/assets/337b3ab4-29c3-40cd-8710-3f5c04898dd7)

The charts react to changes to the KQL bar:

https://github.com/user-attachments/assets/ed0e8f14-ba66-46ae-94df-6c8064c7a648

### Notes

Compared to the mocks (link at the end of the PR description), it was decided to not add the icons to the left of the next for the middle and right chart of the KPI section. These might be added in the future, but there is some complexity related to fetching them (especially for the alert by host) and more thoughts need to be had to make sure we're handling all the possible cases.

## How to test

This needs to be ran in Serverless:
- `yarn es serverless --projectType security`
- `yarn serverless-security --no-base-path`

You also need to enable the AI for SOC tier, by adding the following to your `serverless.security.dev.yaml` file:
```
xpack.securitySolutionServerless.productTypes:
  [
    { product_line: 'ai_soc', product_tier: 'search_ai_lake' },
  ]
```

And this to generate data: `yarn test:generate:serverless-dev`

Use one of these Serverless users:
- `platform_engineer`
- `endpoint_operations_analyst`
- `endpoint_policy_manager`
- `admin`
- `system_indices_superuser`

### Notes

You'll need to either have some AI for SOC integrations installed, or more easily you can:
-  change the `alert_summary.tsx` line `38` from `if (installedPackages.length === 0) {` to `if (installedPackages.length > 0) {` to force the wrapper component to render
- update `42` of the same `alert_summary.tsx` file from `return <Wrapper packages={installedPackages} />;` to `return <Wrapper packages={availablePackages} />;` to be able to see some packages

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

Mocks: https://www.figma.com/design/DYs7j4GQdAhg7aWTLI4R69/AI4DSOC?node-id=3284-70999&m=dev
Ticket: https://github.com/elastic/security-team/issues/11958