### PR TITLE
[A11y][APM] Use `nameTooltip` api for dependencies tables

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/dependency_detail_operations/dependency_detail_operations_list/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/dependency_detail_operations/dependency_detail_operations_list/index.tsx
@@ -9,6 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { keyBy } from 'lodash';
 import React, { useEffect } from 'react';
 import { usePerformanceContext } from '@kbn/ebt-tools';
+import type { EuiBasicTableColumn } from '@elastic/eui';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { useSearchServiceDestinationMetrics } from '../../../../context/time_range_metadata/use_search_service_destination_metrics';
 import { useApmParams } from '../../../../hooks/use_apm_params';
@@ -18,7 +19,6 @@ import { useTimeRange } from '../../../../hooks/use_time_range';
 import type { SpanMetricGroup } from '../../../shared/dependencies_table/get_span_metric_columns';
 import { getSpanMetricColumns } from '../../../shared/dependencies_table/get_span_metric_columns';
 import { EmptyMessage } from '../../../shared/empty_message';
-import type { ITableColumn } from '../../../shared/managed_table';
 import { ManagedTable } from '../../../shared/managed_table';
 import { getComparisonEnabled } from '../../../shared/time_comparison/get_comparison_enabled';
 import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
@@ -147,7 +147,7 @@ export function DependencyDetailOperationsList() {
     }
   }, [onPageReady, primaryStatsFetch, comparisonStatsFetch, rangeFrom, rangeTo]);
 
