### PR TITLE
[8.18] [Docs] Add page about Kibana's color modes (#215930)

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -9,6 +9,8 @@ include::landing-page.asciidoc[]
 
 include::user/index.asciidoc[]
 
+include::user/dark-mode.asciidoc[]
+
 include::accessibility.asciidoc[]
 
 include::CHANGELOG.asciidoc[]

--- a/docs/user/dark-mode.asciidoc
+++ b/docs/user/dark-mode.asciidoc
@@ -1,0 +1,24 @@
+[chapter]
+[[kibana-dark-mode]]
+= Use dark mode in Kibana
+
+The dark mode changes Kibana's default light appearance to a darker and higher-contrast color theme. From the application header, you can turn on dark mode or synchronize the color mode with your operating system settings.
+
+TIP: If you're using {ecloud}, this setting only applies to the Kibana UI of your serverless projects and hosted deployments. If you'd like to change the {ecloud} Console color theme too, you must do so separately from its respective interface.
+
+[float]
+== Change your color mode preferences
+
+. Open the user menu from the header.
+. Select **Appearance**.
+. Choose a color mode:
+
+** **Light**: The default color mode of Kibana
+** **Dark**: The dark and high-contrast color mode of Kibana
+** **System**: Synchronizes Kibana's color mode with your system settings
+** deprecated:[8.18.0,This option will be removed in a future version and automatically replaced with the System color mode.] **Space default**: Sets the color mode to the value defined in the <<kibana-settings-reference,settings of the Space>>
+
+. Select **Save changes**.
+. Refresh the page to apply the selected color mode.
+
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[Docs] Add page about Kibana's color modes (#215930)](https://github.com/elastic/kibana/pull/215930)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"florent-leborgne","email":"florent.leborgne@elastic.co"},"sourceCommit":{"committedDate":"2025-03-26T10:39:43Z","message":"[Docs] Add page about Kibana's color modes (#215930)\n\nThis PR adds documentation about Kibana's dark mode options available\nfrom the UI.\n\nRelates to: https://github.com/elastic/platform-docs-team/issues/614","sha":"ad2056054343dd3d31c103d10cce842400a93718","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","backport:version","v8.18.0"],"number":215930,"url":"https://github.com/elastic/kibana/pull/215930","mergeCommit":{"message":"[Docs] Add page about Kibana's color modes (#215930)\n\nThis PR adds documentation about Kibana's dark mode options available\nfrom the UI.\n\nRelates to: https://github.com/elastic/platform-docs-team/issues/614","sha":"ad2056054343dd3d31c103d10cce842400a93718"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->