### PR TITLE
[8.18] [APM] Fix entry item in waterfall shouldn't be orphan (#214700)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
@@ -749,7 +749,39 @@ describe('waterfall_helpers', () => {
           parentId: 'myTransactionId1',
         } as IWaterfallSpan,
       ];
-      expect(getOrphanItemsIds(traceItems).length).toBe(0);
+      expect(getOrphanItemsIds(traceItems, traceItems[0].id).length).toBe(0);
+    });
+
+    it('should return missing items count: 0 if first item is orphan', () => {
+      const traceItems: IWaterfallSpanOrTransaction[] = [
+        {
+          doc: {
+            processor: { event: 'transaction' },
+            trace: { id: 'myTrace' },
+            transaction: {
+              id: 'myTransactionId1',
+            },
+          } as WaterfallTransaction,
+          docType: 'transaction',
+          id: 'myTransactionId1',
+          parentId: 'myNotExistingTransactionId0',
+        } as IWaterfallTransaction,
+        {
+          doc: {
+            processor: { event: 'span' },
+            span: {
+              id: 'myOrphanSpanId',
+            },
+            parent: {
+              id: 'myTransactionId1',
+            },
+          } as WaterfallSpan,
+          docType: 'span',
+          id: 'myOrphanSpanId',
+          parentId: 'myTransactionId1',
+        } as IWaterfallSpan,
+      ];
+      expect(getOrphanItemsIds(traceItems, traceItems[0].id).length).toBe(0);
     });
 
     it('should return missing items count if there are orphan items', () => {
@@ -770,7 +802,7 @@ describe('waterfall_helpers', () => {
           parentId: 'myNotExistingTransactionId1',
         } as IWaterfallSpan,
       ];
-      expect(getOrphanItemsIds(traceItems).length).toBe(1);
+      expect(getOrphanItemsIds(traceItems, traceItems[0].id).length).toBe(1);
     });
   });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[APM] Fix entry item in waterfall shouldn't be orphan (#214700)](https://github.com/elastic/kibana/pull/214700)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-03-18T10:02:30Z","message":"[APM] Fix entry item in waterfall shouldn't be orphan (#214700)\n\n## Summary\n\nCloses #213074\n\nThis PR fixes the scenario where the entry waterfall transaction is\ntreated as an orphan, causing it to reparent itself and be duplicated\nmultiple times.\n\n---------\n\nCo-authored-by: Cauê Marcondes <55978943+cauemarcondes@users.noreply.github.com>","sha":"dbb2aeda4d422a6a03a74f437cd25f515309654a","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:obs-ux-infra_services","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.0.1","v8.17.5"],"title":"[APM] Fix entry item in waterfall shouldn't be orphan","number":214700,"url":"https://github.com/elastic/kibana/pull/214700","mergeCommit":{"message":"[APM] Fix entry item in waterfall shouldn't be orphan (#214700)\n\n## Summary\n\nCloses #213074\n\nThis PR fixes the scenario where the entry waterfall transaction is\ntreated as an orphan, causing it to reparent itself and be duplicated\nmultiple times.\n\n---------\n\nCo-authored-by: Cauê Marcondes <55978943+cauemarcondes@users.noreply.github.com>","sha":"dbb2aeda4d422a6a03a74f437cd25f515309654a"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.17"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214928","number":214928,"state":"MERGED","mergeCommit":{"sha":"a0aebf185976baa6b9a11549876b16e5c752d95a","message":"[9.0] [APM] Fix entry item in waterfall shouldn't be orphan (#214700) (#214928)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[APM] Fix entry item in waterfall shouldn't be orphan\n(#214700)](https://github.com/elastic/kibana/pull/214700)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214700","number":214700,"mergeCommit":{"message":"[APM] Fix entry item in waterfall shouldn't be orphan (#214700)\n\n## Summary\n\nCloses #213074\n\nThis PR fixes the scenario where the entry waterfall transaction is\ntreated as an orphan, causing it to reparent itself and be duplicated\nmultiple times.\n\n---------\n\nCo-authored-by: Cauê Marcondes <55978943+cauemarcondes@users.noreply.github.com>","sha":"dbb2aeda4d422a6a03a74f437cd25f515309654a"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214927","number":214927,"state":"MERGED","mergeCommit":{"sha":"ccc2c36864ea68a4823c2239b39eb08e4d636ee2","message":"[8.x] [APM] Fix entry item in waterfall shouldn't be orphan (#214700) (#214927)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[APM] Fix entry item in waterfall shouldn't be orphan\n(#214700)](https://github.com/elastic/kibana/pull/214700)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"8.17","label":"v8.17.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->