### PR TITLE
[ES|QL] Handles the regex warning

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -63,19 +63,26 @@ export const useDebounceWithOptions = (
   );
 };
 
-// Quotes can be used as separators for multiple warnings unless
-// they are escaped with backslashes. This regexp will match any
-// quoted string that is not escaped.
+/**
+ * Quotes can be used as separators for multiple warnings unless
+ * they are escaped with backslashes. This regexp will match any
+ * quoted string that is not escaped.
+ *
+ * The warning comes from ES and a user can't change it.
+ * This function is used to parse the warning message and format it
+ * so it can be displayed in the editor.
+ **/
 const quotedWarningMessageRegexp = /"([^"\\]|\\.)*"/g;
+const warningItemLength = 200;
 
 export const parseWarning = (warning: string): MonacoMessage[] => {
   if (quotedWarningMessageRegexp.test(warning)) {
     const matches = warning.match(quotedWarningMessageRegexp);
     if (matches) {
       return matches.map((message) => {
-        // start extracting the quoted message and with few default positioning
-        // replaces the quotes only if they are not escaped
-        let warningMessage = message.replace(/(?<!\\)"|\\/g, '');
+        // replaces the quotes only if they are not escaped,
+        // we limit the length to 200 characters to reduce ReDoS risks
+        let warningMessage = message.substring(0, warningItemLength).replace(/(?<!\\)"|\\/g, '');
         let startColumn = 1;
         let startLineNumber = 1;
         // initialize the length to 10 in case no error word found

--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -73,16 +73,17 @@ export const useDebounceWithOptions = (
  * so it can be displayed in the editor.
  **/
 const quotedWarningMessageRegexp = /"([^"\\]|\\.)*"/g;
-const warningItemLength = 200;
+const maxWarningLength = 1000;
 
 export const parseWarning = (warning: string): MonacoMessage[] => {
-  if (quotedWarningMessageRegexp.test(warning)) {
-    const matches = warning.match(quotedWarningMessageRegexp);
+  // we limit the length to reduce ReDoS risks
+  const truncatedWarning = warning.substring(0, maxWarningLength);
+  if (quotedWarningMessageRegexp.test(truncatedWarning)) {
+    const matches = truncatedWarning.match(quotedWarningMessageRegexp);
     if (matches) {
       return matches.map((message) => {
         // replaces the quotes only if they are not escaped,
-        // we limit the length to 200 characters to reduce ReDoS risks
-        let warningMessage = message.substring(0, warningItemLength).replace(/(?<!\\)"|\\/g, '');
+        let warningMessage = message.replace(/(?<!\\)"|\\/g, '');
         let startColumn = 1;
         let startLineNumber = 1;
         // initialize the length to 10 in case no error word found


### PR DESCRIPTION
## Summary

Closes  https://github.com/elastic/kibana-team/issues/1574

This PR:
- limits the text to 1000 chars to reduce ReDos risks
- adds a comment explaining that this is not a string that a user can change and it comes from ES. We are just formatting this client side.


Tested with

```
bash ./scripts/codeql/quick_check.sh -s src/platform/packages/private/kbn-esql-editor/
```

and it passes now!




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->