### PR TITLE
[Discover Tabs] Fix an edge case when calculating tab widths

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/src/utils/calculate_responsive_tabs.test.ts
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/utils/calculate_responsive_tabs.test.ts
@@ -11,7 +11,10 @@ import { calculateResponsiveTabs, PLUS_BUTTON_SPACE } from './calculate_responsi
 import { getNewTabPropsForIndex } from '../hooks/use_new_tab_props';
 import { MAX_TAB_WIDTH, MIN_TAB_WIDTH } from '../constants';
 
-const items = Array.from({ length: 5 }).map((_, i) => getNewTabPropsForIndex(i));
+function generateItems(count: number) {
+  return Array.from({ length: count }).map((_, i) => getNewTabPropsForIndex(i));
+}
+const items = generateItems(5);
 
 describe('calculateResponsiveTabs', () => {
   it('renders a single tab without limitation', () => {
@@ -71,7 +74,7 @@ describe('calculateResponsiveTabs', () => {
     const numberOfItems = 7;
     const containerWidth = 1310;
     const tabsSizeConfig = calculateResponsiveTabs({
-      items: Array.from({ length: numberOfItems }).map((_, i) => getNewTabPropsForIndex(i)),
+      items: generateItems(numberOfItems),
       containerWidth,
     });
 

--- a/src/platform/packages/shared/kbn-unified-tabs/src/utils/calculate_responsive_tabs.test.ts
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/utils/calculate_responsive_tabs.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { calculateResponsiveTabs } from './calculate_responsive_tabs';
+import { calculateResponsiveTabs, PLUS_BUTTON_SPACE } from './calculate_responsive_tabs';
 import { getNewTabPropsForIndex } from '../hooks/use_new_tab_props';
 import { MAX_TAB_WIDTH, MIN_TAB_WIDTH } from '../constants';
 
@@ -63,6 +63,21 @@ describe('calculateResponsiveTabs', () => {
     expect(tabsSizeConfig).toEqual({
       isScrollable: false,
       regularTabMaxWidth: MAX_TAB_WIDTH,
+      regularTabMinWidth: MIN_TAB_WIDTH,
+    });
+  });
+
+  it('returns reasonable sizes when the available space is enough to fit all tabs with float-precision width', () => {
+    const numberOfItems = 7;
+    const containerWidth = 1310;
+    const tabsSizeConfig = calculateResponsiveTabs({
+      items: Array.from({ length: numberOfItems }).map((_, i) => getNewTabPropsForIndex(i)),
+      containerWidth,
+    });
+
+    expect(tabsSizeConfig).toEqual({
+      isScrollable: false, // the test checks that all tabs are fitting the container and no scroll is needed
+      regularTabMaxWidth: (containerWidth - PLUS_BUTTON_SPACE) / numberOfItems,
       regularTabMinWidth: MIN_TAB_WIDTH,
     });
   });

--- a/src/platform/packages/shared/kbn-unified-tabs/src/utils/calculate_responsive_tabs.ts
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/utils/calculate_responsive_tabs.ts
@@ -10,7 +10,7 @@
 import type { TabItem, TabsSizeConfig } from '../types';
 import { MAX_TAB_WIDTH, MIN_TAB_WIDTH } from '../constants';
 
-const PLUS_BUTTON_SPACE = 24 + 8; // button width + gap
+export const PLUS_BUTTON_SPACE = 24 + 8; // button width + gap
 
 interface GetTabsSizeConfigProps {
   items: TabItem[];
@@ -26,16 +26,22 @@ export const calculateResponsiveTabs = ({
   const availableContainerWidth =
     (containerWidth || window.innerWidth) - (hasReachedMaxItemsCount ? 0 : PLUS_BUTTON_SPACE);
 
-  let calculatedTabWidth =
-    items.length > 0 ? availableContainerWidth / items.length : MAX_TAB_WIDTH;
+  let wasSpaceEquallyDivided = items.length > 0;
+  let calculatedTabWidth = wasSpaceEquallyDivided
+    ? availableContainerWidth / items.length
+    : MAX_TAB_WIDTH;
 
   if (calculatedTabWidth > MAX_TAB_WIDTH) {
     calculatedTabWidth = MAX_TAB_WIDTH;
+    wasSpaceEquallyDivided = false;
   } else if (calculatedTabWidth < MIN_TAB_WIDTH) {
     calculatedTabWidth = MIN_TAB_WIDTH;
+    wasSpaceEquallyDivided = false;
   }
 
-  const numberOfVisibleItems = Math.floor(availableContainerWidth / calculatedTabWidth);
+  const numberOfVisibleItems = wasSpaceEquallyDivided
+    ? items.length
+    : Math.floor(availableContainerWidth / calculatedTabWidth);
 
   return {
     isScrollable: items.length > numberOfVisibleItems,


### PR DESCRIPTION
- Follow up for https://github.com/elastic/kibana/pull/213739

## Summary

This PR fixes an edge case in calculating whether to show the scroll buttons for the tabs or not. It was because of not handling float values correctly.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



