### PR TITLE
Fix cleanup in dataset quality field limit test suite

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/update_field_limit.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/dataset_quality/update_field_limit.ts
@@ -94,6 +94,9 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         roleAuthc: adminRoleAuthc,
         pkg,
       });
+      await esClient.cluster.deleteComponentTemplate({
+        name: `${type}-${integrationsDataset}@custom`,
+      });
       await samlAuth.invalidateM2mApiKeyWithRoleScope(adminRoleAuthc);
     });
 


### PR DESCRIPTION
## Summary

This PR fixes the incomplete cleanup of the dataset quality field limit test suite which caused the suite to fail on retry.

### Details

When this test suite ran a second time against the same project, it failed with
```
Error: expected '50' to equal '1000'
```
It turned out that the component template that was created as part of this test suite was not cleaned up. So it already existed when running the suite a second time which changed the behavior and caused the test failure.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->