### PR TITLE
[8.x] [ResponseOps] Fix connector test (#208754)

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/delete.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/delete.ts
@@ -302,28 +302,23 @@ export default function deleteActionTests({ getService }: FtrProviderContext) {
     }
 
     it('should delete a connector with an unsupported type', async () => {
+      const { space, user } = SuperuserAtSpace1;
       await kibanaServer.importExport.load(
-        'x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/fixtures/unsupported_connector_type.json'
+        'x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/fixtures/unsupported_connector_type.json',
+        { space: space.id }
       );
 
-      const { space, user } = SuperuserAtSpace1;
-      const { body: createdConnector } = await supertest
-        .post(`${getUrlPrefix(space.id)}/api/actions/connector`)
-        .set('kbn-xsrf', 'foo')
-        .send({
-          name: 'My Connector',
-          connector_type_id: 'test.index-record',
-          config: {
-            unencrypted: `This value shouldn't get encrypted`,
-          },
-          secrets: {
-            encrypted: 'This value should be encrypted',
-          },
-        })
-        .expect(200);
+      const res = await supertestWithoutAuth
+        .get(`${getUrlPrefix(space.id)}/api/actions/connectors`)
+        .auth(user.username, user.password);
+
+      const invalidConnector = res.body.find(
+        (connector: { connector_type_id: string; id: string }) =>
+          connector.connector_type_id === '.invalid-type'
+      );
 
       const response = await supertestWithoutAuth
-        .delete(`${getUrlPrefix(space.id)}/api/actions/connector/${createdConnector.id}`)
+        .delete(`${getUrlPrefix(space.id)}/api/actions/connector/${invalidConnector.id}`)
         .auth(user.username, user.password)
         .set('kbn-xsrf', 'foo');
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ResponseOps] Fix connector test (#208754)](https://github.com/elastic/kibana/pull/208754)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Antonio","email":"antonio.coelho@elastic.co"},"sourceCommit":{"committedDate":"2025-01-31T08:11:15Z","message":"[ResponseOps] Fix connector test (#208754)\n\n## Summary\r\n\r\nThis PR fixes a test introduced in\r\nhttps://github.com/elastic/kibana/pull/208033","sha":"5a57f40f6708fbb74b5929e7cd3856524825c8b5","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","backport missing","backport:prev-major","v8.18.0","v8.16.4","v8.17.2","v9.1.0"],"title":"[ResponseOps] Fix connector test","number":208754,"url":"https://github.com/elastic/kibana/pull/208754","mergeCommit":{"message":"[ResponseOps] Fix connector test (#208754)\n\n## Summary\r\n\r\nThis PR fixes a test introduced in\r\nhttps://github.com/elastic/kibana/pull/208033","sha":"5a57f40f6708fbb74b5929e7cd3856524825c8b5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209061","number":209061,"state":"MERGED","mergeCommit":{"sha":"e67cc7a182ce649b1d08140dfacf2e2b1f56238d","message":"[8.18] [ResponseOps] Fix connector test (#208754) (#209061)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[ResponseOps] Fix connector test\n(#208754)](https://github.com/elastic/kibana/pull/208754)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Antonio <antonio.coelho@elastic.co>"}},{"branch":"8.16","label":"v8.16.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209058","number":209058,"state":"MERGED","mergeCommit":{"sha":"c2c44902042a48f2baf6fcc43191df210398f6a2","message":"[8.16] [ResponseOps] Fix connector test (#208754) (#209058)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.16`:\n- [[ResponseOps] Fix connector test\n(#208754)](https://github.com/elastic/kibana/pull/208754)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Antonio <antonio.coelho@elastic.co>"}},{"branch":"8.17","label":"v8.17.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209060","number":209060,"state":"MERGED","mergeCommit":{"sha":"c9595ceb0ba80b9d3d50ceb92a2e75564d3bfd2f","message":"[8.17] [ResponseOps] Fix connector test (#208754) (#209060)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.17`:\n- [[ResponseOps] Fix connector test\n(#208754)](https://github.com/elastic/kibana/pull/208754)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Antonio <antonio.coelho@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208754","number":208754,"mergeCommit":{"message":"[ResponseOps] Fix connector test (#208754)\n\n## Summary\r\n\r\nThis PR fixes a test introduced in\r\nhttps://github.com/elastic/kibana/pull/208033","sha":"5a57f40f6708fbb74b5929e7cd3856524825c8b5"}}]}] BACKPORT-->