### PR TITLE
[A11y][APM] Add `aria-label` to fold traces button

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -134,7 +134,17 @@ export function Waterfall({
             z-index: ${euiTheme.levels.content};
           `}
           aria-label={i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel', {
-            defaultMessage: `Click to ${isAccordionOpen ? 'fold' : 'unfold'} the waterfall`,
+            defaultMessage: `Click to ${
+              isAccordionOpen ? '{accordionOpen}' : '{accordionClosed}'
+            } the waterfall`,
+            values: {
+              accordionOpen: i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel.fold', {
+                defaultMessage: 'fold',
+              }),
+              accordionClosed: i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel.unfold', {
+                defaultMessage: 'unfold',
+              }),
+            },
           })}
           iconType={isAccordionOpen ? 'fold' : 'unfold'}
           onClick={() => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -134,16 +134,15 @@ export function Waterfall({
             z-index: ${euiTheme.levels.content};
           `}
           aria-label={i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel', {
-            defaultMessage: `Click to ${
-              isAccordionOpen ? '{accordionOpen}' : '{accordionClosed}'
-            } the waterfall`,
+            defaultMessage: 'Click to {isAccordionOpen} the waterfall',
             values: {
-              accordionOpen: i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel.fold', {
-                defaultMessage: 'fold',
-              }),
-              accordionClosed: i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel.unfold', {
-                defaultMessage: 'unfold',
-              }),
+              isAccordionOpen: isAccordionOpen
+                ? i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel.fold', {
+                    defaultMessage: 'fold',
+                  })
+                : i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel.unfold', {
+                    defaultMessage: 'unfold',
+                  }),
             },
           })}
           iconType={isAccordionOpen ? 'fold' : 'unfold'}

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -133,6 +133,9 @@ export function Waterfall({
             position: absolute;
             z-index: ${euiTheme.levels.content};
           `}
+          aria-label={i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel', {
+            defaultMessage: `Click to ${isAccordionOpen ? 'fold' : 'unfold'} the waterfall`,
+          })}
           iconType={isAccordionOpen ? 'fold' : 'unfold'}
           onClick={() => {
             setIsAccordionOpen((isOpen) => !isOpen);


### PR DESCRIPTION
## Summary

Fixes #212228

This PR adds `aria-label` to the fold/unfold traces button.

![image](https://github.com/user-attachments/assets/7c14d3d1-c246-4b85-a80c-4fb51dd1f305)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->