### PR TITLE
[Fleet] Keep the query params `returnAppId` and `returnPath` when switching tabs the integration details page

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -618,6 +618,12 @@ export function Detail() {
       return [];
     }
     const packageInfoKey = pkgKeyFromPackageInfo(packageInfo);
+    const pathValues = {
+      pkgkey: packageInfoKey,
+      ...(integration ? { integration } : {}),
+      ...(returnAppId ? { returnAppId } : {}),
+      ...(returnPath ? { returnPath } : {}),
+    };
 
     const tabs: WithHeaderLayoutProps['tabs'] = [
       {
@@ -630,12 +636,7 @@ export function Detail() {
         ),
         isSelected: panel === 'overview',
         'data-test-subj': `tab-overview`,
-        href: getHref('integration_details_overview', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-          ...(returnAppId ? { returnAppId } : {}),
-          ...(returnPath ? { returnPath } : {}),
-        }),
+        href: getHref('integration_details_overview', pathValues),
       },
     ];
 
@@ -650,12 +651,7 @@ export function Detail() {
         ),
         isSelected: panel === 'policies',
         'data-test-subj': `tab-policies`,
-        href: getHref('integration_details_policies', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-          ...(returnAppId ? { returnAppId } : {}),
-          ...(returnPath ? { returnPath } : {}),
-        }),
+        href: getHref('integration_details_policies', pathValues),
       });
     }
 
@@ -676,12 +672,7 @@ export function Detail() {
         ),
         isSelected: panel === 'assets',
         'data-test-subj': `tab-assets`,
-        href: getHref('integration_details_assets', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-          ...(returnAppId ? { returnAppId } : {}),
-          ...(returnPath ? { returnPath } : {}),
-        }),
+        href: getHref('integration_details_assets', pathValues),
       });
     }
 
@@ -696,12 +687,7 @@ export function Detail() {
         ),
         isSelected: panel === 'settings',
         'data-test-subj': `tab-settings`,
-        href: getHref('integration_details_settings', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-          ...(returnAppId ? { returnAppId } : {}),
-          ...(returnPath ? { returnPath } : {}),
-        }),
+        href: getHref('integration_details_settings', pathValues),
       });
     }
 
@@ -716,12 +702,7 @@ export function Detail() {
         ),
         isSelected: panel === 'configs',
         'data-test-subj': `tab-configs`,
-        href: getHref('integration_details_configs', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-          ...(returnAppId ? { returnAppId } : {}),
-          ...(returnPath ? { returnPath } : {}),
-        }),
+        href: getHref('integration_details_configs', pathValues),
       });
     }
 
@@ -736,12 +717,7 @@ export function Detail() {
         ),
         isSelected: panel === 'custom',
         'data-test-subj': `tab-custom`,
-        href: getHref('integration_details_custom', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-          ...(returnAppId ? { returnAppId } : {}),
-          ...(returnPath ? { returnPath } : {}),
-        }),
+        href: getHref('integration_details_custom', pathValues),
       });
     }
 
@@ -756,12 +732,7 @@ export function Detail() {
         ),
         isSelected: panel === 'api-reference',
         'data-test-subj': `tab-api-reference`,
-        href: getHref('integration_details_api_reference', {
-          pkgkey: packageInfoKey,
-          ...(integration ? { integration } : {}),
-          ...(returnAppId ? { returnAppId } : {}),
-          ...(returnPath ? { returnPath } : {}),
-        }),
+        href: getHref('integration_details_api_reference', pathValues),
       });
     }
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -633,6 +633,8 @@ export function Detail() {
         href: getHref('integration_details_overview', {
           pkgkey: packageInfoKey,
           ...(integration ? { integration } : {}),
+          ...(returnAppId ? { returnAppId } : {}),
+          ...(returnPath ? { returnPath } : {}),
         }),
       },
     ];
@@ -651,6 +653,8 @@ export function Detail() {
         href: getHref('integration_details_policies', {
           pkgkey: packageInfoKey,
           ...(integration ? { integration } : {}),
+          ...(returnAppId ? { returnAppId } : {}),
+          ...(returnPath ? { returnPath } : {}),
         }),
       });
     }
