### PR TITLE
[A11y][APM] Adds `aria-label` to Transaction type select on service overview

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/transaction_type_select.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/transaction_type_select.tsx
@@ -7,6 +7,7 @@
 
 import { EuiSelect } from '@elastic/eui';
 import type { FormEvent } from 'react';
+import { i18n } from '@kbn/i18n';
 import React, { useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from '@emotion/styled';
@@ -42,6 +43,10 @@ export function TransactionTypeSelect() {
     <>
       <EuiSelectWithWidth
         fullWidth={isSmall}
+        aria-label={i18n.translate(
+          'xpack.apm.serviceOverview.filterByTransactionTypeSelect.ariaLabel',
+          { defaultMessage: 'Filter by transaction type select' }
+        )}
         data-test-subj="headerFilterTransactionType"
         onChange={handleChange}
         options={options}


### PR DESCRIPTION
## Summary

Fixes #210262

This PR adds an `aria-label` to solve the "Select element must have an accessible name" A11y critical issue.

## How to test
1. Download the [axe devtools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
2. Go into a service overview and run the scanner from axe devtools
3. You should see a critical error
4. Checkout this branch
5. Error should be solved

<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->