### PR TITLE
[8.x] [ResponseOps]consistent-type-imports linting rule for RO packages/plugins - PR4 (#212508)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1651,6 +1651,10 @@ module.exports = {
         'x-pack/platform/plugins/shared/stack_connectors/**/*.{ts, tsx}',
         'x-pack/platform/plugins/shared/triggers_actions_ui/**/*.{ts, tsx}',
         'x-pack/platform/plugins/shared/embeddable_alerts_table/**/*.{ts,tsx}',
+        'x-pack/test/alerting_api_integration/**/*.{ts, tsx}',
+        'x-pack/test/cases_api_integration/**/*.{ts, tsx}',
+        'x-pack/test/rule_registry/**/*.{ts, tsx}',
+        'x-pack/test/api_integration/apis/cases/**/*.{ts, tsx}',
       ],
       rules: {
         '@typescript-eslint/consistent-type-imports': 'error',

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/cases_webhook.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/cases_webhook.ts
@@ -9,7 +9,7 @@ import {
   ExternalServiceSimulator,
   getExternalServiceSimulatorPath,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function casesWebhookTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/email.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/email.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function emailTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/es_index.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/es_index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function indexTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/jira.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/jira.ts
@@ -9,7 +9,7 @@ import {
   getExternalServiceSimulatorPath,
   ExternalServiceSimulator,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function jiraTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/pagerduty.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/pagerduty.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function pagerdutyTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/resilient.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/resilient.ts
@@ -9,7 +9,7 @@ import {
   getExternalServiceSimulatorPath,
   ExternalServiceSimulator,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function resilientTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/server_log.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/server_log.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function serverLogTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/servicenow.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/servicenow.ts
@@ -9,7 +9,7 @@ import {
   getExternalServiceSimulatorPath,
   ExternalServiceSimulator,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function servicenowTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/slack.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/slack.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import getPort from 'get-port';
 import { getSlackServer } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function slackTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/swimlane.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/swimlane.ts
@@ -9,7 +9,7 @@ import {
   ExternalServiceSimulator,
   getExternalServiceSimulatorPath,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function swimlaneTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/webhook.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/connector_types/webhook.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import getPort from 'get-port';
 import { getWebhookServer } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function webhookTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/actions/index.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/actions/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function connectorsTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/alerts/basic_noop_alert_type.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/alerts/basic_noop_alert_type.ts
@@ -6,7 +6,7 @@
  */
 
 import { getTestRuleData } from '../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function basicRuleTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/alerts/gold_noop_alert_type.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/alerts/gold_noop_alert_type.ts
@@ -6,7 +6,7 @@
  */
 
 import { getTestRuleData } from '../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function emailTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/alerts/index.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/alerts/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/basic/tests/index.ts
+++ b/x-pack/test/alerting_api_integration/basic/tests/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingApiIntegrationTests({

--- a/x-pack/test/alerting_api_integration/common/config.ts
+++ b/x-pack/test/alerting_api_integration/common/config.ts
@@ -8,10 +8,11 @@
 import path from 'path';
 import getPort from 'get-port';
 import { CA_CERT_PATH } from '@kbn/dev-utils';
-import { FtrConfigProviderContext, findTestPluginPaths } from '@kbn/test';
+import type { FtrConfigProviderContext } from '@kbn/test';
+import { findTestPluginPaths } from '@kbn/test';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 import { getAllExternalServiceSimulatorPaths } from '@kbn/actions-simulators-plugin/server/plugin';
-import { ExperimentalConfigKeys } from '@kbn/stack-connectors-plugin/common/experimental_features';
+import type { ExperimentalConfigKeys } from '@kbn/stack-connectors-plugin/common/experimental_features';
 import { SENTINELONE_CONNECTOR_ID } from '@kbn/stack-connectors-plugin/common/sentinelone/constants';
 import { CROWDSTRIKE_CONNECTOR_ID } from '@kbn/stack-connectors-plugin/common/crowdstrike/constants';
 import { MICROSOFT_DEFENDER_ENDPOINT_CONNECTOR_ID } from '@kbn/stack-connectors-plugin/common/microsoft_defender_endpoint/constants';

--- a/x-pack/test/alerting_api_integration/common/ftr_provider_context.d.ts
+++ b/x-pack/test/alerting_api_integration/common/ftr_provider_context.d.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { GenericFtrProviderContext } from '@kbn/test';
+import type { GenericFtrProviderContext } from '@kbn/test';
 
-import { services } from './services';
+import type { services } from './services';
 
 export type FtrProviderContext = GenericFtrProviderContext<typeof services, {}>;

--- a/x-pack/test/alerting_api_integration/common/lib/alert_utils.ts
+++ b/x-pack/test/alerting_api_integration/common/lib/alert_utils.ts
@@ -6,11 +6,11 @@
  */
 
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
-import { AlertsFilter } from '@kbn/alerting-plugin/common/rule';
-import { SupertestWithoutAuthProviderType } from '@kbn/ftr-common-functional-services';
-import { SnoozeBody } from '@kbn/alerting-plugin/common/routes/rule/apis/snooze';
-import { Space, User } from '../types';
-import { ObjectRemover } from './object_remover';
+import type { AlertsFilter } from '@kbn/alerting-plugin/common/rule';
+import type { SupertestWithoutAuthProviderType } from '@kbn/ftr-common-functional-services';
+import type { SnoozeBody } from '@kbn/alerting-plugin/common/routes/rule/apis/snooze';
+import type { Space, User } from '../types';
+import type { ObjectRemover } from './object_remover';
 import { getUrlPrefix } from './space_test_utils';
 import { getTestRuleData } from './get_test_rule_data';
 

--- a/x-pack/test/alerting_api_integration/common/lib/get_event_log.ts
+++ b/x-pack/test/alerting_api_integration/common/lib/get_event_log.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import { IValidatedEventInternalDocInfo } from '@kbn/event-log-plugin/server';
+import type { IValidatedEventInternalDocInfo } from '@kbn/event-log-plugin/server';
 import { getUrlPrefix } from '.';
-import { FtrProviderContext } from '../ftr_provider_context';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 interface GreaterThanEqualCondition {
   gte: number;

--- a/x-pack/test/alerting_api_integration/common/lib/log_supertest_errors.ts
+++ b/x-pack/test/alerting_api_integration/common/lib/log_supertest_errors.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import SuperTest from 'supertest';
-import { ToolingLog } from '@kbn/tooling-log';
+import type SuperTest from 'supertest';
+import type { ToolingLog } from '@kbn/tooling-log';
 
 export interface LogErrorDetailsInterface {
   (this: SuperTest.Test, err: Error & { response?: any }): SuperTest.Test;

--- a/x-pack/test/alerting_api_integration/common/lib/task_manager_utils.ts
+++ b/x-pack/test/alerting_api_integration/common/lib/task_manager_utils.ts
@@ -6,7 +6,7 @@
  */
 import type { Client } from '@elastic/elasticsearch';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
-import { SerializedConcreteTaskInstance } from '@kbn/task-manager-plugin/server/task';
+import type { SerializedConcreteTaskInstance } from '@kbn/task-manager-plugin/server/task';
 
 export interface TaskManagerDoc {
   type: string;

--- a/x-pack/test/alerting_api_integration/common/lib/wait_for_execution_count.ts
+++ b/x-pack/test/alerting_api_integration/common/lib/wait_for_execution_count.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import expect from '@kbn/expect';
-import supertest from 'supertest';
+import type supertest from 'supertest';
 import { getUrlPrefix } from './space_test_utils';
 
 async function delay(millis: number): Promise<void> {

--- a/x-pack/test/alerting_api_integration/common/plugins/aad/server/plugin.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/aad/server/plugin.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import {
+import type {
   Plugin,
   CoreSetup,
   RequestHandlerContext,
@@ -14,8 +14,8 @@ import {
   IKibanaResponse,
 } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
-import { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
-import { SpacesPluginSetup } from '@kbn/spaces-plugin/server';
+import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
+import type { SpacesPluginSetup } from '@kbn/spaces-plugin/server';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { AD_HOC_RUN_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server/saved_objects';
 

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/bedrock_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/bedrock_simulation.ts
@@ -5,11 +5,12 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 
 import { EventStreamCodec } from '@smithy/eventstream-codec';
 import { fromUtf8, toUtf8 } from '@smithy/util-utf8';
-import { ProxyArgs, Simulator } from './simulator';
+import type { ProxyArgs } from './simulator';
+import { Simulator } from './simulator';
 
 export class BedrockSimulator extends Simulator {
   private readonly returnError: boolean;

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/d3security_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/d3security_simulation.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 
-import { ProxyArgs, Simulator } from './simulator';
+import type { ProxyArgs } from './simulator';
+import { Simulator } from './simulator';
 
 export class D3SecuritySimulator extends Simulator {
   private readonly returnError: boolean;

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/data_handler.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/data_handler.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 
 export const getDataFromRequest = async (request: http.IncomingMessage) => {
   if (request.method !== 'POST' && request.method !== 'PATCH') {

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/gemini_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/gemini_simulation.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 
-import { ProxyArgs, Simulator } from './simulator';
+import type { ProxyArgs } from './simulator';
+import { Simulator } from './simulator';
 
 export class GeminiSimulator extends Simulator {
   private readonly returnError: boolean;

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/inference_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/inference_simulation.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 
-import { ProxyArgs, Simulator } from './simulator';
+import type { ProxyArgs } from './simulator';
+import { Simulator } from './simulator';
 
 export class InferenceSimulator extends Simulator {
   private readonly returnError: boolean;

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/jira_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/jira_simulation.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import {
+import type {
   RequestHandlerContext,
   KibanaRequest,
   KibanaResponseFactory,

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/ms_exchage_server_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/ms_exchage_server_simulation.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import {
+import type {
   RequestHandlerContext,
   KibanaRequest,
   KibanaResponseFactory,

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/openai_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/openai_simulation.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 
-import { ProxyArgs, Simulator } from './simulator';
+import type { ProxyArgs } from './simulator';
+import { Simulator } from './simulator';
 
 export class OpenAISimulator extends Simulator {
   private readonly returnError: boolean;

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/opsgenie_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/opsgenie_simulation.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 
-import { ProxyArgs, Simulator } from './simulator';
+import type { ProxyArgs } from './simulator';
+import { Simulator } from './simulator';
 
 export class OpsgenieSimulator extends Simulator {
   private readonly returnError: boolean;

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/pagerduty_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/pagerduty_simulation.ts
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import {
+import type {
   RequestHandlerContext,
   KibanaRequest,
   KibanaResponseFactory,

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/plugin.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/plugin.ts
@@ -5,17 +5,17 @@
  * 2.0.
  */
 
-import http from 'http';
-import https from 'https';
-import { Plugin, CoreSetup } from '@kbn/core/server';
+import type http from 'http';
+import type https from 'https';
+import type { Plugin, CoreSetup } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
-import { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
-import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import {
+import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type {
   PluginSetupContract as ActionsPluginSetupContract,
   PluginStartContract as ActionsPluginStartContract,
 } from '@kbn/actions-plugin/server/plugin';
-import { ActionType } from '@kbn/actions-plugin/server';
+import type { ActionType } from '@kbn/actions-plugin/server';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
 import { initPlugin as initPagerduty } from './pagerduty_simulation';
 import { initPlugin as initSwimlane } from './swimlane_simulation';

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/resilient_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/resilient_simulation.ts
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-import http from 'http';
-import {
+import type http from 'http';
+import type {
   RequestHandlerContext,
   KibanaRequest,
   KibanaResponseFactory,
   IKibanaResponse,
   IRouter,
 } from '@kbn/core/server';
-import { ProxyArgs, Simulator } from './simulator';
+import type { ProxyArgs } from './simulator';
+import { Simulator } from './simulator';
 
 export const resilientFailedResponse = {
   errors: {

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/servicenow_oauth_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/servicenow_oauth_simulation.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import {
+import type {
   RequestHandlerContext,
   KibanaRequest,
   KibanaResponseFactory,

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/thehive_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/thehive_simulation.ts
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 
-import { ProxyArgs, Simulator } from './simulator';
+import type { ProxyArgs } from './simulator';
+import { Simulator } from './simulator';
 
 export class TheHiveSimulator extends Simulator {
   private readonly returnError: boolean;

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/tines_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/tines_simulation.ts
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-import http from 'http';
-import {
+import type http from 'http';
+import type {
   RequestHandlerContext,
   KibanaRequest,
   KibanaResponseFactory,
   IKibanaResponse,
   IRouter,
 } from '@kbn/core/server';
-import { ProxyArgs, Simulator } from './simulator';
+import type { ProxyArgs } from './simulator';
+import { Simulator } from './simulator';
 
 export const tinesStory1 = { name: 'story 1', id: 1, team: 'team', published: true };
 export const tinesStory2 = { name: 'story 2', id: 2, team: 'team', published: true };

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/torq_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/torq_simulation.ts
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import {
+import type {
   RequestHandlerContext,
   KibanaRequest,
   KibanaResponseFactory,

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/unsecured_actions_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/unsecured_actions_simulation.ts
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import {
+import type {
   CoreSetup,
   RequestHandlerContext,
   KibanaRequest,
@@ -14,7 +14,7 @@ import {
   IKibanaResponse,
   IRouter,
 } from '@kbn/core/server';
-import { FixtureStartDeps } from './plugin';
+import type { FixtureStartDeps } from './plugin';
 
 export function initPlugin(router: IRouter, coreSetup: CoreSetup<FixtureStartDeps>) {
   router.post(

--- a/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/xmatters_simulation.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/actions_simulators/server/xmatters_simulation.ts
@@ -6,7 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import {
+import type {
   RequestHandlerContext,
   KibanaRequest,
   KibanaResponseFactory,

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/action_types.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/action_types.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { CoreSetup } from '@kbn/core/server';
-import { schema, TypeOf } from '@kbn/config-schema';
-import { ActionType } from '@kbn/actions-plugin/server';
-import { FixtureStartDeps, FixtureSetupDeps } from './plugin';
+import type { CoreSetup } from '@kbn/core/server';
+import type { TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
+import type { ActionType } from '@kbn/actions-plugin/server';
+import type { FixtureStartDeps, FixtureSetupDeps } from './plugin';
 import {
   getTestSubActionConnector,
   getTestSubActionConnectorWithoutSubActions,

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/connector_adapters.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/connector_adapters.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { ConnectorAdapter } from '@kbn/alerting-plugin/server';
-import { CoreSetup } from '@kbn/core/server';
+import type { ConnectorAdapter } from '@kbn/alerting-plugin/server';
+import type { CoreSetup } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
-import { FixtureStartDeps, FixtureSetupDeps } from './plugin';
+import type { FixtureStartDeps, FixtureSetupDeps } from './plugin';
 
 export function defineConnectorAdapters(
   core: CoreSetup<FixtureStartDeps>,

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/index.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { PluginInitializerContext } from '@kbn/core/server';
+import type { PluginInitializerContext } from '@kbn/core/server';
 import { FixturePlugin } from './plugin';
 
 export const plugin = async (initContext: PluginInitializerContext) =>

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/lib/retry_if_conflicts.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/lib/retry_if_conflicts.ts
@@ -11,7 +11,7 @@
 // have the caller make explicit conflict checks, where the conflict was
 // caused by a background update.
 
-import { Logger } from '@kbn/core/server';
+import type { Logger } from '@kbn/core/server';
 
 type RetryableForConflicts<T> = () => Promise<T>;
 

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/plugin.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/plugin.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import {
+import type {
   Plugin,
   CoreSetup,
   CoreStart,
@@ -14,20 +14,20 @@ import {
   ElasticsearchClient,
 } from '@kbn/core/server';
 import { firstValueFrom, Subject } from 'rxjs';
-import { PluginSetupContract as ActionsPluginSetup } from '@kbn/actions-plugin/server/plugin';
-import { AlertingServerSetup, AlertingServerStart } from '@kbn/alerting-plugin/server/plugin';
-import {
+import type { PluginSetupContract as ActionsPluginSetup } from '@kbn/actions-plugin/server/plugin';
+import type { AlertingServerSetup, AlertingServerStart } from '@kbn/alerting-plugin/server/plugin';
+import type {
   TaskManagerSetupContract,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server/plugin';
-import { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
-import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
-import { SecurityPluginStart } from '@kbn/security-plugin/server';
-import { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
-import { RuleRegistryPluginSetupContract } from '@kbn/rule-registry-plugin/server';
-import { IEventLogClientService, IEventLogService } from '@kbn/event-log-plugin/server';
-import { NotificationsPluginStart } from '@kbn/notifications-plugin/server';
+import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { SecurityPluginStart } from '@kbn/security-plugin/server';
+import type { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+import type { RuleRegistryPluginSetupContract } from '@kbn/rule-registry-plugin/server';
+import type { IEventLogClientService, IEventLogService } from '@kbn/event-log-plugin/server';
+import type { NotificationsPluginStart } from '@kbn/notifications-plugin/server';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/routes.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/routes.ts
@@ -7,7 +7,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import pRetry from 'p-retry';
-import {
+import type {
   CoreSetup,
   RequestHandlerContext,
   KibanaRequest,
@@ -17,24 +17,24 @@ import {
   SavedObject,
 } from '@kbn/core/server';
 import { schema } from '@kbn/config-schema';
-import { InvalidatePendingApiKey } from '@kbn/alerting-plugin/server/types';
-import { RawRule } from '@kbn/alerting-plugin/server/types';
-import {
+import type { InvalidatePendingApiKey } from '@kbn/alerting-plugin/server/types';
+import type { RawRule } from '@kbn/alerting-plugin/server/types';
+import type {
   ConcreteTaskInstance,
   TaskInstance,
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import { SECURITY_EXTENSION_ID, SPACES_EXTENSION_ID } from '@kbn/core-saved-objects-server';
 import { queryOptionsSchema } from '@kbn/event-log-plugin/server/event_log_client';
-import { NotificationsPluginStart } from '@kbn/notifications-plugin/server';
+import type { NotificationsPluginStart } from '@kbn/notifications-plugin/server';
 import {
   RULE_SAVED_OBJECT_TYPE,
   API_KEY_PENDING_INVALIDATION_TYPE,
 } from '@kbn/alerting-plugin/server';
 import { ActionExecutionSourceType } from '@kbn/actions-plugin/server/types';
 import { AlertingEventLogger } from '@kbn/alerting-plugin/server/lib/alerting_event_logger/alerting_event_logger';
-import { IEventLogger } from '@kbn/event-log-plugin/server';
-import { FixtureStartDeps } from './plugin';
+import type { IEventLogger } from '@kbn/event-log-plugin/server';
+import type { FixtureStartDeps } from './plugin';
 import { retryIfConflicts } from './lib/retry_if_conflicts';
 
 export function defineRoutes(

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
@@ -6,11 +6,12 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { Logger } from '@kbn/logging';
-import { CoreSetup, ElasticsearchClient } from '@kbn/core/server';
-import { schema, TypeOf } from '@kbn/config-schema';
+import type { Logger } from '@kbn/logging';
+import type { CoreSetup, ElasticsearchClient } from '@kbn/core/server';
+import type { TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
 import { curry, range, times } from 'lodash';
-import {
+import type {
   RuleType,
   AlertInstanceState,
   AlertInstanceContext,
@@ -18,7 +19,7 @@ import {
   RuleTypeParams,
 } from '@kbn/alerting-plugin/server';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
-import { FixtureStartDeps, FixtureSetupDeps } from './plugin';
+import type { FixtureStartDeps, FixtureSetupDeps } from './plugin';
 
 export const EscapableStrings = {
   escapableBold: '*bold*',

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/sub_action_connector.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/sub_action_connector.ts
@@ -6,12 +6,13 @@
  */
 
 // eslint-disable-next-line max-classes-per-file
-import { AxiosError } from 'axios';
+import type { AxiosError } from 'axios';
 import type { ServiceParams } from '@kbn/actions-plugin/server';
-import { PluginSetupContract as ActionsPluginSetup } from '@kbn/actions-plugin/server/plugin';
-import { schema, TypeOf } from '@kbn/config-schema';
-import { SubActionConnectorType } from '@kbn/actions-plugin/server/sub_action_framework/types';
-import { ConnectorUsageCollector } from '@kbn/actions-plugin/server/types';
+import type { PluginSetupContract as ActionsPluginSetup } from '@kbn/actions-plugin/server/plugin';
+import type { TypeOf } from '@kbn/config-schema';
+import { schema } from '@kbn/config-schema';
+import type { SubActionConnectorType } from '@kbn/actions-plugin/server/sub_action_framework/types';
+import type { ConnectorUsageCollector } from '@kbn/actions-plugin/server/types';
 
 const TestConfigSchema = schema.object({ url: schema.string() });
 const TestSecretsSchema = schema.object({

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts_restricted/server/alert_types.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts_restricted/server/alert_types.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { CoreSetup } from '@kbn/core/server';
-import { RuleType } from '@kbn/alerting-plugin/server';
+import type { CoreSetup } from '@kbn/core/server';
+import type { RuleType } from '@kbn/alerting-plugin/server';
 import { schema } from '@kbn/config-schema';
-import { FixtureStartDeps, FixtureSetupDeps } from './plugin';
+import type { FixtureStartDeps, FixtureSetupDeps } from './plugin';
 
 export function defineAlertTypes(
   core: CoreSetup<FixtureStartDeps>,

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts_restricted/server/plugin.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts_restricted/server/plugin.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import { Plugin, CoreSetup } from '@kbn/core/server';
-import { PluginSetupContract as ActionsPluginSetup } from '@kbn/actions-plugin/server/plugin';
-import { AlertingServerSetup } from '@kbn/alerting-plugin/server/plugin';
-import { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
-import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { Plugin, CoreSetup } from '@kbn/core/server';
+import type { PluginSetupContract as ActionsPluginSetup } from '@kbn/actions-plugin/server/plugin';
+import type { AlertingServerSetup } from '@kbn/alerting-plugin/server/plugin';
+import type { EncryptedSavedObjectsPluginStart } from '@kbn/encrypted-saved-objects-plugin/server';
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { ALERTING_FEATURE_ID } from '@kbn/alerting-plugin/common';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';

--- a/x-pack/test/alerting_api_integration/common/plugins/task_manager_fixture/server/plugin.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/task_manager_fixture/server/plugin.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import {
+import type {
   Plugin,
   CoreSetup,
   CoreStart,
@@ -16,7 +16,7 @@ import {
 } from '@kbn/core/server';
 import { firstValueFrom, Subject } from 'rxjs';
 import { schema } from '@kbn/config-schema';
-import { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 
 export interface SampleTaskManagerFixtureStartDeps {
   taskManager: TaskManagerStartContract;

--- a/x-pack/test/alerting_api_integration/common/retry.ts
+++ b/x-pack/test/alerting_api_integration/common/retry.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { RetryService } from '@kbn/ftr-common-functional-services';
+import type { RetryService } from '@kbn/ftr-common-functional-services';
 import type { ToolingLog } from '@kbn/tooling-log';
 
 /**

--- a/x-pack/test/alerting_api_integration/observability/custom_threshold_rule_data_view.ts
+++ b/x-pack/test/alerting_api_integration/observability/custom_threshold_rule_data_view.ts
@@ -10,7 +10,7 @@ import { Aggregators } from '@kbn/observability-plugin/common/custom_threshold_r
 import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '@kbn/rule-data-utils';
 
 import { COMPARATORS } from '@kbn/alerting-comparators';
-import { FtrProviderContext } from '../common/ftr_provider_context';
+import type { FtrProviderContext } from '../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../common/lib';
 import { createRule } from './helpers/alerting_api_helper';
 import { createDataView, deleteDataView } from './helpers/data_view';

--- a/x-pack/test/alerting_api_integration/observability/helpers/alerting_api_helper.ts
+++ b/x-pack/test/alerting_api_integration/observability/helpers/alerting_api_helper.ts
@@ -8,8 +8,8 @@
 import type { Client } from '@elastic/elasticsearch';
 import type { Agent as SuperTestAgent } from 'supertest';
 import expect from '@kbn/expect';
-import { ToolingLog } from '@kbn/tooling-log';
-import { ThresholdParams } from '@kbn/observability-plugin/common/custom_threshold_rule/types';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { ThresholdParams } from '@kbn/observability-plugin/common/custom_threshold_rule/types';
 import { refreshSavedObjectIndices } from './refresh_index';
 
 export async function createIndexConnector({

--- a/x-pack/test/alerting_api_integration/observability/helpers/alerting_wait_for_helpers.ts
+++ b/x-pack/test/alerting_api_integration/observability/helpers/alerting_wait_for_helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ToolingLog } from '@kbn/tooling-log';
+import type { ToolingLog } from '@kbn/tooling-log';
 
 import type SuperTest from 'supertest';
 import type { Client } from '@elastic/elasticsearch';
@@ -14,7 +14,7 @@ import type {
   SearchResponse,
 } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { RetryService } from '@kbn/ftr-common-functional-services';
-import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { retry } from '../../common/retry';
 
 const TIMEOUT = 70_000;

--- a/x-pack/test/alerting_api_integration/observability/helpers/data_view.ts
+++ b/x-pack/test/alerting_api_integration/observability/helpers/data_view.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { Agent as SuperTestAgent } from 'supertest';
-import { ToolingLog } from '@kbn/tooling-log';
+import type { Agent as SuperTestAgent } from 'supertest';
+import type { ToolingLog } from '@kbn/tooling-log';
 
 export const createDataView = async ({
   supertest,

--- a/x-pack/test/alerting_api_integration/observability/helpers/syntrace.ts
+++ b/x-pack/test/alerting_api_integration/observability/helpers/syntrace.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Client } from '@elastic/elasticsearch';
+import type { Client } from '@elastic/elasticsearch';
 import {
   ApmSynthtraceEsClient,
   ApmSynthtraceKibanaClient,

--- a/x-pack/test/alerting_api_integration/observability/metric_threshold_rule.ts
+++ b/x-pack/test/alerting_api_integration/observability/metric_threshold_rule.ts
@@ -6,8 +6,10 @@
  */
 
 import expect from '@kbn/expect';
-import { cleanup, generate, Dataset, PartialConfig } from '@kbn/data-forge';
-import { Aggregators, MetricThresholdParams } from '@kbn/infra-plugin/common/alerting/metrics';
+import type { Dataset, PartialConfig } from '@kbn/data-forge';
+import { cleanup, generate } from '@kbn/data-forge';
+import type { MetricThresholdParams } from '@kbn/infra-plugin/common/alerting/metrics';
+import { Aggregators } from '@kbn/infra-plugin/common/alerting/metrics';
 import { COMPARATORS } from '@kbn/alerting-comparators';
 import { InfraRuleType } from '@kbn/rule-data-utils';
 import {
@@ -15,7 +17,7 @@ import {
   waitForAlertInIndex,
   waitForRuleStatus,
 } from './helpers/alerting_wait_for_helpers';
-import { FtrProviderContext } from '../common/ftr_provider_context';
+import type { FtrProviderContext } from '../common/ftr_provider_context';
 import { createIndexConnector, createRule } from './helpers/alerting_api_helper';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/observability/synthetics/custom_status_rule.ts
+++ b/x-pack/test/alerting_api_integration/observability/synthetics/custom_status_rule.ts
@@ -7,8 +7,8 @@
 import expect from '@kbn/expect';
 import moment from 'moment';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
-import { SyntheticsMonitorStatusRuleParams as StatusRuleParams } from '@kbn/response-ops-rule-params/synthetics_monitor_status';
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import type { SyntheticsMonitorStatusRuleParams as StatusRuleParams } from '@kbn/response-ops-rule-params/synthetics_monitor_status';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 import { SyntheticsRuleHelper, SYNTHETICS_ALERT_ACTION_INDEX } from './synthetics_rule_helper';
 import { waitForDocumentInIndex } from '../helpers/alerting_wait_for_helpers';
 

--- a/x-pack/test/alerting_api_integration/observability/synthetics/data.ts
+++ b/x-pack/test/alerting_api_integration/observability/synthetics/data.ts
@@ -9,7 +9,7 @@ import {
   SyntheticsMonitorStatusTranslations,
   TlsTranslations,
 } from '@kbn/synthetics-plugin/common/rules/synthetics/translations';
-import { SanitizedRule } from '@kbn/alerting-types';
+import type { SanitizedRule } from '@kbn/alerting-types';
 
 export const statusRule = {
   id: 'dbbc39f0-1781-11ee-80b9-6522650f1d50',

--- a/x-pack/test/alerting_api_integration/observability/synthetics/synthetics_default_rule.ts
+++ b/x-pack/test/alerting_api_integration/observability/synthetics/synthetics_default_rule.ts
@@ -7,9 +7,9 @@
 
 import expect from '@kbn/expect';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
-import { SanitizedRule } from '@kbn/alerting-plugin/common';
+import type { SanitizedRule } from '@kbn/alerting-plugin/common';
 import { omit } from 'lodash';
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 import { statusRule, tlsRule } from './data';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/observability/synthetics/synthetics_rule_helper.ts
+++ b/x-pack/test/alerting_api_integration/observability/synthetics/synthetics_rule_helper.ts
@@ -5,20 +5,20 @@
  * 2.0.
  */
 
-import { SyntheticsMonitorStatusRuleParams as StatusRuleParams } from '@kbn/response-ops-rule-params/synthetics_monitor_status';
+import type { SyntheticsMonitorStatusRuleParams as StatusRuleParams } from '@kbn/response-ops-rule-params/synthetics_monitor_status';
 import type { Client } from '@elastic/elasticsearch';
-import { ToolingLog } from '@kbn/tooling-log';
+import type { ToolingLog } from '@kbn/tooling-log';
 import { makeDownSummary, makeUpSummary } from '@kbn/observability-synthetics-test-data';
-import { RetryService } from '@kbn/ftr-common-functional-services';
-import { EncryptedSyntheticsSavedMonitor } from '@kbn/synthetics-plugin/common/runtime_types';
+import type { RetryService } from '@kbn/ftr-common-functional-services';
+import type { EncryptedSyntheticsSavedMonitor } from '@kbn/synthetics-plugin/common/runtime_types';
 import moment from 'moment';
-import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
-import { Agent as SuperTestAgent } from 'supertest';
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { Agent as SuperTestAgent } from 'supertest';
 import { SYNTHETICS_API_URLS } from '@kbn/synthetics-plugin/common/constants';
 import expect from '@kbn/expect';
 import { PrivateLocationTestService } from '../../../api_integration/apis/synthetics/services/private_location_test_service';
 import { waitForAlertInIndex } from '../helpers/alerting_wait_for_helpers';
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 import { createIndexConnector, createRule } from '../helpers/alerting_api_helper';
 
 export const SYNTHETICS_ALERT_ACTION_INDEX = 'alert-action-synthetics';

--- a/x-pack/test/alerting_api_integration/packages/helpers/es_test_index_tool.ts
+++ b/x-pack/test/alerting_api_integration/packages/helpers/es_test_index_tool.ts
@@ -6,7 +6,7 @@
  */
 import { omit } from 'lodash';
 import type { Client } from '@elastic/elasticsearch';
-import { DeleteByQueryRequest } from '@elastic/elasticsearch/lib/api/types';
+import type { DeleteByQueryRequest } from '@elastic/elasticsearch/lib/api/types';
 
 export const ES_TEST_INDEX_NAME = '.kibana-alerting-test-data';
 

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/api_key.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/api_key.ts
@@ -7,14 +7,15 @@
 
 import expect from '@kbn/expect';
 import moment from 'moment';
-import { ALERTING_CASES_SAVED_OBJECT_INDEX, SavedObject } from '@kbn/core-saved-objects-server';
-import { AdHocRunSO } from '@kbn/alerting-plugin/server/data/ad_hoc_run/types';
+import type { SavedObject } from '@kbn/core-saved-objects-server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import type { AdHocRunSO } from '@kbn/alerting-plugin/server/data/ad_hoc_run/types';
 import { get } from 'lodash';
 import {
   AD_HOC_RUN_SAVED_OBJECT_TYPE,
   RULE_SAVED_OBJECT_TYPE,
 } from '@kbn/alerting-plugin/server/saved_objects';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import { SuperuserAtSpace1 } from '../../../../scenarios';
 import {
   getEventLog,
@@ -22,7 +23,7 @@ import {
   getUrlPrefix,
   ObjectRemover,
 } from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function apiKeyBackfillTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/delete.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/delete.ts
@@ -8,15 +8,11 @@
 import expect from '@kbn/expect';
 import moment from 'moment';
 import { asyncForEach } from '@kbn/std';
-import { GetResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { GetResponse } from '@elastic/elasticsearch/lib/api/types';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
-import {
-  getTestRuleData,
-  getUrlPrefix,
-  ObjectRemover,
-  TaskManagerDoc,
-} from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { TaskManagerDoc } from '../../../../../common/lib';
+import { getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function deleteBackfillTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/delete_rule.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/delete_rule.ts
@@ -7,17 +7,14 @@
 
 import expect from '@kbn/expect';
 import moment from 'moment';
-import { ALERTING_CASES_SAVED_OBJECT_INDEX, SavedObject } from '@kbn/core-saved-objects-server';
-import { AdHocRunSO } from '@kbn/alerting-plugin/server/data/ad_hoc_run/types';
+import type { SavedObject } from '@kbn/core-saved-objects-server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import type { AdHocRunSO } from '@kbn/alerting-plugin/server/data/ad_hoc_run/types';
 import { get } from 'lodash';
 import { SuperuserAtSpace1 } from '../../../../scenarios';
-import {
-  getTestRuleData,
-  getUrlPrefix,
-  ObjectRemover,
-  TaskManagerDoc,
-} from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { TaskManagerDoc } from '../../../../../common/lib';
+import { getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function deleteRuleForBackfillTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/find.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/find.ts
@@ -10,7 +10,7 @@ import moment from 'moment';
 import { asyncForEach } from '@kbn/std';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
 import { getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function findBackfillTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/get.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/get.ts
@@ -10,7 +10,7 @@ import moment from 'moment';
 import { asyncForEach } from '@kbn/std';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
 import { getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getBackfillTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function backfillTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/schedule.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/schedule.ts
@@ -7,14 +7,15 @@
 
 import expect from '@kbn/expect';
 import moment from 'moment';
-import { ALERTING_CASES_SAVED_OBJECT_INDEX, SavedObject } from '@kbn/core-saved-objects-server';
-import { AdHocRunSO } from '@kbn/alerting-plugin/server/data/ad_hoc_run/types';
+import type { SavedObject } from '@kbn/core-saved-objects-server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import type { AdHocRunSO } from '@kbn/alerting-plugin/server/data/ad_hoc_run/types';
 import { get } from 'lodash';
 import { AD_HOC_RUN_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server/saved_objects';
 import { asyncForEach } from '../../../../../../functional/services/transform/api';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
 import { checkAAD, getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { TEST_ACTIONS_INDEX, getScheduledTask } from './test_utils';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner.ts
@@ -26,14 +26,14 @@ import {
   TIMESTAMP,
 } from '@kbn/rule-data-utils';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import {
   AD_HOC_RUN_SAVED_OBJECT_TYPE,
   RULE_SAVED_OBJECT_TYPE,
 } from '@kbn/alerting-plugin/server/saved_objects';
 import { ALERT_ORIGINAL_TIME } from '@kbn/security-solution-plugin/common/field_maps/field_names';
 import { DOCUMENT_SOURCE } from '../../../../../spaces_only/tests/alerting/create_test_data';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { SuperuserAtSpace1 } from '../../../../scenarios';
 import { getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
 import {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner_with_actions.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/task_runner_with_actions.ts
@@ -11,7 +11,7 @@ import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 import { asyncForEach } from '../../../../../../functional/services/transform/api';
 import { SuperuserAtSpace1 } from '../../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import {
   TEST_ACTIONS_INDEX,
   indexTestDocs,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/test_utils.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/backfill/test_utils.ts
@@ -6,14 +6,16 @@
  */
 
 import { asyncForEach } from '@kbn/std';
-import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
+import type { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
+import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import type { Client } from '@elastic/elasticsearch';
 import moment from 'moment';
-import { FtrProviderContext, RetryService } from '@kbn/ftr-common-functional-services';
+import type { FtrProviderContext, RetryService } from '@kbn/ftr-common-functional-services';
 import { AD_HOC_RUN_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server/saved_objects';
 import { ALERT_ORIGINAL_TIME } from '@kbn/security-solution-plugin/common/field_maps/field_names';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { TaskManagerDoc, getEventLog } from '../../../../../common/lib';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import type { TaskManagerDoc } from '../../../../../common/lib';
+import { getEventLog } from '../../../../../common/lib';
 import {
   DOCUMENT_REFERENCE,
   DOCUMENT_SOURCE,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_untrack.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_untrack.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { ALERT_STATUS, ALERT_UUID } from '@kbn/rule-data-utils';
 import { getUrlPrefix, ObjectRemover, getTestRuleData, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 
 const alertAsDataIndex = '.internal.alerts-observability.test.alerts.alerts-default-000001';

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_untrack_by_query.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/bulk_untrack_by_query.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { ALERT_STATUS, ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { getUrlPrefix, ObjectRemover, getTestRuleData, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 
 const alertAsDataIndex = '.internal.alerts-observability.test.alerts.alerts-default-000001';

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/create.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/create.ts
@@ -13,15 +13,15 @@ import {
   SUB_ACTION,
 } from '@kbn/stack-connectors-plugin/common/sentinelone/constants';
 import { systemActionScenario, UserAtSpaceScenarios } from '../../../scenarios';
+import type { TaskManagerDoc } from '../../../../common/lib';
 import {
   checkAAD,
   getTestRuleData,
   getUnauthorizedErrorMessage,
   getUrlPrefix,
   ObjectRemover,
-  TaskManagerDoc,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/delete.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/delete.ts
@@ -13,7 +13,7 @@ import {
   getUnauthorizedErrorMessage,
   ObjectRemover,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createDeleteTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/disable.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/disable.ts
@@ -8,7 +8,8 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { TaskManagerDoc } from '../../../../common/lib';
 import {
   AlertUtils,
   checkAAD,
@@ -16,7 +17,6 @@ import {
   getTestRuleData,
   ObjectRemover,
   getUnauthorizedErrorMessage,
-  TaskManagerDoc,
 } from '../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/enable.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/enable.ts
@@ -8,7 +8,8 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { TaskManagerDoc } from '../../../../common/lib';
 import {
   AlertUtils,
   checkAAD,
@@ -16,7 +17,6 @@ import {
   getTestRuleData,
   ObjectRemover,
   getUnauthorizedErrorMessage,
-  TaskManagerDoc,
 } from '../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/execution_status.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/execution_status.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { RuleExecutionStatusErrorReasons } from '@kbn/alerting-plugin/common';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function executionStatusAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/find.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/find.ts
@@ -10,7 +10,7 @@ import { chunk, omit } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { SuperuserAtSpace1, UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createFindTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/find_internal.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/find_internal.ts
@@ -13,7 +13,7 @@ import {
   ML_ANOMALY_DETECTION_RULE_TYPE_ID,
   OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
 } from '@kbn/rule-data-utils';
-import { Space } from '../../../../common/types';
+import type { Space } from '../../../../common/types';
 import {
   Space1AllAtSpace1,
   StackAlertsOnly,
@@ -21,7 +21,7 @@ import {
   UserAtSpaceScenarios,
 } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createFindTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/fill_gap_by_id.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/fill_gap_by_id.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import moment from 'moment';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getTestRuleData } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/find.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/find.ts
@@ -6,7 +6,7 @@
  */
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import {
   getUrlPrefix,
   ObjectRemover,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/get_gaps_summary_by_rule_ids.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/get_gaps_summary_by_rule_ids.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getTestRuleData } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/get_rules_with_gaps.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/get_rules_with_gaps.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getTestRuleData } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function gapsTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/update_gaps.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/gap/update_gaps.ts
@@ -10,7 +10,7 @@ import moment from 'moment';
 import { AD_HOC_RUN_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server/saved_objects';
 import { SuperuserAtSpace1 } from '../../../../scenarios';
 import { getUrlPrefix, ObjectRemover, getTestRuleData } from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib/get_event_log';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/get.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/get.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
-import { SupertestWithoutAuthProviderType } from '@kbn/ftr-common-functional-services';
+import type { Agent as SuperTestAgent } from 'supertest';
+import type { SupertestWithoutAuthProviderType } from '@kbn/ftr-common-functional-services';
 import { SuperuserAtSpace1, UserAtSpaceScenarios } from '../../../scenarios';
 import {
   getUrlPrefix,
@@ -15,7 +15,7 @@ import {
   ObjectRemover,
   getUnauthorizedErrorMessage,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 const getTestUtils = (
   describeType: 'internal' | 'public',

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/get_alert_state.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/get_alert_state.ts
@@ -12,7 +12,7 @@ import {
   getTestRuleData,
   getUnauthorizedErrorMessage,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/get_alert_summary.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/get_alert_summary.ts
@@ -13,7 +13,7 @@ import {
   getTestRuleData,
   getUnauthorizedErrorMessage,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { setupSpacesAndUsers, tearDown } from '../../../setup';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/retain_api_key.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/retain_api_key.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { AlertUtils, getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/rule_types.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/alerting/rule_types.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { omit } from 'lodash';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix } from '../../../../common/lib/space_test_utils';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function listRuleTypes({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group1/tests/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingApiIntegrationTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/bulk_enqueue.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/bulk_enqueue.ts
@@ -6,11 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { systemActionScenario, UserAtSpaceScenarios } from '../../../scenarios';
 import { getEventLog, getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix } from '../../../../common/lib/space_test_utils';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function listActionTypesTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/bedrock.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/bedrock.ts
@@ -13,8 +13,8 @@ import {
 } from '@kbn/actions-simulators-plugin/server/bedrock_simulation';
 import { DEFAULT_TOKEN_LIMIT } from '@kbn/stack-connectors-plugin/common/bedrock/constants';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog, getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
 
 const connectorTypeId = '.bedrock';

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/cases_webhook.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/cases_webhook.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
@@ -14,8 +14,8 @@ import {
   ExternalServiceSimulator,
 } from '@kbn/actions-simulators-plugin/server/plugin';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/crowdstrike.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/crowdstrike.ts
@@ -9,11 +9,11 @@ import {
   CROWDSTRIKE_CONNECTOR_ID,
   SUB_ACTION,
 } from '@kbn/stack-connectors-plugin/common/crowdstrike/constants';
-import { FeaturesPrivileges, Role } from '@kbn/security-plugin/common';
-import SuperTest from 'supertest';
+import type { FeaturesPrivileges, Role } from '@kbn/security-plugin/common';
+import type SuperTest from 'supertest';
 import expect from '@kbn/expect';
 import { getUrlPrefix } from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { createSupertestErrorLogger } from '../../../../../common/lib/log_supertest_errors';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/d3security.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/d3security.ts
@@ -12,8 +12,8 @@ import {
   d3SecuritySuccessResponse,
 } from '@kbn/actions-simulators-plugin/server/d3security_simulation';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 const connectorTypeId = '.d3security';

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/email.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/email.ts
@@ -11,8 +11,8 @@ import {
   ExternalServiceSimulator,
   getExternalServiceSimulatorPath,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/es_index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/es_index.ts
@@ -7,8 +7,8 @@
 import type { Client } from '@elastic/elasticsearch';
 import expect from '@kbn/expect';
 
-import { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 const ES_TEST_INDEX_NAME = 'functional-test-actions-index';

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/es_index_preconfigured.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/es_index_preconfigured.ts
@@ -7,7 +7,7 @@
 
 import type { Client } from '@elastic/elasticsearch';
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // from: x-pack/test/alerting_api_integration/common/config.ts
 const ACTION_ID = 'preconfigured-es-index-action';

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/gemini.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/gemini.ts
@@ -12,7 +12,7 @@ import {
 } from '@kbn/actions-simulators-plugin/server/gemini_simulation';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { DEFAULT_GEMINI_MODEL } from '@kbn/stack-connectors-plugin/common/gemini/constants';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 const connectorTypeId = '.gemini';
 const name = 'A Gemini action';

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/inference.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/inference.ts
@@ -6,14 +6,14 @@
  */
 
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import {
   InferenceSimulator,
   inferenceSuccessResponse,
 } from '@kbn/actions-simulators-plugin/server/inference_simulation';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
 import { getEventLog } from '../../../../../common/lib';
 

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/jira.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/jira.ts
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import {
@@ -16,7 +16,7 @@ import {
 } from '@kbn/actions-simulators-plugin/server/plugin';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { MAX_OTHER_FIELDS_LENGTH } from '@kbn/stack-connectors-plugin/common/jira/constants';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/microsoft_defender_endpoint.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/microsoft_defender_endpoint.ts
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-import { FeaturesPrivileges, Role } from '@kbn/security-plugin-types-common';
+import type { FeaturesPrivileges, Role } from '@kbn/security-plugin-types-common';
 import {
   MICROSOFT_DEFENDER_ENDPOINT_CONNECTOR_ID,
   MICROSOFT_DEFENDER_ENDPOINT_SUB_ACTION,
 } from '@kbn/stack-connectors-plugin/common/microsoft_defender_endpoint/constants';
-import SuperTest from 'supertest';
+import type SuperTest from 'supertest';
 import expect from '@kbn/expect';
 import { getUrlPrefix } from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { createSupertestErrorLogger } from '../../../../../common/lib/log_supertest_errors';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/oauth_access_token.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/oauth_access_token.ts
@@ -8,14 +8,14 @@
 import fs from 'fs';
 import expect from '@kbn/expect';
 import { promisify } from 'util';
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import { KBN_KEY_PATH } from '@kbn/dev-utils';
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import {
   ExternalServiceSimulator,
   getExternalServiceSimulatorPath,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function oAuthAccessTokenTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/openai.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/openai.ts
@@ -6,14 +6,14 @@
  */
 
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import {
   OpenAISimulator,
   genAiSuccessResponse,
 } from '@kbn/actions-simulators-plugin/server/openai_simulation';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
 import { getEventLog } from '../../../../../common/lib';
 

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/opsgenie.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/opsgenie.ts
@@ -6,14 +6,14 @@
  */
 
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import {
   OpsgenieSimulator,
   opsgenieSuccessResponse,
 } from '@kbn/actions-simulators-plugin/server/opsgenie_simulation';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/pagerduty.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/pagerduty.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import {
   getExternalServiceSimulatorPath,
   ExternalServiceSimulator,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/resilient.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/resilient.ts
@@ -6,11 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { ResilientSimulator } from '@kbn/actions-simulators-plugin/server/resilient_simulation';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/sentinelone.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/sentinelone.ts
@@ -9,11 +9,11 @@ import {
   SENTINELONE_CONNECTOR_ID,
   SUB_ACTION,
 } from '@kbn/stack-connectors-plugin/common/sentinelone/constants';
-import { FeaturesPrivileges, Role } from '@kbn/security-plugin/common';
-import SuperTest from 'supertest';
+import type { FeaturesPrivileges, Role } from '@kbn/security-plugin/common';
+import type SuperTest from 'supertest';
 import expect from '@kbn/expect';
 import { getUrlPrefix } from '../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { createSupertestErrorLogger } from '../../../../../common/lib/log_supertest_errors';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/server_log.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/server_log.ts
@@ -6,9 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_itom.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_itom.ts
@@ -5,17 +5,17 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
 import { asyncForEach } from '@kbn/std';
 import getPort from 'get-port';
-import http from 'http';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type http from 'http';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import { getServiceNowServer } from '@kbn/actions-simulators-plugin/server/plugin';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_itsm.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_itsm.ts
@@ -5,18 +5,18 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
 import { asyncForEach } from '@kbn/std';
 import getPort from 'get-port';
-import http from 'http';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type http from 'http';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import { getServiceNowServer } from '@kbn/actions-simulators-plugin/server/plugin';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { MAX_ADDITIONAL_FIELDS_LENGTH } from '@kbn/stack-connectors-plugin/common/servicenow/constants';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_sir.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/servicenow_sir.ts
@@ -5,18 +5,18 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
 import { asyncForEach } from '@kbn/std';
 import getPort from 'get-port';
-import http from 'http';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type http from 'http';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import { getServiceNowServer } from '@kbn/actions-simulators-plugin/server/plugin';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { MAX_ADDITIONAL_FIELDS_LENGTH } from '@kbn/stack-connectors-plugin/common/servicenow/constants';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/slack_api.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/slack_api.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function slackTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/slack_webhook.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/slack_webhook.ts
@@ -5,15 +5,15 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
-import http from 'http';
+import type http from 'http';
 import getPort from 'get-port';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import { getSlackServer } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/swimlane.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/swimlane.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
 import getPort from 'get-port';
-import http from 'http';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type http from 'http';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import { getSwimlaneServer } from '@kbn/actions-simulators-plugin/server/plugin';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/thehive.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/thehive.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 
 import { TheHiveSimulator } from '@kbn/actions-simulators-plugin/server/thehive_simulation';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 const connectorTypeId = '.thehive';
 const name = 'TheHive action';

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/tines.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/tines.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import {
   TinesSimulator,
@@ -16,7 +16,7 @@ import {
   tinesWebhookSuccessResponse,
 } from '@kbn/actions-simulators-plugin/server/tines_simulation';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 const connectorTypeId = '.tines';

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/torq.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/torq.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers/get_proxy_server';
 import {
   getExternalServiceSimulatorPath,
   ExternalServiceSimulator,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/webhook.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
-import http from 'http';
+import type httpProxy from 'http-proxy';
+import type http from 'http';
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { URL, format as formatUrl } from 'url';
 import getPort from 'get-port';
@@ -18,7 +18,7 @@ import {
   ExternalServiceSimulator,
   getWebhookServer,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 const defaultValues: Record<string, any> = {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/xmatters.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/xmatters.ts
@@ -5,16 +5,16 @@
  * 2.0.
  */
 
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 import expect from '@kbn/expect';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import {
   getExternalServiceSimulatorPath,
   ExternalServiceSimulator,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types_system.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types_system.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix } from '../../../../common/lib/space_test_utils';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function listActionTypesTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/create.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/create.ts
@@ -10,7 +10,7 @@ import expect from '@kbn/expect';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { checkAAD, getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/delete.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/delete.ts
@@ -11,7 +11,7 @@ import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integrati
 
 import { UserAtSpaceScenarios, SuperuserAtSpace1 } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function deleteActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/execute.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/execute.ts
@@ -6,12 +6,13 @@
  */
 
 import expect from '@kbn/expect';
-import { IValidatedEvent, nanosToMillis } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import { nanosToMillis } from '@kbn/event-log-plugin/server';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { ActionExecutionSourceType } from '@kbn/actions-plugin/server/lib/action_execution_source';
 import { systemActionScenario, UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/get.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/get.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/get_all.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/get_all.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getAllActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/get_all_system.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/get_all_system.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { SuperuserAtSpace1, UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getAllActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { setupSpacesAndUsers, tearDown } from '../../../setup';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/sub_action_framework/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/sub_action_framework/index.ts
@@ -8,8 +8,8 @@
 import type SuperTest from 'supertest';
 import expect from '@kbn/expect';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
-import { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/generated/schemas';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog, getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
 
 /**

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/sub_feature_descriptions.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/sub_feature_descriptions.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 const SUB_FEATURE_DESC_PREFIX = 'Includes: ';
 

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/update.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/update.ts
@@ -11,7 +11,7 @@ import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integrati
 
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { checkAAD, getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function updateActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/aggregate.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/aggregate.ts
@@ -6,10 +6,10 @@
  */
 
 import expect from '@kbn/expect';
-import { Space, User } from '../../../../common/types';
+import type { Space, User } from '../../../../common/types';
 import { Space1AllAtSpace1, SuperuserAtSpace1, UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createAggregateTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { setupSpacesAndUsers, tearDown } from '../../../setup';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/mute_all.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/mute_all.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/mute_instance.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/mute_instance.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/rbac_legacy.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/rbac_legacy.ts
@@ -10,7 +10,7 @@ import { SavedObjectsUtils } from '@kbn/core/server';
 import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios, Superuser } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, AlertUtils } from '../../../../common/lib';
 import { setupSpacesAndUsers } from '../../../setup';
 

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/unmute_all.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/unmute_all.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/unmute_instance.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/unmute_instance.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/update.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/update.ts
@@ -6,11 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import { Response as SupertestResponse } from 'supertest';
+import type { Response as SupertestResponse } from 'supertest';
 import { RuleNotifyWhen, RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
-import { RawRule } from '@kbn/alerting-plugin/server/types';
+import type { RawRule } from '@kbn/alerting-plugin/server/types';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
-import { SavedObject } from '@kbn/core-saved-objects-api-server';
+import type { SavedObject } from '@kbn/core-saved-objects-api-server';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { SuperuserAtSpace1, systemActionScenario, UserAtSpaceScenarios } from '../../../scenarios';
 import {
@@ -21,7 +21,7 @@ import {
   ensureDatetimeIsWithinRange,
   getUnauthorizedErrorMessage,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createUpdateTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/update_api_key.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/update_api_key.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingApiIntegrationTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/alerting_and_actions_telemetry.ts
@@ -9,14 +9,9 @@ import expect from '@kbn/expect';
 import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 import { OpenAISimulator } from '@kbn/actions-simulators-plugin/server/openai_simulation';
 import { Spaces, Superuser } from '../../../scenarios';
-import {
-  getUrlPrefix,
-  getEventLog,
-  getTestRuleData,
-  TaskManagerDoc,
-  ObjectRemover,
-} from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { TaskManagerDoc } from '../../../../common/lib';
+import { getUrlPrefix, getEventLog, getTestRuleData, ObjectRemover } from '../../../../common/lib';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createAlertingAndActionsTelemetryTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/telemetry/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { setupSpacesAndUsers, tearDown } from '../../../setup';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_delete.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_delete.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios, SuperuserAtSpace1 } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   getUrlPrefix,
   getTestRuleData,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_disable.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_disable.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios, SuperuserAtSpace1 } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   getUrlPrefix,
   getTestRuleData,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_edit.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_edit.ts
@@ -6,10 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import { SavedObject } from '@kbn/core/server';
-import { RuleNotifyWhen, SanitizedRule } from '@kbn/alerting-plugin/common';
+import type { SavedObject } from '@kbn/core/server';
+import type { SanitizedRule } from '@kbn/alerting-plugin/common';
+import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
-import { RawRule } from '@kbn/alerting-plugin/server/types';
+import type { RawRule } from '@kbn/alerting-plugin/server/types';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { SuperuserAtSpace1, systemActionScenario, UserAtSpaceScenarios } from '../../../scenarios';
@@ -20,7 +21,7 @@ import {
   ObjectRemover,
   getUnauthorizedErrorMessage,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createUpdateTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_enable.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/bulk_enable.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios, SuperuserAtSpace1 } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   getUrlPrefix,
   getTestRuleData,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/clone.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/clone.ts
@@ -7,18 +7,19 @@
 
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
-import { ALERTING_CASES_SAVED_OBJECT_INDEX, SavedObject } from '@kbn/core-saved-objects-server';
-import { RawRule } from '@kbn/alerting-plugin/server/types';
+import type { SavedObject } from '@kbn/core-saved-objects-server';
+import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
+import type { RawRule } from '@kbn/alerting-plugin/server/types';
 import { Spaces, UserAtSpaceScenarios } from '../../../scenarios';
+import type { TaskManagerDoc } from '../../../../common/lib';
 import {
   checkAAD,
   getTestRuleData,
   getUnauthorizedErrorMessage,
   getUrlPrefix,
   ObjectRemover,
-  TaskManagerDoc,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 interface RuleSpace {
   body: any;

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/fields_rule.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/fields_rule.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getRuleFieldsTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/get_flapping_settings.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/get_flapping_settings.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { DEFAULT_FLAPPING_SETTINGS } from '@kbn/alerting-plugin/common';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, resetRulesSettings } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getFlappingSettingsTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/get_query_delay_settings.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/get_query_delay_settings.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { DEFAULT_QUERY_DELAY_SETTINGS } from '@kbn/alerting-plugin/common';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, resetRulesSettings } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getQueryDelaySettingsTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { setupSpacesAndUsers, tearDown } from '../../../setup';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/resolve.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/resolve.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { SuperuserAtSpace1 } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/run_soon.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/run_soon.ts
@@ -13,7 +13,7 @@ import {
   getUrlPrefix,
   ObjectRemover,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/bulk_edit_with_circuit_breaker.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/bulk_edit_with_circuit_breaker.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/bulk_enable_with_circuit_breaker.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/bulk_enable_with_circuit_breaker.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/create_with_circuit_breaker.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/create_with_circuit_breaker.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/enable_with_circuit_breaker.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/enable_with_circuit_breaker.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/get_schedule_frequency.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/get_schedule_frequency.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { UserAtSpaceScenarios } from '../../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../../common/lib';
 

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { setupSpacesAndUsers, tearDown } from '../../../../setup';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/update_with_circuit_breaker.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/schedule_circuit_breaker/update_with_circuit_breaker.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/suggestions_value_alert.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/suggestions_value_alert.ts
@@ -8,7 +8,7 @@
 import expect from 'expect';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createRuleSuggestionValuesTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/suggestions_value_rule.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/suggestions_value_rule.ts
@@ -8,7 +8,7 @@
 import expect from 'expect';
 import { Spaces, UserAtSpaceScenarios } from '../../../scenarios';
 import { getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 interface RuleSpace {
   body: any;

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/update_flapping_settings.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/update_flapping_settings.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios, Superuser } from '../../../scenarios';
 import { getUrlPrefix, resetRulesSettings } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function updateFlappingSettingsTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/update_query_delay_settings.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/update_query_delay_settings.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { DEFAULT_QUERY_DELAY_SETTINGS } from '@kbn/alerting-plugin/common';
 import { UserAtSpaceScenarios, Superuser } from '../../../scenarios';
 import { getUrlPrefix, resetRulesSettings } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function updateQueryDelaySettingsTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/user_managed_api_key.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/alerting/user_managed_api_key.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { generateAPIKeyName } from '@kbn/alerting-plugin/server/rules_client/common';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import {
   checkAAD,
@@ -16,7 +16,7 @@ import {
   getUrlPrefix,
   ObjectRemover,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { SuperuserAtSpace1 } from '../../../scenarios';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingApiIntegrationTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/active_maintenance_windows.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/active_maintenance_windows.ts
@@ -9,7 +9,7 @@ import moment from 'moment';
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function activeMaintenanceWindowTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/archive_maintenance_window.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/archive_maintenance_window.ts
@@ -9,7 +9,7 @@ import moment from 'moment';
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function updateMaintenanceWindowTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/create_maintenance_window.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/create_maintenance_window.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 const scopedQuery = {
   kql: "_id: '1234'",

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/delete_maintenance_window.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/delete_maintenance_window.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function deleteMaintenanceWindowTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/find_maintenance_windows.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/find_maintenance_windows.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function findMaintenanceWindowTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/finish_maintenance_window.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/finish_maintenance_window.ts
@@ -7,7 +7,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function findMaintenanceWindowTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/get_maintenance_window.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/get_maintenance_window.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getMaintenanceWindowTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { setupSpacesAndUsers, tearDown } from '../../../setup';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/update_maintenance_window.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group3/tests/maintenance_window/update_maintenance_window.ts
@@ -9,7 +9,7 @@ import moment from 'moment';
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 const scopedQuery = {
   kql: "_id: '1234'",

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/alerts.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/alerts.ts
@@ -8,14 +8,15 @@
 import expect from '@kbn/expect';
 import { expect as expectExpect } from 'expect';
 import { omit, padStart } from 'lodash';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { IValidatedEvent, nanosToMillis } from '@kbn/event-log-plugin/server';
-import { TaskRunning, TaskRunningStage } from '@kbn/task-manager-plugin/server/task_running';
-import { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+import type { estypes } from '@elastic/elasticsearch';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import { nanosToMillis } from '@kbn/event-log-plugin/server';
+import type { TaskRunning, TaskRunningStage } from '@kbn/task-manager-plugin/server/task_running';
+import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios, Superuser, SuperuserAtSpace1 } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   getUrlPrefix,
   getTestRuleData,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/event_log.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/event_log.ts
@@ -7,13 +7,11 @@
 
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
-import {
-  descriptorToArray,
-  SavedObjectDescriptor,
-} from '@kbn/encrypted-saved-objects-plugin/server/crypto';
+import type { SavedObjectDescriptor } from '@kbn/encrypted-saved-objects-plugin/server/crypto';
+import { descriptorToArray } from '@kbn/encrypted-saved-objects-plugin/server/crypto';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { validateEvent } from '../../../../spaces_only/tests/alerting/group1/event_log';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/excluded.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/excluded.ts
@@ -15,7 +15,7 @@ import {
   getEventLog,
   AlertUtils,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/get_action_error_log.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/get_action_error_log.ts
@@ -16,7 +16,7 @@ import {
   getEventLog,
   getUnauthorizedErrorMessage,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetActionErrorLogTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/get_global_execution_kpi.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/get_global_execution_kpi.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getGlobalExecutionKpiTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/get_rule_execution_kpi.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/get_rule_execution_kpi.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getRuleExecutionKpiTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/global_execution_log.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/global_execution_log.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function globalExecutionLogTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/health.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/health.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover, AlertUtils } from '../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { setupSpacesAndUsers, tearDown } from '../../../setup';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/mustache_templates.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/mustache_templates.ts
@@ -12,17 +12,17 @@
  * then validates that the simulator receives the escaped versions.
  */
 
-import http from 'http';
+import type http from 'http';
 import getPort from 'get-port';
 import axios from 'axios';
-import httpProxy from 'http-proxy';
+import type httpProxy from 'http-proxy';
 
 import expect from '@kbn/expect';
 import { getHttpProxyServer } from '@kbn/alerting-api-integration-helpers';
 import { getSlackServer } from '@kbn/actions-simulators-plugin/server/plugin';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function executionStatusAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/snooze.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/snooze.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/snooze_internal.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/snooze_internal.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/unsnooze.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/unsnooze.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/unsnooze_internal.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/alerting/unsnooze_internal.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { UserAtSpaceScenarios } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/index.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group4/tests/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingApiIntegrationTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/security_and_spaces/scenarios.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/scenarios.ts
@@ -10,7 +10,7 @@ import {
   ALL_FLAPPING_SETTINGS_SUB_FEATURE_ID,
 } from '@kbn/alerting-plugin/common';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
-import { Space, User } from '../common/types';
+import type { Space, User } from '../common/types';
 
 const NoKibanaPrivileges: User = {
   username: 'no_kibana_privileges',

--- a/x-pack/test/alerting_api_integration/security_and_spaces/setup.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/setup.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 import { isCustomRoleSpecification } from '../common/types';
 import { Spaces, Users } from './scenarios';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/scenarios.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/scenarios.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Space } from '../common/types';
+import type { Space } from '../common/types';
 
 const Space1: Space = {
   id: 'space1',

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/action_task_params/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/action_task_params/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { buildUp, tearDown } from '../helpers';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/action_task_params/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/action_task_params/migrations.ts
@@ -6,10 +6,10 @@
  */
 
 import expect from '@kbn/expect';
-import { SavedObject, SavedObjectReference } from '@kbn/core/server';
+import type { SavedObject, SavedObjectReference } from '@kbn/core/server';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
-import { ActionTaskParams } from '@kbn/actions-plugin/server/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { ActionTaskParams } from '@kbn/actions-plugin/server/types';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/bulk_enqueue.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/bulk_enqueue.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { Spaces } from '../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/check_registered_connector_types.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/check_registered_connector_types.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createRegisteredConnectorTypeTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../scenarios';
 import { getUrlPrefix } from '../../../common/lib/space_test_utils';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function listActionTypesTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/email.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/email.ts
@@ -6,7 +6,7 @@
  */
 import expect from '@kbn/expect';
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { ObjectRemover } from '../../../../../common/lib';
 import { EmailDomainsAllowed } from '../../config';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/email_html.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/email_html.ts
@@ -7,8 +7,8 @@
 import expect from '@kbn/expect';
 
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getEventLog, ObjectRemover } from '../../../../../common/lib';
 import { EmailDomainsAllowed } from '../../config';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/es_index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/es_index.ts
@@ -7,7 +7,7 @@
 import type { Client } from '@elastic/elasticsearch';
 import expect from '@kbn/expect';
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 const ES_TEST_INDEX_NAME = 'functional-test-connectors-index';
 const ES_TEST_DATASTREAM_PREFIX = 'functional-test-connectors-ds';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/preconfigured_alert_history_connector.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/preconfigured_alert_history_connector.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { AlertHistoryDefaultIndexName } from '@kbn/actions-plugin/common';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getTestRuleData, ObjectRemover } from '../../../../../common/lib';
 
 const ALERT_HISTORY_OVERRIDE_INDEX = 'kibana-alert-history-not-the-default';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/webhook.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types/stack/webhook.ts
@@ -5,17 +5,17 @@
  * 2.0.
  */
 
-import http from 'http';
-import https from 'https';
+import type http from 'http';
+import type https from 'https';
 import getPort from 'get-port';
-import { Agent as SuperTestAgent } from 'supertest';
+import type { Agent as SuperTestAgent } from 'supertest';
 import expect from '@kbn/expect';
 import { URL, format as formatUrl } from 'url';
 import {
   getWebhookServer,
   getHttpsWebhookServer,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { createTlsWebhookServer } from '../../../../../common/lib/get_tls_webhook_servers';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types_system.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/connector_types_system.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../scenarios';
 import { getUrlPrefix } from '../../../common/lib/space_test_utils';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function listActionTypesTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/create.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/create.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../scenarios';
 import { checkAAD, getUrlPrefix, ObjectRemover } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/delete.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/delete.ts
@@ -7,7 +7,7 @@
 
 import { Spaces } from '../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function deleteActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/execute.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/execute.ts
@@ -6,13 +6,14 @@
  */
 import type { Client } from '@elastic/elasticsearch';
 import expect from '@kbn/expect';
-import { IValidatedEvent, nanosToMillis } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import { nanosToMillis } from '@kbn/event-log-plugin/server';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { ActionExecutionSourceType } from '@kbn/actions-plugin/server/lib/action_execution_source';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { Spaces } from '../../scenarios';
 import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/execute_unsecured_action.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/execute_unsecured_action.ts
@@ -9,7 +9,7 @@ import getPort from 'get-port';
 import expect from '@kbn/expect';
 import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { getWebhookServer } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover } from '../../../common/lib';
 import { Spaces } from '../../scenarios';
 import { createWebhookAction } from './connector_types/stack/webhook';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get.ts
@@ -7,7 +7,7 @@
 
 import { Spaces } from '../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get_all.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get_all.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getAllActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get_all_system.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get_all_system.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function getAllActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get_all_unsecured_actions.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/get_all_unsecured_actions.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../common/lib';
 import { Spaces } from '../../scenarios';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { buildUp, tearDown } from '../helpers';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/max_queued_actions_circuit_breaker.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/max_queued_actions_circuit_breaker.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { getEventLog, ObjectRemover } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/migrations.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { asyncForEach } from '@kbn/std';
 import { getUrlPrefix } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/monitoring_collection.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/monitoring_collection.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 const CLUSTER_ACTIONS_MONITORING_COLLECTION_URL = `/api/monitoring_collection/cluster_actions`;
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/schedule_unsecured_action.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/schedule_unsecured_action.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import type { SearchTotalHits } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { Spaces } from '../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/type_not_enabled.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/type_not_enabled.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 const PREWRITTEN_ACTION_ID = 'uuid-actionId';
 const DISABLED_ACTION_TYPE = 'test.not-enabled';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/update.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/update.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../scenarios';
 import { checkAAD, getUrlPrefix, ObjectRemover } from '../../../common/lib';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function updateActionTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/create_test_data.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/create_test_data.ts
@@ -7,7 +7,8 @@
 import type { Client } from '@elastic/elasticsearch';
 import { times } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
+import type { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
+import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 
 // default end date
 export const END_DATE = '2020-01-01T00:00:00Z';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/aggregate.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/aggregate.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createAggregateTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/alerts_base.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/alerts_base.ts
@@ -7,14 +7,14 @@
 
 import expect from '@kbn/expect';
 import { omit } from 'lodash';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { Response as SupertestResponse } from 'supertest';
+import type { estypes } from '@elastic/elasticsearch';
+import type { Response as SupertestResponse } from 'supertest';
 import { RecoveredActionGroup } from '@kbn/alerting-plugin/common';
-import { TaskRunning, TaskRunningStage } from '@kbn/task-manager-plugin/server/task_running';
-import { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+import type { TaskRunning, TaskRunningStage } from '@kbn/task-manager-plugin/server/task_running';
+import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
-import { Space } from '../../../../common/types';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { Space } from '../../../../common/types';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   getUrlPrefix,
   getTestRuleData,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/create.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/create.ts
@@ -6,22 +6,23 @@
  */
 
 import expect from '@kbn/expect';
-import { SavedObject } from '@kbn/core/server';
-import { RawRule, RuleNotifyWhen } from '@kbn/alerting-plugin/server/types';
+import type { SavedObject } from '@kbn/core/server';
+import type { RawRule } from '@kbn/alerting-plugin/server/types';
+import { RuleNotifyWhen } from '@kbn/alerting-plugin/server/types';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { omit } from 'lodash';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
+import type { TaskManagerDoc } from '../../../../common/lib';
 import {
   checkAAD,
   getUrlPrefix,
   getTestRuleData,
   ObjectRemover,
   getUnauthorizedErrorMessage,
-  TaskManagerDoc,
   resetRulesSettings,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/delete.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/delete.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createDeleteTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/disable.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/disable.ts
@@ -10,7 +10,8 @@ import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { ALERT_STATUS } from '@kbn/rule-data-utils';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { TaskManagerDoc } from '../../../../common/lib';
 import {
   AlertUtils as RuleUtils,
   checkAAD,
@@ -18,7 +19,6 @@ import {
   getTestRuleData,
   ObjectRemover,
   getEventLog,
-  TaskManagerDoc,
 } from '../../../../common/lib';
 import { validateEvent } from './event_log';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/enable.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/enable.ts
@@ -8,14 +8,14 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { TaskManagerDoc } from '../../../../common/lib';
 import {
   AlertUtils,
   checkAAD,
   getUrlPrefix,
   getTestRuleData,
   ObjectRemover,
-  TaskManagerDoc,
 } from '../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/event_log.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/event_log.ts
@@ -9,11 +9,8 @@ import moment from 'moment';
 import expect from '@kbn/expect';
 import { get } from 'lodash';
 import { setTimeout as setTimeoutAsync } from 'timers/promises';
-import {
-  IValidatedEvent,
-  nanosToMillis,
-  IValidatedEventInternalDocInfo,
-} from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent, IValidatedEventInternalDocInfo } from '@kbn/event-log-plugin/server';
+import { nanosToMillis } from '@kbn/event-log-plugin/server';
 import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
 import { ES_TEST_INDEX_NAME, ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
@@ -26,7 +23,7 @@ import {
   getEventLog,
   resetRulesSettings,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { TEST_CACHE_EXPIRATION_TIME } from '../create_test_data';
 
 const InstanceActions = new Set<string | undefined>([

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/find.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/find.ts
@@ -6,11 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
+import type { Agent as SuperTestAgent } from 'supertest';
 import { fromKueryExpression } from '@kbn/es-query';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 async function createAlert(
   objectRemover: ObjectRemover,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/find_internal.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/find_internal.ts
@@ -6,11 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
+import type { Agent as SuperTestAgent } from 'supertest';
 import { fromKueryExpression } from '@kbn/es-query';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 async function createAlert(
   objectRemover: ObjectRemover,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get.ts
@@ -6,10 +6,10 @@
  */
 
 import expect from '@kbn/expect';
-import { Agent as SuperTestAgent } from 'supertest';
+import type { Agent as SuperTestAgent } from 'supertest';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 const getTestUtils = (
   describeType: 'internal' | 'public',

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_action_error_log.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_action_error_log.ts
@@ -10,7 +10,7 @@ import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover, getTestRuleData, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetActionErrorLogTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_alert_state.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_alert_state.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover, getTestRuleData } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetAlertStateTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_alert_summary.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_alert_summary.ts
@@ -16,7 +16,7 @@ import {
   AlertUtils,
   getEventLog,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { TEST_CACHE_EXPIRATION_TIME } from '../create_test_data';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_execution_log.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_execution_log.ts
@@ -10,7 +10,7 @@ import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover, getTestRuleData, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetExecutionLogTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_rule_tags.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/get_rule_tags.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 const tags = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { buildUp, tearDown } from '../../helpers';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/rule_types.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/rule_types.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix } from '../../../../common/lib/space_test_utils';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function listRuleTypes({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/alerts_default_space.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/alerts_default_space.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { Spaces } from '../../../scenarios';
 import { alertTests } from '../group1/alerts_base';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/alerts_space1.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/alerts_space1.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { Spaces } from '../../../scenarios';
 import { alertTests } from '../group1/alerts_base';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/bulk_edit.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/bulk_edit.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { omit } from 'lodash';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createUpdateTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/execution_status.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/execution_status.ts
@@ -15,7 +15,7 @@ import {
   ObjectRemover,
   ensureDatetimesAreOrdered,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function executionStatusAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { buildUp, tearDown } from '../../helpers';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/ml_rule_types/anomaly_detection/alert.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/ml_rule_types/anomaly_detection/alert.ts
@@ -8,14 +8,14 @@
 import expect from '@kbn/expect';
 import { sample } from 'lodash';
 import { duration } from 'moment';
-import { Datafeed, Job } from '@kbn/ml-plugin/common/types/anomaly_detection_jobs';
-import { MlAnomalyDetectionAlertParams } from '@kbn/ml-plugin/common/types/alerts';
+import type { Datafeed, Job } from '@kbn/ml-plugin/common/types/anomaly_detection_jobs';
+import type { MlAnomalyDetectionAlertParams } from '@kbn/ml-plugin/common/types/alerts';
 import { ANOMALY_SCORE_MATCH_GROUP_ID } from '@kbn/ml-plugin/server/lib/alerts/register_anomaly_detection_alert_type';
 import { ML_ALERT_TYPES } from '@kbn/ml-plugin/common/constants/alerts';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { Spaces } from '../../../../../scenarios';
 import { getUrlPrefix, ObjectRemover } from '../../../../../../common/lib';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 
 const ACTION_TYPE_ID = '.index';
 const ALERT_TYPE_ID = ML_ALERT_TYPES.ANOMALY_DETECTION;

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/ml_rule_types/anomaly_detection/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/ml_rule_types/anomaly_detection/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/ml_rule_types/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/ml_rule_types/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function monitoringAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring_collection.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/monitoring_collection.ts
@@ -15,7 +15,7 @@ import {
   createWaitForExecutionCount,
   getEventLog,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { createEsDocuments } from '../create_test_data';
 
 const NODE_RULES_MONITORING_COLLECTION_URL = `/api/monitoring_collection/node_rules`;

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/mute_all.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/mute_all.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/mute_instance.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/mute_instance.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/transform_rule_types/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/transform_rule_types/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/transform_rule_types/transform_health/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/transform_rule_types/transform_health/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/transform_rule_types/transform_health/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/transform_rule_types/transform_health/rule.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { PutTransformsRequestSchema } from '@kbn/transform-plugin/server/routes/api_schemas/transforms';
+import type { PutTransformsRequestSchema } from '@kbn/transform-plugin/server/routes/api_schemas/transforms';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import {
   ALERT_ACTION_GROUP,
@@ -20,7 +20,7 @@ import {
   EVENT_ACTION,
 } from '@kbn/rule-data-utils';
 import { TRANSFORM_HEALTH_RESULTS } from '@kbn/transform-plugin/common/constants';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../../../../common/lib';
 import { Spaces } from '../../../../../scenarios';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/unmute_all.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/unmute_all.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/unmute_instance.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/unmute_instance.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/update.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/update.ts
@@ -15,7 +15,7 @@ import {
   ObjectRemover,
   resetRulesSettings,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createUpdateTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/update_api_key.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group2/update_api_key.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/common.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/common.ts
@@ -7,9 +7,10 @@
 
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { STACK_AAD_INDEX_NAME } from '@kbn/stack-alerts-plugin/server/rule_types';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { Spaces } from '../../../../../scenarios';
-import { getUrlPrefix, ObjectRemover } from '../../../../../../common/lib';
+import type { ObjectRemover } from '../../../../../../common/lib';
+import { getUrlPrefix } from '../../../../../../common/lib';
 import { createEsDocuments, createEsDocumentsWithGroups } from '../../../create_test_data';
 
 export const RULE_TYPE_ID = '.es-query';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { ALERT_REASON, ALERT_URL } from '@kbn/rule-data-utils';
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../../../../common/lib';
 import {
   createConnector,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/query_dsl_only.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/query_dsl_only.ts
@@ -9,12 +9,12 @@ import expect from '@kbn/expect';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { pull } from 'lodash';
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../../../../common/lib';
 import { createDataStream, deleteDataStream } from '../../../create_test_data';
+import type { CreateRuleParams } from './common';
 import {
   createConnector,
-  CreateRuleParams,
   ES_GROUPS_TO_WRITE,
   ES_TEST_DATA_STREAM_NAME,
   ES_TEST_INDEX_REFERENCE,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/rule.ts
@@ -11,8 +11,9 @@ import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 
 import { ALERT_REASON, ALERT_URL } from '@kbn/rule-data-utils';
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover } from '../../../../../../common/lib';
+import type { SourceField } from './common';
 import {
   createConnector,
   ES_GROUPS_TO_WRITE,
@@ -25,7 +26,6 @@ import {
   RULE_INTERVAL_MILLIS,
   RULE_INTERVAL_SECONDS,
   RULE_TYPE_ID,
-  SourceField,
 } from './common';
 import { createDataStream, deleteDataStream } from '../../../create_test_data';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/alert.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/alert.ts
@@ -12,7 +12,7 @@ import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integrati
 import { STACK_AAD_INDEX_NAME } from '@kbn/stack-alerts-plugin/server/rule_types';
 import { ALERT_REASON } from '@kbn/rule-data-utils';
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../../../common/lib';
 import { createEsDocumentsWithGroups } from '../../../create_test_data';
 import { createDataStream, deleteDataStream } from '../../../create_test_data';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/fields_endpoint.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/fields_endpoint.ts
@@ -10,7 +10,7 @@ import expect from '@kbn/expect';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix } from '../../../../../../common/lib';
 
 const API_URI = 'internal/triggers_actions_ui/data/_fields';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/indices_endpoint.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/indices_endpoint.ts
@@ -10,7 +10,7 @@ import expect from '@kbn/expect';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix } from '../../../../../../common/lib';
 import { createEsDocumentsWithGroups } from '../../../create_test_data';
 import { createDataStream, deleteDataStream } from '../../../create_test_data';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/time_series_query_endpoint.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/index_threshold/time_series_query_endpoint.ts
@@ -7,11 +7,11 @@
 
 import expect from '@kbn/expect';
 
-import { TimeSeriesQuery } from '@kbn/triggers-actions-ui-plugin/server';
+import type { TimeSeriesQuery } from '@kbn/triggers-actions-ui-plugin/server';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix } from '../../../../../../common/lib';
 
 import { createEsDocumentsWithGroups } from '../../../create_test_data';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { buildUp, tearDown } from '../../helpers';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/maintenance_window_flows.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/maintenance_window_flows.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   createRule,
   createAction,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/maintenance_window_scoped_query.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/maintenance_window_scoped_query.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type { Alert } from '@kbn/alerts-as-data-utils';
 import { ALERT_MAINTENANCE_WINDOW_IDS } from '@kbn/rule-data-utils';
 import { getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   createRule,
   createAction,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/test_helpers.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/test_helpers.ts
@@ -12,7 +12,8 @@ import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import type { Agent as SuperTestAgent } from 'supertest';
 import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
-import { getUrlPrefix, getTestRuleData, ObjectRemover, getEventLog } from '../../../../common/lib';
+import type { ObjectRemover } from '../../../../common/lib';
+import { getUrlPrefix, getTestRuleData, getEventLog } from '../../../../common/lib';
 import { Spaces } from '../../../scenarios';
 import { TEST_CACHE_EXPIRATION_TIME } from '../create_test_data';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_delay.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_delay.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { get } from 'lodash';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
 import { Spaces } from '../../../scenarios';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_severity.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alert_severity.ts
@@ -7,13 +7,13 @@
 
 import expect from '@kbn/expect';
 import type { Alert } from '@kbn/alerts-as-data-utils';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import {
   ALERT_ACTION_GROUP,
   ALERT_SEVERITY_IMPROVING,
   ALERT_PREVIOUS_ACTION_GROUP,
 } from '@kbn/rule-data-utils';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getEventLog, getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
 import { Spaces } from '../../../scenarios';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import { setTimeout as setTimeoutAsync } from 'timers/promises';
 import type { Alert } from '@kbn/alerts-as-data-utils';
 import { omit } from 'lodash';
@@ -39,14 +39,14 @@ import {
   EVENT_KIND,
   SPACE_IDS,
 } from '@kbn/rule-data-utils';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { Spaces } from '../../../../scenarios';
+import type { TaskManagerDoc } from '../../../../../common/lib';
 import {
   getEventLog,
   getTestRuleData,
   getUrlPrefix,
   ObjectRemover,
-  TaskManagerDoc,
 } from '../../../../../common/lib';
 import { TEST_CACHE_EXPIRATION_TIME } from '../../create_test_data';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_alert_delay.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_alert_delay.ts
@@ -7,8 +7,8 @@
 
 import expect from '@kbn/expect';
 import { get } from 'lodash';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import type { Alert } from '@kbn/alerts-as-data-utils';
 import {
   ALERT_ACTION_GROUP,
@@ -35,14 +35,14 @@ import {
 } from '@kbn/rule-data-utils';
 import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
 import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { Spaces } from '../../../../scenarios';
+import type { TaskManagerDoc } from '../../../../../common/lib';
 import {
   getEventLog,
   getTestRuleData,
   getUrlPrefix,
   ObjectRemover,
-  TaskManagerDoc,
 } from '../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_conflicts.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_conflicts.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { Client } from '@elastic/elasticsearch';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { Client } from '@elastic/elasticsearch';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import type { Alert } from '@kbn/alerts-as-data-utils';
 import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 import { basename } from 'node:path';
@@ -22,7 +22,7 @@ import {
   ALERT_WORKFLOW_TAGS,
   ALERT_CONSECUTIVE_MATCHES,
 } from '@kbn/rule-data-utils';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { Spaces } from '../../../../scenarios';
 import { getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../../common/lib';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_flapping.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_flapping.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import type { Alert } from '@kbn/alerts-as-data-utils';
 import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
 import { setTimeout as setTimeoutAsync } from 'timers/promises';
@@ -16,15 +16,15 @@ import {
   ALERT_RULE_UUID,
   ALERT_PENDING_RECOVERED_COUNT,
 } from '@kbn/rule-data-utils';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { Spaces } from '../../../../scenarios';
+import type { TaskManagerDoc } from '../../../../../common/lib';
 import {
   getEventLog,
   getTestRuleData,
   getUrlPrefix,
   ObjectRemover,
   resetRulesSettings,
-  TaskManagerDoc,
 } from '../../../../../common/lib';
 import { TEST_CACHE_EXPIRATION_TIME } from '../../create_test_data';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertsAsDataTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/install_resources.ts
@@ -8,7 +8,7 @@
 import { alertFieldMap, ecsFieldMap, legacyAlertFieldMap } from '@kbn/alerts-as-data-utils';
 import { mappingFromFieldMap } from '@kbn/alerting-plugin/common';
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createAlertsAsDataInstallResourcesTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/auto_recover/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/auto_recover/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/auto_recover/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/auto_recover/rule.ts
@@ -10,7 +10,7 @@ import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integrati
 import { RecoveredActionGroup } from '@kbn/alerting-plugin/common';
 
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, TaskManagerUtils } from '../../../../../../common/lib';
 import { createEsDocuments } from '../../../create_test_data';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/cancellable/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/cancellable/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/cancellable/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/cancellable/rule.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { ESTestIndexTool } from '@kbn/alerting-api-integration-helpers';
 
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../../../common/lib';
 import { createEsDocuments } from '../../../create_test_data';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/alert_limit_services.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/alert_limit_services.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingCircuitBreakerTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/circuit_breaker/index_threshold_max_alerts.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../../../common/lib';
 import { createEsDocumentsWithGroups } from '../../../create_test_data';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/long_running/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/long_running/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function alertingTests({ loadTestFile }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/long_running/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/long_running/rule.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 
 import { Spaces } from '../../../../../scenarios';
-import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../../../common/lib';
 
 const RULE_INTERVAL_SECONDS = 3;

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/bulk_disable.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/bulk_disable.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { ALERT_STATUS } from '@kbn/rule-data-utils';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
 
 const alertAsDataIndex = '.internal.alerts-observability.test.alerts.alerts-default-000001';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/bulk_edit.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/bulk_edit.ts
@@ -17,7 +17,7 @@ import {
   ObjectRemover,
   getEventLog,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 const getSnoozeSchedule = () => {
   return {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/capped_action_type.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/capped_action_type.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getEventLog, getTestRuleData, getUrlPrefix, ObjectRemover } from '../../../../common/lib';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/check_registered_rule_types.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/check_registered_rule_types.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createRegisteredRuleTypeTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/ephemeral.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/ephemeral.ts
@@ -7,12 +7,12 @@
 
 import expect from '@kbn/expect';
 import { flatten } from 'lodash';
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import { DEFAULT_MAX_EPHEMERAL_ACTIONS_PER_ALERT } from '@kbn/alerting-plugin/server/config';
 import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover, getTestRuleData, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createNotifyWhenTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/event_log_alerts.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/event_log_alerts.ts
@@ -6,10 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import { IValidatedEvent, nanosToMillis } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import { nanosToMillis } from '@kbn/event-log-plugin/server';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, getTestRuleData, ObjectRemover, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function eventLogAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/flapping_history.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/flapping_history.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { get } from 'lodash';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
 import { Spaces } from '../../../scenarios';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/generate_alert_schemas.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/generate_alert_schemas.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import execa from 'execa';
-import { RuleType } from '@kbn/alerting-plugin/server';
+import type { RuleType } from '@kbn/alerting-plugin/server';
 import {
   alertFieldMap,
   ecsFieldMap,
@@ -15,7 +15,7 @@ import {
   createSchemaFromFieldMap,
 } from '@kbn/alerts-as-data-utils';
 import { contextToSchemaName } from '@kbn/alerting-plugin/common';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function checkAlertSchemasTest({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { buildUp, tearDown } from '../../helpers';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations.ts
@@ -13,7 +13,7 @@ import type { SavedObjectReference } from '@kbn/core/server';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { getUrlPrefix } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations/8_2_0.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations/8_2_0.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import type { RawRule } from '@kbn/alerting-plugin/server/types';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/migrations/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function migrationTests({ loadTestFile, getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/mustache_templates.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/mustache_templates.ts
@@ -12,7 +12,7 @@
  * then validates that the simulator receives the escaped versions.
  */
 
-import http from 'http';
+import type http from 'http';
 import getPort from 'get-port';
 import axios from 'axios';
 
@@ -24,7 +24,7 @@ import {
   getTestRuleData as getCoreTestRuleData,
   ObjectRemover,
 } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function executionStatusAlertTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/muted_alerts.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/muted_alerts.ts
@@ -10,7 +10,7 @@ import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
 import { ALERT_INSTANCE_ID, ALERT_RULE_UUID, ALERT_STATUS } from '@kbn/rule-data-utils';
 import { nodeBuilder } from '@kbn/es-query';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
 
 const alertAsDataIndex = '.internal.alerts-observability.test.alerts.alerts-default-000001';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/notify_when.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/notify_when.ts
@@ -7,10 +7,10 @@
 
 import expect from '@kbn/expect';
 
-import { IValidatedEvent } from '@kbn/event-log-plugin/server';
+import type { IValidatedEvent } from '@kbn/event-log-plugin/server';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix, ObjectRemover, getTestRuleData, getEventLog } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function createNotifyWhenTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/run_soon.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/run_soon.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { getUrlPrefix, getTestRuleData, ObjectRemover } from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 const LOADED_RULE_ID = '74f3e6d7-b7bb-477d-ac28-92ee22728e6e';
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/scheduled_task_id.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/scheduled_task_id.ts
@@ -6,13 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import {
-  getUrlPrefix,
-  TaskManagerDoc,
-  ObjectRemover,
-  getTestRuleData,
-} from '../../../../common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { TaskManagerDoc } from '../../../../common/lib';
+import { getUrlPrefix, ObjectRemover, getTestRuleData } from '../../../../common/lib';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 const MIGRATED_RULE_ID = '74f3e6d7-b7bb-477d-ac28-92ee22728e6e';
 const MIGRATED_TASK_ID = '329798f0-b0b0-11ea-9510-fdf248d5f2a4';

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze_internal.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/snooze_internal.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { v4 as uuidv4 } from 'uuid';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/unsnooze.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/unsnooze.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/unsnooze_internal.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/unsnooze_internal.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { RULE_SAVED_OBJECT_TYPE } from '@kbn/alerting-plugin/server';
 import { Spaces } from '../../../scenarios';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   AlertUtils,
   checkAAD,

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/helpers.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/helpers.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 import { Spaces } from '../scenarios';
 
 export async function buildUp(getService: FtrProviderContext['getService']) {

--- a/x-pack/test/alerting_api_integration/spaces_only_legacy/scenarios.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only_legacy/scenarios.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Space } from '../common/types';
+import type { Space } from '../common/types';
 
 const Space1: Space = {
   id: 'space1',

--- a/x-pack/test/alerting_api_integration/spaces_only_legacy/tests/actions/connector_types/stack/webhook.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only_legacy/tests/actions/connector_types/stack/webhook.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import http from 'http';
-import https from 'https';
+import type http from 'http';
+import type https from 'https';
 import getPort from 'get-port';
 import expect from '@kbn/expect';
 import { URL, format as formatUrl } from 'url';
@@ -14,7 +14,7 @@ import {
   getWebhookServer,
   getHttpsWebhookServer,
 } from '@kbn/actions-simulators-plugin/server/plugin';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { createTlsWebhookServer } from '../../../../../common/lib/get_tls_webhook_servers';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/alerting_api_integration/spaces_only_legacy/tests/index.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only_legacy/tests/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../common/ftr_provider_context';
 import { Spaces } from '../scenarios';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/api_integration/apis/cases/bulk_get_user_profiles.ts
+++ b/x-pack/test/api_integration/apis/cases/bulk_get_user_profiles.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { APP_ID as CASES_APP_ID } from '@kbn/cases-plugin/common/constants';
 import { APP_ID as SECURITY_SOLUTION_APP_ID } from '@kbn/security-solution-plugin/common/constants';
 import { observabilityFeatureId as OBSERVABILITY_APP_ID } from '@kbn/observability-plugin/common';
-import { FtrProviderContext } from '../../ftr_provider_context';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 
 import { deleteAllCaseItems } from '../../../cases_api_integration/common/lib/api';
 import {

--- a/x-pack/test/api_integration/apis/cases/common/roles.ts
+++ b/x-pack/test/api_integration/apis/cases/common/roles.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Role } from '../../../../cases_api_integration/common/lib/authentication/types';
+import type { Role } from '../../../../cases_api_integration/common/lib/authentication/types';
 
 /**
  * Roles for Cases in Security Solution

--- a/x-pack/test/api_integration/apis/cases/common/users.ts
+++ b/x-pack/test/api_integration/apis/cases/common/users.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { User } from '../../../../cases_api_integration/common/lib/authentication/types';
+import type { User } from '../../../../cases_api_integration/common/lib/authentication/types';
 import {
   casesAll,
   casesV2All,

--- a/x-pack/test/api_integration/apis/cases/config.ts
+++ b/x-pack/test/api_integration/apis/cases/config.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrConfigProviderContext } from '@kbn/test';
+import type { FtrConfigProviderContext } from '@kbn/test';
 
 export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   const baseIntegrationTestsConfig = await readConfigFile(require.resolve('../../config.ts'));

--- a/x-pack/test/api_integration/apis/cases/files.ts
+++ b/x-pack/test/api_integration/apis/cases/files.ts
@@ -7,8 +7,8 @@
 
 import expect from '@kbn/expect';
 
-import { BaseFilesClient } from '@kbn/shared-ux-file-types';
-import { User } from '../../../cases_api_integration/common/lib/authentication/types';
+import type { BaseFilesClient } from '@kbn/shared-ux-file-types';
+import type { User } from '../../../cases_api_integration/common/lib/authentication/types';
 import {
   createFile,
   uploadFile,
@@ -19,7 +19,7 @@ import {
   deleteAllFilesForKind,
   deleteFileForFileKind,
 } from '../../../cases_api_integration/common/lib/api';
-import { FtrProviderContext } from '../../ftr_provider_context';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 import {
   casesAllUser,
   casesReadUser,

--- a/x-pack/test/api_integration/apis/cases/index.ts
+++ b/x-pack/test/api_integration/apis/cases/index.ts
@@ -13,7 +13,7 @@ import {
 import { loginUsers } from '../../../cases_api_integration/common/lib/api/user_profiles';
 import { casesAllUser, obsCasesAllUser, secAllUser, users } from './common/users';
 import { roles } from './common/roles';
-import { FtrProviderContext } from '../../ftr_provider_context';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ loadTestFile, getService }: FtrProviderContext) {
   describe('cases', function () {

--- a/x-pack/test/api_integration/apis/cases/privileges.ts
+++ b/x-pack/test/api_integration/apis/cases/privileges.ts
@@ -8,10 +8,13 @@
 import expect from '@kbn/expect';
 import { APP_ID as CASES_APP_ID } from '@kbn/cases-plugin/common/constants';
 import { AttachmentType } from '@kbn/cases-plugin/common';
-import { CaseStatuses, UserCommentAttachmentPayload } from '@kbn/cases-plugin/common/types/domain';
+import type {
+  CaseStatuses,
+  UserCommentAttachmentPayload,
+} from '@kbn/cases-plugin/common/types/domain';
 import { APP_ID as SECURITY_SOLUTION_APP_ID } from '@kbn/security-solution-plugin/common/constants';
 import { observabilityFeatureId as OBSERVABILITY_APP_ID } from '@kbn/observability-plugin/common';
-import { FtrProviderContext } from '../../ftr_provider_context';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 
 import {
   createCase,

--- a/x-pack/test/api_integration/apis/cases/suggest_user_profiles.ts
+++ b/x-pack/test/api_integration/apis/cases/suggest_user_profiles.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { APP_ID as CASES_APP_ID, MAX_SUGGESTED_PROFILES } from '@kbn/cases-plugin/common/constants';
 import { APP_ID as SECURITY_SOLUTION_APP_ID } from '@kbn/security-solution-plugin/common/constants';
 import { observabilityFeatureId as OBSERVABILITY_APP_ID } from '@kbn/observability-plugin/common';
-import { FtrProviderContext } from '../../ftr_provider_context';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 
 import { deleteAllCaseItems } from '../../../cases_api_integration/common/lib/api';
 import { suggestUserProfiles } from '../../../cases_api_integration/common/lib/api/user_profiles';

--- a/x-pack/test/cases_api_integration/common/config.ts
+++ b/x-pack/test/cases_api_integration/common/config.ts
@@ -8,7 +8,8 @@
 import path from 'path';
 
 import { CA_CERT_PATH } from '@kbn/dev-utils';
-import { FtrConfigProviderContext, findTestPluginPaths } from '@kbn/test';
+import type { FtrConfigProviderContext } from '@kbn/test';
+import { findTestPluginPaths } from '@kbn/test';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 
 import { getAllExternalServiceSimulatorPaths } from '@kbn/actions-simulators-plugin/server/plugin';

--- a/x-pack/test/cases_api_integration/common/ftr_provider_context.d.ts
+++ b/x-pack/test/cases_api_integration/common/ftr_provider_context.d.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { GenericFtrProviderContext } from '@kbn/test';
+import type { GenericFtrProviderContext } from '@kbn/test';
 
-import { services } from './services';
+import type { services } from './services';
 
 export type FtrProviderContext = GenericFtrProviderContext<typeof services, {}>;

--- a/x-pack/test/cases_api_integration/common/lib/alerts.ts
+++ b/x-pack/test/cases_api_integration/common/lib/alerts.ts
@@ -7,12 +7,13 @@
 
 import expect from '@kbn/expect';
 import type SuperTest from 'supertest';
-import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { ToolingLog } from '@kbn/tooling-log';
+import type { estypes } from '@elastic/elasticsearch';
+import type { ToolingLog } from '@kbn/tooling-log';
 import { DETECTION_ENGINE_QUERY_SIGNALS_URL } from '@kbn/security-solution-plugin/common/constants';
-import { DetectionAlert } from '@kbn/security-solution-plugin/common/api/detection_engine';
-import { RiskEnrichmentFields } from '@kbn/security-solution-plugin/server/lib/detection_engine/rule_types/utils/enrichments/types';
-import { AttachmentType, Case } from '@kbn/cases-plugin/common';
+import type { DetectionAlert } from '@kbn/security-solution-plugin/common/api/detection_engine';
+import type { RiskEnrichmentFields } from '@kbn/security-solution-plugin/server/lib/detection_engine/rule_types/utils/enrichments/types';
+import type { Case } from '@kbn/cases-plugin/common';
+import { AttachmentType } from '@kbn/cases-plugin/common';
 import { ALERT_CASE_IDS } from '@kbn/rule-data-utils';
 import {
   getRuleForAlertTesting,
@@ -23,7 +24,7 @@ import {
   getQueryAlertIds,
 } from '../../../common/utils/security_solution';
 import { superUser } from './authentication/users';
-import { User } from './authentication/types';
+import type { User } from './authentication/types';
 import { getSpaceUrlPrefix } from './api/helpers';
 import { createCase, deleteCases } from './api/case';
 import { createComment, deleteAllComments } from './api';

--- a/x-pack/test/cases_api_integration/common/lib/api/attachments.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/attachments.ts
@@ -11,8 +11,9 @@ import {
   getCaseFindAttachmentsUrl,
   getCasesDeleteFileAttachmentsUrl,
 } from '@kbn/cases-plugin/common/api';
-import { Case, AttachmentType } from '@kbn/cases-plugin/common';
-import {
+import type { Case } from '@kbn/cases-plugin/common';
+import { AttachmentType } from '@kbn/cases-plugin/common';
+import type {
   BulkGetAttachmentsResponse,
   AttachmentRequest,
   BulkCreateAttachmentsRequest,
@@ -20,8 +21,8 @@ import {
   AttachmentsFindResponse,
   PostFileAttachmentRequest,
 } from '@kbn/cases-plugin/common/types/api';
-import { Attachments, Attachment } from '@kbn/cases-plugin/common/types/domain';
-import { User } from '../authentication/types';
+import type { Attachments, Attachment } from '@kbn/cases-plugin/common/types/domain';
+import type { User } from '../authentication/types';
 import { superUser } from '../authentication/users';
 import { getSpaceUrlPrefix, setupAuth } from './helpers';
 import { createCase } from './case';

--- a/x-pack/test/cases_api_integration/common/lib/api/case.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/case.ts
@@ -6,15 +6,15 @@
  */
 
 import { CASES_URL } from '@kbn/cases-plugin/common';
-import { Case, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
-import {
+import type { Case, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
+import type {
   CasePostRequest,
   CasesFindResponse,
   CasesPatchRequest,
 } from '@kbn/cases-plugin/common/types/api';
 import type SuperTest from 'supertest';
-import { ToolingLog } from '@kbn/tooling-log';
-import { User } from '../authentication/types';
+import type { ToolingLog } from '@kbn/tooling-log';
+import type { User } from '../authentication/types';
 
 import { superUser } from '../authentication/users';
 import { getSpaceUrlPrefix, setupAuth } from './helpers';

--- a/x-pack/test/cases_api_integration/common/lib/api/configuration.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/configuration.ts
@@ -6,18 +6,18 @@
  */
 
 import { CASE_CONFIGURE_URL } from '@kbn/cases-plugin/common/constants';
-import {
+import type {
   ConfigurationPatchRequest,
   ConfigurationRequest,
 } from '@kbn/cases-plugin/common/types/api';
-import {
+import type {
   CaseConnector,
   Configuration,
   Configurations,
-  ConnectorTypes,
 } from '@kbn/cases-plugin/common/types/domain';
+import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import type SuperTest from 'supertest';
-import { User } from '../authentication/types';
+import type { User } from '../authentication/types';
 
 import { superUser } from '../authentication/users';
 import { getSpaceUrlPrefix, setupAuth } from './helpers';

--- a/x-pack/test/cases_api_integration/common/lib/api/connectors.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/connectors.ts
@@ -6,30 +6,33 @@
  */
 
 import getPort from 'get-port';
-import http from 'http';
+import type http from 'http';
 
 import type SuperTest from 'supertest';
 import { CASE_CONFIGURE_CONNECTORS_URL } from '@kbn/cases-plugin/common/constants';
 import { getCaseConnectorsUrl } from '@kbn/cases-plugin/common/api';
-import {
+import type {
   ActionResult,
   ActionTypeExecutorResult,
   FindActionResult,
 } from '@kbn/actions-plugin/server/types';
 import { getServiceNowServer } from '@kbn/actions-simulators-plugin/server/plugin';
 import { RecordingServiceNowSimulator } from '@kbn/actions-simulators-plugin/server/servicenow_simulation';
-import {
+import type {
   Case,
   CaseConnector,
   Configuration,
   ConnectorTypes,
 } from '@kbn/cases-plugin/common/types/domain';
-import { CasePostRequest, GetCaseConnectorsResponse } from '@kbn/cases-plugin/common/types/api';
+import type {
+  CasePostRequest,
+  GetCaseConnectorsResponse,
+} from '@kbn/cases-plugin/common/types/api';
 import { camelCase, mapKeys } from 'lodash';
-import { User } from '../authentication/types';
+import type { User } from '../authentication/types';
 import { superUser } from '../authentication/users';
 import { getPostCaseRequest } from '../mock';
-import { ObjectRemover as ActionsRemover } from '../../../../alerting_api_integration/common/lib';
+import type { ObjectRemover as ActionsRemover } from '../../../../alerting_api_integration/common/lib';
 import { createConfiguration, getConfigurationRequest } from './configuration';
 import { createCase } from './case';
 import { getSpaceUrlPrefix } from './helpers';

--- a/x-pack/test/cases_api_integration/common/lib/api/files.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/files.ts
@@ -7,11 +7,11 @@
 
 import type SuperTest from 'supertest';
 import { apiRoutes as fileApiRoutes } from '@kbn/files-plugin/public/files_client/files_client';
-import { BaseFilesClient } from '@kbn/shared-ux-file-types';
+import type { BaseFilesClient } from '@kbn/shared-ux-file-types';
 import { OWNERS } from '@kbn/cases-plugin/common/constants';
 import { constructFileKindIdByOwner } from '@kbn/cases-plugin/common/files';
 import { superUser } from '../authentication/users';
-import { User } from '../authentication/types';
+import type { User } from '../authentication/types';
 import { getSpaceUrlPrefix } from './helpers';
 
 export const downloadFile = async ({

--- a/x-pack/test/cases_api_integration/common/lib/api/helpers.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/helpers.ts
@@ -6,7 +6,7 @@
  */
 
 import type SuperTest from 'supertest';
-import { User } from '../authentication/types';
+import type { User } from '../authentication/types';
 
 export const getSpaceUrlPrefix = (spaceId: string | undefined | null) => {
   return spaceId && spaceId !== 'default' ? `/s/${spaceId}` : ``;

--- a/x-pack/test/cases_api_integration/common/lib/api/index.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/index.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { TransportResult } from '@elastic/elasticsearch';
 import type { Client } from '@elastic/elasticsearch';
-import { GetResponse } from '@elastic/elasticsearch/lib/api/types';
+import type { GetResponse } from '@elastic/elasticsearch/lib/api/types';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server/src/saved_objects_index_pattern';
 
 import type SuperTest from 'supertest';
@@ -27,20 +27,20 @@ import {
   INTERNAL_GET_CASE_CATEGORIES_URL,
   INTERNAL_CASE_SIMILAR_CASES_URL,
 } from '@kbn/cases-plugin/common/constants';
-import { CaseMetricsFeature } from '@kbn/cases-plugin/common';
+import type { CaseMetricsFeature } from '@kbn/cases-plugin/common';
 import type { SingleCaseMetricsResponse, CasesMetricsResponse } from '@kbn/cases-plugin/common';
-import { SignalHit } from '@kbn/security-solution-plugin/server/lib/detection_engine/rule_types/types';
-import { CasePersistedAttributes } from '@kbn/cases-plugin/server/common/types/case';
+import type { SignalHit } from '@kbn/security-solution-plugin/server/lib/detection_engine/rule_types/types';
+import type { CasePersistedAttributes } from '@kbn/cases-plugin/server/common/types/case';
 import type { SavedObjectsRawDocSource } from '@kbn/core/server';
 import type { ConfigurationPersistedAttributes } from '@kbn/cases-plugin/server/common/types/configure';
-import {
+import type {
   ConnectorMappingsAttributes,
   Case,
   Cases,
   CaseStatuses,
   CaseCustomField,
 } from '@kbn/cases-plugin/common/types/domain';
-import {
+import type {
   AddObservableRequest,
   UpdateObservableRequest,
   AlertResponse,
@@ -62,7 +62,7 @@ import {
   getCaseDeleteObservableUrl,
   getCaseFindUserActionsUrl,
 } from '@kbn/cases-plugin/common/api';
-import { User } from '../authentication/types';
+import type { User } from '../authentication/types';
 import { superUser } from '../authentication/users';
 import { getSpaceUrlPrefix, setupAuth } from './helpers';
 

--- a/x-pack/test/cases_api_integration/common/lib/api/omit.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/omit.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Case, Attachment } from '@kbn/cases-plugin/common/types/domain';
+import type { Case, Attachment } from '@kbn/cases-plugin/common/types/domain';
 import { omit } from 'lodash';
 
 interface CommonSavedObjectAttributes {

--- a/x-pack/test/cases_api_integration/common/lib/api/telemetry.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/telemetry.ts
@@ -10,7 +10,7 @@ import {
   ELASTIC_HTTP_VERSION_HEADER,
   X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
 } from '@kbn/core-http-common';
-import { CasesTelemetry } from '@kbn/cases-plugin/server/telemetry/types';
+import type { CasesTelemetry } from '@kbn/cases-plugin/server/telemetry/types';
 import { CASES_TELEMETRY_TASK_NAME } from '@kbn/cases-plugin/common/constants';
 
 interface CasesTelemetryPayload {

--- a/x-pack/test/cases_api_integration/common/lib/api/user_actions.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/user_actions.ts
@@ -11,16 +11,15 @@ import {
   getCaseUserActionStatsUrl,
   getCaseUsersUrl,
 } from '@kbn/cases-plugin/common/api';
-import {
-  CaseUserActionDeprecatedResponse,
-  CaseUserActionsDeprecatedResponse,
+import type {
   CaseUserActionStatsResponse,
   GetCaseUsersResponse,
   UserActionFindRequest,
   UserActionFindResponse,
 } from '@kbn/cases-plugin/common/types/api';
 import type SuperTest from 'supertest';
-import { User } from '../authentication/types';
+import type { UserAction } from '@kbn/cases-plugin/common/types/domain';
+import type { User } from '../authentication/types';
 
 import { superUser } from '../authentication/users';
 import { getSpaceUrlPrefix } from './helpers';

--- a/x-pack/test/cases_api_integration/common/lib/api/user_actions.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/user_actions.ts
@@ -12,13 +12,14 @@ import {
   getCaseUsersUrl,
 } from '@kbn/cases-plugin/common/api';
 import type {
+  CaseUserActionDeprecatedResponse,
+  CaseUserActionsDeprecatedResponse,
   CaseUserActionStatsResponse,
   GetCaseUsersResponse,
   UserActionFindRequest,
   UserActionFindResponse,
 } from '@kbn/cases-plugin/common/types/api';
 import type SuperTest from 'supertest';
-import type { UserAction } from '@kbn/cases-plugin/common/types/domain';
 import type { User } from '../authentication/types';
 
 import { superUser } from '../authentication/users';

--- a/x-pack/test/cases_api_integration/common/lib/api/user_profiles.ts
+++ b/x-pack/test/cases_api_integration/common/lib/api/user_profiles.ts
@@ -6,20 +6,21 @@
  */
 
 import type SuperTest from 'supertest';
-import { parse as parseCookie, Cookie } from 'tough-cookie';
+import type { Cookie } from 'tough-cookie';
+import { parse as parseCookie } from 'tough-cookie';
 
 import { INTERNAL_SUGGEST_USER_PROFILES_URL } from '@kbn/cases-plugin/common/constants';
-import { UserProfileService } from '@kbn/cases-plugin/server/services';
+import type { UserProfileService } from '@kbn/cases-plugin/server/services';
 import type {
   UserProfile,
   UserProfileAvatarData,
   UserProfileWithAvatar,
 } from '@kbn/user-profile-components';
-import { SuggestUserProfilesRequest } from '@kbn/cases-plugin/common/types/api';
+import type { SuggestUserProfilesRequest } from '@kbn/cases-plugin/common/types/api';
 import { superUser } from '../authentication/users';
-import { User } from '../authentication/types';
+import type { User } from '../authentication/types';
 import { getSpaceUrlPrefix } from './helpers';
-import { FtrProviderContext as CommonFtrProviderContext } from '../../ftr_provider_context';
+import type { FtrProviderContext as CommonFtrProviderContext } from '../../ftr_provider_context';
 import { getUserInfo } from '../authentication';
 
 interface BulkGetUserProfilesParams<T> {

--- a/x-pack/test/cases_api_integration/common/lib/authentication/index.ts
+++ b/x-pack/test/cases_api_integration/common/lib/authentication/index.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { FtrProviderContext as CommonFtrProviderContext } from '../../ftr_provider_context';
-import { Role, User, UserInfo } from './types';
+import type { FtrProviderContext as CommonFtrProviderContext } from '../../ftr_provider_context';
+import type { Role, User, UserInfo } from './types';
 import { obsOnly, secOnly, secOnlyNoDelete, secOnlyRead, users } from './users';
 import { roles } from './roles';
 import { spaces } from './spaces';

--- a/x-pack/test/cases_api_integration/common/lib/authentication/roles.ts
+++ b/x-pack/test/cases_api_integration/common/lib/authentication/roles.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Role } from './types';
+import type { Role } from './types';
 
 const defaultElasticsearchPrivileges = {
   elasticsearch: {

--- a/x-pack/test/cases_api_integration/common/lib/authentication/spaces.ts
+++ b/x-pack/test/cases_api_integration/common/lib/authentication/spaces.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Space } from './types';
+import type { Space } from './types';
 
 const space1: Space = {
   id: 'space1',

--- a/x-pack/test/cases_api_integration/common/lib/authentication/users.ts
+++ b/x-pack/test/cases_api_integration/common/lib/authentication/users.ts
@@ -27,7 +27,7 @@ import {
   securitySolutionOnlyNoCreateComment,
   securitySolutionOnlyReadCreateComment,
 } from './roles';
-import { User } from './types';
+import type { User } from './types';
 
 export const superUser: User = {
   username: 'superuser',

--- a/x-pack/test/cases_api_integration/common/lib/mock.ts
+++ b/x-pack/test/cases_api_integration/common/lib/mock.ts
@@ -5,12 +5,8 @@
  * 2.0.
  */
 
-import {
+import type {
   Case,
-  AttachmentType,
-  CaseStatuses,
-  CaseSeverity,
-  ExternalReferenceStorageType,
   FileAttachmentMetadata,
   AlertAttachmentPayload,
   UserCommentAttachmentPayload,
@@ -20,6 +16,12 @@ import {
   PersistableStateAttachmentPayload,
   Attachment,
 } from '@kbn/cases-plugin/common/types/domain';
+import {
+  AttachmentType,
+  CaseStatuses,
+  CaseSeverity,
+  ExternalReferenceStorageType,
+} from '@kbn/cases-plugin/common/types/domain';
 import type {
   CasePostRequest,
   PostFileAttachmentRequest,
@@ -27,7 +29,7 @@ import type {
 import { FILE_ATTACHMENT_TYPE } from '@kbn/cases-plugin/common/constants';
 import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import { FILE_SO_TYPE } from '@kbn/files-plugin/common';
-import { AttachmentRequest, CasesFindResponse } from '@kbn/cases-plugin/common/types/api';
+import type { AttachmentRequest, CasesFindResponse } from '@kbn/cases-plugin/common/types/api';
 
 export const defaultUser = { email: null, full_name: null, username: 'elastic' };
 /**

--- a/x-pack/test/cases_api_integration/common/lib/validation.ts
+++ b/x-pack/test/cases_api_integration/common/lib/validation.ts
@@ -6,9 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import { AttachmentTotals, Case, RelatedCase } from '@kbn/cases-plugin/common/types/domain';
+import type { AttachmentTotals, Case, RelatedCase } from '@kbn/cases-plugin/common/types/domain';
 import { xorWith, isEqual } from 'lodash';
-import { GetRelatedCasesByAlertResponse } from '@kbn/cases-plugin/common/types/api';
+import type { GetRelatedCasesByAlertResponse } from '@kbn/cases-plugin/common/types/api';
 
 type AttachmentTotalsKeys = keyof AttachmentTotals;
 

--- a/x-pack/test/cases_api_integration/common/plugins/cases/server/attachments/external_reference.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/cases/server/attachments/external_reference.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ExternalReferenceAttachmentType } from '@kbn/cases-plugin/server/attachment_framework/types';
+import type { ExternalReferenceAttachmentType } from '@kbn/cases-plugin/server/attachment_framework/types';
 
 export const getExternalReferenceAttachment = (): ExternalReferenceAttachmentType => ({
   id: '.test',

--- a/x-pack/test/cases_api_integration/common/plugins/cases/server/attachments/persistable_state.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/cases/server/attachments/persistable_state.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { PersistableStateAttachmentTypeSetup } from '@kbn/cases-plugin/server/attachment_framework/types';
+import type { PersistableStateAttachmentTypeSetup } from '@kbn/cases-plugin/server/attachment_framework/types';
 
 export const getPersistableStateAttachment = (): PersistableStateAttachmentTypeSetup => ({
   id: '.test',

--- a/x-pack/test/cases_api_integration/common/plugins/cases/server/index.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/cases/server/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { PluginInitializerContext } from '@kbn/core/server';
+import type { PluginInitializerContext } from '@kbn/core/server';
 import { FixturePlugin } from './plugin';
 
 export const plugin = async (initializerContext: PluginInitializerContext) =>

--- a/x-pack/test/cases_api_integration/common/plugins/cases/server/plugin.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/cases/server/plugin.ts
@@ -5,15 +5,21 @@
  * 2.0.
  */
 
-import { Plugin, CoreSetup, CoreStart, PluginInitializerContext, Logger } from '@kbn/core/server';
-import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
-import { SecurityPluginStart } from '@kbn/security-plugin/server';
+import type {
+  Plugin,
+  CoreSetup,
+  CoreStart,
+  PluginInitializerContext,
+  Logger,
+} from '@kbn/core/server';
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import type { CasesServerStart, CasesServerSetup } from '@kbn/cases-plugin/server';
-import { FilesSetup } from '@kbn/files-plugin/server';
-import { PluginStartContract as ActionsPluginsStart } from '@kbn/actions-plugin/server/plugin';
+import type { FilesSetup } from '@kbn/files-plugin/server';
+import type { PluginStartContract as ActionsPluginsStart } from '@kbn/actions-plugin/server/plugin';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
-import { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
 import { getPersistableStateAttachment } from './attachments/persistable_state';
 import { getExternalReferenceAttachment } from './attachments/external_reference';
 import { registerRoutes } from './routes';

--- a/x-pack/test/cases_api_integration/common/plugins/cases/server/routes.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/cases/server/routes.ts
@@ -13,7 +13,7 @@ import type {
   ExternalReferenceAttachmentType,
   PersistableStateAttachmentTypeSetup,
 } from '@kbn/cases-plugin/server/attachment_framework/types';
-import { BulkCreateCasesRequest, CasesPatchRequest } from '@kbn/cases-plugin/common/types/api';
+import type { BulkCreateCasesRequest, CasesPatchRequest } from '@kbn/cases-plugin/common/types/api';
 import { ActionExecutionSourceType } from '@kbn/actions-plugin/server/types';
 import { CASES_TELEMETRY_TASK_NAME } from '@kbn/cases-plugin/common/constants';
 import type { FixtureStartDeps } from './plugin';

--- a/x-pack/test/cases_api_integration/common/plugins/observability/server/plugin.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/observability/server/plugin.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import { Plugin, CoreSetup } from '@kbn/core/server';
+import type { Plugin, CoreSetup } from '@kbn/core/server';
 import { hiddenTypes as filesSavedObjectTypes } from '@kbn/files-plugin/server/saved_objects';
-import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
-import { SecurityPluginStart } from '@kbn/security-plugin/server';
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
 
 export interface FixtureSetupDeps {

--- a/x-pack/test/cases_api_integration/common/plugins/security_solution/server/plugin.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/security_solution/server/plugin.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 
-import { Plugin, CoreSetup } from '@kbn/core/server';
+import type { Plugin, CoreSetup } from '@kbn/core/server';
 import { hiddenTypes as filesSavedObjectTypes } from '@kbn/files-plugin/server/saved_objects';
-import { FeaturesPluginSetup } from '@kbn/features-plugin/server';
-import { SpacesPluginStart } from '@kbn/spaces-plugin/server';
-import { SecurityPluginStart } from '@kbn/security-plugin/server';
+import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
+import type { SecurityPluginStart } from '@kbn/security-plugin/server';
 import { KibanaFeatureScope } from '@kbn/features-plugin/common';
 
 export interface FixtureSetupDeps {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/attachments_framework/registered_persistable_state_basic.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/attachments_framework/registered_persistable_state_basic.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/cases/assignees.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/cases/assignees.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { getPostCaseRequest } from '../../../../common/lib/mock';
 import { createCase, updateCase, findCases, deleteAllCaseItems } from '../../../../common/lib/api';
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/cases/push_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/cases/push_case.ts
@@ -6,7 +6,7 @@
  */
 
 import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { postCaseReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/configure/get_connectors.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/configure/get_connectors.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import { getCaseConnectors } from '../../../../common/lib/api';
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/index.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import {
   createSpacesAndUsers,
   deleteSpacesAndUsers,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/internal/suggest_user_profiles.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/basic/internal/suggest_user_profiles.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { deleteAllCaseItems, suggestUserProfiles } from '../../../../common/lib/api';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/alerts/get_alerts_attached_to_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/alerts/get_alerts_attached_to_case.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { getPostCaseRequest, postCommentAlertReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/alerts/get_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/alerts/get_cases.ts
@@ -7,8 +7,8 @@
 
 import expect from '@kbn/expect';
 import { CASES_URL } from '@kbn/cases-plugin/common/constants';
-import { Case } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { Case } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   getPostCaseRequest,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/attachments_framework/external_references.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/attachments_framework/external_references.ts
@@ -13,8 +13,8 @@ import {
   CASE_USER_ACTION_SAVED_OBJECT,
 } from '@kbn/cases-plugin/common/constants';
 import { AttachmentType, UserActionTypes } from '@kbn/cases-plugin/common/types/domain';
-import { AttachmentRequest } from '@kbn/cases-plugin/common/types/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { AttachmentRequest } from '@kbn/cases-plugin/common/types/api';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   defaultUser,
   postCaseReq,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/attachments_framework/persistable_state.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/attachments_framework/persistable_state.ts
@@ -13,7 +13,7 @@ import {
   CASE_COMMENT_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
 } from '@kbn/cases-plugin/common/constants';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   defaultUser,
   persistableStateAttachment,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/bulk_create_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/bulk_create_cases.ts
@@ -7,10 +7,10 @@
 
 import type SuperTest from 'supertest';
 import expect from '@kbn/expect';
-import { BulkCreateCasesResponse } from '@kbn/cases-plugin/common/types/api';
+import type { BulkCreateCasesResponse } from '@kbn/cases-plugin/common/types/api';
 import { CaseSeverity } from '@kbn/cases-plugin/common';
 import { CaseStatuses, CustomFieldTypes } from '@kbn/cases-plugin/common/types/domain';
-import { User } from '../../../../common/lib/authentication/types';
+import type { User } from '../../../../common/lib/authentication/types';
 import { defaultUser, getPostCaseRequest, postCaseResp } from '../../../../common/lib/mock';
 import {
   deleteAllCaseItems,
@@ -19,7 +19,7 @@ import {
   removeServerGeneratedPropertiesFromCase,
   removeServerGeneratedPropertiesFromUserAction,
 } from '../../../../common/lib/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   secOnly,
   secOnlyRead,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/categories/get_categories.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/categories/get_categories.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import { deleteCasesByESQuery, createCase, getCategories } from '../../../../../common/lib/api';
 import { getPostCaseRequest } from '../../../../../common/lib/mock';

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/delete_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/delete_cases.ts
@@ -8,14 +8,14 @@
 import expect from '@kbn/expect';
 import type SuperTest from 'supertest';
 import { MAX_COMMENTS_PER_PAGE } from '@kbn/cases-plugin/common/constants';
+import type { Alerts } from '../../../../common/lib/alerts';
 import {
-  Alerts,
   createCaseAttachAlertAndDeleteCase,
   createSecuritySolutionAlerts,
   getAlertById,
   getSecuritySolutionAlerts,
 } from '../../../../common/lib/alerts';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   getFilesAttachmentReq,
@@ -62,7 +62,7 @@ import {
   OBSERVABILITY_FILE_KIND,
   SECURITY_SOLUTION_FILE_KIND,
 } from '../../../../common/lib/constants';
-import { User } from '../../../../common/lib/authentication/types';
+import type { User } from '../../../../common/lib/authentication/types';
 import {
   createAlertsIndex,
   deleteAllRules,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
@@ -16,14 +16,10 @@ import {
   MAX_REPORTERS_FILTER_LENGTH,
   MAX_TAGS_FILTER_LENGTH,
 } from '@kbn/cases-plugin/common/constants';
-import {
-  Case,
-  CaseSeverity,
-  CaseStatuses,
-  AttachmentType,
-} from '@kbn/cases-plugin/common/types/domain';
+import type { Case } from '@kbn/cases-plugin/common/types/domain';
+import { CaseSeverity, CaseStatuses, AttachmentType } from '@kbn/cases-plugin/common/types/domain';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   postCaseReq,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/get_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/get_case.ts
@@ -9,8 +9,8 @@ import expect from '@kbn/expect';
 
 import { getCaseDetailsUrl } from '@kbn/cases-plugin/common/api';
 import { CASES_URL } from '@kbn/cases-plugin/common/constants';
-import { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   defaultUser,
   postCaseReq,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/import_export.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/import_export.ts
@@ -7,31 +7,30 @@
 
 import expect from '@kbn/expect';
 import { join } from 'path';
-import { SavedObject } from '@kbn/core/server';
-import supertest from 'supertest';
+import type { SavedObject } from '@kbn/core/server';
+import type supertest from 'supertest';
 import {
   CASE_SAVED_OBJECT,
   CASE_USER_ACTION_SAVED_OBJECT,
   CASE_COMMENT_SAVED_OBJECT,
 } from '@kbn/cases-plugin/common/constants';
-import {
+import type {
   UserCommentAttachmentAttributes,
   CaseAttributes,
-  CaseStatuses,
-  CaseSeverity,
 } from '@kbn/cases-plugin/common/types/domain';
+import { CaseStatuses, CaseSeverity } from '@kbn/cases-plugin/common/types/domain';
 import {
   CasePersistedSeverity,
   CasePersistedStatus,
 } from '@kbn/cases-plugin/server/common/types/case';
-import {
+import type {
   CaseUserActionWithoutReferenceIds,
   CommentUserAction,
   ConnectorUserAction,
   CreateCaseUserAction,
   PushedUserAction,
 } from '@kbn/cases-plugin/common/types/domain';
-import { CasePostRequest } from '@kbn/cases-plugin/common';
+import type { CasePostRequest } from '@kbn/cases-plugin/common';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 import {
   deleteAllCaseItems,
@@ -42,7 +41,7 @@ import {
   findAttachments,
 } from '../../../../common/lib/api';
 import { getPostCaseRequest, postCommentUserReq } from '../../../../common/lib/mock';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/migrations.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/migrations.ts
@@ -7,12 +7,12 @@
 
 import expect from '@kbn/expect';
 import { CASES_URL, SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common/constants';
-import { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import type { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
 import {
   CasePersistedSeverity,
   CasePersistedStatus,
 } from '@kbn/cases-plugin/server/common/types/case';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import {
   deleteAllCaseItems,
   getCase,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -9,16 +9,15 @@ import expect from '@kbn/expect';
 import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 
 import { DETECTION_ENGINE_QUERY_SIGNALS_URL } from '@kbn/security-solution-plugin/common/constants';
+import type { CaseCustomFields, Cases } from '@kbn/cases-plugin/common/types/domain';
 import {
   AttachmentType,
-  CaseCustomFields,
-  Cases,
   CaseSeverity,
   CaseStatuses,
   ConnectorTypes,
   CustomFieldTypes,
 } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   defaultUser,
   getPostCaseRequest,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
@@ -13,7 +13,8 @@ import {
   CaseSeverity,
   CustomFieldTypes,
 } from '@kbn/cases-plugin/common/types/domain';
-import { ConnectorJiraTypeFields, ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
+import type { ConnectorJiraTypeFields } from '@kbn/cases-plugin/common/types/domain';
+import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import { getPostCaseRequest, postCaseResp, defaultUser } from '../../../../common/lib/mock';
 import {
   deleteAllCaseItems,
@@ -33,7 +34,7 @@ import {
   noKibanaPrivileges,
   testDisabled,
 } from '../../../../common/lib/authentication/users';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/reporters/get_reporters.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/reporters/get_reporters.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import { defaultUser, getPostCaseRequest } from '../../../../../common/lib/mock';
 import { createCase, deleteCasesByESQuery, getReporters } from '../../../../../common/lib/api';

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/resolve_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/resolve_case.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 
-import { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import type { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
 import { CASES_URL } from '@kbn/cases-plugin/common/constants';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/resolve_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/resolve_case.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 
 import { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
 import { CASES_URL } from '@kbn/cases-plugin/common/constants';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   defaultUser,
   postCaseReq,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/status/get_status.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/status/get_status.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
 import { CASE_STATUS_URL } from '@kbn/cases-plugin/common/constants';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import { getPostCaseRequest, postCaseReq } from '../../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/tags/get_tags.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/tags/get_tags.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import { deleteCasesByESQuery, createCase, getTags } from '../../../../../common/lib/api';
 import { getPostCaseRequest } from '../../../../../common/lib/mock';

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/client/update_alert_status.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/client/update_alert_status.ts
@@ -6,8 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import { Cases, CaseStatuses, AttachmentType } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { Cases } from '@kbn/cases-plugin/common/types/domain';
+import { CaseStatuses, AttachmentType } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { postCaseReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
+import type { Alerts } from '../../../../common/lib/alerts';
 import {
-  Alerts,
   createCaseAttachAlertAndDeleteAlert,
   createSecuritySolutionAlerts,
   getAlertById,
@@ -18,7 +18,7 @@ import {
   deleteAllAlerts,
   deleteAllRules,
 } from '../../../../../common/utils/security_solution';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { getPostCaseRequest, postCaseReq, postCommentUserReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comments.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
+import type { Alerts } from '../../../../common/lib/alerts';
 import {
-  Alerts,
   createCaseAttachAlertAndDeleteAlert,
   createSecuritySolutionAlerts,
   getAlertById,
@@ -18,7 +18,7 @@ import {
   deleteAllAlerts,
   deleteAllRules,
 } from '../../../../../common/utils/security_solution';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   getPostCaseRequest,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/find_comments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/find_comments.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 
 import { CASES_URL, MAX_COMMENTS_PER_PAGE } from '@kbn/cases-plugin/common/constants';
 import { AttachmentType } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   getPostCaseRequest,
   persistableStateAttachment,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/get_all_comments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/get_all_comments.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { getCaseCommentsUrl } from '@kbn/cases-plugin/common/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { postCaseReq, getPostCaseRequest, postCommentUserReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/get_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/get_comment.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { postCaseReq, postCommentUserReq, getPostCaseRequest } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/migrations.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/migrations.ts
@@ -7,8 +7,8 @@
 
 import expect from '@kbn/expect';
 import { CASES_URL, SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common/constants';
-import { AlertAttachment } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { AlertAttachment } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { deleteAllCaseItems, getComment } from '../../../../common/lib/api';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/patch_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/patch_comment.ts
@@ -8,13 +8,12 @@
 import { set } from '@kbn/safer-lodash-set';
 import { omit } from 'lodash/fp';
 import expect from '@kbn/expect';
-import {
+import type {
   AlertAttachmentAttributes,
   UserCommentAttachmentAttributes,
-  AttachmentType,
-  CaseStatuses,
 } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import { AttachmentType, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   defaultUser,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/post_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/post_comment.ts
@@ -9,16 +9,18 @@ import { omit } from 'lodash/fp';
 import expect from '@kbn/expect';
 import { ALERT_CASE_IDS, ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 
-import {
-  AttachmentType,
+import type {
   UserCommentAttachmentAttributes,
   AlertAttachmentAttributes,
-  CaseStatuses,
   ExternalReferenceSOAttachmentPayload,
   AlertAttachmentPayload,
+} from '@kbn/cases-plugin/common/types/domain';
+import {
+  AttachmentType,
+  CaseStatuses,
   ExternalReferenceStorageType,
 } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   defaultUser,
   postCaseReq,
@@ -69,7 +71,7 @@ import {
   createSecuritySolutionAlerts,
   getAlertById,
 } from '../../../../common/lib/alerts';
-import { User } from '../../../../common/lib/authentication/types';
+import type { User } from '../../../../common/lib/authentication/types';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/get_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/get_configure.ts
@@ -11,7 +11,7 @@ import {
   CustomFieldTypes,
 } from '@kbn/cases-plugin/common/types/domain';
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   removeServerGeneratedPropertiesFromSavedObject,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/migrations.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/migrations.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common/constants';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import {
   getConfiguration,
   getConfigureSavedObjectsFromES,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/patch_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/patch_configure.ts
@@ -11,8 +11,8 @@ import {
   ConnectorTypes,
   CustomFieldTypes,
 } from '@kbn/cases-plugin/common/types/domain';
-import { ConfigurationPatchRequest } from '@kbn/cases-plugin/common/types/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { ConfigurationPatchRequest } from '@kbn/cases-plugin/common/types/api';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/post_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/post_configure.ts
@@ -12,7 +12,7 @@ import {
   CustomFieldTypes,
 } from '@kbn/cases-plugin/common/types/domain';
 import { MAX_CUSTOM_FIELD_LABEL_LENGTH } from '@kbn/cases-plugin/common/constants';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/files/post_file.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/files/post_file.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { ExternalReferenceAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import type { ExternalReferenceAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
 import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
 import {
   globalRead,
@@ -18,7 +18,7 @@ import {
   secOnlyRead,
   superUser,
 } from '../../../../common/lib/authentication/users';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { defaultUser, postCaseReq, postFileReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/index.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ loadTestFile }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_create_attachments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_create_attachments.ts
@@ -9,14 +9,12 @@ import { omit } from 'lodash/fp';
 import expect from '@kbn/expect';
 import { ALERT_CASE_IDS, ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 
-import { Case, AttachmentType } from '@kbn/cases-plugin/common';
-import { BulkCreateAttachmentsRequest } from '@kbn/cases-plugin/common/types/api';
-import {
-  ExternalReferenceSOAttachmentPayload,
-  CaseStatuses,
-  ExternalReferenceStorageType,
-} from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { Case } from '@kbn/cases-plugin/common';
+import { AttachmentType } from '@kbn/cases-plugin/common';
+import type { BulkCreateAttachmentsRequest } from '@kbn/cases-plugin/common/types/api';
+import type { ExternalReferenceSOAttachmentPayload } from '@kbn/cases-plugin/common/types/domain';
+import { CaseStatuses, ExternalReferenceStorageType } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   defaultUser,
   postCaseReq,
@@ -68,7 +66,7 @@ import {
   createSecuritySolutionAlerts,
   getAlertById,
 } from '../../../../common/lib/alerts';
-import { User } from '../../../../common/lib/authentication/types';
+import type { User } from '../../../../common/lib/authentication/types';
 import { SECURITY_SOLUTION_FILE_KIND } from '../../../../common/lib/constants';
 import { arraysToEqual } from '../../../../common/lib/validation';
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_delete_file_attachments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_delete_file_attachments.ts
@@ -6,12 +6,12 @@
  */
 
 import expect from '@kbn/expect';
-import { Case } from '@kbn/cases-plugin/common';
+import type { Case } from '@kbn/cases-plugin/common';
 import { constructFileKindIdByOwner } from '@kbn/cases-plugin/common/files';
-import { Owner } from '@kbn/cases-plugin/common/constants/types';
+import type { Owner } from '@kbn/cases-plugin/common/constants/types';
 import { CASES_TEST_FIXTURE_FILE_KIND_ID } from '@kbn/cases-api-integration-test-plugin/server/files';
 import { getFilesAttachmentReq, getPostCaseRequest } from '../../../../common/lib/mock';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   bulkCreateAttachments,
   bulkGetAttachments,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_get_attachments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_get_attachments.ts
@@ -6,13 +6,13 @@
  */
 
 import expect from '@kbn/expect';
-import {
+import type {
   ExternalReferenceAttachmentAttributes,
   ExternalReferenceSOAttachmentAttributes,
   Case,
   PersistableStateAttachment,
 } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   postCaseReq,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_get_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/bulk_get_cases.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { AttachmentType } from '@kbn/cases-plugin/common';
 import { MAX_BULK_GET_CASES } from '@kbn/cases-plugin/common/constants';
 import { getPostCaseRequest, postCaseReq } from '../../../../common/lib/mock';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   deleteAllCaseItems,
   bulkGetCases,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/find_user_actions.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/find_user_actions.ts
@@ -6,18 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import {
-  AttachmentType,
-  Case,
-  CaseSeverity,
-  CaseStatuses,
-} from '@kbn/cases-plugin/common/types/domain';
+import type { Case } from '@kbn/cases-plugin/common/types/domain';
+import { AttachmentType, CaseSeverity, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
 import { MAX_USER_ACTIONS_PER_PAGE } from '@kbn/cases-plugin/common/constants';
-import {
-  UserActionTypes,
-  CommentUserAction,
-  ConnectorTypes,
-} from '@kbn/cases-plugin/common/types/domain';
+import type { CommentUserAction } from '@kbn/cases-plugin/common/types/domain';
+import { UserActionTypes, ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import {
   globalRead,
   noKibanaPrivileges,
@@ -46,7 +39,7 @@ import {
   updateComment,
 } from '../../../../common/lib/api';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/get_connectors.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/get_connectors.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { createCase, deleteAllCaseItems } from '../../../../common/lib/api';
 import { getPostCaseRequest } from '../../../../common/lib/mock';
 import { getConnectors } from '../../../../common/lib/api';

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { CaseMetricsFeature } from '@kbn/cases-plugin/common';
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { createCase, deleteAllCaseItems, getCaseMetrics } from '../../../../../common/lib/api';
 import {
   secOnly,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics_actions.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics_actions.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { CaseMetricsFeature } from '@kbn/cases-plugin/common';
 import { getPostCaseRequest, postCommentActionsReq } from '../../../../../common/lib/mock';
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import {
   createCase,
   createComment,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics_alerts.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics_alerts.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { CaseMetricsFeature } from '@kbn/cases-plugin/common';
 import { getPostCaseRequest, postCommentAlertReq } from '../../../../../common/lib/mock';
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import {
   createCase,
   createComment,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics_connectors.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_case_metrics_connectors.ts
@@ -11,7 +11,7 @@ import { CaseMetricsFeature } from '@kbn/cases-plugin/common';
 import { getPostCaseRequest } from '../../../../../common/lib/mock';
 import { ObjectRemover as ActionsRemover } from '../../../../../../alerting_api_integration/common/lib';
 
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import {
   createCase,
   deleteAllCaseItems,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_cases_metrics.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/metrics/get_cases_metrics.ts
@@ -18,7 +18,7 @@ import {
   obsSecRead,
   obsSec,
 } from '../../../../../common/lib/authentication/users';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import {
   createCase,
   deleteAllCaseItems,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/replace_custom_field.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/replace_custom_field.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { CustomFieldTypes } from '@kbn/cases-plugin/common/types/domain';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { postCaseReq, getPostCaseRequest } from '../../../../common/lib/mock';
 import {
   deleteAllCaseItems,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/search_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/search_cases.ts
@@ -10,7 +10,7 @@ import { CustomFieldTypes } from '@kbn/cases-plugin/common/types/domain';
 import { CASES_INTERNAL_URL } from '@kbn/cases-plugin/common/constants';
 import { CaseSeverity } from '@kbn/cases-plugin/common/types/domain';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { postCaseReq, findCasesResp, getPostCaseRequest } from '../../../../common/lib/mock';
 import {
   ensureSavedObjectIsAuthorized,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/user_actions_get_users.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/internal/user_actions_get_users.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { Cookie } from 'tough-cookie';
-import { UserProfile } from '@kbn/security-plugin/common';
+import type { Cookie } from 'tough-cookie';
+import type { UserProfile } from '@kbn/security-plugin/common';
 import { GetCaseUsersResponseRt } from '@kbn/cases-plugin/common/types/api';
 import { securitySolutionOnlyAllSpacesRole } from '../../../../common/lib/authentication/roles';
 import { getPostCaseRequest } from '../../../../common/lib/mock';
@@ -21,7 +21,7 @@ import {
   bulkGetUserProfiles,
   updateUserProfileAvatar,
 } from '../../../../common/lib/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { createUsersAndRoles, deleteUsersAndRoles } from '../../../../common/lib/authentication';
 import {
   obsOnly,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/kibana_alerting_cases_index.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/kibana_alerting_cases_index.ts
@@ -23,7 +23,7 @@ import {
   getCaseUserActionsSavedObjectsFromES,
   getConfigureSavedObjectsFromES,
 } from '../../../common/lib/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/migrations.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/migrations.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ loadTestFile }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/telemetry.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/telemetry.ts
@@ -15,7 +15,7 @@ import {
   createComment,
   bulkCreateAttachments,
 } from '../../../common/lib/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { superUser } from '../../../common/lib/authentication/users';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/find_user_actions.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/find_user_actions.ts
@@ -6,13 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import { Case, CaseSeverity, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
+import type { Case } from '@kbn/cases-plugin/common/types/domain';
+import { CaseSeverity, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
 import { MAX_USER_ACTIONS_PER_PAGE } from '@kbn/cases-plugin/common/constants';
-import {
-  UserActionTypes,
-  CommentUserAction,
-  ConnectorTypes,
-} from '@kbn/cases-plugin/common/types/domain';
+import type { CommentUserAction } from '@kbn/cases-plugin/common/types/domain';
+import { UserActionTypes, ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import {
   globalRead,
   noKibanaPrivileges,
@@ -40,7 +38,7 @@ import {
   getCaseUserActions,
 } from '../../../../common/lib/api';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/get_all_user_actions.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/get_all_user_actions.ts
@@ -7,19 +7,21 @@
 
 import expect from '@kbn/expect';
 
-import {
+import type {
   Case,
-  CaseSeverity,
-  CaseStatuses,
   UserCommentAttachmentPayload,
-  AttachmentType,
   CreateCaseUserAction,
-  ConnectorTypes,
-  CustomFieldTypes,
   CaseCustomFields,
 } from '@kbn/cases-plugin/common/types/domain';
+import {
+  CaseSeverity,
+  CaseStatuses,
+  AttachmentType,
+  ConnectorTypes,
+  CustomFieldTypes,
+} from '@kbn/cases-plugin/common/types/domain';
 import { getCaseUserActionUrl } from '@kbn/cases-plugin/common/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { postCaseReq, postCommentUserReq, getPostCaseRequest } from '../../../../common/lib/mock';
 import {
   deleteAllCaseItems,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/get_user_action_stats.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/get_user_action_stats.ts
@@ -6,7 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { Case, CaseSeverity, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
+import type { Case } from '@kbn/cases-plugin/common/types/domain';
+import { CaseSeverity, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
 
 import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import {
@@ -29,7 +30,7 @@ import {
   postCommentUserReq,
   postExternalReferenceESReq,
 } from '../../../../common/lib/mock';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   bulkCreateAttachments,
   createCase,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/migrations.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/migrations.ts
@@ -7,11 +7,11 @@
 
 import expect from '@kbn/expect';
 import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common/constants';
-import type { UserActions, UserActionTypes } from '@kbn/cases-plugin/common/types/domain';
+import { UserActionTypes } from '@kbn/cases-plugin/common/types/domain';
 import { CaseUserActionsDeprecatedResponse } from '@kbn/cases-plugin/common/types/api';
 import { AttachmentType } from '@kbn/cases-plugin/common/types/domain';
 import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
-import { deleteAllCaseItems, findCaseUserActions } from '../../../../common/lib/api';
+import { deleteAllCaseItems, getCaseUserActions } from '../../../../common/lib/api';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/migrations.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/migrations.ts
@@ -7,11 +7,11 @@
 
 import expect from '@kbn/expect';
 import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common/constants';
-import { AttachmentType } from '@kbn/cases-plugin/common/types/domain';
+import type { UserActions, UserActionTypes } from '@kbn/cases-plugin/common/types/domain';
 import { CaseUserActionsDeprecatedResponse } from '@kbn/cases-plugin/common/types/api';
-import { UserActionTypes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
-import { deleteAllCaseItems, getCaseUserActions } from '../../../../common/lib/api';
+import { AttachmentType } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import { deleteAllCaseItems, findCaseUserActions } from '../../../../common/lib/api';
 
 // eslint-disable-next-line import/no-default-export
 export default function createGetTests({ getService }: FtrProviderContext) {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/migrations.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/user_actions/migrations.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common/constants';
 import { UserActionTypes } from '@kbn/cases-plugin/common/types/domain';
-import { CaseUserActionsDeprecatedResponse } from '@kbn/cases-plugin/common/types/api';
+import type { CaseUserActionsDeprecatedResponse } from '@kbn/cases-plugin/common/types/api';
 import { AttachmentType } from '@kbn/cases-plugin/common/types/domain';
 import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { deleteAllCaseItems, getCaseUserActions } from '../../../../common/lib/api';

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/no_public_base_url/index.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/no_public_base_url/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { createSpacesAndUsers, deleteSpacesAndUsers } from '../../../common/lib/authentication';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/no_public_base_url/push.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/no_public_base_url/push.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { RecordingServiceNowSimulator } from '@kbn/actions-simulators-plugin/server/servicenow_simulation';
+import type { RecordingServiceNowSimulator } from '@kbn/actions-simulators-plugin/server/servicenow_simulation';
 import { arraysToEqual } from '../../../common/lib/validation';
 import {
   postCommentUserReq,
@@ -17,7 +17,7 @@ import {
   postExternalReferenceESReq,
   persistableStateAttachment,
 } from '../../../common/lib/mock';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../alerting_api_integration/common/lib';
 
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/attachments_framework/registered_persistable_state_trial.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/attachments_framework/registered_persistable_state_trial.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/assignees.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/assignees.ts
@@ -19,7 +19,7 @@ import {
   bulkGetUserProfiles,
 } from '../../../../common/lib/api';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { superUser } from '../../../../common/lib/authentication/users';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/find_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/find_cases.ts
@@ -6,9 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import { Cookie } from 'tough-cookie';
-import { UserProfile } from '@kbn/security-plugin/common';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { Cookie } from 'tough-cookie';
+import type { UserProfile } from '@kbn/security-plugin/common';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { findCasesResp, getPostCaseRequest } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/patch_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/patch_case.ts
@@ -14,7 +14,7 @@ import {
   removeServerGeneratedPropertiesFromCase,
   updateCase,
 } from '../../../../common/lib/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 export const defaultUser = { email: null, full_name: null, username: 'elastic' };
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/post_case.ts
@@ -13,7 +13,7 @@ import {
   createCase,
   removeServerGeneratedPropertiesFromCase,
 } from '../../../../common/lib/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
@@ -7,13 +7,14 @@
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import http from 'http';
+import type http from 'http';
 
 import expect from '@kbn/expect';
-import { CaseStatuses, AttachmentType, User } from '@kbn/cases-plugin/common/types/domain';
-import { RecordingServiceNowSimulator } from '@kbn/actions-simulators-plugin/server/servicenow_simulation';
-import { CaseConnector } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { User } from '@kbn/cases-plugin/common/types/domain';
+import { CaseStatuses, AttachmentType } from '@kbn/cases-plugin/common/types/domain';
+import type { RecordingServiceNowSimulator } from '@kbn/actions-simulators-plugin/server/servicenow_simulation';
+import type { CaseConnector } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/user_actions/find_user_actions.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/user_actions/find_user_actions.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
 import { UserActionTypes } from '@kbn/cases-plugin/common/types/domain';
 import { getPostCaseRequest } from '../../../../../common/lib/mock';
@@ -20,7 +20,7 @@ import {
 } from '../../../../../common/lib/api';
 
 import { ObjectRemover as ActionsRemover } from '../../../../../../alerting_api_integration/common/lib';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/user_actions/get_all_user_actions.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/cases/user_actions/get_all_user_actions.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
-import { User } from '@kbn/cases-plugin/common/types/domain';
-import {
+import type { User } from '@kbn/cases-plugin/common/types/domain';
+import type {
   PushedUserAction,
   UserActionWithDeprecatedResponse,
 } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import { defaultUser, getPostCaseRequest } from '../../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/get_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/get_configure.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
-import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/get_connectors.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/get_connectors.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/index.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ loadTestFile }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/patch_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/patch_configure.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
-import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/post_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/configure/post_configure.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
-import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/connectors/cases/cases_connector.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/connectors/cases/cases_connector.ts
@@ -9,30 +9,29 @@ import expect from '@kbn/expect';
 import type SuperTest from 'supertest';
 import { createHash } from 'node:crypto';
 import stringify from 'json-stable-stringify';
-import {
+import type {
   CasesConnectorRunParams,
   OracleRecordAttributes,
 } from '@kbn/cases-plugin/server/connectors/cases/types';
-import { AttachmentType, CasePostRequest } from '@kbn/cases-plugin/common';
+import type { CasePostRequest } from '@kbn/cases-plugin/common';
+import { AttachmentType } from '@kbn/cases-plugin/common';
+import type { AlertAttachment, Attachments, Case } from '@kbn/cases-plugin/common/types/domain';
 import {
-  AlertAttachment,
-  Attachments,
-  Case,
   CaseStatuses,
   CaseSeverity,
   ConnectorTypes,
   CustomFieldTypes,
 } from '@kbn/cases-plugin/common/types/domain';
-import { KbnClient } from '@kbn/test';
-import { CasePersistedAttributes } from '@kbn/cases-plugin/server/common/types/case';
+import type { KbnClient } from '@kbn/test';
+import type { CasePersistedAttributes } from '@kbn/cases-plugin/server/common/types/case';
 import {
   SEVERITY_EXTERNAL_TO_ESMODEL,
   STATUS_EXTERNAL_TO_ESMODEL,
 } from '@kbn/cases-plugin/server/common/constants';
-import { Client } from '@elastic/elasticsearch';
+import type { Client } from '@elastic/elasticsearch';
 import { ALERTING_CASES_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import { CASE_RULES_SAVED_OBJECT } from '@kbn/cases-plugin/common/constants';
-import { User } from '../../../../../common/lib/authentication/types';
+import type { User } from '../../../../../common/lib/authentication/types';
 import {
   globalRead,
   noKibanaPrivileges,
@@ -50,7 +49,7 @@ import {
   createComment,
 } from '../../../../../common/lib/api';
 import { getPostCaseRequest, postCommentAlertReq } from '../../../../../common/lib/mock';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 import { roles as api_int_roles } from '../../../../../../api_integration/apis/cases/common/roles';
 import {
   casesAllUser,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/create_comment_sub_privilege.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/create_comment_sub_privilege.ts
@@ -7,11 +7,9 @@
 
 import expect from '@kbn/expect';
 
-import {
-  AttachmentType,
-  ExternalReferenceSOAttachmentPayload,
-} from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { ExternalReferenceSOAttachmentPayload } from '@kbn/cases-plugin/common/types/domain';
+import { AttachmentType } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import {
   fileAttachmentMetadata,
   getFilesAttachmentReq,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/delete_sub_privilege.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/delete_sub_privilege.ts
@@ -6,7 +6,7 @@
  */
 
 import { CASES_URL } from '@kbn/cases-plugin/common';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 import { getPostCaseRequest, postCommentUserReq } from '../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/index.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import {
   createSpacesAndUsers,
   deleteSpacesAndUsers,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/bulk_delete_file_attachments.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/bulk_delete_file_attachments.ts
@@ -6,9 +6,9 @@
  */
 
 import { constructFileKindIdByOwner } from '@kbn/cases-plugin/common/files';
-import { Owner } from '@kbn/cases-plugin/common/constants/types';
+import type { Owner } from '@kbn/cases-plugin/common/constants/types';
 import { getFilesAttachmentReq, getPostCaseRequest } from '../../../../common/lib/mock';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   bulkCreateAttachments,
   createCase,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/get_connectors.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/get_connectors.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
 
 import {
@@ -26,7 +26,7 @@ import {
   superUser,
 } from '../../../../common/lib/authentication/users';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   createCase,
   createComment,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/get_user_action_stats.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/get_user_action_stats.ts
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
 
 import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { postCaseReq } from '../../../../common/lib/mock';
 import {
   createCaseWithConnector,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/observables.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/observables.ts
@@ -19,7 +19,7 @@ import {
   getCase,
 } from '../../../../common/lib/api';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/similar_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/similar_cases.ts
@@ -16,7 +16,7 @@ import {
   similarCases,
 } from '../../../../common/lib/api';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/suggest_user_profiles.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/suggest_user_profiles.ts
@@ -7,13 +7,13 @@
 
 import expect from '@kbn/expect';
 import { loginUsers, suggestUserProfiles } from '../../../../common/lib/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   superUser,
   obsOnly,
   noCasesPrivilegesSpace1,
 } from '../../../../common/lib/authentication/users';
-import { Role, User } from '../../../../common/lib/authentication/types';
+import type { Role, User } from '../../../../common/lib/authentication/types';
 import { createUsersAndRoles, deleteUsersAndRoles } from '../../../../common/lib/authentication';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/user_actions_get_users.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/internal/user_actions_get_users.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { Cookie } from 'tough-cookie';
-import { UserProfile } from '@kbn/security-plugin/common';
+import type { Cookie } from 'tough-cookie';
+import type { UserProfile } from '@kbn/security-plugin/common';
 import { securitySolutionOnlyAllSpacesRole } from '../../../../common/lib/authentication/roles';
 import { getPostCaseRequest } from '../../../../common/lib/mock';
 import {
@@ -18,7 +18,7 @@ import {
   loginUsers,
   bulkGetUserProfiles,
 } from '../../../../common/lib/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { createUsersAndRoles, deleteUsersAndRoles } from '../../../../common/lib/authentication';
 import { secOnlySpacesAll, superUser } from '../../../../common/lib/authentication/users';
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/user_profiles/get_current.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/trial/user_profiles/get_current.ts
@@ -7,9 +7,10 @@
 
 import expect from '@kbn/expect';
 import { AttachmentType } from '@kbn/cases-plugin/common';
-import { CreateCaseUserAction, User, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
+import type { CreateCaseUserAction, User } from '@kbn/cases-plugin/common/types/domain';
+import { CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
 import { setupSuperUserProfile } from '../../../../common/lib/api/user_profiles';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { superUser } from '../../../../common/lib/authentication/users';
 import {
   createCase,

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/alerts/get_cases.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/alerts/get_cases.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { getPostCaseRequest, postCommentAlertReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/delete_cases.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/delete_cases.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { getPostCaseRequest } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/find_cases.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/find_cases.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { postCaseReq, findCasesResp } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/get_case.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/get_case.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { postCaseResp, getPostCaseRequest, nullUser } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/patch_cases.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { nullUser, postCaseReq, postCaseResp } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/post_case.ts
@@ -16,7 +16,7 @@ import {
   getAuthWithSuperUser,
 } from '../../../../common/lib/api';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ getService }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/reporters/get_reporters.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/reporters/get_reporters.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import { getPostCaseRequest } from '../../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/status/get_status.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/status/get_status.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import { postCaseReq } from '../../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/tags/get_tags.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/cases/tags/get_tags.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../../common/ftr_provider_context';
 
 import {
   deleteCasesByESQuery,

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/delete_comment.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/delete_comment.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { postCaseReq, postCommentUserReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/find_comments.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/find_comments.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { CASES_URL } from '@kbn/cases-plugin/common/constants';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { getPostCaseRequest, postCommentUserReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/get_all_comments.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/get_all_comments.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { postCaseReq, postCommentUserReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/get_comment.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/get_comment.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { postCaseReq, postCommentUserReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/patch_comment.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/patch_comment.ts
@@ -6,11 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import {
-  UserCommentAttachmentAttributes,
-  AttachmentType,
-} from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import { AttachmentType } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { nullUser, postCaseReq, postCommentUserReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/post_comment.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/comments/post_comment.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { nullUser, postCaseReq, postCommentUserReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/configure/get_configure.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/configure/get_configure.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { nullUser } from '../../../../common/lib/mock';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   removeServerGeneratedPropertiesFromSavedObject,

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/configure/patch_configure.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/configure/patch_configure.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   getConfigurationRequest,

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/configure/post_configure.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/configure/post_configure.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import {
   getConfigurationRequest,

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/files/post_file.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/files/post_file.ts
@@ -6,9 +6,9 @@
  */
 
 import expect from '@kbn/expect';
-import { ExternalReferenceAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import type { ExternalReferenceAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
 import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { nullUser, postCaseReq, postFileReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/index.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ loadTestFile }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/internal/bulk_create_attachments.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/internal/bulk_create_attachments.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { UserCommentAttachmentAttributes } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { nullUser, postCaseReq, postCommentUserReq } from '../../../../common/lib/mock';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/internal/suggest_user_profiles.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/internal/suggest_user_profiles.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { suggestUserProfiles } from '../../../../common/lib/api';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService }: FtrProviderContext) {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/metrics/get_cases_metrics.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/metrics/get_cases_metrics.ts
@@ -8,7 +8,7 @@
 import { CaseMetricsFeature } from '@kbn/cases-plugin/common';
 import expect from '@kbn/expect';
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   deleteAllCaseItems,
   getAuthWithSuperUser,

--- a/x-pack/test/cases_api_integration/spaces_only/tests/common/user_actions/get_all_user_actions.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/common/user_actions/get_all_user_actions.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { getPostCaseRequest } from '../../../../common/lib/mock';
 import { deleteAllCaseItems, createCase, getAuthWithSuperUser } from '../../../../common/lib/api';

--- a/x-pack/test/cases_api_integration/spaces_only/tests/trial/cases/push_case.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/trial/cases/push_case.ts
@@ -6,9 +6,9 @@
  */
 
 /* eslint-disable @typescript-eslint/naming-convention */
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 
 import { nullUser } from '../../../../common/lib/mock';

--- a/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/get_configure.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/get_configure.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
-import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/get_connectors.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/get_connectors.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/index.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default ({ loadTestFile }: FtrProviderContext): void => {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/patch_configure.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/patch_configure.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
-import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/post_configure.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/trial/configure/post_configure.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import http from 'http';
+import type http from 'http';
 import expect from '@kbn/expect';
-import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 
 import {

--- a/x-pack/test/cases_api_integration/spaces_only/tests/trial/index.ts
+++ b/x-pack/test/cases_api_integration/spaces_only/tests/trial/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { createSpaces, deleteSpaces } from '../../../common/lib/authentication';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/common/config.ts
+++ b/x-pack/test/rule_registry/common/config.ts
@@ -7,7 +7,8 @@
 
 import path from 'path';
 import { CA_CERT_PATH } from '@kbn/dev-utils';
-import { FtrConfigProviderContext, findTestPluginPaths } from '@kbn/test';
+import type { FtrConfigProviderContext } from '@kbn/test';
+import { findTestPluginPaths } from '@kbn/test';
 import { ScoutTestRunConfigCategory } from '@kbn/scout-info';
 
 import { getAllExternalServiceSimulatorPaths } from '@kbn/actions-simulators-plugin/server/plugin';

--- a/x-pack/test/rule_registry/common/ftr_provider_context.d.ts
+++ b/x-pack/test/rule_registry/common/ftr_provider_context.d.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { GenericFtrProviderContext } from '@kbn/test';
+import type { GenericFtrProviderContext } from '@kbn/test';
 
-import { services } from './services';
+import type { services } from './services';
 
 export type FtrProviderContext = GenericFtrProviderContext<typeof services, {}>;

--- a/x-pack/test/rule_registry/common/lib/authentication/index.ts
+++ b/x-pack/test/rule_registry/common/lib/authentication/index.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { FtrProviderContext as CommonFtrProviderContext } from '../../ftr_provider_context';
-import { Role, User, UserInfo } from './types';
+import type { FtrProviderContext as CommonFtrProviderContext } from '../../ftr_provider_context';
+import type { Role, User, UserInfo } from './types';
 import { allUsers } from './users';
 import { allRoles } from './roles';
 import { spaces } from './spaces';

--- a/x-pack/test/rule_registry/common/lib/authentication/roles.ts
+++ b/x-pack/test/rule_registry/common/lib/authentication/roles.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Role } from './types';
+import type { Role } from './types';
 
 export const noKibanaPrivileges: Role = {
   name: 'no_kibana_privileges',

--- a/x-pack/test/rule_registry/common/lib/authentication/spaces.ts
+++ b/x-pack/test/rule_registry/common/lib/authentication/spaces.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Space } from './types';
+import type { Space } from './types';
 
 const space1: Space = {
   id: 'space1',

--- a/x-pack/test/rule_registry/common/lib/authentication/users.ts
+++ b/x-pack/test/rule_registry/common/lib/authentication/users.ts
@@ -33,7 +33,7 @@ import {
   stackAlertsOnlyReadSpacesAll as stackAlertsOnlyReadSpacesAllRole,
   stackAlertsOnlyAllSpacesAll as stackAlertsOnlyAllSpacesAllRole,
 } from './roles';
-import { User } from './types';
+import type { User } from './types';
 
 export const superUser: User = {
   username: 'superuser',

--- a/x-pack/test/rule_registry/common/lib/helpers/cleanup_registry_indices.ts
+++ b/x-pack/test/rule_registry/common/lib/helpers/cleanup_registry_indices.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
-import { GetService } from '../../types';
+import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
+import type { GetService } from '../../types';
 
 export const cleanupRegistryIndices = async (getService: GetService, client: IRuleDataClient) => {
   const es = getService('es');

--- a/x-pack/test/rule_registry/common/lib/helpers/cleanup_target_indices.ts
+++ b/x-pack/test/rule_registry/common/lib/helpers/cleanup_target_indices.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { GetService } from '../../types';
-import { User } from '../authentication/types';
+import type { GetService } from '../../types';
+import type { User } from '../authentication/types';
 import { getAlertsTargetIndices } from './get_alerts_target_indices';
 
 export const cleanupTargetIndices = async (getService: GetService, user: User, spaceId: string) => {

--- a/x-pack/test/rule_registry/common/lib/helpers/create_alert.ts
+++ b/x-pack/test/rule_registry/common/lib/helpers/create_alert.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { User } from '../authentication/types';
-import { GetService, AlertDef } from '../../types';
+import type { User } from '../authentication/types';
+import type { GetService, AlertDef } from '../../types';
 import { getSpaceUrlPrefix } from '../authentication/spaces';
 
 export const createAlert = async (

--- a/x-pack/test/rule_registry/common/lib/helpers/create_apm_metric_index.ts
+++ b/x-pack/test/rule_registry/common/lib/helpers/create_apm_metric_index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { APM_METRIC_INDEX_NAME } from '../../constants';
-import { GetService } from '../../types';
+import type { GetService } from '../../types';
 
 export const createApmMetricIndex = async (getService: GetService) => {
   const es = getService('es');

--- a/x-pack/test/rule_registry/common/lib/helpers/delete_alert.ts
+++ b/x-pack/test/rule_registry/common/lib/helpers/delete_alert.ts
@@ -6,9 +6,9 @@
  */
 
 import { APM_METRIC_INDEX_NAME } from '../../constants';
-import { GetService } from '../../types';
+import type { GetService } from '../../types';
 import { getSpaceUrlPrefix } from '../authentication/spaces';
-import { User } from '../authentication/types';
+import type { User } from '../authentication/types';
 import { getAlertsTargetIndices } from './get_alerts_target_indices';
 
 export const deleteAlert = async (

--- a/x-pack/test/rule_registry/common/lib/helpers/get_alerts_target_indices.ts
+++ b/x-pack/test/rule_registry/common/lib/helpers/get_alerts_target_indices.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 import { ALERTS_TARGET_INDICES_URL } from '../../constants';
-import { GetService } from '../../types';
-import { User } from '../authentication/types';
+import type { GetService } from '../../types';
+import type { User } from '../authentication/types';
 import { getSpaceUrlPrefix } from '../authentication/spaces';
 
 export const getAlertsTargetIndices = async (

--- a/x-pack/test/rule_registry/common/lib/helpers/wait_until_next_execution.ts
+++ b/x-pack/test/rule_registry/common/lib/helpers/wait_until_next_execution.ts
@@ -4,12 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { Rule } from '@kbn/alerting-plugin/common';
-import { GetService } from '../../types';
+import type { Rule } from '@kbn/alerting-plugin/common';
+import type { GetService } from '../../types';
 import { getAlertsTargetIndices } from './get_alerts_target_indices';
 import { BULK_INDEX_DELAY, MAX_POLLS } from '../../constants';
 import { getSpaceUrlPrefix } from '../authentication/spaces';
-import { User } from '../authentication/types';
+import type { User } from '../authentication/types';
 
 export async function waitUntilNextExecution(
   getService: GetService,

--- a/x-pack/test/rule_registry/common/services/cluster_client.ts
+++ b/x-pack/test/rule_registry/common/services/cluster_client.ts
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-import { Client, Transport } from '@elastic/elasticsearch';
+import { Transport } from '@elastic/elasticsearch';
 import { createEsClientForFtrConfig } from '@kbn/test';
 import type {
   TransportRequestParams,
   TransportRequestOptions,
   TransportResult,
+  Client,
 } from '@elastic/elasticsearch';
 
-import { FtrProviderContext } from '../ftr_provider_context';
+import type { FtrProviderContext } from '../ftr_provider_context';
 
 /*
  registers Kibana-specific @elastic/elasticsearch client instance.

--- a/x-pack/test/rule_registry/common/types.ts
+++ b/x-pack/test/rule_registry/common/types.ts
@@ -4,16 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { GenericFtrProviderContext } from '@kbn/test';
-import {
+import type { GenericFtrProviderContext } from '@kbn/test';
+import type {
   Rule,
   RuleTypeParams,
   ActionGroupIdsOf,
   AlertInstanceState as AlertState,
   AlertInstanceContext as AlertContext,
 } from '@kbn/alerting-plugin/common';
-import { RuleTypeState } from '@kbn/alerting-plugin/server';
-import { services } from './services';
+import type { RuleTypeState } from '@kbn/alerting-plugin/server';
+import type { services } from './services';
 
 export type GetService = GenericFtrProviderContext<typeof services, {}>['getService'];
 

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/bulk_update_alerts.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/bulk_update_alerts.ts
@@ -29,7 +29,7 @@ import {
 } from '../../../common/lib/authentication/users';
 
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 interface TestCase {

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/find_alerts.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/find_alerts.ts
@@ -31,7 +31,7 @@ import {
   noKibanaPrivileges,
 } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 interface TestCase {

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_aad_fields_by_rule_type.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_aad_fields_by_rule_type.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { obsOnlySpacesAll } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alert_by_id.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alert_by_id.ts
@@ -28,7 +28,7 @@ import {
   noKibanaPrivileges,
 } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 interface TestCase {

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alert_summary.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alert_summary.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 import { superUser } from '../../../common/lib/authentication/users';
 

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alerts_index.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_alerts_index.ts
@@ -14,7 +14,7 @@ import {
   stackAlertsOnlyReadSpacesAll,
 } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_browser_fields_by_rule_type_ids.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/get_browser_fields_by_rule_type_ids.ts
@@ -9,7 +9,7 @@ import expect from 'expect';
 import { OBSERVABILITY_RULE_TYPE_IDS } from '@kbn/rule-data-utils';
 import { superUser, obsOnlySpacesAll, secOnlyRead } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/index.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { createSpacesAndUsers, deleteSpacesAndUsers } from '../../../common/lib/authentication';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/security_and_spaces/tests/basic/update_alert.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/basic/update_alert.ts
@@ -27,7 +27,7 @@ import {
   noKibanaPrivileges,
 } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 interface TestCase {

--- a/x-pack/test/rule_registry/security_and_spaces/tests/trial/get_alerts.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/trial/get_alerts.ts
@@ -15,7 +15,7 @@ import {
   obsMinReadAlertsReadSpacesAll,
 } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/security_and_spaces/tests/trial/index.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/trial/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import {
   createSpaces,
   createUsersAndRoles,

--- a/x-pack/test/rule_registry/security_and_spaces/tests/trial/update_alert.ts
+++ b/x-pack/test/rule_registry/security_and_spaces/tests/trial/update_alert.ts
@@ -15,7 +15,7 @@ import {
   obsMinAllSpacesAll,
 } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/spaces_only/tests/basic/index.ts
+++ b/x-pack/test/rule_registry/spaces_only/tests/basic/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { createSpaces, deleteSpaces } from '../../../common/lib/authentication';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/spaces_only/tests/trial/get_alert_by_id.ts
+++ b/x-pack/test/rule_registry/spaces_only/tests/trial/get_alert_by_id.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 
 import { superUser } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/spaces_only/tests/trial/index.ts
+++ b/x-pack/test/rule_registry/spaces_only/tests/trial/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { createSpaces, deleteSpaces } from '../../../common/lib/authentication';
 
 // eslint-disable-next-line import/no-default-export

--- a/x-pack/test/rule_registry/spaces_only/tests/trial/update_alert.ts
+++ b/x-pack/test/rule_registry/spaces_only/tests/trial/update_alert.ts
@@ -8,7 +8,7 @@ import expect from '@kbn/expect';
 
 import { superUser } from '../../../common/lib/authentication/users';
 import type { User } from '../../../common/lib/authentication/types';
-import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../common/ftr_provider_context';
 import { getSpaceUrlPrefix } from '../../../common/lib/authentication/spaces';
 
 // eslint-disable-next-line import/no-default-export


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ResponseOps]consistent-type-imports linting rule for RO packages/plugins - PR4 (#212508)](https://github.com/elastic/kibana/pull/212508)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2025-03-26T13:27:06Z","message":"[ResponseOps]consistent-type-imports linting rule for RO packages/plugins - PR4 (#212508)\n\n- Enabled @typescript-eslint/consistent-type-imports eslint rule for\nResponseOps packages and plugins:\n- this rule ensures that imports used only for type declarations are\nconsistently written using import type syntax\n\n- fixed type imports for:\n    - x-pack/test/alerting_api_integration\n    - x-pack/test/cases_api_integration\n    - x-pack/test/rule_registry\n    - x-pack/test/api_integration/apis/cases\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d60335a19581c300a5e4123734ab8ba236711abe","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","v9.1.0","v8.19.0"],"title":"[ResponseOps]consistent-type-imports linting rule for RO packages/plugins - PR4","number":212508,"url":"https://github.com/elastic/kibana/pull/212508","mergeCommit":{"message":"[ResponseOps]consistent-type-imports linting rule for RO packages/plugins - PR4 (#212508)\n\n- Enabled @typescript-eslint/consistent-type-imports eslint rule for\nResponseOps packages and plugins:\n- this rule ensures that imports used only for type declarations are\nconsistently written using import type syntax\n\n- fixed type imports for:\n    - x-pack/test/alerting_api_integration\n    - x-pack/test/cases_api_integration\n    - x-pack/test/rule_registry\n    - x-pack/test/api_integration/apis/cases\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d60335a19581c300a5e4123734ab8ba236711abe"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212508","number":212508,"mergeCommit":{"message":"[ResponseOps]consistent-type-imports linting rule for RO packages/plugins - PR4 (#212508)\n\n- Enabled @typescript-eslint/consistent-type-imports eslint rule for\nResponseOps packages and plugins:\n- this rule ensures that imports used only for type declarations are\nconsistently written using import type syntax\n\n- fixed type imports for:\n    - x-pack/test/alerting_api_integration\n    - x-pack/test/cases_api_integration\n    - x-pack/test/rule_registry\n    - x-pack/test/api_integration/apis/cases\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d60335a19581c300a5e4123734ab8ba236711abe"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->