### PR TITLE
[ResponseOps][MaintenanceWindows] Fix flaky rules list MW callout test

### DIFF
--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.test.tsx
@@ -1382,8 +1382,7 @@ describe('rules_list with show only capability', () => {
   });
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/203179
-describe.skip('MaintenanceWindowsMock', () => {
+describe('MaintenanceWindowsMock', () => {
   beforeEach(() => {
     fetchActiveMaintenanceWindowsMock.mockResolvedValue([]);
 
@@ -1456,11 +1455,10 @@ describe.skip('MaintenanceWindowsMock', () => {
 
     renderWithProviders(<RulesList />);
 
-    await expect(
-      screen.findByText('Rule notifications are stopped while maintenance windows are running.')
-    ).rejects.toThrow();
-
-    expect(fetchActiveMaintenanceWindowsMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(fetchActiveMaintenanceWindowsMock).toHaveBeenCalledTimes(1));
+    expect(
+      screen.queryByText('Rule notifications are stopped while maintenance windows are running.')
+    ).not.toBeInTheDocument();
   });
 
   it('shows MaintenanceWindowCallout for a specific category', async () => {


### PR DESCRIPTION
## Summary

Attempts to fix the flakyness of #203179 by waiting for the mocked request to complete instead of the text finder to timeout. Timing analysis shows a reduction from `~4000ms` down to just `~70ms` of wait time for the final assertion.

## References

Closes #203179

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->