### PR TITLE
Turn off React strict mode in SharedUX Storybook

### DIFF
--- a/src/platform/packages/private/shared-ux/storybook/config/main.ts
+++ b/src/platform/packages/private/shared-ux/storybook/config/main.ts
@@ -15,7 +15,4 @@ module.exports = {
     '../../**/*.stories.+(tsx|mdx)',
     '../../../../shared/shared-ux/**/*.stories.+(tsx|mdx)',
   ],
-  reactOptions: {
-    strictMode: true,
-  },
 };


### PR DESCRIPTION
## Summary

This PR removes React strict mode from Storybook stories owned by SharedUX team. This is needed because both `EuiTooltip` and `EuiAccordion` are currently not compatible with strict mode and they won't function properly in stories.

As requested in https://github.com/elastic/kibana/pull/214854#discussion_r2012415842 I opened a separate PR to address this problem.





