### PR TITLE
[A11y][APM] Add `aria-label` to popover service in service overview

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/service_icons/icon_popover.tsx
@@ -43,6 +43,7 @@ export function IconPopover({
           color="text"
           onClick={onClick}
           iconType={icon.type}
+          aria-label={title}
           iconSize={icon.size ?? 'l'}
           className="serviceIcon_button"
           data-test-subj={`popover_${title}`}


### PR DESCRIPTION
## Summary

Fixes #210258

This PR adds an `aria-label` with the same content as the title to solve the "Button must have a discernible text" A11y critical issue.

## How to test
1. Download the [axe devtools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
2. Go into a service overview and run the scanner from axe devtools
3. You should see a critical error
4. Checkout this branch
5. Error should be solved


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->