### PR TITLE
[8.18] [Search] enable enterpriseSearch plugin in Security  (#216234)

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/server/capabilities/capabilities_switcher.test.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/capabilities/capabilities_switcher.test.ts
@@ -407,8 +407,8 @@ describe('capabilitiesSwitcher', () => {
       {
         space.solution = 'security';
 
-        // It should disable enterpriseSearch and observability features
-        // which correspond to feature_1 and feature_2
+        // It should disable observability features
+        // which corresponds to feature_2
         const result = await switcher(request, capabilities, false);
 
         const expectedCapabilities = buildCapabilities();
@@ -417,8 +417,6 @@ describe('capabilitiesSwitcher', () => {
         expectedCapabilities.catalogue.feature2Entry = false;
         expectedCapabilities.navLinks.feature3 = false;
         expectedCapabilities.management.kibana.somethingElse = false;
-        expectedCapabilities.feature_1.bar = false;
-        expectedCapabilities.feature_1.foo = false;
         expectedCapabilities.feature_2.bar = false;
         expectedCapabilities.feature_2.foo = false;
 

--- a/x-pack/platform/plugins/shared/spaces/server/lib/utils/space_solution_disabled_features.test.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/lib/utils/space_solution_disabled_features.test.ts
@@ -73,7 +73,7 @@ describe('#withSpaceSolutionDisabledFeatures', () => {
   });
 
   describe('when the space solution is "security"', () => {
-    test('it removes the "observability" and "enterpriseSearch" features', () => {
+    test('it removes the "observability" feature', () => {
       const spaceDisabledFeatures: string[] = ['baz'];
       const spaceSolution = 'security';
 
@@ -83,7 +83,7 @@ describe('#withSpaceSolutionDisabledFeatures', () => {
         spaceSolution
       );
 
-      expect(result).toEqual(['feature1', 'feature2']); // "baz" from the spaceDisabledFeatures should not be removed
+      expect(result).toEqual(['feature1']); // "baz" from the spaceDisabledFeatures should not be removed
     });
   });
 });

--- a/x-pack/platform/plugins/shared/spaces/server/lib/utils/space_solution_disabled_features.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/lib/utils/space_solution_disabled_features.ts
@@ -67,7 +67,6 @@ export function withSpaceSolutionDisabledFeatures(
   } else if (spaceSolution === 'security') {
     disabledFeatureKeysFromSolution = getFeatureIdsForCategories(features, [
       'observability',
-      'enterpriseSearch',
     ]).filter((featureId) => !enabledFeaturesPerSolution.security.includes(featureId));
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `8.18`:
 - [[Search] enable enterpriseSearch plugin in Security  (#216234)](https://github.com/elastic/kibana/pull/216234)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Meghan Murphy","email":"meghan.murphy@elastic.co"},"sourceCommit":{"committedDate":"2025-03-31T22:04:49Z","message":"[Search] enable enterpriseSearch plugin in Security  (#216234)\n\n## Summary\n\nThis PR enables Enterprise Search in 8.x for Security spaces so that\nconnectors and crawlers are available.\n### Closes  https://github.com/elastic/search-team/issues/9281\n\n<img width=\"1899\" alt=\"Screenshot 2025-03-27 at 4 27 02 PM\"\nsrc=\"https://github.com/user-attachments/assets/d3ab37f3-c6b4-4bdb-8650-0b71feffe4bc\"\n/>\n\n<img width=\"1903\" alt=\"Screenshot 2025-03-27 at 4 27 09 PM\"\nsrc=\"https://github.com/user-attachments/assets/eb0043c6-7781-4024-bc36-7f6cb11d2269\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5b07825d6c18d046f9a43e7d7c68fcf75ecefb09","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v8.18.0","v8.19.0","v8.17.5"],"title":"[Search] enable enterpriseSearch plugin in Security ","number":216234,"url":"https://github.com/elastic/kibana/pull/216234","mergeCommit":{"message":"[Search] enable enterpriseSearch plugin in Security  (#216234)\n\n## Summary\n\nThis PR enables Enterprise Search in 8.x for Security spaces so that\nconnectors and crawlers are available.\n### Closes  https://github.com/elastic/search-team/issues/9281\n\n<img width=\"1899\" alt=\"Screenshot 2025-03-27 at 4 27 02 PM\"\nsrc=\"https://github.com/user-attachments/assets/d3ab37f3-c6b4-4bdb-8650-0b71feffe4bc\"\n/>\n\n<img width=\"1903\" alt=\"Screenshot 2025-03-27 at 4 27 09 PM\"\nsrc=\"https://github.com/user-attachments/assets/eb0043c6-7781-4024-bc36-7f6cb11d2269\"\n/>\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5b07825d6c18d046f9a43e7d7c68fcf75ecefb09"}},"sourceBranch":"8.x","suggestedTargetBranches":["8.18","8.17"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->