### PR TITLE
[A11y][APM] Add `aria-label` to latency selector in service overview

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/latency_chart/latency_aggregation_type_select.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/charts/latency_chart/latency_aggregation_type_select.tsx
@@ -27,6 +27,9 @@ export function LatencyAggregationTypeSelect({
     <EuiSelect
       data-test-subj="apmLatencyChartSelect"
       compressed
+      aria-label={i18n.translate('xpack.apm.serviceOverview.latencyChartTitle.selector', {
+        defaultMessage: 'Metric selector',
+      })}
       prepend={i18n.translate('xpack.apm.serviceOverview.latencyChartTitle.prepend', {
         defaultMessage: 'Metric',
       })}


### PR DESCRIPTION
## Summary

Fixes #210270

This PR adds an `aria-label`  to solve the "Element missing an accessible name" A11y critical issue.

## How to test
1. Download the [axe devtools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
2. Go into a service overview and run the scanner from axe devtools
3. You should see a critical error
4. Checkout this branch
5. Error should be solved


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->