### PR TITLE
Discover esc closes flyout when focus is on filter

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -27,6 +27,7 @@ import {
   useEuiTheme,
   useIsWithinMinBreakpoint,
   EuiFlyoutProps,
+  isDOMNode,
 } from '@elastic/eui';
 import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils/types';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
@@ -135,11 +136,7 @@ export function UnifiedDocViewerFlyout({
         return;
       }
 
-      if (
-        ev.target instanceof Node &&
-        ev.currentTarget.contains(ev.target) &&
-        ev.key === keys.ESCAPE
-      ) {
+      if (isDOMNode(ev.target) && ev.currentTarget.contains(ev.target) && ev.key === keys.ESCAPE) {
         ev.preventDefault();
         ev.stopPropagation();
         onClose();

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -135,7 +135,11 @@ export function UnifiedDocViewerFlyout({
         return;
       }
 
-      if (ev.key === keys.ESCAPE) {
+      if (
+        ev.target instanceof Node &&
+        ev.currentTarget.contains(ev.target) &&
+        ev.key === keys.ESCAPE
+      ) {
         ev.preventDefault();
         ev.stopPropagation();
         onClose();


### PR DESCRIPTION
## Summary

Closes [[Analytics:Discover page]Esc closes flyout when focus is on Filter by field type options](https://github.com/elastic/kibana/issues/214367)

In this PR, following EUI team suggestion from the linked issue, we ensure flyout closes in correct order for nested portal-rendered components (like `EuiPopover`).

Steps to reproduce:

1. Navigate to `Toggle dialog with details` and press Enter.
2. Navigate to `Filter by type` and press Enter.
3. Navigate to any option in the opened dialog.
4. Press Esc.

Expected behavior: 
When user press Esc key, only `Filter by type` popover closes, but user is still focused on `Filter by type` and the flyout remains open.


Screen recording: 


https://github.com/user-attachments/assets/d27b65e0-2e6e-4e55-97f5-dbdbef42a567



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



