### PR TITLE
[8.x] [ResponseOps] - fixes for a11y issues  (#216129)

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/common/translations.ts
+++ b/x-pack/platform/plugins/shared/cases/public/common/translations.ts
@@ -273,6 +273,10 @@ export const SYNC_ALERTS_SWITCH_LABEL_OFF = i18n.translate(
   }
 );
 
+export const SYNC_ALERTS = i18n.translate('xpack.cases.settings.syncAlerts', {
+  defaultMessage: 'Sync alerts',
+});
+
 export const SYNC_ALERTS_HELP = i18n.translate('xpack.cases.components.create.syncAlertHelpText', {
   defaultMessage: 'Enabling this option will sync the alert statuses with the case status.',
 });

--- a/x-pack/platform/plugins/shared/cases/public/components/case_settings/sync_alerts_switch.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/case_settings/sync_alerts_switch.tsx
@@ -41,6 +41,7 @@ const SyncAlertsSwitchComponent: React.FC<Props> = ({
       onChange={onChange}
       disabled={disabled}
       data-test-subj="sync-alerts-switch"
+      aria-label={i18n.SYNC_ALERTS}
     />
   );
 };

--- a/x-pack/platform/plugins/shared/cases/public/components/files/add_file.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/files/add_file.tsx
@@ -119,7 +119,11 @@ const AddFileComponent: React.FC<AddFileProps> = ({ caseId }) => {
         {i18n.ADD_FILE}
       </EuiButton>
       {isModalVisible && (
-        <EuiModal data-test-subj="cases-files-add-modal" onClose={closeModal}>
+        <EuiModal
+          data-test-subj="cases-files-add-modal"
+          onClose={closeModal}
+          aria-label={i18n.ADD_FILE}
+        >
           <EuiModalHeader>
             <EuiModalHeaderTitle>{i18n.ADD_FILE}</EuiModalHeaderTitle>
           </EuiModalHeader>

--- a/x-pack/platform/plugins/shared/cases/public/components/severity/selector.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/severity/selector.tsx
@@ -10,6 +10,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiHealth, EuiSuperSelect } from '@elastic/e
 import React from 'react';
 import type { CaseSeverity } from '../../../common/types/domain';
 import { severities } from './config';
+import * as i18n from './translations';
 
 interface Props {
   selectedSeverity: CaseSeverity;
@@ -53,6 +54,7 @@ export const SeveritySelector: React.FC<Props> = ({
       valueOfSelected={selectedSeverity}
       onChange={onSeverityChange}
       data-test-subj="case-severity-selection"
+      aria-label={i18n.SEVERITY_TITLE}
     />
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ResponseOps] - fixes for a11y issues  (#216129)](https://github.com/elastic/kibana/pull/216129)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Georgiana-Andreea Onoleață","email":"georgiana.onoleata@elastic.co"},"sourceCommit":{"committedDate":"2025-04-01T14:31:00Z","message":"[ResponseOps] - fixes for a11y issues  (#216129)\n\nCloses https://github.com/elastic/kibana/issues/205857\nCloses https://github.com/elastic/kibana/issues/205846\nCloses https://github.com/elastic/kibana/issues/205700\n\n## Summary\n\n- added the missing aria-labels\n\n- related to https://github.com/elastic/kibana/issues/205846:\n- \"Columns dialog in Alerts tab. Only drag handle is announced with\ninstructions, column names (Rule, Assignees...) are not announced.\" -\nEUI team has opened a related issue to address this:\nhttps://github.com/elastic/eui/issues/8516\n\n- related to https://github.com/elastic/kibana/issues/205700: \n- \"When reaching Description field - navigation instantly goes to \"Bold\nbutton\". No announcement about Description field itself\". This issue\nwill be fixed after fixing the EuiMarkdown toolbar focus one:\nhttps://github.com/elastic/eui/issues/3500","sha":"469e109edc84baf583f53983695c49abab3ac1fa","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:version","v9.1.0","v8.19.0"],"title":"[ResponseOps] - fixes for a11y issues ","number":216129,"url":"https://github.com/elastic/kibana/pull/216129","mergeCommit":{"message":"[ResponseOps] - fixes for a11y issues  (#216129)\n\nCloses https://github.com/elastic/kibana/issues/205857\nCloses https://github.com/elastic/kibana/issues/205846\nCloses https://github.com/elastic/kibana/issues/205700\n\n## Summary\n\n- added the missing aria-labels\n\n- related to https://github.com/elastic/kibana/issues/205846:\n- \"Columns dialog in Alerts tab. Only drag handle is announced with\ninstructions, column names (Rule, Assignees...) are not announced.\" -\nEUI team has opened a related issue to address this:\nhttps://github.com/elastic/eui/issues/8516\n\n- related to https://github.com/elastic/kibana/issues/205700: \n- \"When reaching Description field - navigation instantly goes to \"Bold\nbutton\". No announcement about Description field itself\". This issue\nwill be fixed after fixing the EuiMarkdown toolbar focus one:\nhttps://github.com/elastic/eui/issues/3500","sha":"469e109edc84baf583f53983695c49abab3ac1fa"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216129","number":216129,"mergeCommit":{"message":"[ResponseOps] - fixes for a11y issues  (#216129)\n\nCloses https://github.com/elastic/kibana/issues/205857\nCloses https://github.com/elastic/kibana/issues/205846\nCloses https://github.com/elastic/kibana/issues/205700\n\n## Summary\n\n- added the missing aria-labels\n\n- related to https://github.com/elastic/kibana/issues/205846:\n- \"Columns dialog in Alerts tab. Only drag handle is announced with\ninstructions, column names (Rule, Assignees...) are not announced.\" -\nEUI team has opened a related issue to address this:\nhttps://github.com/elastic/eui/issues/8516\n\n- related to https://github.com/elastic/kibana/issues/205700: \n- \"When reaching Description field - navigation instantly goes to \"Bold\nbutton\". No announcement about Description field itself\". This issue\nwill be fixed after fixing the EuiMarkdown toolbar focus one:\nhttps://github.com/elastic/eui/issues/3500","sha":"469e109edc84baf583f53983695c49abab3ac1fa"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->