### PR TITLE
[8.x] [Response Ops][Flaky Tests] Remove duplicated click creating connector (#216145)

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/triggers_actions_ui/alert_create_flyout.ts
@@ -64,7 +64,6 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await find.clickByCssSelector(
         '[data-test-subj="create-connector-flyout-save-btn"]:not(disabled)'
       );
-      await testSubjects.click('create-connector-flyout-save-btn');
     });
 
     const toastTitle = await toasts.getTitleAndDismiss();
@@ -178,8 +177,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await testSubjects.click('rulesTab');
     });
 
-    // Failing: See https://github.com/elastic/kibana/issues/202328
-    it.skip('should delete the right action when the same action has been added twice', async () => {
+    it('should delete the right action when the same action has been added twice', async () => {
       // create a new rule
       const ruleName = generateUniqueKey();
       await rules.common.defineIndexThresholdAlert(ruleName);


### PR DESCRIPTION
# Backport

Closes https://github.com/elastic/kibana/issues/202328

This will backport the following commits from `main` to `8.x`:
 - [[Response Ops][Flaky Tests] Remove duplicated click creating connector (#216145)](https://github.com/elastic/kibana/pull/216145)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-28T11:43:25Z","message":"[Response Ops][Flaky Tests] Remove duplicated click creating connector (#216145)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/202328\n\nThe test itself wasn't failing but the setup was. The test failing does\nso because it's the first one in the test suite. We are trying to click\non the flyout save button twice one right after the other. What I think\nis happening is that the first one manages to close the flyout before\nthe second click gets the chance to trigger.\n\nAlso the image in CI is this where we can see the flyout is closed\nalready but it's still trying to close it\n\n![image](https://github.com/user-attachments/assets/c606f776-aab4-4884-94e2-a2c258a30546)","sha":"e16ba346e39df1843b45017137d4c894c357bb13","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","v9.0.0","backport:version","v8.18.0","v9.1.0"],"title":"[Response Ops][Flaky Tests] Remove duplicated click creating connector","number":216145,"url":"https://github.com/elastic/kibana/pull/216145","mergeCommit":{"message":"[Response Ops][Flaky Tests] Remove duplicated click creating connector (#216145)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/202328\n\nThe test itself wasn't failing but the setup was. The test failing does\nso because it's the first one in the test suite. We are trying to click\non the flyout save button twice one right after the other. What I think\nis happening is that the first one manages to close the flyout before\nthe second click gets the chance to trigger.\n\nAlso the image in CI is this where we can see the flyout is closed\nalready but it's still trying to close it\n\n![image](https://github.com/user-attachments/assets/c606f776-aab4-4884-94e2-a2c258a30546)","sha":"e16ba346e39df1843b45017137d4c894c357bb13"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216281","number":216281,"state":"MERGED","mergeCommit":{"sha":"391a07f3d1ba07910a5dc2b38ded98a9468c86e5","message":"[9.0] [Response Ops][Flaky Tests] Remove duplicated click creating connector (#216145) (#216281)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Response Ops][Flaky Tests] Remove duplicated click creating\nconnector (#216145)](https://github.com/elastic/kibana/pull/216145)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216280","number":216280,"state":"MERGED","mergeCommit":{"sha":"24c65a5dcc93040cd5900b6c85175a20be7e2fb0","message":"[8.18] [Response Ops][Flaky Tests] Remove duplicated click creating connector (#216145) (#216280)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Response Ops][Flaky Tests] Remove duplicated click creating\nconnector (#216145)](https://github.com/elastic/kibana/pull/216145)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Julian Gernun <17549662+jcger@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216145","number":216145,"mergeCommit":{"message":"[Response Ops][Flaky Tests] Remove duplicated click creating connector (#216145)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/202328\n\nThe test itself wasn't failing but the setup was. The test failing does\nso because it's the first one in the test suite. We are trying to click\non the flyout save button twice one right after the other. What I think\nis happening is that the first one manages to close the flyout before\nthe second click gets the chance to trigger.\n\nAlso the image in CI is this where we can see the flyout is closed\nalready but it's still trying to close it\n\n![image](https://github.com/user-attachments/assets/c606f776-aab4-4884-94e2-a2c258a30546)","sha":"e16ba346e39df1843b45017137d4c894c357bb13"}}]}] BACKPORT-->