### PR TITLE
[Cloud Security] Warning callout for agentless deployment with traffic filters

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
@@ -17,6 +17,8 @@ import {
   EuiTitle,
   EuiRadioGroupOption,
   EuiText,
+  EuiCallOut,
+  EuiLink,
 } from '@elastic/eui';
 import { SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ } from '../../test_subjects';
 
@@ -96,6 +98,23 @@ export const SetupTechnologySelector = ({
     );
   };
 
+  const limitationsMessage = (
+    <FormattedMessage
+      id="xpack.csp.setupTechnologySelector.comingSoon"
+      defaultMessage="Agentless deployment does not work if you are using {link}."
+      values={{
+        link: (
+          <EuiLink
+            href="https://www.elastic.co/guide/en/cloud-enterprise/current/ece-traffic-filtering-deployment-configuration.html"
+            target="_blank"
+          >
+            Traffic filtering
+          </EuiLink>
+        ),
+      }}
+    />
+  );
+
   return (
     <>
       <EuiSpacer size="l" />
@@ -107,7 +126,9 @@ export const SetupTechnologySelector = ({
           />
         </h2>
       </EuiTitle>
-      <EuiSpacer size="s" />
+      <EuiSpacer size="m" />
+      <EuiCallOut title={limitationsMessage} color="warning" iconType="alert" size="m" />
+      <EuiSpacer size="m" />
       <EuiRadioGroup
         disabled={disabled}
         data-test-subj={SETUP_TECHNOLOGY_SELECTOR_TEST_SUBJ}


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/security-team/issues/12218

Add a call out warning to inform the user that agentless deployments will not work with traffic filters.

![Screenshot 2025-03-25 at 3 32 43 PM](https://github.com/user-attachments/assets/a607b0a6-924a-4e82-9678-0deaf7e426e1)



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->