### PR TITLE
Simplify and reduce flakiness of license.public

### DIFF
--- a/x-pack/test/licensing_plugin/public/updates.ts
+++ b/x-pack/test/licensing_plugin/public/updates.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { LicensingPluginSetup } from '@kbn/licensing-plugin/public';
-import { FtrProviderContext } from '../services';
+import type { ILicense, LicensingPluginStart } from '@kbn/licensing-plugin/public';
+import type { FtrProviderContext } from '../services';
 import { createScenario } from '../scenario';
 import '@kbn/core-provider-plugin/types';
 
@@ -24,70 +24,48 @@ export default function (ftrContext: FtrProviderContext) {
       await scenario.teardown();
     });
 
+    const fetchLatestLicense = async (): Promise<ILicense> => {
+      return await browser.executeAsync(async (cb) => {
+        const {
+          start: { core, plugins },
+          testUtils,
+        } = window._coreProvider;
+        const licensing: LicensingPluginStart = plugins.licensing;
+
+        // this call enforces signature check to detect license update and causes license re-fetch
+        await core.http.get('/');
+        // trigger a manual refresh, just to be sure
+        await licensing.refresh();
+        // wait a bit to make sure the older values have passed through the replay(1)
+        await testUtils.delay(1000);
+        cb(await licensing.getLicense());
+      });
+    };
+
     it('provides changes in license types', async () => {
       await scenario.setup();
       await scenario.waitForPluginToDetectLicenseUpdate();
 
-      expect(
-        await browser.executeAsync(async (cb) => {
-          const { setup, testUtils } = window._coreProvider;
-          // this call enforces signature check to detect license update
-          // and causes license re-fetch
-          await setup.core.http.get('/');
-          await testUtils.delay(1000);
-
-          const licensing: LicensingPluginSetup = setup.plugins.licensing;
-          licensing.license$.subscribe((license) => cb(license.type));
-        })
-      ).to.be('basic');
+      // fetch default license
+      let license = await fetchLatestLicense();
+      expect(license.type).to.be('basic');
 
       // license hasn't changed
       await scenario.waitForPluginToDetectLicenseUpdate();
+      license = await fetchLatestLicense();
+      expect(license.type).to.be('basic');
 
-      expect(
-        await browser.executeAsync(async (cb) => {
-          const { setup, testUtils } = window._coreProvider;
-          // this call enforces signature check to detect license update
-          // and causes license re-fetch
-          await setup.core.http.get('/');
-          await testUtils.delay(1000);
-
-          const licensing: LicensingPluginSetup = setup.plugins.licensing;
-          licensing.license$.subscribe((license) => cb(license.type));
-        })
-      ).to.be('basic');
-
+      // switch to trial (can do it only once)
       await scenario.startTrial();
       await scenario.waitForPluginToDetectLicenseUpdate();
+      license = await fetchLatestLicense();
+      expect(license.type).to.be('trial');
 
-      expect(
-        await browser.executeAsync(async (cb) => {
-          const { setup, testUtils } = window._coreProvider;
-          // this call enforces signature check to detect license update
-          // and causes license re-fetch
-          await setup.core.http.get('/');
-          await testUtils.delay(1000);
-
-          const licensing: LicensingPluginSetup = setup.plugins.licensing;
-          licensing.license$.subscribe((license) => cb(license.type));
-        })
-      ).to.be('trial');
-
+      // switch back to basic
       await scenario.startBasic();
       await scenario.waitForPluginToDetectLicenseUpdate();
-
-      expect(
-        await browser.executeAsync(async (cb) => {
-          const { setup, testUtils } = window._coreProvider;
-          // this call enforces signature check to detect license update
-          // and causes license re-fetch
-          await setup.core.http.get('/');
-          await testUtils.delay(1000);
-
-          const licensing: LicensingPluginSetup = setup.plugins.licensing;
-          licensing.license$.subscribe((license) => cb(license.type));
-        })
-      ).to.be('basic');
+      license = await fetchLatestLicense();
+      expect(license.type).to.be('basic');
 
       // banner shown only when license expired not just deleted
       await testSubjects.missingOrFail('licenseExpiredBanner');


### PR DESCRIPTION
## Summary

* Factorise logic to fetch latest license.
* Add an extra `manualRefresh` step, to ensure we get the latest emission.

Aims at tackling [latest failures](https://github.com/elastic/kibana/issues/53575#issuecomment-2751034614) on licensing tests.

<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->