### PR TITLE
[UA] Fix hardcoded docs path

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -375,6 +375,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       reindexWithPipeline: `${ELASTICSEARCH_DOCS}docs-reindex.html#reindex-with-an-ingest-pipeline`,
       logsDatastream: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/reference/${DOC_LINK_VERSION}/logs-data-stream.html`,
       usingLogsDbIndexModeWithESSecurity: `${ELASTIC_WEBSITE_URL}guide/en/security/${DOC_LINK_VERSION}/detections-logsdb-index-mode-impact.html`,
+      dataStreamReindex: `${ELASTICSEARCH_DOCS}data-stream-reindex-api.html#reindex-data-stream-api-settings`,
     },
     rollupJobs: `${KIBANA_DOCS}data-rollups.html`,
     elasticsearch: {

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -331,6 +331,7 @@ export interface DocLinks {
     readonly reindexWithPipeline: string;
     readonly logsDatastream: string;
     readonly usingLogsDbIndexModeWithESSecurity: string;
+    readonly dataStreamReindex: string;
   };
   readonly rollupJobs: string;
   readonly elasticsearch: Record<string, string>;

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/confirm_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/confirm_step.tsx
@@ -119,10 +119,7 @@ export const ConfirmMigrationFlyoutStep: React.FunctionComponent<{
             defaultMessage="You can increase the speed of reindexing by changing throttling configuration on ES. Where changing throttling configuration allows you to utilize more resources to speed up the reindexing process. {learnMoreHtml}"
             values={{
               learnMoreHtml: (
-                <EuiLink
-                  href={links.upgradeAssistant.dataStreamReindex}
-                  target="_blank"
-                >
+                <EuiLink href={links.upgradeAssistant.dataStreamReindex} target="_blank">
                   <FormattedMessage
                     id="xpack.upgradeAssistant.dataStream.migration.flyout.warningsStep.learnMoreLink"
                     defaultMessage="Learn more"

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/confirm_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/confirm_step.tsx
@@ -120,7 +120,7 @@ export const ConfirmMigrationFlyoutStep: React.FunctionComponent<{
             values={{
               learnMoreHtml: (
                 <EuiLink
-                  href={`${links.elasticsearch.docsBase}data-stream-reindex-api.html#reindex-data-stream-api-settings`}
+                  href={`${links.upgradeAssistant.dataStreamReindex}data-stream-reindex-api.html#reindex-data-stream-api-settings`}
                   target="_blank"
                 >
                   <FormattedMessage

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/confirm_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/data_streams/flyout/steps/confirm/confirm_step.tsx
@@ -120,7 +120,7 @@ export const ConfirmMigrationFlyoutStep: React.FunctionComponent<{
             values={{
               learnMoreHtml: (
                 <EuiLink
-                  href={`${links.upgradeAssistant.dataStreamReindex}data-stream-reindex-api.html#reindex-data-stream-api-settings`}
+                  href={links.upgradeAssistant.dataStreamReindex}
                   target="_blank"
                 >
                   <FormattedMessage


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/215227

## Summary

Fixes a hardcoded docs path and moves it to the get_docs_link file.