### PR TITLE
[Lens] Fix failing test on save to library

### DIFF
--- a/x-pack/test/functional/apps/lens/dashboard.ts
+++ b/x-pack/test/functional/apps/lens/dashboard.ts
@@ -236,7 +236,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     it('save lens panel to embeddable library', async () => {
       const originalPanel = await testSubjects.find('embeddablePanelHeading-lnsPieVis');
       await panelActions.saveToLibrary('lnsPieVis - copy', originalPanel);
-      await testSubjects.click('confirmSaveSavedObjectButton');
       await testSubjects.existOrFail('addPanelToLibrarySuccess');
 
       const updatedPanel = await testSubjects.find('embeddablePanelHeading-lnsPieVis-copy');


### PR DESCRIPTION
The failure was caused by the test waiting for an element that was already waited for: the save button in the saveToLibrary modal.
Probably due to timing issues of selenium the second wait in some cases was working, making this less consistent.
I've removed the external wait as is already done in the saveToLibrary function

Fix https://github.com/elastic/kibana/issues/205230
