### PR TITLE
Adds a test for time params vs ES for date and datenanos fields

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/esql_validation_meta_tests.json
@@ -3218,6 +3218,16 @@
       "warning": []
     },
     {
+      "query": "from a_index | where dateField > ?_tstart AND dateField < ?_tend",
+      "error": [],
+      "warning": []
+    },
+    {
+      "query": "from a_index | where dateNanosField > ?_tstart AND dateNanosField < ?_tend",
+      "error": [],
+      "warning": []
+    },
+    {
       "query": "from a_index | where - doubleField > 0",
       "error": [],
       "warning": []

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.test.ts
@@ -799,6 +799,13 @@ describe('validation logic', () => {
         }
       }
 
+      for (const type of ['date', 'dateNanos']) {
+        testErrorsAndWarnings(
+          `from a_index | where ${type}Field > ?_tstart AND ${type}Field < ?_tend`,
+          []
+        );
+      }
+
       for (const nesting of NESTED_DEPTHS) {
         for (const evenOp of ['-', '+']) {
           for (const oddOp of ['-', '+']) {

--- a/src/platform/test/api_integration/apis/esql/errors.ts
+++ b/src/platform/test/api_integration/apis/esql/errors.ts
@@ -11,6 +11,7 @@ import Fs from 'fs';
 import Path from 'path';
 import expect from '@kbn/expect';
 import { MappingProperty } from '@elastic/elasticsearch/lib/api/types';
+import { hasStartEndParams } from '@kbn/esql-utils';
 import { REPO_ROOT } from '@kbn/repo-info';
 import uniqBy from 'lodash/uniqBy';
 import { groupBy, mapValues } from 'lodash';
@@ -119,11 +120,23 @@ export default function ({ getService }: FtrProviderContext) {
     error: { message: string } | undefined;
   }> {
     try {
+      const params = hasStartEndParams(query)
+        ? [
+            {
+              _tstart: '2025-02-23T23:00:00.000Z',
+            },
+            {
+              _tend: '2025-03-26T09:09:08.139Z',
+            },
+          ]
+        : [];
       const resp = await es.transport.request<EsqlTable>({
         method: 'POST',
         path: '/_query',
         body: {
           query,
+          // testing the kibana time variables in case they are used in the query
+          params,
         },
       });
       return { resp, error: undefined };

--- a/src/platform/test/tsconfig.json
+++ b/src/platform/test/tsconfig.json
@@ -77,5 +77,6 @@
     "@kbn/core-deprecations-common",
     "@kbn/data-grid-in-table-search",
     "@kbn/scout-info",
+    "@kbn/esql-utils",
   ]
 }


### PR DESCRIPTION
## Summary

Making sure we test this https://github.com/elastic/elasticsearch/issues/125439 

Add a testing scenario for date, date_nanos and time params

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->