### PR TITLE
[maps] upgrade to maplibre 5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1197,7 +1197,7 @@
     "lru-cache": "^11.0.2",
     "lz-string": "^1.4.4",
     "mapbox-gl-draw-rectangle-mode": "1.0.4",
-    "maplibre-gl": "5.1.1",
+    "maplibre-gl": "5.3.0",
     "markdown-it": "^14.1.0",
     "mdast-util-to-hast": "10.2.0",
     "memoize-one": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22847,10 +22847,10 @@ maplibre-gl@3.1.0:
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.3"
 
-maplibre-gl@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-5.1.1.tgz#734444c730de4463d0469bb2782650d78ac6b356"
-  integrity sha512-0Z6ODzyFu/grwT6K1eIBpv6MZE4xnJD1AV+Yq1hPzOh/YCY36r9BlSaU7d7n2/HJOaoKOy0b2YF8cS4dD+iEVQ==
+maplibre-gl@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-5.3.0.tgz#31fcc6f689dd0d342446a2baa29bbb8015f9f3dc"
+  integrity sha512-qru6B6jHlDPR4Q9/P4W1zEPbPofR4wwYbrrjiHKWI7yLtyXmpJ1/G1KaIYDr5uNdFbPZ7uiZAWdqtfdNLmIhGg==
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.2"
     "@mapbox/jsonlint-lines-primitives" "^2.0.2"


### PR DESCRIPTION
[Maplibre 5.3](https://github.com/maplibre/maplibre-gl-js/blob/main/CHANGELOG.md#530) release fixes circle layer hitbox in Globe projection mode (https://github.com/maplibre/maplibre-gl-js/pull/5599). This issue is noticeable in Kibana and makes it difficult to open tooltips with circle markers (default point marker) and globe projection.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->