### PR TITLE
[Discover Tabs] Fix tabs storybook and fetch preview data on hover

### DIFF
--- a/src/platform/packages/shared/kbn-unified-tabs/__mocks__/get_preview_data.ts
+++ b/src/platform/packages/shared/kbn-unified-tabs/__mocks__/get_preview_data.ts
@@ -7,4 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { TabPreview, type TabPreviewProps } from './tab_preview';
+import { TabStatus, TabItem } from '../src/types';
+
+export const getPreviewDataMock = (item: TabItem) => ({
+  query: {
+    esql: 'SELECT * FROM table',
+  },
+  status: TabStatus.SUCCESS,
+});

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/__stories__/tab.stories.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/__stories__/tab.stories.tsx
@@ -12,6 +12,7 @@ import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Tab, type TabProps } from '../tab';
 import { servicesMock } from '../../../__mocks__/services';
+import { getPreviewDataMock } from '../../../__mocks__/get_preview_data';
 import { MAX_TAB_WIDTH, MIN_TAB_WIDTH } from '../../constants';
 
 const asyncAction =
@@ -40,6 +41,7 @@ const TabTemplate: StoryFn<TabProps> = (args) => (
   <Tab
     {...args}
     tabsSizeConfig={tabsSizeConfig}
+    getPreviewData={getPreviewDataMock}
     services={servicesMock}
     onLabelEdited={asyncAction('onLabelEdited')}
     onSelect={asyncAction('onSelect')}

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/__stories__/tabs.stories.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/__stories__/tabs.stories.tsx
@@ -13,6 +13,7 @@ import { action } from '@storybook/addon-actions';
 import { TabbedContent, type TabbedContentProps } from '../tabbed_content';
 import { useNewTabProps } from '../../hooks/use_new_tab_props';
 import { servicesMock } from '../../../__mocks__/services';
+import { getPreviewDataMock } from '../../../__mocks__/get_preview_data';
 
 export default {
   title: 'Unified Tabs/Tabs',
@@ -33,6 +34,7 @@ const TabbedContentTemplate: StoryFn<TabbedContentProps> = (args) => {
     <TabbedContent
       {...args}
       createItem={getNewTabDefaultProps}
+      getPreviewData={getPreviewDataMock}
       services={servicesMock}
       onChanged={action('onClosed')}
       renderContent={(item) => (

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.test.tsx
@@ -12,8 +12,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Tab } from './tab';
 import { MAX_TAB_WIDTH, MIN_TAB_WIDTH } from '../../constants';
-import { TabStatus } from '../../types';
 import { servicesMock } from '../../../__mocks__/services';
+import { getPreviewDataMock } from '../../../__mocks__/get_preview_data';
 
 const tabItem = {
   id: 'test-id',
@@ -29,13 +29,6 @@ const tabsSizeConfig = {
   regularTabMinWidth: MIN_TAB_WIDTH,
 };
 
-const previewQuery = {
-  query: {
-    esql: 'SELECT * FROM table',
-  },
-  status: TabStatus.SUCCESS,
-};
-
 describe('Tab', () => {
   it('renders tab', async () => {
     const onLabelEdited = jest.fn();
@@ -49,10 +42,10 @@ describe('Tab', () => {
         item={tabItem}
         isSelected={false}
         services={servicesMock}
+        getPreviewData={getPreviewDataMock}
         onLabelEdited={onLabelEdited}
         onSelect={onSelect}
         onClose={onClose}
-        tabPreviewData={previewQuery}
       />
     );
 
@@ -95,10 +88,10 @@ describe('Tab', () => {
         isSelected={false}
         services={servicesMock}
         getTabMenuItems={getTabMenuItems}
+        getPreviewData={getPreviewDataMock}
         onLabelEdited={jest.fn()}
         onSelect={jest.fn()}
         onClose={jest.fn()}
-        tabPreviewData={previewQuery}
       />
     );
 
@@ -125,10 +118,10 @@ describe('Tab', () => {
         item={tabItem}
         isSelected={false}
         services={servicesMock}
+        getPreviewData={getPreviewDataMock}
         onLabelEdited={onLabelEdited}
         onSelect={onSelect}
         onClose={onClose}
-        tabPreviewData={previewQuery}
       />
     );
 
@@ -160,10 +153,10 @@ describe('Tab', () => {
         item={tabItem}
         isSelected={false}
         services={servicesMock}
+        getPreviewData={getPreviewDataMock}
         onLabelEdited={onLabelEdited}
         onSelect={onSelect}
         onClose={onClose}
-        tabPreviewData={previewQuery}
       />
     );
 

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
@@ -65,7 +65,7 @@ export const Tab: React.FC<TabProps> = (props) => {
     defaultMessage: 'Click to select or double-click to edit session name',
   });
 
-  const hidePreview = () => setShowPreview(false);
+  const hidePreview = useCallback(() => setShowPreview(false), [setShowPreview]);
 
   const onSelectEvent = useCallback(
     async (event: MouseEvent<HTMLElement>) => {
@@ -76,7 +76,7 @@ export const Tab: React.FC<TabProps> = (props) => {
         await onSelect(item);
       }
     },
-    [onSelect, item, isSelected]
+    [onSelect, item, isSelected, hidePreview]
   );
 
   const onCloseEvent = useCallback(
@@ -97,10 +97,10 @@ export const Tab: React.FC<TabProps> = (props) => {
     [onSelectEvent]
   );
 
-  const handleDoubleClick = useCallback(() => {
+  const onDoubleClick = useCallback(() => {
     setIsInlineEditActive(true);
     hidePreview();
-  }, []);
+  }, [setIsInlineEditActive, hidePreview]);
 
   const mainTabContent = (
     <EuiFlexGroup
@@ -126,7 +126,7 @@ export const Tab: React.FC<TabProps> = (props) => {
               data-test-subj={`unifiedTabs_selectTabBtn_${item.id}`}
               type="button"
               onClick={onSelectEvent}
-              onDoubleClick={handleDoubleClick}
+              onDoubleClick={onDoubleClick}
             >
               <EuiText color="inherit" size="s" css={getTabLabelCss(euiTheme)}>
                 {item.label}

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab/tab.tsx
@@ -21,15 +21,9 @@ import {
 import { TabMenu } from '../tab_menu';
 import { EditTabLabel, type EditTabLabelProps } from './edit_tab_label';
 import { getTabAttributes } from '../../utils/get_tab_attributes';
-import type {
-  TabItem,
-  TabsSizeConfig,
-  GetTabMenuItems,
-  TabsServices,
-  TabPreviewData,
-} from '../../types';
+import type { TabItem, TabsSizeConfig, GetTabMenuItems, TabsServices } from '../../types';
 import { TabWithBackground } from '../tabs_visual_glue_to_header/tab_with_background';
-import { TabPreview } from '../tab_preview';
+import { TabPreview, type TabPreviewProps } from '../tab_preview';
 
 export interface TabProps {
   item: TabItem;
@@ -37,11 +31,11 @@ export interface TabProps {
   tabContentId: string;
   tabsSizeConfig: TabsSizeConfig;
   getTabMenuItems?: GetTabMenuItems;
+  getPreviewData: TabPreviewProps['getPreviewData'];
   services: TabsServices;
   onLabelEdited: EditTabLabelProps['onLabelEdited'];
   onSelect: (item: TabItem) => Promise<void>;
   onClose: ((item: TabItem) => Promise<void>) | undefined;
-  tabPreviewData: TabPreviewData;
 }
 
 export const Tab: React.FC<TabProps> = (props) => {
@@ -51,11 +45,11 @@ export const Tab: React.FC<TabProps> = (props) => {
     tabContentId,
     tabsSizeConfig,
     getTabMenuItems,
+    getPreviewData,
     services,
     onLabelEdited,
     onSelect,
     onClose,
-    tabPreviewData,
   } = props;
   const { euiTheme } = useEuiTheme();
   const tabRef = useRef<HTMLDivElement | null>(null);
@@ -175,8 +169,8 @@ export const Tab: React.FC<TabProps> = (props) => {
       showPreview={showPreview}
       setShowPreview={setShowPreview}
       stopPreviewOnHover={isInlineEditActive || isActionPopoverOpen}
-      tabPreviewData={tabPreviewData}
       tabItem={item}
+      getPreviewData={getPreviewData}
     >
       <TabWithBackground
         {...getTabAttributes(item, tabContentId)}

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tab_preview/tab_preview.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tab_preview/tab_preview.test.tsx
@@ -10,15 +10,8 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TabPreview } from './tab_preview';
-import type { TabPreviewData, TabItem } from '../../types';
-import { TabStatus } from '../../types';
-
-const tabPreviewData: TabPreviewData = {
-  query: {
-    esql: 'SELECT * FROM table',
-  },
-  status: TabStatus.SUCCESS,
-};
+import type { TabItem } from '../../types';
+import { getPreviewDataMock } from '../../../__mocks__/get_preview_data';
 
 const tabItem: TabItem = {
   id: 'test-id',
@@ -35,7 +28,7 @@ describe('TabPreview', () => {
       <TabPreview
         showPreview={false}
         setShowPreview={setShowPreview}
-        tabPreviewData={tabPreviewData}
+        getPreviewData={getPreviewDataMock}
         tabItem={tabItem}
         stopPreviewOnHover={false}
         previewDelay={0}
@@ -63,7 +56,7 @@ describe('TabPreview', () => {
       <TabPreview
         showPreview={true}
         setShowPreview={setShowPreview}
-        tabPreviewData={tabPreviewData}
+        getPreviewData={getPreviewDataMock}
         tabItem={tabItem}
         stopPreviewOnHover={false}
       >
@@ -90,7 +83,7 @@ describe('TabPreview', () => {
       <TabPreview
         showPreview={false}
         setShowPreview={setShowPreview}
-        tabPreviewData={tabPreviewData}
+        getPreviewData={getPreviewDataMock}
         tabItem={tabItem}
         stopPreviewOnHover={true}
       >

--- a/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_bar/tabs_bar.tsx
+++ b/src/platform/packages/shared/kbn-unified-tabs/src/components/tabs_bar/tabs_bar.tsx
@@ -12,7 +12,7 @@ import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, useEuiTheme } from '@elastic/eui';
 import { Tab, type TabProps } from '../tab';
-import type { TabItem, TabsServices, TabPreviewData } from '../../types';
+import type { TabItem, TabsServices } from '../../types';
 import { getTabIdAttribute } from '../../utils/get_tab_attributes';
 import { useResponsiveTabs } from '../../hooks/use_responsive_tabs';
 import { TabsBarWithBackground } from '../tabs_visual_glue_to_header/tabs_bar_with_background';
@@ -23,14 +23,13 @@ const growingFlexItemCss = css`
 
 export type TabsBarProps = Pick<
   TabProps,
-  'getTabMenuItems' | 'onLabelEdited' | 'onSelect' | 'onClose' | 'tabContentId'
+  'getTabMenuItems' | 'getPreviewData' | 'onLabelEdited' | 'onSelect' | 'onClose' | 'tabContentId'
 > & {
   items: TabItem[];
   selectedItem: TabItem | null;
   maxItemsCount?: number;
   services: TabsServices;
   onAdd: () => Promise<void>;
-  getPreviewData: (item: TabItem) => TabPreviewData;
 };
 
 export const TabsBar: React.FC<TabsBarProps> = ({
@@ -106,10 +105,10 @@ export const TabsBar: React.FC<TabsBarProps> = ({
                   tabsSizeConfig={tabsSizeConfig}
                   services={services}
                   getTabMenuItems={getTabMenuItems}
+                  getPreviewData={getPreviewData}
                   onLabelEdited={onLabelEdited}
                   onSelect={onSelect}
                   onClose={items.length > 1 ? onClose : undefined} // prevents closing the last tab
-                  tabPreviewData={getPreviewData(item)}
                 />
               ))}
             </EuiFlexGroup>


### PR DESCRIPTION
- Follow up for https://github.com/elastic/kibana/pull/214090

## Summary

This PR fixes storybook for Tabs package.

Also I changed a little the logic of `TabPreview` so it fetches data and renders popover content only once a tab is hovered now as mentioned before in https://github.com/elastic/kibana/pull/214090#discussion_r2005165954. And fixed `useCallback` deps in `Tab` component.


## Testing

Two options are possible:

1. start Storybook with `yarn storybook unified_tabs`  and navigate to `http://localhost:9001`.
2. start Kibana with `yarn start --run-examples`. Then navigate to the Unified Tabs example plugin `http://localhost:5601/app/unifiedTabsExamples`.


