### PR TITLE
[Profiling] Add FrameType and color for Go

### DIFF
--- a/src/platform/packages/shared/kbn-profiling-utils/common/profiling.ts
+++ b/src/platform/packages/shared/kbn-profiling-utils/common/profiling.ts
@@ -22,6 +22,8 @@ export type FileID = string;
 
 /**
  * Frame type
+ * These frame types need to match with the constants defined in
+ * https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/main/libpf/frametype.go
  */
 export enum FrameType {
   Unsymbolized = 0,
@@ -35,6 +37,7 @@ export enum FrameType {
   JavaScript,
   PHPJIT,
   DotNET,
+  Go,
   ErrorFlag = 0x80,
   Error = 0xff,
 
@@ -56,6 +59,7 @@ const frameTypeDescriptions = {
   [FrameType.JavaScript]: 'JavaScript',
   [FrameType.PHPJIT]: 'PHP JIT',
   [FrameType.DotNET]: '.NET',
+  [FrameType.Go]: 'Go',
   [FrameType.ErrorFlag]: 'ErrorFlag',
   [FrameType.Error]: 'Error',
   [FrameType.Root]: 'Root',

--- a/x-pack/solutions/observability/plugins/profiling/common/frame_type_colors.ts
+++ b/x-pack/solutions/observability/plugins/profiling/common/frame_type_colors.ts
@@ -44,6 +44,7 @@ export const FRAME_TYPE_COLOR_MAP = {
   [FrameType.JavaScript]: [0xcbc3e3, 0xd5cfe8, 0xdfdbee, 0xeae7f3],
   [FrameType.PHPJIT]: [0xccfc82, 0xd1fc8e, 0xd6fc9b, 0xdbfca7],
   [FrameType.DotNET]: [0x6c60e1, 0x8075e5, 0x948be9, 0xa8a0ed],
+  [FrameType.Go]: [0x00add8, 0x31bee0, 0x68cce7],
   [FrameType.ErrorFlag]: [0x0, 0x0, 0x0, 0x0], // This is a special case, it's not a real frame type
   [FrameType.Error]: [0xfd8484, 0xfd9d9d, 0xfeb5b5, 0xfecece],
   [FrameType.Root]: [RED, RED, RED, RED],


### PR DESCRIPTION
## Summary

OTel Semantic Conventions [defines](https://github.com/open-telemetry/semantic-conventions/pull/2003) a type for Go and OTel eBPF profiler is about to start with pushing Go frames (either with https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/409 or https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/408)

FYI: @elastic/ingest-otel-data 

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] ~~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~ not relevant
- [ ] ~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~~ not relevant
- [ ] ~~[Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~~ not relevant
- [ ] ~~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~ not relevant
- [ ] ~~This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~~ not relevant
- [ ] ~~[Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~~ not relevant
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) - `release_note:skip`

