### PR TITLE
[Fleet] disable unenroll action on agentless agents

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_details_page/components/actions_menu.tsx
@@ -79,7 +79,7 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
           </EuiContextMenuItem>,
           <EuiContextMenuItem
             icon="refresh"
-            disabled={!isAgentUpgradeable(agent)}
+            disabled={!isAgentUpgradeable(agent) || agentPolicy?.supports_agentless === true}
             onClick={() => {
               setIsUpgradeModalOpen(true);
             }}
@@ -146,7 +146,9 @@ export const AgentDetailsActionMenu: React.FunctionComponent<{
       ? [
           <EuiContextMenuItem
             icon="trash"
-            disabled={!hasFleetAllPrivileges || !agent.active}
+            disabled={
+              !hasFleetAllPrivileges || !agent.active || agentPolicy?.supports_agentless === true
+            }
             onClick={() => {
               setIsUnenrollModalOpen(true);
             }}

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_row_actions.tsx
@@ -83,7 +83,7 @@ export const TableRowActions: React.FunctionComponent<{
       </EuiContextMenuItem>,
       <EuiContextMenuItem
         key="agentUnenrollBtn"
-        disabled={!agent.active}
+        disabled={!agent.active || agentPolicy?.supports_agentless === true}
         icon="trash"
         onClick={() => {
           onUnenrollClick();

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/unenroll.ts
@@ -10,7 +10,7 @@ import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/
 import { v4 as uuidv4 } from 'uuid';
 
 import type { Agent } from '../../types';
-import { HostedAgentPolicyRestrictionRelatedError } from '../../errors';
+import { FleetError, HostedAgentPolicyRestrictionRelatedError } from '../../errors';
 import { SO_SEARCH_LIMIT } from '../../constants';
 import { getCurrentNamespace } from '../spaces/get_current_namespace';
 import { agentsKueryNamespaceFilter } from '../spaces/agent_namespaces';
@@ -37,6 +37,10 @@ async function unenrollAgentIsAllowed(
     throw new HostedAgentPolicyRestrictionRelatedError(
       `Cannot unenroll ${agentId} from a hosted agent policy ${agentPolicy.id}`
     );
+  }
+
+  if (agentPolicy?.supports_agentless) {
+    throw new FleetError(`Cannot unenroll agentless agent ${agentId}`);
   }
 
   return true;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/209173

Disable Unenroll agent action on agentless agents

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/6603bac5-b0b1-4a20-8b16-f121bd69e969" />
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/e41bca5b-f73d-44bc-b095-9970a25f6322" />


<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->