### PR TITLE
[ResponseOps][Task Manager] Task manager had an issue calculating capacity estimation. averageLoadPercentage: NaN

### DIFF
--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/capacity_estimation.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/capacity_estimation.ts
@@ -277,6 +277,7 @@ export function withCapacityEstimate(
       };
     } catch (e) {
       // Return monitoredStats with out capacity estimation
+      logger.debug(e.message);
     }
   }
   return monitoredStats;

--- a/x-pack/platform/plugins/shared/task_manager/server/monitoring/capacity_estimation.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/monitoring/capacity_estimation.ts
@@ -277,7 +277,6 @@ export function withCapacityEstimate(
       };
     } catch (e) {
       // Return monitoredStats with out capacity estimation
-      logger.error(e.message);
     }
   }
   return monitoredStats;


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/215045

## Summary

This PR removes this log as it's not needed and is causing alerts in serverless.




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->