### PR TITLE
[9.0] [scout] Remove perf stats validation for Discover (#215130)

### DIFF
--- a/x-pack/platform/plugins/private/discover_enhanced/ui_tests/tests/discover_cdp_perf.spec.ts
+++ b/x-pack/platform/plugins/private/discover_enhanced/ui_tests/tests/discover_cdp_perf.spec.ts
@@ -95,6 +95,7 @@ test.describe(
       page,
       pageObjects,
       perfTracker,
+      log,
     }) => {
       const beforeMetrics = await perfTracker.capturePagePerformanceMetrics(cdp);
 
@@ -113,18 +114,7 @@ test.describe(
         afterMetrics
       );
 
-      expect(
-        perfStats.cpuTime.diff,
-        'CPU time (seconds) usage during page navigation should not exceed 1.5 seconds'
-      ).toBeLessThan(1.5);
-      expect(
-        perfStats.scriptTime.diff,
-        'Additional time spent executing JS scripts should not exceed 0.5 second'
-      ).toBeLessThan(0.5);
-      expect(
-        perfStats.layoutTime.diff,
-        'Total layout computation time should not exceed 0.1 second'
-      ).toBeLessThan(0.06);
+      log.info(`Performance Metrics for Discover app: ${JSON.stringify(perfStats, null, 2)}`);
     });
   }
 );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[scout] Remove perf stats validation for Discover (#215130)](https://github.com/elastic/kibana/pull/215130)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-03-22T18:31:54Z","message":"[scout] Remove perf stats validation for Discover (#215130)\n\n## Summary\n\nWith #212397 we added 2 tests for Discover app (loading `/app/discover`)\nto track:\n- js bundles loaded on page\n- perf metrics like CPU time, Layout time and Script time fetched with\nCDP Performance Domain API\n\nWhile the first test for bundles _didn't report any failures_, second\ntest to validate Perf metrics fails periodically:\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34729#0195a4de-6cd5-4d1e-be11-5d02be6de2b0\n```\nError: CPU time (seconds) usage during page navigation should not exceed 1.5 seconds\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 1.5\nReceived:   1.591343\n```\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34877\n```\nError: Additional time spent executing JS scripts should not exceed 0.5 second\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 0.5\nReceived:   0.601434\n```\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34899\n```\nError: Total layout computation time should not exceed 0.06 second\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 0.06\nReceived:   0.061723\n```\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34912#0195adb8-4536-42b7-ab4d-524535fdad9a\n```\nError: Additional time spent executing JS scripts should not exceed 0.5 second\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 0.5\nReceived:   0.561259\n```\n\nIt was worth an experiment, but due to flakiness we decided to keep only\nbundles limits validation for now and see if it is stable in the long\nrun.\n\nIf Data-Discovery team has interest in collecting Perf metrics without\nstrict validation in PRs, we can discuss the options. Alternatively we\ncan wait for Scout GA and you can deep dive into your own performance\ntesting with Playwright/CDP.","sha":"4dc27ba4aaa5bbc0a18a1964f58f2f63e2ccde16","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:version","test:scout","v9.1.0","v8.19.0"],"title":"[scout] Remove perf stats validation for Discover","number":215130,"url":"https://github.com/elastic/kibana/pull/215130","mergeCommit":{"message":"[scout] Remove perf stats validation for Discover (#215130)\n\n## Summary\n\nWith #212397 we added 2 tests for Discover app (loading `/app/discover`)\nto track:\n- js bundles loaded on page\n- perf metrics like CPU time, Layout time and Script time fetched with\nCDP Performance Domain API\n\nWhile the first test for bundles _didn't report any failures_, second\ntest to validate Perf metrics fails periodically:\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34729#0195a4de-6cd5-4d1e-be11-5d02be6de2b0\n```\nError: CPU time (seconds) usage during page navigation should not exceed 1.5 seconds\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 1.5\nReceived:   1.591343\n```\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34877\n```\nError: Additional time spent executing JS scripts should not exceed 0.5 second\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 0.5\nReceived:   0.601434\n```\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34899\n```\nError: Total layout computation time should not exceed 0.06 second\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 0.06\nReceived:   0.061723\n```\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34912#0195adb8-4536-42b7-ab4d-524535fdad9a\n```\nError: Additional time spent executing JS scripts should not exceed 0.5 second\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 0.5\nReceived:   0.561259\n```\n\nIt was worth an experiment, but due to flakiness we decided to keep only\nbundles limits validation for now and see if it is stable in the long\nrun.\n\nIf Data-Discovery team has interest in collecting Perf metrics without\nstrict validation in PRs, we can discuss the options. Alternatively we\ncan wait for Scout GA and you can deep dive into your own performance\ntesting with Playwright/CDP.","sha":"4dc27ba4aaa5bbc0a18a1964f58f2f63e2ccde16"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215130","number":215130,"mergeCommit":{"message":"[scout] Remove perf stats validation for Discover (#215130)\n\n## Summary\n\nWith #212397 we added 2 tests for Discover app (loading `/app/discover`)\nto track:\n- js bundles loaded on page\n- perf metrics like CPU time, Layout time and Script time fetched with\nCDP Performance Domain API\n\nWhile the first test for bundles _didn't report any failures_, second\ntest to validate Perf metrics fails periodically:\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34729#0195a4de-6cd5-4d1e-be11-5d02be6de2b0\n```\nError: CPU time (seconds) usage during page navigation should not exceed 1.5 seconds\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 1.5\nReceived:   1.591343\n```\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34877\n```\nError: Additional time spent executing JS scripts should not exceed 0.5 second\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 0.5\nReceived:   0.601434\n```\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34899\n```\nError: Total layout computation time should not exceed 0.06 second\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 0.06\nReceived:   0.061723\n```\n\n\nhttps://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/34912#0195adb8-4536-42b7-ab4d-524535fdad9a\n```\nError: Additional time spent executing JS scripts should not exceed 0.5 second\n\nexpect(received).toBeLessThan(expected)\n\nExpected: < 0.5\nReceived:   0.561259\n```\n\nIt was worth an experiment, but due to flakiness we decided to keep only\nbundles limits validation for now and see if it is stable in the long\nrun.\n\nIf Data-Discovery team has interest in collecting Perf metrics without\nstrict validation in PRs, we can discuss the options. Alternatively we\ncan wait for Scout GA and you can deep dive into your own performance\ntesting with Playwright/CDP.","sha":"4dc27ba4aaa5bbc0a18a1964f58f2f63e2ccde16"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->