### PR TITLE
[Security] Make tour step go under header

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/tours/setup_guide/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/siem_migrations/rules/components/tours/setup_guide/index.tsx
@@ -61,6 +61,7 @@ export const SiemMigrationSetupTour: React.FC<SetupTourProps> = React.memo(({ ch
       content={i18n.SETUP_SIEM_MIGRATION_TOUR_CONTENT}
       isStepOpen={showTour}
       maxWidth={tourState.tourPopoverWidth}
+      zIndex={1}
       onFinish={onTourFinished}
       step={1}
       stepsTotal={1}


### PR DESCRIPTION
## Summary

The tour step on the getting start page goes over the global nav bar on scroll. This PR makes it go below similar to the rest of the page content.

**Before**
![CleanShot 2025-03-24 at 14 56 14@2x](https://github.com/user-attachments/assets/e40be0ec-93c3-4d51-bf06-c9c42d5ff131)


**After**
![CleanShot 2025-03-24 at 14 55 31@2x](https://github.com/user-attachments/assets/8d1fb11e-9712-46bf-a895-2e7927896e9e)


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

N/A


