### PR TITLE
[8.18] [ES|QL] Hide "not" operators from suggestions menu (#216355)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/scripts/generate_function_definitions.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/scripts/generate_function_definitions.ts
@@ -622,7 +622,7 @@ const enrichOperators = (
     const isInOperator = op.name === 'in' || op.name === 'not_in';
     const isLikeOperator = /like/i.test(op.name);
     const isNotOperator =
-      op.name?.toLowerCase()?.startsWith('not_') && (isInOperator || isInOperator);
+      op.name?.toLowerCase()?.startsWith('not_') && (isInOperator || isLikeOperator);
 
     let signatures = op.signatures.map((s) => ({
       ...s,
@@ -743,7 +743,7 @@ function printGeneratedFunctionsFile(
     name: '${functionName}',
     description: i18n.translate('kbn-esql-validation-autocomplete.esql.definitions.${name}', { defaultMessage: ${JSON.stringify(
       removeAsciiDocInternalCrossReferences(removeInlineAsciiDocLinks(description), functionNames)
-    )} }),${functionDefinition.ignoreAsSuggestion ? 'ignoreAsSuggestion: true,\n' : ''}
+    )} }),${functionDefinition.ignoreAsSuggestion ? 'ignoreAsSuggestion: true,' : ''}
     preview: ${functionDefinition.preview || 'false'},
     alias: ${alias ? `['${alias.join("', '")}']` : 'undefined'},
     signatures: ${JSON.stringify(signatures, null, 2)},

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/generated/operators.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/generated/operators.ts
@@ -4513,6 +4513,7 @@ const notLikeDefinition: FunctionDefinition = {
   }),
   preview: false,
   alias: undefined,
+  ignoreAsSuggestion: true,
   signatures: [
     {
       params: [
@@ -4563,6 +4564,7 @@ const notRlikeDefinition: FunctionDefinition = {
   }),
   preview: false,
   alias: undefined,
+  ignoreAsSuggestion: true,
   signatures: [
     {
       params: [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ES|QL] Hide "not" operators from suggestions menu (#216355)](https://github.com/elastic/kibana/pull/216355)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2025-03-31T19:25:08Z","message":"[ES|QL] Hide \"not\" operators from suggestions menu (#216355)\n\n## Summary\n\nin https://github.com/elastic/kibana/pull/205565 we accidentally removed\nthe behavior where we don't show `NOT LIKE` and `NOT RLIKE` in the\nsuggestions list. We want to show these eventually but right now, it's\nbroken behavior:\n\n\n\nhttps://github.com/user-attachments/assets/0a7f860d-3a12-49cf-94b3-668848cff6ae\n\n---------\n\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4970bb95ccb99b7cedfde51a3f4d56906607e28d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Feature:ES|QL","Team:ESQL","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[ES|QL] Hide \"not\" operators from suggestions menu","number":216355,"url":"https://github.com/elastic/kibana/pull/216355","mergeCommit":{"message":"[ES|QL] Hide \"not\" operators from suggestions menu (#216355)\n\n## Summary\n\nin https://github.com/elastic/kibana/pull/205565 we accidentally removed\nthe behavior where we don't show `NOT LIKE` and `NOT RLIKE` in the\nsuggestions list. We want to show these eventually but right now, it's\nbroken behavior:\n\n\n\nhttps://github.com/user-attachments/assets/0a7f860d-3a12-49cf-94b3-668848cff6ae\n\n---------\n\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4970bb95ccb99b7cedfde51a3f4d56906607e28d"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216355","number":216355,"mergeCommit":{"message":"[ES|QL] Hide \"not\" operators from suggestions menu (#216355)\n\n## Summary\n\nin https://github.com/elastic/kibana/pull/205565 we accidentally removed\nthe behavior where we don't show `NOT LIKE` and `NOT RLIKE` in the\nsuggestions list. We want to show these eventually but right now, it's\nbroken behavior:\n\n\n\nhttps://github.com/user-attachments/assets/0a7f860d-3a12-49cf-94b3-668848cff6ae\n\n---------\n\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4970bb95ccb99b7cedfde51a3f4d56906607e28d"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216533","number":216533,"state":"OPEN"}]}] BACKPORT-->