### PR TITLE
[8.x] [A11y][APM] Change tpm abbreviation to trace per minute for screen-readers (#216282)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/common/utils/formatters/duration.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/utils/formatters/duration.ts
@@ -154,6 +154,15 @@ export const getDurationFormatter: TimeFormatterBuilder = memoize(
 );
 
 export function asTransactionRate(value: Maybe<number>) {
+  const displayedValue = asTransactionValue(value);
+
+  return i18n.translate('xpack.apm.transactionRateLabel', {
+    defaultMessage: `{displayedValue} tpm`,
+    values: { displayedValue },
+  });
+}
+
+export function asTransactionValue(value: Maybe<number>) {
   if (!isFiniteNumber(value)) {
     return NOT_AVAILABLE_LABEL;
   }
@@ -168,10 +177,7 @@ export function asTransactionRate(value: Maybe<number>) {
     displayedValue = asDecimal(value);
   }
 
-  return i18n.translate('xpack.apm.transactionRateLabel', {
-    defaultMessage: `{displayedValue} tpm`,
-    values: { displayedValue },
-  });
+  return displayedValue;
 }
 
 export function asExactTransactionRate(value: number) {

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/trace_list.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/top_traces_overview/trace_list.tsx
@@ -5,14 +5,18 @@
  * 2.0.
  */
 
-import { EuiIcon, EuiToolTip, RIGHT_ALIGNMENT } from '@elastic/eui';
+import { EuiIcon, EuiScreenReaderOnly, EuiToolTip, RIGHT_ALIGNMENT } from '@elastic/eui';
 import { usePerformanceContext } from '@kbn/ebt-tools';
 import type { TypeOf } from '@kbn/typed-react-router-config';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useMemo } from 'react';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 import type { ApmRoutes } from '../../routing/apm_route_config';
-import { asMillisecondDuration, asTransactionRate } from '../../../../common/utils/formatters';
+import {
+  asMillisecondDuration,
+  asTransactionRate,
+  asTransactionValue,
+} from '../../../../common/utils/formatters';
 import { useApmParams } from '../../../hooks/use_apm_params';
 import type { FetcherResult } from '../../../hooks/use_fetcher';
 import { FETCH_STATUS } from '../../../hooks/use_fetcher';
@@ -99,7 +103,22 @@ export function getTraceListColumns({
       }),
       sortable: true,
       dataType: 'number',
-      render: (_, { transactionsPerMinute }) => asTransactionRate(transactionsPerMinute),
+      render: (_, { transactionsPerMinute }) => (
+        <>
+          <span aria-hidden="true">{asTransactionRate(transactionsPerMinute)}</span>
+          <EuiScreenReaderOnly>
+            <span>
+              {asTransactionValue(transactionsPerMinute)}{' '}
+              {i18n.translate(
+                'xpack.apm.tracesTable.tracesPerMinuteColumn.screenReaderAbbreviation',
+                {
+                  defaultMessage: 'traces per minute',
+                }
+              )}
+            </span>
+          </EuiScreenReaderOnly>
+        </>
+      ),
     },
     {
       field: 'impact',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[A11y][APM] Change tpm abbreviation to trace per minute for screen-readers (#216282)](https://github.com/elastic/kibana/pull/216282)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-03-31T15:36:26Z","message":"[A11y][APM] Change tpm abbreviation to trace per minute for screen-readers (#216282)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/194984\n\nThis PR uses the `EuiScreenReaderOnly` component to spell out trace per\nminute instead of its abbreviation for screen readers\n\n---------\n\nCo-authored-by: jennypavlova <jennypavlova94@gmail.com>","sha":"a23c6d066210bc4f29bd900e67c04387ed633f5a","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","apm","Team:obs-ux-infra_services","backport:version","a11y","v9.1.0","v8.19.0"],"title":"[A11y][APM] Change tpm abbreviation to trace per minute for screen-readers","number":216282,"url":"https://github.com/elastic/kibana/pull/216282","mergeCommit":{"message":"[A11y][APM] Change tpm abbreviation to trace per minute for screen-readers (#216282)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/194984\n\nThis PR uses the `EuiScreenReaderOnly` component to spell out trace per\nminute instead of its abbreviation for screen readers\n\n---------\n\nCo-authored-by: jennypavlova <jennypavlova94@gmail.com>","sha":"a23c6d066210bc4f29bd900e67c04387ed633f5a"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216282","number":216282,"mergeCommit":{"message":"[A11y][APM] Change tpm abbreviation to trace per minute for screen-readers (#216282)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/194984\n\nThis PR uses the `EuiScreenReaderOnly` component to spell out trace per\nminute instead of its abbreviation for screen readers\n\n---------\n\nCo-authored-by: jennypavlova <jennypavlova94@gmail.com>","sha":"a23c6d066210bc4f29bd900e67c04387ed633f5a"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->