### PR TITLE
[Security Solution] Rename use_data_view to use_data_view_spec

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
@@ -67,7 +67,7 @@ describe('DataViewPicker', () => {
 
   beforeEach(() => {
     jest.mocked(useDataViewSpec).mockReturnValue({
-      dataView: {
+      dataViewSpec: {
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
         name: 'Default Security Data View',
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
@@ -19,7 +19,7 @@ import { TestProviders } from '../../../common/mock/test_providers';
 import { useSelectDataView } from '../../hooks/use_select_data_view';
 
 jest.mock('../../hooks/use_data_view_spec', () => ({
-  useDataView: jest.fn(),
+  useDataViewSpec: jest.fn(),
 }));
 
 jest.mock('../../hooks/use_select_data_view', () => ({

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { DataViewPicker } from '.';
-import { useDataView } from '../../hooks/use_data_view';
+import { useDataViewSpec } from '../../hooks/use_data_view_spec';
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, DataViewManagerScopeName } from '../../constants';
 import { sharedDataViewManagerSlice } from '../../redux/slices';
 import { useDispatch } from 'react-redux';
@@ -18,7 +18,7 @@ import { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
 import { TestProviders } from '../../../common/mock/test_providers';
 import { useSelectDataView } from '../../hooks/use_select_data_view';
 
-jest.mock('../../hooks/use_data_view', () => ({
+jest.mock('../../hooks/use_data_view_spec', () => ({
   useDataView: jest.fn(),
 }));
 
@@ -66,7 +66,7 @@ describe('DataViewPicker', () => {
   let mockDispatch = jest.fn();
 
   beforeEach(() => {
-    jest.mocked(useDataView).mockReturnValue({
+    jest.mocked(useDataViewSpec).mockReturnValue({
       dataView: {
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
         name: 'Default Security Data View',

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -28,7 +28,7 @@ export const DataViewPicker = memo((props: { scope: DataViewManagerScopeName }) 
   const closeDataViewEditor = useRef<() => void | undefined>();
   const closeFieldEditor = useRef<() => void | undefined>();
 
-  const { dataView, status } = useDataViewSpec(props.scope);
+  const { dataViewSpec: dataView, status } = useDataViewSpec(props.scope);
 
   const dataViewId = dataView?.id;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -13,7 +13,7 @@ import { DataView, type DataViewListItem } from '@kbn/data-views-plugin/public';
 import type { DataViewManagerScopeName } from '../../constants';
 import { useKibana } from '../../../common/lib/kibana';
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID } from '../../constants';
-import { useDataView } from '../../hooks/use_data_view';
+import { useDataViewSpec } from '../../hooks/use_data_view_spec';
 import { sharedStateSelector } from '../../redux/selectors';
 import { sharedDataViewManagerSlice } from '../../redux/slices';
 import { useSelectDataView } from '../../hooks/use_select_data_view';
@@ -28,7 +28,7 @@ export const DataViewPicker = memo((props: { scope: DataViewManagerScopeName }) 
   const closeDataViewEditor = useRef<() => void | undefined>();
   const closeFieldEditor = useRef<() => void | undefined>();
 
-  const { dataView, status } = useDataView(props.scope);
+  const { dataView, status } = useDataViewSpec(props.scope);
 
   const dataViewId = dataView?.id;
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/components/data_view_picker/index.tsx
@@ -28,9 +28,9 @@ export const DataViewPicker = memo((props: { scope: DataViewManagerScopeName }) 
   const closeDataViewEditor = useRef<() => void | undefined>();
   const closeFieldEditor = useRef<() => void | undefined>();
 
-  const { dataViewSpec: dataView, status } = useDataViewSpec(props.scope);
+  const { dataViewSpec, status } = useDataViewSpec(props.scope);
 
-  const dataViewId = dataView?.id;
+  const dataViewId = dataViewSpec?.id;
 
   const createNewDataView = useCallback(() => {
     closeDataViewEditor.current = dataViewEditor.openEditor({
@@ -91,16 +91,16 @@ export const DataViewPicker = memo((props: { scope: DataViewManagerScopeName }) 
       return { label: 'Loading' };
     }
 
-    if (dataView.id === DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID) {
+    if (dataViewSpec.id === DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID) {
       return {
         label: 'Default Security Data View',
       };
     }
 
     return {
-      label: dataView?.name || dataView?.id || 'Data view',
+      label: dataViewSpec?.name || dataViewSpec?.id || 'Data view',
     };
-  }, [dataView.id, dataView?.name, status]);
+  }, [dataViewSpec.id, dataViewSpec?.name, status]);
 
   const { adhocDataViews: adhocDataViewSpecs, dataViews } = useSelector(sharedStateSelector);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
@@ -13,7 +13,7 @@ import { useDataViewSpec } from './use_data_view_spec';
 import { type FieldSpec } from '@kbn/data-views-plugin/common';
 
 jest.mock('./use_data_view_spec', () => ({
-  useDataView: jest.fn(),
+  useDataViewSpec: jest.fn(),
 }));
 
 describe('useBrowserFields', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
@@ -9,16 +9,16 @@ import { renderHook } from '@testing-library/react';
 import { TestProviders } from '../../common/mock';
 import { useBrowserFields } from './use_browser_fields';
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, DataViewManagerScopeName } from '../constants';
-import { useDataView } from './use_data_view';
+import { useDataViewSpec } from './use_data_view_spec';
 import { type FieldSpec } from '@kbn/data-views-plugin/common';
 
-jest.mock('./use_data_view', () => ({
+jest.mock('./use_data_view_spec', () => ({
   useDataView: jest.fn(),
 }));
 
 describe('useBrowserFields', () => {
   beforeAll(() => {
-    jest.mocked(useDataView).mockReturnValue({
+    jest.mocked(useDataViewSpec).mockReturnValue({
       dataView: {
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
         fields: {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.test.ts
@@ -19,7 +19,7 @@ jest.mock('./use_data_view_spec', () => ({
 describe('useBrowserFields', () => {
   beforeAll(() => {
     jest.mocked(useDataViewSpec).mockReturnValue({
-      dataView: {
+      dataViewSpec: {
         id: DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID,
         fields: {
           '@timestamp': {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
@@ -8,11 +8,11 @@
 import { useMemo } from 'react';
 import type { BrowserFields } from '@kbn/timelines-plugin/common';
 import { type DataViewManagerScopeName } from '../constants';
-import { useDataView } from './use_data_view';
+import { useDataViewSpec } from './use_data_view_spec';
 import { getDataViewStateFromIndexFields } from '../../common/containers/source/use_data_view';
 
 export const useBrowserFields = (scope: DataViewManagerScopeName): BrowserFields => {
-  const { dataView } = useDataView(scope);
+  const { dataView } = useDataViewSpec(scope);
 
   return useMemo(() => {
     if (!dataView) {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
@@ -12,7 +12,7 @@ import { useDataViewSpec } from './use_data_view_spec';
 import { getDataViewStateFromIndexFields } from '../../common/containers/source/use_data_view';
 
 export const useBrowserFields = (scope: DataViewManagerScopeName): BrowserFields => {
-  const { dataView } = useDataViewSpec(scope);
+  const { dataViewSpec: dataView } = useDataViewSpec(scope);
 
   return useMemo(() => {
     if (!dataView) {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_browser_fields.ts
@@ -12,18 +12,18 @@ import { useDataViewSpec } from './use_data_view_spec';
 import { getDataViewStateFromIndexFields } from '../../common/containers/source/use_data_view';
 
 export const useBrowserFields = (scope: DataViewManagerScopeName): BrowserFields => {
-  const { dataViewSpec: dataView } = useDataViewSpec(scope);
+  const { dataViewSpec } = useDataViewSpec(scope);
 
   return useMemo(() => {
-    if (!dataView) {
+    if (!dataViewSpec) {
       return {};
     }
 
     const { browserFields } = getDataViewStateFromIndexFields(
-      dataView?.title ?? '',
-      dataView.fields
+      dataViewSpec?.title ?? '',
+      dataViewSpec.fields
     );
 
     return browserFields;
-  }, [dataView]);
+  }, [dataViewSpec]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.test.ts
@@ -9,7 +9,7 @@ import { renderHook } from '@testing-library/react';
 import { type DataView } from '@kbn/data-views-plugin/public';
 
 import { DataViewManagerScopeName } from '../constants';
-import { useDataView } from './use_data_view';
+import { useDataViewSpec } from './use_data_view_spec';
 import { useFullDataView } from './use_full_data_view';
 
 jest.mock('./use_full_data_view');
@@ -27,7 +27,7 @@ describe('useDataView', () => {
   });
 
   it('should return correct dataView from the store, based on the provided scope', () => {
-    const wrapper = renderHook((scope) => useDataView(scope), {
+    const wrapper = renderHook((scope) => useDataViewSpec(scope), {
       initialProps: DataViewManagerScopeName.default,
     });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.test.ts
@@ -14,7 +14,7 @@ import { useFullDataView } from './use_full_data_view';
 
 jest.mock('./use_full_data_view');
 
-describe('useDataView', () => {
+describe('useDataViewSpec', () => {
   beforeEach(() => {
     jest.mocked(useFullDataView).mockReturnValue({
       dataView: {
@@ -35,7 +35,7 @@ describe('useDataView', () => {
 
     expect(wrapper.result.current).toMatchObject({
       status: expect.any(String),
-      dataView: expect.objectContaining({ id: expect.any(String) }),
+      dataViewSpec: expect.objectContaining({ id: expect.any(String) }),
     });
 
     wrapper.rerender(DataViewManagerScopeName.timeline);
@@ -43,7 +43,7 @@ describe('useDataView', () => {
 
     expect(wrapper.result.current).toMatchObject({
       status: expect.any(String),
-      dataView: expect.objectContaining({ id: expect.any(String) }),
+      dataViewSpec: expect.objectContaining({ id: expect.any(String) }),
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
@@ -12,7 +12,7 @@ import { useFullDataView } from './use_full_data_view';
 /**
  * Returns data view selection for given scopeName
  */
-export const useDataView = (scopeName: DataViewManagerScopeName) => {
+export const useDataViewSpec = (scopeName: DataViewManagerScopeName) => {
   const { dataView, status } = useFullDataView(scopeName);
 
   return useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
@@ -20,7 +20,7 @@ export const useDataViewSpec = (scopeName: DataViewManagerScopeName) => {
     // https://github.com/elastic/security-team/issues/11959
     if (!dataView) {
       return {
-        dataView: {
+        dataViewSpec: {
           id: '',
           title: '',
         },
@@ -28,6 +28,6 @@ export const useDataViewSpec = (scopeName: DataViewManagerScopeName) => {
       };
     }
 
-    return { status, dataView: dataView?.toSpec?.() };
+    return { status, dataViewSpec: dataView?.toSpec?.() };
   }, [dataView, status]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
@@ -7,10 +7,10 @@
 
 import { useMemo } from 'react';
 import type { DataViewManagerScopeName } from '../constants';
-import { useDataView } from './use_data_view';
+import { useDataViewSpec } from './use_data_view_spec';
 
 export const useSelectedPatterns = (scope: DataViewManagerScopeName): string[] => {
-  const { dataView } = useDataView(scope);
+  const { dataView } = useDataViewSpec(scope);
 
   return useMemo(() => dataView?.title?.split(',') ?? [], [dataView?.title]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
@@ -10,7 +10,7 @@ import type { DataViewManagerScopeName } from '../constants';
 import { useDataViewSpec } from './use_data_view_spec';
 
 export const useSelectedPatterns = (scope: DataViewManagerScopeName): string[] => {
-  const { dataView } = useDataViewSpec(scope);
+  const { dataViewSpec: dataView } = useDataViewSpec(scope);
 
   return useMemo(() => dataView?.title?.split(',') ?? [], [dataView?.title]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_selected_patterns.ts
@@ -10,7 +10,7 @@ import type { DataViewManagerScopeName } from '../constants';
 import { useDataViewSpec } from './use_data_view_spec';
 
 export const useSelectedPatterns = (scope: DataViewManagerScopeName): string[] => {
-  const { dataViewSpec: dataView } = useDataViewSpec(scope);
+  const { dataViewSpec } = useDataViewSpec(scope);
 
-  return useMemo(() => dataView?.title?.split(',') ?? [], [dataView?.title]);
+  return useMemo(() => dataViewSpec?.title?.split(',') ?? [], [dataViewSpec?.title]);
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
@@ -21,7 +21,7 @@ import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strate
 import { useEnableExperimental } from '../../../../common/hooks/use_experimental_features';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
 import { useBrowserFields } from '../../../../data_view_manager/hooks/use_browser_fields';
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../../data_view_manager/hooks/use_data_view_spec';
 import type { CustomBulkAction } from '../../../../../common/types';
 import { combineQueries } from '../../../../common/lib/kuery';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -74,7 +74,7 @@ export const useAddBulkToTimelineAction = ({
   const [disableActionOnSelectAll, setDisabledActionOnSelectAll] = useState(false);
   const { newDataViewPickerEnabled } = useEnableExperimental();
 
-  const { dataView: experimentalDataView } = useDataView(scopeId);
+  const { dataView: experimentalDataView } = useDataViewSpec(scopeId);
   const experimentalBrowserFields = useBrowserFields(scopeId);
   const experimentalSelectedPatterns = useSelectedPatterns(scopeId);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_add_bulk_to_timeline.tsx
@@ -74,7 +74,7 @@ export const useAddBulkToTimelineAction = ({
   const [disableActionOnSelectAll, setDisabledActionOnSelectAll] = useState(false);
   const { newDataViewPickerEnabled } = useEnableExperimental();
 
-  const { dataView: experimentalDataView } = useDataViewSpec(scopeId);
+  const { dataViewSpec: experimentalDataView } = useDataViewSpec(scopeId);
   const experimentalBrowserFields = useBrowserFields(scopeId);
   const experimentalSelectedPatterns = useSelectedPatterns(scopeId);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
@@ -81,7 +81,9 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
       SourcererScopeName.timeline
     );
 
-    const { dataView: experimentalDataView } = useDataViewSpec(DataViewManagerScopeName.timeline);
+    const { dataViewSpec: experimentalDataView } = useDataViewSpec(
+      DataViewManagerScopeName.timeline
+    );
     const experimentalBrowserFields = useBrowserFields(DataViewManagerScopeName.timeline);
 
     const browserFields = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/modal/header/index.tsx
@@ -22,7 +22,7 @@ import { useEnableExperimental } from '../../../../common/hooks/use_experimental
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { SourcererScopeName } from '../../../../sourcerer/store/model';
 
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../../data_view_manager/hooks/use_data_view_spec';
 import { NewTimelineButton } from '../actions/new_timeline_button';
 import { OpenTimelineButton } from '../actions/open_timeline_button';
 import { APP_ID } from '../../../../../common';
@@ -81,7 +81,7 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(
       SourcererScopeName.timeline
     );
 
-    const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.timeline);
+    const { dataView: experimentalDataView } = useDataViewSpec(DataViewManagerScopeName.timeline);
     const experimentalBrowserFields = useBrowserFields(DataViewManagerScopeName.timeline);
 
     const browserFields = useMemo(() => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
@@ -163,7 +163,7 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
     let { dataViewId, selectedPatterns } = useSourcererDataView(SourcererScopeName.timeline);
     const { newDataViewPickerEnabled } = useEnableExperimental();
 
-    const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
+    const { dataViewSpec: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
     const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
 
     if (newDataViewPickerEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/open_timeline/index.tsx
@@ -58,7 +58,7 @@ import { useStartTransaction } from '../../../common/lib/apm/use_start_transacti
 import { TIMELINE_ACTIONS } from '../../../common/lib/apm/user_actions';
 import { defaultUdtHeaders } from '../timeline/body/column_headers/default_headers';
 import { timelineDefaults } from '../../store/defaults';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../data_view_manager/hooks/use_data_view_spec';
 
 interface OwnProps<TCache = object> {
   /** Displays open timeline in modal */
@@ -163,7 +163,7 @@ export const StatefulOpenTimelineComponent = React.memo<OpenTimelineOwnProps>(
     let { dataViewId, selectedPatterns } = useSourcererDataView(SourcererScopeName.timeline);
     const { newDataViewPickerEnabled } = useEnableExperimental();
 
-    const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+    const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
     const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
 
     if (newDataViewPickerEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -109,7 +109,7 @@ const StatefulTimelineComponent: React.FC<Props> = ({
   const experimentalDataView = useDataViewSpec(SourcererScopeName.timeline);
 
   const selectedDataViewId = newDataViewPickerEnabled
-    ? experimentalDataView.dataView?.id ?? ''
+    ? experimentalDataView.dataViewSpec?.id ?? ''
     : selectedDataViewIdSourcerer;
 
   const selectedPatterns = newDataViewPickerEnabled

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/index.tsx
@@ -32,7 +32,7 @@ import { useResolveConflict } from '../../../common/hooks/use_resolve_conflict';
 import { sourcererSelectors } from '../../../common/store';
 import { defaultUdtHeaders } from './body/column_headers/default_headers';
 import { useSelectedPatterns } from '../../../data_view_manager/hooks/use_selected_patterns';
-import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../data_view_manager/hooks/use_data_view_spec';
 import { TimelineContext } from './context';
 
 const TimelineBody = styled.div`
@@ -106,7 +106,7 @@ const StatefulTimelineComponent: React.FC<Props> = ({
 
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
   const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const experimentalDataView = useDataView(SourcererScopeName.timeline);
+  const experimentalDataView = useDataViewSpec(SourcererScopeName.timeline);
 
   const selectedDataViewId = newDataViewPickerEnabled
     ? experimentalDataView.dataView?.id ?? ''

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
@@ -29,7 +29,7 @@ import {
   startSelector,
 } from '../../../../common/components/super_date_picker/selectors';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../../data_view_manager/hooks/use_data_view_spec';
 
 interface KpiExpandedProps {
   timelineId: string;
@@ -38,7 +38,7 @@ interface KpiExpandedProps {
 export const TimelineKpisContainer = ({ timelineId }: KpiExpandedProps) => {
   const { newDataViewPickerEnabled } = useEnableExperimental();
   const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+  const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
   const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
 
   let { browserFields, sourcererDataView, selectedPatterns } = useSourcererDataView(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/kpi/kpi_container.tsx
@@ -38,7 +38,7 @@ interface KpiExpandedProps {
 export const TimelineKpisContainer = ({ timelineId }: KpiExpandedProps) => {
   const { newDataViewPickerEnabled } = useEnableExperimental();
   const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
-  const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
+  const { dataViewSpec: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
   const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
 
   let { browserFields, sourcererDataView, selectedPatterns } = useSourcererDataView(

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
@@ -12,7 +12,7 @@ import { useDispatch } from 'react-redux';
 import { css } from '@emotion/css';
 
 import { useEnableExperimental } from '../../../../../common/hooks/use_experimental_features';
-import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../../../data_view_manager/hooks/use_data_view_spec';
 import type { EqlOptions } from '../../../../../../common/search_strategy';
 import { useDeepEqualSelector } from '../../../../../common/hooks/use_selector';
 import { SourcererScopeName } from '../../../../../sourcerer/store/model';
@@ -70,7 +70,7 @@ export const EqlQueryBarTimeline = memo(({ timelineId }: { timelineId: string })
 
   const { newDataViewPickerEnabled } = useEnableExperimental();
 
-  const { dataView: experimentalDataView, status } = useDataView(SourcererScopeName.timeline);
+  const { dataView: experimentalDataView, status } = useDataViewSpec(SourcererScopeName.timeline);
   const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
 
   if (newDataViewPickerEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/eql/index.tsx
@@ -70,7 +70,9 @@ export const EqlQueryBarTimeline = memo(({ timelineId }: { timelineId: string })
 
   const { newDataViewPickerEnabled } = useEnableExperimental();
 
-  const { dataView: experimentalDataView, status } = useDataViewSpec(SourcererScopeName.timeline);
+  const { dataViewSpec: experimentalDataView, status } = useDataViewSpec(
+    SourcererScopeName.timeline
+  );
   const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
 
   if (newDataViewPickerEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
@@ -14,7 +14,7 @@ import { FilterStateStore } from '@kbn/es-query';
 import type { FilterManager, SavedQuery, SavedQueryTimeFilter } from '@kbn/data-plugin/public';
 import styled from '@emotion/styled';
 import { useEnableExperimental } from '../../../../common/hooks/use_experimental_features';
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../../data_view_manager/hooks/use_data_view_spec';
 import { InputsModelId } from '../../../../common/store/inputs/constants';
 import { SourcererScopeName } from '../../../../sourcerer/store/model';
 
@@ -116,7 +116,7 @@ export const QueryBarTimeline = memo<QueryBarTimelineComponentProps>(
     let { browserFields, sourcererDataView } = useSourcererDataView(SourcererScopeName.timeline);
 
     const { newDataViewPickerEnabled } = useEnableExperimental();
-    const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+    const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
     const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
 
     if (newDataViewPickerEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/query_bar/index.tsx
@@ -116,7 +116,7 @@ export const QueryBarTimeline = memo<QueryBarTimelineComponentProps>(
     let { browserFields, sourcererDataView } = useSourcererDataView(SourcererScopeName.timeline);
 
     const { newDataViewPickerEnabled } = useEnableExperimental();
-    const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
+    const { dataViewSpec: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
     const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);
 
     if (newDataViewPickerEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
@@ -77,7 +77,7 @@ const StatefulSearchOrFilterComponent = React.memo<Props>(
 
     let { sourcererDataView } = useSourcererDataView(SourcererScopeName.timeline);
 
-    const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
+    const { dataViewSpec: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
     const { newDataViewPickerEnabled } = useEnableExperimental();
 
     if (newDataViewPickerEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/index.tsx
@@ -18,7 +18,7 @@ import type { DataView } from '@kbn/data-views-plugin/common';
 import { FilterItems } from '@kbn/unified-search-plugin/public';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useEnableExperimental } from '../../../../common/hooks/use_experimental_features';
-import { useDataView } from '../../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../../data_view_manager/hooks/use_data_view_spec';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
 import { useKibana } from '../../../../common/lib/kibana';
@@ -77,7 +77,7 @@ const StatefulSearchOrFilterComponent = React.memo<Props>(
 
     let { sourcererDataView } = useSourcererDataView(SourcererScopeName.timeline);
 
-    const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+    const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
     const { newDataViewPickerEnabled } = useEnableExperimental();
 
     if (newDataViewPickerEnabled) {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
@@ -63,7 +63,7 @@ export const DiscoverTabContent: FC<DiscoverTabContentProps> = ({ timelineId }) 
   const dispatch = useDispatch();
 
   const { newDataViewPickerEnabled } = useEnableExperimental();
-  const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.detections);
+  const { dataViewSpec: experimentalDataView } = useDataViewSpec(SourcererScopeName.detections);
 
   const { dataViewId } = useSourcererDataView(SourcererScopeName.detections);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/esql/index.tsx
@@ -20,7 +20,7 @@ import { useDispatch } from 'react-redux';
 import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { APP_STATE_URL_KEY } from '@kbn/discover-plugin/common';
 import { useEnableExperimental } from '../../../../../common/hooks/use_experimental_features';
-import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../../../data_view_manager/hooks/use_data_view_spec';
 import { updateSavedSearchId } from '../../../../store/actions';
 import { useDiscoverInTimelineContext } from '../../../../../common/components/discover_in_timeline/use_discover_in_timeline_context';
 import { useKibana } from '../../../../../common/lib/kibana';
@@ -63,7 +63,7 @@ export const DiscoverTabContent: FC<DiscoverTabContentProps> = ({ timelineId }) 
   const dispatch = useDispatch();
 
   const { newDataViewPickerEnabled } = useEnableExperimental();
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.detections);
+  const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.detections);
 
   const { dataViewId } = useSourcererDataView(SourcererScopeName.detections);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -14,7 +14,7 @@ import type { EuiDataGridControlColumn } from '@elastic/eui';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
 import { useSourcererDataView } from '../../../../../sourcerer/containers';
-import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../../../data_view_manager/hooks/use_data_view_spec';
 import { useSelectedPatterns } from '../../../../../data_view_manager/hooks/use_selected_patterns';
 import { useFetchNotes } from '../../../../../notes/hooks/use_fetch_notes';
 import {
@@ -91,7 +91,7 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   );
 
   const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const { dataView: experimentalDataView } = useDataView(SourcererScopeName.timeline);
+  const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
 
   if (newDataViewPickerEnabled) {
     selectedPatterns = experimentalSelectedPatterns;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/pinned/index.tsx
@@ -91,7 +91,7 @@ export const PinnedTabContentComponent: React.FC<Props> = ({
   );
 
   const experimentalSelectedPatterns = useSelectedPatterns(SourcererScopeName.timeline);
-  const { dataView: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
+  const { dataViewSpec: experimentalDataView } = useDataViewSpec(SourcererScopeName.timeline);
 
   if (newDataViewPickerEnabled) {
     selectedPatterns = experimentalSelectedPatterns;

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -91,7 +91,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   const dispatch = useDispatch();
   const { newDataViewPickerEnabled } = useEnableExperimental();
 
-  const { dataView: experimentalDataView, status: sourcererStatus } = useDataViewSpec(
+  const { dataViewSpec: experimentalDataView, status: sourcererStatus } = useDataViewSpec(
     SourcererScopeName.timeline
   );
   const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.tsx
@@ -17,7 +17,7 @@ import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
 import { useSelectedPatterns } from '../../../../../data_view_manager/hooks/use_selected_patterns';
 import { useBrowserFields } from '../../../../../data_view_manager/hooks/use_browser_fields';
-import { useDataView } from '../../../../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../../../../data_view_manager/hooks/use_data_view_spec';
 import { useFetchNotes } from '../../../../../notes/hooks/use_fetch_notes';
 import {
   DocumentDetailsLeftPanelKey,
@@ -91,7 +91,7 @@ export const QueryTabContentComponent: React.FC<Props> = ({
   const dispatch = useDispatch();
   const { newDataViewPickerEnabled } = useEnableExperimental();
 
-  const { dataView: experimentalDataView, status: sourcererStatus } = useDataView(
+  const { dataView: experimentalDataView, status: sourcererStatus } = useDataViewSpec(
     SourcererScopeName.timeline
   );
   const experimentalBrowserFields = useBrowserFields(SourcererScopeName.timeline);

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
@@ -59,7 +59,7 @@ export const useCreateTimeline = ({
   ) ?? { id: '', patternList: [] };
 
   const { newDataViewPickerEnabled } = useEnableExperimental();
-  const { dataView: experimentalDataView } = useDataViewSpec(DataViewManagerScopeName.default);
+  const { dataViewSpec: experimentalDataView } = useDataViewSpec(DataViewManagerScopeName.default);
 
   const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.default);
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/hooks/use_create_timeline.tsx
@@ -21,7 +21,7 @@ import { defaultUdtHeaders } from '../components/timeline/body/column_headers/de
 import { timelineDefaults } from '../store/defaults';
 import { useSelectDataView } from '../../data_view_manager/hooks/use_select_data_view';
 import { DataViewManagerScopeName } from '../../data_view_manager/constants';
-import { useDataView } from '../../data_view_manager/hooks/use_data_view';
+import { useDataViewSpec } from '../../data_view_manager/hooks/use_data_view_spec';
 import { useSelectedPatterns } from '../../data_view_manager/hooks/use_selected_patterns';
 import { sourcererActions, sourcererSelectors } from '../../sourcerer/store';
 import { SourcererScopeName } from '../../sourcerer/store/model';
@@ -59,7 +59,7 @@ export const useCreateTimeline = ({
   ) ?? { id: '', patternList: [] };
 
   const { newDataViewPickerEnabled } = useEnableExperimental();
-  const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.default);
+  const { dataView: experimentalDataView } = useDataViewSpec(DataViewManagerScopeName.default);
 
   const experimentalSelectedPatterns = useSelectedPatterns(DataViewManagerScopeName.default);
 


### PR DESCRIPTION
## Summary

Just naming things, the goal is to highlight the fact the hook returns the spec and not the DataView instance.
No testing is required as the change does not alter the logic.