### PR TITLE
[Upgrade Assistant] fix logs index pattern

### DIFF
--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/deprecation_logs/consts.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/deprecation_logs/consts.ts
@@ -8,4 +8,4 @@
  */
 
 export const DEPRECATION_LOGS_PROFILE_ID = 'deprecation-logs-profile';
-export const DEPRECATION_LOGS_PATTERN_PREFIX = '.logs-deprecation';
+export const DEPRECATION_LOGS_PATTERN_PREFIX = '.logs-elasticsearch';

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/deprecation_logs/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/common/deprecation_logs/profile.test.ts
@@ -16,9 +16,15 @@ import { DEPRECATION_LOGS_PROFILE_ID } from './consts';
 
 describe('deprecationLogsProfileProvider', () => {
   const deprecationLogsProfileProvider = createDeprecationLogsDataSourceProfileProvider();
-  const VALID_INDEX_PATTERN = '.logs-deprecation.elasticsearch-default';
-  const VALID_MIXED_INDEX_PATTERN =
+
+  const INVALID_IN_V9_INDEX_PATTERN = '.logs-deprecation.elasticsearch-default';
+  const INVALID_IN_V9_MIXED_INDEX_PATTERN =
     '.logs-deprecation.elasticsearch-default,.logs-deprecation.abc,.logs-deprecation.def';
+
+  const VALID_INDEX_PATTERN = '.logs-elasticsearch.deprecation-default';
+  const VALID_MIXED_INDEX_PATTERN =
+    '.logs-elasticsearch.deprecation-default,.logs-elasticsearch.abc,.logs-elasticsearch.def';
+
   const INVALID_MIXED_INDEX_PATTERN = '.logs-deprecation.elasticsearch-default,metrics-*';
   const INVALID_INDEX_PATTERN = 'my_source-access-*';
   const ROOT_CONTEXT: ContextWithProfileId<RootContext> = {
@@ -62,11 +68,29 @@ describe('deprecationLogsProfileProvider', () => {
     expect(result).toEqual(RESOLUTION_MISMATCH);
   });
 
+  it('should NOT match data view sources prior with pre-9.0 index patterns', () => {
+    const result = deprecationLogsProfileProvider.resolve({
+      rootContext: ROOT_CONTEXT,
+      dataSource: createDataViewDataSource({ dataViewId: INVALID_IN_V9_INDEX_PATTERN }),
+      dataView: createStubIndexPattern({ spec: { title: INVALID_IN_V9_INDEX_PATTERN } }),
+    });
+    expect(result).toEqual(RESOLUTION_MISMATCH);
+  });
+
   it('should NOT match data view sources with a mixed pattern containing not allowed index patterns', () => {
     const result = deprecationLogsProfileProvider.resolve({
       rootContext: ROOT_CONTEXT,
       dataSource: createDataViewDataSource({ dataViewId: INVALID_MIXED_INDEX_PATTERN }),
       dataView: createStubIndexPattern({ spec: { title: INVALID_MIXED_INDEX_PATTERN } }),
+    });
+    expect(result).toEqual(RESOLUTION_MISMATCH);
+  });
+
+  it('should NOT match data view sources with a mixed pattern containing pre-9.0 index patterns', () => {
+    const result = deprecationLogsProfileProvider.resolve({
+      rootContext: ROOT_CONTEXT,
+      dataSource: createDataViewDataSource({ dataViewId: INVALID_IN_V9_MIXED_INDEX_PATTERN }),
+      dataView: createStubIndexPattern({ spec: { title: INVALID_IN_V9_MIXED_INDEX_PATTERN } }),
     });
     expect(result).toEqual(RESOLUTION_MISMATCH);
   });

--- a/x-pack/platform/plugins/private/upgrade_assistant/common/constants.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/common/constants.ts
@@ -14,8 +14,8 @@ export const CLOUD_SNAPSHOT_REPOSITORY = 'found-snapshots';
 
 export const DEPRECATION_WARNING_UPPER_LIMIT = 999999;
 export const DEPRECATION_LOGS_SOURCE_ID = 'deprecation_logs';
-export const DEPRECATION_LOGS_INDEX = '.logs-deprecation.elasticsearch-default';
-export const DEPRECATION_LOGS_INDEX_PATTERN = '.logs-deprecation.elasticsearch-default';
+export const DEPRECATION_LOGS_INDEX = '.logs-elasticsearch.deprecation-default';
+export const DEPRECATION_LOGS_INDEX_PATTERN = '.logs-elasticsearch.deprecation-default';
 
 export const CLUSTER_UPGRADE_STATUS_POLL_INTERVAL_MS = 45000;
 export const CLOUD_BACKUP_STATUS_POLL_INTERVAL_MS = 60000;


### PR DESCRIPTION
## Summary
In `9.0+`,  Elasticsearch's deprecation logs have changed the dataset name to be consistent across products. Previously the dataset was `deprecations.elasticsearch`, but it is now `elasticsearch.deprecations` (adhering to the pattern across elasticsearch of product.group).

To fix this in UA we updated the index pattern constant used to create the data view to `.logs-elasticsearch.deprecation-default`


Pending Fix to be merged in ES first before we test and merge this change.