### PR TITLE
[9.0] Clear gap filters after unmounting component (#211588)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_gaps/components/rules_with_gaps_overview_panel/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import {
   EuiButton,
@@ -38,6 +38,16 @@ export const RulesWithGapsOverviewPanel = () => {
     statuses: [gapStatus.UNFILLED, gapStatus.PARTIALLY_FILLED],
   });
   const [isPopoverOpen, setPopover] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      // reset filter options when unmounting
+      setFilterOptions({
+        gapSearchRange: defaultRangeValue,
+        showRulesWithGaps: false,
+      });
+    };
+  }, [setFilterOptions]);
 
   const rangeValueToLabel = {
     [GapRangeValue.LAST_24_H]: i18n.RULE_GAPS_OVERVIEW_PANEL_LAST_24_HOURS_LABEL,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Clear gap filters after unmounting component (#211588)](https://github.com/elastic/kibana/pull/211588)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Khristinin Nikita","email":"nikita.khristinin@elastic.co"},"sourceCommit":{"committedDate":"2025-02-21T09:22:57Z","message":"Clear gap filters after unmounting component (#211588)\n\n## When we move out monitoring tab we reset filters to show only rule\nwith gaps\n\n\n\n\nhttps://github.com/user-attachments/assets/d86b248e-62e1-41c7-9873-8140a8d86b81\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"24d948db43cd55e4a25836ba3d227aaffbd08891","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:prev-minor","backport:version","v8.18.0","v9.1.0"],"title":"Clear gap filters after unmounting component","number":211588,"url":"https://github.com/elastic/kibana/pull/211588","mergeCommit":{"message":"Clear gap filters after unmounting component (#211588)\n\n## When we move out monitoring tab we reset filters to show only rule\nwith gaps\n\n\n\n\nhttps://github.com/user-attachments/assets/d86b248e-62e1-41c7-9873-8140a8d86b81\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"24d948db43cd55e4a25836ba3d227aaffbd08891"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/212020","number":212020,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211588","number":211588,"mergeCommit":{"message":"Clear gap filters after unmounting component (#211588)\n\n## When we move out monitoring tab we reset filters to show only rule\nwith gaps\n\n\n\n\nhttps://github.com/user-attachments/assets/d86b248e-62e1-41c7-9873-8140a8d86b81\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"24d948db43cd55e4a25836ba3d227aaffbd08891"}},{"url":"https://github.com/elastic/kibana/pull/212021","number":212021,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->