### PR TITLE
[Fleet] Use fleet error in cspm plugin

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/index.ts
@@ -202,3 +202,5 @@ export type {
 } from './types';
 
 export { ElasticsearchAssetType } from './types';
+
+export { FleetError } from './errors';

--- a/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/server/plugin.ts
@@ -14,11 +14,12 @@ import type {
   SavedObjectsClientContract,
 } from '@kbn/core/server';
 import type { DeepReadonly } from 'utility-types';
-import type {
-  PostDeletePackagePoliciesResponse,
-  PackagePolicy,
-  NewPackagePolicy,
-  UpdatePackagePolicy,
+import {
+  type PostDeletePackagePoliciesResponse,
+  type PackagePolicy,
+  type NewPackagePolicy,
+  type UpdatePackagePolicy,
+  FleetError,
 } from '@kbn/fleet-plugin/common';
 import type {
   TaskManagerSetupContract,
@@ -118,13 +119,13 @@ export class CspPlugin
             const license = await plugins.licensing.getLicense();
             if (isCspPackage(packagePolicy.package?.name)) {
               if (!isSubscriptionAllowed(this.isCloudEnabled, license)) {
-                throw new Error(
+                throw new FleetError(
                   'To use this feature you must upgrade your subscription or start a trial'
                 );
               }
 
               if (!isSingleEnabledInput(packagePolicy.inputs)) {
-                throw new Error('Only one enabled input is allowed per policy');
+                throw new FleetError('Only one enabled input is allowed per policy');
               }
             }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/ingest-dev/issues/5266

Changed Error to FleetError in CSPM so that the error response code is 400 instead of 500.
500 is not appropriate, it triggers alerts in our serverless SLOs.

<img width="1777" alt="image" src="https://github.com/user-attachments/assets/b9b0e8cf-db54-427a-bc45-db0b806a150f" />


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->