### PR TITLE
[APM] Span links: add tooltip explaining the reason for missing linked span details

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/span_links/span_links_table.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/span_links/span_links_table.tsx
@@ -72,13 +72,16 @@ export function SpanLinksTable({ items }: Props) {
                 type="stopSlash"
                 size="m"
                 color="subdued"
-                content={i18n.translate(
-                  'xpack.apm.apm.spanLinks.table.serviceName.unknown.tooltip',
+                aria-label={i18n.translate(
+                  'xpack.apm.spanLinks.table.serviceName.unknown.tooltip.ariaLabel',
                   {
-                    defaultMessage:
-                      'This span has not yet been completed, please check again in a while.',
+                    defaultMessage: 'Icon tooltip for unknown service name',
                   }
                 )}
+                content={i18n.translate('xpack.apm.spanLinks.table.serviceName.unknown.tooltip', {
+                  defaultMessage:
+                    'This span has not yet been completed, please check again in a while.',
+                })}
               />
             </EuiFlexItem>
             <EuiFlexItem>
@@ -146,7 +149,9 @@ export function SpanLinksTable({ items }: Props) {
             button={
               <EuiButtonIcon
                 data-test-subj="apmColumnsButton"
-                aria-label="Edit"
+                aria-label={i18n.translate('xpack.apm.spanLinks.table.actions.edit.ariaLabel', {
+                  defaultMessage: 'Edit',
+                })}
                 iconType="boxesHorizontal"
                 onClick={() => {
                   setIdActionMenuOpen(id);
@@ -177,6 +182,10 @@ export function SpanLinksTable({ items }: Props) {
                 <EuiCopy textToCopy={traceId}>
                   {(copy) => (
                     <EuiButtonEmpty
+                      aria-label={i18n.translate(
+                        'xpack.apm.spanLinks.table.actions.copyParentTraceId.ariaLabel',
+                        { defaultMessage: 'Copy parent trace id' }
+                      )}
                       data-test-subj="apmColumnsCopyParentTraceIdButton"
                       onClick={() => {
                         copy();
@@ -210,6 +219,12 @@ export function SpanLinksTable({ items }: Props) {
                 <EuiCopy textToCopy={spanId}>
                   {(copy) => (
                     <EuiButtonEmpty
+                      aria-label={i18n.translate(
+                        'xpack.apm.spanLinks.table.actions.copySpanId.ariaLabel',
+                        {
+                          defaultMessage: 'Copy span id',
+                        }
+                      )}
                       data-test-subj="apmColumnsCopySpanIdButton"
                       onClick={() => {
                         copy();

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/span_links/span_links_table.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/span_links/span_links_table.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
+  EuiIconTip,
   EuiInMemoryTable,
   EuiLink,
   EuiPopover,
@@ -66,8 +67,19 @@ export function SpanLinksTable({ items }: Props) {
         }
         return (
           <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <EuiIcon type="stopSlash" size="m" color="subdued" />
+            <EuiFlexItem grow={false} css={{ lineHeight: 1 }}>
+              <EuiIconTip
+                type="stopSlash"
+                size="m"
+                color="subdued"
+                content={i18n.translate(
+                  'xpack.apm.apm.spanLinks.table.serviceName.unknown.tooltip',
+                  {
+                    defaultMessage:
+                      'This span has not yet been completed, please check again in a while.',
+                  }
+                )}
+              />
             </EuiFlexItem>
             <EuiFlexItem>
               {i18n.translate('xpack.apm.spanLinks.table.serviceName.unknown', {


### PR DESCRIPTION
Closes #214558

### Summary

When fetching details for the Span Links flyout, it is possible that the parent span has not yet been ingested, resulting in an 'Unknown' service name which might be misleading to users. To avoid confusion, we decided to add tooltip to the icon with explanation. 

<img width="2558" alt="image" src="https://github.com/user-attachments/assets/9e29544b-28df-43b2-9987-24c6d90c481e" />

### How to test:
- use edge-oblt data
- in Applications go to `accountingservice` service
- select `orders receive` transaction
- in trace waterfall click `Span Links` button




<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->