### PR TITLE
[8.17] [APM] Prevent `getChildrenGroupedByParentId` to include the parent in the children list (#214957)

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -338,8 +338,23 @@ function reparentSpans(waterfallItems: IWaterfallSpanOrTransaction[]) {
   });
 }
 
-const getChildrenGroupedByParentId = (waterfallItems: IWaterfallSpanOrTransaction[]) =>
-  groupBy(waterfallItems, (item) => (item.parentId ? item.parentId : ROOT_ID));
+const getChildrenGroupedByParentId = (waterfallItems: IWaterfallSpanOrTransaction[]) => {
+  const childrenGroups = groupBy(waterfallItems, (item) => item.parentId ?? ROOT_ID);
+
+  const childrenGroupedByParentId = Object.entries(childrenGroups).reduce(
+    (acc, [parentId, items]) => {
+      // we shouldn't include the parent item in the children list
+      const filteredItems = items.filter((item) => item.id !== parentId);
+      return {
+        ...acc,
+        [parentId]: filteredItems,
+      };
+    },
+    {}
+  );
+
+  return childrenGroupedByParentId;
+};
 
 const getEntryWaterfallTransaction = (
   entryTransactionId: string,
@@ -493,6 +508,7 @@ function getChildren({
   path,
   waterfall,
   waterfallItemId,
+  rootId,
 }: {
   waterfallItemId: string;
   waterfall: IWaterfall;
@@ -500,8 +516,10 @@ function getChildren({
     criticalPathSegmentsById: Dictionary<CriticalPathSegment[]>;
     showCriticalPath: boolean;
   };
+  rootId: string;
 }) {
   const children = waterfall.childrenByParentId[waterfallItemId] ?? [];
+
   return path.showCriticalPath
     ? children.filter((child) => path.criticalPathSegmentsById[child.id]?.length)
     : children;
@@ -527,7 +545,12 @@ function buildTree({
   for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
     const node = queue[queueIndex];
 
-    const children = getChildren({ path, waterfall, waterfallItemId: node.item.id });
+    const children = getChildren({
+      path,
+      waterfall,
+      waterfallItemId: node.item.id,
+      rootId: root.item.id,
+    });
 
     // Set childrenToLoad for all nodes enqueued.
     // this allows lazy loading of child nodes


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[APM] Prevent `getChildrenGroupedByParentId` to include the parent in the children list (#214957)](https://github.com/elastic/kibana/pull/214957)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-03-19T12:28:20Z","message":"[APM] Prevent `getChildrenGroupedByParentId` to include the parent in the children list (#214957)\n\n## Summary\n\nCloses #213074\n\nThis PR prevents `getChildrenGroupedByParentId` to include the parent\nitem in the children list, as this was causing some duplication.\n\n| Before | After |\n\n|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|\n<img width=\"1433\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/788684a8-21d7-48a6-820c-07b1fb3d0045\"\n/>|<img width=\"858\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b68129e1-137d-42fe-a7ce-70373447ece9\"\n/>|\n|<img width=\"1372\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ff6a5ac8-b46a-4eea-9c4c-638f4b479dc8\"\n/>|<img width=\"844\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/31ef881c-a6d0-41ea-80d4-aebd587e76cd\"\n/>|","sha":"0ee664a555d860b045291b5757bafce33decedb3","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:obs-ux-infra_services","backport:version","v8.18.0","v9.1.0","v8.19.0","v9.0.1","v8.17.5"],"title":"[APM] Prevent `getChildrenGroupedByParentId` to include the parent in the children list","number":214957,"url":"https://github.com/elastic/kibana/pull/214957","mergeCommit":{"message":"[APM] Prevent `getChildrenGroupedByParentId` to include the parent in the children list (#214957)\n\n## Summary\n\nCloses #213074\n\nThis PR prevents `getChildrenGroupedByParentId` to include the parent\nitem in the children list, as this was causing some duplication.\n\n| Before | After |\n\n|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|\n<img width=\"1433\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/788684a8-21d7-48a6-820c-07b1fb3d0045\"\n/>|<img width=\"858\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b68129e1-137d-42fe-a7ce-70373447ece9\"\n/>|\n|<img width=\"1372\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ff6a5ac8-b46a-4eea-9c4c-638f4b479dc8\"\n/>|<img width=\"844\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/31ef881c-a6d0-41ea-80d4-aebd587e76cd\"\n/>|","sha":"0ee664a555d860b045291b5757bafce33decedb3"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.17"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215153","number":215153,"state":"MERGED","mergeCommit":{"sha":"6c0c502e8e15bea18d8c96408f28b11e7f1a535f","message":"[9.0] [APM] Prevent `getChildrenGroupedByParentId` to include the parent in the children list (#214957) (#215153)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[APM] Prevent `getChildrenGroupedByParentId` to include the parent in\nthe children list\n(#214957)](https://github.com/elastic/kibana/pull/214957)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214957","number":214957,"mergeCommit":{"message":"[APM] Prevent `getChildrenGroupedByParentId` to include the parent in the children list (#214957)\n\n## Summary\n\nCloses #213074\n\nThis PR prevents `getChildrenGroupedByParentId` to include the parent\nitem in the children list, as this was causing some duplication.\n\n| Before | After |\n\n|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|\n<img width=\"1433\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/788684a8-21d7-48a6-820c-07b1fb3d0045\"\n/>|<img width=\"858\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/b68129e1-137d-42fe-a7ce-70373447ece9\"\n/>|\n|<img width=\"1372\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ff6a5ac8-b46a-4eea-9c4c-638f4b479dc8\"\n/>|<img width=\"844\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/31ef881c-a6d0-41ea-80d4-aebd587e76cd\"\n/>|","sha":"0ee664a555d860b045291b5757bafce33decedb3"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215152","number":215152,"state":"MERGED","mergeCommit":{"sha":"42e65b516782cb2895a5ee7e832885ed608cd4b9","message":"[8.x] [APM] Prevent `getChildrenGroupedByParentId` to include the parent in the children list (#214957) (#215152)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[APM] Prevent `getChildrenGroupedByParentId` to include the parent in\nthe children list\n(#214957)](https://github.com/elastic/kibana/pull/214957)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"8.17","label":"v8.17.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->