### PR TITLE
[Dashboards] Fix panel actions hidden behind top nav in maximize mode

### DIFF
--- a/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/use_hover_actions_styles.tsx
+++ b/src/platform/plugins/private/presentation_panel/public/panel_component/panel_header/use_hover_actions_styles.tsx
@@ -81,6 +81,10 @@ export const useHoverActionStyles = (isEditMode: boolean, showBorder?: boolean) 
         opacity: 1;
         visibility: visible;
         transition: none; // apply transition delay on hover out only
+        // when the panel is in fullscreen mode, increase the z-index of the hover actions to be above the sticky nav
+        .kbnGridPanel--expanded & {
+          z-index: ${euiTheme.levels.toast};
+        }
       }
     `;
   }, [euiTheme, showBorder, isEditMode]);


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/216289

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->