### PR TITLE
chore(deps): upgrade `vega` from `5.31.0` to `5.33.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1306,7 +1306,7 @@
     "usng.js": "^0.4.5",
     "utility-types": "^3.10.0",
     "uuid": "11.1.0",
-    "vega": "^5.26.0",
+    "vega": "^5.33.0",
     "vega-interpreter": "^1.0.4",
     "vega-lite": "^5.5.0",
     "vega-schema-url-parser": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30895,10 +30895,10 @@ vega-event-selector@^3.0.1, vega-event-selector@~3.0.0, vega-event-selector@~3.0
   resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-3.0.1.tgz#b99e92147b338158f8079d81b28b2e7199c2e259"
   integrity sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==
 
-vega-expression@^5.1.2, vega-expression@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-5.1.2.tgz#1ed0677787b8e5f4047c9b847ecc20da0a2a8d05"
-  integrity sha512-fFeDTh4UtOxlZWL54jf1ZqJHinyerWq/ROiqrQxqLkNJRJ86RmxYTgXwt65UoZ/l4VUv9eAd2qoJeDEf610Umw==
+vega-expression@^5.2.0, vega-expression@~5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-5.2.0.tgz#a5dfa8dd79066082add1846618f3d7f0a364305f"
+  integrity sha512-WRMa4ny3iZIVAzDlBh3ipY2QUuLk2hnJJbfbncPgvTF7BUgbIbKq947z+JicWksYbokl8n1JHXJoqi3XvpG0Zw==
   dependencies:
     "@types/estree" "^1.0.0"
     vega-util "^1.17.3"
@@ -30931,19 +30931,19 @@ vega-format@^1.1.3, vega-format@~1.1.3:
     vega-time "^2.1.3"
     vega-util "^1.17.3"
 
-vega-functions@^5.16.0, vega-functions@~5.16.0:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.16.0.tgz#e72b5237cb3c507b42658d89286d07ac708d3f90"
-  integrity sha512-uXjSDbbGcFLCQTZZI+OiZK0U+2dLWC26ONdO0g9RhPzXXzR3niPcFOA0bc/OeiHdTexqsLjOiXxR/K2BckB8gQ==
+vega-functions@^5.18.0, vega-functions@~5.18.0:
+  version "5.18.0"
+  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.18.0.tgz#297fbb982492622bf57ca8148447ad88cdee859c"
+  integrity sha512-+D+ey4bDAhZA2CChh7bRZrcqRUDevv05kd2z8xH+il7PbYQLrhi6g1zwvf8z3KpgGInFf5O13WuFK5DQGkz5lQ==
   dependencies:
     d3-array "^3.2.2"
     d3-color "^3.1.0"
     d3-geo "^3.1.0"
     vega-dataflow "^5.7.7"
-    vega-expression "^5.1.2"
+    vega-expression "^5.2.0"
     vega-scale "^7.4.2"
     vega-scenegraph "^4.13.1"
-    vega-selections "^5.5.0"
+    vega-selections "^5.6.0"
     vega-statistics "^1.9.0"
     vega-time "^2.1.3"
     vega-util "^1.17.3"
@@ -31014,14 +31014,14 @@ vega-loader@^4.5.3, vega-loader@~4.5.3:
     vega-format "^1.1.3"
     vega-util "^1.17.3"
 
-vega-parser@~6.4.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.4.1.tgz#1ba0c59e7299d75a93dd433c5deec6592991ef67"
-  integrity sha512-ZjF5aQfRe3yD5e2zYZcWWkUn9zGzUonMIirWTp3S3UBCujz+aT0+Ls6wbHdAH6hCPj3PVVkSWuuLkGEIUpWqyQ==
+vega-parser@~6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.6.0.tgz#f6aa6fc07c89f83196a1951ed9cf832436a429ab"
+  integrity sha512-jltyrwCTtWeidi/6VotLCybhIl+ehwnzvFWYOdWNUP0z/EskdB64YmawNwjCjzTBMemeiQtY6sJPPbewYqe3Vg==
   dependencies:
     vega-dataflow "^5.7.7"
     vega-event-selector "^3.0.1"
-    vega-functions "^5.16.0"
+    vega-functions "^5.18.0"
     vega-scale "^7.4.2"
     vega-util "^1.17.3"
 
@@ -31081,13 +31081,13 @@ vega-schema-url-parser@^2.2.0:
   resolved "https://registry.yarnpkg.com/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz#a0d1e02915adfbfcb1fd517c8c2ebe2419985c1e"
   integrity sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==
 
-vega-selections@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.5.0.tgz#ccdd2320ea13d619f2ba2595301b7d280e4b473b"
-  integrity sha512-TkpklUg9yhKjnTEs3Ls0eSI2aMJ8+tRicrFAKlDyrEBNMSSEaMsSJ84Ro5xpRra+GMBkGXFYgwTPC7y3tj20Gg==
+vega-selections@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.6.0.tgz#9ffa55039f2e7ad71d4926147b8d458375ce611f"
+  integrity sha512-UE2w78rUUbaV3Ph+vQbQDwh8eywIJYRxBiZdxEG/Tr/KtFMLdy2BDgNZuuDO1Nv8jImPJwONmqjNhNDYwM0VJQ==
   dependencies:
     d3-array "3.2.4"
-    vega-expression "^5.1.2"
+    vega-expression "^5.2.0"
     vega-util "^1.17.3"
 
 vega-spec-injector@^0.0.2:
@@ -31129,14 +31129,14 @@ vega-transforms@~4.12.1:
     vega-time "^2.1.3"
     vega-util "^1.17.3"
 
-vega-typings@~1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-1.4.0.tgz#5223287f2e5aa891900f0b70ea9a48c4cdbf01a6"
-  integrity sha512-UTXjuasq0Q8uMuzz/qow4moVHFJ5atYdQu871QZJ/zgWY3Po4du3dIGBVQN4fYEv6seKhDvxpEFke2rqx81Wqw==
+vega-typings@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-1.5.0.tgz#f3304157b86b8bf45c983959d1530f8098cd5493"
+  integrity sha512-tcZ2HwmiQEOXIGyBMP8sdCnoFoVqHn4KQ4H0MQiHwzFU1hb1EXURhfc+Uamthewk4h/9BICtAM3AFQMjBGpjQA==
   dependencies:
     "@types/geojson" "7946.0.4"
     vega-event-selector "^3.0.1"
-    vega-expression "^5.1.2"
+    vega-expression "^5.2.0"
     vega-util "^1.17.3"
 
 vega-util@^1.17.0, vega-util@^1.17.1, vega-util@^1.17.3, vega-util@~1.17.0, vega-util@~1.17.2:
@@ -31153,16 +31153,16 @@ vega-view-transforms@~4.6.1:
     vega-scenegraph "^4.13.1"
     vega-util "^1.17.3"
 
-vega-view@~5.14.0:
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.14.0.tgz#b0f21c448e8c43af6014a76fad31cd5e5fb232d4"
-  integrity sha512-gg2ukCviKG6Nofmr0Y6hFbr9romRMzmXHe3ljNJ5QyRnkwmQ7HbTvXOyS9cZZ0VtuhSRw+uiyd0Pg+nep0IhwA==
+vega-view@~5.16.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.16.0.tgz#e3882f9dcb9368322a255224e5e54db864b3c226"
+  integrity sha512-Nxp1MEAY+8bphIm+7BeGFzWPoJnX9+hgvze6wqCAPoM69YiyVR0o0VK8M2EESIL+22+Owr0Fdy94hWHnmon5tQ==
   dependencies:
     d3-array "^3.2.2"
     d3-timer "^3.0.1"
     vega-dataflow "^5.7.7"
     vega-format "^1.1.3"
-    vega-functions "^5.16.0"
+    vega-functions "^5.18.0"
     vega-runtime "^6.2.1"
     vega-scenegraph "^4.13.1"
     vega-util "^1.17.3"
@@ -31187,24 +31187,24 @@ vega-wordcloud@~4.1.6:
     vega-statistics "^1.9.0"
     vega-util "^1.17.3"
 
-vega@^5.26.0:
-  version "5.31.0"
-  resolved "https://registry.yarnpkg.com/vega/-/vega-5.31.0.tgz#6d07f92f47df060a7c0fadcfadfc6a7cb705e1de"
-  integrity sha512-ZZ+8kcKqCeRi7pBdS7kfBpfhV2gDpa6N950GKGWFw0QL4fH319A9o8FAJzdY8zK0WW0PKrivZSoRmK9fWUxnhg==
+vega@^5.33.0:
+  version "5.33.0"
+  resolved "https://registry.yarnpkg.com/vega/-/vega-5.33.0.tgz#15e5eb9a4a42aaac0564257795daea3acc0d1b21"
+  integrity sha512-jNAGa7TxLojOpMMMrKMXXBos4K6AaLJbCgGDOw1YEkLRjUkh12pcf65J2lMSdEHjcEK47XXjKiOUVZ8L+MniBA==
   dependencies:
     vega-crossfilter "~4.1.3"
     vega-dataflow "~5.7.7"
     vega-encode "~4.10.2"
     vega-event-selector "~3.0.1"
-    vega-expression "~5.1.2"
+    vega-expression "~5.2.0"
     vega-force "~4.2.2"
     vega-format "~1.1.3"
-    vega-functions "~5.16.0"
+    vega-functions "~5.18.0"
     vega-geo "~4.4.3"
     vega-hierarchy "~4.1.3"
     vega-label "~1.3.1"
     vega-loader "~4.5.3"
-    vega-parser "~6.4.1"
+    vega-parser "~6.6.0"
     vega-projection "~1.6.2"
     vega-regression "~1.3.1"
     vega-runtime "~6.2.1"
@@ -31213,9 +31213,9 @@ vega@^5.26.0:
     vega-statistics "~1.9.0"
     vega-time "~2.1.3"
     vega-transforms "~4.12.1"
-    vega-typings "~1.4.0"
+    vega-typings "~1.5.0"
     vega-util "~1.17.2"
-    vega-view "~5.14.0"
+    vega-view "~5.16.0"
     vega-view-transforms "~4.6.1"
     vega-voronoi "~4.2.4"
     vega-wordcloud "~4.1.6"


### PR DESCRIPTION
## Summary

Upgrade `vega` from `5.31.0` to `5.33.0`:
* https://github.com/vega/vega/releases/tag/v5.32.0
* https://github.com/vega/vega/releases/tag/v5.33.0

<!--ONMERGE {"backportTargets":["7.17","8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->