### PR TITLE
Prevent layout shifts after UnifiedSearch loads async

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/search_bar/index.tsx
+++ b/src/platform/plugins/shared/unified_search/public/search_bar/index.tsx
@@ -8,19 +8,39 @@
  */
 
 import React from 'react';
+import { useEuiTheme } from '@elastic/eui';
 import type { AggregateQuery, Query } from '@kbn/es-query';
 import type { SearchBarProps } from './search_bar';
 
-const Fallback = () => <div />;
+type FallbackProps = Pick<SearchBarProps<AggregateQuery>, 'displayStyle'>;
+
+const Fallback = ({ displayStyle }: FallbackProps) => {
+  const { euiTheme } = useEuiTheme();
+  return (
+    <div
+      css={{
+        minHeight: `calc(${euiTheme.size.xxl} + ${euiTheme.size.s} * 2)`, // in px
+        marginBottom:
+          displayStyle && ['detached', 'withBorders'].includes(displayStyle)
+            ? euiTheme.border.width.thin // in px
+            : '0px',
+      }}
+    />
+  );
+};
 
 const LazySearchBar = React.lazy(() => import('./search_bar'));
 const WrappedSearchBar = <QT extends AggregateQuery | Query = Query>(
   props: Omit<SearchBarProps<QT>, 'intl' | 'kibana'>
-) => (
-  <React.Suspense fallback={<Fallback />}>
-    <LazySearchBar {...(props as SearchBarProps<AggregateQuery>)} />
-  </React.Suspense>
-);
+) => {
+  const typeCastedProps = props as SearchBarProps<AggregateQuery>;
+  const { displayStyle } = typeCastedProps;
+  return (
+    <React.Suspense fallback={<Fallback {...{ displayStyle }} />}>
+      <LazySearchBar {...typeCastedProps} />
+    </React.Suspense>
+  );
+};
 
 export const SearchBar = WrappedSearchBar;
 export type { StatefulSearchBarProps } from './create_search_bar';


### PR DESCRIPTION
## Summary

Part of the solution for:
- https://github.com/elastic/security-team/issues/12209.

Adjusts UnifiedSearch's Fallback (used by React Suspense while module is loading) height to be equal to the final UI rendered to prevent layout shifts when a page opens and renders it.

### Motivation

The `UnifiedSearch` module is used across all Kibana. It renders a `<Fallback>` component with React Suspense while the whole module is loading async. Once loaded, React swaps `<Fallback>` with the loaded UI. The problem is their sizes are different, and thus, it gives the impression of a jumpy UI with perceived low performance.

The consequence of layout shifts is browsers need to perform a new rendering cycle, affecting performance negatively:
1. **Layout**. This means they need to calculate again the exact position and size of every visible element, an expensive operation also known as "reflow".
2. **Paint**. Once the layout is ready, browsers need to fill those pixels with colors, borders, text, shadow, etc...
3. **Composite (Layering and rendering)**. Finally, browsers put everything together in different layers and render them on screen.

## Screenshots

### Asset Inventory before the fix

| State | Screenshot |
|--------|--------|
| Fallback | <img width="690" alt="Screenshot 2025-03-24 at 16 03 51" src="https://github.com/user-attachments/assets/ce8e9bc3-723b-4678-9079-5e605c2fe89f" /> |
| Loaded | <img width="690" alt="Screenshot 2025-03-24 at 14 10 44" src="https://github.com/user-attachments/assets/6de30b38-91e7-4e0a-b2b4-db4477972842" /> | 

### Asset Inventory after the fix

| State | Screenshot |
|--------|--------|
| Fallback | <img width="690" alt="Screenshot 2025-03-24 at 14 10 22" src="https://github.com/user-attachments/assets/d2868766-3ca8-401b-9b79-63b2acde7c4a" /> |
| Loaded | <img width="690" alt="Screenshot 2025-03-24 at 14 10 44" src="https://github.com/user-attachments/assets/6de30b38-91e7-4e0a-b2b4-db4477972842" /> | 

### Discover after the fix

> [!NOTE]
> This only addresses the case with regular queries. If running the ES|QL mode, there's still a layout shift caused by the Monaco editor rendered async within the UnifiedSearch boundaries. This is beyond the scope of this PR

| State | Screenshot |
|--------|--------|
| Fallback | <img width="690" alt="Screenshot 2025-03-25 at 11 55 29" src="https://github.com/user-attachments/assets/e91fbb27-256e-40f8-ba20-8c4952ca8bc2" /> |
| Loaded | <img width="690" alt="Screenshot 2025-03-25 at 11 55 41" src="https://github.com/user-attachments/assets/48453d4f-e108-42a4-ae28-9495f6b754dd" /> | 

### Alerts and Findings after the fix

> [!NOTE]
> Alerts and Findings need a separate fix to render UnifiedSearch with the page template's first render, not after

As of now, both pages render first a blank page template while they wait for their data-view to load. This happens before rendering the UnifiedSearch fallback, which means there will still be a layout shift when they open. A separate fix is needed to prevent layout shifts there. However, if this is addressed, swapping Fallback with the Loaded counterpart happens in-place as the images below:

| State | Screenshot |
|--------|--------|
| Fallback | <img width="690" alt="Screenshot 2025-03-25 at 12 06 33" src="https://github.com/user-attachments/assets/ec3f6709-cc67-4828-8c9e-ee140b618bb4" /> |
| Loaded |  <img width="690" alt="Screenshot 2025-03-25 at 12 06 20" src="https://github.com/user-attachments/assets/6894e9cf-6a26-41a4-a0c1-293c7f4872a6" /> | 

| State | Screenshot |
|--------|--------|
| Fallback | <img width="690" alt="Screenshot 2025-03-25 at 12 07 22" src="https://github.com/user-attachments/assets/f79ea420-573f-4d46-a5d9-afcc2b6ea9bb" /> |
| Loaded | <img width="690" alt="Screenshot 2025-03-25 at 12 07 09" src="https://github.com/user-attachments/assets/d67f2368-1919-4ee9-a938-fc2ecd2d215e" /> | 

### Edge-case: Multiple filters visible

> [!NOTE]
> Layout shifts will still happen with the filter bar visible and multiple filters applied

When the `showFilterBar` prop is `true` in UnifiedSearch and the number of applied filters is high enough to be broken into multiple lines, it's impossible to calculate the height of the component without waiting for it to be loaded, rendered and then measure the DOM node's height. This means layout shifts will still happen and it's totally out of the scope of this PR.

## More details

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Suspensed `<Fallback>` component now depends on the `query` prop, which might cause some re-renderings in case its value changes. However, performance impact should be minimal.

<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->