-  const columns: Array<ITableColumn<OperationStatisticsItem>> = [
+  const columns: Array<EuiBasicTableColumn<OperationStatisticsItem>> = [
     {
       name: i18n.translate('xpack.apm.dependencyDetailOperationsList.spanNameColumnLabel', {
         defaultMessage: 'Span name',

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/dependency_detail_operations/dependency_detail_operations_list/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/dependency_detail_operations/dependency_detail_operations_list/index.tsx
@@ -9,7 +9,6 @@ import { i18n } from '@kbn/i18n';
 import { keyBy } from 'lodash';
 import React, { useEffect } from 'react';
 import { usePerformanceContext } from '@kbn/ebt-tools';
-import type { EuiBasicTableColumn } from '@elastic/eui';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { useSearchServiceDestinationMetrics } from '../../../../context/time_range_metadata/use_search_service_destination_metrics';
 import { useApmParams } from '../../../../hooks/use_apm_params';
@@ -19,7 +18,7 @@ import { useTimeRange } from '../../../../hooks/use_time_range';
 import type { SpanMetricGroup } from '../../../shared/dependencies_table/get_span_metric_columns';
 import { getSpanMetricColumns } from '../../../shared/dependencies_table/get_span_metric_columns';
 import { EmptyMessage } from '../../../shared/empty_message';
-import { ManagedTable } from '../../../shared/managed_table';
+import { type ITableColumn, ManagedTable } from '../../../shared/managed_table';
 import { getComparisonEnabled } from '../../../shared/time_comparison/get_comparison_enabled';
 import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
 import { DependencyOperationDetailLink } from '../../dependency_operation_detail_view/dependency_operation_detail_link';
@@ -147,7 +146,7 @@ export function DependencyDetailOperationsList() {
     }
   }, [onPageReady, primaryStatsFetch, comparisonStatsFetch, rangeFrom, rangeTo]);
 
-  const columns: Array<EuiBasicTableColumn<OperationStatisticsItem>> = [
+  const columns: Array<ITableColumn<OperationStatisticsItem>> = [
     {
       name: i18n.translate('xpack.apm.dependencyDetailOperationsList.spanNameColumnLabel', {
         defaultMessage: 'Span name',

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/dependencies_table/get_span_metric_columns.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/dependencies_table/get_span_metric_columns.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 import React from 'react';
-import type { EuiBasicTableColumn } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, RIGHT_ALIGNMENT } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ChartType, getTimeSeriesColor } from '../charts/helper/get_timeseries_color';
@@ -20,6 +19,7 @@ import {
 import type { Coordinate } from '../../../../typings/timeseries';
 import { ImpactBar } from '../impact_bar';
 import { isFiniteNumber } from '../../../../common/utils/is_finite_number';
+import type { ITableColumn } from '../managed_table';
 
 export interface SpanMetricGroup {
   latency: number | null;
@@ -49,7 +49,7 @@ export function getSpanMetricColumns({
 }: {
   comparisonFetchStatus: FETCH_STATUS;
   shouldShowSparkPlots: boolean;
-}): Array<EuiBasicTableColumn<SpanMetricGroup>> {
+}): Array<ITableColumn<SpanMetricGroup>> {
   const isLoading = isPending(comparisonFetchStatus);
 
   return [

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/dependencies_table/get_span_metric_columns.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/dependencies_table/get_span_metric_columns.tsx
@@ -5,11 +5,11 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiIconTip, RIGHT_ALIGNMENT } from '@elastic/eui';
+import type { EuiBasicTableColumn } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, RIGHT_ALIGNMENT } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ChartType, getTimeSeriesColor } from '../charts/helper/get_timeseries_color';
 import { ListMetric } from '../list_metric';
-import type { ITableColumn } from '../managed_table';
 import type { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { isPending } from '../../../hooks/use_fetcher';
 import {
@@ -49,7 +49,7 @@ export function getSpanMetricColumns({
 }: {
   comparisonFetchStatus: FETCH_STATUS;
   shouldShowSparkPlots: boolean;
-}): Array<ITableColumn<SpanMetricGroup>> {
+}): Array<EuiBasicTableColumn<SpanMetricGroup>> {
   const isLoading = isPending(comparisonFetchStatus);
 
   return [
@@ -107,24 +107,15 @@ export function getSpanMetricColumns({
     },
     {
       field: 'failureRate',
-      name: (
-        <>
-          {i18n.translate('xpack.apm.dependenciesTable.columnErrorRate', {
-            defaultMessage: 'Failed transaction rate',
-          })}
-          &nbsp;
-          <EuiIconTip
-            size="s"
-            color="subdued"
-            type="questionInCircle"
-            content={i18n.translate('xpack.apm.dependenciesTable.columnErrorRateTip', {
-              defaultMessage:
-                "The percentage of failed transactions for the selected service. HTTP server transactions with a 4xx status code (client error) aren't considered failures because the caller, not the server, caused the failure.",
-            })}
-            className="eui-alignCenter"
-          />
-        </>
-      ),
+      name: i18n.translate('xpack.apm.dependenciesTable.columnErrorRate', {
+        defaultMessage: 'Failed transaction rate',
+      }),
+      nameTooltip: {
+        content: i18n.translate('xpack.apm.dependenciesTable.columnErrorRateTip', {
+          defaultMessage:
+            "The percentage of failed transactions for the selected service. HTTP server transactions with a 4xx status code (client error) aren't considered failures because the caller, not the server, caused the failure.",
+        }),
+      },
       align: RIGHT_ALIGNMENT,
       render: (_, { failureRate, currentStats, previousStats }) => {
         const { currentPeriodColor, previousPeriodColor } = getTimeSeriesColor(
@@ -148,24 +139,15 @@ export function getSpanMetricColumns({
     },
     {
       field: 'impact',
-      name: (
-        <>
-          {i18n.translate('xpack.apm.dependenciesTable.columnImpact', {
-            defaultMessage: 'Impact',
-          })}
-          &nbsp;
-          <EuiIconTip
-            size="s"
-            color="subdued"
-            type="questionInCircle"
-            className="eui-alignCenter"
-            content={i18n.translate('xpack.apm.dependenciesTable.columnImpactTip', {
-              defaultMessage:
-                'The most used and slowest endpoints in your service. Calculated by multiplying latency by throughput.',
-            })}
-          />
-        </>
-      ),
+      name: i18n.translate('xpack.apm.dependenciesTable.columnImpact', {
+        defaultMessage: 'Impact',
+      }),
+      nameTooltip: {
+        content: i18n.translate('xpack.apm.dependenciesTable.columnImpactTip', {
+          defaultMessage:
+            'The most used and slowest endpoints in your service. Calculated by multiplying latency by throughput.',
+        }),
+      },
       align: RIGHT_ALIGNMENT,
       render: (_, { impact, previousStats }) => {
         return (

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -5,14 +5,13 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiTitle, type EuiBasicTableColumn } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
 import type { ConnectionStatsItemWithComparisonData } from '../../../../common/connections';
 import { useBreakpoints } from '../../../hooks/use_breakpoints';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { EmptyMessage } from '../empty_message';
-import type { ITableColumn } from '../managed_table';
 import { ManagedTable } from '../managed_table';
 import { OverviewTableContainer } from '../overview_table_container';
 import { TruncateWithTooltip } from '../truncate_with_tooltip';
@@ -87,7 +86,7 @@ export function DependenciesTable({
     [dependencies]
   );
 
-  const columns: Array<ITableColumn<FormattedSpanMetricGroup>> = [
+  const columns: Array<EuiBasicTableColumn<FormattedSpanMetricGroup>> = [
     {
       field: 'name',
       name: nameColumnTitle,

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiTitle, type EuiBasicTableColumn } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useMemo } from 'react';
 import type { ConnectionStatsItemWithComparisonData } from '../../../../common/connections';
 import { useBreakpoints } from '../../../hooks/use_breakpoints';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { EmptyMessage } from '../empty_message';
-import { ManagedTable } from '../managed_table';
+import { type ITableColumn, ManagedTable } from '../managed_table';
 import { OverviewTableContainer } from '../overview_table_container';
 import { TruncateWithTooltip } from '../truncate_with_tooltip';
 import type { SpanMetricGroup } from './get_span_metric_columns';
@@ -86,7 +86,7 @@ export function DependenciesTable({
     [dependencies]
   );
 
-  const columns: Array<EuiBasicTableColumn<FormattedSpanMetricGroup>> = [
+  const columns: Array<ITableColumn<FormattedSpanMetricGroup>> = [
     {
       field: 'name',
       name: nameColumnTitle,

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { EuiBasicTableColumn } from '@elastic/eui';
+import type { EuiBasicTableColumn, EuiTableFieldDataColumnType } from '@elastic/eui';
 import { EuiBasicTable, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { isEmpty, merge, orderBy } from 'lodash';
 import type { ReactNode } from 'react';
@@ -68,7 +68,7 @@ export const shouldfetchServer = ({
 
 function UnoptimizedManagedTable<T extends object>(props: {
   items: T[];
-  columns: Array<ITableColumn<T>>;
+  columns: Array<EuiBasicTableColumn<T>>;
   rowHeader?: string | false;
   noItemsMessage?: React.ReactNode;
   isLoading?: boolean;
@@ -96,6 +96,7 @@ function UnoptimizedManagedTable<T extends object>(props: {
 }) {
   const [searchQuery, setSearchQuery] = useState('');
   const history = useHistory();
+  const firstField = (props.columns[0] as EuiTableFieldDataColumnType<T>)?.field as string;
 
   const {
     items,
@@ -109,7 +110,7 @@ function UnoptimizedManagedTable<T extends object>(props: {
     pagination = true,
     initialPageIndex = 0,
     initialPageSize = 10,
-    initialSortField = props.columns[0]?.field || '',
+    initialSortField = firstField || '',
     initialSortDirection = 'asc',
     showPerPageOptions = true,
 
@@ -292,8 +293,8 @@ function UnoptimizedManagedTable<T extends object>(props: {
               : noItemsMessage
           }
           items={renderedItems}
-          columns={columns as unknown as Array<EuiBasicTableColumn<T>>} // EuiBasicTableColumn is stricter than ITableColumn
-          rowHeader={rowHeader === false ? undefined : rowHeader ?? columns[0]?.field}
+          columns={columns}
+          rowHeader={rowHeader === false ? undefined : rowHeader ?? firstField}
           sorting={sorting}
           onChange={onTableChange}
           {...(paginationProps ? { pagination: paginationProps } : {})}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { EuiBasicTableColumn, EuiTableFieldDataColumnType } from '@elastic/eui';
+import type { EuiBasicTableColumn } from '@elastic/eui';
 import { EuiBasicTable, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { isEmpty, merge, orderBy } from 'lodash';
 import type { ReactNode } from 'react';
@@ -36,6 +36,7 @@ export interface ITableColumn<T extends object> {
   width?: string;
   sortable?: boolean;
   truncateText?: boolean;
+  nameTooltip?: EuiBasicTableColumn<T>['nameTooltip'];
   render?: (value: any, item: T) => unknown;
 }
 
@@ -68,7 +69,7 @@ export const shouldfetchServer = ({
 
 function UnoptimizedManagedTable<T extends object>(props: {
   items: T[];
-  columns: Array<EuiBasicTableColumn<T>>;
+  columns: Array<ITableColumn<T>>;
   rowHeader?: string | false;
   noItemsMessage?: React.ReactNode;
   isLoading?: boolean;
@@ -96,7 +97,6 @@ function UnoptimizedManagedTable<T extends object>(props: {
 }) {
   const [searchQuery, setSearchQuery] = useState('');
   const history = useHistory();
-  const firstField = (props.columns[0] as EuiTableFieldDataColumnType<T>)?.field as string;
 
   const {
     items,
@@ -110,7 +110,7 @@ function UnoptimizedManagedTable<T extends object>(props: {
     pagination = true,
     initialPageIndex = 0,
     initialPageSize = 10,
-    initialSortField = firstField || '',
+    initialSortField = props.columns[0]?.field || '',
     initialSortDirection = 'asc',
     showPerPageOptions = true,
 
@@ -293,8 +293,8 @@ function UnoptimizedManagedTable<T extends object>(props: {
               : noItemsMessage
           }
           items={renderedItems}
-          columns={columns}
-          rowHeader={rowHeader === false ? undefined : rowHeader ?? firstField}
+          columns={columns as unknown as Array<EuiBasicTableColumn<T>>} // EuiBasicTableColumn is stricter than ITableColumn
+          rowHeader={rowHeader === false ? undefined : rowHeader ?? columns[0]?.field}
           sorting={sorting}
           onChange={onTableChange}
           {...(paginationProps ? { pagination: paginationProps } : {})}


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/195041

This PR addresses the issue where the table name's tooltip cannot be focused with keyboard.

## Video

https://github.com/user-attachments/assets/bec887fd-5a3b-4fa9-b84b-17a1a4187fbc



<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->