### PR TITLE
[Embeddables][Serialized State Only] Use serialized state in state transfer service

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -87,7 +87,7 @@ export function getDashboardApi({
   const panelsManager = initializePanelsManager(
     incomingEmbeddable,
     initialState.panels,
-    initialPanelsRuntimeState ?? {},
+    incomingEmbeddable || !initialPanelsRuntimeState ? {} : initialPanelsRuntimeState,
     trackPanel,
     getPanelReferences,
     pushPanelReferences

--- a/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.test.ts
+++ b/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.test.ts
@@ -125,13 +125,13 @@ describe('embeddable state transfer', () => {
 
   it('can send an outgoing embeddable package state', async () => {
     await stateTransfer.navigateToWithEmbeddablePackage(destinationApp, {
-      state: { type: 'coolestType', input: { savedObjectId: '150' } },
+      state: { type: 'coolestType', serializedState: { rawState: { savedObjectId: '150' } } },
     });
     expect(store.set).toHaveBeenCalledWith(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
       [EMBEDDABLE_PACKAGE_STATE_KEY]: {
         [destinationApp]: {
           type: 'coolestType',
-          input: { savedObjectId: '150' },
+          serializedState: { rawState: { savedObjectId: '150' } },
         },
       },
     });
@@ -145,14 +145,14 @@ describe('embeddable state transfer', () => {
       kibanaIsNowForSports: 'extremeSportsKibana',
     });
     await stateTransfer.navigateToWithEmbeddablePackage(destinationApp, {
-      state: { type: 'coolestType', input: { savedObjectId: '150' } },
+      state: { type: 'coolestType', serializedState: { rawState: { savedObjectId: '150' } } },
     });
     expect(store.set).toHaveBeenCalledWith(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, {
       kibanaIsNowForSports: 'extremeSportsKibana',
       [EMBEDDABLE_PACKAGE_STATE_KEY]: {
         [destinationApp]: {
           type: 'coolestType',
-          input: { savedObjectId: '150' },
+          serializedState: { rawState: { savedObjectId: '150' } },
         },
       },
     });
@@ -163,7 +163,7 @@ describe('embeddable state transfer', () => {
 
   it('sets isTransferInProgress to true when sending an outgoing embeddable package state', async () => {
     await stateTransfer.navigateToWithEmbeddablePackage(destinationApp, {
-      state: { type: 'coolestType', input: { savedObjectId: '150' } },
+      state: { type: 'coolestType', serializedState: { rawState: { savedObjectId: '150' } } },
     });
     expect(stateTransfer.isTransferInProgress).toEqual(true);
     currentAppId$.next(destinationApp);
@@ -220,12 +220,15 @@ describe('embeddable state transfer', () => {
       [EMBEDDABLE_PACKAGE_STATE_KEY]: {
         [testAppId]: {
           type: 'skisEmbeddable',
-          input: { savedObjectId: '123' },
+          serializedState: { rawState: { savedObjectId: '123' } },
         },
       },
     });
     const fetchedState = stateTransfer.getIncomingEmbeddablePackage(testAppId);
-    expect(fetchedState).toEqual({ type: 'skisEmbeddable', input: { savedObjectId: '123' } });
+    expect(fetchedState).toEqual({
+      type: 'skisEmbeddable',
+      serializedState: { rawState: { savedObjectId: '123' } },
+    });
   });
 
   it('can fetch an incoming embeddable package state and ignore state for other apps', async () => {
@@ -233,21 +236,24 @@ describe('embeddable state transfer', () => {
       [EMBEDDABLE_PACKAGE_STATE_KEY]: {
         [testAppId]: {
           type: 'skisEmbeddable',
-          input: { savedObjectId: '123' },
+          serializedState: { rawState: { savedObjectId: '123' } },
         },
         testApp2: {
           type: 'crossCountryEmbeddable',
-          input: { savedObjectId: '456' },
+          serializedState: { rawState: { savedObjectId: '456' } },
         },
       },
     });
     const fetchedState = stateTransfer.getIncomingEmbeddablePackage(testAppId);
-    expect(fetchedState).toEqual({ type: 'skisEmbeddable', input: { savedObjectId: '123' } });
+    expect(fetchedState).toEqual({
+      type: 'skisEmbeddable',
+      serializedState: { rawState: { savedObjectId: '123' } },
+    });
 
     const fetchedState2 = stateTransfer.getIncomingEmbeddablePackage('testApp2');
     expect(fetchedState2).toEqual({
       type: 'crossCountryEmbeddable',
-      input: { savedObjectId: '456' },
+      serializedState: { rawState: { savedObjectId: '456' } },
     });
   });
 
@@ -268,7 +274,7 @@ describe('embeddable state transfer', () => {
       [EMBEDDABLE_PACKAGE_STATE_KEY]: {
         [testAppId]: {
           type: 'coolestType',
-          input: { savedObjectId: '150' },
+          serializedState: { rawState: { savedObjectId: '150' } },
         },
       },
       iSHouldStillbeHere: 'doing the sports thing',

--- a/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.ts
+++ b/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.ts
@@ -133,14 +133,18 @@ export class EmbeddableStateTransfer {
    * A wrapper around the {@link ApplicationStart.navigateToApp} method which navigates to the specified appId
    * with {@link EmbeddablePackageState | embeddable package state}
    */
-  public async navigateToWithEmbeddablePackage(
+  public async navigateToWithEmbeddablePackage<SerializedStateType extends object = object>(
     appId: string,
-    options?: { path?: string; state: EmbeddablePackageState }
+    options?: { path?: string; state: EmbeddablePackageState<SerializedStateType> }
   ): Promise<void> {
     this.isTransferInProgress = true;
-    await this.navigateToWithState<EmbeddablePackageState>(appId, EMBEDDABLE_PACKAGE_STATE_KEY, {
-      ...options,
-    });
+    await this.navigateToWithState<EmbeddablePackageState<SerializedStateType>>(
+      appId,
+      EMBEDDABLE_PACKAGE_STATE_KEY,
+      {
+        ...options,
+      }
+    );
   }
 
   private getIncomingState<IncomingStateType>(

--- a/src/platform/plugins/shared/embeddable/public/state_transfer/types.ts
+++ b/src/platform/plugins/shared/embeddable/public/state_transfer/types.ts
@@ -7,6 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { SerializedPanelState } from '@kbn/presentation-publishing';
+
 export const EMBEDDABLE_EDITOR_STATE_KEY = 'embeddable_editor_state';
 
 /**
@@ -36,12 +38,9 @@ export const EMBEDDABLE_PACKAGE_STATE_KEY = 'embeddable_package_state';
  * A state package that contains all fields necessary to create or update an embeddable by reference or by value in a container.
  * @public
  */
-export interface EmbeddablePackageState {
+export interface EmbeddablePackageState<SerializedStateType extends object = object> {
   type: string;
-  /**
-   * For react embeddables, this input must be runtime state.
-   */
-  input: object;
+  serializedState: SerializedPanelState<SerializedStateType>;
   embeddableId?: string;
   size?: {
     width?: number;
@@ -57,7 +56,7 @@ export interface EmbeddablePackageState {
 export function isEmbeddablePackageState(state: unknown): state is EmbeddablePackageState {
   return (
     ensureFieldOfTypeExists('type', state, 'string') &&
-    ensureFieldOfTypeExists('input', state, 'object')
+    ensureFieldOfTypeExists('serializedState', state, 'object')
   );
 }
 

--- a/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression.ts
+++ b/x-pack/platform/plugins/private/canvas/canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression.ts
@@ -25,20 +25,20 @@ export function embeddableInputToExpression<
   UseGenericEmbeddable extends boolean,
   ConditionalReturnType = UseGenericEmbeddable extends true ? string : string | undefined
 >(
-  input: object,
+  state: object,
   embeddableType: string,
   palettes?: PaletteRegistry,
   useGenericEmbeddable?: UseGenericEmbeddable
 ): ConditionalReturnType {
   // if `useGenericEmbeddable` is `true`, it **always** returns a string
   if (useGenericEmbeddable) {
-    return genericToExpression(input, embeddableType) as ConditionalReturnType;
+    return genericToExpression(state, embeddableType) as ConditionalReturnType;
   }
 
   // otherwise, depending on if the embeddable type is defined, it might return undefined
   if (inputToExpressionTypeMap[embeddableType]) {
     return inputToExpressionTypeMap[embeddableType](
-      input as any,
+      state as any,
       palettes
     ) as ConditionalReturnType;
   }

--- a/x-pack/platform/plugins/private/canvas/public/components/hooks/workpad/use_incoming_embeddable.ts
+++ b/x-pack/platform/plugins/private/canvas/public/components/hooks/workpad/use_incoming_embeddable.ts
@@ -40,7 +40,7 @@ export const useIncomingEmbeddable = (selectedPage: CanvasPage) => {
 
   useEffect(() => {
     if (isByValueEnabled && incomingEmbeddable) {
-      const { embeddableId, input: incomingInput, type } = incomingEmbeddable;
+      const { embeddableId, serializedState: incomingState, type } = incomingEmbeddable;
 
       // retrieve existing element
       const originalElement = selectedPage.elements.find(
@@ -65,7 +65,7 @@ export const useIncomingEmbeddable = (selectedPage: CanvasPage) => {
           return;
         }
 
-        const originalInput = decode(
+        const originalState = decode(
           originalAst.chain[functionIndex].arguments.config[0] as string
         );
 
@@ -75,16 +75,15 @@ export const useIncomingEmbeddable = (selectedPage: CanvasPage) => {
         const argumentPath = [embeddableId, 'expressionRenderable'];
         dispatch(clearValue({ path: argumentPath }));
 
-        let updatedInput;
+        let updatedState;
 
         // if type was changed, we should not provide originalInput
         if (originalType !== type) {
-          updatedInput = incomingInput;
+          updatedState = incomingState;
         } else {
-          updatedInput = { ...originalInput, ...incomingInput };
+          updatedState = { ...originalState, ...incomingState.rawState };
         }
-
-        const expression = embeddableInputToExpression(updatedInput, type, undefined, true);
+        const expression = embeddableInputToExpression(updatedState, type, undefined, true);
 
         dispatch(
           updateEmbeddableExpression({
@@ -99,7 +98,12 @@ export const useIncomingEmbeddable = (selectedPage: CanvasPage) => {
         // select new embeddable element
         dispatch(selectToplevelNodes([embeddableId]));
       } else {
-        const expression = embeddableInputToExpression(incomingInput, type, undefined, true);
+        const expression = embeddableInputToExpression(
+          incomingState.rawState,
+          type,
+          undefined,
+          true
+        );
         dispatch(addElement(selectedPage.id, { expression }));
       }
     }

--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
@@ -34,6 +34,7 @@ import type { EuiContextMenuProps } from '@elastic/eui/src/components/context_me
 import { isDefined } from '@kbn/ml-is-defined';
 import type { ChangePointDetectionViewType } from '@kbn/aiops-change-point-detection/constants';
 import {
+  CHANGE_POINT_CHART_DATA_VIEW_REF_NAME,
   CHANGE_POINT_DETECTION_VIEW_TYPE,
   EMBEDDABLE_CHANGE_POINT_CHART_TYPE,
 } from '@kbn/aiops-change-point-detection/constants';
@@ -57,6 +58,7 @@ import { useChangePointResults } from './use_change_point_agg_request';
 import { useSplitFieldCardinality } from './use_split_field_cardinality';
 import { ViewTypeSelector } from './view_type_selector';
 import { CASES_TOAST_MESSAGES_TITLES } from '../../cases/constants';
+import { getDataviewReferences } from '../../embeddables/get_dataview_references';
 
 const selectControlCss = { width: '350px' };
 
@@ -493,7 +495,10 @@ const FieldPanel: FC<FieldPanelProps> = ({
       };
 
       const state = {
-        input: embeddableInput,
+        serializedState: {
+          rawState: embeddableInput,
+          references: getDataviewReferences(dataView.id, CHANGE_POINT_CHART_DATA_VIEW_REF_NAME),
+        },
         type: EMBEDDABLE_CHANGE_POINT_CHART_TYPE,
       };
 

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/attachments_menu.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_categorization/attachments_menu.tsx
@@ -28,13 +28,17 @@ import {
 import React, { useCallback, useState } from 'react';
 import { useMemo } from 'react';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import { EMBEDDABLE_PATTERN_ANALYSIS_TYPE } from '@kbn/aiops-log-pattern-analysis/constants';
+import {
+  EMBEDDABLE_PATTERN_ANALYSIS_TYPE,
+  PATTERN_ANALYSIS_DATA_VIEW_REF_NAME,
+} from '@kbn/aiops-log-pattern-analysis/constants';
 import { useTimeRangeUpdates } from '@kbn/ml-date-picker';
 import type { PatternAnalysisEmbeddableState } from '../../embeddables/pattern_analysis/types';
 import type { RandomSamplerOption, RandomSamplerProbability } from './sampling_menu/random_sampler';
 import { useCasesModal } from '../../hooks/use_cases_modal';
 import { useAiopsAppContext } from '../../hooks/use_aiops_app_context';
 import { CASES_TOAST_MESSAGES_TITLES } from '../../cases/constants';
+import { getDataviewReferences } from '../../embeddables/get_dataview_references';
 
 const SavedObjectSaveModalDashboard = withSuspense(LazySavedObjectSaveModalDashboard);
 
@@ -92,7 +96,10 @@ export const AttachmentsMenu = ({
       };
 
       const state = {
-        input: embeddableInput,
+        serializedState: {
+          rawState: embeddableInput,
+          references: getDataviewReferences(dataView.id, PATTERN_ANALYSIS_DATA_VIEW_REF_NAME),
+        },
         type: EMBEDDABLE_PATTERN_ANALYSIS_TYPE,
       };
 

--- a/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_attachments_menu.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/log_rate_analysis/log_rate_analysis_content/log_rate_analysis_attachments_menu.tsx
@@ -10,7 +10,10 @@ import { LazySavedObjectSaveModalDashboard } from '@kbn/presentation-util-plugin
 import { withSuspense } from '@kbn/shared-ux-utility';
 import React, { useState, useCallback, useMemo } from 'react';
 import { useTimeRangeUpdates } from '@kbn/ml-date-picker';
-import { EMBEDDABLE_LOG_RATE_ANALYSIS_TYPE } from '@kbn/aiops-log-rate-analysis/constants';
+import {
+  EMBEDDABLE_LOG_RATE_ANALYSIS_TYPE,
+  LOG_RATE_ANALYSIS_DATA_VIEW_REF_NAME,
+} from '@kbn/aiops-log-rate-analysis/constants';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import type { EuiContextMenuProps } from '@elastic/eui';
@@ -33,6 +36,7 @@ import { useCasesModal } from '../../../hooks/use_cases_modal';
 import { useDataSource } from '../../../hooks/use_data_source';
 import type { LogRateAnalysisEmbeddableState } from '../../../embeddables/log_rate_analysis/types';
 import { useAiopsAppContext } from '../../../hooks/use_aiops_app_context';
+import { getDataviewReferences } from '../../../embeddables/get_dataview_references';
 
 const SavedObjectSaveModalDashboard = withSuspense(LazySavedObjectSaveModalDashboard);
 
@@ -88,7 +92,10 @@ export const LogRateAnalysisAttachmentsMenu = ({
       };
 
       const state = {
-        input: embeddableInput,
+        serializedState: {
+          rawState: embeddableInput,
+          references: getDataviewReferences(dataView.id, LOG_RATE_ANALYSIS_DATA_VIEW_REF_NAME),
+        },
         type: EMBEDDABLE_LOG_RATE_ANALYSIS_TYPE,
       };
 

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/embeddable_change_point_chart_factory.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/embeddable_change_point_chart_factory.tsx
@@ -9,10 +9,8 @@ import {
   CHANGE_POINT_CHART_DATA_VIEW_REF_NAME,
   EMBEDDABLE_CHANGE_POINT_CHART_TYPE,
 } from '@kbn/aiops-change-point-detection/constants';
-import type { Reference } from '@kbn/content-management-utils';
 import type { StartServicesAccessor } from '@kbn/core-lifecycle-browser';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import { DATA_VIEW_SAVED_OBJECT_TYPE } from '@kbn/data-views-plugin/common';
 import type { ReactEmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import { i18n } from '@kbn/i18n';
 import {
@@ -37,6 +35,7 @@ import type {
   ChangePointEmbeddableRuntimeState,
   ChangePointEmbeddableState,
 } from './types';
+import { getDataviewReferences } from '../get_dataview_references';
 
 export type EmbeddableChangePointChartType = typeof EMBEDDABLE_CHANGE_POINT_CHART_TYPE;
 
@@ -116,15 +115,6 @@ export const getChangePointChartEmbeddableFactory = (
           dataViews$,
           serializeState: () => {
             const dataViewId = changePointControlsApi.dataViewId.getValue();
-            const references: Reference[] = dataViewId
-              ? [
-                  {
-                    type: DATA_VIEW_SAVED_OBJECT_TYPE,
-                    name: CHANGE_POINT_CHART_DATA_VIEW_REF_NAME,
-                    id: dataViewId,
-                  },
-                ]
-              : [];
             return {
               rawState: {
                 timeRange: undefined,
@@ -132,7 +122,7 @@ export const getChangePointChartEmbeddableFactory = (
                 ...timeRangeManager.serialize(),
                 ...serializeChangePointChartState(),
               },
-              references,
+              references: getDataviewReferences(dataViewId, CHANGE_POINT_CHART_DATA_VIEW_REF_NAME),
             };
           },
         },

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/get_dataview_references.ts
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/get_dataview_references.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Reference } from '@kbn/content-management-utils';
+import { DATA_VIEW_SAVED_OBJECT_TYPE } from '@kbn/data-views-plugin/common';
+
+export const getDataviewReferences = (dataViewId: string | undefined, refName: string) => {
+  const references: Reference[] = dataViewId
+    ? [
+        {
+          type: DATA_VIEW_SAVED_OBJECT_TYPE,
+          name: refName,
+          id: dataViewId,
+        },
+      ]
+    : [];
+  return references;
+};

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/log_rate_analysis/embeddable_log_rate_analysis_factory.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/log_rate_analysis/embeddable_log_rate_analysis_factory.tsx
@@ -9,10 +9,8 @@ import {
   EMBEDDABLE_LOG_RATE_ANALYSIS_TYPE,
   LOG_RATE_ANALYSIS_DATA_VIEW_REF_NAME,
 } from '@kbn/aiops-log-rate-analysis/constants';
-import type { Reference } from '@kbn/content-management-utils';
 import type { StartServicesAccessor } from '@kbn/core-lifecycle-browser';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import { DATA_VIEW_SAVED_OBJECT_TYPE } from '@kbn/data-views-plugin/common';
 import type { ReactEmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import { i18n } from '@kbn/i18n';
 import {
@@ -37,6 +35,7 @@ import type {
   LogRateAnalysisEmbeddableRuntimeState,
   LogRateAnalysisEmbeddableState,
 } from './types';
+import { getDataviewReferences } from '../get_dataview_references';
 
 export type EmbeddableLogRateAnalysisType = typeof EMBEDDABLE_LOG_RATE_ANALYSIS_TYPE;
 
@@ -120,15 +119,6 @@ export const getLogRateAnalysisEmbeddableFactory = (
           dataViews$,
           serializeState: () => {
             const dataViewId = logRateAnalysisControlsApi.dataViewId.getValue();
-            const references: Reference[] = dataViewId
-              ? [
-                  {
-                    type: DATA_VIEW_SAVED_OBJECT_TYPE,
-                    name: LOG_RATE_ANALYSIS_DATA_VIEW_REF_NAME,
-                    id: dataViewId,
-                  },
-                ]
-              : [];
             return {
               rawState: {
                 timeRange: undefined,
@@ -136,7 +126,7 @@ export const getLogRateAnalysisEmbeddableFactory = (
                 ...timeRangeManager.serialize(),
                 ...serializeLogRateAnalysisChartState(),
               },
-              references,
+              references: getDataviewReferences(dataViewId, LOG_RATE_ANALYSIS_DATA_VIEW_REF_NAME),
             };
           },
         },

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/pattern_analysis/embeddable_pattern_analysis_factory.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/pattern_analysis/embeddable_pattern_analysis_factory.tsx
@@ -9,10 +9,8 @@ import {
   EMBEDDABLE_PATTERN_ANALYSIS_TYPE,
   PATTERN_ANALYSIS_DATA_VIEW_REF_NAME,
 } from '@kbn/aiops-log-pattern-analysis/constants';
-import type { Reference } from '@kbn/content-management-utils';
 import type { StartServicesAccessor } from '@kbn/core-lifecycle-browser';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import { DATA_VIEW_SAVED_OBJECT_TYPE } from '@kbn/data-views-plugin/common';
 import type { ReactEmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import { i18n } from '@kbn/i18n';
 import {
@@ -36,6 +34,7 @@ import type {
   PatternAnalysisEmbeddableRuntimeState,
   PatternAnalysisEmbeddableState,
 } from './types';
+import { getDataviewReferences } from '../get_dataview_references';
 
 export type EmbeddablePatternAnalysisType = typeof EMBEDDABLE_PATTERN_ANALYSIS_TYPE;
 
@@ -119,15 +118,6 @@ export const getPatternAnalysisEmbeddableFactory = (
           dataViews$,
           serializeState: () => {
             const dataViewId = patternAnalysisControlsApi.dataViewId.getValue();
-            const references: Reference[] = dataViewId
-              ? [
-                  {
-                    type: DATA_VIEW_SAVED_OBJECT_TYPE,
-                    name: PATTERN_ANALYSIS_DATA_VIEW_REF_NAME,
-                    id: dataViewId,
-                  },
-                ]
-              : [];
             return {
               rawState: {
                 timeRange: undefined,
@@ -135,7 +125,7 @@ export const getPatternAnalysisEmbeddableFactory = (
                 ...timeRangeManager.serialize(),
                 ...serializePatternAnalysisChartState(),
               },
-              references,
+              references: getDataviewReferences(dataViewId, PATTERN_ANALYSIS_DATA_VIEW_REF_NAME),
             };
           },
         },

--- a/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
@@ -45,9 +45,7 @@ const DEFAULT_TIMERANGE: TimeRange = {
   mode: 'relative',
 };
 
-type LensIncomingEmbeddablePackage = Omit<EmbeddablePackageState, 'input'> & {
-  input: TypedLensByValueInput;
-};
+type LensIncomingEmbeddablePackage = EmbeddablePackageState<TypedLensByValueInput>;
 
 type LensEuiMarkdownEditorUiPlugin = EuiMarkdownEditorUiPlugin<{
   timeRange: TypedLensByValueInput['timeRange'];
@@ -253,7 +251,7 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
 
     if (
       incomingEmbeddablePackage?.type === 'lens' &&
-      incomingEmbeddablePackage?.input?.attributes
+      incomingEmbeddablePackage?.serializedState?.rawState?.attributes
     ) {
       const lensTime = timefilter.getTime();
       const newTimeRange =
@@ -269,7 +267,7 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
 
       if (draftComment?.position) {
         handleUpdate(
-          incomingEmbeddablePackage?.input.attributes,
+          incomingEmbeddablePackage.serializedState.rawState.attributes,
           newTimeRange,
           draftComment.position
         );
@@ -277,7 +275,7 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
       }
 
       if (draftComment) {
-        handleAdd(incomingEmbeddablePackage?.input.attributes, newTimeRange);
+        handleAdd(incomingEmbeddablePackage.serializedState.rawState.attributes, newTimeRange);
       }
     }
   }, [embeddable, storage, timefilter, currentAppId, handleAdd, handleUpdate, draftComment]);

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container.test.tsx
@@ -261,7 +261,12 @@ describe('runSaveLensVisualization', () => {
           // make sure the new savedObject id is removed from the new input
           expect.objectContaining({
             state: expect.objectContaining({
-              input: expect.objectContaining({ savedObjectId: undefined }),
+              serializedState: expect.objectContaining({
+                rawState: expect.objectContaining({ savedObjectId: undefined }),
+                references: expect.arrayContaining([
+                  expect.objectContaining({ type: 'index-pattern' }),
+                ]),
+              }),
             }),
           })
         );
@@ -288,7 +293,12 @@ describe('runSaveLensVisualization', () => {
           // make sure the new savedObject id is passed with the new input
           expect.objectContaining({
             state: expect.objectContaining({
-              input: expect.objectContaining({ savedObjectId: '1234' }),
+              serializedState: expect.objectContaining({
+                rawState: expect.objectContaining({ savedObjectId: '1234' }),
+                references: expect.arrayContaining([
+                  expect.objectContaining({ type: 'index-pattern' }),
+                ]),
+              }),
             }),
           })
         );

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container_helpers.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container_helpers.test.ts
@@ -30,7 +30,7 @@ describe('redirectToDashboard', () => {
     });
     expect(navigateToWithEmbeddablePackageSpy).toHaveBeenCalledWith('security', {
       path: '#/view/id',
-      state: { input: { test: 'test' }, type: 'lens' },
+      state: { serializedState: { rawState: { test: 'test' }, references: [] }, type: 'lens' },
     });
   });
 
@@ -49,7 +49,7 @@ describe('redirectToDashboard', () => {
     });
     expect(navigateToWithEmbeddablePackageSpy).toHaveBeenCalledWith('dashboards', {
       path: '#/view/id',
-      state: { input: { test: 'test' }, type: 'lens' },
+      state: { serializedState: { rawState: { test: 'test' }, references: [] }, type: 'lens' },
     });
   });
 });

--- a/x-pack/platform/plugins/shared/maps/public/routes/map_page/saved_map/saved_map.ts
+++ b/x-pack/platform/plugins/shared/maps/public/routes/map_page/saved_map/saved_map.ts
@@ -469,11 +469,11 @@ export class SavedMap {
     await this._syncAttributesWithStore();
 
     let mapSerializedState: MapSerializedState | undefined;
+    const { attributes, references } = extractReferences({
+      attributes: this._attributes,
+    });
     if (saveByReference) {
       try {
-        const { attributes, references } = extractReferences({
-          attributes: this._attributes,
-        });
         const savedObjectsTagging = getSavedObjectsTagging();
         const tagReferences =
           savedObjectsTagging && tags ? savedObjectsTagging.ui.updateTagsReferences([], tags) : [];
@@ -521,7 +521,7 @@ export class SavedMap {
         state: {
           embeddableId: newCopyOnSave ? undefined : this._embeddableId,
           type: MAP_SAVED_OBJECT_TYPE,
-          input: mapSerializedState,
+          serializedState: { rawState: mapSerializedState, references },
         },
         path: this._originatingPath,
       });
@@ -530,7 +530,7 @@ export class SavedMap {
       await this._getStateTransfer().navigateToWithEmbeddablePackage('dashboards', {
         state: {
           type: MAP_SAVED_OBJECT_TYPE,
-          input: mapSerializedState,
+          serializedState: { rawState: mapSerializedState, references },
         },
         path: dashboardId === 'new' ? '#/create' : `#/view/${dashboardId}`,
       });

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_context_menu.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_context_menu.tsx
@@ -194,7 +194,7 @@ export const AnomalyContextMenu: FC<AnomalyContextMenuProps> = ({
       };
 
       const state = {
-        input: embeddableInput,
+        serializedState: { rawState: embeddableInput, references: [] },
         type: ANOMALY_EXPLORER_CHARTS_EMBEDDABLE_TYPE,
       };
 

--- a/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/explorer/anomaly_timeline.tsx
@@ -381,7 +381,7 @@ export const AnomalyTimeline: FC<AnomalyTimelineProps> = React.memo(
         };
 
         const state = {
-          input: embeddableInput,
+          serializedState: { rawState: embeddableInput, references: [] },
           type: ANOMALY_SWIMLANE_EMBEDDABLE_TYPE,
         };
 

--- a/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_controls/timeseriesexplorer_controls.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/timeseriesexplorer/components/timeseriesexplorer_controls/timeseriesexplorer_controls.tsx
@@ -193,7 +193,7 @@ export const TimeSeriesExplorerControls: FC<Props> = ({
       };
 
       const state = {
-        input: embeddableInput,
+        serializedState: { rawState: embeddableInput, references: [] },
         type: ANOMALY_SINGLE_METRIC_VIEWER_EMBEDDABLE_TYPE,
       };
 

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/error_budget_chart_panel.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/error_budget_chart_panel.tsx
@@ -47,7 +47,7 @@ export function ErrorBudgetChartPanel({ data, isLoading, slo, selectedTabId, onB
       };
 
       const state = {
-        input: embeddableInput,
+        serializedState: { rawState: embeddableInput },
         type: SLO_ERROR_BUDGET_ID,
       };
 

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/hooks/use_slo_list_actions.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/hooks/use_slo_list_actions.ts
@@ -39,7 +39,7 @@ export function useSloListActions({
       };
 
       const state = {
-        input: embeddableInput,
+        serializedState: { rawState: embeddableInput },
         type: SLO_OVERVIEW_EMBEDDABLE_ID,
       };
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/add_to_dashboard.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/add_to_dashboard.tsx
@@ -49,7 +49,7 @@ export const AddToDashboard = ({
       const embeddableInput = {};
 
       const state = {
-        input: embeddableInput,
+        serializedState: { rawState: embeddableInput },
         type,
       };
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/213153

## Summary

This PR ensures that the embeddable state transfer service **exclusively** uases serialized state. Previously, the transfer service accepted **either** runtime state or serialized state - but we are in the process of removing the concept of "runtime state" for embeddables (at least as far as the Dashboard is concerned), and this is one step towards that goal.

Note that this PR is built off the subset of "embeddable state transfer service related" changes from https://github.com/elastic/kibana/pull/215416 - all I did was clean up these changes, finalized some of the cases that were missed in the original draft, and updated tests as necessary.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



