### PR TITLE
🌊 Streams: Normalize paddings

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/wrapper.tsx
@@ -31,7 +31,7 @@ export function Wrapper({
   return (
     <EuiFlexGroup
       direction="column"
-      gutterSize="l"
+      gutterSize="m"
       className={css`
         max-width: 100%;
       `}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/components/stream_stats_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/components/stream_stats_panel.tsx
@@ -121,7 +121,7 @@ export function StreamStatsPanel({
   });
 
   return (
-    <EuiFlexGroup direction="row" gutterSize="s">
+    <EuiFlexGroup direction="row" gutterSize="m">
       <EuiFlexItem grow={3}>
         <EuiPanel hasShadow={false} hasBorder>
           <EuiFlexGroup direction="column" gutterSize="xs">

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/stream_detail_overview.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/stream_detail_overview.tsx
@@ -160,7 +160,7 @@ export function StreamDetailOverview({ definition }: { definition?: IngestStream
 
   return (
     <>
-      <EuiFlexGroup direction="column">
+      <EuiFlexGroup direction="column" gutterSize="m">
         <EuiFlexItem grow={false}>
           <EuiFlexGroup direction="row" justifyContent="flexEnd">
             <EuiFlexItem grow>
@@ -207,7 +207,7 @@ export function StreamDetailOverview({ definition }: { definition?: IngestStream
         </EuiFlexItem>
 
         <EuiFlexItem grow>
-          <EuiFlexGroup direction="row">
+          <EuiFlexGroup direction="row" gutterSize="m">
             <EuiFlexItem grow={4}>{definition && <TabsPanel tabs={tabs} />}</EuiFlexItem>
             <EuiFlexItem grow={8}>
               <StreamChartPanel

--- a/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_body/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_body/index.tsx
@@ -25,6 +25,7 @@ export function StreamsAppPageBody({
         border-radius: 0px;
         display: flex;
         overflow-y: auto;
+        padding-top: ${theme.size.base};
         ${!background ? `background-color: transparent;` : ''}
       `}
       paddingSize="l"

--- a/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_header/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_header/index.tsx
@@ -21,7 +21,7 @@ export function StreamsAppPageHeader({
     <EuiFlexGroup direction="column" gutterSize="none">
       <EuiPageHeader
         className={css`
-          padding: ${theme.size.m} ${theme.size.l};
+          padding: ${theme.size.l} ${theme.size.l} ${theme.size.m};
         `}
       >
         {title}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_header/streams_app_page_header_title.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_header/streams_app_page_header_title.tsx
@@ -4,19 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiTitle, useEuiTheme } from '@elastic/eui';
-import { css } from '@emotion/css';
+import { EuiTitle } from '@elastic/eui';
 import React from 'react';
 
 export function StreamsAppPageHeaderTitle({ title }: { title: React.ReactNode }) {
-  const theme = useEuiTheme().euiTheme;
   return (
-    <EuiTitle
-      size="l"
-      className={css`
-        padding-top: ${theme.size.m};
-      `}
-    >
+    <EuiTitle size="l">
       <h1>{title}</h1>
     </EuiTitle>
   );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_header/streams_app_page_header_title.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/streams_app_page_header/streams_app_page_header_title.tsx
@@ -4,12 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { EuiTitle } from '@elastic/eui';
+import { EuiTitle, useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/css';
 import React from 'react';
 
 export function StreamsAppPageHeaderTitle({ title }: { title: React.ReactNode }) {
+  const theme = useEuiTheme().euiTheme;
   return (
-    <EuiTitle size="l">
+    <EuiTitle
+      size="l"
+      className={css`
+        padding-top: ${theme.size.m};
+      `}
+    >
       <h1>{title}</h1>
     </EuiTitle>
   );


### PR DESCRIPTION
Normalizes padding to align with design:

More padding above the title:
<img width="390" alt="Screenshot 2025-03-28 at 12 03 35" src="https://github.com/user-attachments/assets/145d9f58-b65f-4774-b4a7-0af9bdc2ad8b" />

Unsure - should this apply to listing page as well?
<img width="422" alt="Screenshot 2025-03-28 at 12 05 45" src="https://github.com/user-attachments/assets/c095f617-6e48-49c0-b8cf-18e6e0b954ff" />

Same paddings between all the panels:
<img width="1161" alt="Screenshot 2025-03-28 at 12 06 13" src="https://github.com/user-attachments/assets/1447bb5f-cd34-4876-923a-fb796e41cca5" />

Same padding above and below sub tab group in management:
<img width="522" alt="Screenshot 2025-03-28 at 12 06 34" src="https://github.com/user-attachments/assets/c0c94cad-82c6-4e59-b10b-d10c6cda6898" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->