### PR TITLE
[9.0] [Synthetics] Add KQL Filter to TLS Alerting Rule (#215110)

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_params/synthetics_tls/v1.ts
+++ b/src/platform/packages/shared/response-ops/rule_params/synthetics_tls/v1.ts
@@ -14,6 +14,12 @@ export const tlsRuleParamsSchema = schema.object(
     search: schema.maybe(schema.string()),
     certExpirationThreshold: schema.maybe(schema.number()),
     certAgeThreshold: schema.maybe(schema.number()),
+    monitorIds: schema.maybe(schema.arrayOf(schema.string())),
+    locations: schema.maybe(schema.arrayOf(schema.string())),
+    tags: schema.maybe(schema.arrayOf(schema.string())),
+    monitorTypes: schema.maybe(schema.arrayOf(schema.string())),
+    projects: schema.maybe(schema.arrayOf(schema.string())),
+    kqlQuery: schema.maybe(schema.string()),
   },
   {
     meta: { description: 'The parameters for the rule.' },

--- a/x-pack/solutions/observability/packages/synthetics-test-data/src/make_summaries.ts
+++ b/x-pack/solutions/observability/packages/synthetics-test-data/src/make_summaries.ts
@@ -19,6 +19,8 @@ export interface DocOverrides {
     label: string;
   };
   configId?: string;
+  tlsNotBefore?: string;
+  tlsNotAfter?: string;
 }
 
 export const makeUpSummary = ({
@@ -28,9 +30,11 @@ export const makeUpSummary = ({
   configId,
   testRunId,
   location,
+  tlsNotBefore,
+  tlsNotAfter,
 }: DocOverrides = {}) => ({
   ...getGeoData(location),
-  ...commons,
+  ...getCommons({ tlsNotBefore, tlsNotAfter }),
   summary: {
     up: 1,
     down: 0,
@@ -61,7 +65,7 @@ export const makeDownSummary = ({
   configId,
 }: DocOverrides = {}) => ({
   ...getGeoData(location),
-  ...commons,
+  ...getCommons(),
   summary: {
     up: 0,
     down: 1,
@@ -115,7 +119,13 @@ const getMonitorData = ({
   status: status ?? 'down',
 });
 
-const commons = {
+const getCommons = ({
+  tlsNotBefore,
+  tlsNotAfter,
+}: {
+  tlsNotBefore?: string;
+  tlsNotAfter?: string;
+} = {}) => ({
   url: {
     scheme: 'https',
     port: 443,
@@ -163,15 +173,14 @@ const commons = {
   tls: {
     established: true,
     cipher: 'TLS-AES-128-GCM-SHA256',
-    certificate_not_valid_before: '2022-11-28T08:19:01.000Z',
     server: {
       x509: {
-        not_after: '2023-02-20T08:19:00.000Z',
+        not_after: tlsNotAfter || '2023-02-20T08:19:00.000Z',
         subject: {
           distinguished_name: 'CN=www.google.com',
           common_name: 'www.google.com',
         },
-        not_before: '2022-11-28T08:19:01.000Z',
+        not_before: tlsNotBefore || '2022-11-28T08:19:01.000Z',
         public_key_algorithm: 'ECDSA',
         public_key_curve: 'P-256',
         signature_algorithm: 'SHA256-RSA',
@@ -192,7 +201,6 @@ const commons = {
       },
     },
     version: '1.3',
-    certificate_not_valid_after: '2023-02-20T08:19:00.000Z',
     version_protocol: 'tls',
   },
   http: {
@@ -238,4 +246,4 @@ const commons = {
   meta: {
     space_id: 'default',
   },
-};
+});

--- a/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -56,4 +56,5 @@ export enum SYNTHETICS_API_URLS {
   DYNAMIC_SETTINGS = `/api/synthetics/settings`,
 
   INSPECT_STATUS_RULE = '/internal/synthetics/inspect_status_rule',
+  INSPECT_TLS_RULE = '/internal/synthetics/inspect_tls_rule',
 }

--- a/x-pack/solutions/observability/plugins/synthetics/common/requests/get_certs_request_body.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/requests/get_certs_request_body.ts
@@ -109,7 +109,7 @@ export const getCertsRequestBody = ({
                     ? [
                         {
                           range: {
-                            'tls.certificate_not_valid_before': {
+                            'tls.server.x509.not_before': {
                               lte: absoluteDate(notValidBefore),
                             },
                           },
@@ -120,7 +120,7 @@ export const getCertsRequestBody = ({
                     ? [
                         {
                           range: {
-                            'tls.certificate_not_valid_after': {
+                            'tls.server.x509.not_after': {
                               lte: absoluteDate(notValidAfter),
                             },
                           },

--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/alert_rules/common.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/alert_rules/common.ts
@@ -84,4 +84,5 @@ export type StatusRuleInspect = AlertOverviewStatus & {
     type: string;
   }>;
 };
+export type TLSRuleInspect = StatusRuleInspect;
 export type AlertStatusConfigs = Record<string, AlertStatusMetaData>;

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/custom_status_alert.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/custom_status_alert.journey.ts
@@ -19,11 +19,11 @@ journey(`CustomStatusAlert`, async ({ page, params }) => {
   let configId: string;
 
   before(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
   });
 
   after(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
   });
 
   step('Go to monitors page', async () => {

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/custom_tls_alert.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/custom_tls_alert.journey.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { journey, step, before, after, expect } from '@elastic/synthetics';
+import { RetryService } from '@kbn/ftr-common-functional-services';
+import { syntheticsAppPageProvider } from '../../page_objects/synthetics_app';
+import { SyntheticsServices } from '../services/synthetics_services';
+
+journey(`CustomTLSAlert`, async ({ page, params }) => {
+  const syntheticsApp = syntheticsAppPageProvider({ page, kibanaUrl: params.kibanaUrl, params });
+
+  const services = new SyntheticsServices(params);
+  const retry: RetryService = params.getService('retry');
+
+  const tlsRuleName = 'synthetics-e2e-monitor-tls-rule';
+
+  let configId: string;
+
+  before(async () => {
+    await services.cleanUp();
+  });
+
+  after(async () => {
+    await services.cleanUp();
+  });
+
+  step('Go to monitors page', async () => {
+    await syntheticsApp.navigateToOverview(true, 15);
+  });
+
+  step('Add test monitor', async () => {
+    configId = await services.addTestMonitor(
+      'Test Monitor',
+      {
+        type: 'http',
+        urls: 'https://www.google.com',
+        locations: ['us_central'],
+      },
+      configId,
+      { tls: { enabled: true } }
+    );
+    const tomorrowDate = new Date();
+    tomorrowDate.setDate(tomorrowDate.getDate() + 1);
+    // Mocking a test summary document for the created monitor with a TLS certificate that expires tomorrow
+    await services.addTestSummaryDocument({
+      configId,
+      tlsNotAfter: tomorrowDate.toISOString(),
+      tlsNotBefore: new Date().toISOString(),
+    });
+  });
+
+  step('Should open the create TLS rule flyout', async () => {
+    await page.getByTestId('syntheticsRefreshButtonButton').click();
+    await page.getByTestId('syntheticsAlertsRulesButton').click();
+    await page.getByTestId('manageTlsRuleName').click();
+    await page.getByTestId('createNewTLSRule').click();
+
+    await expect(page.getByTestId('addRuleFlyoutTitle')).toBeVisible();
+  });
+
+  // This is needed for the intermediate release process -> https://docs.google.com/document/d/1mU5jlIfCKyXdDPtEzAz1xTpFXFCWxqdO5ldYRVO_hgM/edit?tab=t.0#heading=h.2b1v1tr0ep8m
+  // After the next serverless release the commit containing these changes can be reverted
+  step.skip('Should filter monitors using the KQL filter bar', async () => {
+    // Using the KQL filter to search for a monitor type of "tcp", 0 existing monitors should be found because the type of the test monitor is 'http'
+    await page.fill('[data-test-subj="queryInput"]', `monitor.type: "tcp" `);
+    await page.keyboard.press('Enter');
+    await expect(page.getByTestId('syntheticsRuleVizMonitorQueryIDsButton')).toHaveText(
+      '0 existing monitors'
+    );
+
+    // Set it back to empty string
+    await page.fill('[data-test-subj="queryInput"]', '');
+    await page.keyboard.press('Enter');
+  });
+
+  // This is needed for the intermediate release process -> https://docs.google.com/document/d/1mU5jlIfCKyXdDPtEzAz1xTpFXFCWxqdO5ldYRVO_hgM/edit?tab=t.0#heading=h.2b1v1tr0ep8m
+  // After the next serverless release the commit containing these changes can be reverted
+  step.skip('Should filter monitors by type', async () => {
+    await page.getByRole('button', { name: 'Type All' }).click();
+    await page.getByTestId('comboBoxInput').click();
+    await page.getByRole('option', { name: 'http' }).click();
+    await page.getByTestId('ruleDefinition').getByRole('button', { name: 'Type http' }).click();
+    await expect(page.getByTestId('syntheticsRuleVizMonitorQueryIDsButton')).toHaveText(
+      '1 existing monitor'
+    );
+  });
+
+  step('Should create TLS rule', async () => {
+    // This is to check that when the user clicks on the "Create new TLS rule" button, a POST request is made to the API
+    let requestMade = false;
+    page.on('request', (request) => {
+      if (request.url().includes('api/alerting/rule') && request.method() === 'POST') {
+        requestMade = true;
+      }
+    });
+
+    // Setting the rule schedule to 1 second so that the alert will be created quickly
+    await page.getByTestId('ruleScheduleUnitInput').selectOption('second');
+    await page.getByTestId('ruleFormStep-details').click();
+    await page.waitForSelector('[data-test-subj="ruleFlyoutFooterSaveButton"]');
+    await page.fill('[data-test-subj="ruleDetailsNameInput"]', tlsRuleName);
+    await page.getByTestId('ruleFlyoutFooterSaveButton').click();
+    await page.getByTestId('confirmModalConfirmButton').click();
+
+    expect(requestMade).toBe(true);
+  });
+
+  step('Verify rule creation', async () => {
+    await syntheticsApp.goToRulesPage();
+    await page.waitForSelector(`text='${tlsRuleName}'`);
+  });
+
+  step('Verify alert creation', async () => {
+    await page.getByTestId('observability-nav-observability-overview-alerts').click();
+
+    await retry.tryForTime(5 * 1000, async () => {
+      await page.getByTestId('querySubmitButton').click();
+      await expect(page.getByText(tlsRuleName)).toBeVisible();
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/default_status_alert.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/alert_rules/default_status_alert.journey.ts
@@ -28,11 +28,11 @@ journey(`DefaultStatusAlert`, async ({ page, params }) => {
   let configId2: string;
 
   before(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
   });
 
   after(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
   });
 
   step('setup monitor', async () => {

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/index.ts
@@ -20,6 +20,7 @@ export * from './global_parameters.journey';
 export * from './detail_flyout';
 export * from './alert_rules/default_status_alert.journey';
 export * from './alert_rules/custom_status_alert.journey';
+export * from './alert_rules/custom_tls_alert.journey';
 export * from './test_now_mode.journey';
 export * from './monitor_details_page/monitor_summary.journey';
 export * from './test_run_details.journey';

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/monitor_details_page/monitor_summary.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/monitor_details_page/monitor_summary.journey.ts
@@ -30,7 +30,7 @@ journeySkip(`MonitorSummaryTab`, async ({ page, params }) => {
   let configId: string;
 
   before(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
     await services.enableMonitorManagedViaApi();
     configId = await services.addTestMonitor('Test Monitor', {
       type: 'http',
@@ -44,7 +44,7 @@ journeySkip(`MonitorSummaryTab`, async ({ page, params }) => {
   });
 
   after(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
   });
 
   step('Go to monitor summary page', async () => {

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/services/synthetics_services.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/services/synthetics_services.ts
@@ -59,10 +59,11 @@ export class SyntheticsServices {
   async addTestMonitor(
     name: string,
     data: Record<string, any> = { type: 'browser' },
-    configId?: string
+    configId?: string,
+    options: { tls: { enabled: boolean } } = { tls: { enabled: false } }
   ) {
     const testData = {
-      alert: { status: { enabled: true } },
+      alert: { status: { enabled: true }, tls: options.tls },
       locations: [{ id: 'us_central', isServiceManaged: true }],
       ...(data?.type !== 'browser' ? {} : data),
       ...(data || {}),
@@ -120,6 +121,8 @@ export class SyntheticsServices {
     stepIndex = 1,
     locationName,
     configId,
+    tlsNotBefore,
+    tlsNotAfter,
   }: {
     monitorId?: string;
     docType?: 'summaryUp' | 'summaryDown' | 'journeyStart' | 'journeyEnd' | 'stepEnd';
@@ -129,6 +132,8 @@ export class SyntheticsServices {
     stepIndex?: number;
     locationName?: string;
     configId?: string;
+    tlsNotBefore?: string;
+    tlsNotAfter?: string;
   } = {}) {
     const getService = this.params.getService;
     const es: Client = getService('es');
@@ -149,6 +154,8 @@ export class SyntheticsServices {
       },
       configId,
       monitorId: monitorId ?? configId,
+      tlsNotAfter,
+      tlsNotBefore,
     };
 
     switch (docType) {
@@ -190,20 +197,20 @@ export class SyntheticsServices {
     });
   }
 
-  async cleaUp() {
+  async cleanUp() {
     try {
       const getService = this.params.getService;
       const server = getService('kibanaServer');
 
       await server.savedObjects.clean({ types: ['synthetics-monitor', 'alert'] });
-      await this.cleaUpAlerts();
+      await this.cleanUpAlerts();
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log(e);
     }
   }
 
-  async cleaUpAlerts() {
+  async cleanUpAlerts() {
     try {
       const getService = this.params.getService;
       const es: Client = getService('es');

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/step_details.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/step_details.journey.ts
@@ -15,7 +15,7 @@ journey(`StepDetailsPage`, async ({ page, params }) => {
   const services = new SyntheticsServices(params);
 
   before(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
     await services.enableMonitorManagedViaApi();
     await services.addTestMonitor(
       'https://www.google.com',
@@ -33,7 +33,7 @@ journey(`StepDetailsPage`, async ({ page, params }) => {
   });
 
   after(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
   });
 
   step('Go to step details page', async () => {

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/test_now_mode.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/test_now_mode.journey.ts
@@ -53,7 +53,7 @@ journeySkip(`TestNowMode`, async ({ page, params }) => {
       }
     });
 
-    await services.cleaUp();
+    await services.cleanUp();
     await services.enableMonitorManagedViaApi();
     await services.addTestMonitor('Test Monitor', {
       type: 'http',
@@ -65,7 +65,7 @@ journeySkip(`TestNowMode`, async ({ page, params }) => {
   });
 
   after(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
   });
 
   step('Go to monitors page', async () => {

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/test_run_details.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/test_run_details.journey.ts
@@ -21,7 +21,7 @@ journeySkip(`TestRunDetailsPage`, async ({ page, params }) => {
   const services = new SyntheticsServices(params);
 
   before(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
     await services.enableMonitorManagedViaApi();
     await services.addTestMonitor(
       'https://www.google.com',
@@ -47,7 +47,7 @@ journeySkip(`TestRunDetailsPage`, async ({ page, params }) => {
   });
 
   after(async () => {
-    await services.cleaUp();
+    await services.cleanUp();
   });
 
   step('Go to monitor summary page', async () => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/alert_tls.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/alert_tls.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiExpression, EuiFlexItem, EuiFlexGroup, EuiSpacer } from '@elastic/eui';
+import { EuiExpression, EuiFlexItem, EuiFlexGroup, EuiSpacer, EuiTitle } from '@elastic/eui';
 import React from 'react';
 import { ValueExpression } from '@kbn/triggers-actions-ui-plugin/public';
 import { i18n } from '@kbn/i18n';
@@ -17,7 +17,7 @@ interface Props {
   setExpirationThreshold: (value: number) => void;
 }
 
-export const AlertTlsComponent: React.FC<Props> = ({
+export const AlertTlsCondition: React.FC<Props> = ({
   ageThreshold,
   expirationThreshold,
   setAgeThreshold,
@@ -25,7 +25,16 @@ export const AlertTlsComponent: React.FC<Props> = ({
 }) => (
   <>
     <EuiSpacer size="m" />
-    <EuiFlexGroup direction="column" gutterSize="none">
+    <EuiFlexGroup direction="column" gutterSize="s">
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xs">
+          <h3>
+            {i18n.translate('xpack.synthetics.rules.tls.condition.title', {
+              defaultMessage: 'Condition',
+            })}
+          </h3>
+        </EuiTitle>
+      </EuiFlexItem>
       <EuiFlexItem>
         <EuiExpression
           aria-label={TlsTranslations.criteriaAriaLabel}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/field_filters.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/field_filters.tsx
@@ -7,7 +7,10 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
-import { useFetchSyntheticsSuggestions } from '../hooks/use_fetch_synthetics_suggestions';
+import {
+  FetchSyntheticsSuggestionsFilters,
+  useFetchSyntheticsSuggestions,
+} from '../hooks/use_fetch_synthetics_suggestions';
 import { StatusRuleParamsProps } from '../status_rule_ui';
 import { LocationsField, MonitorField, MonitorTypeField, ProjectsField, TagsField } from './fields';
 
@@ -16,9 +19,10 @@ type FieldKeys = 'monitorIds' | 'projects' | 'tags' | 'locations' | 'monitorType
 interface Props {
   ruleParams: StatusRuleParamsProps['ruleParams'];
   setRuleParams: StatusRuleParamsProps['setRuleParams'];
+  filters?: FetchSyntheticsSuggestionsFilters;
 }
 
-export const FieldFilters = ({ ruleParams, setRuleParams }: Props) => {
+export const FieldFilters = ({ ruleParams, setRuleParams, filters }: Props) => {
   const [search, setSearch] = useState<string>('');
   const [selectedField, setSelectedField] = useState<string>();
 
@@ -29,6 +33,7 @@ export const FieldFilters = ({ ruleParams, setRuleParams }: Props) => {
   } = useFetchSyntheticsSuggestions({
     search,
     fieldName: selectedField,
+    filters,
   });
 
   const onFieldChange = useCallback(

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/hooks/use_fetch_synthetics_suggestions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/hooks/use_fetch_synthetics_suggestions.ts
@@ -21,14 +21,17 @@ export interface UseFetchSyntheticsSuggestions {
   allSuggestions?: Record<string, Suggestion[]>;
 }
 
+export interface FetchSyntheticsSuggestionsFilters {
+  locations?: string[];
+  monitorIds?: string[];
+  tags?: string[];
+  projects?: string[];
+  monitorTypes?: string[];
+}
+
 export interface Params {
   fieldName?: string;
-  filters?: {
-    locations?: string[];
-    monitorIds?: string[];
-    tags?: string[];
-    projects?: string[];
-  };
+  filters?: FetchSyntheticsSuggestionsFilters;
   search: string;
 }
 
@@ -40,7 +43,7 @@ export function useFetchSyntheticsSuggestions({
   search,
 }: Params): UseFetchSyntheticsSuggestions {
   const { http } = useKibana<ClientPluginsStart>().services;
-  const { locations, monitorIds, tags, projects } = filters || {};
+  const { locations, monitorIds, tags, projects, monitorTypes } = filters || {};
 
   const { loading, data } = useFetcher(
     async ({ signal }) => {
@@ -50,12 +53,13 @@ export function useFetchSyntheticsSuggestions({
           monitorQueryIds: monitorIds || [],
           tags: tags || [],
           projects: projects || [],
+          monitorTypes: monitorTypes || [],
           query: search,
         },
         signal,
       });
     },
-    [http, locations, monitorIds, tags, projects, search]
+    [http, locations, monitorIds, tags, projects, search, monitorTypes]
   );
 
   return {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/query_bar.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/query_bar.tsx
@@ -16,9 +16,11 @@ import { ClientPluginsStart } from '../../../../plugin';
 export function AlertSearchBar({
   kqlQuery,
   onChange,
+  filtersForSuggestions,
 }: {
   kqlQuery: string;
   onChange: (val: { kqlQuery?: string; filters?: Filter[] }) => void;
+  filtersForSuggestions?: Filter[];
 }) {
   const {
     data: { query },
@@ -71,6 +73,7 @@ export function AlertSearchBar({
         query={{ query: String(kqlQuery), language: 'kuery' }}
         autoSubmit={true}
         disableLanguageSwitcher={true}
+        filtersForSuggestions={filtersForSuggestions}
       />
     </EuiFormRow>
   );

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/rule_monitors_table.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/rule_monitors_table.tsx
@@ -11,14 +11,14 @@ import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useSelector } from 'react-redux';
 import { uniqBy } from 'lodash';
-import { selectInspectStatusRule } from '../../state/alert_rules/selectors';
+import { selectInspectRule } from '../../state/alert_rules/selectors';
 import { ClientPluginsStart } from '../../../../plugin';
 
 export const RuleMonitorsTable = () => {
   const {
     services: { http },
   } = useKibana<ClientPluginsStart>();
-  const { data } = useSelector(selectInspectStatusRule);
+  const { data } = useSelector(selectInspectRule);
 
   const [pageIndex, setPageIndex] = React.useState(0);
   const [pageSize, setPageSize] = React.useState(10);

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/rule_viz.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/rule_viz.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect } from 'react';
+import {
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSpacer,
+} from '@elastic/eui';
+import { useSelector, useDispatch } from 'react-redux';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { i18n } from '@kbn/i18n';
+import { useInspectorContext } from '@kbn/observability-shared-plugin/public';
+import { PayloadAction } from '@reduxjs/toolkit';
+import { RuleMonitorsTable } from './rule_monitors_table';
+import { apiService } from '../../../../utils/api_service';
+import { selectInspectRule } from '../../state/alert_rules/selectors';
+import { ClientPluginsStart } from '../../../../plugin';
+
+export const RuleViz = ({ dispatchedAction }: { dispatchedAction: PayloadAction<unknown> }) => {
+  const { data, loading } = useSelector(selectInspectRule);
+  const dispatch = useDispatch();
+  const {
+    services: { inspector },
+  } = useKibana<ClientPluginsStart>();
+
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+
+  const { inspectorAdapters, addInspectorRequest } = useInspectorContext();
+
+  const inspect = () => {
+    inspector.open(inspectorAdapters);
+  };
+
+  useEffect(() => {
+    apiService.addInspectorRequest = addInspectorRequest;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    inspectorAdapters?.requests?.reset();
+    dispatch(dispatchedAction);
+  }, [dispatchedAction, dispatch, inspectorAdapters?.requests]);
+
+  return (
+    <EuiCallOut iconType="search" size="s">
+      <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexItem grow={false}>
+          {i18n.translate('xpack.synthetics.statusRuleViz.ruleAppliesToFlexItemLabel', {
+            defaultMessage: 'Rule applies to ',
+          })}
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            isOpen={isPopoverOpen}
+            closePopover={() => setIsPopoverOpen(false)}
+            button={
+              loading ? undefined : (
+                <EuiButtonEmpty
+                  data-test-subj="syntheticsStatusRuleVizMonitorQueryIDsButton"
+                  size="xs"
+                  onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                >
+                  {i18n.translate('xpack.synthetics.statusRuleViz.monitorQueryIdsPopoverButton', {
+                    defaultMessage:
+                      '{total} existing {total, plural, one {monitor} other {monitors}}',
+                    values: { total: data?.monitors.length },
+                  })}
+                </EuiButtonEmpty>
+              )
+            }
+          >
+            <EuiPopoverTitle>
+              {i18n.translate('xpack.synthetics.statusRuleViz.monitorsPopoverTitleLabel', {
+                defaultMessage: 'Monitors',
+              })}
+            </EuiPopoverTitle>
+            {i18n.translate('xpack.synthetics.statusRuleViz.ruleAppliesToFollowingPopoverLabel', {
+              defaultMessage: 'Rule applies to following existing monitors.',
+            })}
+            <EuiSpacer size="s" />
+            <RuleMonitorsTable />
+          </EuiPopover>
+        </EuiFlexItem>
+        {loading && (
+          <EuiFlexItem grow={false}>
+            <EuiLoadingSpinner size="s" />
+          </EuiFlexItem>
+        )}
+        {/* to push detail button to end*/}
+        <EuiFlexItem />
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            data-test-subj="syntheticsRuleVizInspectButton"
+            onClick={inspect}
+            iconType="inspect"
+            size="xs"
+          >
+            {i18n.translate('xpack.synthetics.rules.details', {
+              defaultMessage: 'Details',
+            })}
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiCallOut>
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/tls_rule_ui.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/tls_rule_ui.tsx
@@ -6,17 +6,31 @@
  */
 
 import { useDispatch, useSelector } from 'react-redux';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { RuleTypeParamsExpressionProps } from '@kbn/triggers-actions-ui-plugin/public';
 import type { TLSRuleParams } from '@kbn/response-ops-rule-params/synthetics_tls';
-import { AlertTlsComponent } from './alert_tls';
+import { EuiSpacer } from '@elastic/eui';
+import { buildPhrasesFilter } from '@kbn/es-query';
+import { AlertTlsCondition } from './alert_tls';
 import { getDynamicSettingsAction, selectDynamicSettings } from '../../state/settings';
 import { DYNAMIC_SETTINGS_DEFAULTS } from '../../../../../common/constants';
+import { AlertSearchBar } from './query_bar';
+import { TLSRuleViz } from './tls_rule_viz';
+import { useSyntheticsDataView } from '../../contexts/synthetics_data_view_context';
+import { FieldFilters } from './common/field_filters';
+import { MonitorTypeEnum } from '../monitor_add_edit/types';
+
+export type TLSRuleParamsProps = RuleTypeParamsExpressionProps<TLSRuleParams>;
+
+const tlsMonitorTypes = [MonitorTypeEnum.HTTP, MonitorTypeEnum.TCP];
 
 export const TLSRuleComponent: React.FC<{
-  ruleParams: RuleTypeParamsExpressionProps<TLSRuleParams>['ruleParams'];
-  setRuleParams: RuleTypeParamsExpressionProps<TLSRuleParams>['setRuleParams'];
-}> = ({ ruleParams, setRuleParams }) => {
+  ruleParams: TLSRuleParamsProps['ruleParams'];
+  setRuleParams: TLSRuleParamsProps['setRuleParams'];
+  // This is needed for the intermediate release process -> https://docs.google.com/document/d/1mU5jlIfCKyXdDPtEzAz1xTpFXFCWxqdO5ldYRVO_hgM/edit?tab=t.0#heading=h.2b1v1tr0ep8m
+  // After the next serverless release the commit containing these changes can be reverted
+  showMonitorFilters?: boolean;
+}> = ({ ruleParams, setRuleParams, showMonitorFilters = false }) => {
   const dispatch = useDispatch();
 
   const { settings } = useSelector(selectDynamicSettings);
@@ -27,20 +41,55 @@ export const TLSRuleComponent: React.FC<{
     }
   }, [dispatch, settings]);
 
+  const onFiltersChange = useCallback(
+    (val: { kqlQuery?: string }) => {
+      setRuleParams('kqlQuery', val.kqlQuery);
+    },
+    [setRuleParams]
+  );
+
+  const dataView = useSyntheticsDataView();
+  const monitorTypeField = dataView?.getFieldByName('monitor.type');
+
+  // filtersForSuggestions can be applied only if dataView and monitorTypeField are available
+  const filtersForSuggestions =
+    dataView && monitorTypeField
+      ? [buildPhrasesFilter(monitorTypeField, tlsMonitorTypes, dataView)]
+      : undefined;
+
   return (
-    <AlertTlsComponent
-      ageThreshold={
-        ruleParams.certAgeThreshold ??
-        settings?.certAgeThreshold ??
-        DYNAMIC_SETTINGS_DEFAULTS.certAgeThreshold
-      }
-      expirationThreshold={
-        ruleParams.certExpirationThreshold ??
-        settings?.certExpirationThreshold ??
-        DYNAMIC_SETTINGS_DEFAULTS.certExpirationThreshold
-      }
-      setAgeThreshold={(value) => setRuleParams('certAgeThreshold', Number(value))}
-      setExpirationThreshold={(value) => setRuleParams('certExpirationThreshold', Number(value))}
-    />
+    <>
+      {showMonitorFilters ? (
+        <>
+          <AlertSearchBar
+            kqlQuery={ruleParams.kqlQuery ?? ''}
+            onChange={onFiltersChange}
+            filtersForSuggestions={filtersForSuggestions}
+          />
+          <EuiSpacer size="m" />
+          <FieldFilters
+            ruleParams={ruleParams}
+            setRuleParams={setRuleParams}
+            filters={{ monitorTypes: tlsMonitorTypes }}
+          />
+          <TLSRuleViz ruleParams={ruleParams} />
+          <EuiSpacer size="m" />
+        </>
+      ) : null}
+      <AlertTlsCondition
+        ageThreshold={
+          ruleParams.certAgeThreshold ??
+          settings?.certAgeThreshold ??
+          DYNAMIC_SETTINGS_DEFAULTS.certAgeThreshold
+        }
+        expirationThreshold={
+          ruleParams.certExpirationThreshold ??
+          settings?.certExpirationThreshold ??
+          DYNAMIC_SETTINGS_DEFAULTS.certExpirationThreshold
+        }
+        setAgeThreshold={(value) => setRuleParams('certAgeThreshold', Number(value))}
+        setExpirationThreshold={(value) => setRuleParams('certExpirationThreshold', Number(value))}
+      />
+    </>
   );
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/tls_rule_viz.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/tls_rule_viz.tsx
@@ -6,15 +6,11 @@
  */
 
 import React, { useMemo } from 'react';
-import { inspectStatusRuleAction } from '../../state/alert_rules';
-import { StatusRuleParamsProps } from './status_rule_ui';
+import { inspectTLSRuleAction } from '../../state/alert_rules';
+import { TLSRuleParamsProps } from './tls_rule_ui';
 import { RuleViz } from './rule_viz';
 
-export const StatusRuleViz = ({
-  ruleParams,
-}: {
-  ruleParams: StatusRuleParamsProps['ruleParams'];
-}) => {
-  const dispatchedAction = useMemo(() => inspectStatusRuleAction.get(ruleParams), [ruleParams]);
+export const TLSRuleViz = ({ ruleParams }: { ruleParams: TLSRuleParamsProps['ruleParams'] }) => {
+  const dispatchedAction = useMemo(() => inspectTLSRuleAction.get(ruleParams), [ruleParams]);
   return <RuleViz dispatchedAction={dispatchedAction} />;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/contexts/synthetics_data_view_context.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/contexts/synthetics_data_view_context.tsx
@@ -10,6 +10,7 @@ import { useFetcher } from '@kbn/observability-shared-plugin/public';
 import { DataViewsPublicPluginStart, DataView } from '@kbn/data-views-plugin/public';
 import { SYNTHETICS_INDEX_PATTERN } from '../../../../common/constants';
 
+// TODO: This should be changed to createContext<DataView | undefined> because this is the type returned by useFetcher, not changing it because not sure of the side effects
 export const SyntheticsDataViewContext = createContext({} as DataView);
 
 export const SyntheticsDataViewContextProvider: FC<

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/lib/alert_types/lazy_wrapper/tls_alert.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/lib/alert_types/lazy_wrapper/tls_alert.tsx
@@ -6,15 +6,14 @@
  */
 
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 import { CoreStart } from '@kbn/core/public';
-import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import type { RuleTypeParamsExpressionProps } from '@kbn/triggers-actions-ui-plugin/public';
 import type { TLSRuleParams } from '@kbn/response-ops-rule-params/synthetics_tls';
 import { TLSRuleComponent } from '../../../components/alerts/tls_rule_ui';
 import { ClientPluginsStart } from '../../../../../plugin';
 import { kibanaService } from '../../../../../utils/kibana_service';
-import { store } from '../../../state';
+import { getSyntheticsAppProps } from '../../../render_app';
+import { SyntheticsSharedContext } from '../../../contexts/synthetics_shared_context';
 
 interface Props {
   coreStart: CoreStart;
@@ -26,11 +25,11 @@ interface Props {
 // eslint-disable-next-line import/no-default-export
 export default function TLSAlert({ coreStart, plugins, ruleParams, setRuleParams }: Props) {
   kibanaService.coreStart = coreStart;
+  const props = getSyntheticsAppProps();
+
   return (
-    <ReduxProvider store={store}>
-      <KibanaContextProvider services={{ ...coreStart, ...plugins }}>
-        <TLSRuleComponent ruleParams={ruleParams} setRuleParams={setRuleParams} />
-      </KibanaContextProvider>
-    </ReduxProvider>
+    <SyntheticsSharedContext {...props}>
+      <TLSRuleComponent ruleParams={ruleParams} setRuleParams={setRuleParams} />
+    </SyntheticsSharedContext>
   );
 }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/actions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/actions.ts
@@ -5,10 +5,14 @@
  * 2.0.
  */
 
-import { StatusRuleInspect } from '../../../../../common/runtime_types/alert_rules/common';
+import {
+  StatusRuleInspect,
+  TLSRuleInspect,
+} from '../../../../../common/runtime_types/alert_rules/common';
 import { StatusRuleParamsProps } from '../../components/alerts/status_rule_ui';
 import { DEFAULT_ALERT_RESPONSE } from '../../../../../common/types/default_alerts';
 import { createAsyncAction } from '../utils/actions';
+import { TLSRuleParamsProps } from '../../components/alerts/tls_rule_ui';
 
 export const getDefaultAlertingAction = createAsyncAction<void, DEFAULT_ALERT_RESPONSE>(
   'getDefaultAlertingAction'
@@ -30,3 +34,8 @@ export const inspectStatusRuleAction = createAsyncAction<
   StatusRuleParamsProps['ruleParams'],
   StatusRuleInspect
 >('inspectStatusRuleAction');
+
+export const inspectTLSRuleAction = createAsyncAction<
+  TLSRuleParamsProps['ruleParams'],
+  TLSRuleInspect
+>('inspectTLSRuleAction');

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/api.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/api.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import { StatusRuleInspect } from '../../../../../common/runtime_types/alert_rules/common';
+import {
+  StatusRuleInspect,
+  TLSRuleInspect,
+} from '../../../../../common/runtime_types/alert_rules/common';
 import { StatusRuleParamsProps } from '../../components/alerts/status_rule_ui';
 import { SYNTHETICS_API_URLS } from '../../../../../common/constants';
 import { DEFAULT_ALERT_RESPONSE } from '../../../../../common/types/default_alerts';
@@ -15,6 +18,12 @@ export async function inspectStatusAlertAPI(
   ruleParams: StatusRuleParamsProps['ruleParams']
 ): Promise<StatusRuleInspect> {
   return apiService.post(SYNTHETICS_API_URLS.INSPECT_STATUS_RULE, ruleParams);
+}
+
+export async function inspectTLSAlertAPI(
+  ruleParams: StatusRuleParamsProps['ruleParams']
+): Promise<TLSRuleInspect> {
+  return apiService.post(SYNTHETICS_API_URLS.INSPECT_TLS_RULE, ruleParams);
 }
 
 export async function getDefaultAlertingAPI(): Promise<DEFAULT_ALERT_RESPONSE> {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/effects.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/effects.ts
@@ -12,6 +12,7 @@ import {
   enableDefaultAlertingSilentlyAction,
   getDefaultAlertingAction,
   inspectStatusRuleAction,
+  inspectTLSRuleAction,
   updateDefaultAlertingAction,
 } from './actions';
 import { fetchEffectFactory } from '../utils/fetch_effect';
@@ -19,6 +20,7 @@ import {
   enableDefaultAlertingAPI,
   getDefaultAlertingAPI,
   inspectStatusAlertAPI,
+  inspectTLSAlertAPI,
   updateDefaultAlertingAPI,
 } from './api';
 
@@ -84,6 +86,21 @@ export function* inspectStatusRuleEffect() {
       '',
       i18n.translate('xpack.synthetics.settings.statusRule.inspect', {
         defaultMessage: 'Failed to inspect monitor status rule type.',
+      })
+    )
+  );
+}
+
+export function* inspectTLSRuleEffect() {
+  yield takeLeading(
+    inspectTLSRuleAction.get,
+    fetchEffectFactory(
+      inspectTLSAlertAPI,
+      inspectTLSRuleAction.success,
+      inspectTLSRuleAction.fail,
+      '',
+      i18n.translate('xpack.synthetics.settings.TLSRule.inspect', {
+        defaultMessage: 'Failed to inspect monitor TLS rule type.',
       })
     )
   );

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/index.ts
@@ -14,6 +14,7 @@ import {
   enableDefaultAlertingSilentlyAction,
   getDefaultAlertingAction,
   inspectStatusRuleAction,
+  inspectTLSRuleAction,
   updateDefaultAlertingAction,
 } from './actions';
 
@@ -78,6 +79,18 @@ export const defaultAlertingReducer = createReducer(initialSettingState, (builde
       state.inspectError = null;
     })
     .addCase(inspectStatusRuleAction.fail, (state, action) => {
+      state.inspectError = action.payload;
+      state.inspectLoading = false;
+    })
+    .addCase(inspectTLSRuleAction.get, (state) => {
+      state.inspectLoading = true;
+    })
+    .addCase(inspectTLSRuleAction.success, (state, action) => {
+      state.inspectData = action.payload;
+      state.inspectLoading = false;
+      state.inspectError = null;
+    })
+    .addCase(inspectTLSRuleAction.fail, (state, action) => {
       state.inspectError = action.payload;
       state.inspectLoading = false;
     });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/selectors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/alert_rules/selectors.ts
@@ -12,7 +12,7 @@ const getState = (appState: SyntheticsAppState) => appState.defaultAlerting;
 export const selectSyntheticsAlerts = createSelector(getState, (state) => state.data);
 export const selectSyntheticsAlertsLoading = createSelector(getState, (state) => state.loading);
 export const selectSyntheticsAlertsLoaded = createSelector(getState, (state) => state.success);
-export const selectInspectStatusRule = createSelector(getState, (state) => {
+export const selectInspectRule = createSelector(getState, (state) => {
   return {
     loading: state.inspectLoading,
     data: state.inspectData,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/root_effect.ts
@@ -19,6 +19,7 @@ import {
   enableDefaultAlertingSilentlyEffect,
   getDefaultAlertingEffect,
   inspectStatusRuleEffect,
+  inspectTLSRuleEffect,
   updateDefaultAlertingEffect,
 } from './alert_rules/effects';
 import { executeEsQueryEffect } from './elasticsearch';
@@ -82,6 +83,7 @@ export const rootEffect = function* root(): Generator {
     fork(fetchOverviewTrendStats),
     fork(refreshOverviewTrendStats),
     fork(inspectStatusRuleEffect),
+    fork(inspectTLSRuleEffect),
     ...privateLocationsEffects.map((effect) => fork(effect)),
   ]);
 };

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/filter_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/queries/filter_monitors.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
+import { KueryNode, fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { SyntheticsMonitorStatusRuleParams as StatusRuleParams } from '@kbn/response-ops-rule-params/synthetics_monitor_status';
 import { SyntheticsEsClient } from '../../../lib';
@@ -27,7 +27,17 @@ export async function queryFilterMonitors({
   if (!ruleParams.kqlQuery) {
     return;
   }
-  const filters = toElasticsearchQuery(fromKueryExpression(ruleParams.kqlQuery));
+
+  let kueryNode: KueryNode;
+
+  // This is to check if the kqlQuery is valid, if it is not the fromKueryExpression will throw an error
+  try {
+    kueryNode = fromKueryExpression(ruleParams.kqlQuery);
+  } catch (error) {
+    return;
+  }
+
+  const filters = toElasticsearchQuery(kueryNode);
   const { body: result } = await esClient.search(
     {
       body: {

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule.ts
@@ -72,7 +72,7 @@ export const registerSyntheticsTLSCheckRule = (
         TLSAlert
       >
     ) => {
-      const { state: ruleState, params, services, spaceId, previousStartedAt } = options;
+      const { state: ruleState, params, services, spaceId, previousStartedAt, rule } = options;
       const { alertsClient, savedObjectsClient, scopedClusterClient } = services;
       if (!alertsClient) {
         throw new AlertsClientError();
@@ -85,7 +85,9 @@ export const registerSyntheticsTLSCheckRule = (
         savedObjectsClient,
         scopedClusterClient.asCurrentUser,
         server,
-        syntheticsMonitorClient
+        syntheticsMonitorClient,
+        spaceId,
+        rule.name
       );
 
       const { foundCerts, certs, absoluteExpirationThreshold, absoluteAgeThreshold, latestPings } =

--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
@@ -8,10 +8,13 @@ import {
   SavedObjectsClientContract,
   SavedObjectsFindResult,
 } from '@kbn/core-saved-objects-api-server';
+import { Logger } from '@kbn/core/server';
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { TLSRuleParams } from '@kbn/response-ops-rule-params/synthetics_tls';
 import moment from 'moment';
+import { isEmpty } from 'lodash';
+import { TLSRuleInspect } from '../../../common/runtime_types/alert_rules/common';
 import { FINAL_SUMMARY_FILTER } from '../../../common/constants/client_defaults';
 import { formatFilterString } from '../common';
 import { SyntheticsServerSetup } from '../../types';
@@ -32,6 +35,8 @@ import { SyntheticsMonitorClient } from '../../synthetics_service/synthetics_mon
 import { monitorAttributes } from '../../../common/types/saved_objects';
 import { AlertConfigKey } from '../../../common/constants/monitor_management';
 import { SyntheticsEsClient } from '../../lib';
+import { queryFilterMonitors } from '../status_rule/queries/filter_monitors';
+import { parseArrayFilters, parseLocationFilter } from '../../routes/common';
 
 export class TLSRuleExecutor {
   previousStartedAt: Date | null;
@@ -41,6 +46,9 @@ export class TLSRuleExecutor {
   server: SyntheticsServerSetup;
   syntheticsMonitorClient: SyntheticsMonitorClient;
   monitors: Array<SavedObjectsFindResult<EncryptedSyntheticsMonitorAttributes>> = [];
+  logger: Logger;
+  spaceId: string;
+  ruleName: string;
 
   constructor(
     previousStartedAt: Date | null,
@@ -48,7 +56,9 @@ export class TLSRuleExecutor {
     soClient: SavedObjectsClientContract,
     scopedClient: ElasticsearchClient,
     server: SyntheticsServerSetup,
-    syntheticsMonitorClient: SyntheticsMonitorClient
+    syntheticsMonitorClient: SyntheticsMonitorClient,
+    spaceId: string,
+    ruleName: string
   ) {
     this.previousStartedAt = previousStartedAt;
     this.params = p;
@@ -58,14 +68,60 @@ export class TLSRuleExecutor {
     });
     this.server = server;
     this.syntheticsMonitorClient = syntheticsMonitorClient;
+    this.logger = server.logger;
+    this.spaceId = spaceId;
+    this.ruleName = ruleName;
+  }
+
+  debug(message: string) {
+    this.logger.debug(`[TLS Rule Executor][${this.ruleName}] ${message}`);
   }
 
   async getMonitors() {
     const HTTP_OR_TCP = `${monitorAttributes}.${ConfigKey.MONITOR_TYPE}: http or ${monitorAttributes}.${ConfigKey.MONITOR_TYPE}: tcp`;
+
+    const baseFilter = `${monitorAttributes}.${AlertConfigKey.TLS_ENABLED}: true and (${HTTP_OR_TCP})`;
+
+    const configIds = await queryFilterMonitors({
+      spaceId: this.spaceId,
+      esClient: this.esClient,
+      ruleParams: this.params,
+    });
+
+    if (this.params.kqlQuery && isEmpty(configIds)) {
+      this.debug(`No monitor found with the given KQL query ${this.params.kqlQuery}`);
+      return processMonitors([]);
+    }
+
+    const locationIds = await parseLocationFilter(
+      {
+        savedObjectsClient: this.soClient,
+        server: this.server,
+        syntheticsMonitorClient: this.syntheticsMonitorClient,
+      },
+      this.params.locations
+    );
+
+    const { filtersStr } = parseArrayFilters({
+      configIds,
+      filter: baseFilter,
+      tags: this.params?.tags,
+      locations: locationIds,
+      monitorTypes: this.params?.monitorTypes,
+      monitorQueryIds: this.params?.monitorIds,
+      projects: this.params?.projects,
+    });
+
     this.monitors = await getAllMonitors({
       soClient: this.soClient,
-      filter: `${monitorAttributes}.${AlertConfigKey.TLS_ENABLED}: true and (${HTTP_OR_TCP})`,
+      filter: filtersStr,
     });
+
+    this.debug(
+      `Found ${this.monitors.length} monitors for params ${JSON.stringify(
+        this.params
+      )} | parsed location filter is ${JSON.stringify(locationIds)} `
+    );
 
     const {
       allIds,
@@ -134,6 +190,10 @@ export class TLSRuleExecutor {
       filters,
       monitorIds: enabledMonitorQueryIds,
     });
+
+    this.debug(
+      `Found ${certs.length} certificates: ` + certs.map((cert) => cert.sha256).join(', ')
+    );
 
     const latestPings = await this.getLatestPingsForMonitors(certs);
 
@@ -219,6 +279,16 @@ export class TLSRuleExecutor {
 
     return body.hits.hits.map((hit) => hit._source as TLSLatestPing);
   }
+  getRuleThresholdOverview = async (): Promise<TLSRuleInspect> => {
+    await this.getMonitors();
+    return {
+      monitors: this.monitors.map((monitor) => ({
+        id: monitor.id,
+        name: monitor.attributes.name,
+        type: monitor.attributes.type,
+      })),
+    } as TLSRuleInspect; // The returned object is cast to TLSRuleInspect because the AlertOverviewStatus is not included. The AlertOverviewStatus is probably not used in the frontend, we should check if it is still needed
+  };
 }
 
 export type TLSLatestPing = Pick<Ping, '@timestamp' | 'monitor' | 'url' | 'tls' | 'config_id'>;

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { syntheticsInspectStatusRuleRoute } from './rules/inspect_status_rule';
+import { syntheticsInspectTLSRuleRoute } from './rules/inspect_tls_rule';
 import { syntheticsGetLatestTestRunRoute } from './pings/get_latest_test_run';
 import { deleteSyntheticsParamsBulkRoute } from './settings/params/delete_params_bulk';
 import { deleteSyntheticsMonitorBulkRoute } from './monitor_cruds/bulk_cruds/delete_monitor_bulk';
@@ -103,6 +104,7 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   syntheticsGetPingHeatmapRoute,
   createOverviewTrendsRoute,
   syntheticsInspectStatusRuleRoute,
+  syntheticsInspectTLSRuleRoute,
 ];
 
 export const syntheticsAppPublicRestApiRoutes: SyntheticsRestApiRouteFactory[] = [

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/rules/inspect_tls_rule.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/rules/inspect_tls_rule.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { TLSRuleParams, tlsRuleParamsSchema } from '@kbn/response-ops-rule-params/synthetics_tls';
+import { SyntheticsRestApiRouteFactory } from '../types';
+import { SYNTHETICS_API_URLS } from '../../../common/constants';
+import { TLSRuleExecutor } from '../../alert_rules/tls_rule/tls_rule_executor';
+
+export const syntheticsInspectTLSRuleRoute: SyntheticsRestApiRouteFactory = () => ({
+  method: 'POST',
+  path: SYNTHETICS_API_URLS.INSPECT_TLS_RULE,
+  validate: {
+    body: tlsRuleParamsSchema,
+  },
+  handler: async ({
+    request,
+    server,
+    syntheticsMonitorClient,
+    savedObjectsClient,
+    context,
+    spaceId,
+  }) => {
+    const { elasticsearch } = await context.core;
+
+    const tlsRule = new TLSRuleExecutor(
+      new Date(),
+      request.body as TLSRuleParams,
+      savedObjectsClient,
+      elasticsearch.client.asCurrentUser,
+      server,
+      syntheticsMonitorClient,
+      spaceId,
+      'Inspect TLS Rule'
+    );
+
+    return tlsRule.getRuleThresholdOverview();
+  },
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Synthetics] Add KQL Filter to TLS Alerting Rule (#215110)](https://github.com/elastic/kibana/pull/215110)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-03-27T17:57:51Z","message":"[Synthetics] Add KQL Filter to TLS Alerting Rule (#215110)\n\nThis PR partially solves issue #214346 by adding the KQL Filter when\ncreating a TLS Alerting Rule.\n\nBecause of [the intermediate release\nprocess](https://docs.google.com/document/d/1mU5jlIfCKyXdDPtEzAz1xTpFXFCWxqdO5ldYRVO_hgM/edit?tab=t.0#heading=h.2b1v1tr0ep8m)\nthe UI to add the new filters is not shown, another PR will enable it\nafter the next serverless release.\n\nIn details:\n\nBE:\n- Extended `tlsRuleParamsSchema` to accept `monitorIds`, `locations`,\n`tags`, `monitorTypes`, `projects`, `kqlQuery`\n- Extended `TLSRuleExecutor` functionality, added tests\n- Added new `/internal/synthetics/inspect_tls_rule` endpoint \n\nFE:\n- Added `AlertSearchBar`, `FieldFilters` and `TLSRuleViz` to the\n`TLSRuleComponent`, making sure that only `http` and `tcp` monitors are\nconsidered\n\nFinal result:\n\n\nhttps://github.com/user-attachments/assets/613cdb73-2184-4b10-8dd5-549868b7672d\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"b8a29d40965ba565638777d16dddadadbfc86510","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.0.0","release_note:feature","ci:project-deploy-observability","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Synthetics] Add KQL Filter to TLS Alerting Rule","number":215110,"url":"https://github.com/elastic/kibana/pull/215110","mergeCommit":{"message":"[Synthetics] Add KQL Filter to TLS Alerting Rule (#215110)\n\nThis PR partially solves issue #214346 by adding the KQL Filter when\ncreating a TLS Alerting Rule.\n\nBecause of [the intermediate release\nprocess](https://docs.google.com/document/d/1mU5jlIfCKyXdDPtEzAz1xTpFXFCWxqdO5ldYRVO_hgM/edit?tab=t.0#heading=h.2b1v1tr0ep8m)\nthe UI to add the new filters is not shown, another PR will enable it\nafter the next serverless release.\n\nIn details:\n\nBE:\n- Extended `tlsRuleParamsSchema` to accept `monitorIds`, `locations`,\n`tags`, `monitorTypes`, `projects`, `kqlQuery`\n- Extended `TLSRuleExecutor` functionality, added tests\n- Added new `/internal/synthetics/inspect_tls_rule` endpoint \n\nFE:\n- Added `AlertSearchBar`, `FieldFilters` and `TLSRuleViz` to the\n`TLSRuleComponent`, making sure that only `http` and `tcp` monitors are\nconsidered\n\nFinal result:\n\n\nhttps://github.com/user-attachments/assets/613cdb73-2184-4b10-8dd5-549868b7672d\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"b8a29d40965ba565638777d16dddadadbfc86510"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215110","number":215110,"mergeCommit":{"message":"[Synthetics] Add KQL Filter to TLS Alerting Rule (#215110)\n\nThis PR partially solves issue #214346 by adding the KQL Filter when\ncreating a TLS Alerting Rule.\n\nBecause of [the intermediate release\nprocess](https://docs.google.com/document/d/1mU5jlIfCKyXdDPtEzAz1xTpFXFCWxqdO5ldYRVO_hgM/edit?tab=t.0#heading=h.2b1v1tr0ep8m)\nthe UI to add the new filters is not shown, another PR will enable it\nafter the next serverless release.\n\nIn details:\n\nBE:\n- Extended `tlsRuleParamsSchema` to accept `monitorIds`, `locations`,\n`tags`, `monitorTypes`, `projects`, `kqlQuery`\n- Extended `TLSRuleExecutor` functionality, added tests\n- Added new `/internal/synthetics/inspect_tls_rule` endpoint \n\nFE:\n- Added `AlertSearchBar`, `FieldFilters` and `TLSRuleViz` to the\n`TLSRuleComponent`, making sure that only `http` and `tcp` monitors are\nconsidered\n\nFinal result:\n\n\nhttps://github.com/user-attachments/assets/613cdb73-2184-4b10-8dd5-549868b7672d\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"b8a29d40965ba565638777d16dddadadbfc86510"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->