### PR TITLE
[8.18] [SecuritySolution] Update API key permissions on refreshing data view API (#215738)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/request_context.ts
@@ -166,6 +166,7 @@ const createSecuritySolutionRequestContextMock = (
     getAssetCriticalityDataClient: jest.fn(() => clients.assetCriticalityDataClient),
     getAuditLogger: jest.fn(() => mockAuditLogger),
     getDataViewsService: jest.fn(),
+    getEntityStoreApiKeyManager: jest.fn(),
     getEntityStoreDataClient: jest.fn(() => clients.entityStoreDataClient),
     getSiemRuleMigrationsClient: jest.fn(() => clients.siemRuleMigrationsClient),
     getInferenceClient: jest.fn(() => clients.getInferenceClient()),

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/routes/apply_dataview_indices.ts
@@ -58,6 +58,9 @@ export const applyDataViewIndicesEntityEngineRoute = (
             });
           }
 
+          const apiKeyManager = secSol.getEntityStoreApiKeyManager();
+          await apiKeyManager.generate();
+
           if (errors.length === 0) {
             return response.ok({
               body: {
@@ -75,7 +78,7 @@ export const applyDataViewIndicesEntityEngineRoute = (
             });
           }
         } catch (e) {
-          logger.error('Error in ApplyEntityEngineDataViewIndices:', e);
+          logger.error(`Error in ApplyEntityEngineDataViewIndices: ${e.message}`);
           const error = transformError(e);
           return siemResponse.error({
             statusCode: error.statusCode,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/tasks/data_view_refresh/data_view_refresh_task.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/entity_analytics/entity_store/tasks/data_view_refresh/data_view_refresh_task.ts
@@ -110,7 +110,13 @@ export const registerEntityStoreDataViewRefreshTask = ({
       request,
     });
 
-    await entityStoreClient.applyDataViewIndices();
+    const { errors } = await entityStoreClient.applyDataViewIndices();
+
+    if (errors.length > 0) {
+      logger.error(
+        `Errors applying data view changes to the entity store. Errors: \n${errors.join('\n\n')}`
+      );
+    }
   };
 
   taskManager.registerTaskDefinitions({

--- a/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/request_context_factory.ts
@@ -108,6 +108,16 @@ export class RequestContextFactory implements IRequestContextFactory {
 
     const getAuditLogger = () => security?.audit.asScoped(request);
 
+    const getEntityStoreApiKeyManager = () =>
+      getApiKeyManager({
+        core: coreStart,
+        logger: options.logger,
+        security: startPlugins.security,
+        encryptedSavedObjects: startPlugins.encryptedSavedObjects,
+        request,
+        namespace: getSpaceId(),
+      });
+
     // List of endpoint authz for the current request's user. Will be initialized the first
     // time it is requested (see `getEndpointAuthz()` below)
     let endpointAuthz: Immutable<EndpointAuthz>;
@@ -143,6 +153,8 @@ export class RequestContextFactory implements IRequestContextFactory {
       getAuditLogger,
 
       getDataViewsService: () => dataViewsService,
+
+      getEntityStoreApiKeyManager,
 
       getDetectionRulesClient: memoize(() => {
         const mlAuthz = buildMlAuthz({
@@ -257,14 +269,7 @@ export class RequestContextFactory implements IRequestContextFactory {
           experimentalFeatures: config.experimentalFeatures,
           telemetry: core.analytics,
           config: config.entityAnalytics.entityStore,
-          apiKeyManager: getApiKeyManager({
-            core: coreStart,
-            logger,
-            security: startPlugins.security,
-            encryptedSavedObjects: startPlugins.encryptedSavedObjects,
-            request,
-            namespace: getSpaceId(),
-          }),
+          apiKeyManager: getEntityStoreApiKeyManager(),
           security: startPlugins.security,
           request,
         });

--- a/x-pack/solutions/security/plugins/security_solution/server/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/types.ts
@@ -38,6 +38,7 @@ import type { AssetCriticalityDataClient } from './lib/entity_analytics/asset_cr
 import type { IDetectionRulesClient } from './lib/detection_engine/rule_management/logic/detection_rules_client/detection_rules_client_interface';
 import type { EntityStoreDataClient } from './lib/entity_analytics/entity_store/entity_store_data_client';
 import type { SiemRuleMigrationsClient } from './lib/siem_migrations/rules/siem_rule_migrations_service';
+import type { ApiKeyManager } from './lib/entity_analytics/entity_store/auth/api_key';
 export { AppClient };
 
 export interface SecuritySolutionApiRequestHandlerContext {
@@ -55,6 +56,7 @@ export interface SecuritySolutionApiRequestHandlerContext {
   getRacClient: (req: KibanaRequest) => Promise<AlertsClient>;
   getAuditLogger: () => AuditLogger | undefined;
   getDataViewsService: () => DataViewsService;
+  getEntityStoreApiKeyManager: () => ApiKeyManager;
   getExceptionListClient: () => ExceptionListClient | null;
   getInternalFleetServices: () => EndpointInternalFleetServicesInterface;
   getRiskEngineDataClient: () => RiskEngineDataClient;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[SecuritySolution] Update API key permissions on refreshing data view API (#215738)](https://github.com/elastic/kibana/pull/215738)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2025-03-26T10:03:45Z","message":"[SecuritySolution] Update API key permissions on refreshing data view API (#215738)\n\nUpdate the API key when entity store `apply_dataview_indices` is called.\n\n## Summary\nThis change allows the user to update the privileges the entity store\ndata view refresh task uses. This will enable them to fix problems when\nthe user that enabled the entity store doesn't have all data view\nindices privileges.\n\nThis PR also improves some error messages that were hard to read.\n\n### Context\n* `apply_dataview_indices`is an API that updates the entity store\ntransform with the indices defined in the security solution data view.\n* There is a background task that calls `apply_dataview_indices` from\ntime to time\n* The background task uses the API key to access the security solution\ndata view indices.\n\n\n### How to test it\n* Create a kibana instance with security data\n* Create a user that only has access the necessary access to the entity\nstore indices\n* Enable the entity store with a the created user\n* Login with a superuser \n* Add a new index to the security solution data view, which the created\nuser cannot access.\n* The task will fail because it uses the API key from the unprivileged\nuser.\n* Call `apply_dataview_indices` with the superuser (`POST\nkbn:api/entity_store/engines/apply_dataview_indices`)\n* The request should succeed because it is using the superuser\ncredentials\n* Add a new index to the security solution data view, which the created\nuser cannot access.\n* The task should succeed because it is using the superuser API key\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"e201b947be53e4e903ab1126592c3853f66108df","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","v9.0.0","Team: SecuritySolution","Team:Entity Analytics","backport:version","v9.1.0","v8.19.0","v8.18.1","v9.0.1"],"title":"[SecuritySolution] Update API key permissions on refreshing data view API","number":215738,"url":"https://github.com/elastic/kibana/pull/215738","mergeCommit":{"message":"[SecuritySolution] Update API key permissions on refreshing data view API (#215738)\n\nUpdate the API key when entity store `apply_dataview_indices` is called.\n\n## Summary\nThis change allows the user to update the privileges the entity store\ndata view refresh task uses. This will enable them to fix problems when\nthe user that enabled the entity store doesn't have all data view\nindices privileges.\n\nThis PR also improves some error messages that were hard to read.\n\n### Context\n* `apply_dataview_indices`is an API that updates the entity store\ntransform with the indices defined in the security solution data view.\n* There is a background task that calls `apply_dataview_indices` from\ntime to time\n* The background task uses the API key to access the security solution\ndata view indices.\n\n\n### How to test it\n* Create a kibana instance with security data\n* Create a user that only has access the necessary access to the entity\nstore indices\n* Enable the entity store with a the created user\n* Login with a superuser \n* Add a new index to the security solution data view, which the created\nuser cannot access.\n* The task will fail because it uses the API key from the unprivileged\nuser.\n* Call `apply_dataview_indices` with the superuser (`POST\nkbn:api/entity_store/engines/apply_dataview_indices`)\n* The request should succeed because it is using the superuser\ncredentials\n* Add a new index to the security solution data view, which the created\nuser cannot access.\n* The task should succeed because it is using the superuser API key\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"e201b947be53e4e903ab1126592c3853f66108df"}},"sourceBranch":"main","suggestedTargetBranches":["8.x","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216004","number":216004,"state":"MERGED","mergeCommit":{"sha":"6c4126fd55ee8e00ecbb19054b1baddd2ff07903","message":"[9.0] [SecuritySolution] Update API key permissions on refreshing data view API (#215738) (#216004)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[SecuritySolution] Update API key permissions on refreshing data view\nAPI (#215738)](https://github.com/elastic/kibana/pull/215738)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Pablo Machado <pablo.nevesmachado@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215738","number":215738,"mergeCommit":{"message":"[SecuritySolution] Update API key permissions on refreshing data view API (#215738)\n\nUpdate the API key when entity store `apply_dataview_indices` is called.\n\n## Summary\nThis change allows the user to update the privileges the entity store\ndata view refresh task uses. This will enable them to fix problems when\nthe user that enabled the entity store doesn't have all data view\nindices privileges.\n\nThis PR also improves some error messages that were hard to read.\n\n### Context\n* `apply_dataview_indices`is an API that updates the entity store\ntransform with the indices defined in the security solution data view.\n* There is a background task that calls `apply_dataview_indices` from\ntime to time\n* The background task uses the API key to access the security solution\ndata view indices.\n\n\n### How to test it\n* Create a kibana instance with security data\n* Create a user that only has access the necessary access to the entity\nstore indices\n* Enable the entity store with a the created user\n* Login with a superuser \n* Add a new index to the security solution data view, which the created\nuser cannot access.\n* The task will fail because it uses the API key from the unprivileged\nuser.\n* Call `apply_dataview_indices` with the superuser (`POST\nkbn:api/entity_store/engines/apply_dataview_indices`)\n* The request should succeed because it is using the superuser\ncredentials\n* Add a new index to the security solution data view, which the created\nuser cannot access.\n* The task should succeed because it is using the superuser API key\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"e201b947be53e4e903ab1126592c3853f66108df"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->