### PR TITLE
[SecuritySolution] Update API key permissions on refreshing data view API

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -168,6 +168,7 @@ const createSecuritySolutionRequestContextMock = (
     getAssetCriticalityDataClient: jest.fn(() => clients.assetCriticalityDataClient),
     getAuditLogger: jest.fn(() => mockAuditLogger),
     getDataViewsService: jest.fn(),
+    getApiKeyManager: jest.fn(),
     getEntityStoreDataClient: jest.fn(() => clients.entityStoreDataClient),
     getSiemRuleMigrationsClient: jest.fn(() => clients.siemRuleMigrationsClient),
     getInferenceClient: jest.fn(() => clients.getInferenceClient()),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -168,7 +168,7 @@ const createSecuritySolutionRequestContextMock = (
     getAssetCriticalityDataClient: jest.fn(() => clients.assetCriticalityDataClient),
     getAuditLogger: jest.fn(() => mockAuditLogger),
     getDataViewsService: jest.fn(),
-    getApiKeyManager: jest.fn(),
+    getEntityStoreApiKeyManager: jest.fn(),
     getEntityStoreDataClient: jest.fn(() => clients.entityStoreDataClient),
     getSiemRuleMigrationsClient: jest.fn(() => clients.siemRuleMigrationsClient),
     getInferenceClient: jest.fn(() => clients.getInferenceClient()),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
@@ -58,7 +58,7 @@ export const applyDataViewIndicesEntityEngineRoute = (
             });
           }
 
-          const apiKeyManager = secSol.getApiKeyManager();
+          const apiKeyManager = secSol.getEntityStoreApiKeyManager();
           await apiKeyManager.generate();
 
           if (errors.length === 0) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
@@ -58,6 +58,9 @@ export const applyDataViewIndicesEntityEngineRoute = (
             });
           }
 
