### PR TITLE
[Synthetics] When changing condition type of a monitor status rule other conditions are not changed

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/for_the_last_expression.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/alerts/common/for_the_last_expression.tsx
@@ -139,16 +139,12 @@ export const ForTheLastExpression = ({ ruleParams, setRuleParams }: Props) => {
             case 'checksWindow':
               setRuleParams('condition', {
                 ...ruleParams.condition,
-                downThreshold: 5,
-                locationsThreshold: 1,
                 window: { numberOfChecks: 5 },
               });
               break;
             case 'timeWindow':
               setRuleParams('condition', {
                 ...ruleParams.condition,
-                downThreshold: 5,
-                locationsThreshold: 1,
                 window: { time: { unit: 'm', size: 5 } },
               });
               break;


### PR DESCRIPTION
This PR closes #197786 .


https://github.com/user-attachments/assets/85c92b09-f477-4e42-9fb7-a8143876e079





<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->