### PR TITLE
[Docs] Reproduce #209403 in new API docs

### DIFF
--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -48332,7 +48332,8 @@ paths:
   /api/upgrade_assistant/reindex/batch:
     post:
       description: |
-        Start or resume multiple reindexing tasks in one request. Additionally, reindexing tasks started or resumed via the batch endpoint will be placed on a queue and run one-by-one, which ensures that minimal cluster resources are consumed over time.
+        Start or resume multiple reindexing tasks in one request. Additionally, [reindexing](https://www.elastic.co/docs/api/doc/kibana/operation/operation-start-upgrade-reindex) tasks for upgrading indices that are started or resumed via the batch endpoint will be placed on a queue and executed one-by-one. This ensures that minimal cluster resources are consumed over time.
+        Note that this API does not support data streams.
       operationId: batch-start-upgrade-reindex
       requestBody:
         content:
@@ -48418,7 +48419,6 @@ paths:
       summary: Batch start or resume reindexing
       tags:
         - upgrade
-      x-state: Technical Preview
   /api/upgrade_assistant/reindex/batch/queue:
     get:
       description: |

--- a/x-pack/platform/plugins/private/upgrade_assistant/docs/openapi/upgrade_apis.yaml
+++ b/x-pack/platform/plugins/private/upgrade_assistant/docs/openapi/upgrade_apis.yaml
@@ -259,8 +259,10 @@ paths:
       summary: Batch start or resume reindexing
       description: >
         Start or resume multiple reindexing tasks in one request.
-        Additionally, reindexing tasks started or resumed via the batch endpoint will be placed on a queue and run one-by-one, which ensures that minimal cluster resources are consumed over time.
-      x-state: Technical Preview
+        Additionally, [reindexing](https://www.elastic.co/docs/api/doc/kibana/operation/operation-start-upgrade-reindex) tasks for upgrading indices that are started or resumed via the batch endpoint will be placed on a queue and executed one-by-one.
+        This ensures that minimal cluster resources are consumed over time.
+
+        Note that this API does not support data streams.
       operationId: batch-start-upgrade-reindex
       tags:
         - upgrade


### PR DESCRIPTION
This change reproduces the asciidoc change made in https://github.com/elastic/kibana/pull/209403 into the new API docs. It'll be picked up the next time the API docs output is generated and refreshed.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->