### PR TITLE
[8.x] [Cloud Security] Hide agentless traffic filtering callout in Serverless (#216239)

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -975,6 +975,7 @@ export const CspPolicyTemplateForm = memo<PackagePolicyReplaceDefineStepExtensio
 
         {shouldRenderAgentlessSelector && (
           <SetupTechnologySelector
+            showLimitationsMessage={!isServerless}
             disabled={isEditPage}
             setupTechnology={setupTechnology}
             onSetupTechnologyChange={(value) => {

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/setup_technology_selector/setup_technology_selector.tsx
@@ -26,10 +26,12 @@ export const SetupTechnologySelector = ({
   disabled,
   setupTechnology,
   onSetupTechnologyChange,
+  showLimitationsMessage = true,
 }: {
   disabled: boolean;
   setupTechnology: SetupTechnology;
   onSetupTechnologyChange: (value: SetupTechnology) => void;
+  showLimitationsMessage?: boolean;
 }) => {
   const radioGroupItemId1 = useGeneratedHtmlId({
     prefix: 'radioGroupItem',
@@ -127,7 +129,9 @@ export const SetupTechnologySelector = ({
         </h2>
       </EuiTitle>
       <EuiSpacer size="m" />
-      <EuiCallOut title={limitationsMessage} color="warning" iconType="alert" size="m" />
+      {showLimitationsMessage && (
+        <EuiCallOut title={limitationsMessage} color="warning" iconType="alert" size="m" />
+      )}
       <EuiSpacer size="m" />
       <EuiRadioGroup
         disabled={disabled}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Cloud Security] Hide agentless traffic filtering callout in Serverless (#216239)](https://github.com/elastic/kibana/pull/216239)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"seanrathier","email":"sean.rathier@gmail.com"},"sourceCommit":{"committedDate":"2025-03-31T15:04:28Z","message":"[Cloud Security] Hide agentless traffic filtering callout in Serverless (#216239)","sha":"e86127ab497327dd129feb5bf5dea39aa675cc76","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Cloud Security","backport:prev-minor","v9.1.0","backport:8.18"],"title":"[Cloud Security] Hide agentless traffic filtering callout in Serverless","number":216239,"url":"https://github.com/elastic/kibana/pull/216239","mergeCommit":{"message":"[Cloud Security] Hide agentless traffic filtering callout in Serverless (#216239)","sha":"e86127ab497327dd129feb5bf5dea39aa675cc76"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216496","number":216496,"state":"MERGED","mergeCommit":{"sha":"bb3ac40a5cf5cb62248f8ae25562064af8ea3330","message":"[9.0] [Cloud Security] Hide agentless traffic filtering callout in Serverless (#216239) (#216496)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Cloud Security] Hide agentless traffic filtering callout in\nServerless (#216239)](https://github.com/elastic/kibana/pull/216239)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: seanrathier <sean.rathier@gmail.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216239","number":216239,"mergeCommit":{"message":"[Cloud Security] Hide agentless traffic filtering callout in Serverless (#216239)","sha":"e86127ab497327dd129feb5bf5dea39aa675cc76"}}]}] BACKPORT-->