### PR TITLE
[Fleet] fix remote es output, add doc to test remote clusters

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/remote_clusters_ccr.md
+++ b/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/remote_clusters_ccr.md
@@ -1,0 +1,94 @@
+# Test sync integrations feature 
+
+## Start Cluster 1 (remote)
+
+- Start ES 1
+
+```
+yarn es snapshot -E http.port=9500 -E transport.port=9600 -E path.data=../remote --license trial -E http.host=0.0.0.0
+```
+
+- Start Kibana 1
+
+```
+yarn start --server.port=5701 --elasticsearch.hosts=http://localhost:9500 --dev.basePathProxyTarget=5703
+```
+
+## Start Cluster 2 (main)
+
+- Start ES 2
+
+```
+yarn es snapshot --license trial -E path.data=/tmp/es-data -E http.host=0.0.0.0
+```
+
+- Start Kibana 2
+
+```
+yarn start
+```
+
+## Enable feature flag
+
+- Add to `kibana.dev.yml`
+
+```
+xpack.fleet.enableExperimental: ['enableSyncIntegrationsOnRemote']
+```
+
+## Add remote ES output
+- Add remote ES output to Cluster 2
+
+```
+xpack.fleet.outputs:
+  - name: 'Preconfiged remote output'
+    type: 'remote_elasticsearch'
+    id: 'remote-output'
+    hosts: ["http://<local_ip>:9500"]
+    sync_integrations: true
+    kibana_url: "http://localhost:5701"
+    secrets:
+      service_token: token
+      kibana_api_key: key
+```
+
+## Add Remote Cluster
+
+- Add Remote Cluster to Cluster 1
+
+http://localhost:5701/app/management/data/remote_clusters 
+
+Add Remote cluster with remote address `localhost:9300`
+
+## Set up CCR
+
+- Add follower index to Cluster 1
+  - Leader index `fleet-synced-integrations`
+  - Follower index `fleet-synced-integrations-ccr-remote1`
+
+
+## Check contents of sync integrations indices
+
+- In Cluster 1
+```
+GET fleet-synced-integrations-ccr-remote1/_search
+```
+
+- In Cluster 2
+```
+GET fleet-synced-integrations/_search
+```
+
+## Read data from remote with CCS
+
+- Enroll Fleet Server to Cluster 2
+
+- Create Agent Policy in Cluster 2 and use remote output for integrations and monitoring
+
+- Enroll Agent to Cluster 2 to the Agent policy
+
+- Check data in Cluster 1 with CCS
+
+```
+GET remote1:metrics-*/_search
+```

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.test.ts
@@ -1681,6 +1681,9 @@ describe('generateFleetConfig', () => {
           certificate: 'my-cert',
           key: 'my-key',
         },
+        secrets: {
+          service_token: { id: 'my-service-token' },
+        },
       },
       {
         id: 'output-2',
@@ -1707,6 +1710,9 @@ describe('generateFleetConfig', () => {
         certificate: 'my-cert',
         certificate_authorities: ['/tmp/ssl/ca.crt'],
         key: 'my-key',
+      },
+      secrets: {
+        service_token: { id: 'my-service-token' },
       },
     });
   });
@@ -1842,6 +1848,7 @@ describe('generateFleetConfig', () => {
           ssl: {
             key: { id: 'my-secret-key' },
           },
+          service_token: { id: 'my-service-token' },
         },
       },
     ] as any;
@@ -1864,6 +1871,7 @@ describe('generateFleetConfig', () => {
             id: 'my-secret-key',
           },
         },
+        service_token: { id: 'my-service-token' },
       },
       ssl: {
         certificate: 'my-cert',

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -386,11 +386,7 @@ export function generateFleetConfig(
     // if both ssl.es_key and secrets.ssl.es_key are present, prefer the secrets'
     if (output?.secrets) {
       config.secrets = {
-        ssl: {
-          ...(output.secrets?.ssl?.key && {
-            key: output.secrets.ssl.key,
-          }),
-        },
+        ...output?.secrets,
       };
     }
   }

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -581,9 +581,7 @@ export function transformOutputToFullPolicyOutput(
     ...((output.type === outputType.Kafka || output.type === outputType.Logstash) && ssl
       ? { ssl }
       : {}),
-    ...((output.type === outputType.Kafka || output.type === outputType.Logstash) && secrets
-      ? { secrets }
-      : {}),
+    ...(secrets ? { secrets } : {}),
   };
 
   if (proxy) {


### PR DESCRIPTION
## Summary

Fix Remote ES output with secret token secret. The secrets were not correctly saved to the full agent policy, bug introduced in this pr: https://github.com/elastic/kibana/pull/208745

Also added a doc how to test sync integrations feature with 2 local clusters.

To test:
- create remote ES output with service token as a secret
- create an agent policy and use the remote ES output as data and monitoring output
- check that the full agent policy contains `outputs.secrets`
- enroll an agent and verify that it becomes healthy and the data is ingested to the remote cluster

<img width="1704" alt="image" src="https://github.com/user-attachments/assets/1744fb71-75b4-44f9-ade9-8a29dd44fd95" />
<img width="1619" alt="image" src="https://github.com/user-attachments/assets/941936a3-ddc6-42c9-9c49-a941ae9007b6" />
<img width="816" alt="image" src="https://github.com/user-attachments/assets/e9b703fb-b032-4879-8f0a-c69e67f1a4b2" />
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/077d6f1e-efc2-486b-a6d5-9a87ae012471" />

