### PR TITLE
[8.15] Fix plugin list for 8.x (asciidoc-based) docs (#215671)

### DIFF
--- a/docs/developer/plugin-list.asciidoc
+++ b/docs/developer/plugin-list.asciidoc
@@ -74,7 +74,7 @@ as uiSettings within the code.
 
 
 |{kib-repo}blob/{branch}/src/plugins/data_view_management[dataViewManagement]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/data_views/README.mdx[dataViews]
@@ -103,7 +103,7 @@ This API doesn't support angular, for registering angular dev tools, bootstrap a
 
 
 |{kib-repo}blob/{branch}/src/plugins/esql_datagrid/README.md[esqlDataGrid]
-|Contains a Discover-like table specifically for ES|QL queries:
+|Contains a Discover-like table specifically for ES\|QL queries:
 
 
 |{kib-repo}blob/{branch}/src/plugins/es_ui_shared/README.md[esUiShared]
@@ -123,11 +123,11 @@ This API doesn't support angular, for registering angular dev tools, bootstrap a
 
 
 |{kib-repo}blob/{branch}/src/plugins/chart_expressions/expression_gauge[expressionGauge]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/chart_expressions/expression_heatmap[expressionHeatmap]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/expression_image/README.md[expressionImage]
@@ -388,11 +388,11 @@ The plugin exposes the static DefaultEditorController class to consume.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/gauge[visTypeGauge]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/heatmap[visTypeHeatmap]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_type_markdown/README.md[visTypeMarkdown]
@@ -400,11 +400,11 @@ The plugin exposes the static DefaultEditorController class to consume.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/metric[visTypeMetric]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/pie[visTypePie]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/table/README.md[visTypeTable]
@@ -412,7 +412,7 @@ The plugin exposes the static DefaultEditorController class to consume.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/tagcloud[visTypeTagcloud]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/timelion/README.md[visTypeTimelion]
@@ -420,23 +420,23 @@ The plugin exposes the static DefaultEditorController class to consume.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/timeseries[visTypeTimeseries]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/vega[visTypeVega]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/vislib[visTypeVislib]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/vis_types/xy[visTypeXy]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/src/plugins/visualizations[visualizations]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |===
@@ -467,11 +467,11 @@ The plugin exposes the static DefaultEditorController class to consume.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/observability_solution/apm_data_access[apmDataAccess]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/observability_solution/assets_data_access[assetsDataAccess]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/banners/README.md[banners]
@@ -591,7 +591,7 @@ activities.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/file_upload[fileUpload]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/fleet/README.md[fleet]
@@ -643,7 +643,7 @@ the infrastructure monitoring use-case within Kibana.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/observability_solution/investigate/README.md[investigate]
-|undefined
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/kubernetes_security/README.md[kubernetesSecurity]
@@ -684,7 +684,7 @@ using the CURL scripts in the scripts folder.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/logstash[logstash]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/maps/README.md[maps]
@@ -753,7 +753,7 @@ Elastic.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/observability_solution/profiling_data_access[profilingDataAccess]
-|WARNING: Missing README.
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/remote_clusters/README.md[remoteClusters]
@@ -831,7 +831,7 @@ It leverages universal configuration and other APIs in the serverless plugin to 
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/serverless/README.mdx[serverless]
-|
+|WARNING: Missing or empty README.
 
 
 |{kib-repo}blob/{branch}/x-pack/plugins/serverless_observability/README.mdx[serverlessObservability]

--- a/packages/kbn-dev-utils/src/plugin_list/generate_plugin_list.ts
+++ b/packages/kbn-dev-utils/src/plugin_list/generate_plugin_list.ts
@@ -15,6 +15,10 @@ import { Plugins } from './discover_plugins';
 
 const sortPlugins = (plugins: Plugins) => plugins.sort((a, b) => a.id.localeCompare(b.id));
 
+function markdownEscape(snippet: string): string {
+  return snippet.replaceAll('|', '\\|');
+}
+
 function* printPlugins(plugins: Plugins, includes: string[]) {
   for (const plugin of sortPlugins(plugins)) {
     const path = normalizePath(plugin.relativeReadmePath || plugin.relativeDir);
@@ -28,9 +32,9 @@ function* printPlugins(plugins: Plugins, includes: string[]) {
       yield `|{kib-repo}blob/{branch}/${path}[${plugin.id}]`;
     }
 
-    yield plugin.relativeReadmePath === undefined
-      ? '|WARNING: Missing README.'
-      : `|${plugin.readmeSnippet}`;
+    yield plugin.relativeReadmePath && plugin.readmeSnippet
+      ? `|${markdownEscape(plugin.readmeSnippet)}`
+      : '|WARNING: Missing or empty README.';
 
     yield '';
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.15`:
 - [Fix plugin list for 8.x (asciidoc-based) docs (#215671)](https://github.com/elastic/kibana/pull/215671)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gerard Soldevila","email":"gerard.soldevila@elastic.co"},"sourceCommit":{"committedDate":"2025-03-24T13:33:38Z","message":"Fix plugin list for 8.x (asciidoc-based) docs (#215671)\n\n## Summary\n\nApply the same fixes as https://github.com/elastic/kibana/pull/215648,\nbut for 8.x series.","sha":"35f17542d096452067bf792d99ed60fc0c981759","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","backport:all-open"],"title":"Fix plugin list for 8.x (asciidoc-based) docs","number":215671,"url":"https://github.com/elastic/kibana/pull/215671","mergeCommit":{"message":"Fix plugin list for 8.x (asciidoc-based) docs (#215671)\n\n## Summary\n\nApply the same fixes as https://github.com/elastic/kibana/pull/215648,\nbut for 8.x series.","sha":"35f17542d096452067bf792d99ed60fc0c981759"}},"sourceBranch":"8.x","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->