### PR TITLE
[8.x] [Security Solution][Detection Engine] Remove CreateRuleOptions, pass options through security rule wrapper instead (#216039)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
@@ -51,10 +51,7 @@ import type { RuleExecutionContext, StatusChangeArgs } from '../../../rule_monit
 
 import type { ConfigType } from '../../../../../config';
 import { alertInstanceFactoryStub } from './alert_instance_factory_stub';
-import type {
-  CreateRuleOptions,
-  CreateSecurityRuleTypeWrapperProps,
-} from '../../../rule_types/types';
+import type { CreateSecurityRuleTypeWrapperProps } from '../../../rule_types/types';
 import {
   createEqlAlertType,
   createEsqlAlertType,
@@ -79,7 +76,6 @@ export const previewRulesRoute = (
   config: ConfigType,
   ml: SetupPlugins['ml'],
   security: SetupPlugins['security'],
-  ruleOptions: CreateRuleOptions,
   securityRuleTypeOptions: CreateSecurityRuleTypeWrapperProps,
   previewRuleDataClient: IRuleDataClient,
   getStartServices: StartServicesAccessor<StartPlugins>,
@@ -356,7 +352,6 @@ export const previewRulesRoute = (
             case 'query':
               const queryAlertType = previewRuleTypeWrapper(
                 createQueryAlertType({
-                  ...ruleOptions,
                   id: QUERY_RULE_TYPE_ID,
                   name: 'Custom Query Rule',
                 })
@@ -380,7 +375,6 @@ export const previewRulesRoute = (
             case 'saved_query':
               const savedQueryAlertType = previewRuleTypeWrapper(
                 createQueryAlertType({
-                  ...ruleOptions,
                   id: SAVED_QUERY_RULE_TYPE_ID,
                   name: 'Saved Query Rule',
                 })
@@ -402,9 +396,7 @@ export const previewRulesRoute = (
               );
               break;
             case 'threshold':
-              const thresholdAlertType = previewRuleTypeWrapper(
-                createThresholdAlertType(ruleOptions)
-              );
+              const thresholdAlertType = previewRuleTypeWrapper(createThresholdAlertType());
               await runExecutors(
                 thresholdAlertType.executor,
                 thresholdAlertType.id,
@@ -422,9 +414,7 @@ export const previewRulesRoute = (
               );
               break;
             case 'threat_match':
-              const threatMatchAlertType = previewRuleTypeWrapper(
-                createIndicatorMatchAlertType(ruleOptions)
-              );
+              const threatMatchAlertType = previewRuleTypeWrapper(createIndicatorMatchAlertType());
               await runExecutors(
                 threatMatchAlertType.executor,
                 threatMatchAlertType.id,
@@ -442,7 +432,7 @@ export const previewRulesRoute = (
               );
               break;
             case 'eql':
-              const eqlAlertType = previewRuleTypeWrapper(createEqlAlertType(ruleOptions));
+              const eqlAlertType = previewRuleTypeWrapper(createEqlAlertType());
               await runExecutors(
                 eqlAlertType.executor,
                 eqlAlertType.id,
@@ -463,7 +453,7 @@ export const previewRulesRoute = (
               if (config.experimentalFeatures.esqlRulesDisabled) {
                 throw Error('ES|QL rule type is not supported');
               }
-              const esqlAlertType = previewRuleTypeWrapper(createEsqlAlertType(ruleOptions));
+              const esqlAlertType = previewRuleTypeWrapper(createEsqlAlertType());
               await runExecutors(
                 esqlAlertType.executor,
                 esqlAlertType.id,
@@ -481,7 +471,7 @@ export const previewRulesRoute = (
               );
               break;
             case 'machine_learning':
-              const mlAlertType = previewRuleTypeWrapper(createMlAlertType(ruleOptions));
+              const mlAlertType = previewRuleTypeWrapper(createMlAlertType(ml));
               await runExecutors(
                 mlAlertType.executor,
                 mlAlertType.id,
@@ -499,9 +489,7 @@ export const previewRulesRoute = (
               );
               break;
             case 'new_terms':
-              const newTermsAlertType = previewRuleTypeWrapper(
-                createNewTermsAlertType(ruleOptions)
-              );
+              const newTermsAlertType = previewRuleTypeWrapper(createNewTermsAlertType());
               await runExecutors(
                 newTermsAlertType.executor,
                 newTermsAlertType.id,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/register_routes.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_preview/api/register_routes.ts
@@ -11,7 +11,7 @@ import type { IRuleDataClient } from '@kbn/rule-registry-plugin/server';
 import type { ConfigType } from '../../../../config';
 import type { SetupPlugins, StartPlugins } from '../../../../plugin_contract';
 import type { SecuritySolutionPluginRouter } from '../../../../types';
-import type { CreateRuleOptions, CreateSecurityRuleTypeWrapperProps } from '../../rule_types/types';
+import type { CreateSecurityRuleTypeWrapperProps } from '../../rule_types/types';
 
 import { previewRulesRoute } from './preview_rules/route';
 
@@ -20,7 +20,6 @@ export const registerRulePreviewRoutes = (
   config: ConfigType,
   ml: SetupPlugins['ml'],
   security: SetupPlugins['security'],
-  ruleOptions: CreateRuleOptions,
   securityRuleTypeOptions: CreateSecurityRuleTypeWrapperProps,
   previewRuleDataClient: IRuleDataClient,
   getStartServices: StartServicesAccessor<StartPlugins>,
@@ -32,7 +31,6 @@ export const registerRulePreviewRoutes = (
     config,
     ml,
     security,
-    ruleOptions,
     securityRuleTypeOptions,
     previewRuleDataClient,
     getStartServices,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions/schedule_notification_response_actions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_response_actions/schedule_notification_response_actions.ts
@@ -14,16 +14,19 @@ import { endpointResponseAction } from './endpoint_response_action';
 import type { ScheduleNotificationActions } from '../rule_types/types';
 import type { Alert, AlertWithAgent } from './types';
 
-interface ScheduleNotificationResponseActionsService {
+interface ScheduleNotificationResponseActionsServiceParams {
   endpointAppContextService: EndpointAppContextService;
   osqueryCreateActionService?: SetupPlugins['osquery']['createActionService'];
 }
 
+export type ScheduleNotificationResponseActionsService = (
+  params: ScheduleNotificationActions
+) => void;
 export const getScheduleNotificationResponseActionsService =
   ({
     osqueryCreateActionService,
     endpointAppContextService,
-  }: ScheduleNotificationResponseActionsService) =>
+  }: ScheduleNotificationResponseActionsServiceParams): ScheduleNotificationResponseActionsService =>
   async ({ signals, signalsCount, responseActions }: ScheduleNotificationActions) => {
     if (!signalsCount || !responseActions?.length) {
       return;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/__mocks__/shared_params.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/__mocks__/shared_params.ts
@@ -13,6 +13,9 @@ import type { SecuritySharedParams } from '../types';
 import { getListClientMock } from '@kbn/lists-plugin/server/services/lists/list_client.mock';
 import { createRuleDataClientMock } from '@kbn/rule-registry-plugin/server/rule_data_client/rule_data_client.mock';
 import { getCompleteRuleMock } from '../../rule_schema/mocks';
+import { allowedExperimentalValues } from '../../../../../common/experimental_features';
+import { createMockTelemetryEventsSender } from '../../../telemetry/__mocks__';
+import { licensingMock } from '@kbn/licensing-plugin/server/mocks';
 
 export const getSharedParamsMock = <T extends RuleParams = QueryRuleParams>({
   ruleParams,
@@ -28,6 +31,7 @@ export const getSharedParamsMock = <T extends RuleParams = QueryRuleParams>({
   inputIndex: DEFAULT_INDEX_PATTERN,
   alertTimestampOverride: undefined,
   publicBaseUrl: 'http://testkibanabaseurl.com',
+  experimentalFeatures: allowedExperimentalValues,
   intendedTimestamp: undefined,
   primaryTimestamp: '@timestamp',
   listClient: getListClientMock(),
@@ -45,5 +49,8 @@ export const getSharedParamsMock = <T extends RuleParams = QueryRuleParams>({
   refreshOnIndexingAlerts: false,
   ignoreFields: {},
   ignoreFieldsRegexes: [],
+  eventsTelemetry: createMockTelemetryEventsSender(true),
+  licensing: licensingMock.createSetup(),
+  scheduleNotificationResponseActionsService: () => null,
   ...rewrites,
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -106,6 +106,9 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
     experimentalFeatures,
     alerting,
     analytics,
+    eventsTelemetry,
+    licensing,
+    scheduleNotificationResponseActionsService,
   }) =>
   (type) => {
     const { alertIgnoreFields: ignoreFields, alertMergeStrategy: mergeStrategy } = config;
@@ -370,7 +373,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
               message: gapErrorMessage,
               metrics: {
                 executionGap: remainingGap,
-                gapRange: experimentalFeatures?.storeGapsInEventLogEnabled ? gap : undefined,
+                gapRange: experimentalFeatures.storeGapsInEventLogEnabled ? gap : undefined,
               },
             });
           }
@@ -449,6 +452,9 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                     spaceId,
                     ignoreFields: ignoreFieldsObject,
                     ignoreFieldsRegexes,
+                    eventsTelemetry,
+                    licensing,
+                    scheduleNotificationResponseActionsService,
                   },
                 });
 
@@ -527,7 +533,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   indexingDurations: result.bulkCreateTimes,
                   enrichmentDurations: result.enrichmentTimes,
                   executionGap: remainingGap,
-                  gapRange: experimentalFeatures?.storeGapsInEventLogEnabled ? gap : undefined,
+                  gapRange: experimentalFeatures.storeGapsInEventLogEnabled ? gap : undefined,
                 },
                 userError: result.userError,
               });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/eql/create_eql_alert_type.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/eql/create_eql_alert_type.ts
@@ -11,17 +11,13 @@ import { DEFAULT_APP_CATEGORIES } from '@kbn/core-application-common';
 import { SERVER_APP_ID } from '../../../../../common/constants';
 import { EqlRuleParams } from '../../rule_schema';
 import { eqlExecutor } from './eql';
-import type { CreateRuleOptions, SecurityAlertType, SignalSourceHit } from '../types';
+import type { SecurityAlertType, SignalSourceHit } from '../types';
 import { validateIndexPatterns } from '../utils';
 import { getIsAlertSuppressionActive } from '../utils/get_is_alert_suppression_active';
 import { wrapSuppressedAlerts } from '../utils/wrap_suppressed_alerts';
 import type { BuildReasonMessage } from '../utils/reason_formatters';
 
-export const createEqlAlertType = (
-  createOptions: CreateRuleOptions
-): SecurityAlertType<EqlRuleParams, {}> => {
-  const { experimentalFeatures, licensing, scheduleNotificationResponseActionsService } =
-    createOptions;
+export const createEqlAlertType = (): SecurityAlertType<EqlRuleParams, {}> => {
   return {
     id: EQL_RULE_TYPE_ID,
     name: 'Event Correlation Rule',
@@ -66,7 +62,7 @@ export const createEqlAlertType = (
 
       const isAlertSuppressionActive = await getIsAlertSuppressionActive({
         alertSuppression: sharedParams.completeRule.ruleParams.alertSuppression,
-        licensing,
+        licensing: sharedParams.licensing,
       });
 
       const wrapSuppressedHits = (
@@ -84,9 +80,10 @@ export const createEqlAlertType = (
         services,
         wrapSuppressedHits,
         isAlertSuppressionActive,
-        experimentalFeatures,
+        experimentalFeatures: sharedParams.experimentalFeatures,
         state,
-        scheduleNotificationResponseActionsService,
+        scheduleNotificationResponseActionsService:
+          sharedParams.scheduleNotificationResponseActionsService,
       });
       return { ...result, state, ...(loggedRequests ? { loggedRequests } : {}) };
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/eql/eql.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/eql/eql.ts
@@ -13,7 +13,6 @@ import type { ExperimentalFeatures } from '../../../../../common';
 import type {
   SearchAfterAndBulkCreateReturnType,
   SignalSource,
-  CreateRuleOptions,
   WrapSuppressedHits,
   SecuritySharedParams,
   SecurityRuleServices,
@@ -47,6 +46,7 @@ import { logShardFailures } from '../utils/log_shard_failure';
 import { checkErrorDetails } from '../utils/check_error_details';
 import { wrapSequences } from './wrap_sequences';
 import { bulkCreate, wrapHits } from '../factories';
+import type { ScheduleNotificationResponseActionsService } from '../../rule_response_actions/schedule_notification_response_actions';
 
 interface EqlExecutorParams {
   sharedParams: SecuritySharedParams<EqlRuleParams>;
@@ -55,7 +55,7 @@ interface EqlExecutorParams {
   isAlertSuppressionActive: boolean;
   experimentalFeatures: ExperimentalFeatures;
   state?: Record<string, unknown>;
-  scheduleNotificationResponseActionsService: CreateRuleOptions['scheduleNotificationResponseActionsService'];
+  scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
 }
 
 export const eqlExecutor = async ({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/esql/create_esql_alert_type.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/esql/create_esql_alert_type.ts
@@ -11,12 +11,9 @@ import { DEFAULT_APP_CATEGORIES } from '@kbn/core-application-common';
 import { SERVER_APP_ID } from '../../../../../common/constants';
 import { EsqlRuleParams } from '../../rule_schema';
 import { esqlExecutor } from './esql';
-import type { CreateRuleOptions, SecurityAlertType } from '../types';
+import type { SecurityAlertType } from '../types';
 
-export const createEsqlAlertType = (
-  createOptions: CreateRuleOptions
-): SecurityAlertType<EsqlRuleParams, {}> => {
-  const { licensing, scheduleNotificationResponseActionsService } = createOptions;
+export const createEsqlAlertType = (): SecurityAlertType<EsqlRuleParams, {}> => {
   return {
     id: ESQL_RULE_TYPE_ID,
     name: 'ES|QL Rule',
@@ -48,8 +45,9 @@ export const createEsqlAlertType = (
     executor: (params) =>
       esqlExecutor({
         ...params,
-        licensing,
-        scheduleNotificationResponseActionsService,
+        licensing: params.sharedParams.licensing,
+        scheduleNotificationResponseActionsService:
+          params.sharedParams.scheduleNotificationResponseActionsService,
       }),
   };
 };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/esql/esql.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/esql/esql.ts
@@ -23,12 +23,7 @@ import { rowToDocument, mergeEsqlResultInSource, getMvExpandUsage } from './util
 import { fetchSourceDocuments } from './fetch_source_documents';
 import { buildReasonMessageForEsqlAlert } from '../utils/reason_formatters';
 import type { RulePreviewLoggedRequest } from '../../../../../common/api/detection_engine/rule_preview/rule_preview.gen';
-import type {
-  CreateRuleOptions,
-  SecurityRuleServices,
-  SecuritySharedParams,
-  SignalSource,
-} from '../types';
+import type { SecurityRuleServices, SecuritySharedParams, SignalSource } from '../types';
 import { logEsqlRequest } from '../utils/logged_requests';
 import { getDataTierFilter } from '../utils/get_data_tier_filter';
 import { checkErrorDetails } from '../utils/check_error_details';
@@ -49,6 +44,7 @@ import {
   getIsAlertSuppressionActive,
 } from '../utils/get_is_alert_suppression_active';
 import { bulkCreate } from '../factories';
+import type { ScheduleNotificationResponseActionsService } from '../../rule_response_actions/schedule_notification_response_actions';
 
 export const esqlExecutor = async ({
   sharedParams,
@@ -61,7 +57,7 @@ export const esqlExecutor = async ({
   services: SecurityRuleServices;
   state: Record<string, unknown>;
   licensing: LicensingPluginSetup;
-  scheduleNotificationResponseActionsService: CreateRuleOptions['scheduleNotificationResponseActionsService'];
+  scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
 }) => {
   const {
     completeRule,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/create_indicator_match_alert_type.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/create_indicator_match_alert_type.ts
@@ -12,15 +12,12 @@ import { SERVER_APP_ID } from '../../../../../common/constants';
 
 import { ThreatRuleParams } from '../../rule_schema';
 import { indicatorMatchExecutor } from './indicator_match';
-import type { CreateRuleOptions, SecurityAlertType, SignalSourceHit } from '../types';
+import type { SecurityAlertType, SignalSourceHit } from '../types';
 import { validateIndexPatterns } from '../utils';
 import { wrapSuppressedAlerts } from '../utils/wrap_suppressed_alerts';
 import type { BuildReasonMessage } from '../utils/reason_formatters';
 
-export const createIndicatorMatchAlertType = (
-  createOptions: CreateRuleOptions
-): SecurityAlertType<ThreatRuleParams, {}> => {
-  const { eventsTelemetry, licensing, scheduleNotificationResponseActionsService } = createOptions;
+export const createIndicatorMatchAlertType = (): SecurityAlertType<ThreatRuleParams, {}> => {
   return {
     id: INDICATOR_RULE_TYPE_ID,
     name: 'Indicator Match Rule',
@@ -77,10 +74,11 @@ export const createIndicatorMatchAlertType = (
       const result = await indicatorMatchExecutor({
         sharedParams,
         services,
-        eventsTelemetry,
+        eventsTelemetry: sharedParams.eventsTelemetry,
         wrapSuppressedHits,
-        licensing,
-        scheduleNotificationResponseActionsService,
+        licensing: sharedParams.licensing,
+        scheduleNotificationResponseActionsService:
+          sharedParams.scheduleNotificationResponseActionsService,
       });
       return { ...result, state };
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/indicator_match.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/indicator_match.ts
@@ -7,16 +7,12 @@
 
 import type { LicensingPluginSetup } from '@kbn/licensing-plugin/server';
 
-import type {
-  WrapSuppressedHits,
-  SecuritySharedParams,
-  CreateRuleOptions,
-  SecurityRuleServices,
-} from '../types';
+import type { WrapSuppressedHits, SecuritySharedParams, SecurityRuleServices } from '../types';
 import type { ITelemetryEventsSender } from '../../../telemetry/sender';
 import { createThreatSignals } from './threat_mapping/create_threat_signals';
 import type { ThreatRuleParams } from '../../rule_schema';
 import { withSecuritySpan } from '../../../../utils/with_security_span';
+import type { ScheduleNotificationResponseActionsService } from '../../rule_response_actions/schedule_notification_response_actions';
 
 export const indicatorMatchExecutor = async ({
   sharedParams,
@@ -31,7 +27,7 @@ export const indicatorMatchExecutor = async ({
   eventsTelemetry: ITelemetryEventsSender | undefined;
   wrapSuppressedHits: WrapSuppressedHits;
   licensing: LicensingPluginSetup;
-  scheduleNotificationResponseActionsService: CreateRuleOptions['scheduleNotificationResponseActionsService'];
+  scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
 }) => {
   return withSecuritySpan('indicatorMatchExecutor', async () => {
     return createThreatSignals({

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/types.ts
@@ -24,11 +24,11 @@ import type {
   WrapSuppressedHits,
   OverrideBodyQuery,
   SecuritySharedParams,
-  CreateRuleOptions,
   SecurityRuleServices,
 } from '../../types';
 import type { ThreatRuleParams } from '../../../rule_schema';
 import type { IRuleExecutionLogForExecutors } from '../../../rule_monitoring';
+import type { ScheduleNotificationResponseActionsService } from '../../../rule_response_actions/schedule_notification_response_actions';
 
 export type SortOrderOrUndefined = 'asc' | 'desc' | undefined;
 
@@ -38,7 +38,7 @@ export interface CreateThreatSignalsOptions {
   services: SecurityRuleServices;
   wrapSuppressedHits: WrapSuppressedHits;
   licensing: LicensingPluginSetup;
-  scheduleNotificationResponseActionsService: CreateRuleOptions['scheduleNotificationResponseActionsService'];
+  scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
 }
 
 export interface CreateThreatSignalOptions {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/ml/create_ml_alert_type.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/ml/create_ml_alert_type.ts
@@ -13,13 +13,13 @@ import { SERVER_APP_ID } from '../../../../../common/constants';
 import { MachineLearningRuleParams } from '../../rule_schema';
 import { getIsAlertSuppressionActive } from '../utils/get_is_alert_suppression_active';
 import { mlExecutor } from './ml';
-import type { CreateRuleOptions, SecurityAlertType, WrapSuppressedHits } from '../types';
+import type { SecurityAlertType, WrapSuppressedHits } from '../types';
 import { wrapSuppressedAlerts } from '../utils/wrap_suppressed_alerts';
+import type { SetupPlugins } from '../../../../plugin';
 
 export const createMlAlertType = (
-  createOptions: CreateRuleOptions
+  ml: SetupPlugins['ml']
 ): SecurityAlertType<MachineLearningRuleParams, { isLoggedRequestsEnabled?: boolean }> => {
-  const { ml, licensing, scheduleNotificationResponseActionsService } = createOptions;
   return {
     id: ML_RULE_TYPE_ID,
     name: 'Machine Learning Rule',
@@ -53,7 +53,7 @@ export const createMlAlertType = (
 
       const isAlertSuppressionActive = await getIsAlertSuppressionActive({
         alertSuppression: sharedParams.completeRule.ruleParams.alertSuppression,
-        licensing,
+        licensing: sharedParams.licensing,
       });
       const isLoggedRequestsEnabled = Boolean(state?.isLoggedRequestsEnabled);
 
@@ -70,7 +70,8 @@ export const createMlAlertType = (
         services,
         wrapSuppressedHits,
         isAlertSuppressionActive,
-        scheduleNotificationResponseActionsService,
+        scheduleNotificationResponseActionsService:
+          sharedParams.scheduleNotificationResponseActionsService,
         isLoggedRequestsEnabled,
       });
       return { ...result, state, ...(isLoggedRequestsEnabled ? { loggedRequests } : {}) };

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/ml/ml.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/ml/ml.ts
@@ -14,12 +14,7 @@ import type { MachineLearningRuleParams } from '../../rule_schema';
 import { bulkCreateMlSignals } from './bulk_create_ml_signals';
 import { filterEventsAgainstList } from '../utils/large_list_filters/filter_events_against_list';
 import { findMlSignals } from './find_ml_signals';
-import type {
-  CreateRuleOptions,
-  SecurityRuleServices,
-  SecuritySharedParams,
-  WrapSuppressedHits,
-} from '../types';
+import type { SecurityRuleServices, SecuritySharedParams, WrapSuppressedHits } from '../types';
 import {
   addToSearchAfterReturn,
   createErrorsFromShard,
@@ -33,6 +28,7 @@ import type { AnomalyResults } from '../../../machine_learning';
 import { bulkCreateSuppressedAlertsInMemory } from '../utils/bulk_create_suppressed_alerts_in_memory';
 import { buildReasonMessageForMlAlert } from '../utils/reason_formatters';
 import { alertSuppressionTypeGuard } from '../utils/get_is_alert_suppression_active';
+import type { ScheduleNotificationResponseActionsService } from '../../rule_response_actions/schedule_notification_response_actions';
 
 interface MachineLearningRuleExecutorParams {
   sharedParams: SecuritySharedParams<MachineLearningRuleParams>;
@@ -40,7 +36,7 @@ interface MachineLearningRuleExecutorParams {
   services: SecurityRuleServices;
   wrapSuppressedHits: WrapSuppressedHits;
   isAlertSuppressionActive: boolean;
-  scheduleNotificationResponseActionsService: CreateRuleOptions['scheduleNotificationResponseActionsService'];
+  scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
   isLoggedRequestsEnabled?: boolean;
 }
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/new_terms/create_new_terms_alert_type.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/new_terms/create_new_terms_alert_type.ts
@@ -12,7 +12,7 @@ import { DEFAULT_APP_CATEGORIES } from '@kbn/core-application-common';
 import { SERVER_APP_ID } from '../../../../../common/constants';
 
 import { NewTermsRuleParams } from '../../rule_schema';
-import type { CreateRuleOptions, SecurityAlertType } from '../types';
+import type { SecurityAlertType } from '../types';
 import { singleSearchAfter } from '../utils/single_search_after';
 import { getFilter } from '../utils/get_filter';
 import { wrapNewTermsAlerts } from './wrap_new_terms_alerts';
@@ -50,10 +50,10 @@ import type { RulePreviewLoggedRequest } from '../../../../../common/api/detecti
 import * as i18n from '../translations';
 import { bulkCreate } from '../factories';
 
-export const createNewTermsAlertType = (
-  createOptions: CreateRuleOptions
-): SecurityAlertType<NewTermsRuleParams, { isLoggedRequestsEnabled?: boolean }> => {
-  const { logger, licensing, scheduleNotificationResponseActionsService } = createOptions;
+export const createNewTermsAlertType = (): SecurityAlertType<
+  NewTermsRuleParams,
+  { isLoggedRequestsEnabled?: boolean }
+> => {
   return {
     id: NEW_TERMS_RULE_TYPE_ID,
     name: 'New Terms Rule',
@@ -99,7 +99,7 @@ export const createNewTermsAlertType = (
     producer: SERVER_APP_ID,
     solution: 'security',
     async executor(execOptions) {
-      const { sharedParams, services, params, state } = execOptions;
+      const { sharedParams, services, params, state, logger } = execOptions;
 
       const {
         ruleExecutionLogger,
@@ -112,6 +112,8 @@ export const createNewTermsAlertType = (
         aggregatableTimestampField,
         exceptionFilter,
         unprocessedExceptions,
+        licensing,
+        scheduleNotificationResponseActionsService,
       } = sharedParams;
 
       const isLoggedRequestsEnabled = Boolean(state?.isLoggedRequestsEnabled);

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.test.ts
@@ -49,6 +49,9 @@ describe('Custom Query Alerts', () => {
 
   const { dependencies, executor, services } = mocks;
   const { actions, alerting, lists, logger, ruleDataClient } = dependencies;
+
+  const eventsTelemetry = createMockTelemetryEventsSender(true);
+
   const securityRuleTypeWrapper = createSecurityRuleTypeWrapper({
     actions,
     lists,
@@ -57,10 +60,13 @@ describe('Custom Query Alerts', () => {
     ruleDataClient,
     ruleExecutionLoggerFactory: ruleStatusLogger,
     version: '8.3',
+    experimentalFeatures: allowedExperimentalValues,
     publicBaseUrl,
     alerting,
+    eventsTelemetry,
+    licensing,
+    scheduleNotificationResponseActionsService: () => null,
   });
-  const eventsTelemetry = createMockTelemetryEventsSender(true);
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -69,11 +75,6 @@ describe('Custom Query Alerts', () => {
   it('does not send an alert when no events found', async () => {
     const queryAlertType = securityRuleTypeWrapper(
       createQueryAlertType({
-        eventsTelemetry,
-        licensing,
-        scheduleNotificationResponseActionsService: () => null,
-        experimentalFeatures: allowedExperimentalValues,
-        logger,
         id: QUERY_RULE_TYPE_ID,
         name: 'Custom Query Rule',
       })
@@ -116,11 +117,6 @@ describe('Custom Query Alerts', () => {
   it('sends an alert when events are found', async () => {
     const queryAlertType = securityRuleTypeWrapper(
       createQueryAlertType({
-        eventsTelemetry,
-        licensing,
-        scheduleNotificationResponseActionsService: () => null,
-        experimentalFeatures: allowedExperimentalValues,
-        logger,
         id: QUERY_RULE_TYPE_ID,
         name: 'Custom Query Rule',
       })
@@ -164,11 +160,6 @@ describe('Custom Query Alerts', () => {
     });
     const queryAlertType = securityRuleTypeWrapper(
       createQueryAlertType({
-        eventsTelemetry,
-        licensing,
-        scheduleNotificationResponseActionsService: () => null,
-        experimentalFeatures: allowedExperimentalValues,
-        logger,
         id: QUERY_RULE_TYPE_ID,
         name: 'Custom Query Rule',
       })

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/create_query_alert_type.ts
@@ -22,8 +22,7 @@ export interface QueryRuleState {
 export const createQueryAlertType = (
   createOptions: CreateQueryRuleOptions
 ): SecurityAlertType<UnifiedQueryRuleParams, QueryRuleState> => {
-  const { eventsTelemetry, scheduleNotificationResponseActionsService, licensing, id, name } =
-    createOptions;
+  const { id, name } = createOptions;
   return {
     id,
     name,
@@ -67,11 +66,12 @@ export const createQueryAlertType = (
       const { sharedParams, services, state } = execOptions;
       return queryExecutor({
         sharedParams,
-        eventsTelemetry,
+        eventsTelemetry: sharedParams.eventsTelemetry,
         services,
         bucketHistory: state.suppressionGroupHistory,
-        licensing,
-        scheduleNotificationResponseActionsService,
+        licensing: sharedParams.licensing,
+        scheduleNotificationResponseActionsService:
+          sharedParams.scheduleNotificationResponseActionsService,
         isLoggedRequestsEnabled: Boolean(state?.isLoggedRequestsEnabled),
       });
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/query.ts
@@ -15,7 +15,8 @@ import type { ITelemetryEventsSender } from '../../../telemetry/sender';
 import type { UnifiedQueryRuleParams } from '../../rule_schema';
 import { buildReasonMessageForQueryAlert } from '../utils/reason_formatters';
 import { withSecuritySpan } from '../../../../utils/with_security_span';
-import type { CreateRuleOptions, SecurityRuleServices, SecuritySharedParams } from '../types';
+import type { SecurityRuleServices, SecuritySharedParams } from '../types';
+import type { ScheduleNotificationResponseActionsService } from '../../rule_response_actions/schedule_notification_response_actions';
 
 export const queryExecutor = async ({
   sharedParams,
@@ -30,7 +31,7 @@ export const queryExecutor = async ({
   eventsTelemetry: ITelemetryEventsSender | undefined;
   services: SecurityRuleServices;
   bucketHistory?: BucketHistory[];
-  scheduleNotificationResponseActionsService: CreateRuleOptions['scheduleNotificationResponseActionsService'];
+  scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
   licensing: LicensingPluginSetup;
   isLoggedRequestsEnabled: boolean;
 }) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/create_threshold_alert_type.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/create_threshold_alert_type.ts
@@ -13,13 +13,13 @@ import { SERVER_APP_ID } from '../../../../../common/constants';
 import { ThresholdRuleParams } from '../../rule_schema';
 import { thresholdExecutor } from './threshold';
 import type { ThresholdAlertState } from './types';
-import type { CreateRuleOptions, SecurityAlertType } from '../types';
+import type { SecurityAlertType } from '../types';
 import { validateIndexPatterns } from '../utils';
 
-export const createThresholdAlertType = (
-  createOptions: CreateRuleOptions
-): SecurityAlertType<ThresholdRuleParams, ThresholdAlertState> => {
-  const { licensing, scheduleNotificationResponseActionsService } = createOptions;
+export const createThresholdAlertType = (): SecurityAlertType<
+  ThresholdRuleParams,
+  ThresholdAlertState
+> => {
   return {
     id: THRESHOLD_RULE_TYPE_ID,
     name: 'Threshold Rule',
@@ -66,8 +66,9 @@ export const createThresholdAlertType = (
         services,
         startedAt,
         state,
-        licensing,
-        scheduleNotificationResponseActionsService,
+        licensing: sharedParams.licensing,
+        scheduleNotificationResponseActionsService:
+          sharedParams.scheduleNotificationResponseActionsService,
       });
       return result;
     },

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
@@ -21,7 +21,6 @@ import { bulkCreateSuppressedThresholdAlerts } from './bulk_create_suppressed_th
 import type {
   SearchAfterAndBulkCreateReturnType,
   SecuritySharedParams,
-  CreateRuleOptions,
   SecurityRuleServices,
 } from '../types';
 import type { ThresholdAlertState, ThresholdSignalHistory } from './types';
@@ -33,6 +32,7 @@ import {
 import { withSecuritySpan } from '../../../../utils/with_security_span';
 import { buildThresholdSignalHistory } from './build_signal_history';
 import { getSignalHistory, transformBulkCreatedItemsToHits } from './utils';
+import type { ScheduleNotificationResponseActionsService } from '../../rule_response_actions/schedule_notification_response_actions';
 
 export const thresholdExecutor = async ({
   sharedParams,
@@ -47,7 +47,7 @@ export const thresholdExecutor = async ({
   startedAt: Date;
   state: ThresholdAlertState;
   licensing: LicensingPluginSetup;
-  scheduleNotificationResponseActionsService: CreateRuleOptions['scheduleNotificationResponseActionsService'];
+  scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
 }): Promise<SearchAfterAndBulkCreateReturnType & { state: ThresholdAlertState }> => {
   const {
     completeRule,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
@@ -54,6 +54,7 @@ import type {
   RuleResponse,
 } from '../../../../common/api/detection_engine/model/rule_schema';
 import type { ThresholdResult } from './threshold/types';
+import type { ScheduleNotificationResponseActionsService } from '../rule_response_actions/schedule_notification_response_actions';
 
 export interface SecurityAlertTypeReturnValue<TState extends RuleTypeState> {
   bulkCreateTimes: string[];
@@ -94,11 +95,14 @@ export interface SecuritySharedParams<TParams extends RuleParams = RuleParams> {
   alertTimestampOverride: Date | undefined;
   refreshOnIndexingAlerts: RefreshTypes;
   publicBaseUrl: string | undefined;
-  experimentalFeatures?: ExperimentalFeatures;
+  experimentalFeatures: ExperimentalFeatures;
   intendedTimestamp: Date | undefined;
   spaceId: string;
   ignoreFields: Record<string, boolean>;
   ignoreFieldsRegexes: string[];
+  eventsTelemetry: ITelemetryEventsSender | undefined;
+  licensing: LicensingPluginSetup;
+  scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
 }
 
 type SecurityActionGroupId = 'default';
@@ -146,9 +150,12 @@ export interface CreateSecurityRuleTypeWrapperProps {
   ruleExecutionLoggerFactory: IRuleMonitoringService['createRuleExecutionLogClientForExecutors'];
   version: string;
   isPreview?: boolean;
-  experimentalFeatures?: ExperimentalFeatures;
+  experimentalFeatures: ExperimentalFeatures;
   alerting: SetupPlugins['alerting'];
   analytics?: AnalyticsServiceSetup;
+  eventsTelemetry: ITelemetryEventsSender | undefined;
+  licensing: LicensingPluginSetup;
+  scheduleNotificationResponseActionsService: ScheduleNotificationResponseActionsService;
 }
 
 export type CreateSecurityRuleTypeWrapper = (
@@ -157,22 +164,13 @@ export type CreateSecurityRuleTypeWrapper = (
   type: SecurityAlertType<TParams, TState>
 ) => RuleType<TParams, TParams, TState, AlertInstanceState, AlertInstanceContext, 'default'>;
 
-export interface CreateRuleOptions {
-  experimentalFeatures: ExperimentalFeatures;
-  logger: Logger;
-  ml?: SetupPlugins['ml'];
-  eventsTelemetry?: ITelemetryEventsSender | undefined;
-  licensing: LicensingPluginSetup;
-  scheduleNotificationResponseActionsService: (params: ScheduleNotificationActions) => void;
-}
-
 export interface ScheduleNotificationActions {
   signals: unknown[];
   signalsCount: number;
   responseActions: RuleResponseAction[] | undefined;
 }
 
-export interface CreateQueryRuleOptions extends CreateRuleOptions {
+export interface CreateQueryRuleOptions {
   id: typeof QUERY_RULE_TYPE_ID | typeof SAVED_QUERY_RULE_TYPE_ID;
   name: 'Custom Query Rule' | 'Saved Query Rule';
 }

--- a/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/plugin.ts
@@ -82,7 +82,6 @@ import { PolicyWatcher } from './endpoint/lib/policy/license_watch';
 import previewPolicy from './lib/detection_engine/routes/index/preview_policy.json';
 import type { IRuleMonitoringService } from './lib/detection_engine/rule_monitoring';
 import { createRuleMonitoringService } from './lib/detection_engine/rule_monitoring';
-import type { CreateRuleOptions } from './lib/detection_engine/rule_types/types';
 // eslint-disable-next-line no-restricted-imports
 import {
   isLegacyNotificationRuleExecutor,
@@ -320,19 +319,6 @@ export class Plugin implements ISecuritySolutionPlugin {
     let ruleDataClient: IRuleDataClient | null = null;
     let previewRuleDataClient: IRuleDataClient | null = null;
 
-    // rule options are used both to create and preview rules.
-    const ruleOptions: CreateRuleOptions = {
-      experimentalFeatures,
-      logger: this.logger,
-      ml: plugins.ml,
-      eventsTelemetry: this.telemetryEventsSender,
-      licensing: plugins.licensing,
-      scheduleNotificationResponseActionsService: getScheduleNotificationResponseActionsService({
-        endpointAppContextService: this.endpointAppContextService,
-        osqueryCreateActionService: plugins.osquery.createActionService,
-      }),
-    };
-
     const ruleDataServiceOptions = {
       feature: SERVER_APP_ID,
       registrationContext: 'security',
@@ -370,42 +356,40 @@ export class Plugin implements ISecuritySolutionPlugin {
       experimentalFeatures: config.experimentalFeatures,
       alerting: plugins.alerting,
       analytics: core.analytics,
+      eventsTelemetry: this.telemetryEventsSender,
+      licensing: plugins.licensing,
+      scheduleNotificationResponseActionsService: getScheduleNotificationResponseActionsService({
+        endpointAppContextService: this.endpointAppContextService,
+        osqueryCreateActionService: plugins.osquery?.createActionService,
+      }),
     };
 
     const securityRuleTypeWrapper = createSecurityRuleTypeWrapper(securityRuleTypeOptions);
 
-    plugins.alerting.registerType(securityRuleTypeWrapper(createEqlAlertType({ ...ruleOptions })));
+    plugins.alerting.registerType(securityRuleTypeWrapper(createEqlAlertType()));
     if (!experimentalFeatures.esqlRulesDisabled) {
-      plugins.alerting.registerType(
-        securityRuleTypeWrapper(createEsqlAlertType({ ...ruleOptions }))
-      );
+      plugins.alerting.registerType(securityRuleTypeWrapper(createEsqlAlertType()));
     }
     plugins.alerting.registerType(
       securityRuleTypeWrapper(
         createQueryAlertType({
-          ...ruleOptions,
           id: SAVED_QUERY_RULE_TYPE_ID,
           name: 'Saved Query Rule',
         })
       )
     );
-    plugins.alerting.registerType(
-      securityRuleTypeWrapper(createIndicatorMatchAlertType(ruleOptions))
-    );
-    plugins.alerting.registerType(securityRuleTypeWrapper(createMlAlertType(ruleOptions)));
+    plugins.alerting.registerType(securityRuleTypeWrapper(createIndicatorMatchAlertType()));
+    plugins.alerting.registerType(securityRuleTypeWrapper(createMlAlertType(plugins.ml)));
     plugins.alerting.registerType(
       securityRuleTypeWrapper(
         createQueryAlertType({
-          ...ruleOptions,
           id: QUERY_RULE_TYPE_ID,
           name: 'Custom Query Rule',
         })
       )
     );
-    plugins.alerting.registerType(securityRuleTypeWrapper(createThresholdAlertType(ruleOptions)));
-    plugins.alerting.registerType(
-      securityRuleTypeWrapper(createNewTermsAlertType({ ...ruleOptions }))
-    );
+    plugins.alerting.registerType(securityRuleTypeWrapper(createThresholdAlertType()));
+    plugins.alerting.registerType(securityRuleTypeWrapper(createNewTermsAlertType()));
 
     // TODO We need to get the endpoint routes inside of initRoutes
     initRoutes(
@@ -418,7 +402,6 @@ export class Plugin implements ISecuritySolutionPlugin {
       ruleDataService,
       logger,
       ruleDataClient,
-      ruleOptions,
       core.getStartServices,
       securityRuleTypeOptions,
       previewRuleDataClient,

--- a/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/routes/index.ts
@@ -34,10 +34,7 @@ import { readPrivilegesRoute } from '../lib/detection_engine/routes/privileges/r
 import type { SetupPlugins, StartPlugins } from '../plugin';
 import type { ConfigType } from '../config';
 import type { ITelemetryEventsSender } from '../lib/telemetry/sender';
-import type {
-  CreateRuleOptions,
-  CreateSecurityRuleTypeWrapperProps,
-} from '../lib/detection_engine/rule_types/types';
+import type { CreateSecurityRuleTypeWrapperProps } from '../lib/detection_engine/rule_types/types';
 import type { ITelemetryReceiver } from '../lib/telemetry/receiver';
 import { telemetryDetectionRulesPreviewRoute } from '../lib/detection_engine/routes/telemetry/telemetry_detection_rules_preview_route';
 import { readAlertsIndexExistsRoute } from '../lib/detection_engine/routes/index/read_alerts_index_exists_route';
@@ -75,7 +72,6 @@ export const initRoutes = (
   ruleDataService: RuleDataPluginService,
   logger: Logger,
   ruleDataClient: IRuleDataClient | null,
-  ruleOptions: CreateRuleOptions,
   getStartServices: StartServicesAccessor<StartPlugins>,
   securityRuleTypeOptions: CreateSecurityRuleTypeWrapperProps,
   previewRuleDataClient: IRuleDataClient,
@@ -96,7 +92,6 @@ export const initRoutes = (
     config,
     ml,
     security,
-    ruleOptions,
     securityRuleTypeOptions,
     previewRuleDataClient,
     getStartServices,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution][Detection Engine] Remove CreateRuleOptions, pass options through security rule wrapper instead (#216039)](https://github.com/elastic/kibana/pull/216039)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marshall Main","email":"55718608+marshallmain@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-28T14:52:44Z","message":"[Security Solution][Detection Engine] Remove CreateRuleOptions, pass options through security rule wrapper instead (#216039)\n\n## Summary\n\nAnother small refactor follow up to\nhttps://github.com/elastic/kibana/pull/212694. Overall, the goal here is\nto increase consistency in how security rule executors receive common\nparameters. `CreateRuleOptions` contained parameters that were passed in\nto every security rule type and sometimes used in the `executor` -\nbypassing the executor function's parameters. With this PR, params that\nare used across multiple security rule type executors like `licensing`,\n`experimentalFeatures`, `scheduleNotificationResponseActionsService`,\netc are all passed through the executor options from the shared security\nrule type wrapper.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0e63fce8aa7d35406efa0fc75bf3b86b0cced0d6","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detection Engine","backport:version","v9.1.0","v8.19.0"],"title":"[Security Solution][Detection Engine] Remove CreateRuleOptions, pass options through security rule wrapper instead","number":216039,"url":"https://github.com/elastic/kibana/pull/216039","mergeCommit":{"message":"[Security Solution][Detection Engine] Remove CreateRuleOptions, pass options through security rule wrapper instead (#216039)\n\n## Summary\n\nAnother small refactor follow up to\nhttps://github.com/elastic/kibana/pull/212694. Overall, the goal here is\nto increase consistency in how security rule executors receive common\nparameters. `CreateRuleOptions` contained parameters that were passed in\nto every security rule type and sometimes used in the `executor` -\nbypassing the executor function's parameters. With this PR, params that\nare used across multiple security rule type executors like `licensing`,\n`experimentalFeatures`, `scheduleNotificationResponseActionsService`,\netc are all passed through the executor options from the shared security\nrule type wrapper.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0e63fce8aa7d35406efa0fc75bf3b86b0cced0d6"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216039","number":216039,"mergeCommit":{"message":"[Security Solution][Detection Engine] Remove CreateRuleOptions, pass options through security rule wrapper instead (#216039)\n\n## Summary\n\nAnother small refactor follow up to\nhttps://github.com/elastic/kibana/pull/212694. Overall, the goal here is\nto increase consistency in how security rule executors receive common\nparameters. `CreateRuleOptions` contained parameters that were passed in\nto every security rule type and sometimes used in the `executor` -\nbypassing the executor function's parameters. With this PR, params that\nare used across multiple security rule type executors like `licensing`,\n`experimentalFeatures`, `scheduleNotificationResponseActionsService`,\netc are all passed through the executor options from the shared security\nrule type wrapper.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0e63fce8aa7d35406efa0fc75bf3b86b0cced0d6"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->