### PR TITLE
[Security Solution] Rename use full data view hook

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/with_data_view/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/with_data_view/index.tsx
@@ -10,7 +10,7 @@ import type { ComponentType } from 'react';
 import type { ReactElement } from 'react-markdown';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import { DataViewManagerScopeName } from '../../../data_view_manager/constants';
-import { useFullDataView } from '../../../data_view_manager/hooks/use_full_data_view';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 import { DataViewErrorComponent } from './data_view_error';
 import { useEnableExperimental } from '../../hooks/use_experimental_features';
 
@@ -34,7 +34,7 @@ export const withDataView = <P extends WithDataViewArg>(
   fallback?: ReactElement
 ) => {
   const ComponentWithDataView = (props: OmitDataView<P>) => {
-    const { dataView: experimentalDataView } = useFullDataView(DataViewManagerScopeName.timeline);
+    const { dataView: experimentalDataView } = useDataView(DataViewManagerScopeName.timeline);
 
     const dataView = useGetScopedSourcererDataView({
       sourcererScope: SourcererScopeName.timeline,

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.test.ts
@@ -9,7 +9,7 @@ import { act, renderHook } from '@testing-library/react';
 import { TestProviders } from '../../common/mock';
 import { DEFAULT_SECURITY_SOLUTION_DATA_VIEW_ID, DataViewManagerScopeName } from '../constants';
 
-import { useFullDataView } from './use_full_data_view';
+import { useDataView } from './use_data_view';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
 import { useSelector } from 'react-redux';
 
@@ -20,7 +20,7 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
-describe('useFullDataView', () => {
+describe('useDataView', () => {
   beforeEach(() => {
     jest.mocked(useIsExperimentalFeatureEnabled).mockReturnValue(true);
     jest
@@ -30,7 +30,7 @@ describe('useFullDataView', () => {
 
   describe('when data view is available', () => {
     it('should return DataView instance', async () => {
-      const wrapper = renderHook(() => useFullDataView(DataViewManagerScopeName.default), {
+      const wrapper = renderHook(() => useDataView(DataViewManagerScopeName.default), {
         wrapper: TestProviders,
       });
 
@@ -41,7 +41,7 @@ describe('useFullDataView', () => {
 
   describe('when data view fields are not available', () => {
     it('should return undefined', () => {
-      const wrapper = renderHook(() => useFullDataView(DataViewManagerScopeName.default), {
+      const wrapper = renderHook(() => useDataView(DataViewManagerScopeName.default), {
         wrapper: TestProviders,
       });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view.ts
@@ -19,7 +19,7 @@ import type { SharedDataViewSelectionState } from '../redux/types';
  * This hook should be used whenever we need the actual DataView and not just the spec for the
  * selected data view.
  */
-export const useFullDataView = (
+export const useDataView = (
   dataViewManagerScope: DataViewManagerScopeName
 ): { dataView: DataView | undefined; status: SharedDataViewSelectionState['status'] } => {
   const {

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.test.ts
@@ -10,13 +10,13 @@ import { type DataView } from '@kbn/data-views-plugin/public';
 
 import { DataViewManagerScopeName } from '../constants';
 import { useDataViewSpec } from './use_data_view_spec';
-import { useFullDataView } from './use_full_data_view';
+import { useDataView } from './use_data_view';
 
-jest.mock('./use_full_data_view');
+jest.mock('./use_data_view');
 
 describe('useDataViewSpec', () => {
   beforeEach(() => {
-    jest.mocked(useFullDataView).mockReturnValue({
+    jest.mocked(useDataView).mockReturnValue({
       dataView: {
         id: 'test',
         title: 'test',
@@ -31,7 +31,7 @@ describe('useDataViewSpec', () => {
       initialProps: DataViewManagerScopeName.default,
     });
 
-    expect(jest.mocked(useFullDataView)).toHaveBeenCalledWith(DataViewManagerScopeName.default);
+    expect(jest.mocked(useDataView)).toHaveBeenCalledWith(DataViewManagerScopeName.default);
 
     expect(wrapper.result.current).toMatchObject({
       status: expect.any(String),
@@ -39,7 +39,7 @@ describe('useDataViewSpec', () => {
     });
 
     wrapper.rerender(DataViewManagerScopeName.timeline);
-    expect(jest.mocked(useFullDataView)).toHaveBeenCalledWith(DataViewManagerScopeName.timeline);
+    expect(jest.mocked(useDataView)).toHaveBeenCalledWith(DataViewManagerScopeName.timeline);
 
     expect(wrapper.result.current).toMatchObject({
       status: expect.any(String),

--- a/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/data_view_manager/hooks/use_data_view_spec.ts
@@ -7,13 +7,13 @@
 
 import { useMemo } from 'react';
 import type { DataViewManagerScopeName } from '../constants';
-import { useFullDataView } from './use_full_data_view';
+import { useDataView } from './use_data_view';
 
 /**
  * Returns data view selection for given scopeName
  */
 export const useDataViewSpec = (scopeName: DataViewManagerScopeName) => {
-  const { dataView, status } = useFullDataView(scopeName);
+  const { dataView, status } = useDataView(scopeName);
 
   return useMemo(() => {
     // NOTE: remove this after we are ready for undefined (lazy) data view everywhere in the app

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.test.tsx
@@ -25,7 +25,7 @@ jest.mock('react-router-dom', () => {
 jest.mock('../../overview/components/events_by_dataset');
 jest.mock('../../sourcerer/containers');
 jest.mock('../../common/components/user_privileges');
-jest.mock('../../data_view_manager/hooks/use_full_data_view', () => ({
+jest.mock('../../data_view_manager/hooks/use_data_view', () => ({
   useFullDataView: jest.fn(() => ({ matchedIndices: [] })),
 }));
 jest.mock('../../common/hooks/use_experimental_features');

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.test.tsx
@@ -26,7 +26,7 @@ jest.mock('../../overview/components/events_by_dataset');
 jest.mock('../../sourcerer/containers');
 jest.mock('../../common/components/user_privileges');
 jest.mock('../../data_view_manager/hooks/use_data_view', () => ({
-  useFullDataView: jest.fn(() => ({ matchedIndices: [] })),
+  useDataView: jest.fn(() => ({ matchedIndices: [] })),
 }));
 jest.mock('../../common/hooks/use_experimental_features');
 

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/pages/timelines_page.tsx
@@ -21,7 +21,7 @@ import { SecurityRoutePageWrapper } from '../../common/components/security_route
 import { DataViewManagerScopeName } from '../../data_view_manager/constants';
 import { useSourcererDataView } from '../../sourcerer/containers';
 import { useIsExperimentalFeatureEnabled } from '../../common/hooks/use_experimental_features';
-import { useFullDataView } from '../../data_view_manager/hooks/use_full_data_view';
+import { useDataView } from '../../data_view_manager/hooks/use_data_view';
 
 export const DEFAULT_SEARCH_RESULTS_PER_PAGE = 10;
 
@@ -31,7 +31,7 @@ export const TimelinesPage = React.memo(() => {
   const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
   let { indicesExist } = useSourcererDataView();
 
-  const { dataView } = useFullDataView(DataViewManagerScopeName.default);
+  const { dataView } = useDataView(DataViewManagerScopeName.default);
   // NOTE: there should be a Suspense / some kind of loader here as this value is not settled immediately
   const experimentalIndicesExist = !!dataView?.matchedIndices?.length;
 


### PR DESCRIPTION
## Summary

Renaming `useFullDataView` to `useDataView`, for clarity. We also have `useDataViewSpec` now, introduced in https://github.com/elastic/kibana/pull/216461.

