### PR TITLE
[8.17] [Security Solution][Telemetry] Collect additional index stats (#213822)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/configuration.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/configuration.ts
@@ -27,9 +27,13 @@ class TelemetryConfigurationDTO {
     num_docs_to_sample: 10,
   };
   private readonly DEFAULT_INDICES_METADATA_CONFIG = {
-    indices_threshold: 10000,
+    indices_threshold: 10_000,
     datastreams_threshold: 1000,
-    indices_settings_threshold: 10000,
+    indices_settings_threshold: 10_000,
+
+    index_query_size: 1024,
+    ilm_stats_query_size: 1024,
+    ilm_policy_query_size: 1024,
 
     max_prefixes: 10, // @deprecated
     max_group_size: 100, // @deprecated

--- a/x-pack/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -11,7 +11,13 @@ import type {
   ResponseActionsApiCommandNames,
 } from '../../../../common/endpoint/service/response_actions/constants';
 import type { BulkUpsertAssetCriticalityRecordsResponse } from '../../../../common/api/entity_analytics';
-import type { DataStreams, IlmPolicies, IlmsStats, IndicesStats } from '../indices.metadata.types';
+import type {
+  DataStreams,
+  IlmPolicies,
+  IlmsStats,
+  IndicesSettings,
+  IndicesStats,
+} from '../indices.metadata.types';
 import type { NodeIngestPipelinesStats } from '../ingest_pipelines_stats.types';
 
 export const RISK_SCORE_EXECUTION_SUCCESS_EVENT: EventTypeOpts<{
@@ -284,6 +290,14 @@ export const TELEMETRY_DATA_STREAM_EVENT: EventTypeOpts<DataStreams> = {
             type: 'keyword',
             _meta: { description: 'Name of the data stream' },
           },
+          ilm_policy: {
+            type: 'keyword',
+            _meta: { optional: true, description: 'ILM policy associated to the datastream' },
+          },
+          template: {
+            type: 'keyword',
+            _meta: { optional: true, description: 'Template associated to the datastream' },
+          },
           indices: {
             type: 'array',
             items: {
@@ -296,7 +310,7 @@ export const TELEMETRY_DATA_STREAM_EVENT: EventTypeOpts<DataStreams> = {
           },
         },
       },
-      _meta: { description: 'Datastreams' },
+      _meta: { description: 'Datastream settings' },
     },
   },
 };
@@ -312,6 +326,7 @@ export const TELEMETRY_INDEX_STATS_EVENT: EventTypeOpts<IndicesStats> = {
             type: 'keyword',
             _meta: { description: 'The name of the index being monitored.' },
           },
+
           query_total: {
             type: 'long',
             _meta: {
@@ -327,11 +342,38 @@ export const TELEMETRY_INDEX_STATS_EVENT: EventTypeOpts<IndicesStats> = {
                 'The total time spent on query execution across all search requests, measured in milliseconds.',
             },
           },
+
+          docs_count_primaries: {
+            type: 'long',
+            _meta: {
+              optional: true,
+              description:
+                'The total number of documents currently stored in the index (primary shards).',
+            },
+          },
+          docs_deleted_primaries: {
+            type: 'long',
+            _meta: {
+              optional: true,
+              description:
+                'The total number of documents that have been marked as deleted in the index (primary shards).',
+            },
+          },
+          docs_total_size_in_bytes_primaries: {
+            type: 'long',
+            _meta: {
+              optional: true,
+              description:
+                'The total size, in bytes, of all documents stored in the index, including storage overhead (primary shards).',
+            },
+          },
+
           docs_count: {
             type: 'long',
             _meta: {
               optional: true,
-              description: 'The total number of documents currently stored in the index.',
+              description:
+                'The total number of documents currently stored in the index (primary and replica shards).',
             },
           },
           docs_deleted: {
@@ -339,7 +381,7 @@ export const TELEMETRY_INDEX_STATS_EVENT: EventTypeOpts<IndicesStats> = {
             _meta: {
               optional: true,
               description:
-                'The total number of documents that have been marked as deleted in the index.',
+                'The total number of documents that have been marked as deleted in the index (primary and replica shards).',
             },
           },
           docs_total_size_in_bytes: {
@@ -347,12 +389,62 @@ export const TELEMETRY_INDEX_STATS_EVENT: EventTypeOpts<IndicesStats> = {
             _meta: {
               optional: true,
               description:
-                'The total size, in bytes, of all documents stored in the index, including storage overhead.',
+                'The total size, in bytes, of all documents stored in the index, including storage overhead (primary and replica shards).',
+            },
+          },
+
+          index_failed: {
+            type: 'long',
+            _meta: {
+              optional: true,
+              description:
+                'The total number of documents failed to index (primary and replica shards).',
+            },
+          },
+          index_failed_due_to_version_conflict: {
+            type: 'long',
+            _meta: {
+              optional: true,
+              description:
+                'The total number of documents failed to index due to version conflict (primary and replica shards).',
             },
           },
         },
       },
-      _meta: { description: 'Datastreams' },
+      _meta: { description: 'Index stats' },
+    },
+  },
+};
+
+export const TELEMETRY_INDEX_SETTINGS_EVENT: EventTypeOpts<IndicesSettings> = {
+  eventType: 'telemetry_index_settings_event',
+  schema: {
+    items: {
+      type: 'array',
+      items: {
+        properties: {
+          index_name: {
+            type: 'keyword',
+            _meta: { description: 'The name of the index.' },
+          },
+          default_pipeline: {
+            type: 'keyword',
+            _meta: {
+              optional: true,
+              description: 'Pipeline applied if no pipeline parameter specified when indexing.',
+            },
+          },
+          final_pipeline: {
+            type: 'keyword',
+            _meta: {
+              optional: true,
+              description:
+                'Pipeline applied to the document at the end of the indexing process, after the document has been indexed.',
+            },
+          },
+        },
+      },
+      _meta: { description: 'Index settings' },
     },
   },
 };
