### PR TITLE
[Cloud Security] handle grouping in multi value fields

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/index.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/index.tsx
@@ -28,7 +28,7 @@ interface GroupPanelProps<T> {
   onToggleGroup?: (isOpen: boolean, groupBucket: GroupingBucket<T>) => void;
   renderChildComponent: (groupFilter: Filter[]) => React.ReactElement;
   selectedGroup: string;
-  shouldIgnoreFieldSize?: boolean;
+  multiValueFields?: string[];
 }
 
 const DefaultGroupPanelRenderer = ({
@@ -73,7 +73,7 @@ const GroupPanelComponent = <T,>({
   renderChildComponent,
   selectedGroup,
   nullGroupMessage,
-  shouldIgnoreFieldSize,
+  multiValueFields,
 }: GroupPanelProps<T>) => {
   const lastForceState = useRef(forceState);
   useEffect(() => {
@@ -100,8 +100,8 @@ const GroupPanelComponent = <T,>({
     () =>
       isNullGroup
         ? getNullGroupFilter(selectedGroup)
-        : createGroupFilter(selectedGroup, groupFieldValue.asArray, shouldIgnoreFieldSize),
-    [groupFieldValue.asArray, isNullGroup, selectedGroup, shouldIgnoreFieldSize]
+        : createGroupFilter(selectedGroup, groupFieldValue.asArray, multiValueFields),
+    [groupFieldValue.asArray, isNullGroup, selectedGroup, multiValueFields]
   );
 
   const onToggle = useCallback(

--- a/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/index.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/accordion_panel/index.tsx
@@ -28,6 +28,7 @@ interface GroupPanelProps<T> {
   onToggleGroup?: (isOpen: boolean, groupBucket: GroupingBucket<T>) => void;
   renderChildComponent: (groupFilter: Filter[]) => React.ReactElement;
   selectedGroup: string;
+  shouldIgnoreFieldSize?: boolean;
 }
 
 const DefaultGroupPanelRenderer = ({
@@ -72,6 +73,7 @@ const GroupPanelComponent = <T,>({
   renderChildComponent,
   selectedGroup,
   nullGroupMessage,
+  shouldIgnoreFieldSize,
 }: GroupPanelProps<T>) => {
   const lastForceState = useRef(forceState);
   useEffect(() => {
@@ -98,8 +100,8 @@ const GroupPanelComponent = <T,>({
     () =>
       isNullGroup
         ? getNullGroupFilter(selectedGroup)
-        : createGroupFilter(selectedGroup, groupFieldValue.asArray),
-    [groupFieldValue.asArray, isNullGroup, selectedGroup]
+        : createGroupFilter(selectedGroup, groupFieldValue.asArray, shouldIgnoreFieldSize),
+    [groupFieldValue.asArray, isNullGroup, selectedGroup, shouldIgnoreFieldSize]
   );
 
   const onToggle = useCallback(

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
@@ -61,7 +61,7 @@ export interface GroupingProps<T> {
   // usefull in combination with shouldFlattenMultiValueField param in GroupingQueryArgs
   // because if the field is a multi-value field, and we emit each value separatly the size of the field will be ignored
   // when filtering by it
-  shouldIgnoreFieldSize?: boolean;
+  multiValueFields?: string[];
 }
 
 const GroupingComponent = <T,>({
@@ -85,7 +85,7 @@ const GroupingComponent = <T,>({
   tracker,
   unit = defaultUnit,
   groupsUnit = GROUPS_UNIT,
-  shouldIgnoreFieldSize,
+  multiValueFields,
 }: GroupingProps<T>) => {
   const { euiTheme } = useEuiTheme();
   const xsFontSize = useEuiFontSize('xs').fontSize;
@@ -143,7 +143,7 @@ const GroupingComponent = <T,>({
                       : createGroupFilter(
                           selectedGroup,
                           Array.isArray(groupBucket.key) ? groupBucket.key : [groupBucket.key],
-                          shouldIgnoreFieldSize
+                          multiValueFields
                         )
                   }
                   groupNumber={groupNumber}
@@ -179,7 +179,7 @@ const GroupingComponent = <T,>({
               }
               selectedGroup={selectedGroup}
               groupingLevel={groupingLevel}
-              shouldIgnoreFieldSize={shouldIgnoreFieldSize}
+              multiValueFields={multiValueFields}
             />
             {groupingLevel > 0 ? null : <EuiSpacer size="s" />}
           </span>
@@ -200,7 +200,7 @@ const GroupingComponent = <T,>({
       tracker,
       trigger,
       unit,
-      shouldIgnoreFieldSize,
+      multiValueFields,
     ]
   );
 

--- a/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/components/grouping.tsx
@@ -57,6 +57,11 @@ export interface GroupingProps<T> {
   ) => void;
   unit?: (n: number) => string;
   groupsUnit?: (n: number, parentSelectedGroup: string, hasNullGroup: boolean) => string;
+  // determines if the field size should be ignored when creating a filter
+  // usefull in combination with shouldFlattenMultiValueField param in GroupingQueryArgs
+  // because if the field is a multi-value field, and we emit each value separatly the size of the field will be ignored
+  // when filtering by it
+  shouldIgnoreFieldSize?: boolean;
 }
 
 const GroupingComponent = <T,>({
@@ -80,10 +85,10 @@ const GroupingComponent = <T,>({
   tracker,
   unit = defaultUnit,
   groupsUnit = GROUPS_UNIT,
+  shouldIgnoreFieldSize,
 }: GroupingProps<T>) => {
   const { euiTheme } = useEuiTheme();
   const xsFontSize = useEuiFontSize('xs').fontSize;
-
   const countCss = css`
     font-size: ${xsFontSize};
     font-weight: ${euiTheme.font.weight.semiBold};
@@ -137,7 +142,8 @@ const GroupingComponent = <T,>({
                       ? getNullGroupFilter(selectedGroup)
                       : createGroupFilter(
                           selectedGroup,
-                          Array.isArray(groupBucket.key) ? groupBucket.key : [groupBucket.key]
+                          Array.isArray(groupBucket.key) ? groupBucket.key : [groupBucket.key],
+                          shouldIgnoreFieldSize
                         )
                   }
                   groupNumber={groupNumber}
@@ -173,6 +179,7 @@ const GroupingComponent = <T,>({
               }
               selectedGroup={selectedGroup}
               groupingLevel={groupingLevel}
+              shouldIgnoreFieldSize={shouldIgnoreFieldSize}
             />
             {groupingLevel > 0 ? null : <EuiSpacer size="s" />}
           </span>
@@ -193,6 +200,7 @@ const GroupingComponent = <T,>({
       tracker,
       trigger,
       unit,
+      shouldIgnoreFieldSize,
     ]
   );
 

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.test.ts
@@ -33,4 +33,25 @@ describe('createGroupFilter', () => {
     const result = createGroupFilter(selectedGroup, null);
     expect(result).toHaveLength(0);
   });
+
+  it('returns filter without script key when selectedGroup is included in multiValueFields', () => {
+    const multiValueFields = ['vulnerability.id'];
+    const selectedGroupMock = 'vulnerability.id';
+    const cveMockData = ['CVE-2021-12345', 'CVE-2021-56789'];
+    const result = createGroupFilter(selectedGroupMock, cveMockData, multiValueFields);
+    expect(result[0].query.script).toBeUndefined();
+  });
+
+  it('returns filter with script key when selectedGroup is not included in multiValueFields', () => {
+    const multiValueFields = ['vulnerability.id'];
+    const selectedGroupMock = 'vulnerability.title';
+    const cveMockData = ['CVE-2021-12345', 'CVE-2021-56789'];
+
+    const mockResponse = {
+      source: "doc[params['field']].size()==params['size']",
+      params: { field: 'vulnerability.title', size: 2 },
+    };
+    const result = createGroupFilter(selectedGroupMock, cveMockData, multiValueFields);
+    expect(result[0].query.script.script).toEqual(mockResponse);
+  });
 });

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.ts
@@ -11,6 +11,9 @@ import type { Filter } from '@kbn/es-query';
 import { FILTERS } from '@kbn/es-query';
 export const getEmptyValue = () => '—';
 
+export const checkIsFlattenResults = (groupByField: string, fields: string[] = []): boolean =>
+  fields.includes(groupByField);
+
 type StrictFilter = Filter & {
   query: Record<string, any>;
 };
@@ -18,8 +21,10 @@ type StrictFilter = Filter & {
 export const createGroupFilter = (
   selectedGroup: string,
   values?: string[] | null,
-  shouldIgnoreFieldSize?: boolean
+  multiValueFields?: string[]
 ): StrictFilter[] => {
+  const shouldIgnoreFieldSize = checkIsFlattenResults(selectedGroup, multiValueFields);
+
   return values != null && values.length > 0
     ? values.reduce(
         (acc: StrictFilter[], query) => [

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.ts
@@ -17,9 +17,10 @@ type StrictFilter = Filter & {
 
 export const createGroupFilter = (
   selectedGroup: string,
-  values?: string[] | null
-): StrictFilter[] =>
-  values != null && values.length > 0
+  values?: string[] | null,
+  shouldIgnoreFieldSize?: boolean
+): StrictFilter[] => {
+  return values != null && values.length > 0
     ? values.reduce(
         (acc: StrictFilter[], query) => [
           ...acc,
@@ -43,32 +44,35 @@ export const createGroupFilter = (
             },
           },
         ],
-        [
-          {
-            meta: {
-              alias: null,
-              disabled: false,
-              type: FILTERS.CUSTOM,
-              negate: false,
-              key: selectedGroup,
-            },
-            query: {
-              script: {
-                script: {
-                  // this will give us an exact match for events with multiple values on the group field
-                  // for example, when values === ['a'], we match events with ['a'], but not ['a', 'b', 'c']
-                  source: "doc[params['field']].size()==params['size']",
-                  params: {
-                    field: selectedGroup,
-                    size: values.length,
+        shouldIgnoreFieldSize
+          ? []
+          : [
+              {
+                meta: {
+                  alias: null,
+                  disabled: false,
+                  type: FILTERS.CUSTOM,
+                  negate: false,
+                  key: selectedGroup,
+                },
+                query: {
+                  script: {
+                    script: {
+                      // this will give us an exact match for events with multiple values on the group field
+                      // for example, when values === ['a'], we match events with ['a'], but not ['a', 'b', 'c']
+                      source: "doc[params['field']].size()==params['size']",
+                      params: {
+                        field: selectedGroup,
+                        size: values.length,
+                      },
+                    },
                   },
                 },
               },
-            },
-          },
-        ]
+            ]
       )
     : [];
+};
 
 export const getNullGroupFilter = (selectedGroup: string): StrictFilter[] => [
   {

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.ts
@@ -24,7 +24,6 @@ export const createGroupFilter = (
   multiValueFields?: string[]
 ): StrictFilter[] => {
   const shouldIgnoreFieldSize = checkIsFlattenResults(selectedGroup, multiValueFields);
-
   return values != null && values.length > 0
     ? values.reduce(
         (acc: StrictFilter[], query) => [

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
@@ -7,185 +7,148 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { GroupingQueryArgs } from './types';
 import { getGroupingQuery, parseGroupingQuery } from '.';
 import { getEmptyValue } from './helpers';
-import type { GroupingAggregation } from '../../..';
-import { groupingBucket } from '../../mocks';
+import { GroupingAggregation } from '../../..';
+import { groupingBucket, mocktestProps1, mockTestProps2 } from '../../mocks';
 
-const testProps: GroupingQueryArgs = {
-  additionalFilters: [],
-  timeRange: {
-    from: '2022-12-28T15:35:32.871Z',
-    to: '2023-02-23T06:59:59.999Z',
-  },
-  groupByField: 'host.name',
-  statsAggregations: [
-    {
-      alertsCount: {
-        cardinality: {
-          field: 'kibana.alert.uuid',
-        },
-      },
-    },
-    {
-      rulesCountAggregation: {
-        cardinality: {
-          field: 'kibana.alert.rule.rule_id',
-        },
-      },
-    },
-    {
-      countSeveritySubAggregation: {
-        cardinality: {
-          field: 'kibana.alert.severity',
-        },
-      },
-    },
-    {
-      severitiesSubAggregation: {
-        terms: {
-          field: 'kibana.alert.severity',
-        },
-      },
-    },
-    {
-      usersCountAggregation: {
-        cardinality: {
-          field: 'user.name',
-        },
-      },
-    },
-  ],
-  pageNumber: 0,
-  rootAggregations: [],
-  runtimeMappings: {},
-  uniqueValue: 'whatAGreatAndUniqueValue',
-  size: 25,
-};
 describe('group selector', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  it('Sets runtime field and terms query', () => {
-    const result = getGroupingQuery(testProps);
 
-    expect(result.runtime_mappings.groupByField.script.params.selectedGroup).toEqual('host.name');
+  describe('getGroupingQuery', () => {
+    it('Sets runtime field and terms query', () => {
+      const result = getGroupingQuery(mocktestProps1);
 
-    expect(result.aggs.groupByFields.aggs).toEqual({
-      bucket_truncate: { bucket_sort: { from: 0, size: 25 } },
-      alertsCount: { cardinality: { field: 'kibana.alert.uuid' } },
-      rulesCountAggregation: { cardinality: { field: 'kibana.alert.rule.rule_id' } },
-      countSeveritySubAggregation: { cardinality: { field: 'kibana.alert.severity' } },
-      severitiesSubAggregation: { terms: { field: 'kibana.alert.severity' } },
-      usersCountAggregation: { cardinality: { field: 'user.name' } },
+      expect(result.runtime_mappings.groupByField.script.params.selectedGroup).toEqual('host.name');
+
+      expect(result.aggs.groupByFields.aggs).toEqual({
+        bucket_truncate: { bucket_sort: { from: 0, size: 25 } },
+        alertsCount: { cardinality: { field: 'kibana.alert.uuid' } },
+        rulesCountAggregation: { cardinality: { field: 'kibana.alert.rule.rule_id' } },
+        countSeveritySubAggregation: { cardinality: { field: 'kibana.alert.severity' } },
+        severitiesSubAggregation: { terms: { field: 'kibana.alert.severity' } },
+        usersCountAggregation: { cardinality: { field: 'user.name' } },
+      });
+      expect(result.aggs.alertsCount).toBeUndefined();
+      expect(result.aggs.groupsNumber).toBeUndefined();
+      expect(result.query.bool.filter.length).toEqual(1);
     });
-    expect(result.aggs.alertsCount).toBeUndefined();
-    expect(result.aggs.groupsNumber).toBeUndefined();
-    expect(result.query.bool.filter.length).toEqual(1);
-  });
-  it('Sets additional rootAggregations', () => {
-    const result = getGroupingQuery({
-      ...testProps,
-      rootAggregations: [
-        {
-          alertsCount: {
-            terms: {
-              field: 'kibana.alert.rule.producer',
-              exclude: ['alerts'],
+
+    it('Sets additional rootAggregations', () => {
+      const result = getGroupingQuery({
+        ...mocktestProps1,
+        rootAggregations: [
+          {
+            alertsCount: {
+              terms: {
+                field: 'kibana.alert.rule.producer',
+                exclude: ['alerts'],
+              },
             },
           },
-        },
-        {
-          groupsNumber: {
-            cardinality: {
-              field: 'host.name',
+          {
+            groupsNumber: {
+              cardinality: {
+                field: 'host.name',
+              },
             },
           },
-        },
-      ],
+        ],
+      });
+      expect(result.aggs.alertsCount).toEqual({
+        terms: { field: 'kibana.alert.rule.producer', exclude: ['alerts'] },
+      });
+      expect(result.aggs.groupsNumber).toEqual({ cardinality: { field: 'host.name' } });
     });
-    expect(result.aggs.alertsCount).toEqual({
-      terms: { field: 'kibana.alert.rule.producer', exclude: ['alerts'] },
-    });
-    expect(result.aggs.groupsNumber).toEqual({ cardinality: { field: 'host.name' } });
-  });
-  it('Additional filters get added to the query', () => {
-    const result = getGroupingQuery({
-      ...testProps,
-      additionalFilters: [
-        {
-          bool: {
-            must: [],
-            filter: [
-              {
-                term: {
-                  'kibana.alert.workflow_status': 'open',
+
+    it('Additional filters get added to the query', () => {
+      const result = getGroupingQuery({
+        ...mocktestProps1,
+        additionalFilters: [
+          {
+            bool: {
+              must: [],
+              filter: [
+                {
+                  term: {
+                    'kibana.alert.workflow_status': 'open',
+                  },
                 },
-              },
-            ],
-            should: [],
-            must_not: [
-              {
-                exists: {
-                  field: 'kibana.alert.building_block_type',
+              ],
+              should: [],
+              must_not: [
+                {
+                  exists: {
+                    field: 'kibana.alert.building_block_type',
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
-        },
-      ],
+        ],
+      });
+      expect(result.query.bool.filter.length).toEqual(2);
     });
-    expect(result.query.bool.filter.length).toEqual(2);
+
+    it('groupByField script should contain logic which gets all values of groupByField', () => {
+      const scriptResponse = {
+        source:
+          "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
+        params: {
+          selectedGroup: 'resource.name',
+          uniqueValue: 'whatAGreatAndUniqueValue',
+        },
+      };
+
+      const result = getGroupingQuery(mockTestProps2);
+
+      expect(result.runtime_mappings.groupByField.script).toEqual(scriptResponse);
+      expect(result.aggs.unitsCount).toEqual({ value_count: { field: 'groupByField' } });
+    });
+
+    it('groupByField script should flatten documents in runtime by groupByField', () => {
+      const groupByField = 'resource.name';
+      const countByKeyForMultiValueFields = 'event.id';
+
+      const scriptResponse = {
+        source:
+          "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) } else { for (def id : doc[params['selectedGroup']]) { emit(id) }}",
+        params: {
+          selectedGroup: groupByField,
+          uniqueValue: 'whatAGreatAndUniqueValue',
+        },
+      };
+
+      const result = getGroupingQuery({
+        ...mockTestProps2,
+        multiValueFieldsToFlatten: [groupByField],
+        countByKeyForMultiValueFields: 'event.id',
+      });
+
+      expect(result.runtime_mappings.groupByField.script).toEqual(scriptResponse);
+      expect(result.aggs.unitsCount).toEqual({
+        value_count: { field: countByKeyForMultiValueFields },
+      });
+    });
   });
 
-  const groupingAggs = {
-    groupByFields: {
-      buckets: [
-        {
-          ...groupingBucket,
-          key: '20.80.64.28',
-        },
-        {
-          ...groupingBucket,
-          key: '0.0.0.0',
-        },
-        {
-          ...groupingBucket,
-          key: testProps.uniqueValue,
-        },
-      ],
-    },
-    unitsCount: {
-      value: 100,
-    },
-    groupsCount: {
-      value: 20,
-    },
-  };
-  it('parseGroupingQuery finds and flags the null group', () => {
-    const result = parseGroupingQuery('source.ip', testProps.uniqueValue, groupingAggs);
-    expect(result).toEqual({
+  describe('parseGroupingQuery', () => {
+    const groupingAggs = {
       groupByFields: {
         buckets: [
           {
             ...groupingBucket,
-            key: ['20.80.64.28'],
-            key_as_string: '20.80.64.28',
-            selectedGroup: 'source.ip',
+            key: '20.80.64.28',
           },
           {
             ...groupingBucket,
-            key: ['0.0.0.0'],
-            key_as_string: '0.0.0.0',
-            selectedGroup: 'source.ip',
+            key: '0.0.0.0',
           },
           {
             ...groupingBucket,
-            key: [getEmptyValue()],
-            key_as_string: getEmptyValue(),
-            selectedGroup: 'source.ip',
-            isNullGroup: true,
+            key: mocktestProps1.uniqueValue,
           },
         ],
       },
@@ -194,64 +157,100 @@ describe('group selector', () => {
       },
       groupsCount: {
         value: 20,
-      },
-    });
-  });
-  it('parseGroupingQuery parses and formats fields witih multiple values', () => {
-    const multiValuedAggs = {
-      ...groupingAggs,
-      groupByFields: {
-        buckets: [
-          {
-            ...groupingBucket,
-            key: `20.80.64.28${testProps.uniqueValue}0.0.0.0${testProps.uniqueValue}1.1.1.1`,
-          },
-          {
-            ...groupingBucket,
-            key: `0.0.0.0`,
-          },
-          {
-            ...groupingBucket,
-            key: `ip.with,comma${testProps.uniqueValue}ip.without.comma`,
-          },
-        ],
       },
     };
-    const result: GroupingAggregation<{}> = parseGroupingQuery(
-      'source.ip',
-      testProps.uniqueValue,
-      multiValuedAggs
-    );
 
-    expect(result).toEqual({
-      groupByFields: {
-        buckets: [
-          {
-            ...groupingBucket,
-            key: ['20.80.64.28', '0.0.0.0', '1.1.1.1'],
-            key_as_string: '20.80.64.28, 0.0.0.0, 1.1.1.1',
-            selectedGroup: 'source.ip',
-          },
-          {
-            ...groupingBucket,
-            key: ['0.0.0.0'],
-            key_as_string: '0.0.0.0',
-            selectedGroup: 'source.ip',
-          },
-          {
-            ...groupingBucket,
-            key: ['ip.with,comma', 'ip.without.comma'],
-            key_as_string: 'ip.with,comma, ip.without.comma',
-            selectedGroup: 'source.ip',
-          },
-        ],
-      },
-      unitsCount: {
-        value: 100,
-      },
-      groupsCount: {
-        value: 20,
-      },
+    it('parseGroupingQuery finds and flags the null group', () => {
+      const result = parseGroupingQuery('source.ip', mocktestProps1.uniqueValue, groupingAggs);
+      expect(result).toEqual({
+        groupByFields: {
+          buckets: [
+            {
+              ...groupingBucket,
+              key: ['20.80.64.28'],
+              key_as_string: '20.80.64.28',
+              selectedGroup: 'source.ip',
+            },
+            {
+              ...groupingBucket,
+              key: ['0.0.0.0'],
+              key_as_string: '0.0.0.0',
+              selectedGroup: 'source.ip',
+            },
+            {
+              ...groupingBucket,
+              key: [getEmptyValue()],
+              key_as_string: getEmptyValue(),
+              selectedGroup: 'source.ip',
+              isNullGroup: true,
+            },
+          ],
+        },
+        unitsCount: {
+          value: 100,
+        },
+        groupsCount: {
+          value: 20,
+        },
+      });
+    });
+
+    it('parseGroupingQuery parses and formats fields witih multiple values', () => {
+      const multiValuedAggs = {
+        ...groupingAggs,
+        groupByFields: {
+          buckets: [
+            {
+              ...groupingBucket,
+              key: `20.80.64.28${mocktestProps1.uniqueValue}0.0.0.0${mocktestProps1.uniqueValue}1.1.1.1`,
+            },
+            {
+              ...groupingBucket,
+              key: `0.0.0.0`,
+            },
+            {
+              ...groupingBucket,
+              key: `ip.with,comma${mocktestProps1.uniqueValue}ip.without.comma`,
+            },
+          ],
+        },
+      };
+      const result: GroupingAggregation<{}> = parseGroupingQuery(
+        'source.ip',
+        mocktestProps1.uniqueValue,
+        multiValuedAggs
+      );
+
+      expect(result).toEqual({
+        groupByFields: {
+          buckets: [
+            {
+              ...groupingBucket,
+              key: ['20.80.64.28', '0.0.0.0', '1.1.1.1'],
+              key_as_string: '20.80.64.28, 0.0.0.0, 1.1.1.1',
+              selectedGroup: 'source.ip',
+            },
+            {
+              ...groupingBucket,
+              key: ['0.0.0.0'],
+              key_as_string: '0.0.0.0',
+              selectedGroup: 'source.ip',
+            },
+            {
+              ...groupingBucket,
+              key: ['ip.with,comma', 'ip.without.comma'],
+              key_as_string: 'ip.with,comma, ip.without.comma',
+              selectedGroup: 'source.ip',
+            },
+          ],
+        },
+        unitsCount: {
+          value: 100,
+        },
+        groupsCount: {
+          value: 20,
+        },
+      });
     });
   });
 });

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
@@ -9,7 +9,7 @@
 
 import { getGroupingQuery, parseGroupingQuery } from '.';
 import { getEmptyValue } from './helpers';
-import { GroupingAggregation } from '../../..';
+import type { GroupingAggregation } from '../../..';
 import { groupingBucket, mocktestProps1, mockTestProps2 } from '../../mocks';
 
 describe('group selector', () => {

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { checkIsFlattenResults, getEmptyValue } from './helpers';
-import { GroupingAggregation, ParsedGroupingAggregation } from '../..';
+import type { GroupingAggregation, ParsedGroupingAggregation } from '../..';
 import type { GroupingQueryArgs, GroupingQuery } from './types';
 /** The maximum number of groups to render */
 export const DEFAULT_GROUP_BY_FIELD_SIZE = 10;

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/types.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/types.ts
@@ -45,8 +45,8 @@ export interface GroupingQueryArgs {
     from: string;
     to: string;
   };
-  shouldFlattenMultiValueField?: boolean;
-  countDocumentsBy?: string;
+  multiValueFieldsToFlatten?: string[];
+  countByKeyForMultiValueFields?: string;
 }
 
 export interface MainAggregation extends NamedAggregation {

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/types.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/types.ts
@@ -45,6 +45,8 @@ export interface GroupingQueryArgs {
     from: string;
     to: string;
   };
+  shouldFlattenMultiValueField?: boolean;
+  countDocumentsBy?: string;
 }
 
 export interface MainAggregation extends NamedAggregation {

--- a/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
@@ -37,7 +37,7 @@ type StaticGroupingProps<T> = Pick<
   | 'onGroupToggle'
   | 'unit'
   | 'groupsUnit'
-  | 'shouldIgnoreFieldSize'
+  | 'multiValueFields'
 >;
 
 /** Type for dynamic grouping component props where T is the consumer `GroupingAggregation`

--- a/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
@@ -32,7 +32,12 @@ export interface UseGrouping<T> {
  */
 type StaticGroupingProps<T> = Pick<
   GroupingProps<T>,
-  'groupPanelRenderer' | 'getGroupStats' | 'onGroupToggle' | 'unit' | 'groupsUnit'
+  | 'groupPanelRenderer'
+  | 'getGroupStats'
+  | 'onGroupToggle'
+  | 'unit'
+  | 'groupsUnit'
+  | 'shouldIgnoreFieldSize'
 >;
 
 /** Type for dynamic grouping component props where T is the consumer `GroupingAggregation`

--- a/src/platform/packages/shared/kbn-grouping/src/mocks.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/mocks.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { GroupingQueryArgs } from './containers/query/types';
+
 export const groupingBucket = {
   key: '192.168.0.4',
   doc_count: 75,
@@ -24,4 +26,141 @@ export const groupingBucket = {
     ],
   },
   countSeveritySubAggregation: { value: 4 },
+};
+
+export const mocktestProps1: GroupingQueryArgs = {
+  additionalFilters: [],
+  timeRange: {
+    from: '2022-12-28T15:35:32.871Z',
+    to: '2023-02-23T06:59:59.999Z',
+  },
+  groupByField: 'host.name',
+  statsAggregations: [
+    {
+      alertsCount: {
+        cardinality: {
+          field: 'kibana.alert.uuid',
+        },
+      },
+    },
+    {
+      rulesCountAggregation: {
+        cardinality: {
+          field: 'kibana.alert.rule.rule_id',
+        },
+      },
+    },
+    {
+      countSeveritySubAggregation: {
+        cardinality: {
+          field: 'kibana.alert.severity',
+        },
+      },
+    },
+    {
+      severitiesSubAggregation: {
+        terms: {
+          field: 'kibana.alert.severity',
+        },
+      },
+    },
+    {
+      usersCountAggregation: {
+        cardinality: {
+          field: 'user.name',
+        },
+      },
+    },
+  ],
+  pageNumber: 0,
+  rootAggregations: [],
+  runtimeMappings: {},
+  uniqueValue: 'whatAGreatAndUniqueValue',
+  size: 25,
+};
+
+export const mockTestProps2: GroupingQueryArgs = {
+  additionalFilters: [],
+  groupByField: 'resource.name',
+  pageNumber: 0,
+  rootAggregations: [
+    {
+      nullGroupItems: {
+        missing: {
+          field: 'resource.name',
+        },
+      },
+    },
+  ],
+  runtimeMappings: {},
+  size: 10,
+  sort: [
+    {
+      groupByField: {
+        order: 'desc',
+      },
+    },
+  ],
+  statsAggregations: [
+    {
+      groupByField: {
+        cardinality: {
+          field: 'resource.name',
+        },
+      },
+      critical: {
+        filter: {
+          term: {
+            'vulnerability.severity': {
+              value: 'CRITICAL',
+              case_insensitive: true,
+            },
+          },
+        },
+      },
+      high: {
+        filter: {
+          term: {
+            'vulnerability.severity': {
+              value: 'HIGH',
+              case_insensitive: true,
+            },
+          },
+        },
+      },
+      medium: {
+        filter: {
+          term: {
+            'vulnerability.severity': {
+              value: 'MEDIUM',
+              case_insensitive: true,
+            },
+          },
+        },
+      },
+      low: {
+        filter: {
+          term: {
+            'vulnerability.severity': {
+              value: 'LOW',
+              case_insensitive: true,
+            },
+          },
+        },
+      },
+    },
+    {
+      resourceId: {
+        terms: {
+          field: 'resource.id',
+          size: 1,
+        },
+      },
+    },
+  ],
+  uniqueValue: 'whatAGreatAndUniqueValue',
+  timeRange: {
+    from: 'now-90d',
+    to: 'now',
+  },
 };

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
@@ -205,6 +205,19 @@ export const VULNERABILITY_GROUPING_OPTIONS = {
 };
 
 /*
+ * ECS schema unique field to describe the event
+ * https://www.elastic.co/guide/en/ecs/current/ecs-event.html
+ */
+export const EVENT_ID = 'event.id';
+
+export const VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS = [
+  VULNERABILITY_FIELDS.VULNERABILITY_ID,
+  'package.name',
+  'package.version',
+  'package.fixed_version',
+];
+
+/*
 The fields below are default columns of the Cloud Security Data Table that need to have keyword mapping.
 The runtime mappings are used to prevent filtering out the data when any of these columns are sorted in the Data Table.
 TODO: Remove the fields below once they are mapped as Keyword in the Third Party integrations, or remove
@@ -224,7 +237,9 @@ to prevent filtering out the data when grouping by the key field.
 TODO: Remove the fields below once they are mapped as Keyword in the Third Party integrations, or remove
 the fields from the runtime mappings if they are removed from the Data Table.
 */
-export const CDR_VULNERABILITY_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {};
+export const CDR_VULNERABILITY_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {
+  [VULNERABILITY_FIELDS.VULNERABILITY_ID]: ['vulnerability.id'],
+};
 export const CDR_MISCONFIGURATION_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {
   [FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID]: ['orchestrator.cluster.id'],
   [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID]: ['cloud.account.id'],

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
@@ -237,9 +237,7 @@ to prevent filtering out the data when grouping by the key field.
 TODO: Remove the fields below once they are mapped as Keyword in the Third Party integrations, or remove
 the fields from the runtime mappings if they are removed from the Data Table.
 */
-export const CDR_VULNERABILITY_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {
-  [VULNERABILITY_FIELDS.VULNERABILITY_ID]: ['vulnerability.id'],
-};
+export const CDR_VULNERABILITY_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {};
 export const CDR_MISCONFIGURATION_GROUPING_RUNTIME_MAPPING_FIELDS: Record<string, string[]> = {
   [FINDINGS_GROUPING_OPTIONS.ORCHESTRATOR_CLUSTER_ID]: ['orchestrator.cluster.id'],
   [FINDINGS_GROUPING_OPTIONS.CLOUD_ACCOUNT_ID]: ['cloud.account.id'],

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/common/constants.ts
@@ -210,11 +210,11 @@ export const VULNERABILITY_GROUPING_OPTIONS = {
  */
 export const EVENT_ID = 'event.id';
 
-export const VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS = [
+export const VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS: string[] = [
   VULNERABILITY_FIELDS.VULNERABILITY_ID,
-  'package.name',
-  'package.version',
-  'package.fixed_version',
+  VULNERABILITY_FIELDS.PACKAGE_NAME,
+  VULNERABILITY_FIELDS.PACKAGE_VERSION,
+  VULNERABILITY_FIELDS.PACKAGE_FIXED_VERSION,
 ];
 
 /*
@@ -234,6 +234,7 @@ export const CDR_MISCONFIGURATION_DATA_TABLE_RUNTIME_MAPPING_FIELDS: string[] = 
 The fields below are used to group the data in the Cloud Security Data Table.
 The keys are the fields that are used to group the data, and the values are the fields that need to have keyword mapping
 to prevent filtering out the data when grouping by the key field.
+WARNING: only add keys which are not mapped as keywords - casting to keywords could have negative effect on performance.
 TODO: Remove the fields below once they are mapped as Keyword in the Third Party integrations, or remove
 the fields from the runtime mappings if they are removed from the Data Table.
 */

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_grouping/use_cloud_security_grouping.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_grouping/use_cloud_security_grouping.ts
@@ -62,18 +62,13 @@ export const useCloudSecurityGrouping = ({
     query: urlQuery.query,
   });
 
-  // check if at least of the groupBy fields might contain multiple value
-  const isGroupByFieldsContainMultipleValues = urlQuery.groupBy?.some((field) =>
-    VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS.includes(field)
-  );
-
   const grouping = useGrouping({
     componentProps: {
       unit,
       groupPanelRenderer,
       getGroupStats,
       groupsUnit,
-      shouldIgnoreFieldSize: isGroupByFieldsContainMultipleValues,
+      multiValueFields: VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS,
     },
     defaultGroupingOptions,
     fields: dataView.fields,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_grouping/use_cloud_security_grouping.ts
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_grouping/use_cloud_security_grouping.ts
@@ -19,6 +19,7 @@ import { useUrlQuery } from '../../common/hooks/use_url_query';
 
 import { FindingsBaseURLQuery } from '../../common/types';
 import { useBaseEsQuery, usePersistedQuery } from '../../common/hooks/use_cloud_posture_data_table';
+import { VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS } from '../../common/constants';
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_MAX_GROUPING_LEVELS = 3;
@@ -61,12 +62,18 @@ export const useCloudSecurityGrouping = ({
     query: urlQuery.query,
   });
 
+  // check if at least of the groupBy fields might contain multiple value
+  const isGroupByFieldsContainMultipleValues = urlQuery.groupBy?.some((field) =>
+    VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS.includes(field)
+  );
+
   const grouping = useGrouping({
     componentProps: {
       unit,
       groupPanelRenderer,
       getGroupStats,
       groupsUnit,
+      shouldIgnoreFieldSize: isGroupByFieldsContainMultipleValues,
     },
     defaultGroupingOptions,
     fields: dataView.fields,

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
@@ -24,6 +24,8 @@ import {
   VULNERABILITY_GROUPING_OPTIONS,
   VULNERABILITY_FIELDS,
   CDR_VULNERABILITY_GROUPING_RUNTIME_MAPPING_FIELDS,
+  EVENT_ID,
+  VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS,
 } from '../../../common/constants';
 import { useDataViewContext } from '../../../common/contexts/data_view_context';
 import {
@@ -212,6 +214,11 @@ export const useLatestVulnerabilitiesGrouping = ({
         }),
       },
     ],
+    shouldFlattenMultiValueField:
+      VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS.includes(currentSelectedGroup),
+    ...(VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS.includes(currentSelectedGroup) && {
+      countDocumentsBy: EVENT_ID,
+    }),
   });
 
   const { data, isFetching } = useGroupedVulnerabilities({

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/pages/vulnerabilities/hooks/use_latest_vulnerabilities_grouping.tsx
@@ -214,11 +214,8 @@ export const useLatestVulnerabilitiesGrouping = ({
         }),
       },
     ],
-    shouldFlattenMultiValueField:
-      VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS.includes(currentSelectedGroup),
-    ...(VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS.includes(currentSelectedGroup) && {
-      countDocumentsBy: EVENT_ID,
-    }),
+    multiValueFieldsToFlatten: VULNERABILITY_GROUPING_MULTIPLE_VALUE_FIELDS,
+    countByKeyForMultiValueFields: EVENT_ID,
   });
 
   const { data, isFetching } = useGroupedVulnerabilities({


### PR DESCRIPTION
## Summary

Purpose of this PR is to handle grouping of multi-value fields which are introduced by Qualys VDMR integrations.
This PR adds the capability to flatten grouping results of the following fields - vulnerability.id, package.name, package.version and package.fixed_version, which are all ECS fields.

It continues the changes of this [PR](https://github.com/elastic/kibana/pull/213039).

### Checklist

**The following topics will be merged as part of another PR**
### Vulnerabilities data grid and Flyout
- [x] grouping by CVE should be handled properly in the UI.
- [x] multi value fields are flattened - each value is counted as separate group key.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR description includes the appropriate Release Notes section, and the correct release_note:* label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


### Screenshots

Grouping before fix by multiple values
![image](https://github.com/user-attachments/assets/21756172-819c-4836-ba3a-79ae9ed6cbad)

Flatten by each value
![image](https://github.com/user-attachments/assets/d329d3f7-b499-4abb-8e40-6c8580be9202)
