### PR TITLE
[8.17] [A11y][APM] Use `nameTooltip` api for dependencies tables (#215940)

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/dependency_detail_operations/dependency_detail_operations_list/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/dependency_detail_operations/dependency_detail_operations_list/index.tsx
@@ -19,7 +19,7 @@ import {
   SpanMetricGroup,
 } from '../../../shared/dependencies_table/get_span_metric_columns';
 import { EmptyMessage } from '../../../shared/empty_message';
-import { ITableColumn, ManagedTable } from '../../../shared/managed_table';
+import { type ITableColumn, ManagedTable } from '../../../shared/managed_table';
 import { getComparisonEnabled } from '../../../shared/time_comparison/get_comparison_enabled';
 import { TruncateWithTooltip } from '../../../shared/truncate_with_tooltip';
 import { DependencyOperationDetailLink } from '../../dependency_operation_detail_view/dependency_operation_detail_link';

--- a/x-pack/plugins/observability_solution/apm/public/components/shared/dependencies_table/get_span_metric_columns.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/shared/dependencies_table/get_span_metric_columns.tsx
@@ -5,12 +5,11 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiIconTip, RIGHT_ALIGNMENT } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, RIGHT_ALIGNMENT } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { ChartType, getTimeSeriesColor } from '../charts/helper/get_timeseries_color';
 import { ListMetric } from '../list_metric';
-import { ITableColumn } from '../managed_table';
-import { FETCH_STATUS, isPending } from '../../../hooks/use_fetcher';
+import { type FETCH_STATUS, isPending } from '../../../hooks/use_fetcher';
 import {
   asMillisecondDuration,
   asPercent,
@@ -19,6 +18,7 @@ import {
 import { Coordinate } from '../../../../typings/timeseries';
 import { ImpactBar } from '../impact_bar';
 import { isFiniteNumber } from '../../../../common/utils/is_finite_number';
+import type { ITableColumn } from '../managed_table';
 
 export interface SpanMetricGroup {
   latency: number | null;
@@ -106,24 +106,15 @@ export function getSpanMetricColumns({
     },
     {
       field: 'failureRate',
-      name: (
-        <>
-          {i18n.translate('xpack.apm.dependenciesTable.columnErrorRate', {
-            defaultMessage: 'Failed transaction rate',
-          })}
-          &nbsp;
-          <EuiIconTip
-            size="s"
-            color="subdued"
-            type="questionInCircle"
-            content={i18n.translate('xpack.apm.dependenciesTable.columnErrorRateTip', {
-              defaultMessage:
-                "The percentage of failed transactions for the selected service. HTTP server transactions with a 4xx status code (client error) aren't considered failures because the caller, not the server, caused the failure.",
-            })}
-            className="eui-alignCenter"
-          />
-        </>
-      ),
+      name: i18n.translate('xpack.apm.dependenciesTable.columnErrorRate', {
+        defaultMessage: 'Failed transaction rate',
+      }),
+      nameTooltip: {
+        content: i18n.translate('xpack.apm.dependenciesTable.columnErrorRateTip', {
+          defaultMessage:
+            "The percentage of failed transactions for the selected service. HTTP server transactions with a 4xx status code (client error) aren't considered failures because the caller, not the server, caused the failure.",
+        }),
+      },
       align: RIGHT_ALIGNMENT,
       render: (_, { failureRate, currentStats, previousStats }) => {
         const { currentPeriodColor, previousPeriodColor } = getTimeSeriesColor(
@@ -147,24 +138,15 @@ export function getSpanMetricColumns({
     },
     {
       field: 'impact',
-      name: (
-        <>
-          {i18n.translate('xpack.apm.dependenciesTable.columnImpact', {
-            defaultMessage: 'Impact',
-          })}
-          &nbsp;
-          <EuiIconTip
-            size="s"
-            color="subdued"
-            type="questionInCircle"
-            className="eui-alignCenter"
-            content={i18n.translate('xpack.apm.dependenciesTable.columnImpactTip', {
-              defaultMessage:
-                'The most used and slowest endpoints in your service. Calculated by multiplying latency by throughput.',
-            })}
-          />
-        </>
-      ),
+      name: i18n.translate('xpack.apm.dependenciesTable.columnImpact', {
+        defaultMessage: 'Impact',
+      }),
+      nameTooltip: {
+        content: i18n.translate('xpack.apm.dependenciesTable.columnImpactTip', {
+          defaultMessage:
+            'The most used and slowest endpoints in your service. Calculated by multiplying latency by throughput.',
+        }),
+      },
       align: RIGHT_ALIGNMENT,
       render: (_, { impact, previousStats }) => {
         return (

--- a/x-pack/plugins/observability_solution/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/shared/dependencies_table/index.tsx
@@ -12,7 +12,7 @@ import type { ConnectionStatsItemWithComparisonData } from '../../../../common/c
 import { useBreakpoints } from '../../../hooks/use_breakpoints';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import { EmptyMessage } from '../empty_message';
-import { ITableColumn, ManagedTable } from '../managed_table';
+import { type ITableColumn, ManagedTable } from '../managed_table';
 import { OverviewTableContainer } from '../overview_table_container';
 import { TruncateWithTooltip } from '../truncate_with_tooltip';
 import { getSpanMetricColumns, SpanMetricGroup } from './get_span_metric_columns';

--- a/x-pack/plugins/observability_solution/apm/public/components/shared/managed_table/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/shared/managed_table/index.tsx
@@ -34,6 +34,7 @@ export interface ITableColumn<T extends object> {
   width?: string;
   sortable?: boolean;
   truncateText?: boolean;
+  nameTooltip?: EuiBasicTableColumn<T>['nameTooltip'];
   render?: (value: any, item: T) => unknown;
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[A11y][APM] Use `nameTooltip` api for dependencies tables (#215940)](https://github.com/elastic/kibana/pull/215940)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-03-26T12:58:34Z","message":"[A11y][APM] Use `nameTooltip` api for dependencies tables (#215940)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/195041\n\nThis PR addresses the issue where the table name's tooltip cannot be\nfocused with keyboard.\n\n## Video\n\n\nhttps://github.com/user-attachments/assets/bec887fd-5a3b-4fa9-b84b-17a1a4187fbc","sha":"35f8739b9a1a8f9bc231161afa39118f7ff4fbaa","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","apm","backport:prev-major","Team:obs-ux-infra_services","a11y","v9.1.0"],"title":"[A11y][APM] Use `nameTooltip` api for dependencies tables","number":215940,"url":"https://github.com/elastic/kibana/pull/215940","mergeCommit":{"message":"[A11y][APM] Use `nameTooltip` api for dependencies tables (#215940)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/195041\n\nThis PR addresses the issue where the table name's tooltip cannot be\nfocused with keyboard.\n\n## Video\n\n\nhttps://github.com/user-attachments/assets/bec887fd-5a3b-4fa9-b84b-17a1a4187fbc","sha":"35f8739b9a1a8f9bc231161afa39118f7ff4fbaa"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215940","number":215940,"mergeCommit":{"message":"[A11y][APM] Use `nameTooltip` api for dependencies tables (#215940)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/195041\n\nThis PR addresses the issue where the table name's tooltip cannot be\nfocused with keyboard.\n\n## Video\n\n\nhttps://github.com/user-attachments/assets/bec887fd-5a3b-4fa9-b84b-17a1a4187fbc","sha":"35f8739b9a1a8f9bc231161afa39118f7ff4fbaa"}},{"url":"https://github.com/elastic/kibana/pull/216034","number":216034,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/216035","number":216035,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->