### PR TITLE
Remove getByRole tests in KPI charts

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/chart_settings_popover/configurations/default/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/chart_settings_popover/configurations/default/index.tsx
@@ -46,6 +46,7 @@ export const useChartSettingsPopoverConfiguration = ({
               setIsPopoverOpen(false);
               handleClick();
             },
+            'data-test-subj': 'inspect',
           },
           {
             name: i18n.RESET_GROUP_BY_FIELDS,
@@ -53,6 +54,7 @@ export const useChartSettingsPopoverConfiguration = ({
               setIsPopoverOpen(false);
               onResetStackByFields();
             },
+            'data-test-subj': 'reset-group-by',
           },
         ],
       },

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/chart_settings_popover/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/chart_settings_popover/index.test.tsx
@@ -5,10 +5,8 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
-
-import { CHART_SETTINGS_POPOVER_ARIA_LABEL } from './translations';
 import { ChartSettingsPopover } from '.';
 
 describe('ChartSettingsPopover', () => {
@@ -31,7 +29,7 @@ describe('ChartSettingsPopover', () => {
   ];
 
   it('renders the chart settings popover', () => {
-    render(
+    const { getByTestId } = render(
       <ChartSettingsPopover
         initialPanelId={initialPanelId}
         isPopoverOpen={false}
@@ -40,8 +38,6 @@ describe('ChartSettingsPopover', () => {
       />
     );
 
-    expect(
-      screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL })
-    ).toBeInTheDocument();
+    expect(getByTestId('chart-settings-popover-button')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/chart_settings_popover/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/chart_settings_popover/index.tsx
@@ -40,6 +40,7 @@ const ChartSettingsPopoverComponent: React.FC<Props> = ({
         iconType="boxesVertical"
         onClick={onButtonClick}
         size="xs"
+        data-test-subj="chart-settings-popover-button"
       />
     ),
     [onButtonClick]

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/field_selection/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/field_selection/index.test.tsx
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
-
 import { TestProviders } from '../../mock';
 import type { Props } from '.';
 import { FieldSelection } from '.';
@@ -31,23 +30,23 @@ const defaultProps: Props = {
 
 describe('FieldSelection', () => {
   test('it renders the (first) "Group by" selection', () => {
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <FieldSelection {...defaultProps} />
       </TestProviders>
     );
 
-    expect(screen.getByRole('combobox', { name: GROUP_BY_LABEL })).toBeInTheDocument();
+    expect(getByTestId('groupBy')).toHaveTextContent(GROUP_BY_LABEL);
   });
 
   test('it renders the (second) "Group by top" selection', () => {
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <FieldSelection {...defaultProps} />
       </TestProviders>
     );
 
-    expect(screen.getByRole('combobox', { name: GROUP_BY_TOP_LABEL })).toBeInTheDocument();
+    expect(getByTestId('groupByTop')).toHaveTextContent(GROUP_BY_TOP_LABEL);
   });
 
   test('it renders the chart options context menu using the provided `uniqueQueryId`', () => {
@@ -56,22 +55,22 @@ describe('FieldSelection', () => {
       chartOptionsContextMenu: (queryId: string) => <div>{queryId}</div>,
     };
 
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <FieldSelection {...propsWithContextMenu} />
       </TestProviders>
     );
 
-    expect(screen.getByText(defaultProps.uniqueQueryId)).toBeInTheDocument();
+    expect(getByTestId('chartOptions')).toHaveTextContent(defaultProps.uniqueQueryId);
   });
 
   test('it does NOT render the chart options context menu when `chartOptionsContextMenu` is undefined', () => {
-    render(
+    const { queryByTestId } = render(
       <TestProviders>
         <FieldSelection {...defaultProps} />
       </TestProviders>
     );
 
-    expect(screen.queryByText(defaultProps.uniqueQueryId)).not.toBeInTheDocument();
+    expect(queryByTestId('chartOptions')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/field_selection/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/field_selection/index.tsx
@@ -77,7 +77,7 @@ const FieldSelectionComponent: React.FC<Props> = ({
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
       {chartOptionsContextMenu != null && (
-        <ChartOptionsFlexItem grow={false}>
+        <ChartOptionsFlexItem grow={false} data-test-subj="chartOptions">
           {chartOptionsContextMenu(uniqueQueryId)}
         </ChartOptionsFlexItem>
       )}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.test.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { AlertsProgressBarPanel } from '.';
 import { useSummaryChartData } from '../alerts_summary_charts_panel/use_summary_chart_data';
-import { STACK_BY_ARIA_LABEL } from '../common/translations';
 import type { GroupBySelection } from './types';
 import { useStackByFields } from '../common/hooks';
 
@@ -84,12 +83,12 @@ describe('Alert by grouping', () => {
     });
 
     test('combo box renders corrected options', async () => {
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <AlertsProgressBarPanel {...defaultProps} setGroupBySelection={setGroupBySelection} />
         </TestProviders>
       );
-      const comboBox = screen.getByRole('combobox', { name: STACK_BY_ARIA_LABEL });
+      const comboBox = getByTestId('comboBoxSearchInput');
       act(() => {
         if (comboBox) {
           comboBox.focus(); // display the combo box options
@@ -104,12 +103,12 @@ describe('Alert by grouping', () => {
 
     test('it invokes setGroupBySelection when an option is selected', async () => {
       const toBeSelected = 'user.name';
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <AlertsProgressBarPanel {...defaultProps} setGroupBySelection={setGroupBySelection} />
         </TestProviders>
       );
-      const comboBox = screen.getByRole('combobox', { name: STACK_BY_ARIA_LABEL });
+      const comboBox = getByTestId('comboBoxSearchInput');
       act(() => {
         if (comboBox) {
           comboBox.focus(); // display the combo box options

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.tsx
@@ -96,7 +96,7 @@ export const AlertsProgressBarPanel: React.FC<AlertsProgressBarPanelProps> = ({
             onSelect={onSelect}
             prepend={''}
             width={DEFAULT_COMBOBOX_WIDTH}
-            dropDownoptions={dropDownOptions}
+            dropDownOptions={dropDownOptions}
           />
         </HeaderSection>
         <AlertsProgressBar

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_context_menu/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/chart_context_menu/index.test.tsx
@@ -5,13 +5,9 @@
  * 2.0.
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 import React from 'react';
-
-import { RESET_GROUP_BY_FIELDS } from '../../../../../common/components/chart_settings_popover/configurations/default/translations';
-import { CHART_SETTINGS_POPOVER_ARIA_LABEL } from '../../../../../common/components/chart_settings_popover/translations';
-import { INSPECT } from '../../../../../common/components/inspect/translations';
 import { DEFAULT_STACK_BY_FIELD, DEFAULT_STACK_BY_FIELD1 } from '../../common/config';
 import { TestProviders } from '../../../../../common/mock';
 import { ChartContextMenu } from '.';
@@ -21,7 +17,7 @@ describe('ChartContextMenu', () => {
   beforeEach(() => jest.clearAllMocks());
 
   test('it renders the chart context menu button', () => {
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <ChartContextMenu
           defaultStackByField={DEFAULT_STACK_BY_FIELD}
@@ -33,13 +29,11 @@ describe('ChartContextMenu', () => {
       </TestProviders>
     );
 
-    expect(
-      screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL })
-    ).toBeInTheDocument();
+    expect(getByTestId('chart-settings-popover-button')).toBeInTheDocument();
   });
 
   test('it renders the Inspect menu item', async () => {
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <ChartContextMenu
           defaultStackByField={DEFAULT_STACK_BY_FIELD}
@@ -51,18 +45,18 @@ describe('ChartContextMenu', () => {
       </TestProviders>
     );
 
-    const menuButton = screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL });
+    const menuButton = getByTestId('chart-settings-popover-button');
     menuButton.click();
     await waitForEuiPopoverOpen();
 
-    expect(screen.getByRole('button', { name: INSPECT })).toBeInTheDocument();
+    expect(getByTestId('inspect')).toBeInTheDocument();
   });
 
   test('it invokes `setStackBy` and `setStackByField1` when the Reset group by fields menu item selected', async () => {
     const setStackBy = jest.fn();
     const setStackByField1 = jest.fn();
 
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <ChartContextMenu
           defaultStackByField={DEFAULT_STACK_BY_FIELD}
@@ -74,11 +68,11 @@ describe('ChartContextMenu', () => {
       </TestProviders>
     );
 
-    const menuButton = screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL });
+    const menuButton = getByTestId('chart-settings-popover-button');
     menuButton.click();
     await waitForEuiPopoverOpen();
 
-    const resetMenuItem = screen.getByRole('button', { name: RESET_GROUP_BY_FIELDS });
+    const resetMenuItem = getByTestId('reset-group-by');
     resetMenuItem.click();
 
     expect(setStackBy).toBeCalledWith('kibana.alert.rule.name');
@@ -88,7 +82,7 @@ describe('ChartContextMenu', () => {
   test('it invokes `onReset` when the `Reset group by fields` menu item clicked', async () => {
     const onReset = jest.fn();
 
-    render(
+    const { getByTestId } = render(
       <TestProviders>
         <ChartContextMenu
           defaultStackByField={DEFAULT_STACK_BY_FIELD}
@@ -101,11 +95,11 @@ describe('ChartContextMenu', () => {
       </TestProviders>
     );
 
-    const menuButton = screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL });
+    const menuButton = getByTestId('chart-settings-popover-button');
     fireEvent.click(menuButton);
     await waitForEuiPopoverOpen();
 
-    const resetMenuItem = screen.getByRole('button', { name: RESET_GROUP_BY_FIELDS });
+    const resetMenuItem = getByTestId('reset-group-by');
     fireEvent.click(resetMenuItem);
 
     expect(onReset).toBeCalled();

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/chart_panels/index.test.tsx
@@ -10,8 +10,6 @@ import React from 'react';
 
 import { useAlertsLocalStorage } from './alerts_local_storage';
 import type { Status } from '../../../../../common/api/detection_engine';
-import { RESET_GROUP_BY_FIELDS } from '../../../../common/components/chart_settings_popover/configurations/default/translations';
-import { CHART_SETTINGS_POPOVER_ARIA_LABEL } from '../../../../common/components/chart_settings_popover/translations';
 import { mockBrowserFields } from '../../../../common/containers/source/mock';
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { TestProviders } from '../../../../common/mock';
@@ -140,10 +138,10 @@ const defaultProps = {
 };
 
 const resetGroupByFields = () => {
-  const menuButton = screen.getByRole('button', { name: CHART_SETTINGS_POPOVER_ARIA_LABEL });
+  const menuButton = screen.getByTestId('chart-settings-popover-button');
   fireEvent.click(menuButton);
 
-  const resetMenuItem = screen.getByRole('button', { name: RESET_GROUP_BY_FIELDS });
+  const resetMenuItem = screen.getByTestId('reset-group-by');
   fireEvent.click(resetMenuItem);
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.test.tsx
@@ -12,7 +12,6 @@ import 'jest-styled-components';
 
 import { TestProviders } from '../../../../common/mock';
 import { KpiPanel, StackByComboBox } from './components';
-import * as i18n from './translations';
 import { useStackByFields } from './hooks';
 
 jest.mock('./hooks');
@@ -108,21 +107,20 @@ describe('components', () => {
       const onSelect = jest.fn();
       const optionToSelect = 'agent.hostname';
 
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
             onSelect={onSelect}
             selected="agent.ephemeral_id"
-            dropDownoptions={[
-              { label: 'agent.ephemeral_id', value: 'agent.ephemeral_id' },
-              { label: 'agent.hostname', value: 'agent.hostname' },
+            dropDownOptions={[
+              { label: optionToSelect, value: optionToSelect, key: optionToSelect },
             ]}
           />
         </TestProviders>
       );
 
-      const comboBox = screen.getByRole('combobox', { name: i18n.STACK_BY_ARIA_LABEL });
+      const comboBox = getByTestId('comboBoxSearchInput');
       comboBox.focus(); // display the combo box options
 
       const option = await screen.findByText(optionToSelect);
@@ -132,7 +130,7 @@ describe('components', () => {
     });
 
     test('it does NOT disable the combo box by default', () => {
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
@@ -142,13 +140,11 @@ describe('components', () => {
         </TestProviders>
       );
 
-      expect(screen.getByRole('combobox', { name: i18n.STACK_BY_ARIA_LABEL })).not.toHaveAttribute(
-        'disabled'
-      );
+      expect(getByTestId('comboBoxSearchInput')).not.toBeDisabled();
     });
 
     test('it disables the combo box when `isDisabled` is true', () => {
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
@@ -158,16 +154,13 @@ describe('components', () => {
           />
         </TestProviders>
       );
-
-      expect(screen.getByRole('combobox', { name: i18n.STACK_BY_ARIA_LABEL })).toHaveAttribute(
-        'disabled'
-      );
+      expect(getByTestId('comboBoxSearchInput')).toBeDisabled();
     });
 
     test('overrides the default accessible name via the `aria-label` prop when provided', () => {
       const customAccessibleName = 'custom';
 
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             aria-label={customAccessibleName}
@@ -178,14 +171,16 @@ describe('components', () => {
           />
         </TestProviders>
       );
-
-      expect(screen.getByRole('combobox', { name: customAccessibleName })).toBeInTheDocument();
+      expect(getByTestId('comboBoxSearchInput')).toHaveAttribute(
+        'aria-label',
+        customAccessibleName
+      );
     });
 
     test('it renders the default label', () => {
       const defaultLabel = 'Stack by';
 
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
@@ -195,13 +190,13 @@ describe('components', () => {
         </TestProviders>
       );
 
-      expect(screen.getByLabelText(defaultLabel)).toBeInTheDocument();
+      expect(getByTestId('stackByComboBox')).toHaveTextContent(defaultLabel);
     });
 
     test('it overrides the default label when `prepend` is specified', () => {
       const prepend = 'Group by';
 
-      render(
+      const { getByTestId } = render(
         <TestProviders>
           <StackByComboBox
             data-test-subj="stackByComboBox"
@@ -212,7 +207,7 @@ describe('components', () => {
         </TestProviders>
       );
 
-      expect(screen.getByLabelText(prepend)).toBeInTheDocument();
+      expect(getByTestId('stackByComboBox')).toHaveTextContent(prepend);
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.tsx
@@ -53,7 +53,7 @@ export const KpiPanel = styled(EuiPanel)<{
 interface StackedBySelectProps {
   'aria-label'?: string;
   'data-test-subj'?: string;
-  dropDownoptions?: Array<EuiComboBoxOptionOption<string>>;
+  dropDownOptions?: Array<EuiComboBoxOptionOption<string>>;
   inputRef?: (inputRef: HTMLInputElement | null) => void;
   isDisabled?: boolean;
   onSelect: (selected: string) => void;
@@ -79,7 +79,7 @@ export const StackByComboBox = React.forwardRef(
       selected,
       inputRef,
       width = DEFAULT_WIDTH,
-      dropDownoptions,
+      dropDownOptions,
       useLensCompatibleFields,
     }: StackedBySelectProps,
     ref
@@ -101,8 +101,8 @@ export const StackByComboBox = React.forwardRef(
     const getExpensiveFields = useStackByFields(useLensCompatibleFields);
 
     const options = useMemo(
-      () => dropDownoptions ?? getExpensiveFields(),
-      [dropDownoptions, getExpensiveFields]
+      () => dropDownOptions ?? getExpensiveFields(),
+      [dropDownOptions, getExpensiveFields]
     );
 
     const singleSelection = useMemo(() => {


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



