### PR TITLE
[Lens] fix toEsql test use all-year UTC timezone

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/to_esql.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/to_esql.test.ts
@@ -282,9 +282,10 @@ describe('to_esql', () => {
     expect(esql).toEqual(undefined);
   });
 
-  it('should work with iana timezones that fall udner utc+0', () => {
+  it('should work with iana timezones that fall under UTC+0', () => {
     uiSettings.get.mockImplementation((key: string) => {
-      if (key === 'dateFormat:tz') return 'Europe/London';
+      // There are only few countries that falls under UTC all year round, others just fall into that configuration half hear when not in DST
+      if (key === 'dateFormat:tz') return 'Atlantic/Reykjavik';
       return defaultUiSettingsGet(key);
     });
 


### PR DESCRIPTION
## Summary

The test should verify if a timezone that falls under UTC offset can correctly transform a formBased lens configuation to an ESQL query.
Unfortunately the choosen timezone (Europe/London) falls under UTC only when not in DST.
I've selected one of the few countries that falls under UTC all year round to have this test pass correctly independently on when it is executed.






<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->