### PR TITLE
[Security Solution][Detection Engine] Remove lastlookbackdate throughout rule executors

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -472,7 +472,6 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   createdSignalsCount: createdSignals.length,
                   suppressedAlertsCount: runResult.suppressedAlertsCount,
                   errors: result.errors.concat(runResult.errors),
-                  lastLookbackDate: runResult.lastLookBackDate,
                   searchAfterTimes: result.searchAfterTimes.concat(runResult.searchAfterTimes),
                   state: runResult.state,
                   success: result.success && runResult.success,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
@@ -88,7 +88,6 @@ export const createThreatSignals = async ({
     enrichmentTimes: [],
     bulkCreateTimes: [],
     searchAfterTimes: [],
-    lastLookBackDate: null,
     createdSignalsCount: 0,
     suppressedAlertsCount: 0,
     createdSignals: [],

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/utils.test.ts
@@ -59,7 +59,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -72,7 +71,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -89,7 +87,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -102,7 +99,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -112,36 +108,6 @@ describe('utils', () => {
       expect(combinedResults.success).toEqual(false);
     });
 
-    test('it should use the latest date if it is set in the new result', () => {
-      const existingResult: SearchAfterAndBulkCreateReturnType = {
-        success: false,
-        warning: false,
-        searchAfterTimes: ['10', '20', '30'],
-        bulkCreateTimes: ['5', '15', '25'],
-        enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
-        createdSignalsCount: 3,
-        createdSignals: Array(3).fill(sampleSignalHit()),
-        errors: [],
-        warningMessages: [],
-      };
-
-      const newResult: SearchAfterAndBulkCreateReturnType = {
-        success: true,
-        warning: false,
-        searchAfterTimes: ['10', '20', '30'],
-        bulkCreateTimes: ['5', '15', '25'],
-        enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'),
-        createdSignalsCount: 3,
-        createdSignals: Array(3).fill(sampleSignalHit()),
-        errors: [],
-        warningMessages: [],
-      };
-      const combinedResults = combineResults(existingResult, newResult);
-      expect(combinedResults.lastLookBackDate?.toISOString()).toEqual('2020-09-16T03:34:32.390Z');
-    });
-
     test('it should combine the searchAfterTimes and the bulkCreateTimes', () => {
       const existingResult: SearchAfterAndBulkCreateReturnType = {
         success: false,
@@ -149,7 +115,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -162,7 +127,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'),
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -185,7 +149,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: ['error 1', 'error 2', 'error 3'],
@@ -198,7 +161,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'),
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: ['error 4', 'error 1', 'error 3', 'error 5'],
@@ -311,7 +273,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -323,7 +284,6 @@ describe('utils', () => {
         searchAfterTimes: ['30'], // max value from existingResult.searchAfterTimes
         bulkCreateTimes: ['25'], // max value from existingResult.bulkCreateTimes
         enrichmentTimes: ['3'], // max value from existingResult.enrichmentTimes
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -341,7 +301,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -353,7 +312,6 @@ describe('utils', () => {
         searchAfterTimes: [],
         bulkCreateTimes: [],
         enrichmentTimes: [],
-        lastLookBackDate: undefined,
         createdSignalsCount: 0,
         createdSignals: [],
         errors: [],
@@ -365,7 +323,6 @@ describe('utils', () => {
         searchAfterTimes: ['30'], // max value from existingResult.searchAfterTimes
         bulkCreateTimes: ['25'], // max value from existingResult.bulkCreateTimes
         enrichmentTimes: ['3'], // max value from existingResult.enrichmentTimes
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -384,7 +341,6 @@ describe('utils', () => {
         searchAfterTimes: [],
         bulkCreateTimes: [],
         enrichmentTimes: [],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: [],
         errors: [],
@@ -396,7 +352,6 @@ describe('utils', () => {
         searchAfterTimes: [],
         bulkCreateTimes: [],
         enrichmentTimes: [],
-        lastLookBackDate: undefined,
         createdSignalsCount: 0,
         createdSignals: [],
         errors: [],
@@ -409,7 +364,6 @@ describe('utils', () => {
         searchAfterTimes: ['0'],
         bulkCreateTimes: ['0'],
         enrichmentTimes: ['0'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: [],
         errors: [],
@@ -428,7 +382,6 @@ describe('utils', () => {
         searchAfterTimes: [],
         bulkCreateTimes: [],
         enrichmentTimes: [],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: [],
         errors: [],
@@ -441,7 +394,6 @@ describe('utils', () => {
         searchAfterTimes: [],
         bulkCreateTimes: [],
         enrichmentTimes: [],
-        lastLookBackDate: undefined,
         createdSignalsCount: 0,
         createdSignals: [],
         errors: [],
@@ -454,7 +406,6 @@ describe('utils', () => {
         searchAfterTimes: ['0'],
         bulkCreateTimes: ['0'],
         enrichmentTimes: ['0'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: [],
         errors: [],
@@ -473,7 +424,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'], // max is 30
         bulkCreateTimes: ['5', '15', '25'], // max is 25
         enrichmentTimes: ['1', '2', '3'], // max is 3
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -485,7 +435,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'),
         createdSignalsCount: 5,
         createdSignals: Array(5).fill(sampleSignalHit()),
         errors: [],
@@ -497,7 +446,6 @@ describe('utils', () => {
         searchAfterTimes: ['40', '5', '15'],
         bulkCreateTimes: ['50', '5', '15'],
         enrichmentTimes: ['4', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T04:34:32.390Z'),
         createdSignalsCount: 8,
         createdSignals: Array(8).fill(sampleSignalHit()),
         errors: [],
@@ -510,7 +458,6 @@ describe('utils', () => {
         searchAfterTimes: ['70'], // max value between newResult1 and newResult2 + max array value of existingResult (40 + 30 = 70)
         bulkCreateTimes: ['75'], // max value between newResult1 and newResult2 + max array value of existingResult (50 + 25 = 75)
         enrichmentTimes: ['7'], // max value between newResult1 and newResult2 + max array value of existingResult (4 + 3 = 7)
-        lastLookBackDate: new Date('2020-09-16T04:34:32.390Z'), // max lastLookBackDate
         createdSignalsCount: 16, // all the signals counted together (8 + 5 + 3)
         createdSignals: Array(16).fill(sampleSignalHit()),
         errors: [],
@@ -529,7 +476,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'], // max is 30
         bulkCreateTimes: ['5', '15', '25'], // max is 25
         enrichmentTimes: ['1', '2', '3'], // max is 3
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -541,7 +487,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'),
         createdSignalsCount: 5,
         createdSignals: Array(5).fill(sampleSignalHit()),
         errors: [],
@@ -553,7 +498,6 @@ describe('utils', () => {
         searchAfterTimes: ['40', '5', '15'],
         bulkCreateTimes: ['50', '5', '15'],
         enrichmentTimes: ['5', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T04:34:32.390Z'),
         createdSignalsCount: 8,
         createdSignals: Array(8).fill(sampleSignalHit()),
         errors: [],
@@ -566,7 +510,6 @@ describe('utils', () => {
         searchAfterTimes: ['70'], // max value between newResult1 and newResult2 + max array value of existingResult (40 + 30 = 70)
         bulkCreateTimes: ['75'], // max value between newResult1 and newResult2 + max array value of existingResult (50 + 25 = 75)
         enrichmentTimes: ['8'], // max value between newResult1 and newResult2 + max array value of existingResult (50 + 3 = 8)
-        lastLookBackDate: new Date('2020-09-16T04:34:32.390Z'), // max lastLookBackDate
         createdSignalsCount: 16, // all the signals counted together (8 + 5 + 3)
         createdSignals: Array(16).fill(sampleSignalHit()),
         errors: [],
@@ -585,7 +528,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'], // max is 30
         bulkCreateTimes: ['5', '15', '25'], // max is 25
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -597,7 +539,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'),
         createdSignalsCount: 5,
         createdSignals: Array(5).fill(sampleSignalHit()),
         errors: [],
@@ -609,7 +550,6 @@ describe('utils', () => {
         searchAfterTimes: ['40', '5', '15'],
         bulkCreateTimes: ['50', '5', '15'],
         enrichmentTimes: ['5', '2', '3'],
-        lastLookBackDate: null,
         createdSignalsCount: 8,
         createdSignals: Array(8).fill(sampleSignalHit()),
         errors: [],
@@ -622,7 +562,6 @@ describe('utils', () => {
         searchAfterTimes: ['70'], // max value between newResult1 and newResult2 + max array value of existingResult (40 + 30 = 70)
         bulkCreateTimes: ['75'], // max value between newResult1 and newResult2 + max array value of existingResult (50 + 25 = 75)
         enrichmentTimes: ['8'], // max value between newResult1 and newResult2 + max array value of existingResult (5 + 3 = 8)
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'), // max lastLookBackDate
         createdSignalsCount: 16, // all the signals counted together (8 + 5 + 3)
         createdSignals: Array(16).fill(sampleSignalHit()),
         errors: [],
@@ -641,7 +580,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -654,7 +592,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['5', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -671,7 +608,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -684,7 +620,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -694,36 +629,6 @@ describe('utils', () => {
       expect(combinedResults.success).toEqual(false);
     });
 
-    test('it should use the latest date if it is set in the new result', () => {
-      const existingResult: SearchAfterAndBulkCreateReturnType = {
-        success: false,
-        warning: false,
-        searchAfterTimes: ['10', '20', '30'],
-        bulkCreateTimes: ['5', '15', '25'],
-        enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
-        createdSignalsCount: 3,
-        createdSignals: Array(3).fill(sampleSignalHit()),
-        errors: [],
-        warningMessages: [],
-      };
-
-      const newResult: SearchAfterAndBulkCreateReturnType = {
-        success: true,
-        warning: false,
-        searchAfterTimes: ['10', '20', '30'],
-        bulkCreateTimes: ['5', '15', '25'],
-        enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'),
-        createdSignalsCount: 3,
-        createdSignals: Array(3).fill(sampleSignalHit()),
-        errors: [],
-        warningMessages: [],
-      };
-      const combinedResults = combineConcurrentResults(existingResult, [newResult]);
-      expect(combinedResults.lastLookBackDate?.toISOString()).toEqual('2020-09-16T03:34:32.390Z');
-    });
-
     test('it should combine the searchAfterTimes and the bulkCreateTimes', () => {
       const existingResult: SearchAfterAndBulkCreateReturnType = {
         success: false,
@@ -731,7 +636,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -744,7 +648,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'),
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: [],
@@ -766,7 +669,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: undefined,
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: ['error 1', 'error 2', 'error 3'],
@@ -779,7 +681,6 @@ describe('utils', () => {
         searchAfterTimes: ['10', '20', '30'],
         bulkCreateTimes: ['5', '15', '25'],
         enrichmentTimes: ['1', '2', '3'],
-        lastLookBackDate: new Date('2020-09-16T03:34:32.390Z'),
         createdSignalsCount: 3,
         createdSignals: Array(3).fill(sampleSignalHit()),
         errors: ['error 4', 'error 1', 'error 3', 'error 5'],
@@ -958,7 +859,6 @@ describe('utils', () => {
           searchAfterTimes: ['10', '20', '30'],
           bulkCreateTimes: ['5', '15', '25'],
           enrichmentTimes: ['1', '2', '3'],
-          lastLookBackDate: undefined,
           createdSignalsCount: 3,
           createdSignals: Array(3).fill(sampleSignalHit()),
           errors: [],
@@ -984,7 +884,6 @@ describe('utils', () => {
           searchAfterTimes: ['10', '20', '30'],
           bulkCreateTimes: ['5', '15', '25'],
           enrichmentTimes: ['1', '2', '3'],
-          lastLookBackDate: undefined,
           createdSignalsCount: 3,
           createdSignals: Array(3).fill(sampleSignalHit()),
           errors: [
@@ -1016,7 +915,6 @@ describe('utils', () => {
           searchAfterTimes: ['10', '20', '30'],
           bulkCreateTimes: ['5', '15', '25'],
           enrichmentTimes: ['1', '2', '3'],
-          lastLookBackDate: undefined,
           createdSignalsCount: 3,
           createdSignals: Array(3).fill(sampleSignalHit()),
           errors: [
@@ -1048,7 +946,6 @@ describe('utils', () => {
           searchAfterTimes: ['10', '20', '30'],
           bulkCreateTimes: ['5', '15', '25'],
           enrichmentTimes: ['1', '2', '3'],
-          lastLookBackDate: undefined,
           createdSignalsCount: 3,
           createdSignals: Array(3).fill(sampleSignalHit()),
           errors: [

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/utils.ts
@@ -95,7 +95,6 @@ export const combineResults = (
     currentResult.searchAfterTimes,
     newResult.searchAfterTimes
   ),
-  lastLookBackDate: newResult.lastLookBackDate,
   createdSignalsCount: currentResult.createdSignalsCount + newResult.createdSignalsCount,
   createdSignals: [...currentResult.createdSignals, ...newResult.createdSignals],
   warningMessages: [...currentResult.warningMessages, ...newResult.warningMessages],
@@ -118,14 +117,12 @@ export const combineConcurrentResults = (
       const maxSearchAfterTime = calculateMax(accum.searchAfterTimes, item.searchAfterTimes);
       const maxEnrichmentTimes = calculateMax(accum.enrichmentTimes, item.enrichmentTimes);
       const maxBulkCreateTimes = calculateMax(accum.bulkCreateTimes, item.bulkCreateTimes);
-      const lastLookBackDate = calculateMaxLookBack(accum.lastLookBackDate, item.lastLookBackDate);
       return {
         success: accum.success && item.success,
         warning: accum.warning || item.warning,
         searchAfterTimes: [maxSearchAfterTime],
         bulkCreateTimes: [maxBulkCreateTimes],
         enrichmentTimes: [maxEnrichmentTimes],
-        lastLookBackDate,
         createdSignalsCount: accum.createdSignalsCount + item.createdSignalsCount,
         createdSignals: [...accum.createdSignals, ...item.createdSignals],
         warningMessages: [...accum.warningMessages, ...item.warningMessages],
@@ -140,7 +137,6 @@ export const combineConcurrentResults = (
       searchAfterTimes: [],
       bulkCreateTimes: [],
       enrichmentTimes: [],
-      lastLookBackDate: undefined,
       createdSignalsCount: 0,
       suppressedAlertsCount: 0,
       createdSignals: [],

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/alert_suppression/group_and_bulk_create.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/query/alert_suppression/group_and_bulk_create.ts
@@ -146,7 +146,6 @@ export const groupAndBulkCreate = async ({
       searchAfterTimes: [],
       enrichmentTimes: [],
       bulkCreateTimes: [],
-      lastLookBackDate: null,
       createdSignalsCount: 0,
       createdSignals: [],
       errors: [],

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
@@ -63,7 +63,6 @@ export interface SecurityAlertTypeReturnValue<TState extends RuleTypeState> {
   createdSignals: unknown[];
   errors: string[];
   userError?: boolean;
-  lastLookbackDate?: Date | null;
   searchAfterTimes: string[];
   state: TState;
   success: boolean;
@@ -334,7 +333,6 @@ export interface SearchAfterAndBulkCreateReturnType {
   searchAfterTimes: string[];
   enrichmentTimes: string[];
   bulkCreateTimes: string[];
-  lastLookBackDate: Date | null | undefined;
   createdSignalsCount: number;
   createdSignals: unknown[];
   errors: string[];

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/index.ts
@@ -15,7 +15,6 @@ export const createResultObject = <TState extends RuleTypeState>(state: TState) 
     createdSignalsCount: 0,
     createdSignals: [],
     errors: [],
-    lastLookbackDate: undefined,
     searchAfterTimes: [],
     state,
     success: true,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.test.ts
@@ -178,7 +178,7 @@ describe('searchAfterAndBulkCreate', () => {
       },
     ];
 
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams: {
         ...sharedParams,
         unprocessedExceptions: [exceptionItem],
@@ -191,7 +191,6 @@ describe('searchAfterAndBulkCreate', () => {
     expect(success).toEqual(true);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(5);
     expect(createdSignalsCount).toEqual(4);
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 
   test('should return success with number of searches less than max signals with gap', async () => {
@@ -266,7 +265,7 @@ describe('searchAfterAndBulkCreate', () => {
         },
       },
     ];
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams: {
         ...sharedParams,
         unprocessedExceptions: [exceptionItem],
@@ -280,7 +279,6 @@ describe('searchAfterAndBulkCreate', () => {
     expect(success).toEqual(true);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(4);
     expect(createdSignalsCount).toEqual(3);
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 
   test('should return success when no search results are in the allowlist', async () => {
@@ -335,7 +333,7 @@ describe('searchAfterAndBulkCreate', () => {
         },
       },
     ];
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams: {
         ...sharedParams,
         unprocessedExceptions: [exceptionItem],
@@ -348,7 +346,6 @@ describe('searchAfterAndBulkCreate', () => {
     expect(success).toEqual(true);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(2);
     expect(createdSignalsCount).toEqual(4);
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 
   test('should return success when all search results are in the allowlist and with sortId present', async () => {
@@ -387,7 +384,7 @@ describe('searchAfterAndBulkCreate', () => {
         },
       },
     ];
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams: {
         ...sharedParams,
         unprocessedExceptions: [exceptionItem],
@@ -400,7 +397,6 @@ describe('searchAfterAndBulkCreate', () => {
     expect(success).toEqual(true);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(2);
     expect(createdSignalsCount).toEqual(0); // should not create any signals because all events were in the allowlist
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 
   test('should return success when empty string sortId present', async () => {
@@ -449,7 +445,7 @@ describe('searchAfterAndBulkCreate', () => {
         )
       );
 
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams,
       services: ruleServices,
       eventsTelemetry: undefined,
@@ -459,7 +455,6 @@ describe('searchAfterAndBulkCreate', () => {
     expect(success).toEqual(true);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(2);
     expect(createdSignalsCount).toEqual(4);
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 
   test('should return success when all search results are in the allowlist and no sortId present', async () => {
@@ -494,7 +489,7 @@ describe('searchAfterAndBulkCreate', () => {
         },
       },
     ];
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams: {
         ...sharedParams,
         unprocessedExceptions: [exceptionItem],
@@ -507,7 +502,6 @@ describe('searchAfterAndBulkCreate', () => {
     expect(success).toEqual(true);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(1);
     expect(createdSignalsCount).toEqual(0); // should not create any signals because all events were in the allowlist
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 
   test('should return success when no sortId present but search results are in the allowlist', async () => {
@@ -556,7 +550,7 @@ describe('searchAfterAndBulkCreate', () => {
         },
       },
     ];
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams: {
         ...sharedParams,
         unprocessedExceptions: [exceptionItem],
@@ -569,7 +563,6 @@ describe('searchAfterAndBulkCreate', () => {
     expect(success).toEqual(true);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(1);
     expect(createdSignalsCount).toEqual(4);
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 
   test('should return success when no exceptions list provided', async () => {
@@ -620,7 +613,7 @@ describe('searchAfterAndBulkCreate', () => {
         }))
       )
     );
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams,
       services: ruleServices,
       eventsTelemetry: undefined,
@@ -630,7 +623,6 @@ describe('searchAfterAndBulkCreate', () => {
     expect(success).toEqual(true);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(2);
     expect(createdSignalsCount).toEqual(4);
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 
   test('should return success with 0 total hits', async () => {
@@ -657,7 +649,7 @@ describe('searchAfterAndBulkCreate', () => {
         }))
       )
     );
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams: {
         ...sharedParams,
         unprocessedExceptions: [exceptionItem],
@@ -669,7 +661,6 @@ describe('searchAfterAndBulkCreate', () => {
     });
     expect(success).toEqual(true);
     expect(createdSignalsCount).toEqual(0);
-    expect(lastLookBackDate).toEqual(null);
   });
 
   test('if returns false when singleSearchAfter throws an exception', async () => {
@@ -696,7 +687,7 @@ describe('searchAfterAndBulkCreate', () => {
         },
       },
     ];
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams: {
         ...sharedParams,
         unprocessedExceptions: [exceptionItem],
@@ -708,7 +699,6 @@ describe('searchAfterAndBulkCreate', () => {
     });
     expect(success).toEqual(false);
     expect(createdSignalsCount).toEqual(0); // should not create signals if search threw error
-    expect(lastLookBackDate).toEqual(null);
   });
 
   test('it returns error array when singleSearchAfter returns errors', async () => {
@@ -816,19 +806,17 @@ describe('searchAfterAndBulkCreate', () => {
         sampleDocSearchResultsNoSortIdNoHits()
       )
     );
-    const { success, createdSignalsCount, lastLookBackDate, errors } =
-      await searchAfterAndBulkCreate({
-        sharedParams,
-        services: ruleServices,
-        eventsTelemetry: undefined,
-        filter: defaultFilter,
-        buildReasonMessage,
-      });
+    const { success, createdSignalsCount, errors } = await searchAfterAndBulkCreate({
+      sharedParams,
+      services: ruleServices,
+      eventsTelemetry: undefined,
+      filter: defaultFilter,
+      buildReasonMessage,
+    });
     expect(success).toEqual(false);
     expect(errors).toEqual(['error on creation']);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(5);
     expect(createdSignalsCount).toEqual(4);
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 
   it('invokes the enrichment callback with signal search results', async () => {
@@ -893,7 +881,7 @@ describe('searchAfterAndBulkCreate', () => {
     );
 
     const mockEnrichment = jest.fn((a) => a);
-    const { success, createdSignalsCount, lastLookBackDate } = await searchAfterAndBulkCreate({
+    const { success, createdSignalsCount } = await searchAfterAndBulkCreate({
       sharedParams,
       enrichment: mockEnrichment,
       services: ruleServices,
@@ -927,6 +915,5 @@ describe('searchAfterAndBulkCreate', () => {
     expect(success).toEqual(true);
     expect(ruleServices.scopedClusterClient.asCurrentUser.search).toHaveBeenCalledTimes(4);
     expect(createdSignalsCount).toEqual(3);
-    expect(lastLookBackDate).toEqual(new Date('2020-04-20T21:27:45+0000'));
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
@@ -744,7 +744,6 @@ describe('utils', () => {
         createdSignalsCount: 0,
         createdSignals: [],
         errors: [],
-        lastLookBackDate: null,
         searchAfterTimes: [],
         success: true,
         warning: false,
@@ -766,7 +765,6 @@ describe('utils', () => {
         createdSignalsCount: 0,
         createdSignals: [],
         errors: [],
-        lastLookBackDate: new Date('2020-04-20T21:27:45.000Z'),
         searchAfterTimes: [],
         success: true,
         warning: false,
@@ -840,45 +838,6 @@ describe('utils', () => {
         primaryTimestamp: 'event.ingested',
       });
       expect(success).toEqual(true);
-    });
-
-    test('It will not set an invalid date time stamp from a non-existent @timestamp when the index is not 100% ECS compliant', () => {
-      const searchResult = sampleDocSearchResultsNoSortId();
-      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = undefined;
-      if (searchResult.hits.hits[0].fields != null) {
-        (searchResult.hits.hits[0].fields['@timestamp'] as unknown) = undefined;
-      }
-      const { lastLookBackDate } = createSearchAfterReturnTypeFromResponse({
-        searchResult,
-        primaryTimestamp: TIMESTAMP,
-      });
-      expect(lastLookBackDate).toEqual(null);
-    });
-
-    test('It will not set an invalid date time stamp from a null @timestamp when the index is not 100% ECS compliant', () => {
-      const searchResult = sampleDocSearchResultsNoSortId();
-      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = null;
-      if (searchResult.hits.hits[0].fields != null) {
-        (searchResult.hits.hits[0].fields['@timestamp'] as unknown) = null;
-      }
-      const { lastLookBackDate } = createSearchAfterReturnTypeFromResponse({
-        searchResult,
-        primaryTimestamp: TIMESTAMP,
-      });
-      expect(lastLookBackDate).toEqual(null);
-    });
-
-    test('It will not set an invalid date time stamp from an invalid @timestamp string', () => {
-      const searchResult = sampleDocSearchResultsNoSortId();
-      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = 'invalid';
-      if (searchResult.hits.hits[0].fields != null) {
-        (searchResult.hits.hits[0].fields['@timestamp'] as unknown) = ['invalid'];
-      }
-      const { lastLookBackDate } = createSearchAfterReturnTypeFromResponse({
-        searchResult,
-        primaryTimestamp: TIMESTAMP,
-      });
-      expect(lastLookBackDate).toEqual(null);
     });
   });
 
@@ -1086,7 +1045,6 @@ describe('utils', () => {
         createdSignalsCount: 0,
         createdSignals: [],
         errors: [],
-        lastLookBackDate: null,
         searchAfterTimes: [],
         success: true,
         warning: false,
@@ -1103,7 +1061,6 @@ describe('utils', () => {
         createdSignalsCount: 5,
         createdSignals: Array(5).fill(sampleSignalHit()),
         errors: ['error 1'],
-        lastLookBackDate: new Date('2020-09-21T18:51:25.193Z'),
         searchAfterTimes: ['123'],
         success: false,
         warning: true,
@@ -1115,7 +1072,6 @@ describe('utils', () => {
         createdSignalsCount: 5,
         createdSignals: Array(5).fill(sampleSignalHit()),
         errors: ['error 1'],
-        lastLookBackDate: new Date('2020-09-21T18:51:25.193Z'),
         searchAfterTimes: ['123'],
         success: false,
         warning: true,
@@ -1137,7 +1093,6 @@ describe('utils', () => {
         createdSignalsCount: 5,
         createdSignals: Array(5).fill(sampleSignalHit()),
         errors: ['error 1'],
-        lastLookBackDate: null,
         searchAfterTimes: [],
         success: true,
         warning: false,
@@ -1157,7 +1112,6 @@ describe('utils', () => {
         createdSignalsCount: 0,
         createdSignals: [],
         errors: [],
-        lastLookBackDate: null,
         searchAfterTimes: [],
         success: true,
         warning: false,
@@ -1183,30 +1137,6 @@ describe('utils', () => {
       expect(success).toEqual(false);
     });
 
-    test('it merges search where the lastLookBackDate is the "next" date when given', () => {
-      const { lastLookBackDate } = mergeReturns([
-        createSearchAfterReturnType({
-          lastLookBackDate: new Date('2020-08-21T19:21:46.194Z'),
-        }),
-        createSearchAfterReturnType({
-          lastLookBackDate: new Date('2020-09-21T19:21:46.194Z'),
-        }),
-      ]);
-      expect(lastLookBackDate).toEqual(new Date('2020-09-21T19:21:46.194Z'));
-    });
-
-    test('it merges search where the lastLookBackDate is the "prev" if given undefined for "next', () => {
-      const { lastLookBackDate } = mergeReturns([
-        createSearchAfterReturnType({
-          lastLookBackDate: new Date('2020-08-21T19:21:46.194Z'),
-        }),
-        createSearchAfterReturnType({
-          lastLookBackDate: undefined,
-        }),
-      ]);
-      expect(lastLookBackDate).toEqual(new Date('2020-08-21T19:21:46.194Z'));
-    });
-
     test('it merges search where values from "next" and "prev" are computed together', () => {
       const merged = mergeReturns([
         createSearchAfterReturnType({
@@ -1215,7 +1145,6 @@ describe('utils', () => {
           createdSignalsCount: 3,
           createdSignals: Array(3).fill(sampleSignalHit()),
           errors: ['error 1', 'error 2'],
-          lastLookBackDate: new Date('2020-08-21T18:51:25.193Z'),
           searchAfterTimes: ['123'],
           success: true,
           warningMessages: ['warning1'],
@@ -1226,7 +1155,6 @@ describe('utils', () => {
           createdSignalsCount: 2,
           createdSignals: Array(2).fill(sampleSignalHit()),
           errors: ['error 3'],
-          lastLookBackDate: new Date('2020-09-21T18:51:25.193Z'),
           searchAfterTimes: ['567'],
           success: true,
           warningMessages: ['warning2'],
@@ -1239,7 +1167,6 @@ describe('utils', () => {
         createdSignalsCount: 5, // Adds the 3 and 2 together
         createdSignals: Array(5).fill(sampleSignalHit()),
         errors: ['error 1', 'error 2', 'error 3'], // concatenates the prev and next together
-        lastLookBackDate: new Date('2020-09-21T18:51:25.193Z'), // takes the next lastLookBackDate
         searchAfterTimes: ['123', '567'], // concatenates the searchAfterTimes together
         success: true, // Defaults to success true is all of it was successful
         warning: true,

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.test.ts
@@ -33,7 +33,6 @@ import {
   createSearchAfterReturnTypeFromResponse,
   createSearchAfterReturnType,
   mergeReturns,
-  lastValidDate,
   getValidDateFromDoc,
   calculateTotal,
   getTotalHitsValue,
@@ -51,7 +50,6 @@ import {
   sampleDocSearchResultsWithSortId,
   sampleEmptyDocSearchResults,
   sampleDocSearchResultsNoSortIdNoHits,
-  sampleDocSearchResultsNoSortId,
   sampleDocNoSortId,
   sampleAlertDocNoSortIdWithTimestamp,
   sampleAlertDocAADNoSortIdWithTimestamp,
@@ -838,84 +836,6 @@ describe('utils', () => {
         primaryTimestamp: 'event.ingested',
       });
       expect(success).toEqual(true);
-    });
-  });
-
-  describe('lastValidDate', () => {
-    test('It returns undefined if the search result contains a null timestamp', () => {
-      const searchResult = sampleDocSearchResultsNoSortId();
-      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = null;
-      if (searchResult.hits.hits[0].fields != null) {
-        (searchResult.hits.hits[0].fields['@timestamp'] as unknown) = null;
-      }
-      const date = lastValidDate({ searchResult, primaryTimestamp: TIMESTAMP });
-      expect(date).toEqual(undefined);
-    });
-
-    test('It returns undefined if the search result contains a undefined timestamp', () => {
-      const searchResult = sampleDocSearchResultsNoSortId();
-      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = undefined;
-      if (searchResult.hits.hits[0].fields != null) {
-        (searchResult.hits.hits[0].fields['@timestamp'] as unknown) = undefined;
-      }
-      const date = lastValidDate({ searchResult, primaryTimestamp: TIMESTAMP });
-      expect(date).toEqual(undefined);
-    });
-
-    test('It returns undefined if the search result contains an invalid string value', () => {
-      const searchResult = sampleDocSearchResultsNoSortId();
-      (searchResult.hits.hits[0]._source['@timestamp'] as unknown) = 'invalid value';
-      if (searchResult.hits.hits[0].fields != null) {
-        (searchResult.hits.hits[0].fields['@timestamp'] as unknown) = ['invalid value'];
-      }
-      const date = lastValidDate({ searchResult, primaryTimestamp: TIMESTAMP });
-      expect(date).toEqual(undefined);
-    });
-
-    test('It returns normal date time if set', () => {
-      const searchResult = sampleDocSearchResultsNoSortId();
-      const date = lastValidDate({ searchResult, primaryTimestamp: TIMESTAMP });
-      expect(date?.toISOString()).toEqual('2020-04-20T21:27:45.000Z');
-    });
-
-    test('It returns date time from field if set there', () => {
-      const timestamp = '2020-10-07T19:27:19.136Z';
-      const searchResult = sampleDocSearchResultsNoSortId();
-      if (searchResult.hits.hits[0] == null) {
-        throw new TypeError('Test requires one element');
-      }
-      searchResult.hits.hits[0] = {
-        ...searchResult.hits.hits[0],
-        fields: {
-          '@timestamp': [timestamp],
-        },
-      };
-      const date = lastValidDate({ searchResult, primaryTimestamp: TIMESTAMP });
-      expect(date?.toISOString()).toEqual(timestamp);
-    });
-
-    test('It returns timestampOverride date time if set', () => {
-      const override = '2020-10-07T19:20:28.049Z';
-      const searchResult = sampleDocSearchResultsNoSortId();
-      searchResult.hits.hits[0]._source.different_timestamp = new Date(override).toISOString();
-      const date = lastValidDate({ searchResult, primaryTimestamp: 'different_timestamp' });
-      expect(date?.toISOString()).toEqual(override);
-    });
-
-    test('It returns timestampOverride date time from fields if set on it', () => {
-      const override = '2020-10-07T19:36:31.110Z';
-      const searchResult = sampleDocSearchResultsNoSortId();
-      if (searchResult.hits.hits[0] == null) {
-        throw new TypeError('Test requires one element');
-      }
-      searchResult.hits.hits[0] = {
-        ...searchResult.hits.hits[0],
-        fields: {
-          different_timestamp: [override],
-        },
-      };
-      const date = lastValidDate({ searchResult, primaryTimestamp: 'different_timestamp' });
-      expect(date?.toISOString()).toEqual(override);
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -582,7 +582,6 @@ export const createSearchAfterReturnTypeFromResponse = <
           )
         );
       }),
-    lastLookBackDate: lastValidDate({ searchResult, primaryTimestamp }),
   });
 };
 
@@ -592,7 +591,6 @@ export const createSearchAfterReturnType = ({
   searchAfterTimes,
   enrichmentTimes,
   bulkCreateTimes,
-  lastLookBackDate,
   createdSignalsCount,
   createdSignals,
   errors,
@@ -604,7 +602,6 @@ export const createSearchAfterReturnType = ({
   searchAfterTimes?: string[] | undefined;
   enrichmentTimes?: string[] | undefined;
   bulkCreateTimes?: string[] | undefined;
-  lastLookBackDate?: Date | undefined;
   createdSignalsCount?: number | undefined;
   createdSignals?: unknown[] | undefined;
   errors?: string[] | undefined;
@@ -617,7 +614,6 @@ export const createSearchAfterReturnType = ({
     searchAfterTimes: searchAfterTimes ?? [],
     enrichmentTimes: enrichmentTimes ?? [],
     bulkCreateTimes: bulkCreateTimes ?? [],
-    lastLookBackDate: lastLookBackDate ?? null,
     createdSignalsCount: createdSignalsCount ?? 0,
     createdSignals: createdSignals ?? [],
     errors: errors ?? [],
@@ -680,7 +676,6 @@ export const mergeReturns = (
       searchAfterTimes: existingSearchAfterTimes,
       bulkCreateTimes: existingBulkCreateTimes,
       enrichmentTimes: existingEnrichmentTimes,
-      lastLookBackDate: existingLastLookBackDate,
       createdSignalsCount: existingCreatedSignalsCount,
       createdSignals: existingCreatedSignals,
       errors: existingErrors,
@@ -694,7 +689,6 @@ export const mergeReturns = (
       searchAfterTimes: newSearchAfterTimes,
       enrichmentTimes: newEnrichmentTimes,
       bulkCreateTimes: newBulkCreateTimes,
-      lastLookBackDate: newLastLookBackDate,
       createdSignalsCount: newCreatedSignalsCount,
       createdSignals: newCreatedSignals,
       errors: newErrors,
@@ -708,7 +702,6 @@ export const mergeReturns = (
       searchAfterTimes: [...existingSearchAfterTimes, ...newSearchAfterTimes],
       enrichmentTimes: [...existingEnrichmentTimes, ...newEnrichmentTimes],
       bulkCreateTimes: [...existingBulkCreateTimes, ...newBulkCreateTimes],
-      lastLookBackDate: newLastLookBackDate ?? existingLastLookBackDate,
       createdSignalsCount: existingCreatedSignalsCount + newCreatedSignalsCount,
       createdSignals: [...existingCreatedSignals, ...newCreatedSignals],
       errors: [...new Set([...existingErrors, ...newErrors])],

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -492,31 +492,6 @@ export const createErrorsFromShard = ({ errors }: { errors: ShardError[] }): str
 };
 
 /**
- * Given a SignalSearchResponse this will return a valid last date if it can find one, otherwise it
- * will return undefined. This tries the "fields" first to get a formatted date time if it can, but if
- * it cannot it will resort to using the "_source" fields second which can be problematic if the date time
- * is not correctly ISO8601 or epoch milliseconds formatted.
- * @param searchResult The result to try and parse out the timestamp.
- * @param primaryTimestamp The primary timestamp to use.
- */
-export const lastValidDate = <
-  TAggregations = Record<estypes.AggregateName, estypes.AggregationsAggregate>
->({
-  searchResult,
-  primaryTimestamp,
-}: {
-  searchResult: SignalSearchResponse<TAggregations>;
-  primaryTimestamp: TimestampOverride;
-}): Date | undefined => {
-  if (searchResult.hits.hits.length === 0) {
-    return undefined;
-  } else {
-    const lastRecord = searchResult.hits.hits[searchResult.hits.hits.length - 1];
-    return getValidDateFromDoc({ doc: lastRecord, primaryTimestamp });
-  }
-};
-
-/**
  * Given a search hit this will return a valid last date if it can find one, otherwise it
  * will return undefined. This tries the "fields" first to get a formatted date time if it can, but if
  * it cannot it will resort to using the "_source" fields second which can be problematic if the date time


### PR DESCRIPTION
## Summary

`lastLookbackDate` is a variable we used to use to set a field on the SIEM rule status SOs, e.g. [here](https://github.com/elastic/kibana/blob/main/x-pack/test/functional/es_archives/cases/migrations/7.11.1/mappings.json#L2068). It contained the date from the last doc in the rule search results, if there were any results. The last doc in the search results should be the most recent one. Since we removed the SIEM rule status SOs, we have not been storing this data anywhere so we don't need to compute it in the rule executors anymore.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->