### PR TITLE
[Search][Playground] support for editing search query

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/common/types.ts
+++ b/x-pack/solutions/search/plugins/search_playground/common/types.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { Document } from '@langchain/core/documents';
 import type { SearchResponse } from '@elastic/elasticsearch/lib/api/types';
 export type IndicesQuerySourceFields = Record<string, QuerySourceFields>;
 
@@ -95,5 +96,6 @@ export interface Pagination {
 }
 
 export interface QueryTestResponse {
+  documents?: Document[];
   searchResponse: SearchResponse;
 }

--- a/x-pack/solutions/search/plugins/search_playground/public/components/app.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/app.tsx
@@ -78,11 +78,21 @@ export const App: React.FC<AppProps> = ({ showDocs = false }) => {
         ) : (
           <>
             <Route exact path={SEARCH_PLAYGROUND_CHAT_PATH} component={Chat} />
-            <Route exact path={PLAYGROUND_CHAT_QUERY_PATH} component={QueryMode} />
+            <Route
+              exact
+              path={PLAYGROUND_CHAT_QUERY_PATH}
+              render={() =>
+                isSearchModeEnabled ? <SearchQueryMode pageMode={pageMode} /> : <QueryMode />
+              }
+            />
             {isSearchModeEnabled && (
               <>
                 <Route exact path={SEARCH_PLAYGROUND_SEARCH_PATH} component={SearchMode} />
-                <Route exact path={PLAYGROUND_SEARCH_QUERY_PATH} component={SearchQueryMode} />
+                <Route
+                  exact
+                  path={PLAYGROUND_SEARCH_QUERY_PATH}
+                  render={() => <SearchQueryMode pageMode={pageMode} />}
+                />
               </>
             )}
           </>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/chat.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/chat.tsx
@@ -36,13 +36,18 @@ import { TelegramIcon } from './telegram_icon';
 import { transformFromChatMessages } from '../utils/transform_to_messages';
 import { useUsageTracker } from '../hooks/use_usage_tracker';
 import { PlaygroundBodySection } from './playground_body_section';
+import { elasticsearchQueryString } from '../utils/user_query';
 
 const buildFormData = (formData: ChatForm): ChatRequestData => ({
   connector_id: formData[ChatFormFields.summarizationModel].connectorId!,
   prompt: formData[ChatFormFields.prompt],
   indices: formData[ChatFormFields.indices].join(),
   citations: formData[ChatFormFields.citations],
-  elasticsearch_query: JSON.stringify(formData[ChatFormFields.elasticsearchQuery]),
+  elasticsearch_query: elasticsearchQueryString(
+    formData[ChatFormFields.elasticsearchQuery],
+    formData[ChatFormFields.userElasticsearchQuery],
+    formData[ChatFormFields.userElasticsearchQueryValidations]
+  ),
   summarization_model: formData[ChatFormFields.summarizationModel].value,
   source_fields: JSON.stringify(formData[ChatFormFields.sourceFields]),
   doc_size: formData[ChatFormFields.docSize],

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/chat_prompt.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/chat_prompt.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { EuiFieldText } from '@elastic/eui';
+import { Controller, useFormContext } from 'react-hook-form';
+import { i18n } from '@kbn/i18n';
+import { ChatFormFields } from '../../types';
+
+export const ChatPrompt = ({ isLoading }: { isLoading: boolean }) => {
+  const { control } = useFormContext();
+
+  return (
+    <Controller
+      control={control}
+      name={ChatFormFields.question}
+      render={({ field }) => (
+        <EuiFieldText
+          data-test-subj="searchPlaygroundChatQuestionFieldText"
+          prepend="{query}"
+          {...field}
+          fullWidth
+          placeholder={i18n.translate(
+            'xpack.searchPlayground.searchMode.queryView.chatQuestion.placeholder',
+            { defaultMessage: 'Ask a question' }
+          )}
+          isLoading={isLoading}
+        />
+      )}
+    />
+  );
+};

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_fields_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_fields_panel.tsx
@@ -33,6 +33,7 @@ const isQueryFieldSelected = (
 };
 
 export interface QueryFieldsPanelProps {
+  disabled: boolean;
   index: string;
   indexFields: QuerySourceFields;
   updateFields: (index: string, fieldName: string, checked: boolean) => void;
@@ -40,6 +41,7 @@ export interface QueryFieldsPanelProps {
 }
 
 export const QueryFieldsPanel = ({
+  disabled,
   index,
   indexFields,
   updateFields,
@@ -107,7 +109,8 @@ export const QueryFieldsPanel = ({
                   <EuiSwitch
                     showLabel={false}
                     label={field.name}
-                    checked={checked}
+                    disabled={disabled}
+                    checked={disabled ? false : checked}
                     onChange={(e) => updateFields(index, field.name, e.target.checked)}
                     compressed
                     data-test-subj={`field-${field.name}-${checked}`}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_fields_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_fields_panel.tsx
@@ -17,6 +17,7 @@ import {
   EuiSpacer,
   EuiSwitch,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -33,7 +34,7 @@ const isQueryFieldSelected = (
 };
 
 export interface QueryFieldsPanelProps {
-  disabled: boolean;
+  customizedQuery: boolean;
   index: string;
   indexFields: QuerySourceFields;
   updateFields: (index: string, fieldName: string, checked: boolean) => void;
@@ -41,7 +42,7 @@ export interface QueryFieldsPanelProps {
 }
 
 export const QueryFieldsPanel = ({
-  disabled,
+  customizedQuery,
   index,
   indexFields,
   updateFields,
@@ -105,12 +106,34 @@ export const QueryFieldsPanel = ({
               ),
               align: 'right',
               render: (checked, field) => {
+                if (customizedQuery) {
+                  return (
+                    <EuiToolTip
+                      content={i18n.translate(
+                        'xpack.searchPlayground.viewQuery.sidePanel.fieldSelection.customized.warning.tooltip',
+                        {
+                          defaultMessage:
+                            'Field selection is not supported with a user-customized query',
+                        }
+                      )}
+                    >
+                      <EuiSwitch
+                        showLabel={false}
+                        label={field.name}
+                        disabled
+                        checked={false}
+                        onChange={() => {}}
+                        compressed
+                        data-test-subj={`field-${field.name}-${checked}`}
+                      />
+                    </EuiToolTip>
+                  );
+                }
                 return (
                   <EuiSwitch
                     showLabel={false}
                     label={field.name}
-                    disabled={disabled}
-                    checked={disabled ? false : checked}
+                    checked={checked}
                     onChange={(e) => updateFields(index, field.name, e.target.checked)}
                     compressed
                     data-test-subj={`field-${field.name}-${checked}`}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_output.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_output.tsx
@@ -6,13 +6,20 @@
  */
 
 import React, { useMemo } from 'react';
-import { EuiFlexGroup, EuiSplitPanel, EuiText, useEuiTheme } from '@elastic/eui';
+import { EuiFlexGroup, EuiSplitPanel, EuiText, EuiLoadingLogo, useEuiTheme } from '@elastic/eui';
 import { CodeEditor } from '@kbn/code-editor';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { isHttpFetchError } from '@kbn/core-http-browser';
 
 import { getErrorMessage } from '../../../common/errors';
 import { FullHeight, QueryViewTitlePanel } from './styles';
 import { QueryTestResponse } from '../../types';
+
+const LOADING_MESSAGE = i18n.translate(
+  'xpack.searchPlayground.viewQuery.queryOutput.loading.message',
+  { defaultMessage: 'Fetching...' }
+);
 
 export interface ElasticsearchQueryOutputProps {
   queryResponse?: QueryTestResponse;
@@ -25,10 +32,14 @@ export const ElasticsearchQueryOutput = ({
   queryResponse,
   isError,
   queryError,
+  isLoading,
 }: ElasticsearchQueryOutputProps) => {
   const { euiTheme } = useEuiTheme();
   const respJSON = useMemo(() => {
     if (isError) {
+      if (isHttpFetchError(queryError)) {
+        return queryError?.body ? JSON.stringify(queryError?.body, null, 2) : queryError.message;
+      }
       return getErrorMessage(queryError);
     }
     return queryResponse ? JSON.stringify(queryResponse.searchResponse, null, 2) : undefined;
@@ -50,7 +61,7 @@ export const ElasticsearchQueryOutput = ({
           <CodeEditor
             dataTestSubj="ViewElasticsearchQueryResponse"
             languageId="json"
-            value={respJSON}
+            value={isLoading ? LOADING_MESSAGE : respJSON}
             options={{
               automaticLayout: true,
               readOnly: true,
@@ -66,14 +77,18 @@ export const ElasticsearchQueryOutput = ({
             css={FullHeight}
             data-test-subj="ViewElasticsearchQueryResponseEmptyState"
           >
-            <EuiText>
-              <p>
-                <FormattedMessage
-                  id="xpack.searchPlayground.viewQuery.queryOutput.emptyPrompt.body"
-                  defaultMessage="Run your query above to view the raw JSON output here."
-                />
-              </p>
-            </EuiText>
+            {isLoading ? (
+              <EuiLoadingLogo />
+            ) : (
+              <EuiText>
+                <p>
+                  <FormattedMessage
+                    id="xpack.searchPlayground.viewQuery.queryOutput.emptyPrompt.body"
+                    defaultMessage="Run your query above to view the raw JSON output here."
+                  />
+                </p>
+              </EuiText>
+            )}
           </EuiFlexGroup>
         )}
       </EuiSplitPanel.Inner>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_side_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_side_panel.tsx
@@ -19,7 +19,6 @@ import { SearchQuery } from './search_query';
 import { QueryFieldsPanel } from './query_fields_panel';
 import { ChatPrompt } from './chat_prompt';
 import { EditContextPanel } from '../edit_context/edit_context_panel';
-import { formatElasticsearchQueryString } from '../../utils/user_query';
 
 export interface QuerySidePanelProps {
   executeQuery: () => void;
@@ -78,8 +77,8 @@ export const QuerySidePanel = ({
       queryFieldsOnChange(updatedQueryFields);
       const updatedQuery = createQuery(updatedQueryFields, sourceFields, fields);
       elasticsearchQueryChange(updatedQuery);
-      // ensure the userQuery matches the updated query.
-      userElasticsearchQueryChange(formatElasticsearchQueryString(updatedQuery));
+      // ensure the userQuery is cleared so it doesn't diverge from the generated query.
+      userElasticsearchQueryChange(null);
       usageTracker?.count(AnalyticsEvents.queryFieldsUpdated, currentIndexFields.length);
     },
     [

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_side_panel.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_side_panel.tsx
@@ -135,7 +135,7 @@ export const QuerySidePanel = ({
               indexFields={group}
               updateFields={updateFields}
               queryFields={queryFields}
-              disabled={userElasticsearchQueryValidations?.isUserCustomized ?? false}
+              customizedQuery={userElasticsearchQueryValidations?.isUserCustomized ?? false}
             />
           </EuiFlexItem>
         ))}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
@@ -59,16 +59,7 @@ export const ElasticsearchQueryViewer = ({
   const editorMounted = useCallback((editor: monacoEditor.editor.IStandaloneCodeEditor) => {
     monacoEditor.languages.json.jsonDefaults.setDiagnosticsOptions({
       validate: true,
-      schemas: [
-        {
-          uri: editor.getModel()?.uri.toString() ?? '', // TODO: probably a better option for this
-          fileMatch: ['*'],
-          schema: {
-            type: 'object',
-            properties: {}, // TODO: load _search JSON schema
-          },
-        },
-      ],
+      schemas: [],
     });
   }, []);
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
@@ -58,8 +58,8 @@ export const ElasticsearchQueryViewer = ({
     [elasticsearchQuery]
   );
   const resetElasticsearchQuery = useCallback(() => {
-    onChangeUserQuery(generatedEsQuery);
-  }, [onChangeUserQuery, generatedEsQuery]);
+    onChangeUserQuery(null);
+  }, [onChangeUserQuery]);
   const editorMounted = useCallback((editor: monacoEditor.editor.IStandaloneCodeEditor) => {
     monacoEditor.languages.json.jsonDefaults.setDiagnosticsOptions({
       validate: true,

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
@@ -129,18 +129,15 @@ export const ElasticsearchQueryViewer = ({
       {userElasticsearchQueryValidations?.isUserCustomized &&
       (userElasticsearchQueryValidations?.userQueryErrors?.length ?? 0) > 0 ? (
         <EuiSplitPanel.Inner grow={false}>
-          <EuiCallOut
-            color="danger"
-            iconType="error"
-            title={i18n.translate('xpack.searchPlayground.viewQuery.invalidQuery.title', {
-              defaultMessage: 'User-customized Query is invalid',
-            })}
-            size="s"
-          >
-            {userElasticsearchQueryValidations.userQueryErrors!.map((error, errorIndex) => (
-              <p key={`user.query.error.${errorIndex}`}>{error}</p>
-            ))}
-          </EuiCallOut>
+          {userElasticsearchQueryValidations.userQueryErrors!.map((error, errorIndex) => (
+            <EuiCallOut
+              key={`user.query.error.${errorIndex}`}
+              color="danger"
+              iconType="error"
+              title={error}
+              size="s"
+            />
+          ))}
         </EuiSplitPanel.Inner>
       ) : null}
       <EuiSplitPanel.Inner paddingSize="none">

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useMemo } from 'react';
 import {
   EuiBadge,
   EuiButton,
+  EuiButtonEmpty,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
@@ -43,7 +44,7 @@ export const ElasticsearchQueryViewer = ({
     name: ChatFormFields.elasticsearchQuery,
   });
   const {
-    field: { value: userElasticsearchQuery },
+    field: { value: userElasticsearchQuery, onChange: onChangeUserQuery },
   } = useController<ChatForm, ChatFormFields.userElasticsearchQuery>({
     name: ChatFormFields.userElasticsearchQuery,
   });
@@ -56,6 +57,9 @@ export const ElasticsearchQueryViewer = ({
     () => formatElasticsearchQueryString(elasticsearchQuery),
     [elasticsearchQuery]
   );
+  const resetElasticsearchQuery = useCallback(() => {
+    onChangeUserQuery(generatedEsQuery);
+  }, [onChangeUserQuery, generatedEsQuery]);
   const editorMounted = useCallback((editor: monacoEditor.editor.IStandaloneCodeEditor) => {
     monacoEditor.languages.json.jsonDefaults.setDiagnosticsOptions({
       validate: true,
@@ -66,8 +70,8 @@ export const ElasticsearchQueryViewer = ({
   return (
     <EuiSplitPanel.Outer grow hasBorder css={FullHeight}>
       <EuiSplitPanel.Inner grow={false} css={QueryViewTitlePanel(euiTheme)}>
-        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-          <EuiFlexItem grow={false}>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="s">
+          <EuiFlexItem grow>
             <EuiFlexGroup gutterSize="s">
               <EuiText>
                 <h5>
@@ -94,6 +98,22 @@ export const ElasticsearchQueryViewer = ({
               )}
             </EuiFlexGroup>
           </EuiFlexItem>
+          {userElasticsearchQueryValidations?.isUserCustomized ? (
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                size="s"
+                iconSide="left"
+                iconType="refresh"
+                data-test-subj="ResetElasticsearchQueryButton"
+                onClick={resetElasticsearchQuery}
+              >
+                <FormattedMessage
+                  id="xpack.searchPlayground.viewQuery.resetQuery.action"
+                  defaultMessage="Reset to default"
+                />
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          ) : null}
           <EuiFlexItem grow={false}>
             <EuiButton
               fill

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/query_viewer.tsx
@@ -24,7 +24,7 @@ import { monaco as monacoEditor } from '@kbn/monaco';
 
 import { Controller, useController, useFormContext } from 'react-hook-form';
 import { ChatForm, ChatFormFields } from '../../types';
-import { FullHeight, QueryViewTitlePanel } from './styles';
+import { FullHeight, QueryViewTitlePanel, PanelFillContainer } from './styles';
 import { formatElasticsearchQueryString } from '../../utils/user_query';
 
 export const ElasticsearchQueryViewer = ({
@@ -151,7 +151,7 @@ export const ElasticsearchQueryViewer = ({
           ))}
         </EuiSplitPanel.Inner>
       ) : null}
-      <EuiSplitPanel.Inner paddingSize="none">
+      <EuiSplitPanel.Inner paddingSize="none" css={PanelFillContainer}>
         <Controller
           control={control}
           name={ChatFormFields.userElasticsearchQuery}

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/search_query.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/search_query.tsx
@@ -12,7 +12,7 @@ import { Controller, useController, useFormContext } from 'react-hook-form';
 import { i18n } from '@kbn/i18n';
 import { ChatForm, ChatFormFields } from '../../types';
 
-export const SearchQuery = () => {
+export const SearchQuery = ({ isLoading }: { isLoading: boolean }) => {
   const { control } = useFormContext();
   const {
     field: { value: searchBarValue },
@@ -37,7 +37,7 @@ export const SearchQuery = () => {
             'xpack.searchPlayground.searchMode.queryView.searchBar.placeholder',
             { defaultMessage: 'Search for documents' }
           )}
-          isLoading={isSubmitting}
+          isLoading={isLoading || isSubmitting}
         />
       )}
     />

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/search_query_mode.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/search_query_mode.tsx
@@ -7,7 +7,6 @@
 
 import React, { useEffect } from 'react';
 import { useController } from 'react-hook-form';
-import { css } from '@emotion/react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -24,7 +23,12 @@ import { ElasticsearchQueryOutput } from './query_output';
 import { QuerySidePanel } from './query_side_panel';
 import { useElasticsearchQuery } from '../../hooks/use_elasticsearch_query';
 import { ChatForm, ChatFormFields, PlaygroundPageMode } from '../../types';
-import { FullHeight, QueryViewContainer, QueryViewSidebarContainer } from './styles';
+import {
+  FullHeight,
+  QueryViewContainer,
+  QueryViewSidebarContainer,
+  PanelFillContainer,
+} from './styles';
 import { disableExecuteQuery } from '../../utils/user_query';
 
 export const SearchQueryMode = ({ pageMode }: { pageMode: PlaygroundPageMode }) => {
@@ -62,14 +66,7 @@ export const SearchQueryMode = ({ pageMode }: { pageMode: PlaygroundPageMode }) 
     >
       <EuiFlexGroup>
         <EuiFlexItem grow={6} css={QueryViewContainer(euiTheme)}>
-          <EuiPanel
-            paddingSize="none"
-            hasShadow={false}
-            css={css({
-              // This is needed to maintain the resizable container height when rendering output editor with larger content
-              height: '95%',
-            })}
-          >
+          <EuiPanel paddingSize="none" hasShadow={false} css={PanelFillContainer}>
             <EuiResizableContainer direction="vertical" css={FullHeight}>
               {(EuiResizablePanel, EuiResizableButton) => (
                 <>

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/search_query_mode.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/search_query_mode.tsx
@@ -35,11 +35,24 @@ export const SearchQueryMode = ({ pageMode }: { pageMode: PlaygroundPageMode }) 
   }, [usageTracker]);
   const { executeQuery, data, error, isError, fetchStatus } = useElasticsearchQuery(pageMode);
   const {
+    field: { value: searchQuery },
+  } = useController<ChatForm, ChatFormFields.searchQuery>({
+    name: ChatFormFields.searchQuery,
+  });
+  const {
+    field: { value: question },
+  } = useController<ChatForm, ChatFormFields.question>({
+    name: ChatFormFields.question,
+  });
+  const {
     field: { value: userElasticsearchQueryValidations },
   } = useController<ChatForm, ChatFormFields.userElasticsearchQueryValidations>({
     name: ChatFormFields.userElasticsearchQueryValidations,
   });
-  const executeQueryDisabled = disableExecuteQuery(userElasticsearchQueryValidations);
+  const executeQueryDisabled = disableExecuteQuery(
+    userElasticsearchQueryValidations,
+    pageMode === PlaygroundPageMode.chat ? question : searchQuery
+  );
   const isLoading = fetchStatus !== 'idle';
 
   return (

--- a/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/styles.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/query_mode/styles.ts
@@ -12,6 +12,11 @@ export const FullHeight = css({
   height: '100%',
 });
 
+export const PanelFillContainer = css({
+  // This is needed to maintain the resizable container height when rendering output editor with larger content
+  height: '90%',
+});
+
 export const QueryViewContainer = (euiTheme: EuiThemeComputed<{}>) =>
   css({
     padding: euiTheme.size.l,

--- a/x-pack/solutions/search/plugins/search_playground/public/components/search_mode/search_mode.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/search_mode/search_mode.tsx
@@ -28,7 +28,7 @@ import { useIndexMappings } from '../../hooks/use_index_mappings';
 
 export const SearchMode: React.FC = () => {
   const { euiTheme } = useEuiTheme();
-  const { control, handleSubmit } = useFormContext();
+  const { control, handleSubmit } = useFormContext<ChatForm>();
   const {
     field: { value: searchBarValue },
     formState: { isSubmitting },

--- a/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/search_playground_setup_page.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/setup_page/search_playground_setup_page.tsx
@@ -64,7 +64,12 @@ export const SearchPlaygroundSetupPage: React.FC = () => {
                 />
               </span>
             </EuiTitle>{' '}
-            <EuiLink href="todo" target="_blank" external>
+            <EuiLink
+              href="todo"
+              target="_blank"
+              data-test-subj="search-playground-setup-documentationLink"
+              external
+            >
               <FormattedMessage
                 id="xpack.searchPlayground.setupPage.documentationLink"
                 defaultMessage="Read documentation"

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/dev_tools.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/dev_tools.tsx
@@ -9,16 +9,27 @@ import React from 'react';
 
 import { EuiCodeBlock } from '@elastic/eui';
 import { useFormContext } from 'react-hook-form';
-import { ChatFormFields } from '../../../types';
+import { ChatForm, ChatFormFields } from '../../../types';
+import { elasticsearchQueryObject } from '../../../utils/user_query';
 
 export const DevToolsCode: React.FC = () => {
-  const { getValues } = useFormContext();
-  const query = getValues(ChatFormFields.elasticsearchQuery) ?? '';
-  const indices = getValues(ChatFormFields.indices) ?? [];
-  const searchQuery = getValues(ChatFormFields.searchQuery) ?? '';
-  const replacedQuery = searchQuery
-    ? JSON.stringify(query, null, 2).replace(/\"{query}\"/g, JSON.stringify(searchQuery))
-    : JSON.stringify(query, null, 2);
+  const { getValues } = useFormContext<ChatForm>();
+  const {
+    [ChatFormFields.indices]: indices,
+    [ChatFormFields.elasticsearchQuery]: esQuery,
+    [ChatFormFields.searchQuery]: searchQuery,
+    [ChatFormFields.userElasticsearchQuery]: userElasticsearchQuery,
+    [ChatFormFields.userElasticsearchQueryValidations]: userElasticsearchQueryValidations,
+  } = getValues();
+  const query = elasticsearchQueryObject(
+    esQuery,
+    userElasticsearchQuery,
+    userElasticsearchQueryValidations
+  );
+  const replacedQuery =
+    searchQuery ?? ''
+      ? JSON.stringify(query, null, 2).replace(/\"{query}\"/g, JSON.stringify(searchQuery))
+      : JSON.stringify(query, null, 2);
 
   return (
     <EuiCodeBlock isCopyable overflowHeight="100%">

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_lang_client.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_lang_client.tsx
@@ -9,6 +9,7 @@ import { EuiCodeBlock } from '@elastic/eui';
 import React from 'react';
 import { ChatForm } from '../../../types';
 import { Prompt } from '../../../../common/prompt';
+import { elasticsearchQueryObject } from '../../../utils/user_query';
 import { getESQuery } from './utils';
 
 export const PY_LANG_CLIENT = (formValues: ChatForm, clientDetails: string) => (
@@ -30,7 +31,11 @@ index_source_fields = ${JSON.stringify(formValues.source_fields, null, 4)}
 
 def get_elasticsearch_results(query):
     es_query = ${getESQuery({
-      ...formValues.elasticsearch_query,
+      ...elasticsearchQueryObject(
+        formValues.elasticsearch_query,
+        formValues.user_elasticsearch_query,
+        formValues.user_elasticsearch_query_validations
+      ),
       size: formValues.doc_size,
     })}
 

--- a/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_langchain_python.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/view_code/examples/py_langchain_python.tsx
@@ -9,6 +9,7 @@ import { EuiCodeBlock } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { ChatForm } from '../../../types';
 import { Prompt } from '../../../../common/prompt';
+import { elasticsearchQueryObject } from '../../../utils/user_query';
 import { getESQuery } from './utils';
 
 export const getSourceFields = (sourceFields: ChatForm['source_fields']) => {
@@ -38,7 +39,13 @@ export const LangchainPythonExmaple = ({
   const { esQuery, hasContentFieldsArray, indices, prompt, sourceFields } = useMemo(() => {
     const fields = getSourceFields(formValues.source_fields);
     return {
-      esQuery: getESQuery(formValues.elasticsearch_query),
+      esQuery: getESQuery(
+        elasticsearchQueryObject(
+          formValues.elasticsearch_query,
+          formValues.user_elasticsearch_query,
+          formValues.user_elasticsearch_query_validations
+        )
+      ),
       indices: formValues.indices.join(','),
       prompt: Prompt(formValues.prompt, {
         context: true,

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_elasticsearch_query.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_elasticsearch_query.ts
@@ -7,22 +7,45 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useFormContext } from 'react-hook-form';
-import { APIRoutes, ChatFormFields, QueryTestResponse } from '../types';
+import {
+  APIRoutes,
+  ChatForm,
+  ChatFormFields,
+  PlaygroundPageMode,
+  QueryTestResponse,
+} from '../types';
 import { useKibana } from './use_kibana';
+import { elasticsearchQueryString } from '../utils/user_query';
 
-export const useElasticsearchQuery = () => {
+export const useElasticsearchQuery = (pageMode: PlaygroundPageMode) => {
   const { http } = useKibana().services;
-  const { getValues } = useFormContext();
+  const { getValues } = useFormContext<ChatForm>();
   const executeEsQuery = () => {
-    const indices = getValues(ChatFormFields.indices);
-    const elasticsearchQuery = getValues(ChatFormFields.elasticsearchQuery);
-    const query = getValues(ChatFormFields.searchQuery);
+    const formValues = getValues();
+    const esQuery = elasticsearchQueryString(
+      formValues[ChatFormFields.elasticsearchQuery],
+      formValues[ChatFormFields.userElasticsearchQuery],
+      formValues[ChatFormFields.userElasticsearchQueryValidations]
+    );
+    const body =
+      pageMode === PlaygroundPageMode.chat
+        ? JSON.stringify({
+            elasticsearch_query: esQuery,
+            indices: formValues[ChatFormFields.indices],
+            query: formValues[ChatFormFields.question],
+            chat_context: {
+              source_fields: JSON.stringify(formValues[ChatFormFields.sourceFields]),
+              doc_size: formValues[ChatFormFields.docSize],
+            },
+          })
+        : JSON.stringify({
+            elasticsearch_query: esQuery,
+            indices: formValues[ChatFormFields.indices],
+            query: formValues[ChatFormFields.searchQuery],
+          });
+
     return http.post<QueryTestResponse>(APIRoutes.POST_QUERY_TEST, {
-      body: JSON.stringify({
-        elasticsearch_query: JSON.stringify(elasticsearchQuery),
-        indices,
-        query,
-      }),
+      body,
     });
   };
 

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_elasticsearch_query.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_elasticsearch_query.ts
@@ -52,6 +52,7 @@ export const useElasticsearchQuery = (pageMode: PlaygroundPageMode) => {
   const { refetch: executeQuery, ...rest } = useQuery({
     queryFn: executeEsQuery,
     enabled: false,
+    retry: false,
   });
 
   return {

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_indices_fields.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_indices_fields.ts
@@ -14,23 +14,16 @@ const initialData = {};
 export const useIndicesFields = (indices: string[] = []) => {
   const { services } = useKibana();
 
-  const { data, isLoading, isFetching } = useQuery<IndicesQuerySourceFields>({
+  const { data, isLoading, isFetching, isFetched } = useQuery<IndicesQuerySourceFields>({
     enabled: indices.length > 0,
     queryKey: ['fields', indices.toString()],
     initialData,
-    queryFn: async () => {
-      const response = await services.http.post<IndicesQuerySourceFields>(
-        APIRoutes.POST_QUERY_SOURCE_FIELDS,
-        {
-          body: JSON.stringify({
-            indices,
-          }),
-        }
-      );
-
-      return response;
-    },
+    queryFn: () =>
+      services.http.post<IndicesQuerySourceFields>(APIRoutes.POST_QUERY_SOURCE_FIELDS, {
+        body: JSON.stringify({
+          indices,
+        }),
+      }),
   });
-
-  return { fields: data, isLoading: isLoading || isFetching };
+  return { fields: data, isFetched, isLoading: isLoading || isFetching };
 };

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_fields_by_indices.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_load_fields_by_indices.test.ts
@@ -27,7 +27,7 @@ describe('useLoadFieldsByIndices', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useUsageTracker as jest.Mock).mockReturnValue(mockUsageTracker);
-    (useIndicesFields as jest.Mock).mockReturnValue({ fields: {} });
+    (useIndicesFields as jest.Mock).mockReturnValue({ fields: {}, isFetched: true });
     (getDefaultQueryFields as jest.Mock).mockReturnValue({ newIndex: ['title', 'body'] });
     (getDefaultSourceFields as jest.Mock).mockReturnValue({ testIndex: ['content'] });
     (createQuery as jest.Mock).mockReturnValue('mocked query');
@@ -44,8 +44,14 @@ describe('useLoadFieldsByIndices', () => {
   };
 
   it('sets values and tracks usage on fields change', () => {
-    (useIndicesFields as jest.Mock).mockReturnValue({ fields: { newIndex: {}, testIndex: {} } });
-    mockGetValues.mockReturnValueOnce([{}, {}]);
+    (useIndicesFields as jest.Mock).mockReturnValue({
+      fields: { newIndex: {}, testIndex: {} },
+      isFetched: true,
+    });
+    mockGetValues.mockReturnValueOnce({
+      [ChatFormFields.queryFields]: {},
+      [ChatFormFields.sourceFields]: {},
+    });
     mockWatch.mockReturnValue(['index1']);
 
     setup();
@@ -64,10 +70,14 @@ describe('useLoadFieldsByIndices', () => {
     it('save changed fields', () => {
       (getDefaultQueryFields as jest.Mock).mockReturnValue({ index: ['title', 'body'] });
       (getDefaultSourceFields as jest.Mock).mockReturnValue({ index: ['title'] });
-      mockGetValues.mockReturnValueOnce([{ index: [] }, { index: ['body'] }]);
+      mockGetValues.mockReturnValueOnce({
+        [ChatFormFields.queryFields]: { index: [] },
+        [ChatFormFields.sourceFields]: { index: ['body'] },
+      });
 
       setup();
 
+      expect(mockSetValue).toHaveBeenCalledTimes(3);
       expect(mockSetValue).toHaveBeenNthCalledWith(2, ChatFormFields.queryFields, {
         index: [],
       });
@@ -79,10 +89,10 @@ describe('useLoadFieldsByIndices', () => {
     it('remove old indices from fields', () => {
       (getDefaultQueryFields as jest.Mock).mockReturnValue({ index: ['title', 'body'] });
       (getDefaultSourceFields as jest.Mock).mockReturnValue({ index: ['title'] });
-      mockGetValues.mockReturnValueOnce([
-        { index: [], oldIndex: ['title'] },
-        { index: ['body'], oldIndex: ['title'] },
-      ]);
+      mockGetValues.mockReturnValueOnce({
+        [ChatFormFields.queryFields]: { index: [], oldIndex: ['title'] },
+        [ChatFormFields.sourceFields]: { index: ['body'], oldIndex: ['title'] },
+      });
 
       setup();
 
@@ -103,10 +113,10 @@ describe('useLoadFieldsByIndices', () => {
         index: ['title'],
         newIndex: ['content'],
       });
-      mockGetValues.mockReturnValueOnce([
-        { index: [], oldIndex: ['title'] },
-        { index: ['body'], oldIndex: ['title'] },
-      ]);
+      mockGetValues.mockReturnValueOnce({
+        [ChatFormFields.queryFields]: { index: [], oldIndex: ['title'] },
+        [ChatFormFields.sourceFields]: { index: ['body'], oldIndex: ['title'] },
+      });
 
       setup();
 

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_search_preview.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_search_preview.ts
@@ -12,6 +12,7 @@ import type { HttpSetup } from '@kbn/core-http-browser';
 import { APIRoutes, ChatForm, ChatFormFields, Pagination } from '../types';
 import { useKibana } from './use_kibana';
 import { DEFAULT_PAGINATION } from '../../common';
+import { elasticsearchQueryObject } from '../utils/user_query';
 
 export interface FetchSearchResultsArgs {
   query: string;
@@ -43,7 +44,7 @@ export const fetchSearchResults = async ({
   pagination: paginationParam = DEFAULT_PAGINATION,
   http,
 }: FetchSearchResultsArgs): Promise<UseSearchPreviewData> => {
-  const { results, pagination: paginationResult } = await http.post<{
+  return http.post<{
     results: SearchHit[];
     pagination: Pagination;
   }>(APIRoutes.POST_SEARCH_QUERY, {
@@ -55,7 +56,6 @@ export const fetchSearchResults = async ({
       from: paginationParam.from,
     }),
   });
-  return { results, pagination: paginationResult };
 };
 
 export const useSearchPreview = ({
@@ -68,13 +68,28 @@ export const useSearchPreview = ({
   const {
     services: { http },
   } = useKibana();
-  const { getValues } = useFormContext();
+  const { getValues } = useFormContext<ChatForm>();
   const indices = getValues(ChatFormFields.indices);
   const elasticsearchQuery = getValues(ChatFormFields.elasticsearchQuery);
+  const queryFn = () => {
+    const formData = getValues();
+    const elasticsearchQueryBody = elasticsearchQueryObject(
+      formData[ChatFormFields.elasticsearchQuery],
+      formData[ChatFormFields.userElasticsearchQuery],
+      formData[ChatFormFields.userElasticsearchQueryValidations]
+    );
+    return fetchSearchResults({
+      query,
+      pagination,
+      http,
+      indices: formData[ChatFormFields.indices],
+      elasticsearchQuery: elasticsearchQueryBody,
+    });
+  };
 
   const { data } = useQuery({
     queryKey: ['search-preview-results', query, indices, elasticsearchQuery, pagination],
-    queryFn: () => fetchSearchResults({ query, pagination, http, indices, elasticsearchQuery }),
+    queryFn,
     initialData: DEFAULT_SEARCH_PREVIEW_DATA,
     enabled: !!query,
     refetchOnWindowFocus: false,

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_source_indices_field.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_source_indices_field.ts
@@ -20,6 +20,11 @@ export const useSourceIndicesFields = () => {
   } = useController({
     name: ChatFormFields.indices,
   });
+  const {
+    field: { onChange: onUserQueryChange },
+  } = useController({
+    name: ChatFormFields.userElasticsearchQuery,
+  });
   const { fields, isLoading: isFieldsLoading } = useIndicesFields(selectedIndices);
 
   const addIndex = useCallback(
@@ -43,9 +48,10 @@ export const useSourceIndicesFields = () => {
   const setIndices = useCallback(
     (indices: IndexName[]) => {
       onIndicesChange(indices);
+      onUserQueryChange(undefined);
       usageTracker?.count(AnalyticsEvents.sourceIndexUpdated, indices.length);
     },
-    [onIndicesChange, usageTracker]
+    [onIndicesChange, onUserQueryChange, usageTracker]
   );
 
   return {

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_source_indices_field.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_source_indices_field.ts
@@ -48,7 +48,7 @@ export const useSourceIndicesFields = () => {
   const setIndices = useCallback(
     (indices: IndexName[]) => {
       onIndicesChange(indices);
-      onUserQueryChange(undefined);
+      onUserQueryChange(null);
       usageTracker?.count(AnalyticsEvents.sourceIndexUpdated, indices.length);
     },
     [onIndicesChange, onUserQueryChange, usageTracker]

--- a/x-pack/solutions/search/plugins/search_playground/public/hooks/use_user_query_validations.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/hooks/use_user_query_validations.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useEffect } from 'react';
+import { UseFormReturn } from 'react-hook-form/dist/types';
+import { useDebounceFn } from '@kbn/react-hooks';
+
+import { ChatForm, ChatFormFields } from '../types';
+import { validateUserElasticSearchQuery } from '../utils/user_query';
+
+const DEBOUNCE_OPTIONS = { wait: 500 };
+export const useUserQueryValidations = ({
+  watch,
+  setValue,
+  getValues,
+}: Pick<UseFormReturn<ChatForm>, 'watch' | 'getValues' | 'setValue'>) => {
+  const userElasticsearchQuery = watch(ChatFormFields.userElasticsearchQuery);
+  const elasticsearchQuery = watch(ChatFormFields.elasticsearchQuery);
+
+  const userQueryValidation = useDebounceFn(() => {
+    const [esQuery, userInputQuery] = getValues([
+      ChatFormFields.elasticsearchQuery,
+      ChatFormFields.userElasticsearchQuery,
+    ]);
+    const validations = validateUserElasticSearchQuery(userInputQuery, esQuery);
+    setValue(ChatFormFields.userElasticsearchQueryValidations, validations);
+  }, DEBOUNCE_OPTIONS);
+  useEffect(() => {
+    userQueryValidation.run();
+  }, [elasticsearchQuery, userElasticsearchQuery, userQueryValidation]);
+};

--- a/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.test.tsx
@@ -53,7 +53,7 @@ const DEFAULT_FORM_STATE: Partial<ChatForm> = {
   search_query: '',
   indices: [],
   summarization_model: undefined,
-  user_elasticsearch_query: undefined,
+  user_elasticsearch_query: null,
   user_elasticsearch_query_validations: {
     isUserCustomized: false,
     isValid: false,
@@ -155,6 +155,7 @@ describe('FormProvider', () => {
           source_fields: {},
           indices: [],
           summarization_model: undefined,
+          user_elasticsearch_query: null,
         })
       );
     });

--- a/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.test.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.test.tsx
@@ -11,7 +11,7 @@ import { FormProvider, LOCAL_STORAGE_KEY } from './form_provider';
 import { useLoadFieldsByIndices } from '../hooks/use_load_fields_by_indices';
 import { useLLMsModels } from '../hooks/use_llms_models';
 import * as ReactHookForm from 'react-hook-form';
-import { ChatFormFields } from '../types';
+import { ChatForm, ChatFormFields } from '../types';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 
 jest.mock('../hooks/use_load_fields_by_indices');
@@ -21,6 +21,9 @@ jest.mock('react-router-dom-v5-compat', () => ({
 }));
 jest.mock('../hooks/use_indices_validation', () => ({
   useIndicesValidation: jest.fn((indices) => ({ isValidated: true, validIndices: indices })),
+}));
+jest.mock('@kbn/react-hooks', () => ({
+  useDebounceFn: (fn: any) => ({ run: fn }),
 }));
 
 let formHookSpy: jest.SpyInstance;
@@ -42,6 +45,20 @@ const localStorageMock = (() => {
     },
   };
 })() as Storage;
+
+const DEFAULT_FORM_STATE: Partial<ChatForm> = {
+  doc_size: 3,
+  prompt: 'You are an assistant for question-answering tasks.',
+  source_fields: {},
+  search_query: '',
+  indices: [],
+  summarization_model: undefined,
+  user_elasticsearch_query: undefined,
+  user_elasticsearch_query_validations: {
+    isUserCustomized: false,
+    isValid: false,
+  },
+};
 
 describe('FormProvider', () => {
   beforeEach(() => {
@@ -65,14 +82,7 @@ describe('FormProvider', () => {
     const { getValues } = formHookSpy.mock.results[0].value;
 
     await waitFor(() => {
-      expect(getValues()).toEqual({
-        doc_size: 3,
-        indices: [],
-        prompt: 'You are an assistant for question-answering tasks.',
-        search_query: '',
-        source_fields: {},
-        summarization_model: undefined,
-      });
+      expect(getValues()).toEqual(DEFAULT_FORM_STATE);
     });
   });
 
@@ -172,12 +182,8 @@ describe('FormProvider', () => {
 
     await waitFor(() => {
       expect(getValues()).toEqual({
+        ...DEFAULT_FORM_STATE,
         prompt: 'Loaded prompt',
-        doc_size: 3,
-        source_fields: {},
-        search_query: '',
-        indices: [],
-        summarization_model: undefined,
       });
     });
   });

--- a/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.tsx
@@ -16,7 +16,7 @@ import { useLLMsModels } from '../hooks/use_llms_models';
 
 type PartialChatForm = Partial<ChatForm>;
 export const LOCAL_STORAGE_KEY = 'search_playground_session';
-export const LOCAL_STORAGE_DEBOUNCE_OPTIONS = { wait: 500 };
+export const LOCAL_STORAGE_DEBOUNCE_OPTIONS = { wait: 100 };
 
 const DEFAULT_FORM_VALUES: PartialChatForm = {
   prompt: 'You are an assistant for question-answering tasks.',

--- a/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/providers/form_provider.tsx
@@ -24,7 +24,7 @@ const DEFAULT_FORM_VALUES: PartialChatForm = {
   source_fields: {},
   indices: [],
   summarization_model: undefined,
-  [ChatFormFields.userElasticsearchQuery]: undefined,
+  [ChatFormFields.userElasticsearchQuery]: null,
   [ChatFormFields.userElasticsearchQueryValidations]: undefined,
 };
 

--- a/x-pack/solutions/search/plugins/search_playground/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/types.ts
@@ -97,7 +97,7 @@ export interface ChatForm {
   [ChatFormFields.docSize]: number;
   [ChatFormFields.queryFields]: { [index: string]: string[] };
   [ChatFormFields.searchQuery]: string;
-  [ChatFormFields.userElasticsearchQuery]: string | undefined;
+  [ChatFormFields.userElasticsearchQuery]: string | null;
   [ChatFormFields.userElasticsearchQueryValidations]: UserQueryValidations | undefined;
 }
 

--- a/x-pack/solutions/search/plugins/search_playground/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/types.ts
@@ -77,6 +77,8 @@ export enum ChatFormFields {
   prompt = 'prompt',
   indices = 'indices',
   elasticsearchQuery = 'elasticsearch_query',
+  userElasticsearchQuery = 'user_elasticsearch_query',
+  userElasticsearchQueryValidations = 'user_elasticsearch_query_validations',
   summarizationModel = 'summarization_model',
   sourceFields = 'source_fields',
   docSize = 'doc_size',
@@ -95,6 +97,14 @@ export interface ChatForm {
   [ChatFormFields.docSize]: number;
   [ChatFormFields.queryFields]: { [index: string]: string[] };
   [ChatFormFields.searchQuery]: string;
+  [ChatFormFields.userElasticsearchQuery]: string | undefined;
+  [ChatFormFields.userElasticsearchQueryValidations]: UserQueryValidations | undefined;
+}
+
+export interface UserQueryValidations {
+  isValid: boolean;
+  isUserCustomized: boolean;
+  userQueryErrors?: string[];
 }
 
 export interface Message {

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.test.ts
@@ -21,8 +21,8 @@ describe('User Query utilities', () => {
         },
       },
     };
-    it('should return false if userQuery is undefined', () => {
-      expect(validateUserElasticSearchQuery(undefined, sampleGeneratedElasticsearchQuery)).toEqual({
+    it('should return false if userQuery is null', () => {
+      expect(validateUserElasticSearchQuery(null, sampleGeneratedElasticsearchQuery)).toEqual({
         isValid: false,
         isUserCustomized: false,
       });
@@ -43,6 +43,18 @@ describe('User Query utilities', () => {
       expect(validateUserElasticSearchQuery(userQuery, sampleGeneratedElasticsearchQuery)).toEqual({
         isValid: false,
         isUserCustomized: true,
+      });
+    });
+    it('should return valid false if userQuery is empty', () => {
+      expect(validateUserElasticSearchQuery('', sampleGeneratedElasticsearchQuery)).toEqual({
+        isValid: false,
+        isUserCustomized: true,
+        userQueryErrors: [expect.any(String)],
+      });
+      expect(validateUserElasticSearchQuery('   ', sampleGeneratedElasticsearchQuery)).toEqual({
+        isValid: false,
+        isUserCustomized: true,
+        userQueryErrors: [expect.any(String)],
       });
     });
     it('should return customized false if queries are equal', () => {
@@ -90,7 +102,7 @@ describe('User Query utilities', () => {
       expect(validateUserElasticSearchQuery(userQuery, sampleGeneratedElasticsearchQuery)).toEqual({
         isValid: false,
         isUserCustomized: true,
-        userQueryErrors: ['User query must contain "{query}" placeholder'],
+        userQueryErrors: ['User query must contain "{query}"'],
       });
     });
     it('should include {query} placeholder error even when query is not valid JSON', () => {
@@ -98,7 +110,7 @@ describe('User Query utilities', () => {
       expect(validateUserElasticSearchQuery(userQuery, sampleGeneratedElasticsearchQuery)).toEqual({
         isValid: false,
         isUserCustomized: true,
-        userQueryErrors: ['User query must contain "{query}" placeholder'],
+        userQueryErrors: [expect.any(String)],
       });
     });
   });

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.test.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { validateUserElasticSearchQuery } from './user_query';
+
+describe('User Query utilities', () => {
+  describe('validateUserElasticSearchQuery', () => {
+    const sampleGeneratedElasticsearchQuery = {
+      retriever: {
+        standard: {
+          query: {
+            multi_match: {
+              query: '{query}',
+              fields: ['foo', 'bar', 'baz'],
+            },
+          },
+        },
+      },
+    };
+    it('should return false if userQuery is undefined', () => {
+      expect(validateUserElasticSearchQuery(undefined, sampleGeneratedElasticsearchQuery)).toEqual({
+        isValid: false,
+        isUserCustomized: false,
+      });
+    });
+    it('should return valid false if userQuery is not a valid JSON', () => {
+      const userQuery = `{
+        "retriever": {
+          "standard": {
+            "query": {
+              "multi_match": {
+                "fields": ["foo", "bar", "baz"]
+                "query": "{query}"
+              }
+            }
+          }
+        }
+      }`;
+      expect(validateUserElasticSearchQuery(userQuery, sampleGeneratedElasticsearchQuery)).toEqual({
+        isValid: false,
+        isUserCustomized: true,
+      });
+    });
+    it('should return customized false if queries are equal', () => {
+      expect(
+        validateUserElasticSearchQuery(
+          JSON.stringify(sampleGeneratedElasticsearchQuery, null, 4),
+          sampleGeneratedElasticsearchQuery
+        )
+      ).toEqual({
+        isValid: true,
+        isUserCustomized: false,
+      });
+    });
+    it('should return customized false if queries are functionally equal', () => {
+      const userQuery = `{
+  "retriever": {
+    "standard": {
+      "query": {
+        "multi_match": {
+          "fields": ["foo", "bar", "baz"],
+          "query": "{query}"
+        }
+      }
+    }
+  }
+}`;
+      expect(validateUserElasticSearchQuery(userQuery, sampleGeneratedElasticsearchQuery)).toEqual({
+        isValid: true,
+        isUserCustomized: false,
+      });
+    });
+    it('should return valid false if user query removes {query} placeholder', () => {
+      const userQuery = `{
+  "retriever": {
+    "standard": {
+      "query": {
+        "multi_match": {
+          "query": "test",
+          "fields": ["foo"]
+        }
+      }
+    }
+  }
+}`;
+      expect(validateUserElasticSearchQuery(userQuery, sampleGeneratedElasticsearchQuery)).toEqual({
+        isValid: false,
+        isUserCustomized: true,
+        userQueryErrors: ['User query must contain "{query}" placeholder'],
+      });
+    });
+    it('should include {query} placeholder error even when query is not valid JSON', () => {
+      const userQuery = `invalid`;
+      expect(validateUserElasticSearchQuery(userQuery, sampleGeneratedElasticsearchQuery)).toEqual({
+        isValid: false,
+        isUserCustomized: true,
+        userQueryErrors: ['User query must contain "{query}" placeholder'],
+      });
+    });
+  });
+});

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.ts
@@ -10,20 +10,23 @@ import { i18n } from '@kbn/i18n';
 import type { ChatForm, ChatFormFields, UserQueryValidations } from '../types';
 
 export const validateUserElasticSearchQuery = (
-  userQuery: string | undefined,
-  elasticsearchQuery: { retriever: any }
+  userQuery: ChatForm[ChatFormFields.userElasticsearchQuery],
+  elasticsearchQuery: ChatForm[ChatFormFields.elasticsearchQuery]
 ): UserQueryValidations => {
-  if (!userQuery) {
+  if (userQuery === null) {
     return { isValid: false, isUserCustomized: false };
   }
   let userQueryErrors: string[] | undefined;
   if (!userQuery.includes('{query}')) {
     userQueryErrors = [
       i18n.translate('xpack.searchPlayground.userQuery.errors.queryPlaceholder', {
-        defaultMessage: 'User query must contain "{query}" placeholder',
+        defaultMessage: 'User query must contain "{query}"',
         values: { query: '{query}' },
       }),
     ];
+  }
+  if (userQuery.trim().length === 0) {
+    return { isValid: false, isUserCustomized: true, userQueryErrors };
   }
   let userQueryObject: {} = {};
   try {

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import deepEqual from 'fast-deep-equal';
+import { i18n } from '@kbn/i18n';
+import type { ChatForm, ChatFormFields, UserQueryValidations } from '../types';
+
+export const validateUserElasticSearchQuery = (
+  userQuery: string | undefined,
+  elasticsearchQuery: { retriever: any }
+): UserQueryValidations => {
+  if (!userQuery) {
+    return { isValid: false, isUserCustomized: false };
+  }
+  let userQueryErrors: string[] | undefined;
+  if (!userQuery.includes('{query}')) {
+    userQueryErrors = [
+      i18n.translate('xpack.searchPlayground.userQuery.errors.queryPlaceholder', {
+        defaultMessage: 'User query must contain "{query}" placeholder',
+        values: { query: '{query}' },
+      }),
+    ];
+  }
+  let userQueryObject: {} = {};
+  try {
+    userQueryObject = JSON.parse(userQuery);
+  } catch (e) {
+    return { isValid: false, isUserCustomized: true, userQueryErrors };
+  }
+  if (deepEqual(userQueryObject, elasticsearchQuery)) {
+    return { isValid: true, isUserCustomized: false };
+  }
+  if (userQueryErrors && userQueryErrors.length > 0) {
+    return {
+      isValid: false,
+      isUserCustomized: true,
+      userQueryErrors,
+    };
+  }
+  return { isValid: true, isUserCustomized: true };
+};
+
+export const disableExecuteQuery = (validations: UserQueryValidations | undefined): boolean => {
+  if (validations?.isUserCustomized) {
+    return validations?.isValid === false;
+  }
+  return false;
+};
+
+export const elasticsearchQueryString = (
+  elasticsearchQuery: ChatForm[ChatFormFields.elasticsearchQuery],
+  userElasticsearchQuery: ChatForm[ChatFormFields.userElasticsearchQuery],
+  userElasticsearchQueryValidations: ChatForm[ChatFormFields.userElasticsearchQueryValidations]
+) => {
+  if (!userElasticsearchQuery || userElasticsearchQueryValidations?.isUserCustomized === false) {
+    return JSON.stringify(elasticsearchQuery);
+  }
+  if (userElasticsearchQueryValidations?.isValid === true) {
+    return userElasticsearchQuery;
+  }
+  return JSON.stringify(elasticsearchQuery);
+};
+
+export const elasticsearchQueryObject = (
+  elasticsearchQuery: ChatForm[ChatFormFields.elasticsearchQuery],
+  userElasticsearchQuery: ChatForm[ChatFormFields.userElasticsearchQuery],
+  userElasticsearchQueryValidations: ChatForm[ChatFormFields.userElasticsearchQueryValidations]
+): { retriever: any } => {
+  if (!userElasticsearchQuery || userElasticsearchQueryValidations?.isUserCustomized === false) {
+    return elasticsearchQuery;
+  }
+  if (userElasticsearchQueryValidations?.isValid === true) {
+    return JSON.parse(userElasticsearchQuery);
+  }
+  return elasticsearchQuery;
+};
+
+export const formatElasticsearchQueryString = (
+  elasticsearchQuery: ChatForm[ChatFormFields.elasticsearchQuery]
+) => JSON.stringify(elasticsearchQuery, null, 2);

--- a/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.ts
+++ b/x-pack/solutions/search/plugins/search_playground/public/utils/user_query.ts
@@ -44,11 +44,14 @@ export const validateUserElasticSearchQuery = (
   return { isValid: true, isUserCustomized: true };
 };
 
-export const disableExecuteQuery = (validations: UserQueryValidations | undefined): boolean => {
-  if (validations?.isUserCustomized) {
-    return validations?.isValid === false;
-  }
-  return false;
+export const disableExecuteQuery = (
+  validations: UserQueryValidations | undefined,
+  query: string
+): boolean => {
+  return (
+    query.trim().length === 0 ||
+    (validations?.isUserCustomized === true && validations?.isValid === false)
+  );
 };
 
 export const elasticsearchQueryString = (

--- a/x-pack/solutions/search/plugins/search_playground/server/routes.ts
+++ b/x-pack/solutions/search/plugins/search_playground/server/routes.ts
@@ -29,6 +29,7 @@ import { fetchIndices } from './lib/fetch_indices';
 import { isNotNullish } from '../common/is_not_nullish';
 import { MODELS } from '../common/models';
 import { ContextLimitError } from './lib/errors';
+import { contextDocumentHitMapper } from './utils/context_document_mapper';
 import { parseSourceFields } from './utils/parse_source_fields';
 import { getErrorMessage } from '../common/errors';
 
@@ -411,12 +412,24 @@ export function defineRoutes({
           indices: schema.arrayOf(schema.string()),
           size: schema.maybe(schema.number({ defaultValue: 10, min: 0 })),
           from: schema.maybe(schema.number({ defaultValue: 0, min: 0 })),
+          chat_context: schema.maybe(
+            schema.object({
+              source_fields: schema.string(),
+              doc_size: schema.number(),
+            })
+          ),
         }),
       },
     },
     errorHandler(logger)(async (context, request, response) => {
       const { client } = (await context.core).elasticsearch;
-      const { elasticsearch_query: elasticsearchQuery, indices, size, from } = request.body;
+      const {
+        elasticsearch_query: elasticsearchQuery,
+        indices,
+        size,
+        from,
+        chat_context: chatContext,
+      } = request.body;
 
       if (indices.length === 0) {
         return response.badRequest({
@@ -425,7 +438,6 @@ export function defineRoutes({
           },
         });
       }
-
       let searchQuery: Partial<SearchRequest>;
       try {
         searchQuery = parseElasticsearchQuery(elasticsearchQuery)(request.body.query);
@@ -437,22 +449,50 @@ export function defineRoutes({
           },
         });
       }
-      const searchResponse = await client.asCurrentUser.search({
-        ...searchQuery,
-        index: indices,
-        from,
-        size,
-      });
-      const body: QueryTestResponse = {
-        searchResponse,
-      };
 
-      return response.ok({
-        body,
-        headers: {
-          'content-type': 'application/json',
-        },
-      });
+      if (!chatContext) {
+        const searchResponse = await client.asCurrentUser.search({
+          ...searchQuery,
+          index: indices,
+          from,
+          size,
+        });
+        const body: QueryTestResponse = {
+          searchResponse,
+        };
+
+        return response.ok({
+          body,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+      } else {
+        let sourceFields: ElasticsearchRetrieverContentField;
+        try {
+          sourceFields = parseSourceFields(chatContext.source_fields);
+        } catch (e) {
+          logger.error('Failed to parse the source fields', e);
+          throw Error(e);
+        }
+        const searchResponse = await client.asCurrentUser.search({
+          ...searchQuery,
+          index: indices,
+          size: chatContext.doc_size,
+        });
+        const documents = searchResponse.hits.hits.map(contextDocumentHitMapper(sourceFields));
+
+        const body: QueryTestResponse = {
+          documents,
+          searchResponse,
+        };
+        return response.ok({
+          body,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+      }
     })
   );
 }

--- a/x-pack/solutions/search/plugins/search_playground/tsconfig.json
+++ b/x-pack/solutions/search/plugins/search_playground/tsconfig.json
@@ -55,6 +55,8 @@
     "@kbn/logging-mocks",
     "@kbn/inference-plugin",
     "@kbn/code-editor",
+    "@kbn/monaco",
+    "@kbn/react-hooks",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/test/functional/page_objects/search_playground_page.ts
+++ b/x-pack/test/functional/page_objects/search_playground_page.ts
@@ -13,6 +13,7 @@ export function SearchPlaygroundPageProvider({ getService }: FtrProviderContext)
   const findService = getService('find');
   const browser = getService('browser');
   const comboBox = getService('comboBox');
+  const retry = getService('retry');
   const selectIndex = async () => {
     await testSubjects.existOrFail('addDataSourcesButton');
     await testSubjects.click('addDataSourcesButton');
@@ -46,8 +47,17 @@ export function SearchPlaygroundPageProvider({ getService }: FtrProviderContext)
       },
 
       async expectSession(): Promise<void> {
-        const session = (await browser.getLocalStorageItem(SESSION_KEY)) || '{}';
-        const state = JSON.parse(session);
+        let state: Record<string, unknown> = {};
+        await retry.try(
+          async () => {
+            const session = (await browser.getLocalStorageItem(SESSION_KEY)) || '{}';
+            state = JSON.parse(session);
+            expect(Object.keys(state).length).to.be.greaterThan(0, 'Session state has no keys');
+          },
+          undefined,
+          200
+        );
+
         expect(state.prompt).to.be('You are an assistant for question-answering tasks.');
         expect(state.doc_size).to.be(3);
         expect(state.elasticsearch_query).eql({

--- a/x-pack/test_serverless/functional/test_suites/search/search_playground/playground_overview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/search_playground/playground_overview.ts
@@ -22,12 +22,14 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     'searchPlayground',
     'embeddedConsole',
   ]);
+  const svlSearchNavigation = getService('svlSearchNavigation');
   const svlCommonApi = getService('svlCommonApi');
   const svlUserManager = getService('svlUserManager');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const esArchiver = getService('esArchiver');
   const log = getService('log');
   const browser = getService('browser');
+  const retry = getService('retry');
   const createIndex = async () => await esArchiver.load(esArchiveIndex);
   let roleAuthc: RoleCredentials;
 
@@ -42,9 +44,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     before(async () => {
       proxy = await createLlmProxy(log);
       await pageObjects.svlCommonPage.loginWithRole('admin');
-      await pageObjects.svlCommonNavigation.sidenav.clickLink({
-        deepLinkId: 'searchPlayground',
-      });
 
       const requestHeader = svlCommonApi.getInternalRequestHeader();
       roleAuthc = await svlUserManager.createM2mApiKeyWithRoleScope('admin');
@@ -57,9 +56,16 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         });
       };
     });
+    beforeEach(async () => {
+      await svlSearchNavigation.navigateToSearchPlayground();
+    });
 
     after(async () => {
-      // await removeOpenAIConnector?.();
+      try {
+        await removeOpenAIConnector?.();
+      } catch {
+        // we can ignore  if this fails
+      }
       await esArchiver.unload(esArchiveIndex);
       proxy.close();
       await svlUserManager.invalidateM2mApiKeyWithRoleScope(roleAuthc);
@@ -218,8 +224,18 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           await pageObjects.searchPlayground.PlaygroundChatPage.navigateToChatPage();
           await pageObjects.searchPlayground.PlaygroundChatPage.updatePrompt("You're a doctor");
           await pageObjects.searchPlayground.PlaygroundChatPage.updateQuestion('i have back pain');
-          await pageObjects.searchPlayground.session.expectInSession('prompt', "You're a doctor");
-          await pageObjects.searchPlayground.session.expectInSession('question', undefined);
+          // wait for session debounce before trying to load new session state.
+          await retry.try(
+            async () => {
+              await pageObjects.searchPlayground.session.expectInSession(
+                'prompt',
+                "You're a doctor"
+              );
+              await pageObjects.searchPlayground.session.expectInSession('question', undefined);
+            },
+            undefined,
+            200
+          );
         });
 
         it('click on manage connector button', async () => {


### PR DESCRIPTION
## Summary

This PR updates the Query Mode in playground to allow the user to customize the query themselves. When the query is customized the GUI for selecting fields is disabled. Changing the index setting will reset the query to the elastic generated search query.

### Screenshots
<img width="1547" alt="image" src="https://github.com/user-attachments/assets/24d94417-4e10-46dd-abaf-49c7196e17c0" />
`{query}` placeholder is required even when customized
<img width="1547" alt="image" src="https://github.com/user-attachments/assets/8522ba4b-5027-49a6-a85d-19857e76e43b" />
"Run" action is disabled when query is not valid JSON
<img width="1547" alt="image" src="https://github.com/user-attachments/assets/c741d755-4659-4dce-857f-4dfbb73b3035" />
Errors are displayed in Query Output
<img width="1547" alt="image" src="https://github.com/user-attachments/assets/34a797c9-6de6-443a-b58c-5ea8f8c5bf79" />

Query field selection is disabled when query is customized

![image](https://github.com/user-attachments/assets/0fcda6c5-a820-4470-b554-9fc1d2ed7950)


### Feature Flag

** This work is behind the `searchPlayground:searchModeEnabled` feature flag **
Enable feature with Dev Tools
```
POST kbn:/internal/kibana/settings/searchPlayground:searchModeEnabled
{"value": true}
```
OR
Enable feature in `kibana.dev.yml`
```yaml
uiSettings.overrides:
  'searchPlayground:searchModeEnabled': true
```


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
