### PR TITLE
[A11y][APM] Add `aria-label` to technical preview badge

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/technical_preview_badge.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/technical_preview_badge.tsx
@@ -20,7 +20,7 @@ export function TechnicalPreviewBadge({ icon, size, style }: Props) {
       label={i18n.translate('xpack.apm.technicalPreviewBadgeLabel', {
         defaultMessage: 'Technical preview',
       })}
-      aria-label={i18n.translate('xpack.apm.technicalPreviewBadgeDescription', {
+      aria-label={i18n.translate('xpack.apm.technicalPreviewBadge.ariaLabel', {
         defaultMessage:
           'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
       })}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/technical_preview_badge.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/technical_preview_badge.tsx
@@ -20,6 +20,10 @@ export function TechnicalPreviewBadge({ icon, size, style }: Props) {
       label={i18n.translate('xpack.apm.technicalPreviewBadgeLabel', {
         defaultMessage: 'Technical preview',
       })}
+      aria-label={i18n.translate('xpack.apm.technicalPreviewBadgeDescription', {
+        defaultMessage:
+          'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
+      })}
       tooltipContent={i18n.translate('xpack.apm.technicalPreviewBadgeDescription', {
         defaultMessage:
           'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/212093

This PR adds the `aria-label` prop so screen readers work with this tooltip text.
![image](https://github.com/user-attachments/assets/8c3d345d-68be-42cb-ab6f-addafd0d7683)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->