### PR TITLE
[Fleet] Display correct toasts on bulk actions

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/hooks/use_bulk_actions.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/installed_integrations/hooks/use_bulk_actions.tsx
@@ -76,7 +76,6 @@ export const BulkActionContextProvider: React.FunctionComponent<{ children: Reac
           setPollingBulkActions((actions) => actions.filter((a) => a.taskId !== action.taskId));
 
           if (res.status === 'success') {
-            // TODO update copy and view integrations https://github.com/elastic/kibana/issues/209892
             toasts.addSuccess({
               title:
                 action.type === 'bulk_upgrade'
@@ -94,7 +93,6 @@ export const BulkActionContextProvider: React.FunctionComponent<{ children: Reac
                     ),
             });
           } else if (res.status === 'failed') {
-            // TODO update copy and view integrations https://github.com/elastic/kibana/issues/209892
             const errorMessage = res.error?.message
               ? res.error?.message
               : res.results
@@ -174,6 +172,21 @@ export function useBulkActions() {
             integrations: items,
           },
         ]);
+        toasts.addInfo({
+          title: i18n.translate(
+            'xpack.fleet.epmInstalledIntegrations.bulkActions.bulkUpgradeInProgressTitle',
+            {
+              defaultMessage: 'Upgrade in progress',
+            }
+          ),
+          content: i18n.translate(
+            'xpack.fleet.epmInstalledIntegrations.bulkActions.bulkUpgradeInProgressDescription',
+            {
+              defaultMessage:
+                'The integrations and the policies are upgrading to the latest version.',
+            }
+          ),
+        });
       } catch (error) {
         toasts.addError(error, {
           title: i18n.translate(
@@ -206,6 +219,14 @@ export function useBulkActions() {
             integrations: items,
           },
         ]);
+        toasts.addInfo({
+          title: i18n.translate(
+            'xpack.fleet.epmInstalledIntegrations.bulkActions.bulkUninstallInProgressTitle',
+            {
+              defaultMessage: 'Uninstall in progress',
+            }
+          ),
+        });
       } catch (error) {
         toasts.addError(error, {
           title: i18n.translate(


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/209892

Add missing toasts on  bulk actions for the new installed integrations table.


## UI Change

<img width="1424" alt="Screenshot 2025-04-01 at 10 52 06 AM" src="https://github.com/user-attachments/assets/79e1f4cc-34e4-4623-ac71-2b8d1373364b" />
<img width="1510" alt="Screenshot 2025-04-01 at 10 52 59 AM" src="https://github.com/user-attachments/assets/cd6d21bb-fc10-4367-b87f-0767e0f58f5d" />
