### PR TITLE
[Index Management] Copy change for index mode field in index templates

### DIFF
--- a/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/steps/step_logistics.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/components/template_form/steps/step_logistics.tsx
@@ -101,7 +101,7 @@ function getFieldsMeta(esDocsBase: string) {
     },
     indexMode: {
       title: i18n.translate('xpack.idxMgmt.templateForm.stepLogistics.indexModeTitle', {
-        defaultMessage: 'Data stream index mode',
+        defaultMessage: 'Index mode',
       }),
       description: i18n.translate('xpack.idxMgmt.templateForm.stepLogistics.indexModeDescription', {
         defaultMessage:
@@ -401,19 +401,6 @@ export const StepLogistics: React.FunctionComponent<Props> = React.memo(
             </FormRow>
           )}
 
-          <FormRow title={indexMode.title} description={indexMode.description}>
-            <UseField
-              path="indexMode"
-              componentProps={{
-                euiFieldProps: {
-                  hasDividers: true,
-                  'data-test-subj': indexMode.testSubject,
-                  options: indexMode.options,
-                },
-              }}
-            />
-          </FormRow>
-
           {/*
             Since data stream and data retention are settings that are only allowed for non legacy,
             we only need to check if data stream is set to true to show the data retention.
@@ -468,6 +455,20 @@ export const StepLogistics: React.FunctionComponent<Props> = React.memo(
               )}
             </FormRow>
           )}
+
+          {/* Index mode */}
+          <FormRow title={indexMode.title} description={indexMode.description}>
+            <UseField
+              path="indexMode"
+              componentProps={{
+                euiFieldProps: {
+                  hasDividers: true,
+                  'data-test-subj': indexMode.testSubject,
+                  options: indexMode.options,
+                },
+              }}
+            />
+          </FormRow>
 
           {/* Order */}
           {isLegacy && (


### PR DESCRIPTION
## Summary

This PR renames the title of the the index mode field from "Data stream index mode" to "Index mode" since this field is no longer enabled/disabled based on the data streams field (since https://github.com/elastic/kibana/pull/207413).

We also switch the places of the index mode field and the data retention field, since the data retention field is displayed only when data streams toggle is switched on, so it makes sense that it is next to this field.

<img width="1166" alt="Screenshot 2025-04-01 at 11 46 45" src="https://github.com/user-attachments/assets/935a7c4e-2d19-4679-8e75-03fed35ce82e" />


https://github.com/user-attachments/assets/40e46c91-9120-44eb-b0de-ef700a5eeedd









<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->