### PR TITLE
[docs] Remove reliance on temporary redirects

### DIFF
--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -511,7 +511,7 @@ If search latency in {{es}} is sufficiently high, such as if you are using cross
 ## Logging and audit settings [ec_logging_and_audit_settings]
 
 ::::{note}
-To change logging settings or to enable auditing you must first [enable deployment logging](docs-content://deploy-manage/monitor/stack-monitoring/elastic-cloud-stack-monitoring.md).
+To change logging settings or to enable auditing you must first [enable deployment logging](docs-content://deploy-manage/monitor/stack-monitoring/ece-ech-stack-monitoring.md).
 ::::
 
 

--- a/docs/reference/configuration-reference/fleet-settings.md
+++ b/docs/reference/configuration-reference/fleet-settings.md
@@ -18,9 +18,9 @@ If a setting is applicable to {{ecloud}} Hosted environments, its name is follow
 
 By default, {{fleet}} is enabled. To use {{fleet}}, you also need to configure {{kib}} and {{es}} hosts.
 
-Many {{fleet}} settings can also be configured directly through the {{fleet}} UI. See [Fleet UI settings](docs-content://reference/ingestion-tools/fleet/fleet-settings.md) for details.
+Many {{fleet}} settings can also be configured directly through the {{fleet}} UI. See [Fleet UI settings](docs-content://reference/fleet/fleet-settings.md) for details.
 
-Go to the [{{fleet}}](docs-content://reference/ingestion-tools/fleet/index.md) docs for more information about {{fleet}}.
+Go to the [{{fleet}}](docs-content://reference/fleet/index.md) docs for more information about {{fleet}}.
 
 ## General {{fleet}} settings [general-fleet-settings-kb]
 
@@ -28,7 +28,7 @@ Go to the [{{fleet}}](docs-content://reference/ingestion-tools/fleet/index.md) d
 :   Set to `true` (default) to enable {{fleet}}.
 
 `xpack.fleet.isAirGapped`
-:   Set to `true` to indicate {{fleet}} is running in an air-gapped environment. Refer to [Air-gapped environments](docs-content://reference/ingestion-tools/fleet/air-gapped.md) for details. Enabling this flag helps Fleet skip needless requests and improve the user experience for air-gapped environments.
+:   Set to `true` to indicate {{fleet}} is running in an air-gapped environment. Refer to [Air-gapped environments](docs-content://reference/fleet/air-gapped.md) for details. Enabling this flag helps Fleet skip needless requests and improve the user experience for air-gapped environments.
 
 `xpack.fleet.createArtifactsBulkBatchSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
 :   Allow to configure batch size for creating and updating Fleet user artifacts.  Examples include creation of Trusted Applications and Endpoint Exceptions in Security. It is available in {{ecloud}} 8.9.0 and later versions.
@@ -40,7 +40,7 @@ Go to the [{{fleet}}](docs-content://reference/ingestion-tools/fleet/index.md) d
 :   The address to use to reach the {{package-manager}} registry.
 
 `xpack.fleet.registryProxyUrl`
-:   The proxy address to use to reach the {{package-manager}} registry if an internet connection is not directly available. Refer to [Air-gapped environments](docs-content://reference/ingestion-tools/fleet/air-gapped.md) for details.
+:   The proxy address to use to reach the {{package-manager}} registry if an internet connection is not directly available. Refer to [Air-gapped environments](docs-content://reference/fleet/air-gapped.md) for details.
 
 `xpack.fleet.packageVerification.gpgKeyPath`
 :   The path on disk to the GPG key used to verify {{package-manager}} packages. If the Elastic public key is ever reissued as a security precaution, you can use this setting to specify the new key.
@@ -197,7 +197,7 @@ These settings are not supported to pre-configure the Endpoint and Cloud Securit
 `xpack.fleet.outputs`
 :   List of outputs that are configured when the {{fleet}} app starts.
 
-    Certain types of outputs have additional required and optional settings. Refer to [Output settings](docs-content://reference/ingestion-tools/fleet/fleet-settings.md#output-settings) in the {{fleet}} and {{agent}} Guide for the full list of settings for each output type.
+    Certain types of outputs have additional required and optional settings. Refer to [Output settings](docs-content://reference/fleet/fleet-settings.md#output-settings) in the {{fleet}} and {{agent}} Guide for the full list of settings for each output type.
 
     If configured in your `kibana.yml`, output settings are grayed out and unavailable in the {{fleet}} UI. To make these settings editable in the UI, do not configure them in the configuration file.
 

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -199,7 +199,7 @@ $$$logging-root-level$$$ `logging.root.level` ![logo cloud](https://doc-icons.s3
 :   Level at which a log record should be logged. Supported levels are: *all*, *fatal*, *error*, *warn*, *info*, *debug*, *trace*, *off*. Levels are ordered from *all* (highest) to *off* and a log record will be logged it its level is higher than or equal to the level of its logger, otherwise the log record is ignored. Use this value to [change the overall log level](docs-content://deploy-manage/monitor/logging-configuration/kibana-log-settings-examples.md#change-overall-log-level). **Default: `info`**.
 
     ::::{tip}
-    Set to `all` to log all events, including system usage information and all requests. Set to `off` to silence all logs.  You can also use the logging [cli commands](docs-content://deploy-manage/monitor/logging-configuration/kibana-logging-cli-configuration.md#logging-cli-migration) to set log level to `verbose` or silence all logs.
+    Set to `all` to log all events, including system usage information and all requests. Set to `off` to silence all logs.  You can also use the logging [cli commands](docs-content://deploy-manage/monitor/logging-configuration/kib-advanced-logging.md#logging-cli-migration) to set log level to `verbose` or silence all logs.
     ::::
 
 
@@ -257,7 +257,7 @@ $$$tilemap-url$$$ `map.tilemap.url` ![logo cloud](https://doc-icons.s3.us-east-2
 `migrations.discardCorruptObjects` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
 :   Discard corrupt saved objects, as well as those that cause transform errors during a migration. Must be set to the target version, for example: `8.4.0`. Default: undefined.
     It is available in {{ecloud}} 8.4.0 and later versions.
-% TBD: Supported only in Elastic Cloud? 
+% TBD: Supported only in Elastic Cloud?
 
 `migrations.maxBatchSizeBytes`
 :   Defines the maximum payload size for indexing batches of upgraded saved objects to avoid migrations failing due to a 413 Request Entity Too Large response from Elasticsearch. This value should be lower than or equal to your Elasticsearch cluster’s `http.max_content_length` configuration option. **Default: `100mb`**

--- a/docs/reference/configuration-reference/reporting-settings.md
+++ b/docs/reference/configuration-reference/reporting-settings.md
@@ -30,7 +30,7 @@ $$$xpack-enable-reporting$$$`xpack.reporting.enabled` ![logo cloud](https://doc-
 :   When `true`, enables the {{report-features}}. Set this to `false` to disable {{report-features}} entirely. The default is `true`.
 
 ::::{note}
-Disabling the {{report-features}} is discouraged. If you need to turn off the ability to generate reports, configure the roles and spaces in the [{{kib}} application privileges](docs-content://deploy-manage/deploy/kibana-reporting-configuration.md#grant-user-access).
+Disabling the {{report-features}} is discouraged. If you need to turn off the ability to generate reports, configure the roles and spaces in the [{{kib}} application privileges](docs-content://deploy-manage/kibana-reporting-configuration.md#grant-user-access).
 
 If needed, you can also prevent a {{kib}} instance from claiming reporting work by setting [`xpack.reporting.queue.pollEnabled: false`](#xpack-reportingQueue-pollEnabled).
 
@@ -87,7 +87,7 @@ $$$xpack-reporting-q-timeout$$$ `xpack.reporting.queue.timeout` ![logo cloud](ht
 ::::{note}
 We recommend using PNG/PDF reports to export moderate amounts of data only. The feature enables a high-level export capability, but it’s not intended for bulk export. If you need to export several pages of image data, consider using multiple report jobs to export a small number of pages at a time. If the screenshot of exported dashboard contains a large number of pixels, consider splitting the large dashboard into smaller artifacts to use less memory and CPU resources.
 
-For the most reliable configuration of PDF/PNG {{report-features}}, consider installing {{kib}} using [Docker](docs-content://deploy-manage/deploy/self-managed/install-with-docker.md) or using [Elastic Cloud](docs-content://deploy-manage/deploy/elastic-cloud.md).
+For the most reliable configuration of PDF/PNG {{report-features}}, consider installing {{kib}} using [Docker](docs-content://deploy-manage/deploy/self-managed/install-kibana-with-docker.md) or using [Elastic Cloud](docs-content://deploy-manage/deploy/elastic-cloud.md).
 
 ::::
 
@@ -119,7 +119,7 @@ If any timeouts from `xpack.screenshotting.capture.timeouts.*` settings occur wh
 For PDF and PNG reports, Reporting spawns a headless Chromium browser process on the server to load and capture a screenshot of the {{kib}} app. When installing {{kib}} on Linux and Windows platforms, the Chromium binary comes bundled with the {{kib}} download. For Mac platforms, the Chromium binary is downloaded the first time {{kib}} is started.
 
 `xpack.screenshotting.browser.chromium.disableSandbox`
-:   It is recommended that you research the feasibility of enabling unprivileged user namespaces. An exception is if you are running {{kib}} in Docker because the container runs in a user namespace with the built-in seccomp/bpf filters. For more information, refer to [Chromium sandbox](docs-content://deploy-manage/deploy/kibana-reporting-configuration.md#reporting-chromium-sandbox). Defaults to `false` for all operating systems except CentOS, Debian, and Red Hat Linux, which use `true`.
+:   It is recommended that you research the feasibility of enabling unprivileged user namespaces. An exception is if you are running {{kib}} in Docker because the container runs in a user namespace with the built-in seccomp/bpf filters. For more information, refer to [Chromium sandbox](docs-content://deploy-manage/kibana-reporting-configuration.md#reporting-chromium-sandbox). Defaults to `false` for all operating systems except CentOS, Debian, and Red Hat Linux, which use `true`.
 
 `xpack.screenshotting.browser.chromium.proxy.enabled`
 :   Enables the proxy for Chromium to use. When set to `true`, you must also specify the `xpack.screenshotting.browser.chromium.proxy.server` setting. Defaults to `false`.

--- a/docs/reference/kibana-audit-events.md
+++ b/docs/reference/kibana-audit-events.md
@@ -6,7 +6,7 @@ navigation_title: Kibana audit events
 
 Audit logging is a [subscription feature](https://www.elastic.co/subscriptions) that you can enable to keep track of security-related events, such as authorization success and failures. Logging these events enables you to monitor Kibana for suspicious activity and provides evidence in the event of an attack.
 
-Refer to [enabling](docs-content://deploy-manage/monitor/logging-configuration/enabling-audit-logs.md) and [configuring](docs-content://deploy-manage/monitor/logging-configuration/configuring-audit-logs.md) audit logs for details on activation and tunning.
+Refer to [enabling](docs-content://deploy-manage/security/logging-configuration/enabling-audit-logs.md) and [configuring](docs-content://deploy-manage/security/logging-configuration/configuring-audit-logs.md) audit logs for details on activation and tunning.
 
 ## Kibana audit events [xpack-security-ecs-audit-logging]
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs-content/pull/914

Removes reliance on temporary redirects in the docs-content repo.

@florent-leborgne can you help me with backport labels? I always get mixed up across repos.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->