### PR TITLE
[8.x] Unauthorized route migration for routes owned by appex-sharedux (#214779)

### DIFF
--- a/src/core/packages/ui-settings/server-internal/src/routes/get.ts
+++ b/src/core/packages/ui-settings/server-internal/src/routes/get.ts
@@ -38,14 +38,32 @@ export function registerGetRoute(router: InternalUiSettingsRouter) {
     }
   };
   router.get(
-    { path: '/api/kibana/settings', validate: false },
+    {
+      path: '/api/kibana/settings',
+      validate: false,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the UI Settings Client',
+        },
+      },
+    },
     async (context, request, response) => {
       const uiSettingsClient = (await context.core).uiSettings.client;
       return await getFromRequest(uiSettingsClient, context, request, response);
     }
   );
   router.get(
-    { path: '/api/kibana/global_settings', validate: false },
+    {
+      path: '/api/kibana/global_settings',
+      validate: false,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route delegates authorization to the UI Settings Client',
+        },
+      },
+    },
     async (context, request, response) => {
       const uiSettingsClient = (await context.core).uiSettings.globalClient;
       return await getFromRequest(uiSettingsClient, context, request, response);

--- a/src/platform/plugins/shared/files/server/routes/public_facing/download.ts
+++ b/src/platform/plugins/shared/files/server/routes/public_facing/download.ts
@@ -74,8 +74,17 @@ export function register(router: FilesRouter) {
       path: FILES_API_ROUTES.public.download,
       validate: { ...rt },
       options: {
-        authRequired: false,
         access: 'public',
+      },
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is public and does not require user authentication',
+        },
+        authc: {
+          enabled: false,
+          reason: 'This route is public and does not require user authentication',
+        },
       },
     },
     handler

--- a/src/platform/plugins/shared/share/server/url_service/http/short_urls/register_goto_route.ts
+++ b/src/platform/plugins/shared/share/server/url_service/http/short_urls/register_goto_route.ts
@@ -18,6 +18,12 @@ export const registerGotoRoute = (router: IRouter, core: CoreSetup) => {
   core.http.resources.register(
     {
       path: '/goto/{id}',
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route handles redirection',
+        },
+      },
       validate: {
         params: schema.object({
           id: schema.string({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Unauthorized route migration for routes owned by appex-sharedux (#214779)](https://github.com/elastic/kibana/pull/214779)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Shostak","email":"165678770+elena-shostak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-18T17:00:53Z","message":"Unauthorized route migration for routes owned by appex-sharedux (#214779)\n\n### Authz API migration for unauthorized routes\n\nThis PR migrates last unauthorized routes owned by your team to a new\nsecurity configuration.\nPlease refer to the documentation for more information: [Authorization\nAPI](https://docs.elastic.dev/kibana-dev-docs/key-concepts/security-api-authorization)\n\n### **Before migration:**\n```ts\nrouter.get({\n  path: '/api/path',\n  ...\n}, handler);\n```\n\n### **After migration:**\n```ts\nrouter.get({\n  path: '/api/path',\n  security: {\n    authz: {\n      enabled: false,\n      reason: 'This route is opted out from authorization because ...',\n    },\n  },\n  ...\n}, handler);\n```","sha":"a7cc00c4fe16d15584bd032bea729453d3b5fcac","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["enhancement","release_note:skip","Feature:Security/Authorization","backport missing","Team:SharedUX","backport:prev-minor","backport:version","Authz: API migration","v9.1.0","v8.19.0"],"title":"Unauthorized route migration for routes owned by appex-sharedux","number":214779,"url":"https://github.com/elastic/kibana/pull/214779","mergeCommit":{"message":"Unauthorized route migration for routes owned by appex-sharedux (#214779)\n\n### Authz API migration for unauthorized routes\n\nThis PR migrates last unauthorized routes owned by your team to a new\nsecurity configuration.\nPlease refer to the documentation for more information: [Authorization\nAPI](https://docs.elastic.dev/kibana-dev-docs/key-concepts/security-api-authorization)\n\n### **Before migration:**\n```ts\nrouter.get({\n  path: '/api/path',\n  ...\n}, handler);\n```\n\n### **After migration:**\n```ts\nrouter.get({\n  path: '/api/path',\n  security: {\n    authz: {\n      enabled: false,\n      reason: 'This route is opted out from authorization because ...',\n    },\n  },\n  ...\n}, handler);\n```","sha":"a7cc00c4fe16d15584bd032bea729453d3b5fcac"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214779","number":214779,"mergeCommit":{"message":"Unauthorized route migration for routes owned by appex-sharedux (#214779)\n\n### Authz API migration for unauthorized routes\n\nThis PR migrates last unauthorized routes owned by your team to a new\nsecurity configuration.\nPlease refer to the documentation for more information: [Authorization\nAPI](https://docs.elastic.dev/kibana-dev-docs/key-concepts/security-api-authorization)\n\n### **Before migration:**\n```ts\nrouter.get({\n  path: '/api/path',\n  ...\n}, handler);\n```\n\n### **After migration:**\n```ts\nrouter.get({\n  path: '/api/path',\n  security: {\n    authz: {\n      enabled: false,\n      reason: 'This route is opted out from authorization because ...',\n    },\n  },\n  ...\n}, handler);\n```","sha":"a7cc00c4fe16d15584bd032bea729453d3b5fcac"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->