### PR TITLE
[Security Solution][Endpoint] Un-skip space awareness FTR tests

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/space_awareness.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/edr_workflows/spaces/trial_license_complete_tier/space_awareness.ts
@@ -24,8 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
   const kbnServer = getService('kibanaServer');
   const log = getService('log');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/203898
-  describe.skip('@ess @serverless @skipInServerlessMKI Endpoint management space awareness support', function () {
+  describe('@ess @serverless @skipInServerlessMKI Endpoint management space awareness support', function () {
     let adminSupertest: TestAgent;
     let dataSpaceA: Awaited<ReturnType<typeof endpointTestresources.loadEndpointData>>;
     let dataSpaceB: Awaited<ReturnType<typeof endpointTestresources.loadEndpointData>>;
@@ -38,15 +37,23 @@ export default function ({ getService }: FtrProviderContext) {
         ensureSpaceIdExists(kbnServer, 'space_b', { log }),
       ]);
 
+      log.info(`Loading endpoint data into space_a`);
+
       dataSpaceA = await endpointTestresources.loadEndpointData({
         spaceId: 'space_a',
         generatorSeed: Math.random().toString(32),
       });
 
+      log.info(`Done with loading of endpoint data into space_a
+
+Loading endpoint data into space_b`);
+
       dataSpaceB = await endpointTestresources.loadEndpointData({
         spaceId: 'space_b',
         generatorSeed: Math.random().toString(32),
       });
+
+      log.info(`Done with loading of endpoint data into space_b`);
 
       log.verbose(
         `mocked data loaded:\nSPACE A:\n${JSON.stringify(


### PR DESCRIPTION
## Summary

- Unskips the Space awareness FTR tests. Unclear why they were failing and logs did not provide much information.
- added some minor info. logs to the data loading part


Closes #203898




<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->