### PR TITLE
[Security Solution][Detection Engine] Simplify searchAfterBulkCreate

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create_factory.ts
@@ -91,18 +91,6 @@ export const searchAfterAndBulkCreateFactory = async ({
     // sortId tells us where to start our next consecutive search_after query
     let sortIds: estypes.SortResults | undefined;
 
-    if (tuple == null || tuple.to == null || tuple.from == null) {
-      ruleExecutionLogger.error(
-        `missing run options fields: ${!tuple.to ? '"tuple.to"' : ''}, ${
-          !tuple.from ? '"tuple.from"' : ''
-        }`
-      );
-      return createSearchAfterReturnType({
-        success: false,
-        errors: ['malformed date tuple'],
-      });
-    }
-
     const maxSignals = maxSignalsOverride ?? tuple.maxSignals;
 
     while (toReturn.createdSignalsCount <= maxSignals) {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create_factory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create_factory.ts
@@ -82,7 +82,7 @@ export const searchAfterAndBulkCreateFactory = async ({
     ruleExecutionLogger,
     listClient,
   } = sharedParams;
-  // eslint-disable-next-line complexity
+
   return withSecuritySpan('searchAfterAndBulkCreate', async () => {
     let toReturn = createSearchAfterReturnType();
     let searchingIteration = 0;

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -46,7 +46,6 @@ import type {
   WrappedSignalHit,
   RuleRangeTuple,
   BaseSignalHit,
-  SignalSourceHit,
   SimpleHit,
   WrappedEventHit,
   SecuritySharedParams,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -626,28 +626,6 @@ export const createSearchAfterReturnType = ({
   };
 };
 
-export const createSearchResultReturnType = <
-  TAggregations = Record<estypes.AggregateName, estypes.AggregationsAggregate>
->(): SignalSearchResponse<TAggregations> => {
-  const hits: SignalSourceHit[] = [];
-  return {
-    took: 0,
-    timed_out: false,
-    _shards: {
-      total: 0,
-      successful: 0,
-      failed: 0,
-      skipped: 0,
-      failures: [],
-    },
-    hits: {
-      total: 0,
-      max_score: 0,
-      hits,
-    },
-  };
-};
-
 /**
  * Merges the return values from bulk creating alerts into the appropriate fields in the combined return object.
  */
@@ -714,54 +692,6 @@ export const mergeReturns = (
       errors: [...new Set([...existingErrors, ...newErrors])],
       warningMessages: [...existingWarningMessages, ...newWarningMessages],
       suppressedAlertsCount: (existingSuppressedAlertsCount ?? 0) + (newSuppressedAlertsCount ?? 0),
-    };
-  });
-};
-
-export const mergeSearchResults = <
-  TAggregations = Record<estypes.AggregateName, estypes.AggregationsAggregate>
->(
-  searchResults: Array<SignalSearchResponse<TAggregations>>
-) => {
-  return searchResults.reduce((prev, next) => {
-    const {
-      took: existingTook,
-      timed_out: existingTimedOut,
-      _shards: existingShards,
-      hits: existingHits,
-    } = prev;
-
-    const {
-      took: newTook,
-      timed_out: newTimedOut,
-      _scroll_id: newScrollId,
-      _shards: newShards,
-      aggregations: newAggregations,
-      hits: newHits,
-    } = next;
-
-    return {
-      took: Math.max(newTook, existingTook),
-      timed_out: newTimedOut && existingTimedOut,
-      _scroll_id: newScrollId,
-      _shards: {
-        total: newShards.total + existingShards.total,
-        successful: newShards.successful + existingShards.successful,
-        failed: newShards.failed + existingShards.failed,
-        // @ts-expect-error @elastic/elaticsearch skipped is optional in ShardStatistics
-        skipped: newShards.skipped + existingShards.skipped,
-        failures: [
-          ...(existingShards.failures != null ? existingShards.failures : []),
-          ...(newShards.failures != null ? newShards.failures : []),
-        ],
-      },
-      aggregations: newAggregations,
-      hits: {
-        total: calculateTotal(prev.hits.total, next.hits.total),
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        max_score: Math.max(newHits.max_score!, existingHits.max_score!),
-        hits: [...existingHits.hits, ...newHits.hits],
-      },
     };
   });
 };


### PR DESCRIPTION
## Summary

Long ago, we did multiple searches on each "page" of results to search for both docs with the timestamp override and default `@timestamp`. We then merged the results together before attempting to bulk create alerts. We no longer do this, instead we have a simpler process that just does one query per page so there's no need to merge search results together.

We also used to build the `tuple` inside `searchAfterBulkCreate`, so we had logic to verify if the tuple was created correctly. The time range tuple is now calculated in the shared security wrapper, which is responsible for any error handling. The TS types tell us that `tuple` and its subcomponents can't be null, we don't need to check in `searchAfterBulkCreate`.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->