### PR TITLE
[9.0] [Fleet] Update minimun package spec version to 2.3 (#214600)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/config.ts
@@ -26,6 +26,7 @@ import { BULK_CREATE_MAX_ARTIFACTS_BYTES } from './services/artifacts/artifacts'
 const DEFAULT_BUNDLED_PACKAGE_LOCATION = path.join(__dirname, '../target/bundled_packages');
 const DEFAULT_GPG_KEY_PATH = path.join(__dirname, '../target/keys/GPG-KEY-elasticsearch');
 
+const REGISTRY_SPEC_MIN_VERSION = '2.3';
 const REGISTRY_SPEC_MAX_VERSION = '3.3';
 
 export const config: PluginConfigDescriptor = {
@@ -228,18 +229,25 @@ export const config: PluginConfigDescriptor = {
             excludePackages: schema.arrayOf(schema.string(), { defaultValue: [] }),
             spec: schema.object(
               {
-                min: schema.maybe(schema.string()),
-                max: schema.string({ defaultValue: REGISTRY_SPEC_MAX_VERSION }),
+                min: schema.string({
+                  coerceFromNumber: true,
+                  defaultValue: REGISTRY_SPEC_MIN_VERSION,
+                }),
+                max: schema.string({
+                  coerceFromNumber: true,
+                  defaultValue: REGISTRY_SPEC_MAX_VERSION,
+                }),
               },
               {
                 defaultValue: {
+                  min: REGISTRY_SPEC_MIN_VERSION,
                   max: REGISTRY_SPEC_MAX_VERSION,
                 },
               }
             ),
             capabilities: schema.arrayOf(
               schema.oneOf([
-                // See package-spec for the list of available capiblities https://github.com/elastic/package-spec/blob/dcc37b652690f8a2bca9cf8a12fc28fd015730a0/spec/integration/manifest.spec.yml#L113
+                // See package-spec for the list of available capabilities https://github.com/elastic/package-spec/blob/dcc37b652690f8a2bca9cf8a12fc28fd015730a0/spec/integration/manifest.spec.yml#L113
                 schema.literal('apm'),
                 schema.literal('enterprise_search'),
                 schema.literal('observability'),
@@ -256,6 +264,7 @@ export const config: PluginConfigDescriptor = {
               capabilities: [],
               excludePackages: [],
               spec: {
+                min: REGISTRY_SPEC_MIN_VERSION,
                 max: REGISTRY_SPEC_MAX_VERSION,
               },
             },

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/fixtures/cloud_kibana_config.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/fixtures/cloud_kibana_config.ts
@@ -11,6 +11,9 @@ export const CLOUD_KIBANA_CONFIG = {
       internal: {
         registry: {
           kibanaVersionCheckEnabled: false,
+          spec: {
+            min: '1.0',
+          },
         },
       },
       packages: [

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/fixtures/cloud_kibana_config_without_apm.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/fixtures/cloud_kibana_config_without_apm.ts
@@ -11,6 +11,9 @@ export const CLOUD_KIBANA_CONFIG_WITHOUT_APM = {
       internal: {
         registry: {
           kibanaVersionCheckEnabled: false,
+          spec: {
+            min: '1.0',
+          },
         },
       },
       packages: [

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/fixtures/cloud_kibana_config_without_policy_id.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/fixtures/cloud_kibana_config_without_policy_id.ts
@@ -11,6 +11,9 @@ export const CLOUD_KIBANA_WITHOUT_PACKAGE_POLICY_ID_CONFIG = {
       internal: {
         registry: {
           kibanaVersionCheckEnabled: false,
+          spec: {
+            min: '1.0',
+          },
         },
       },
       packages: [

--- a/x-pack/platform/plugins/shared/fleet/server/integration_tests/ha_setup.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/integration_tests/ha_setup.test.ts
@@ -178,6 +178,9 @@ describe('Fleet setup preconfiguration with multiple instances Kibana', () => {
     internal: {
       registry: {
         kibanaVersionCheckEnabled: false,
+        spec: {
+          min: '1.0',
+        },
       },
     },
     packages: [

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/registry/index.ts
@@ -276,11 +276,19 @@ function setSpecVersion(url: URL) {
   const specMax = appContextService.getConfig()?.internal?.registry?.spec?.max;
 
   if (specMin) {
-    url.searchParams.set('spec.min', specMin);
+    url.searchParams.set('spec.min', formatSpecVersion(specMin));
   }
   if (specMax) {
-    url.searchParams.set('spec.max', specMax);
+    url.searchParams.set('spec.max', formatSpecVersion(specMax));
   }
+}
+
+function formatSpecVersion(version: string): string {
+  // Version can be coerced from number when obtained through flags, in these cases X.0 versions are coerced to X.
+  if (version.indexOf('.') > 0) {
+    return version;
+  }
+  return version + '.0';
 }
 
 function setCapabilities(url: URL) {

--- a/x-pack/test/fleet_api_integration/config.base.ts
+++ b/x-pack/test/fleet_api_integration/config.base.ts
@@ -91,6 +91,7 @@ export default async function ({ readConfigFile, log }: FtrConfigProviderContext
         `--xpack.fleet.agentless.api.tls.key=./config/node.key`,
         `--xpack.fleet.agentless.api.tls.ca=./config/ca.crt`,
         `--xpack.fleet.internal.registry.kibanaVersionCheckEnabled=false`,
+        `--xpack.fleet.internal.registry.spec.min=1.0`,
         `--logging.loggers=${JSON.stringify([
           ...getKibanaCliLoggers(xPackAPITestsConfig.get('kbnTestServer.serverArgs')),
 

--- a/x-pack/test/functional/config.base.js
+++ b/x-pack/test/functional/config.base.js
@@ -48,7 +48,6 @@ export default async function ({ readConfigFile }) {
         '--server.restrictInternalApis=false',
         // disable fleet task that writes to metrics.fleet_server.* data streams, impacting functional tests
         `--xpack.task_manager.unsafe.exclude_task_types=${JSON.stringify(['Fleet-Metrics-Task'])}`,
-        `--xpack.fleet.internal.registry.kibanaVersionCheckEnabled=false`,
       ],
     },
     uiSettings: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Fleet] Update minimun package spec version to 2.3 (#214600)](https://github.com/elastic/kibana/pull/214600)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jaime Soriano Pastor","email":"jaime.soriano@elastic.co"},"sourceCommit":{"committedDate":"2025-03-25T12:04:29Z","message":"[Fleet] Update minimun package spec version to 2.3 (#214600)\n\nUpdate minimum package spec version to 2.3.\n\nThis effectively removes availability of some problematic packages with\nlower format versions in 9.x, when using the default configuration.\n\nServerless already uses a minimum spec version of 3.0.\n\nThis affects a small set of packages from the integrations repository,\nfor which there are resolution plans.","sha":"8d81ed4a5b6f540ce9847bdd0477f52d514031b3","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:prev-minor","v9.1.0"],"title":"[Fleet] Update minimun package spec version to 2.3","number":214600,"url":"https://github.com/elastic/kibana/pull/214600","mergeCommit":{"message":"[Fleet] Update minimun package spec version to 2.3 (#214600)\n\nUpdate minimum package spec version to 2.3.\n\nThis effectively removes availability of some problematic packages with\nlower format versions in 9.x, when using the default configuration.\n\nServerless already uses a minimum spec version of 3.0.\n\nThis affects a small set of packages from the integrations repository,\nfor which there are resolution plans.","sha":"8d81ed4a5b6f540ce9847bdd0477f52d514031b3"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214600","number":214600,"mergeCommit":{"message":"[Fleet] Update minimun package spec version to 2.3 (#214600)\n\nUpdate minimum package spec version to 2.3.\n\nThis effectively removes availability of some problematic packages with\nlower format versions in 9.x, when using the default configuration.\n\nServerless already uses a minimum spec version of 3.0.\n\nThis affects a small set of packages from the integrations repository,\nfor which there are resolution plans.","sha":"8d81ed4a5b6f540ce9847bdd0477f52d514031b3"}}]}] BACKPORT-->