@@ -462,7 +554,7 @@ export const TELEMETRY_ILM_POLICY_EVENT: EventTypeOpts<IlmPolicies> = {
           },
         },
       },
-      _meta: { description: 'Datastreams' },
+      _meta: { description: 'ILM policies' },
     },
   },
 };
@@ -503,7 +595,7 @@ export const TELEMETRY_ILM_STATS_EVENT: EventTypeOpts<IlmsStats> = {
           },
         },
       },
-      _meta: { description: 'Datastreams' },
+      _meta: { description: 'ILM stats' },
     },
   },
 };
@@ -816,6 +908,7 @@ export const events = [
   TELEMETRY_DATA_STREAM_EVENT,
   TELEMETRY_ILM_POLICY_EVENT,
   TELEMETRY_ILM_STATS_EVENT,
-  TELEMETRY_NODE_INGEST_PIPELINES_STATS_EVENT,
+  TELEMETRY_INDEX_SETTINGS_EVENT,
   TELEMETRY_INDEX_STATS_EVENT,
+  TELEMETRY_NODE_INGEST_PIPELINES_STATS_EVENT,
 ];

--- a/x-pack/plugins/security_solution/server/lib/telemetry/indices.metadata.types.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/indices.metadata.types.ts
@@ -47,11 +47,32 @@ export interface IndicesStats {
 
 export interface IndexStats {
   index_name: string;
+
   query_total?: number;
   query_time_in_millis?: number;
+
+  // values for primary shards
+  docs_count_primaries?: number;
+  docs_deleted_primaries?: number;
+  docs_total_size_in_bytes_primaries?: number;
+
+  // values for primary and replica shards
   docs_count?: number;
   docs_deleted?: number;
   docs_total_size_in_bytes?: number;
+
+  index_failed?: number;
+  index_failed_due_to_version_conflict?: number;
+}
+
+export interface IndicesSettings {
+  items: IndexSettings[];
+}
+
+export interface IndexSettings {
+  index_name: string;
+  default_pipeline?: string;
+  final_pipeline?: string;
 }
 
 export interface Index {
@@ -64,5 +85,7 @@ export interface DataStreams {
 }
 export interface DataStream {
   datastream_name: string;
+  ilm_policy?: string;
+  template?: string;
   indices?: Index[];
 }

--- a/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/receiver.ts
@@ -101,6 +101,7 @@ import type {
   IlmPolicy,
   IlmStats,
   Index,
+  IndexSettings,
   IndexStats,
 } from './indices.metadata.types';
 import { chunkStringsByMaxLength } from './collections_helpers';
@@ -262,11 +263,11 @@ export interface ITelemetryReceiver {
 
   setNumDocsToSample(n: number): void;
 
-  getIndices(): Promise<string[]>;
+  getIndices(): Promise<IndexSettings[]>;
   getDataStreams(): Promise<DataStream[]>;
-  getIndicesStats(indices: string[]): AsyncGenerator<IndexStats, void, unknown>;
-  getIlmsStats(indices: string[]): AsyncGenerator<IlmStats, void, unknown>;
-  getIlmsPolicies(ilms: string[]): AsyncGenerator<IlmPolicy, void, unknown>;
+  getIndicesStats(indices: string[], chunkSize: number): AsyncGenerator<IndexStats, void, unknown>;
+  getIlmsStats(indices: string[], chunkSize: number): AsyncGenerator<IlmStats, void, unknown>;
+  getIlmsPolicies(ilms: string[], chunkSize: number): AsyncGenerator<IlmPolicy, void, unknown>;
 
   getIngestPipelinesStats(timeout: Duration): Promise<NodeIngestPipelinesStats[]>;
 }
@@ -1351,7 +1352,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
     return this._esClient;
   }
 
-  public async getIndices(): Promise<string[]> {
+  public async getIndices(): Promise<IndexSettings[]> {
     const es = this.esClient();
 
     this.logger.l('Fetching indices');
@@ -1359,12 +1360,24 @@ export class TelemetryReceiver implements ITelemetryReceiver {
     const request: IndicesGetRequest = {
       index: '*',
       expand_wildcards: ['open', 'hidden'],
-      filter_path: ['*.settings.index.provided_name'],
+      filter_path: [
+        '*.settings.index.final_pipeline',
+        '*.settings.index.default_pipeline',
+        '*.settings.index.provided_name',
+      ],
     };
 
     return es.indices
       .get(request)
-      .then((indices) => Array.from(Object.keys(indices)))
+      .then((indices) =>
+        Object.entries(indices).map(([index, value]) => {
+          return {
+            index_name: index,
+            default_pipeline: value.settings?.index?.default_pipeline,
+            final_pipeline: value.settings?.index?.final_pipeline,
+          } as IndexSettings;
+        })
+      )
       .catch((error) => {
         this.logger.warn('Error fetching indices', { error_message: error } as LogMeta);
         throw error;
@@ -1379,7 +1392,13 @@ export class TelemetryReceiver implements ITelemetryReceiver {
     const request: IndicesGetDataStreamRequest = {
       name: '*',
       expand_wildcards: ['open', 'hidden'],
-      filter_path: ['data_streams.name', 'data_streams.indices'],
+      filter_path: [
+        'data_streams.indices.ilm_policy',
+        'data_streams.indices.index_name',
+        'data_streams.name',
+        'ilm_policy',
+        'template',
+      ],
     };
 
     return es.indices
@@ -1388,6 +1407,8 @@ export class TelemetryReceiver implements ITelemetryReceiver {
         response.data_streams.map((ds) => {
           return {
             datastream_name: ds.name,
+            ilm_policy: ds.ilm_policy,
+            template: ds.template,
             indices:
               ds.indices?.map((index) => {
                 return {
@@ -1404,12 +1425,13 @@ export class TelemetryReceiver implements ITelemetryReceiver {
       });
   }
 
-  public async *getIndicesStats(indices: string[]) {
+  public async *getIndicesStats(indices: string[], chunkSize: number) {
     const es = this.esClient();
+    const safeChunkSize = Math.min(chunkSize, 3000);
 
     this.logger.l('Fetching indices stats');
 
-    const groupedIndices = chunkStringsByMaxLength(indices);
+    const groupedIndices = chunkStringsByMaxLength(indices, safeChunkSize);
 
     this.logger.l('Splitted indices into groups', {
       groups: groupedIndices.length,
@@ -1420,14 +1442,22 @@ export class TelemetryReceiver implements ITelemetryReceiver {
       const request: IndicesStatsRequest = {
         index: group,
         level: 'indices',
-        metric: ['docs', 'search', 'store'],
+        metric: ['docs', 'search', 'store', 'indexing'],
         expand_wildcards: ['open', 'hidden'],
         filter_path: [
           'indices.*.total.search.query_total',
           'indices.*.total.search.query_time_in_millis',
+
           'indices.*.total.docs.count',
           'indices.*.total.docs.deleted',
           'indices.*.total.store.size_in_bytes',
+
+          'indices.*.primaries.docs.count',
+          'indices.*.primaries.docs.deleted',
+          'indices.*.primaries.store.size_in_bytes',
+
+          'indices.*.total.indexing.index_failed',
+          'indices.*.total.indexing.index_failed_due_to_version_conflict',
         ],
       };
 
@@ -1436,11 +1466,22 @@ export class TelemetryReceiver implements ITelemetryReceiver {
         for (const [indexName, stats] of Object.entries(response.indices ?? {})) {
           yield {
             index_name: indexName,
+
             query_total: stats.total?.search?.query_total,
             query_time_in_millis: stats.total?.search?.query_time_in_millis,
+
             docs_count: stats.total?.docs?.count,
             docs_deleted: stats.total?.docs?.deleted,
             docs_total_size_in_bytes: stats.total?.store?.size_in_bytes,
+
+            index_failed: stats.total?.indexing?.index_failed,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            index_failed_due_to_version_conflict: (stats.total?.indexing as any)
+              ?.index_failed_due_to_version_conflict,
+
+            docs_count_primaries: stats.primaries?.docs?.count,
+            docs_deleted_primaries: stats.primaries?.docs?.deleted,
+            docs_total_size_in_bytes_primaries: stats.primaries?.store?.size_in_bytes,
           } as IndexStats;
         }
       } catch (error) {
@@ -1450,10 +1491,11 @@ export class TelemetryReceiver implements ITelemetryReceiver {
     }
   }
 
-  public async *getIlmsStats(indices: string[]) {
+  public async *getIlmsStats(indices: string[], chunkSize: number) {
     const es = this.esClient();
+    const safeChunkSize = Math.min(chunkSize, 3000);
 
-    const groupedIndices = chunkStringsByMaxLength(indices);
+    const groupedIndices = chunkStringsByMaxLength(indices, safeChunkSize);
 
     this.logger.l('Splitted ilms into groups', {
       groups: groupedIndices.length,
@@ -1487,8 +1529,9 @@ export class TelemetryReceiver implements ITelemetryReceiver {
     }
   }
 
-  public async *getIlmsPolicies(ilms: string[]) {
+  public async *getIlmsPolicies(ilms: string[], chunkSize: number) {
     const es = this.esClient();
+    const safeChunkSize = Math.min(chunkSize, 3000);
 
     const phase = (obj: unknown): Nullable<IlmPhase> => {
       let value: Nullable<IlmPhase>;
@@ -1500,7 +1543,7 @@ export class TelemetryReceiver implements ITelemetryReceiver {
       return value;
     };
 
-    const groupedIlms = chunkStringsByMaxLength(ilms);
+    const groupedIlms = chunkStringsByMaxLength(ilms, safeChunkSize);
 
     this.logger.l('Splitted ilms into groups', {
       groups: groupedIlms.length,

--- a/x-pack/plugins/security_solution/server/lib/telemetry/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/types.ts
@@ -489,6 +489,11 @@ export interface IndicesMetadataConfiguration {
   indices_threshold: number;
   datastreams_threshold: number;
   indices_settings_threshold: number;
+
+  index_query_size: number;
+  ilm_stats_query_size: number;
+  ilm_policy_query_size: number;
+
   max_prefixes: number;
   max_group_size: number;
   min_group_size: number;

--- a/x-pack/test/security_solution_api_integration/test_suites/telemetry/tasks/indices_metadata.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/telemetry/tasks/indices_metadata.ts
@@ -5,21 +5,18 @@
  * 2.0.
  */
 
-import {
-  TELEMETRY_DATA_STREAM_EVENT,
-  TELEMETRY_ILM_POLICY_EVENT,
-  TELEMETRY_ILM_STATS_EVENT,
-  TELEMETRY_INDEX_STATS_EVENT,
-} from '@kbn/security-solution-plugin/server/lib/telemetry/event_based/events';
+import expect from 'expect';
 
 import { FtrProviderContext } from '../../../ftr_provider_context';
 import {
   cleanupDatastreams,
+  cleanupIngestPipelines,
   cleanupPolicies,
   ensureBackingIndices,
   launchTask,
   randomDatastream,
   randomIlmPolicy,
+  randomIngestPipeline,
   taskHasRun,
   waitFor,
 } from '../../../../common/utils/security_solution';
@@ -27,15 +24,23 @@ import {
 const TASK_ID = 'security:indices-metadata-telemetry:1.0.0';
 const NUM_INDICES = 5;
 
+const TELEMETRY_INDEX_STATS_EVENT = 'telemetry_index_stats_event';
+const TELEMETRY_ILM_STATS_EVENT = 'telemetry_ilm_stats_event';
+const TELEMETRY_ILM_POLICY_EVENT = 'telemetry_ilm_policy_event';
+const TELEMETRY_DATA_STREAM_EVENT = 'telemetry_data_stream_event';
+const TELEMETRY_INDEX_SETTINGS_EVENT = 'telemetry_index_settings_event';
+
 export default ({ getService }: FtrProviderContext) => {
   const ebtServer = getService('kibana_ebt_server');
   const kibanaServer = getService('kibanaServer');
   const logger = getService('log');
   const es = getService('es');
 
-  describe('Indices metadata task telemetry', function () {
+  describe('Security Telemetry - Indices metadata task telemetry', function () {
     let dsName: string;
     let policyName: string;
+    let defaultPipeline: string;
+    let finalPipeline: string;
 
     describe('@ess @serverless indices metadata', () => {
       beforeEach(async () => {
@@ -48,60 +53,21 @@ export default ({ getService }: FtrProviderContext) => {
       });
 
       it('should publish data stream events', async () => {
-        const runAt = await launchTask(TASK_ID, kibanaServer, logger);
+        const events = await launchTaskAndWaitForEvents({
+          eventTypes: [TELEMETRY_DATA_STREAM_EVENT],
+          dsName,
+        });
 
-        const opts = {
-          eventTypes: [TELEMETRY_DATA_STREAM_EVENT.eventType],
-          withTimeoutMs: 1000,
-          fromTimestamp: new Date().toISOString(),
-        };
-
-        await waitFor(
-          async () => {
-            const events = await ebtServer
-              .getEvents(Number.MAX_SAFE_INTEGER, opts)
-              .then((result) => result.map((ev) => ev.properties.items))
-              .then((result) => result.flat())
-              .then((result) => result.filter((ev) => (ev as any).datastream_name === dsName));
-
-            const hasRun = await taskHasRun(TASK_ID, kibanaServer, runAt);
-            const eventCount = events.length;
-
-            return hasRun && eventCount === 1;
-          },
-          'waitForTaskToRun',
-          logger
-        );
+        expect(events.length).toEqual(1);
       });
 
       it('should publish index stats events', async () => {
-        const runAt = await launchTask(TASK_ID, kibanaServer, logger);
+        const events = await launchTaskAndWaitForEvents({
+          eventTypes: [TELEMETRY_INDEX_STATS_EVENT],
+          index: dsName,
+        });
 
-        const opts = {
-          eventTypes: [TELEMETRY_INDEX_STATS_EVENT.eventType],
-          withTimeoutMs: 1000,
-          fromTimestamp: new Date().toISOString(),
-        };
-
-        // .ds-<ds-name>-YYYY.MM.DD-NNNNNN
-        const regex = new RegExp(`^\.ds-${dsName}-\\d{4}.\\d{2}.\\d{2}-\\d{6}$`);
-        await waitFor(
-          async () => {
-            const events = await ebtServer
-              .getEvents(Number.MAX_SAFE_INTEGER, opts)
-              .then((result) => result.map((ev) => ev.properties.items))
-              .then((result) => result.flat())
-              .then((result) =>
-                result.filter((ev) => regex.test((ev as any).index_name as string))
-              );
-
-            const hasRun = await taskHasRun(TASK_ID, kibanaServer, runAt);
-
-            return hasRun && events.length === NUM_INDICES;
-          },
-          'waitForTaskToRun',
-          logger
-        );
+        expect(events.length).toEqual(NUM_INDICES);
       });
     });
 
@@ -110,66 +76,209 @@ export default ({ getService }: FtrProviderContext) => {
 
       beforeEach(async () => {
         policyName = await randomIlmPolicy(es);
-        dsName = await randomDatastream(es, policyName);
+        defaultPipeline = await randomIngestPipeline(es);
+        finalPipeline = await randomIngestPipeline(es);
+        dsName = await randomDatastream(es, { policyName, defaultPipeline, finalPipeline });
         await ensureBackingIndices(dsName, NUM_INDICES, es);
       });
 
       afterEach(async () => {
         await cleanupDatastreams(es);
         await cleanupPolicies(es);
+        await cleanupIngestPipelines(es);
       });
 
       it('should publish ilm policy events', async () => {
-        const runAt = await launchTask(TASK_ID, kibanaServer, logger);
+        const events = await launchTaskAndWaitForEvents({
+          eventTypes: [TELEMETRY_ILM_POLICY_EVENT],
+          policyName,
+        });
 
-        const opts = {
-          eventTypes: [TELEMETRY_ILM_POLICY_EVENT.eventType],
-          withTimeoutMs: 1000,
-          fromTimestamp: new Date().toISOString(),
-        };
-
-        await waitFor(
-          async () => {
-            const events = await ebtServer
-              .getEvents(Number.MAX_SAFE_INTEGER, opts)
-              .then((result) => result.map((ev) => ev.properties.items))
-              .then((result) => result.flat())
-              .then((result) => result.filter((ev) => (ev as any).policy_name === policyName));
-
-            const hasRun = await taskHasRun(TASK_ID, kibanaServer, runAt);
-
-            return hasRun && events.length === 1;
-          },
-          'waitForTaskToRun',
-          logger
-        );
+        expect(events.length).toEqual(1);
       });
 
       it('should publish ilm stats events', async () => {
-        const runAt = await launchTask(TASK_ID, kibanaServer, logger);
+        const events = await launchTaskAndWaitForEvents({
+          eventTypes: [TELEMETRY_ILM_STATS_EVENT],
+          policyName,
+        });
 
-        const opts = {
-          eventTypes: [TELEMETRY_ILM_STATS_EVENT.eventType],
-          withTimeoutMs: 1000,
-          fromTimestamp: new Date().toISOString(),
-        };
+        expect(events.length).toEqual(NUM_INDICES);
+      });
 
-        await waitFor(
-          async () => {
-            const events = await ebtServer
-              .getEvents(Number.MAX_SAFE_INTEGER, opts)
-              .then((result) => result.map((ev) => ev.properties.items))
-              .then((result) => result.flat())
-              .then((result) => result.filter((ev) => (ev as any).policy_name === policyName));
+      it('index stats events should have the expected fields', async () => {
+        const numDocs = 10;
 
-            const hasRun = await taskHasRun(TASK_ID, kibanaServer, runAt);
+        // Index some docs
+        await indexRandomDocs(dsName, numDocs);
 
-            return hasRun && events.length === NUM_INDICES;
-          },
-          'waitForTaskToRun',
-          logger
+        // search docs to increment the stats and also to get a valid id
+        const search = await es.search({
+          index: dsName,
+        });
+        const id = search.hits.hits[0]._id ?? '';
+        const index = search.hits.hits[0]._index;
+
+        // create a doc with a version conflict to increment the failed stats
+        await es
+          .create({
+            index: dsName,
+            id,
+            body: { '@timestamp': new Date().toISOString(), foo: 'bar', bar: 99 },
+          })
+          .catch((_) => {});
+
+        // delete a doc to increment the deleted stats
+        await es.delete({ index, id });
+
+        const events = await launchTaskAndWaitForEvents({
+          eventTypes: [TELEMETRY_INDEX_STATS_EVENT],
+          index: dsName,
+        });
+        expect(events.length).toEqual(NUM_INDICES);
+
+        expect(
+          events.some((ev) => {
+            return (ev as any).docs_total_size_in_bytes_primaries > 1;
+          })
+        ).toBeTruthy();
+
+        expect(
+          events.some((ev) => {
+            return (ev as any).docs_deleted_primaries > 1;
+          })
+        ).toBeTruthy();
+
+        expect(
+          events.some((ev) => {
+            return (ev as any).docs_count_primaries === numDocs - 1;
+          })
+        ).toBeTruthy();
+
+        expect(
+          events.some((ev) => {
+            return (ev as any).docs_total_size_in_bytes > 1;
+          })
+        ).toBeTruthy();
+
+        expect(
+          events.some((ev) => {
+            return (ev as any).docs_deleted > 1;
+          })
+        ).toBeTruthy();
+
+        expect(
+          events.some((ev) => {
+            return (ev as any).docs_count === numDocs - 1;
+          })
+        ).toBeTruthy();
+
+        expect(
+          events.some((ev) => {
+            return (ev as any).query_total > 1;
+          })
+        ).toBeTruthy();
+
+        expect(
+          events.some((ev) => {
+            return (ev as any).index_failed_due_to_version_conflict === 1;
+          })
+        ).toBeTruthy();
+
+        expect(
+          events.some((ev) => {
+            return (ev as any).index_failed === 1;
+          })
+        ).toBeTruthy();
+      });
+
+      it('should publish indices settings', async () => {
+        const events = await launchTaskAndWaitForEvents({
+          eventTypes: [TELEMETRY_INDEX_SETTINGS_EVENT],
+          index: dsName,
+        });
+
+        expect(events.length).toEqual(NUM_INDICES);
+        expect(events.filter((v) => v.default_pipeline === defaultPipeline)).toHaveLength(
+          NUM_INDICES
         );
+        expect(events.filter((v) => v.final_pipeline === finalPipeline)).toHaveLength(NUM_INDICES);
       });
     });
+
+    const indexRandomDocs = async (index: string, count: number) => {
+      for (let i = 0; i < count; i++) {
+        await es.index({
+          index,
+          body: { '@timestamp': new Date().toISOString(), foo: 'bar', bar: i },
+        });
+      }
+
+      await waitFor(
+        async () => {
+          const resp = await es.count({ index });
+
+          return resp.count === count;
+        },
+        'waitForTaskToRun',
+        logger
+      );
+    };
+
+    const launchTaskAndWaitForEvents = async (params: {
+      eventTypes: string[];
+      dsName?: string;
+      policyName?: string;
+      index?: string;
+    }) => {
+      const datastream = params.dsName;
+      const index = params.index;
+      const policy = params.policyName;
+
+      const runAt = await launchTask(TASK_ID, kibanaServer, logger);
+      const opts = {
+        eventTypes: params.eventTypes,
+        withTimeoutMs: 1000,
+        fromTimestamp: new Date().toISOString(),
+      };
+
+      // .ds-<ds-name>-YYYY.MM.DD-NNNNNN
+      const regex = new RegExp(`^\.ds-${index}-\\d{4}.\\d{2}.\\d{2}-\\d{6}$`);
+      let events: any[] = [];
+      await waitFor(
+        async () => {
+          events = await ebtServer
+            .getEvents(Number.MAX_SAFE_INTEGER, opts)
+            .then((result) => result.map((ev) => ev.properties.items))
+            .then((result) => result.flat())
+            .then((result) =>
+              result.filter((ev) => {
+                const event = ev as any;
+                return index === undefined || regex.test(event.index_name as string);
+              })
+            )
+            .then((result) =>
+              result.filter((ev) => {
+                const event = ev as any;
+                return datastream === undefined || event.datastream_name === datastream;
+              })
+            )
+            .then((result) =>
+              result.filter((ev) => {
+                const event = ev as any;
+                return policy === undefined || event.policy_name === policy;
+              })
+            );
+
+          const hasRun = await taskHasRun(TASK_ID, kibanaServer, runAt);
+
+          return hasRun && events.length > 0;
+        },
+        'waitForTaskToRun',
+        logger
+      );
+
+      return events;
+    };
   });
 };

--- a/x-pack/test/security_solution_api_integration/test_suites/telemetry/tasks/indices_metadata.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/telemetry/tasks/indices_metadata.ts
@@ -179,12 +179,8 @@ export default ({ getService }: FtrProviderContext) => {
           })
         ).toBeTruthy();
 
-        expect(
-          events.some((ev) => {
-            return (ev as any).index_failed_due_to_version_conflict === 1;
-          })
-        ).toBeTruthy();
-
+        // index_failed_due_to_version_conflict not available in 8.16, only
+        // assert `index_failed`
         expect(
           events.some((ev) => {
             return (ev as any).index_failed === 1;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Security Solution][Telemetry] Collect additional index stats (#213822)](https://github.com/elastic/kibana/pull/213822)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastián Zaffarano","email":"sebastian.zaffarano@elastic.co"},"sourceCommit":{"committedDate":"2025-03-25T13:18:31Z","message":"[Security Solution][Telemetry] Collect additional index stats (#213822)\n\n## Summary\n\n- Collect information about index_failed stats: Adds two new fields,\n`index_failed_due_to_version_conflict` and `index_failed` to the\nexistent\n[TELEMETRY_INDEX_STATS_EVENT](https://github.com/elastic/kibana/blob/933564d713c3f6c090702cdca97a76073d437419/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts#L325)\nEBT event.\n- Since the `docs_count`, `docs_deleted` and `docs_total_size_in_bytes`\nrepresent the totals (i.e., primaries and replicas), add the counterpart\n`_primaries` fields to collect values from primaries to the existent\n[TELEMETRY_INDEX_STATS_EVENT](https://github.com/elastic/kibana/blob/933564d713c3f6c090702cdca97a76073d437419/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts#L325)\nEBT event\n- Add a new `IndexSettings` ebt event with the following information\n```js\nexport interface IndicesSettings {\n  items: IndexSettings[];\n}\n\nexport interface IndexSettings {\n  index_name: string;\n  default_pipeline?: string;\n  final_pipeline?: string;\n}\n```\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"82f6a89e62cfd3cc3cd1cf5a2159c871d91f0e5b","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team: SecuritySolution","backport:prev-minor","backport:prev-major","ci:build-cloud-image","ci:cloud-deploy","ci:cloud-redeploy","ci:project-deploy-security","v8.18.0","v9.1.0","v8.19.0"],"title":"[Security Solution][Telemetry] Collect additional index stats","number":213822,"url":"https://github.com/elastic/kibana/pull/213822","mergeCommit":{"message":"[Security Solution][Telemetry] Collect additional index stats (#213822)\n\n## Summary\n\n- Collect information about index_failed stats: Adds two new fields,\n`index_failed_due_to_version_conflict` and `index_failed` to the\nexistent\n[TELEMETRY_INDEX_STATS_EVENT](https://github.com/elastic/kibana/blob/933564d713c3f6c090702cdca97a76073d437419/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts#L325)\nEBT event.\n- Since the `docs_count`, `docs_deleted` and `docs_total_size_in_bytes`\nrepresent the totals (i.e., primaries and replicas), add the counterpart\n`_primaries` fields to collect values from primaries to the existent\n[TELEMETRY_INDEX_STATS_EVENT](https://github.com/elastic/kibana/blob/933564d713c3f6c090702cdca97a76073d437419/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts#L325)\nEBT event\n- Add a new `IndexSettings` ebt event with the following information\n```js\nexport interface IndicesSettings {\n  items: IndexSettings[];\n}\n\nexport interface IndexSettings {\n  index_name: string;\n  default_pipeline?: string;\n  final_pipeline?: string;\n}\n```\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"82f6a89e62cfd3cc3cd1cf5a2159c871d91f0e5b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215877","number":215877,"state":"MERGED","mergeCommit":{"sha":"6387080d0c98c67f4b1840011f7df156e38590a8","message":"[9.0] [Security Solution][Telemetry] Collect additional index stats (#213822) (#215877)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Security Solution][Telemetry] Collect additional index stats\n(#213822)](https://github.com/elastic/kibana/pull/213822)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215875","number":215875,"state":"MERGED","mergeCommit":{"sha":"39748598329d399ca8adff3433999ee0032b9b00","message":"[8.18] [Security Solution][Telemetry] Collect additional index stats (#213822) (#215875)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Security Solution][Telemetry] Collect additional index stats\n(#213822)](https://github.com/elastic/kibana/pull/213822)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213822","number":213822,"mergeCommit":{"message":"[Security Solution][Telemetry] Collect additional index stats (#213822)\n\n## Summary\n\n- Collect information about index_failed stats: Adds two new fields,\n`index_failed_due_to_version_conflict` and `index_failed` to the\nexistent\n[TELEMETRY_INDEX_STATS_EVENT](https://github.com/elastic/kibana/blob/933564d713c3f6c090702cdca97a76073d437419/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts#L325)\nEBT event.\n- Since the `docs_count`, `docs_deleted` and `docs_total_size_in_bytes`\nrepresent the totals (i.e., primaries and replicas), add the counterpart\n`_primaries` fields to collect values from primaries to the existent\n[TELEMETRY_INDEX_STATS_EVENT](https://github.com/elastic/kibana/blob/933564d713c3f6c090702cdca97a76073d437419/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts#L325)\nEBT event\n- Add a new `IndexSettings` ebt event with the following information\n```js\nexport interface IndicesSettings {\n  items: IndexSettings[];\n}\n\nexport interface IndexSettings {\n  index_name: string;\n  default_pipeline?: string;\n  final_pipeline?: string;\n}\n```\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"82f6a89e62cfd3cc3cd1cf5a2159c871d91f0e5b"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215876","number":215876,"state":"MERGED","mergeCommit":{"sha":"3fa3f0bd7e5158989c19ddb9706c1d153f9f3f8a","message":"[8.x] [Security Solution][Telemetry] Collect additional index stats (#213822) (#215876)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Security Solution][Telemetry] Collect additional index stats\n(#213822)](https://github.com/elastic/kibana/pull/213822)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sebastián Zaffarano <sebastian.zaffarano@elastic.co>"}}]}] BACKPORT-->