### PR TITLE
[ES|QL] Accessible warnings / errors button

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/editor_footer/errors_warnings_popover.tsx
@@ -10,13 +10,13 @@
 import React from 'react';
 import { i18n } from '@kbn/i18n';
 import {
-  EuiText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
   EuiPopover,
   EuiDescriptionList,
   EuiDescriptionListDescription,
+  EuiButtonEmpty,
   euiTextBreakWord,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -26,7 +26,7 @@ import type { MonacoMessage } from '../helpers';
 const getConstsByType = (type: 'error' | 'warning', count: number) => {
   if (type === 'error') {
     return {
-      color: 'danger',
+      color: 'danger' as const,
       message: i18n.translate('esqlEditor.query.errorCount', {
         defaultMessage: '{count} {count, plural, one {error} other {errors}}',
         values: { count },
@@ -37,7 +37,7 @@ const getConstsByType = (type: 'error' | 'warning', count: number) => {
     };
   } else {
     return {
-      color: 'warning',
+      color: 'warning' as const,
       message: i18n.translate('esqlEditor.query.warningCount', {
         defaultMessage: '{count} {count, plural, one {warning} other {warnings}}',
         values: { count },
@@ -123,45 +123,30 @@ export function ErrorsWarningsFooterPopover({
   return (
     <EuiFlexItem grow={false}>
       <EuiFlexGroup gutterSize="xs" responsive={false} alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiIcon
-            type={type}
-            color={color}
-            size="s"
-            onClick={() => {
-              setIsPopoverOpen(!isPopoverOpen);
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiPopover
-            anchorPosition="downLeft"
-            hasArrow={false}
-            panelPaddingSize="s"
-            button={
-              <EuiText
-                size="xs"
-                color={color}
-                css={css`
-                  &:hover {
-                    cursor: pointer;
-                    text-decoration: underline;
-                  }
-                `}
-                onClick={() => {
-                  setIsPopoverOpen(!isPopoverOpen);
-                }}
-              >
-                <p>{isSpaceReduced ? items.length : message}</p>
-              </EuiText>
-            }
-            ownFocus={false}
-            isOpen={isPopoverOpen}
-            closePopover={() => setIsPopoverOpen(false)}
-          >
-            <ErrorsWarningsContent items={items} type={type} onErrorClick={onErrorClick} />
-          </EuiPopover>
-        </EuiFlexItem>
+        <EuiPopover
+          anchorPosition="downLeft"
+          hasArrow={false}
+          panelPaddingSize="s"
+          button={
+            <EuiButtonEmpty
+              iconType={type}
+              iconSize="s"
+              color={color}
+              size="xs"
+              iconSide="left"
+              onClick={() => {
+                setIsPopoverOpen(!isPopoverOpen);
+              }}
+            >
+              {isSpaceReduced ? items.length : message}
+            </EuiButtonEmpty>
+          }
+          ownFocus={false}
+          isOpen={isPopoverOpen}
+          closePopover={() => setIsPopoverOpen(false)}
+        >
+          <ErrorsWarningsContent items={items} type={type} onErrorClick={onErrorClick} />
+        </EuiPopover>
       </EuiFlexGroup>
     </EuiFlexItem>
   );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/215990

Makes the error / warning popover accessible 

![image (89)](https://github.com/user-attachments/assets/f3d9f334-ff75-4c90-ab41-aa6ddad3b5c0)




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->