### PR TITLE
chore(NA): removing specific default version qualifiers from 9.0

### DIFF
--- a/.buildkite/scripts/steps/artifacts/env.sh
+++ b/.buildkite/scripts/steps/artifacts/env.sh
@@ -3,11 +3,7 @@
 set -euo pipefail
 
 RELEASE_BUILD="${RELEASE_BUILD:="false"}"
-if [[ "$RELEASE_BUILD" == "true" ]]; then
-  VERSION_QUALIFIER="${VERSION_QUALIFIER:="rc1"}"
-else
-  VERSION_QUALIFIER="${VERSION_QUALIFIER:=""}"
-fi
+VERSION_QUALIFIER="${VERSION_QUALIFIER:=""}"
 
 BASE_VERSION="$(jq -r '.version' package.json)"
 


### PR DESCRIPTION
This removes the previous default version qualifier from 9.0 as we move close to GA