### PR TITLE
[FIPS] Update fips test overrides

### DIFF
--- a/src/platform/packages/shared/kbn-test/src/functional_tests/lib/fips_overrides.ts
+++ b/src/platform/packages/shared/kbn-test/src/functional_tests/lib/fips_overrides.ts
@@ -9,7 +9,9 @@
 
 // This will only apply overrides when running in FIPS mode
 export function applyFipsOverrides(vars: any) {
+  vars.esTestCluster = { ...(vars.esTestCluster ?? {}) };
   vars.esTestCluster.license = 'trial';
+  vars.esTestCluster.serverArgs = vars.esTestCluster.serverArgs ?? [];
 
   const skipTags = vars.suiteTags?.exclude ?? [];
   skipTags.push('skipFIPS');


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/215743

## Summary

Allow for undefined serverArgs when FIPS test configs are overridden. 




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->