### PR TITLE
[Response Ops] Alert Deletion - Preview Endpoint

### DIFF
--- a/src/platform/packages/shared/kbn-alerting-types/alert_deletion_types.ts
+++ b/src/platform/packages/shared/kbn-alerting-types/alert_deletion_types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export interface AlertDeletionPreview {
+  affectedAlertCount: number;
+}

--- a/src/platform/packages/shared/kbn-alerting-types/index.ts
+++ b/src/platform/packages/shared/kbn-alerting-types/index.ts
@@ -20,3 +20,4 @@ export * from './rule_type_types';
 export * from './rule_types';
 export * from './rule_settings';
 export * from './search_strategy_types';
+export * from './alert_deletion_types';

--- a/src/platform/packages/shared/kbn-alerting-types/rule_settings.ts
+++ b/src/platform/packages/shared/kbn-alerting-types/rule_settings.ts
@@ -35,11 +35,13 @@ export interface RulesSettingsQueryDelayProperties {
 export type RulesSettingsQueryDelay = RulesSettingsQueryDelayProperties &
   RulesSettingsModificationMetadata;
 
+// TODO: Should this still be here as a RuleSetting?
 export interface RulesSettingsAlertDeletionProperties {
   isActiveAlertsDeletionEnabled: boolean;
   isInactiveAlertsDeletionEnabled: boolean;
   activeAlertsDeletionThreshold: number;
   inactiveAlertsDeletionThreshold: number;
+  categoryIds?: string[] | null;
 }
 
 export type RulesSettingsAlertDeletion = RulesSettingsAlertDeletionProperties &

--- a/x-pack/platform/plugins/shared/alerting/common/constants/alert_deletion.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/constants/alert_deletion.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const alertDeletionCategoryIdTypes = {
+  OBSERVABILITY: 'observability',
+  SECURITY_SOLUTION: 'securitySolution',
+  MANAGEMENT: 'management',
+} as const;

--- a/x-pack/platform/plugins/shared/alerting/common/constants/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/constants/index.ts
@@ -15,3 +15,4 @@ export {
 export { PLUGIN } from './plugin';
 export { gapStatus } from './gap_status';
 export type { GapStatus } from './gap_status';
+export { alertDeletionCategoryIdTypes } from './alert_deletion';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { alertDeletionPreviewQuerySchema } from './schemas/latest';
+export { alertDeletionPreviewQuerySchema as alertDeletionPreviewQuerySchemaV1 } from './schemas/v1';
+
+export { alertDeletionPreviewResponseSchema } from './schemas/latest';
+export { alertDeletionPreviewResponseSchema as alertDeletionPreviewResponseSchemaV1 } from './schemas/v1';
+
+export type { AlertDeletionPreviewQuery } from './types/latest';
+export type { AlertDeletionPreviewQuery as AlertDeletionPreviewQueryV1 } from './types/v1';
+
+export type { AlertDeletionPreviewResponse } from './types/latest';
+export type { AlertDeletionPreviewResponse as AlertDeletionPreviewResponseV1 } from './types/v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/schemas/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/schemas/latest.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/schemas/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/schemas/v1.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { schema } from '@kbn/config-schema';
+import { alertDeletionCategoryIdTypes } from '../../../../../constants';
+
+export const alertDeletionPreviewQuerySchema = schema.object({
+  is_active_alerts_deletion_enabled: schema.boolean({
+    meta: {
+      description: 'Enable deletion of active alerts when set to true',
+    },
+  }),
+  active_alerts_deletion_threshold: schema.number({
+    min: 1,
+    max: 1000,
+    meta: {
+      description:
+        'Threshold (in days) for deleting active alerts older than this value, applies only when deletion is enabled',
+    },
+  }),
+  is_inactive_alerts_deletion_enabled: schema.boolean({
+    meta: {
+      description:
+        'Enable deletion of inactive alerts (recovered/closed/untracked) when set to true',
+    },
+  }),
+  inactive_alerts_deletion_threshold: schema.number({
+    min: 1,
+    max: 1000,
+    meta: {
+      description:
+        'Threshold (in days) for deleting inactive alerts (recovered/closed/untracked) older than this value, applies only when deletion is enabled',
+    },
+  }),
+  category_ids: schema.maybe(
+    schema.nullable(
+      schema.arrayOf(
+        schema.oneOf([
+          schema.literal(alertDeletionCategoryIdTypes.OBSERVABILITY),
+          schema.literal(alertDeletionCategoryIdTypes.SECURITY_SOLUTION),
+          schema.literal(alertDeletionCategoryIdTypes.MANAGEMENT),
+        ])
+      )
+    )
+  ),
+});
+
+export const alertDeletionPreviewResponseSchema = schema.object({
+  body: schema.object({
+    affected_alert_count: schema.number(),
+  }),
+});

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/types/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/types/latest.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/types/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/common/routes/rule/apis/alert_deletion/types/v1.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TypeOf } from '@kbn/config-schema';
+import type { alertDeletionPreviewQuerySchemaV1, alertDeletionPreviewResponseSchemaV1 } from '..';
+
+export type AlertDeletionPreviewQuery = TypeOf<typeof alertDeletionPreviewQuerySchemaV1>;
+export type AlertDeletionPreviewResponse = TypeOf<typeof alertDeletionPreviewResponseSchemaV1>;

--- a/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/apis/preview/get_alert_deletion_preview_route.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/apis/preview/get_alert_deletion_preview_route.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { IRouter } from '@kbn/core/server';
+import type { AlertDeletionPreviewResponseV1 } from '../../../../../common/routes/rule/apis/alert_deletion';
+import { alertDeletionPreviewQuerySchemaV1 } from '../../../../../common/routes/rule/apis/alert_deletion';
+import type { ILicenseState } from '../../../../lib';
+import type { AlertingRequestHandlerContext } from '../../../../types';
+import { INTERNAL_BASE_ALERTING_API_PATH } from '../../../../types';
+import { verifyAccessAndContext } from '../../../lib';
+import { API_PRIVILEGES } from '../../../../../common';
+import {
+  transformAlertDeletionPreviewToResponse,
+  transformRequestToAlertDeletionPreviewV1,
+} from '../../transforms';
+
+// TODO: Remove this when the alert deletion client is available
+class FakeAlertDeletionClient {
+  previewTask = async (settings: unknown, spaceId: string) => {
+    return 5;
+  };
+}
+
+export const alertDeletionPreviewRoute = (
+  router: IRouter<AlertingRequestHandlerContext>,
+  licenseState: ILicenseState
+) => {
+  router.get(
+    {
+      // TODO: Should it still be here if it's no setting anymore?
+      path: `${INTERNAL_BASE_ALERTING_API_PATH}/rules/settings/_alert_deletion_preview`,
+      validate: {
+        query: alertDeletionPreviewQuerySchemaV1,
+      },
+      security: {
+        authz: {
+          requiredPrivileges: [`${API_PRIVILEGES.READ_ALERT_DELETION_SETTINGS}`],
+        },
+      },
+      options: {
+        access: 'internal',
+      },
+    },
+    router.handleLegacyErrors(
+      verifyAccessAndContext(licenseState, async function (context, req, res) {
+        const alertingContext = await context.alerting;
+        // TODO: Use this when the alert deletion client is available
+        // const alertDeletionClient = alertingContext.getAlertDeletionClient();
+        const alertDeletionClient = new FakeAlertDeletionClient();
+        const rulesClient = await alertingContext.getRulesClient();
+        const spaceId = rulesClient.getSpaceId();
+        const settings = transformRequestToAlertDeletionPreviewV1(req.query);
+
+        const affectedAlertCount = await alertDeletionClient.previewTask(
+          settings,
+          spaceId || 'default'
+        );
+        const response: AlertDeletionPreviewResponseV1 = transformAlertDeletionPreviewToResponse({
+          affectedAlertCount,
+        });
+        return res.ok(response);
+      })
+    )
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { transformAlertDeletionPreviewToResponse } from './transform_preview_response/latest';
+export { transformRequestToAlertDeletionPreview } from './transform_preview_request/latest';
+
+export { transformAlertDeletionPreviewToResponse as transformAlertDeletionPreviewToResponseV1 } from './transform_preview_response/v1';
+export { transformRequestToAlertDeletionPreview as transformRequestToAlertDeletionPreviewV1 } from './transform_preview_request/v1';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/transform_preview_request/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/transform_preview_request/latest.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/transform_preview_request/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/transform_preview_request/v1.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RulesSettingsAlertDeletionProperties } from '@kbn/alerting-types';
+import type { AlertDeletionPreviewQueryV1 } from '../../../../../common/routes/rule/apis/alert_deletion';
+
+export const transformRequestToAlertDeletionPreview = ({
+  is_active_alerts_deletion_enabled: isActiveAlertsDeletionEnabled,
+  is_inactive_alerts_deletion_enabled: isInactiveAlertsDeletionEnabled,
+  active_alerts_deletion_threshold: activeAlertsDeletionThreshold,
+  inactive_alerts_deletion_threshold: inactiveAlertsDeletionThreshold,
+  category_ids: categoryIds,
+}: AlertDeletionPreviewQueryV1): RulesSettingsAlertDeletionProperties => {
+  return {
+    isActiveAlertsDeletionEnabled,
+    isInactiveAlertsDeletionEnabled,
+    activeAlertsDeletionThreshold,
+    inactiveAlertsDeletionThreshold,
+    categoryIds,
+  };
+};

--- a/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/transform_preview_response/latest.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/transform_preview_response/latest.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/transform_preview_response/v1.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/alert_deletion/transforms/transform_preview_response/v1.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { AlertDeletionPreview } from '@kbn/alerting-types';
+import type { AlertDeletionPreviewResponseV1 } from '../../../../../common/routes/rule/apis/alert_deletion';
+
+export const transformAlertDeletionPreviewToResponse = ({
+  affectedAlertCount,
+}: AlertDeletionPreview): AlertDeletionPreviewResponseV1 => {
+  return {
+    body: {
+      affected_alert_count: affectedAlertCount,
+    },
+  };
+};

--- a/x-pack/platform/plugins/shared/alerting/server/routes/index.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/routes/index.ts
@@ -68,6 +68,8 @@ import { registerAlertsValueSuggestionsRoute } from './suggestions/values_sugges
 import { getQueryDelaySettingsRoute } from './rules_settings/apis/get/get_query_delay_settings';
 import { updateQueryDelaySettingsRoute } from './rules_settings/apis/update/update_query_delay_settings';
 
+import { alertDeletionPreviewRoute } from './alert_deletion/apis/preview/get_alert_deletion_preview_route';
+
 // backfill API
 import { scheduleBackfillRoute } from './backfill/apis/schedule/schedule_backfill_route';
 import { getBackfillRoute } from './backfill/apis/get/get_backfill_route';
@@ -137,6 +139,7 @@ export function defineRoutes(opts: RouteOptions) {
   bulkUntrackAlertsByQueryRoute(router, licenseState);
   muteAlertRoute(router, licenseState);
   unmuteAlertRoute(router, licenseState);
+  alertDeletionPreviewRoute(router, licenseState);
 
   // Maintenance Window APIs
   createMaintenanceWindowRoute(router, licenseState);

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/alert_deletion_preview.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/alert_deletion_preview.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { UserAtSpaceScenarios } from '../../../scenarios';
+import { getUrlPrefix, resetRulesSettings } from '../../../../common/lib';
+import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+
+// eslint-disable-next-line import/no-default-export
+export default function getAlertDeletionPreview({ getService }: FtrProviderContext) {
+  const supertestWithoutAuth = getService('supertestWithoutAuth');
+
+  describe('alertDeletionPreview', () => {
+    beforeEach(async () => {
+      await resetRulesSettings(supertestWithoutAuth, 'space1');
+      await resetRulesSettings(supertestWithoutAuth, 'space2');
+    });
+
+    after(async () => {
+      await resetRulesSettings(supertestWithoutAuth, 'space1');
+      await resetRulesSettings(supertestWithoutAuth, 'space2');
+    });
+
+    for (const scenario of UserAtSpaceScenarios) {
+      const { user, space } = scenario;
+      describe(scenario.id, () => {
+        it('should handle get alert deletion preview request appropriately', async () => {
+          const url = `/internal/alerting/rules/settings/_alert_deletion_preview?is_active_alerts_deletion_enabled=true&active_alerts_deletion_threshold=90&is_inactive_alerts_deletion_enabled=true&inactive_alerts_deletion_threshold=90`;
+
+          const response = await supertestWithoutAuth
+            .get(`${getUrlPrefix(space.id)}${url}`)
+            .auth(user.username, user.password)
+            .send();
+
+          switch (scenario.id) {
+            case 'no_kibana_privileges at space1':
+            case 'space_1_all at space2':
+            case 'space_1_all_with_restricted_fixture at space1':
+            case 'space_1_all_alerts_none_actions at space1':
+              expect(response.statusCode).to.eql(403);
+              expect(response.body).to.eql({
+                error: 'Forbidden',
+                message: `API [GET ${url}] is unauthorized for user, this action is granted by the Kibana privileges [read-alert-deletion-settings]`,
+                statusCode: 403,
+              });
+              break;
+            case 'global_read at space1':
+            case 'superuser at space1':
+            case 'space_1_all at space1':
+              expect(response.statusCode).to.eql(200);
+              // TODO: 5 is the value returned by the fake alert deletion client.
+              // Needs to be updated once we use the right client. Probably just 0
+              expect(response.body.affected_alert_count).to.eql(5);
+              break;
+            default:
+              throw new Error(`Scenario untested: ${JSON.stringify(scenario)}`);
+          }
+        });
+      });
+    }
+  });
+}

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/index.ts
@@ -36,6 +36,7 @@ export default function alertingTests({ loadTestFile, getService }: FtrProviderC
       loadTestFile(require.resolve('./resolve'));
       loadTestFile(require.resolve('./get_alert_deletion_settings'));
       loadTestFile(require.resolve('./update_alert_deletion_settings'));
+      loadTestFile(require.resolve('./alert_deletion_preview'));
     });
   });
 }


### PR DESCRIPTION
## Summary

#[209266](https://github.com/elastic/kibana/issues/209266) Creates an internal endpoint to get the preview of the number of alerts that would be deleted with the current alert deletion settings. UI part will be done in another PR.

> [!WARNING]
> This will be merged into a feature branch.
