### PR TITLE
[ES|QL] Cleanups metrics commands

### DIFF
--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.test.ts
@@ -67,11 +67,11 @@ describe('esql query helpers', () => {
       const idxPattern14 = getIndexPatternFromESQLQuery('METRICS tsdb');
       expect(idxPattern14).toBe('tsdb');
 
-      const idxPattern15 = getIndexPatternFromESQLQuery('METRICS tsdb max(cpu) BY host');
+      const idxPattern15 = getIndexPatternFromESQLQuery('METRICS tsdb | STATS max(cpu) BY host');
       expect(idxPattern15).toBe('tsdb');
 
       const idxPattern16 = getIndexPatternFromESQLQuery(
-        'METRICS pods load=avg(cpu), writes=max(rate(indexing_requests)) BY pod | SORT pod'
+        'METRICS pods | STATS load=avg(cpu), writes=max(rate(indexing_requests)) BY pod | SORT pod'
       );
       expect(idxPattern16).toBe('pods');
 

--- a/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-utils/src/utils/query_parsing_helpers.ts
@@ -38,16 +38,7 @@ export function hasTransformationalCommand(esql?: string) {
   const hasAtLeastOneTransformationalCommand = transformationalCommands.some((command) =>
     ast.find(({ name }) => name === command)
   );
-  if (hasAtLeastOneTransformationalCommand) {
-    return true;
-  }
-  const metricsCommand = ast.find(({ name }) => name === 'metrics');
-
-  if (metricsCommand && 'aggregates' in metricsCommand) {
-    return true;
-  }
-
-  return false;
+  return hasAtLeastOneTransformationalCommand;
 }
 
 export function getLimitFromESQLQuery(esql: string): number {


### PR DESCRIPTION
## Summary

Cleanups the metrics functionality as now it follows the same syntax with FROM

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->