### PR TITLE
[Security Solution] [Attack discovery] Use kibana.alert.building_block_type instead of kibana.alert.rule.building_block_type in alerts preview

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.test.ts
@@ -17,7 +17,7 @@ describe('getAlertSummaryEsqlQuery', () => {
 
     expect(query).toBe(
       `FROM alerts-* METADATA _id, _index, _version, _ignored
-| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT 100
 | STATS Count = count() by \`kibana.alert.rule.name\`
@@ -36,7 +36,7 @@ describe('getAlertSummaryEsqlQuery', () => {
 
     expect(query).toBe(
       `FROM alerts-* METADATA _id, _index, _version, _ignored
-| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT 100
 | STATS Count = count() by \`kibana.alert.severity\`

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alert_summary_tab/get_alert_summary_esql_query/index.ts
@@ -16,7 +16,7 @@ export const getAlertSummaryEsqlQuery = ({
   maxAlerts: number;
   tableStackBy0: string;
 }): string => `FROM ${alertsIndexPattern} METADATA _id, _index, _version, _ignored
-| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT ${maxAlerts}
 | STATS Count = count() by \`${tableStackBy0}\`

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_esql_query/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_esql_query/index.test.ts
@@ -17,7 +17,7 @@ describe('getAlertsPreviewEsqlQuery', () => {
 
     expect(result).toBe(
       `FROM alerts-* METADATA _id, _index, _version, _ignored
-| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT 10
 | RENAME kibana.alert.rule.name AS \`Rule name\`, kibana.alert.risk_score AS \`Risk score\`
@@ -34,7 +34,7 @@ describe('getAlertsPreviewEsqlQuery', () => {
 
     expect(result).toBe(
       `FROM alerts-* METADATA _id, _index, _version, _ignored
-| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT 10
 | RENAME kibana.alert.risk_score AS \`Risk score\`
@@ -51,7 +51,7 @@ describe('getAlertsPreviewEsqlQuery', () => {
 
     expect(result).toBe(
       `FROM alerts-* METADATA _id, _index, _version, _ignored
-| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT 10
 | RENAME kibana.alert.risk_score AS \`Risk score\`
@@ -68,7 +68,7 @@ describe('getAlertsPreviewEsqlQuery', () => {
 
     expect(result).toBe(
       `FROM alerts-* METADATA _id, _index, _version, _ignored
-| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT 5
 | RENAME kibana.alert.rule.name AS \`Rule name\`, kibana.alert.risk_score AS \`Risk score\`
@@ -85,7 +85,7 @@ describe('getAlertsPreviewEsqlQuery', () => {
 
     expect(result).toBe(
       `FROM custom-alerts-* METADATA _id, _index, _version, _ignored
-| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT 10
 | RENAME kibana.alert.rule.name AS \`Rule name\`, kibana.alert.risk_score AS \`Risk score\`

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_esql_query/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/settings_flyout/alert_selection/alerts_preview_tab/get_alerts_preview_esql_query/index.ts
@@ -16,7 +16,7 @@ export const getAlertsPreviewEsqlQuery = ({
   maxAlerts: number;
   tableStackBy0: string;
 }): string => `FROM ${alertsIndexPattern} METADATA _id, _index, _version, _ignored
-| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.rule.building_block_type IS NULL
+| WHERE kibana.alert.workflow_status IN ("open", "acknowledged") AND kibana.alert.building_block_type IS NULL
 | SORT kibana.alert.risk_score DESC, @timestamp DESC
 | LIMIT ${maxAlerts}
 ${getEsqlKeepStatement(tableStackBy0)}


### PR DESCRIPTION
### [Security Solution] [Attack discovery] Use kibana.alert.building_block_type instead of kibana.alert.rule.building_block_type in alerts preview

This PR updates the query used in the Attack discovery alerts preview to fix an issue where EQL sequence rules are counted differently in the preview.

It updates the query to use `kibana.alert.building_block_type` instead of `kibana.alert.rule.building_block_type`.

**Details**

For most rule types generated via the detection engine, the `kibana.alert.building_block_type` and `kibana.alert.rule.building_block_type` fields will both have the same value, for example:

```
{
  "kibana.alert.building_block_type": "default",
  "kibana.alert.rule.building_block_type": "default",
}
```

However, EQL sequence rules can have building block alerts, even through _the rule itself_ is not a building block rule.

To ensure the preview is accurate for EQL sequence rules, (which will have a null `kibana.alert.rule.building_block_type`) the filter must use the non-rule flavor of the field: `kibana.alert.building_block_type`.


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->