### PR TITLE
[8.18] [Cloud Security] Changed agentless limitation callout to have `is not supported` (#215964)

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
@@ -101,7 +101,7 @@ export const SetupTechnologySelector = ({
   const limitationsMessage = (
     <FormattedMessage
       id="xpack.csp.setupTechnologySelector.comingSoon"
-      defaultMessage="Agentless deployment does not work if you are using {link}."
+      defaultMessage="Agentless deployment is not supported if you are using {link}."
       values={{
         link: (
           <EuiLink


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Cloud Security] Changed agentless limitation callout to have `is not supported` (#215964)](https://github.com/elastic/kibana/pull/215964)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"seanrathier","email":"sean.rathier@gmail.com"},"sourceCommit":{"committedDate":"2025-03-26T00:24:44Z","message":"[Cloud Security] Changed agentless limitation callout to have `is not supported` (#215964)","sha":"5dcd3d8b747702765b8bb52372c52c5e212e5990","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Cloud Security","backport:prev-minor","v9.1.0","backport:8.18"],"title":"[Cloud Security] Changed agentless limitation callout to have `is not supported`","number":215964,"url":"https://github.com/elastic/kibana/pull/215964","mergeCommit":{"message":"[Cloud Security] Changed agentless limitation callout to have `is not supported` (#215964)","sha":"5dcd3d8b747702765b8bb52372c52c5e212e5990"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215971","number":215971,"state":"MERGED","mergeCommit":{"sha":"0bdd41e603dd4ceeeb4ff25850a7b00d14f0b0f3","message":"[9.0] [Cloud Security] Changed agentless limitation callout to have `is not supported` (#215964) (#215971)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Cloud Security] Changed agentless limitation callout to have `is not\nsupported` (#215964)](https://github.com/elastic/kibana/pull/215964)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: seanrathier <sean.rathier@gmail.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215964","number":215964,"mergeCommit":{"message":"[Cloud Security] Changed agentless limitation callout to have `is not supported` (#215964)","sha":"5dcd3d8b747702765b8bb52372c52c5e212e5990"}}]}] BACKPORT-->