### PR TITLE
[fix] Fix lint errors introduced parallel to arming the rule

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group5/tests/alerting/rule_types_internal.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group5/tests/alerting/rule_types_internal.ts
@@ -9,7 +9,7 @@ import expect from '@kbn/expect';
 import { omit } from 'lodash';
 import { UserAtSpaceScenarios } from '../../../scenarios';
 import { getUrlPrefix } from '../../../../common/lib/space_test_utils';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function listInternalRuleTypes({ getService }: FtrProviderContext) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/rule_types_internal.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/rule_types_internal.ts
@@ -8,7 +8,7 @@
 import expect from '@kbn/expect';
 import { Spaces } from '../../../scenarios';
 import { getUrlPrefix } from '../../../../common/lib/space_test_utils';
-import { FtrProviderContext } from '../../../../common/ftr_provider_context';
+import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
 export default function listRuleTypes({ getService }: FtrProviderContext) {


### PR DESCRIPTION
## Summary
Quick fix to a lint error present in main after https://github.com/elastic/kibana/pull/212508 - probably a case of merge race condition

see:  https://buildkite.com/elastic/kibana-on-merge/builds/65208#0195d2a4-1f65-4ecc-9c45-25b789d8ca79

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->