@@ -675,6 +679,8 @@ export function Detail() {
         href: getHref('integration_details_assets', {
           pkgkey: packageInfoKey,
           ...(integration ? { integration } : {}),
+          ...(returnAppId ? { returnAppId } : {}),
+          ...(returnPath ? { returnPath } : {}),
         }),
       });
     }
@@ -693,6 +699,8 @@ export function Detail() {
         href: getHref('integration_details_settings', {
           pkgkey: packageInfoKey,
           ...(integration ? { integration } : {}),
+          ...(returnAppId ? { returnAppId } : {}),
+          ...(returnPath ? { returnPath } : {}),
         }),
       });
     }
@@ -711,6 +719,8 @@ export function Detail() {
         href: getHref('integration_details_configs', {
           pkgkey: packageInfoKey,
           ...(integration ? { integration } : {}),
+          ...(returnAppId ? { returnAppId } : {}),
+          ...(returnPath ? { returnPath } : {}),
         }),
       });
     }
@@ -729,6 +739,8 @@ export function Detail() {
         href: getHref('integration_details_custom', {
           pkgkey: packageInfoKey,
           ...(integration ? { integration } : {}),
+          ...(returnAppId ? { returnAppId } : {}),
+          ...(returnPath ? { returnPath } : {}),
         }),
       });
     }
@@ -747,6 +759,8 @@ export function Detail() {
         href: getHref('integration_details_api_reference', {
           pkgkey: packageInfoKey,
           ...(integration ? { integration } : {}),
+          ...(returnAppId ? { returnAppId } : {}),
+          ...(returnPath ? { returnPath } : {}),
         }),
       });
     }
@@ -754,6 +768,8 @@ export function Detail() {
     return tabs;
   }, [
     packageInfo,
+    returnAppId,
+    returnPath,
     panel,
     getHref,
     integration,

--- a/x-pack/platform/plugins/shared/fleet/public/constants/page_paths.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/constants/page_paths.ts
@@ -155,34 +155,40 @@ export const pagePathGetters: {
     return [INTEGRATIONS_BASE_PATH, `/installed/updates_available${categoryPath}${queryParams}`];
   },
   integration_create: () => [INTEGRATIONS_BASE_PATH, `/create`],
-  integration_details_overview: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/overview${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_policies: ({ pkgkey, integration, addAgentToPolicyId }) => {
-    const qs = stringify({ integration, addAgentToPolicyId });
+  integration_details_overview: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/overview${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_policies: ({
+    pkgkey,
+    integration,
+    addAgentToPolicyId,
+    returnAppId,
+    returnPath,
+  }) => {
+    const qs = stringify({ integration, addAgentToPolicyId, returnAppId, returnPath });
     return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/policies${qs ? `?${qs}` : ''}`];
   },
-  integration_details_assets: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/assets${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_settings: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/settings${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_configs: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/configs${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_custom: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/custom${integration ? `?integration=${integration}` : ''}`,
-  ],
-  integration_details_api_reference: ({ pkgkey, integration }) => [
-    INTEGRATIONS_BASE_PATH,
-    `/detail/${pkgkey}/api-reference${integration ? `?integration=${integration}` : ''}`,
-  ],
+  integration_details_assets: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/assets${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_settings: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/settings${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_configs: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/configs${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_custom: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/custom${qs ? `?${qs}` : ''}`];
+  },
+  integration_details_api_reference: ({ pkgkey, integration, returnAppId, returnPath }) => {
+    const qs = stringify({ integration, returnAppId, returnPath });
+    return [INTEGRATIONS_BASE_PATH, `/detail/${pkgkey}/api-reference${qs ? `?${qs}` : ''}`];
+  },
   integration_policy_edit: ({ packagePolicyId }) => [
     INTEGRATIONS_BASE_PATH,
     `/edit-integration/${packagePolicyId}`,


### PR DESCRIPTION
## Summary

Updates so that `returnAppId` and `returnPath` are maintained when the user switches tabs on the Integrations details page.

## Details

We currently have custom logic so that callers of the integrations cards can customize the destinations of the back, cancel and save buttons. This fixes that flow so that that customization is kept if the user switches tabs. 

Followup to https://github.com/elastic/kibana/pull/215561

## Screen recordings

https://github.com/user-attachments/assets/016ae86a-9d2f-434f-88cc-f34aeff9e14d

Relates
- https://github.com/elastic/security-team/issues/11789




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->