+          const apiKeyManager = secSol.getApiKeyManager();
+          await apiKeyManager.generate();
+
           if (errors.length === 0) {
             return response.ok({
               body: {
@@ -75,7 +78,7 @@ export const applyDataViewIndicesEntityEngineRoute = (
             });
           }
         } catch (e) {
-          logger.error('Error in ApplyEntityEngineDataViewIndices:', e);
+          logger.error(`Error in ApplyEntityEngineDataViewIndices: ${e.message}`);
           const error = transformError(e);
           return siemResponse.error({
             statusCode: error.statusCode,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/tasks/data_view_refresh/data_view_refresh_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/tasks/data_view_refresh/data_view_refresh_task.ts
@@ -110,7 +110,13 @@ export const registerEntityStoreDataViewRefreshTask = ({
       request,
     });
 
-    await entityStoreClient.applyDataViewIndices();
+    const { errors } = await entityStoreClient.applyDataViewIndices();
+
+    if (errors.length > 0) {
+      logger.error(
+        `Errors applying data view changes to the entity store. Errors: \n${errors.join('\n\n')}`
+      );
+    }
   };
 
   taskManager.registerTaskDefinitions({

--- a/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
@@ -21,7 +21,7 @@ import { AssetInventoryDataClient } from './lib/asset_inventory/asset_inventory_
 import { createDetectionRulesClient } from './lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client';
 import type { IRuleMonitoringService } from './lib/detection_engine/rule_monitoring';
 import { AssetCriticalityDataClient } from './lib/entity_analytics/asset_criticality';
-import { getApiKeyManager as buildApiKeyManager } from './lib/entity_analytics/entity_store/auth/api_key';
+import { getApiKeyManager } from './lib/entity_analytics/entity_store/auth/api_key';
 import { EntityStoreDataClient } from './lib/entity_analytics/entity_store/entity_store_data_client';
 import { RiskEngineDataClient } from './lib/entity_analytics/risk_engine/risk_engine_data_client';
 import { RiskScoreDataClient } from './lib/entity_analytics/risk_score/risk_score_data_client';
@@ -110,7 +110,7 @@ export class RequestContextFactory implements IRequestContextFactory {
     const getAuditLogger = () => security?.audit.asScoped(request);
 
     const getEntityStoreApiKeyManager = () =>
-      buildApiKeyManager({
+      getApiKeyManager({
         core: coreStart,
         logger: options.logger,
         security: startPlugins.security,

--- a/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
@@ -109,7 +109,7 @@ export class RequestContextFactory implements IRequestContextFactory {
 
     const getAuditLogger = () => security?.audit.asScoped(request);
 
-    const getApiKeyManager = () =>
+    const getEntityStoreApiKeyManager = () =>
       buildApiKeyManager({
         core: coreStart,
         logger: options.logger,
@@ -155,7 +155,7 @@ export class RequestContextFactory implements IRequestContextFactory {
 
       getDataViewsService: () => dataViewsService,
 
-      getApiKeyManager,
+      getEntityStoreApiKeyManager,
 
       getDetectionRulesClient: memoize(() => {
         const mlAuthz = buildMlAuthz({
@@ -270,7 +270,7 @@ export class RequestContextFactory implements IRequestContextFactory {
           config: config.entityAnalytics.entityStore,
           experimentalFeatures: config.experimentalFeatures,
           telemetry: core.analytics,
-          apiKeyManager: getApiKeyManager(),
+          apiKeyManager: getEntityStoreApiKeyManager(),
           security: startPlugins.security,
           request,
         });

--- a/x-pack/solutions/security/plugins/security_solution/server/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/types.ts
@@ -57,7 +57,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getRacClient: (req: KibanaRequest) => Promise<AlertsClient>;
   getAuditLogger: () => AuditLogger | undefined;
   getDataViewsService: () => DataViewsService;
-  getApiKeyManager: () => ApiKeyManager;
+  getEntityStoreApiKeyManager: () => ApiKeyManager;
   getExceptionListClient: () => ExceptionListClient | null;
   getInternalFleetServices: () => EndpointInternalFleetServicesInterface;
   getRiskEngineDataClient: () => RiskEngineDataClient;

--- a/x-pack/solutions/security/plugins/security_solution/server/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/types.ts
@@ -39,6 +39,7 @@ import type { IDetectionRulesClient } from './lib/detection_engine/rule_manageme
 import type { EntityStoreDataClient } from './lib/entity_analytics/entity_store/entity_store_data_client';
 import type { SiemRuleMigrationsClient } from './lib/siem_migrations/rules/siem_rule_migrations_service';
 import type { AssetInventoryDataClient } from './lib/asset_inventory/asset_inventory_data_client';
+import type { ApiKeyManager } from './lib/entity_analytics/entity_store/auth/api_key';
 export { AppClient };
 
 export interface SecuritySolutionApiRequestHandlerContext {
@@ -56,6 +57,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getRacClient: (req: KibanaRequest) => Promise<AlertsClient>;
   getAuditLogger: () => AuditLogger | undefined;
   getDataViewsService: () => DataViewsService;
+  getApiKeyManager: () => ApiKeyManager;
   getExceptionListClient: () => ExceptionListClient | null;
   getInternalFleetServices: () => EndpointInternalFleetServicesInterface;
   getRiskEngineDataClient: () => RiskEngineDataClient;


### PR DESCRIPTION
Update the API key when entity store `apply_dataview_indices` is called.

## Summary
This change allows the user to update the privileges the entity store data view refresh task uses. This will enable them to fix problems when the user that enabled the entity store doesn't have all data view indices privileges. 

This PR also improves some error messages that were hard to read.

### Context
* `apply_dataview_indices`is an API that updates the entity store transform with the indices defined in the security solution data view.  
* There is a background task that calls `apply_dataview_indices` from time to time
* The background task uses the API key to access the security solution data view indices.


### How to test it
* Create a kibana instance with security data
* Create a user that only has access the necessary access to the entity store indices
* Enable the entity store with a the created user
* Login with a superuser 
* Add a new index to the security solution data view, which the created user cannot access.
* The task will fail because it uses the API key from the unprivileged user.
* Call `apply_dataview_indices` with the superuser (`POST kbn:api/entity_store/engines/apply_dataview_indices`)
* The request should succeed because it is using the superuser credentials
* Add a new index to the security solution data view, which the created user cannot access.
* The task should succeed because it is using the superuser API key

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->