### PR TITLE
[8.17] [Synthetics] Fix location filter in status rule executor (#215514)

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
@@ -33,7 +33,7 @@ import {
   getUngroupedReasonMessage,
 } from './message_utils';
 import { queryMonitorStatusAlert } from './queries/query_monitor_status_alert';
-import { parseArrayFilters } from '../../routes/common';
+import { parseArrayFilters, parseLocationFilter } from '../../routes/common';
 import { SyntheticsServerSetup } from '../../types';
 import { SyntheticsEsClient } from '../../lib';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../common/constants';
@@ -114,14 +114,23 @@ export class StatusRuleExecutor {
       return processMonitors([]);
     }
 
+    const locationIds = await parseLocationFilter(
+      {
+        savedObjectsClient: this.soClient,
+        server: this.server,
+        syntheticsMonitorClient: this.syntheticsMonitorClient,
+      },
+      this.params.locations
+    );
+
     const { filtersStr } = parseArrayFilters({
       configIds,
       filter: baseFilter,
-      tags: this.params?.tags,
-      locations: this.params?.locations,
-      monitorTypes: this.params?.monitorTypes,
-      monitorQueryIds: this.params?.monitorIds,
-      projects: this.params?.projects,
+      tags: this.params.tags,
+      locations: locationIds,
+      monitorTypes: this.params.monitorTypes,
+      monitorQueryIds: this.params.monitorIds,
+      projects: this.params.projects,
     });
 
     this.monitors = await getAllMonitors({
@@ -129,7 +138,11 @@ export class StatusRuleExecutor {
       filter: filtersStr,
     });
 
-    this.debug(`Found ${this.monitors.length} monitors for params ${JSON.stringify(this.params)}`);
+    this.debug(
+      `Found ${this.monitors.length} monitors for params ${JSON.stringify(
+        this.params
+      )} | parsed location filter is ${JSON.stringify(locationIds)} `
+    );
     return processMonitors(this.monitors);
   }
 

--- a/x-pack/plugins/observability_solution/synthetics/server/routes/common.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/routes/common.test.ts
@@ -37,7 +37,7 @@ describe('common utils', () => {
       schedules: ['schedule1', 'schedule2'],
     });
     expect(filters.filtersStr).toMatchInlineSnapshot(
-      `"synthetics-monitor.attributes.tags:(\\"tag1\\" OR \\"tag2\\") AND synthetics-monitor.attributes.project_id:(\\"project1\\" OR \\"project2\\") AND synthetics-monitor.attributes.type:(\\"type1\\" OR \\"type2\\") AND synthetics-monitor.attributes.schedule.number:(\\"schedule1\\" OR \\"schedule2\\") AND synthetics-monitor.attributes.id:(\\"query1\\" OR \\"query2\\") AND synthetics-monitor.attributes.config_id:(\\"1\\" OR \\"2\\")"`
+      `"synthetics-monitor.attributes.tags:(\\"tag1\\" OR \\"tag2\\") AND synthetics-monitor.attributes.project_id:(\\"project1\\" OR \\"project2\\") AND synthetics-monitor.attributes.type:(\\"type1\\" OR \\"type2\\") AND synthetics-monitor.attributes.locations.id:(\\"loc1\\" OR \\"loc2\\") AND synthetics-monitor.attributes.schedule.number:(\\"schedule1\\" OR \\"schedule2\\") AND synthetics-monitor.attributes.id:(\\"query1\\" OR \\"query2\\") AND synthetics-monitor.attributes.config_id:(\\"1\\" OR \\"2\\")"`
     );
   });
 });

--- a/x-pack/plugins/observability_solution/synthetics/server/routes/overview_status/overview_status.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/routes/overview_status/overview_status.test.ts
@@ -1190,6 +1190,7 @@ describe('current status route', () => {
           syntheticsEsClient,
           savedObjectsClient: savedObjectsClientMock.create(),
           server: serverMock,
+          request: { query: { locations } },
         } as unknown as RouteContext,
         {
           locations,
@@ -1255,6 +1256,7 @@ describe('current status route', () => {
           {
             syntheticsEsClient,
             savedObjectsClient: savedObjectsClientMock.create(),
+            request: { query: { locations } },
           } as unknown as RouteContext,
           {
             locations,

--- a/x-pack/plugins/observability_solution/synthetics/server/routes/overview_status/overview_status.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/routes/overview_status/overview_status.ts
@@ -47,10 +47,7 @@ export async function getStatus(context: RouteContext, params: OverviewStatusQue
    * latest ping for all enabled monitors.
    */
 
-  const { filtersStr, locationFilter: queryLocations } = await getMonitorFilters({
-    ...params,
-    context,
-  });
+  const { filtersStr, locationIds: queryLocations } = await getMonitorFilters(context);
 
   const allMonitors = await getAllMonitors({
     soClient: savedObjectsClient,

--- a/x-pack/plugins/observability_solution/synthetics/server/routes/suggestions/route.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/routes/suggestions/route.ts
@@ -65,15 +65,9 @@ export const getSyntheticsSuggestionsRoute: SyntheticsRestApiRouteFactory<
       savedObjectsClient,
       server: { logger },
     } = route;
-    const { tags, locations, projects, monitorQueryIds, query } = route.request.query;
+    const { query } = route.request.query;
 
-    const { filtersStr } = await getMonitorFilters({
-      tags,
-      locations,
-      projects,
-      monitorQueryIds,
-      context: route,
-    });
+    const { filtersStr } = await getMonitorFilters(route);
     const { allLocations = [] } = await getAllLocations(route);
     try {
       const data = await savedObjectsClient.find<EncryptedSyntheticsMonitorAttributes>({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Synthetics] Fix location filter in status rule executor (#215514)](https://github.com/elastic/kibana/pull/215514)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-03-26T16:08:25Z","message":"[Synthetics] Fix location filter in status rule executor (#215514)\n\nThis PR closes #215505 by fixing the location filter when creating a\ncustom status rule for monitors.\n\n\n\nhttps://github.com/user-attachments/assets/623b21fb-af45-42ae-a120-e38562451062\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"04d53ec134272fe111bf5553a0f1622418f75f71","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","v8.18.1","v8.17.5"],"title":"[Synthetics] Fix location filter in status rule executor","number":215514,"url":"https://github.com/elastic/kibana/pull/215514","mergeCommit":{"message":"[Synthetics] Fix location filter in status rule executor (#215514)\n\nThis PR closes #215505 by fixing the location filter when creating a\ncustom status rule for monitors.\n\n\n\nhttps://github.com/user-attachments/assets/623b21fb-af45-42ae-a120-e38562451062\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"04d53ec134272fe111bf5553a0f1622418f75f71"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.x","8.18","8.17"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215514","number":215514,"mergeCommit":{"message":"[Synthetics] Fix location filter in status rule executor (#215514)\n\nThis PR closes #215505 by fixing the location filter when creating a\ncustom status rule for monitors.\n\n\n\nhttps://github.com/user-attachments/assets/623b21fb-af45-42ae-a120-e38562451062\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"04d53ec134272fe111bf5553a0f1622418f75f71"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->