### PR TITLE
Track toast errors using APM

### DIFF
--- a/src/core/packages/notifications/browser-internal/src/toasts/lib/toast_error.ts
+++ b/src/core/packages/notifications/browser-internal/src/toasts/lib/toast_error.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+const TOAST_ERROR_NAME = 'ToastError';
+
+export class ToastError<T extends Error> extends Error {
+  constructor(message: string, originalError: T) {
+    super(message);
+    this.name = TOAST_ERROR_NAME;
+    if (originalError.stack) {
+      this.stack = originalError.stack;
+    }
+  }
+}

--- a/src/core/packages/notifications/browser-internal/src/toasts/lib/toast_error.ts
+++ b/src/core/packages/notifications/browser-internal/src/toasts/lib/toast_error.ts
@@ -10,9 +10,12 @@
 const TOAST_ERROR_NAME = 'ToastError';
 
 export class ToastError<T extends Error> extends Error {
+  private original_name: string;
+
   constructor(message: string, originalError: T) {
     super(message);
     this.name = TOAST_ERROR_NAME;
+    this.original_name = originalError.name;
     if (originalError.stack) {
       this.stack = originalError.stack;
     }

--- a/src/core/packages/notifications/browser-internal/src/toasts/toasts_api.tsx
+++ b/src/core/packages/notifications/browser-internal/src/toasts/toasts_api.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import * as Rx from 'rxjs';
 import { omitBy, isUndefined } from 'lodash';
 
+import { apm } from '@elastic/apm-rum';
 import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
 import type { I18nStart } from '@kbn/core-i18n-browser';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
@@ -26,6 +27,7 @@ import type {
 } from '@kbn/core-notifications-browser';
 import type { ThemeServiceStart } from '@kbn/core-theme-browser';
 import type { UserProfileService } from '@kbn/core-user-profile-browser';
+import { ToastError } from './lib/toast_error';
 import { ErrorToast } from './error_toast';
 
 const normalizeToast = (toastOrTitle: ToastInput): ToastInputFields => {
@@ -175,6 +177,8 @@ export class ToastsApi implements IToasts {
    * @returns a {@link Toast}
    */
   public addError(error: Error, options: ErrorToastOptions) {
+    const toastError = new ToastError(error.message, error);
+    apm.captureError(toastError);
     const message = options.toastMessage || error.message;
     return this.add({
       color: 'danger',


### PR DESCRIPTION
Closes https://github.com/elastic/observability-dev/issues/4022

## Summary

In this PR, we are capturing toast errors using APM:

![image](https://github.com/user-attachments/assets/dd30bae4-eacc-4ae9-bbd0-580dbb7b9edf)


### 🧪 How to test

Add the following to your kibana.yml file:

```
elastic.apm.active: true
elastic.apm.transactionSampleRate: 1.0
elastic.apm.environment: yourName <-- Change to your name
```
<details>
<summary>Throw a toast error</summary>

Add this code to a page as [alerts page](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx) and visit http://localhost:5601/kibana/app/observability/alerts

```
useEffect(() => {
    const error = new Error('Mary test error > toasts.addError');
    toasts.addError(error, { title: 'Testing ', toastMessage: error.message });
  }, []);
```

</details>

Then visit [kibana-cloud-apm.elastic.dev](https://kibana-cloud-apm.elastic.dev/app/apm/services/kibana-frontend/errors?comparisonEnabled=true&environment=ENVIRONMENT_ALL&kuery=&latencyAggregationType=avg&offset=1d&rangeFrom=now-1h&rangeTo=now&serviceGroup=&transactionType=page-load) filtered for `yourName` in the environment.