### PR TITLE
[7.17] [APM] Fix query for transaction marks (#215819)

### DIFF
--- a/api_docs/kbn_apm_types.devdocs.json
+++ b/api_docs/kbn_apm_types.devdocs.json
@@ -1,0 +1,5454 @@
+{
+  "id": "@kbn/apm-types",
+  "client": {
+    "classes": [],
+    "functions": [],
+    "interfaces": [],
+    "enums": [],
+    "misc": [],
+    "objects": []
+  },
+  "server": {
+    "classes": [],
+    "functions": [],
+    "interfaces": [],
+    "enums": [],
+    "misc": [],
+    "objects": []
+  },
+  "common": {
+    "classes": [],
+    "functions": [],
+    "interfaces": [
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Agent",
+        "type": "Interface",
+        "tags": [],
+        "label": "Agent",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/fields/agent.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Agent.ephemeral_id",
+            "type": "string",
+            "tags": [],
+            "label": "ephemeral_id",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/fields/agent.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Agent.name",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "name",
+            "description": [],
+            "signature": [
+              "\"ruby\" | \"opentelemetry\" | \"dotnet\" | \"go\" | \"iOS/swift\" | \"java\" | \"js-base\" | \"nodejs\" | \"php\" | \"python\" | \"rum-js\" | \"android/java\" | \"otlp\" | `opentelemetry/${string}` | `otlp/${string}` | \"ios/swift\""
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/fields/agent.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Agent.version",
+            "type": "string",
+            "tags": [],
+            "label": "version",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/fields/agent.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.APMBaseDoc",
+        "type": "Interface",
+        "tags": [],
+        "label": "APMBaseDoc",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/apm_base_doc.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.APMBaseDoc.timestamp",
+            "type": "string",
+            "tags": [],
+            "label": "'@timestamp'",
+            "description": [],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/apm_base_doc.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.APMBaseDoc.agent",
+            "type": "Object",
+            "tags": [],
+            "label": "agent",
+            "description": [],
+            "signature": [
+              "{ name: string; version?: string | undefined; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/apm_base_doc.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.APMBaseDoc.parent",
+            "type": "Object",
+            "tags": [],
+            "label": "parent",
+            "description": [],
+            "signature": [
+              "{ id?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/apm_base_doc.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.APMBaseDoc.trace",
+            "type": "Object",
+            "tags": [],
+            "label": "trace",
+            "description": [],
+            "signature": [
+              "{ id?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/apm_base_doc.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.APMBaseDoc.labels",
+            "type": "Object",
+            "tags": [],
+            "label": "labels",
+            "description": [],
+            "signature": [
+              "{ [key: string]: string | number | boolean; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/apm_base_doc.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.APMBaseDoc.observer",
+            "type": "Object",
+            "tags": [],
+            "label": "observer",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Observer",
+                "text": "Observer"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/apm_base_doc.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.APMError",
+        "type": "Interface",
+        "tags": [],
+        "label": "APMError",
+        "description": [],
+        "signature": [
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.APMError",
+            "text": "APMError"
+          },
+          " extends ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.ErrorRaw",
+            "text": "ErrorRaw"
+          }
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/apm_error.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.APMError.agent",
+            "type": "Object",
+            "tags": [],
+            "label": "agent",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Agent",
+                "text": "Agent"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/apm_error.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Cloud",
+        "type": "Interface",
+        "tags": [],
+        "label": "Cloud",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Cloud.availability_zone",
+            "type": "string",
+            "tags": [],
+            "label": "availability_zone",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Cloud.instance",
+            "type": "Object",
+            "tags": [],
+            "label": "instance",
+            "description": [],
+            "signature": [
+              "{ name?: string | undefined; id?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Cloud.machine",
+            "type": "Object",
+            "tags": [],
+            "label": "machine",
+            "description": [],
+            "signature": [
+              "{ type?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Cloud.project",
+            "type": "Object",
+            "tags": [],
+            "label": "project",
+            "description": [],
+            "signature": [
+              "{ id?: string | undefined; name?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Cloud.provider",
+            "type": "string",
+            "tags": [],
+            "label": "provider",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Cloud.region",
+            "type": "string",
+            "tags": [],
+            "label": "region",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Cloud.account",
+            "type": "Object",
+            "tags": [],
+            "label": "account",
+            "description": [],
+            "signature": [
+              "{ id?: string | undefined; name?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Cloud.image",
+            "type": "Object",
+            "tags": [],
+            "label": "image",
+            "description": [],
+            "signature": [
+              "{ id?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Cloud.service",
+            "type": "Object",
+            "tags": [],
+            "label": "service",
+            "description": [],
+            "signature": [
+              "{ name?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/cloud.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Container",
+        "type": "Interface",
+        "tags": [],
+        "label": "Container",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/container.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Container.id",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "id",
+            "description": [],
+            "signature": [
+              "string | null | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/container.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Container.image",
+            "type": "Object",
+            "tags": [],
+            "label": "image",
+            "description": [],
+            "signature": [
+              "{ name?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/container.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ErrorRaw",
+        "type": "Interface",
+        "tags": [],
+        "label": "ErrorRaw",
+        "description": [],
+        "signature": [
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.ErrorRaw",
+            "text": "ErrorRaw"
+          },
+          " extends ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.APMBaseDoc",
+            "text": "APMBaseDoc"
+          }
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.processor",
+            "type": "Object",
+            "tags": [],
+            "label": "processor",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Processor",
+                "text": "Processor"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.timestamp",
+            "type": "Object",
+            "tags": [],
+            "label": "timestamp",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.TimestampUs",
+                "text": "TimestampUs"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.transaction",
+            "type": "Object",
+            "tags": [],
+            "label": "transaction",
+            "description": [],
+            "signature": [
+              "{ id: string; sampled?: boolean | undefined; type: string; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.error",
+            "type": "Object",
+            "tags": [],
+            "label": "error",
+            "description": [],
+            "signature": [
+              "{ id: string; culprit?: string | undefined; grouping_key: string; exception?: ",
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Exception",
+                "text": "Exception"
+              },
+              "[] | undefined; page?: ",
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Page",
+                "text": "Page"
+              },
+              " | undefined; log?: ",
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Log",
+                "text": "Log"
+              },
+              " | undefined; stack_trace?: string | undefined; custom?: Record<string, unknown> | undefined; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.container",
+            "type": "Object",
+            "tags": [],
+            "label": "container",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Container",
+                "text": "Container"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.host",
+            "type": "Object",
+            "tags": [],
+            "label": "host",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Host",
+                "text": "Host"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.http",
+            "type": "Object",
+            "tags": [],
+            "label": "http",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Http",
+                "text": "Http"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.kubernetes",
+            "type": "Object",
+            "tags": [],
+            "label": "kubernetes",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Kubernetes",
+                "text": "Kubernetes"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.process",
+            "type": "Object",
+            "tags": [],
+            "label": "process",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Process",
+                "text": "Process"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.service",
+            "type": "Object",
+            "tags": [],
+            "label": "service",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Service",
+                "text": "Service"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.url",
+            "type": "Object",
+            "tags": [],
+            "label": "url",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Url",
+                "text": "Url"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.ErrorRaw.user",
+            "type": "Object",
+            "tags": [],
+            "label": "user",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.User",
+                "text": "User"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Event",
+        "type": "Interface",
+        "tags": [],
+        "label": "Event",
+        "description": [],
+        "signature": [
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.Event",
+            "text": "Event"
+          },
+          " extends ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.EventRaw",
+            "text": "EventRaw"
+          }
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/event.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Event.agent",
+            "type": "Object",
+            "tags": [],
+            "label": "agent",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Agent",
+                "text": "Agent"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/event.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.EventRaw",
+        "type": "Interface",
+        "tags": [],
+        "label": "EventRaw",
+        "description": [],
+        "signature": [
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.EventRaw",
+            "text": "EventRaw"
+          },
+          " extends ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.APMBaseDoc",
+            "text": "APMBaseDoc"
+          }
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/event_raw.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.EventRaw.timestamp",
+            "type": "Object",
+            "tags": [],
+            "label": "timestamp",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.TimestampUs",
+                "text": "TimestampUs"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/event_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.EventRaw.transaction",
+            "type": "Object",
+            "tags": [],
+            "label": "transaction",
+            "description": [],
+            "signature": [
+              "{ id: string; sampled?: boolean | undefined; type: string; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/event_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.EventRaw.log",
+            "type": "Object",
+            "tags": [],
+            "label": "log",
+            "description": [],
+            "signature": [
+              "{ message?: string | undefined; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/event_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.EventRaw.event",
+            "type": "Object",
+            "tags": [],
+            "label": "event",
+            "description": [],
+            "signature": [
+              "{ action: string; category: string; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/event_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Exception",
+        "type": "Interface",
+        "tags": [],
+        "label": "Exception",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Exception.attributes",
+            "type": "Object",
+            "tags": [],
+            "label": "attributes",
+            "description": [],
+            "signature": [
+              "{ response?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Exception.code",
+            "type": "string",
+            "tags": [],
+            "label": "code",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Exception.message",
+            "type": "string",
+            "tags": [],
+            "label": "message",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Exception.type",
+            "type": "string",
+            "tags": [],
+            "label": "type",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Exception.module",
+            "type": "string",
+            "tags": [],
+            "label": "module",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Exception.handled",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "handled",
+            "description": [],
+            "signature": [
+              "boolean | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Exception.stacktrace",
+            "type": "Array",
+            "tags": [],
+            "label": "stacktrace",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Stackframe",
+                "text": "Stackframe"
+              },
+              "[] | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Faas",
+        "type": "Interface",
+        "tags": [],
+        "label": "Faas",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/faas.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Faas.id",
+            "type": "string",
+            "tags": [],
+            "label": "id",
+            "description": [],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/faas.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Faas.coldstart",
+            "type": "CompoundType",
+            "tags": [],
+            "label": "coldstart",
+            "description": [],
+            "signature": [
+              "boolean | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/faas.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Faas.execution",
+            "type": "string",
+            "tags": [],
+            "label": "execution",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/faas.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Faas.trigger",
+            "type": "Object",
+            "tags": [],
+            "label": "trigger",
+            "description": [],
+            "signature": [
+              "{ type?: string | undefined; request_id?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/faas.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Host",
+        "type": "Interface",
+        "tags": [],
+        "label": "Host",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/host.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Host.architecture",
+            "type": "string",
+            "tags": [],
+            "label": "architecture",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/host.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Host.hostname",
+            "type": "string",
+            "tags": [],
+            "label": "hostname",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/host.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Host.name",
+            "type": "string",
+            "tags": [],
+            "label": "name",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/host.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Host.ip",
+            "type": "string",
+            "tags": [],
+            "label": "ip",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/host.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Host.os",
+            "type": "Object",
+            "tags": [],
+            "label": "os",
+            "description": [],
+            "signature": [
+              "{ platform?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/host.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Http",
+        "type": "Interface",
+        "tags": [],
+        "label": "Http",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/http.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Http.request",
+            "type": "Object",
+            "tags": [],
+            "label": "request",
+            "description": [],
+            "signature": [
+              "{ method?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/http.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Http.response",
+            "type": "Object",
+            "tags": [],
+            "label": "response",
+            "description": [],
+            "signature": [
+              "{ status_code?: number | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/http.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Http.version",
+            "type": "string",
+            "tags": [],
+            "label": "version",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/http.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Kubernetes",
+        "type": "Interface",
+        "tags": [],
+        "label": "Kubernetes",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/kubernetes.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Kubernetes.pod",
+            "type": "Object",
+            "tags": [],
+            "label": "pod",
+            "description": [],
+            "signature": [
+              "{ uid?: string | null | undefined; name?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/kubernetes.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Kubernetes.namespace",
+            "type": "string",
+            "tags": [],
+            "label": "namespace",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/kubernetes.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Kubernetes.replicaset",
+            "type": "Object",
+            "tags": [],
+            "label": "replicaset",
+            "description": [],
+            "signature": [
+              "{ name?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/kubernetes.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Kubernetes.deployment",
+            "type": "Object",
+            "tags": [],
+            "label": "deployment",
+            "description": [],
+            "signature": [
+              "{ name?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/kubernetes.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Kubernetes.container",
+            "type": "Object",
+            "tags": [],
+            "label": "container",
+            "description": [],
+            "signature": [
+              "{ id?: string | undefined; name?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/kubernetes.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Log",
+        "type": "Interface",
+        "tags": [],
+        "label": "Log",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Log.message",
+            "type": "string",
+            "tags": [],
+            "label": "message",
+            "description": [],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Log.stacktrace",
+            "type": "Array",
+            "tags": [],
+            "label": "stacktrace",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Stackframe",
+                "text": "Stackframe"
+              },
+              "[] | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Observer",
+        "type": "Interface",
+        "tags": [],
+        "label": "Observer",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/observer.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Observer.ephemeral_id",
+            "type": "string",
+            "tags": [],
+            "label": "ephemeral_id",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/observer.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Observer.hostname",
+            "type": "string",
+            "tags": [],
+            "label": "hostname",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/observer.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Observer.id",
+            "type": "string",
+            "tags": [],
+            "label": "id",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/observer.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Observer.name",
+            "type": "string",
+            "tags": [],
+            "label": "name",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/observer.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Observer.type",
+            "type": "string",
+            "tags": [],
+            "label": "type",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/observer.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Observer.version",
+            "type": "string",
+            "tags": [],
+            "label": "version",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/observer.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Observer.version_major",
+            "type": "number",
+            "tags": [],
+            "label": "version_major",
+            "description": [],
+            "signature": [
+              "number | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/observer.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Page",
+        "type": "Interface",
+        "tags": [],
+        "label": "Page",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/page.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Page.url",
+            "type": "string",
+            "tags": [],
+            "label": "url",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/page.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Process",
+        "type": "Interface",
+        "tags": [],
+        "label": "Process",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/process.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Process.args",
+            "type": "Array",
+            "tags": [],
+            "label": "args",
+            "description": [],
+            "signature": [
+              "string[] | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/process.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Process.pid",
+            "type": "number",
+            "tags": [],
+            "label": "pid",
+            "description": [],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/process.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Process.ppid",
+            "type": "number",
+            "tags": [],
+            "label": "ppid",
+            "description": [],
+            "signature": [
+              "number | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/process.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Process.title",
+            "type": "string",
+            "tags": [],
+            "label": "title",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/process.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Processor",
+        "type": "Interface",
+        "tags": [],
+        "label": "Processor",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Processor.name",
+            "type": "string",
+            "tags": [],
+            "label": "name",
+            "description": [],
+            "signature": [
+              "\"error\""
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Processor.event",
+            "type": "string",
+            "tags": [],
+            "label": "event",
+            "description": [],
+            "signature": [
+              "\"error\""
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/error_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Service",
+        "type": "Interface",
+        "tags": [],
+        "label": "Service",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/service.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Service.name",
+            "type": "string",
+            "tags": [],
+            "label": "name",
+            "description": [],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/service.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Service.environment",
+            "type": "string",
+            "tags": [],
+            "label": "environment",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/service.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Service.framework",
+            "type": "Object",
+            "tags": [],
+            "label": "framework",
+            "description": [],
+            "signature": [
+              "{ name?: string | undefined; version?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/service.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Service.node",
+            "type": "Object",
+            "tags": [],
+            "label": "node",
+            "description": [],
+            "signature": [
+              "{ name?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/service.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Service.runtime",
+            "type": "Object",
+            "tags": [],
+            "label": "runtime",
+            "description": [],
+            "signature": [
+              "{ name?: string | undefined; version?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/service.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Service.language",
+            "type": "Object",
+            "tags": [],
+            "label": "language",
+            "description": [],
+            "signature": [
+              "{ name?: string | undefined; version?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/service.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Service.version",
+            "type": "string",
+            "tags": [],
+            "label": "version",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/service.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Span",
+        "type": "Interface",
+        "tags": [],
+        "label": "Span",
+        "description": [],
+        "signature": [
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.Span",
+            "text": "Span"
+          },
+          " extends ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.SpanRaw",
+            "text": "SpanRaw"
+          }
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/span.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Span.agent",
+            "type": "Object",
+            "tags": [],
+            "label": "agent",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Agent",
+                "text": "Agent"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/span.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SpanLink",
+        "type": "Interface",
+        "tags": [],
+        "label": "SpanLink",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/span_links.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanLink.trace",
+            "type": "Object",
+            "tags": [],
+            "label": "trace",
+            "description": [],
+            "signature": [
+              "{ id: string; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/span_links.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanLink.span",
+            "type": "Object",
+            "tags": [],
+            "label": "span",
+            "description": [],
+            "signature": [
+              "{ id: string; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/span_links.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SpanRaw",
+        "type": "Interface",
+        "tags": [],
+        "label": "SpanRaw",
+        "description": [],
+        "signature": [
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.SpanRaw",
+            "text": "SpanRaw"
+          },
+          " extends ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.APMBaseDoc",
+            "text": "APMBaseDoc"
+          }
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.processor",
+            "type": "Object",
+            "tags": [],
+            "label": "processor",
+            "description": [],
+            "signature": [
+              "Processor"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.trace",
+            "type": "Object",
+            "tags": [],
+            "label": "trace",
+            "description": [],
+            "signature": [
+              "{ id: string; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.event",
+            "type": "Object",
+            "tags": [],
+            "label": "event",
+            "description": [],
+            "signature": [
+              "{ outcome?: ",
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.EventOutcome",
+                "text": "EventOutcome"
+              },
+              " | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.service",
+            "type": "Object",
+            "tags": [],
+            "label": "service",
+            "description": [],
+            "signature": [
+              "{ name: string; environment?: string | undefined; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.span",
+            "type": "Object",
+            "tags": [],
+            "label": "span",
+            "description": [],
+            "signature": [
+              "{ destination?: { service: { resource: string; }; } | undefined; action?: string | undefined; duration: { us: number; }; id: string; name: string; stacktrace?: ",
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Stackframe",
+                "text": "Stackframe"
+              },
+              "[] | undefined; subtype?: string | undefined; sync?: boolean | undefined; type: string; http?: { url?: { original?: string | undefined; } | undefined; response: { status_code: number; }; method?: string | undefined; } | undefined; db?: { statement?: string | undefined; type?: string | undefined; } | undefined; message?: { queue?: { name: string; } | undefined; age?: { ms: number; } | undefined; body?: string | undefined; headers?: Record<string, unknown> | undefined; } | undefined; composite?: { count: number; sum: { us: number; }; compression_strategy: string; } | undefined; links?: ",
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.SpanLink",
+                "text": "SpanLink"
+              },
+              "[] | undefined; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.timestamp",
+            "type": "Object",
+            "tags": [],
+            "label": "timestamp",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.TimestampUs",
+                "text": "TimestampUs"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.transaction",
+            "type": "Object",
+            "tags": [],
+            "label": "transaction",
+            "description": [],
+            "signature": [
+              "{ id: string; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.child",
+            "type": "Object",
+            "tags": [],
+            "label": "child",
+            "description": [],
+            "signature": [
+              "{ id: string[]; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.code",
+            "type": "Object",
+            "tags": [],
+            "label": "code",
+            "description": [],
+            "signature": [
+              "{ stacktrace?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.http",
+            "type": "Object",
+            "tags": [],
+            "label": "http",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Http",
+                "text": "Http"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.SpanRaw.url",
+            "type": "Object",
+            "tags": [],
+            "label": "url",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Url",
+                "text": "Url"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/span_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TimestampUs",
+        "type": "Interface",
+        "tags": [],
+        "label": "TimestampUs",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/timestamp_us.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TimestampUs.us",
+            "type": "number",
+            "tags": [],
+            "label": "us",
+            "description": [],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/timestamp_us.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Transaction",
+        "type": "Interface",
+        "tags": [],
+        "label": "Transaction",
+        "description": [],
+        "signature": [
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.Transaction",
+            "text": "Transaction"
+          },
+          " extends ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.TransactionRaw",
+            "text": "TransactionRaw"
+          }
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/transaction.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Transaction.agent",
+            "type": "Object",
+            "tags": [],
+            "label": "agent",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Agent",
+                "text": "Agent"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/transaction.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Transaction.transaction",
+            "type": "Object",
+            "tags": [],
+            "label": "transaction",
+            "description": [],
+            "signature": [
+              "InnerTransactionWithName"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/transaction.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TransactionRaw",
+        "type": "Interface",
+        "tags": [],
+        "label": "TransactionRaw",
+        "description": [],
+        "signature": [
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.TransactionRaw",
+            "text": "TransactionRaw"
+          },
+          " extends ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.APMBaseDoc",
+            "text": "APMBaseDoc"
+          }
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.processor",
+            "type": "Object",
+            "tags": [],
+            "label": "processor",
+            "description": [],
+            "signature": [
+              "Processor"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.timestamp",
+            "type": "Object",
+            "tags": [],
+            "label": "timestamp",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.TimestampUs",
+                "text": "TimestampUs"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.trace",
+            "type": "Object",
+            "tags": [],
+            "label": "trace",
+            "description": [],
+            "signature": [
+              "{ id: string; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.event",
+            "type": "Object",
+            "tags": [],
+            "label": "event",
+            "description": [],
+            "signature": [
+              "{ outcome?: ",
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.EventOutcome",
+                "text": "EventOutcome"
+              },
+              " | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.transaction",
+            "type": "Object",
+            "tags": [],
+            "label": "transaction",
+            "description": [],
+            "signature": [
+              "{ duration: { us: number; }; id: string; marks?: { agent?: { [name: string]: number; } | undefined; } | undefined; name?: string | undefined; page?: ",
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Page",
+                "text": "Page"
+              },
+              " | undefined; result?: string | undefined; sampled: boolean; span_count?: { started?: number | undefined; dropped?: number | undefined; } | undefined; type: string; custom?: Record<string, unknown> | undefined; message?: { queue?: { name: string; } | undefined; age?: { ms: number; } | undefined; body?: string | undefined; headers?: Record<string, unknown> | undefined; } | undefined; }"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.container",
+            "type": "Object",
+            "tags": [],
+            "label": "container",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Container",
+                "text": "Container"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.ecs",
+            "type": "Object",
+            "tags": [],
+            "label": "ecs",
+            "description": [],
+            "signature": [
+              "{ version?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.host",
+            "type": "Object",
+            "tags": [],
+            "label": "host",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Host",
+                "text": "Host"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.http",
+            "type": "Object",
+            "tags": [],
+            "label": "http",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Http",
+                "text": "Http"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.kubernetes",
+            "type": "Object",
+            "tags": [],
+            "label": "kubernetes",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Kubernetes",
+                "text": "Kubernetes"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.process",
+            "type": "Object",
+            "tags": [],
+            "label": "process",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Process",
+                "text": "Process"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.service",
+            "type": "Object",
+            "tags": [],
+            "label": "service",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Service",
+                "text": "Service"
+              }
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.url",
+            "type": "Object",
+            "tags": [],
+            "label": "url",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Url",
+                "text": "Url"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.user",
+            "type": "Object",
+            "tags": [],
+            "label": "user",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.User",
+                "text": "User"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.user_agent",
+            "type": "Object",
+            "tags": [],
+            "label": "user_agent",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.UserAgent",
+                "text": "UserAgent"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.cloud",
+            "type": "Object",
+            "tags": [],
+            "label": "cloud",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Cloud",
+                "text": "Cloud"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.faas",
+            "type": "Object",
+            "tags": [],
+            "label": "faas",
+            "description": [],
+            "signature": [
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.Faas",
+                "text": "Faas"
+              },
+              " | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.TransactionRaw.span",
+            "type": "Object",
+            "tags": [],
+            "label": "span",
+            "description": [],
+            "signature": [
+              "{ links?: ",
+              {
+                "pluginId": "@kbn/apm-types",
+                "scope": "common",
+                "docId": "kibKbnApmTypesPluginApi",
+                "section": "def-common.SpanLink",
+                "text": "SpanLink"
+              },
+              "[] | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/transaction_raw.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Url",
+        "type": "Interface",
+        "tags": [],
+        "label": "Url",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/url.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Url.domain",
+            "type": "string",
+            "tags": [],
+            "label": "domain",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/url.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Url.full",
+            "type": "string",
+            "tags": [],
+            "label": "full",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/url.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.Url.original",
+            "type": "string",
+            "tags": [],
+            "label": "original",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/url.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.User",
+        "type": "Interface",
+        "tags": [],
+        "label": "User",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/user.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.User.id",
+            "type": "string",
+            "tags": [],
+            "label": "id",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/user.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.UserAgent",
+        "type": "Interface",
+        "tags": [],
+        "label": "UserAgent",
+        "description": [],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/user_agent.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "children": [
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.UserAgent.device",
+            "type": "Object",
+            "tags": [],
+            "label": "device",
+            "description": [],
+            "signature": [
+              "{ name: string; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/user_agent.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.UserAgent.name",
+            "type": "string",
+            "tags": [],
+            "label": "name",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/user_agent.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.UserAgent.original",
+            "type": "string",
+            "tags": [],
+            "label": "original",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/user_agent.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.UserAgent.os",
+            "type": "Object",
+            "tags": [],
+            "label": "os",
+            "description": [],
+            "signature": [
+              "{ name: string; version?: string | undefined; full?: string | undefined; } | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/user_agent.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          },
+          {
+            "parentPluginId": "@kbn/apm-types",
+            "id": "def-common.UserAgent.version",
+            "type": "string",
+            "tags": [],
+            "label": "version",
+            "description": [],
+            "signature": [
+              "string | undefined"
+            ],
+            "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/user_agent.ts",
+            "deprecated": false,
+            "trackAdoption": false
+          }
+        ],
+        "initialIsOpen": false
+      }
+    ],
+    "enums": [],
+    "misc": [
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.AGENT",
+        "type": "string",
+        "tags": [],
+        "label": "AGENT",
+        "description": [],
+        "signature": [
+          "\"agent\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.AGENT_ACTIVATION_METHOD",
+        "type": "string",
+        "tags": [],
+        "label": "AGENT_ACTIVATION_METHOD",
+        "description": [],
+        "signature": [
+          "\"agent.activation_method\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.AGENT_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "AGENT_NAME",
+        "description": [],
+        "signature": [
+          "\"agent.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.AGENT_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "AGENT_VERSION",
+        "description": [],
+        "signature": [
+          "\"agent.version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.AgentName",
+        "type": "Type",
+        "tags": [],
+        "label": "AgentName",
+        "description": [],
+        "signature": [
+          "\"ruby\" | \"opentelemetry\" | \"dotnet\" | \"go\" | \"iOS/swift\" | \"java\" | \"js-base\" | \"nodejs\" | \"php\" | \"python\" | \"rum-js\" | \"android/java\" | \"otlp\" | `opentelemetry/${string}` | `otlp/${string}` | \"ios/swift\""
+        ],
+        "path": "src/platform/packages/shared/kbn-elastic-agent-utils/src/agent_names.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.APP_LAUNCH_TIME",
+        "type": "string",
+        "tags": [],
+        "label": "APP_LAUNCH_TIME",
+        "description": [],
+        "signature": [
+          "\"application.launch.time\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.AT_TIMESTAMP",
+        "type": "string",
+        "tags": [],
+        "label": "AT_TIMESTAMP",
+        "description": [],
+        "signature": [
+          "\"@timestamp\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CHILD_ID",
+        "type": "string",
+        "tags": [],
+        "label": "CHILD_ID",
+        "description": [],
+        "signature": [
+          "\"child.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLIENT_GEO_CITY_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "CLIENT_GEO_CITY_NAME",
+        "description": [],
+        "signature": [
+          "\"client.geo.city_name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLIENT_GEO_COUNTRY_ISO_CODE",
+        "type": "string",
+        "tags": [],
+        "label": "CLIENT_GEO_COUNTRY_ISO_CODE",
+        "description": [],
+        "signature": [
+          "\"client.geo.country_iso_code\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLIENT_GEO_COUNTRY_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "CLIENT_GEO_COUNTRY_NAME",
+        "description": [],
+        "signature": [
+          "\"client.geo.country_name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLIENT_GEO_REGION_ISO_CODE",
+        "type": "string",
+        "tags": [],
+        "label": "CLIENT_GEO_REGION_ISO_CODE",
+        "description": [],
+        "signature": [
+          "\"client.geo.region_iso_code\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLIENT_GEO_REGION_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "CLIENT_GEO_REGION_NAME",
+        "description": [],
+        "signature": [
+          "\"client.geo.region_name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD",
+        "description": [],
+        "signature": [
+          "\"cloud\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_ACCOUNT_ID",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_ACCOUNT_ID",
+        "description": [],
+        "signature": [
+          "\"cloud.account.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_ACCOUNT_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_ACCOUNT_NAME",
+        "description": [],
+        "signature": [
+          "\"cloud.account.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_AVAILABILITY_ZONE",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_AVAILABILITY_ZONE",
+        "description": [],
+        "signature": [
+          "\"cloud.availability_zone\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_INSTANCE_ID",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_INSTANCE_ID",
+        "description": [],
+        "signature": [
+          "\"cloud.instance.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_INSTANCE_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_INSTANCE_NAME",
+        "description": [],
+        "signature": [
+          "\"cloud.instance.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_MACHINE_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_MACHINE_TYPE",
+        "description": [],
+        "signature": [
+          "\"cloud.machine.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_PROJECT_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_PROJECT_NAME",
+        "description": [],
+        "signature": [
+          "\"cloud.project.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_PROVIDER",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_PROVIDER",
+        "description": [],
+        "signature": [
+          "\"cloud.provider\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_REGION",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_REGION",
+        "description": [],
+        "signature": [
+          "\"cloud.region\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CLOUD_SERVICE_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "CLOUD_SERVICE_NAME",
+        "description": [],
+        "signature": [
+          "\"cloud.service.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CONTAINER",
+        "type": "string",
+        "tags": [],
+        "label": "CONTAINER",
+        "description": [],
+        "signature": [
+          "\"container\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CONTAINER_ID",
+        "type": "string",
+        "tags": [],
+        "label": "CONTAINER_ID",
+        "description": [],
+        "signature": [
+          "\"container.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.CONTAINER_IMAGE",
+        "type": "string",
+        "tags": [],
+        "label": "CONTAINER_IMAGE",
+        "description": [],
+        "signature": [
+          "\"container.image.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.DATA_STEAM_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "DATA_STEAM_TYPE",
+        "description": [],
+        "signature": [
+          "\"data_stream.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.DESTINATION_ADDRESS",
+        "type": "string",
+        "tags": [],
+        "label": "DESTINATION_ADDRESS",
+        "description": [],
+        "signature": [
+          "\"destination.address\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.DEVICE_MODEL_IDENTIFIER",
+        "type": "string",
+        "tags": [],
+        "label": "DEVICE_MODEL_IDENTIFIER",
+        "description": [],
+        "signature": [
+          "\"device.model.identifier\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ElasticAgentName",
+        "type": "Type",
+        "tags": [],
+        "label": "ElasticAgentName",
+        "description": [
+          "\nWe cannot mark these arrays as const and derive their type\nbecause we need to be able to assign them as mutable entities for ES queries."
+        ],
+        "signature": [
+          "\"ruby\" | \"dotnet\" | \"go\" | \"iOS/swift\" | \"java\" | \"js-base\" | \"nodejs\" | \"php\" | \"python\" | \"rum-js\" | \"android/java\""
+        ],
+        "path": "src/platform/packages/shared/kbn-elastic-agent-utils/src/agent_names.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_CULPRIT",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_CULPRIT",
+        "description": [],
+        "signature": [
+          "\"error.culprit\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_EXC_HANDLED",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_EXC_HANDLED",
+        "description": [],
+        "signature": [
+          "\"error.exception.handled\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_EXC_MESSAGE",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_EXC_MESSAGE",
+        "description": [],
+        "signature": [
+          "\"error.exception.message\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_EXC_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_EXC_TYPE",
+        "description": [],
+        "signature": [
+          "\"error.exception.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_EXCEPTION",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_EXCEPTION",
+        "description": [],
+        "signature": [
+          "\"error.exception\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_GROUP_ID",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_GROUP_ID",
+        "description": [],
+        "signature": [
+          "\"error.grouping_key\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_GROUP_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_GROUP_NAME",
+        "description": [],
+        "signature": [
+          "\"error.grouping_name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_ID",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_ID",
+        "description": [],
+        "signature": [
+          "\"error.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_LOG_LEVEL",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_LOG_LEVEL",
+        "description": [],
+        "signature": [
+          "\"error.log.level\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_LOG_MESSAGE",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_LOG_MESSAGE",
+        "description": [],
+        "signature": [
+          "\"error.log.message\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_PAGE_URL",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_PAGE_URL",
+        "description": [],
+        "signature": [
+          "\"error.page.url\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_STACK_TRACE",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_STACK_TRACE",
+        "description": [],
+        "signature": [
+          "\"error.stack_trace\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.ERROR_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "ERROR_TYPE",
+        "description": [],
+        "signature": [
+          "\"error.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.EVENT_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "EVENT_NAME",
+        "description": [],
+        "signature": [
+          "\"event.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.EVENT_OUTCOME",
+        "type": "string",
+        "tags": [],
+        "label": "EVENT_OUTCOME",
+        "description": [],
+        "signature": [
+          "\"event.outcome\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.EVENT_SUCCESS_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "EVENT_SUCCESS_COUNT",
+        "description": [],
+        "signature": [
+          "\"event.success_count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.EventOutcome",
+        "type": "Type",
+        "tags": [],
+        "label": "EventOutcome",
+        "description": [],
+        "signature": [
+          "\"unknown\" | \"success\" | \"failure\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/event_outcome.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.FAAS_BILLED_DURATION",
+        "type": "string",
+        "tags": [],
+        "label": "FAAS_BILLED_DURATION",
+        "description": [],
+        "signature": [
+          "\"faas.billed_duration\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.FAAS_COLDSTART",
+        "type": "string",
+        "tags": [],
+        "label": "FAAS_COLDSTART",
+        "description": [],
+        "signature": [
+          "\"faas.coldstart\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.FAAS_COLDSTART_DURATION",
+        "type": "string",
+        "tags": [],
+        "label": "FAAS_COLDSTART_DURATION",
+        "description": [],
+        "signature": [
+          "\"faas.coldstart_duration\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.FAAS_DURATION",
+        "type": "string",
+        "tags": [],
+        "label": "FAAS_DURATION",
+        "description": [],
+        "signature": [
+          "\"faas.duration\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.FAAS_ID",
+        "type": "string",
+        "tags": [],
+        "label": "FAAS_ID",
+        "description": [],
+        "signature": [
+          "\"faas.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.FAAS_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "FAAS_NAME",
+        "description": [],
+        "signature": [
+          "\"faas.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.FAAS_TRIGGER_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "FAAS_TRIGGER_TYPE",
+        "description": [],
+        "signature": [
+          "\"faas.trigger.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.HOST",
+        "type": "string",
+        "tags": [],
+        "label": "HOST",
+        "description": [],
+        "signature": [
+          "\"host\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.HOST_ARCHITECTURE",
+        "type": "string",
+        "tags": [],
+        "label": "HOST_ARCHITECTURE",
+        "description": [],
+        "signature": [
+          "\"host.architecture\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.HOST_HOSTNAME",
+        "type": "string",
+        "tags": [],
+        "label": "HOST_HOSTNAME",
+        "description": [],
+        "signature": [
+          "\"host.hostname\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.HOST_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "HOST_NAME",
+        "description": [],
+        "signature": [
+          "\"host.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.HOST_OS_PLATFORM",
+        "type": "string",
+        "tags": [],
+        "label": "HOST_OS_PLATFORM",
+        "description": [],
+        "signature": [
+          "\"host.os.platform\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.HOST_OS_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "HOST_OS_VERSION",
+        "description": [],
+        "signature": [
+          "\"host.os.version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.HTTP_REQUEST_METHOD",
+        "type": "string",
+        "tags": [],
+        "label": "HTTP_REQUEST_METHOD",
+        "description": [],
+        "signature": [
+          "\"http.request.method\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.HTTP_RESPONSE_STATUS_CODE",
+        "type": "string",
+        "tags": [],
+        "label": "HTTP_RESPONSE_STATUS_CODE",
+        "description": [],
+        "signature": [
+          "\"http.response.status_code\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.INDEX",
+        "type": "string",
+        "tags": [],
+        "label": "INDEX",
+        "description": [],
+        "signature": [
+          "\"_index\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.KUBERNETES",
+        "type": "string",
+        "tags": [],
+        "label": "KUBERNETES",
+        "description": [],
+        "signature": [
+          "\"kubernetes\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.KUBERNETES_CONTAINER_ID",
+        "type": "string",
+        "tags": [],
+        "label": "KUBERNETES_CONTAINER_ID",
+        "description": [],
+        "signature": [
+          "\"kubernetes.container.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.KUBERNETES_CONTAINER_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "KUBERNETES_CONTAINER_NAME",
+        "description": [],
+        "signature": [
+          "\"kubernetes.container.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.KUBERNETES_DEPLOYMENT_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "KUBERNETES_DEPLOYMENT_NAME",
+        "description": [],
+        "signature": [
+          "\"kubernetes.deployment.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.KUBERNETES_NAMESPACE",
+        "type": "string",
+        "tags": [],
+        "label": "KUBERNETES_NAMESPACE",
+        "description": [],
+        "signature": [
+          "\"kubernetes.namespace\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.KUBERNETES_NODE_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "KUBERNETES_NODE_NAME",
+        "description": [],
+        "signature": [
+          "\"kubernetes.node.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.KUBERNETES_POD_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "KUBERNETES_POD_NAME",
+        "description": [],
+        "signature": [
+          "\"kubernetes.pod.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.KUBERNETES_POD_UID",
+        "type": "string",
+        "tags": [],
+        "label": "KUBERNETES_POD_UID",
+        "description": [],
+        "signature": [
+          "\"kubernetes.pod.uid\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.KUBERNETES_REPLICASET_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "KUBERNETES_REPLICASET_NAME",
+        "description": [],
+        "signature": [
+          "\"kubernetes.replicaset.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.LABEL_GC",
+        "type": "string",
+        "tags": [],
+        "label": "LABEL_GC",
+        "description": [],
+        "signature": [
+          "\"labels.gc\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.LABEL_LIFECYCLE_STATE",
+        "type": "string",
+        "tags": [],
+        "label": "LABEL_LIFECYCLE_STATE",
+        "description": [],
+        "signature": [
+          "\"labels.lifecycle_state\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.LABEL_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "LABEL_NAME",
+        "description": [],
+        "signature": [
+          "\"labels.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.LABEL_TELEMETRY_AUTO_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "LABEL_TELEMETRY_AUTO_VERSION",
+        "description": [],
+        "signature": [
+          "\"labels.telemetry_auto_version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.LABEL_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "LABEL_TYPE",
+        "description": [],
+        "signature": [
+          "\"labels.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.LINKS_SPAN_ID",
+        "type": "string",
+        "tags": [],
+        "label": "LINKS_SPAN_ID",
+        "description": [],
+        "signature": [
+          "\"links.span_id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.LINKS_TRACE_ID",
+        "type": "string",
+        "tags": [],
+        "label": "LINKS_TRACE_ID",
+        "description": [],
+        "signature": [
+          "\"links.trace_id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.LOG_LEVEL",
+        "type": "string",
+        "tags": [],
+        "label": "LOG_LEVEL",
+        "description": [],
+        "signature": [
+          "\"log.level\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Metric",
+        "type": "Type",
+        "tags": [],
+        "label": "Metric",
+        "description": [],
+        "signature": [
+          "BaseMetric | TransactionBreakdownMetric | SpanBreakdownMetric | TransactionDurationMetric | ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.SpanDestinationMetric",
+            "text": "SpanDestinationMetric"
+          },
+          " | SystemMetric | JVMMetric"
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/ui/metric.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_CGROUP_MEMORY_LIMIT_BYTES",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_CGROUP_MEMORY_LIMIT_BYTES",
+        "description": [],
+        "signature": [
+          "\"system.process.cgroup.memory.mem.limit.bytes\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_CGROUP_MEMORY_USAGE_BYTES",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_CGROUP_MEMORY_USAGE_BYTES",
+        "description": [],
+        "signature": [
+          "\"system.process.cgroup.memory.mem.usage.bytes\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_JAVA_GC_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_JAVA_GC_COUNT",
+        "description": [],
+        "signature": [
+          "\"jvm.gc.count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_JAVA_GC_TIME",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_JAVA_GC_TIME",
+        "description": [],
+        "signature": [
+          "\"jvm.gc.time\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_JAVA_HEAP_MEMORY_COMMITTED",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_JAVA_HEAP_MEMORY_COMMITTED",
+        "description": [],
+        "signature": [
+          "\"jvm.memory.heap.committed\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_JAVA_HEAP_MEMORY_MAX",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_JAVA_HEAP_MEMORY_MAX",
+        "description": [],
+        "signature": [
+          "\"jvm.memory.heap.max\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_JAVA_HEAP_MEMORY_USED",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_JAVA_HEAP_MEMORY_USED",
+        "description": [],
+        "signature": [
+          "\"jvm.memory.heap.used\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_JAVA_NON_HEAP_MEMORY_COMMITTED",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_JAVA_NON_HEAP_MEMORY_COMMITTED",
+        "description": [],
+        "signature": [
+          "\"jvm.memory.non_heap.committed\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_JAVA_NON_HEAP_MEMORY_MAX",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_JAVA_NON_HEAP_MEMORY_MAX",
+        "description": [],
+        "signature": [
+          "\"jvm.memory.non_heap.max\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_JAVA_NON_HEAP_MEMORY_USED",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_JAVA_NON_HEAP_MEMORY_USED",
+        "description": [],
+        "signature": [
+          "\"jvm.memory.non_heap.used\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_JAVA_THREAD_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_JAVA_THREAD_COUNT",
+        "description": [],
+        "signature": [
+          "\"jvm.thread.count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_OTEL_JVM_GC_DURATION",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_OTEL_JVM_GC_DURATION",
+        "description": [],
+        "signature": [
+          "\"process.runtime.jvm.gc.duration\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_OTEL_JVM_PROCESS_CPU_PERCENT",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_OTEL_JVM_PROCESS_CPU_PERCENT",
+        "description": [],
+        "signature": [
+          "\"process.runtime.jvm.cpu.utilization\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_OTEL_JVM_PROCESS_MEMORY_COMMITTED",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_OTEL_JVM_PROCESS_MEMORY_COMMITTED",
+        "description": [],
+        "signature": [
+          "\"process.runtime.jvm.memory.committed\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_OTEL_JVM_PROCESS_MEMORY_LIMIT",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_OTEL_JVM_PROCESS_MEMORY_LIMIT",
+        "description": [],
+        "signature": [
+          "\"process.runtime.jvm.memory.limit\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_OTEL_JVM_PROCESS_MEMORY_USAGE",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_OTEL_JVM_PROCESS_MEMORY_USAGE",
+        "description": [],
+        "signature": [
+          "\"process.runtime.jvm.memory.usage\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_OTEL_JVM_PROCESS_THREADS_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_OTEL_JVM_PROCESS_THREADS_COUNT",
+        "description": [],
+        "signature": [
+          "\"process.runtime.jvm.threads.count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_OTEL_JVM_SYSTEM_CPU_PERCENT",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_OTEL_JVM_SYSTEM_CPU_PERCENT",
+        "description": [],
+        "signature": [
+          "\"process.runtime.jvm.system.cpu.utilization\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_OTEL_SYSTEM_CPU_UTILIZATION",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_OTEL_SYSTEM_CPU_UTILIZATION",
+        "description": [],
+        "signature": [
+          "\"system.cpu.utilization\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_OTEL_SYSTEM_MEMORY_UTILIZATION",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_OTEL_SYSTEM_MEMORY_UTILIZATION",
+        "description": [],
+        "signature": [
+          "\"system.memory.utilization\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_PROCESS_CPU_PERCENT",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_PROCESS_CPU_PERCENT",
+        "description": [],
+        "signature": [
+          "\"system.process.cpu.total.norm.pct\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_SYSTEM_CPU_PERCENT",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_SYSTEM_CPU_PERCENT",
+        "description": [],
+        "signature": [
+          "\"system.cpu.total.norm.pct\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_SYSTEM_FREE_MEMORY",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_SYSTEM_FREE_MEMORY",
+        "description": [],
+        "signature": [
+          "\"system.memory.actual.free\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRIC_SYSTEM_TOTAL_MEMORY",
+        "type": "string",
+        "tags": [],
+        "label": "METRIC_SYSTEM_TOTAL_MEMORY",
+        "description": [],
+        "signature": [
+          "\"system.memory.total\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.MetricRaw",
+        "type": "Type",
+        "tags": [],
+        "label": "MetricRaw",
+        "description": [],
+        "signature": [
+          "BaseMetric | TransactionBreakdownMetric | SpanBreakdownMetric | TransactionDurationMetric | ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.SpanDestinationMetric",
+            "text": "SpanDestinationMetric"
+          },
+          " | SystemMetric | JVMMetric"
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/metric_raw.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRICSET_INTERVAL",
+        "type": "string",
+        "tags": [],
+        "label": "METRICSET_INTERVAL",
+        "description": [],
+        "signature": [
+          "\"metricset.interval\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.METRICSET_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "METRICSET_NAME",
+        "description": [],
+        "signature": [
+          "\"metricset.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.NETWORK_CONNECTION_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "NETWORK_CONNECTION_TYPE",
+        "description": [],
+        "signature": [
+          "\"network.connection.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.OBSERVER_HOSTNAME",
+        "type": "string",
+        "tags": [],
+        "label": "OBSERVER_HOSTNAME",
+        "description": [],
+        "signature": [
+          "\"observer.hostname\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.OBSERVER_LISTENING",
+        "type": "string",
+        "tags": [],
+        "label": "OBSERVER_LISTENING",
+        "description": [],
+        "signature": [
+          "\"observer.listening\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.OBSERVER_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "OBSERVER_VERSION",
+        "description": [],
+        "signature": [
+          "\"observer.version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.OBSERVER_VERSION_MAJOR",
+        "type": "string",
+        "tags": [],
+        "label": "OBSERVER_VERSION_MAJOR",
+        "description": [],
+        "signature": [
+          "\"observer.version_major\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.OpenTelemetryAgentName",
+        "type": "Type",
+        "tags": [],
+        "label": "OpenTelemetryAgentName",
+        "description": [],
+        "signature": [
+          "\"opentelemetry\" | \"otlp\" | `opentelemetry/${string}` | `otlp/${string}`"
+        ],
+        "path": "src/platform/packages/shared/kbn-elastic-agent-utils/src/agent_names.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.PARENT_ID",
+        "type": "string",
+        "tags": [],
+        "label": "PARENT_ID",
+        "description": [],
+        "signature": [
+          "\"parent.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.PROCESS_ARGS",
+        "type": "string",
+        "tags": [],
+        "label": "PROCESS_ARGS",
+        "description": [],
+        "signature": [
+          "\"process.args\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.PROCESS_PID",
+        "type": "string",
+        "tags": [],
+        "label": "PROCESS_PID",
+        "description": [],
+        "signature": [
+          "\"process.pid\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.PROCESSOR_EVENT",
+        "type": "string",
+        "tags": [],
+        "label": "PROCESSOR_EVENT",
+        "description": [],
+        "signature": [
+          "\"processor.event\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.PROCESSOR_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "PROCESSOR_NAME",
+        "description": [],
+        "signature": [
+          "\"processor.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE",
+        "description": [],
+        "signature": [
+          "\"service\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_ENVIRONMENT",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_ENVIRONMENT",
+        "description": [],
+        "signature": [
+          "\"service.environment\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_FRAMEWORK_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_FRAMEWORK_NAME",
+        "description": [],
+        "signature": [
+          "\"service.framework.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_FRAMEWORK_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_FRAMEWORK_VERSION",
+        "description": [],
+        "signature": [
+          "\"service.framework.version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_LANGUAGE_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_LANGUAGE_NAME",
+        "description": [],
+        "signature": [
+          "\"service.language.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_LANGUAGE_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_LANGUAGE_VERSION",
+        "description": [],
+        "signature": [
+          "\"service.language.version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_NAME",
+        "description": [],
+        "signature": [
+          "\"service.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_NODE_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_NODE_NAME",
+        "description": [],
+        "signature": [
+          "\"service.node.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_OVERFLOW_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_OVERFLOW_COUNT",
+        "description": [],
+        "signature": [
+          "\"service_transaction.aggregation.overflow_count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_RUNTIME_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_RUNTIME_NAME",
+        "description": [],
+        "signature": [
+          "\"service.runtime.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_RUNTIME_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_RUNTIME_VERSION",
+        "description": [],
+        "signature": [
+          "\"service.runtime.version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_TARGET_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_TARGET_TYPE",
+        "description": [],
+        "signature": [
+          "\"service.target.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SERVICE_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "SERVICE_VERSION",
+        "description": [],
+        "signature": [
+          "\"service.version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SESSION_ID",
+        "type": "string",
+        "tags": [],
+        "label": "SESSION_ID",
+        "description": [],
+        "signature": [
+          "\"session.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_ACTION",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_ACTION",
+        "description": [],
+        "signature": [
+          "\"span.action\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_COMPOSITE_COMPRESSION_STRATEGY",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_COMPOSITE_COMPRESSION_STRATEGY",
+        "description": [],
+        "signature": [
+          "\"span.composite.compression_strategy\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_COMPOSITE_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_COMPOSITE_COUNT",
+        "description": [],
+        "signature": [
+          "\"span.composite.count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_COMPOSITE_SUM",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_COMPOSITE_SUM",
+        "description": [],
+        "signature": [
+          "\"span.composite.sum.us\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_DESTINATION_SERVICE_RESOURCE",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_DESTINATION_SERVICE_RESOURCE",
+        "description": [],
+        "signature": [
+          "\"span.destination.service.resource\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT",
+        "description": [],
+        "signature": [
+          "\"span.destination.service.response_time.count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM",
+        "description": [],
+        "signature": [
+          "\"span.destination.service.response_time.sum.us\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_DURATION",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_DURATION",
+        "description": [],
+        "signature": [
+          "\"span.duration.us\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_ID",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_ID",
+        "description": [],
+        "signature": [
+          "\"span.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_LINKS",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_LINKS",
+        "description": [],
+        "signature": [
+          "\"span.links\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_LINKS_SPAN_ID",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_LINKS_SPAN_ID",
+        "description": [],
+        "signature": [
+          "\"span.links.span.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_LINKS_TRACE_ID",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_LINKS_TRACE_ID",
+        "description": [],
+        "signature": [
+          "\"span.links.trace.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_NAME",
+        "description": [],
+        "signature": [
+          "\"span.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_SELF_TIME_SUM",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_SELF_TIME_SUM",
+        "description": [],
+        "signature": [
+          "\"span.self_time.sum.us\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_STACKTRACE",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_STACKTRACE",
+        "description": [],
+        "signature": [
+          "\"span.stacktrace\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_SUBTYPE",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_SUBTYPE",
+        "description": [],
+        "signature": [
+          "\"span.subtype\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_SYNC",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_SYNC",
+        "description": [],
+        "signature": [
+          "\"span.sync\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SPAN_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "SPAN_TYPE",
+        "description": [],
+        "signature": [
+          "\"span.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.SpanDestinationMetric",
+        "type": "Type",
+        "tags": [],
+        "label": "SpanDestinationMetric",
+        "description": [],
+        "signature": [
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.APMBaseDoc",
+            "text": "APMBaseDoc"
+          },
+          " & { processor: { name: \"metric\"; event: \"metric\"; }; cloud?: ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.Cloud",
+            "text": "Cloud"
+          },
+          " | undefined; container?: ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.Container",
+            "text": "Container"
+          },
+          " | undefined; kubernetes?: ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.Kubernetes",
+            "text": "Kubernetes"
+          },
+          " | undefined; service?: ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.Service",
+            "text": "Service"
+          },
+          " | undefined; host?: ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.Host",
+            "text": "Host"
+          },
+          " | undefined; } & { span: { destination: { service: { resource: string; response_time: { count: number; sum: { us: number; }; }; }; }; }; }"
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/metric_raw.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.Stackframe",
+        "type": "Type",
+        "tags": [],
+        "label": "Stackframe",
+        "description": [],
+        "signature": [
+          "StackframeBase | ",
+          {
+            "pluginId": "@kbn/apm-types",
+            "scope": "common",
+            "docId": "kibKbnApmTypesPluginApi",
+            "section": "def-common.StackframeWithLineContext",
+            "text": "StackframeWithLineContext"
+          }
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/stackframe.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.StackframeWithLineContext",
+        "type": "Type",
+        "tags": [],
+        "label": "StackframeWithLineContext",
+        "description": [],
+        "signature": [
+          "StackframeBase & { line: Line & { context: string; }; }"
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_schemas/raw/fields/stackframe.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TELEMETRY_SDK_LANGUAGE",
+        "type": "string",
+        "tags": [],
+        "label": "TELEMETRY_SDK_LANGUAGE",
+        "description": [],
+        "signature": [
+          "\"telemetry.sdk.language\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TELEMETRY_SDK_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "TELEMETRY_SDK_NAME",
+        "description": [],
+        "signature": [
+          "\"telemetry.sdk.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TELEMETRY_SDK_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "TELEMETRY_SDK_VERSION",
+        "description": [],
+        "signature": [
+          "\"telemetry.sdk.version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TIER",
+        "type": "string",
+        "tags": [],
+        "label": "TIER",
+        "description": [],
+        "signature": [
+          "\"_tier\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TIMESTAMP_US",
+        "type": "string",
+        "tags": [],
+        "label": "TIMESTAMP_US",
+        "description": [],
+        "signature": [
+          "\"timestamp.us\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRACE_ID",
+        "type": "string",
+        "tags": [],
+        "label": "TRACE_ID",
+        "description": [],
+        "signature": [
+          "\"trace.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_MARKS_AGENT",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_MARKS_AGENT",
+        "description": [],
+        "signature": [
+          "\"transaction.marks.agent\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_DURATION",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_DURATION",
+        "description": [],
+        "signature": [
+          "\"transaction.duration.us\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_DURATION_HISTOGRAM",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_DURATION_HISTOGRAM",
+        "description": [],
+        "signature": [
+          "\"transaction.duration.histogram\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_DURATION_SUMMARY",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_DURATION_SUMMARY",
+        "description": [],
+        "signature": [
+          "\"transaction.duration.summary\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_FAILURE_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_FAILURE_COUNT",
+        "description": [],
+        "signature": [
+          "\"transaction.failure_count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_ID",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_ID",
+        "description": [],
+        "signature": [
+          "\"transaction.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_NAME",
+        "description": [],
+        "signature": [
+          "\"transaction.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_OVERFLOW_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_OVERFLOW_COUNT",
+        "description": [],
+        "signature": [
+          "\"transaction.aggregation.overflow_count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_PAGE_URL",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_PAGE_URL",
+        "description": [],
+        "signature": [
+          "\"transaction.page.url\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_PROFILER_STACK_TRACE_IDS",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_PROFILER_STACK_TRACE_IDS",
+        "description": [],
+        "signature": [
+          "\"transaction.profiler_stack_trace_ids\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_RESULT",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_RESULT",
+        "description": [],
+        "signature": [
+          "\"transaction.result\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_ROOT",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_ROOT",
+        "description": [],
+        "signature": [
+          "\"transaction.root\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_SAMPLED",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_SAMPLED",
+        "description": [],
+        "signature": [
+          "\"transaction.sampled\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_SUCCESS_COUNT",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_SUCCESS_COUNT",
+        "description": [],
+        "signature": [
+          "\"transaction.success_count\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.TRANSACTION_TYPE",
+        "type": "string",
+        "tags": [],
+        "label": "TRANSACTION_TYPE",
+        "description": [],
+        "signature": [
+          "\"transaction.type\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.URL_FULL",
+        "type": "string",
+        "tags": [],
+        "label": "URL_FULL",
+        "description": [],
+        "signature": [
+          "\"url.full\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.USER_AGENT_NAME",
+        "type": "string",
+        "tags": [],
+        "label": "USER_AGENT_NAME",
+        "description": [],
+        "signature": [
+          "\"user_agent.name\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.USER_AGENT_ORIGINAL",
+        "type": "string",
+        "tags": [],
+        "label": "USER_AGENT_ORIGINAL",
+        "description": [],
+        "signature": [
+          "\"user_agent.original\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.USER_AGENT_VERSION",
+        "type": "string",
+        "tags": [],
+        "label": "USER_AGENT_VERSION",
+        "description": [],
+        "signature": [
+          "\"user_agent.version\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.USER_ID",
+        "type": "string",
+        "tags": [],
+        "label": "USER_ID",
+        "description": [],
+        "signature": [
+          "\"user.id\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.VALUE_OTEL_JVM_PROCESS_MEMORY_HEAP",
+        "type": "string",
+        "tags": [],
+        "label": "VALUE_OTEL_JVM_PROCESS_MEMORY_HEAP",
+        "description": [],
+        "signature": [
+          "\"heap\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      },
+      {
+        "parentPluginId": "@kbn/apm-types",
+        "id": "def-common.VALUE_OTEL_JVM_PROCESS_MEMORY_NON_HEAP",
+        "type": "string",
+        "tags": [],
+        "label": "VALUE_OTEL_JVM_PROCESS_MEMORY_NON_HEAP",
+        "description": [],
+        "signature": [
+          "\"non_heap\""
+        ],
+        "path": "x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts",
+        "deprecated": false,
+        "trackAdoption": false,
+        "initialIsOpen": false
+      }
+    ],
+    "objects": []
+  }
+}

--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TIMESTAMP_US = 'timestamp.us';
+export const AT_TIMESTAMP = '@timestamp';
+export const AGENT = 'agent';
+export const AGENT_NAME = 'agent.name';
+export const AGENT_VERSION = 'agent.version';
+export const AGENT_ACTIVATION_METHOD = 'agent.activation_method';
+
+export const DESTINATION_ADDRESS = 'destination.address';
+
+export const CLOUD = 'cloud';
+export const CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone';
+export const CLOUD_PROVIDER = 'cloud.provider';
+export const CLOUD_REGION = 'cloud.region';
+export const CLOUD_MACHINE_TYPE = 'cloud.machine.type';
+export const CLOUD_ACCOUNT_ID = 'cloud.account.id';
+export const CLOUD_ACCOUNT_NAME = 'cloud.account.name';
+export const CLOUD_INSTANCE_ID = 'cloud.instance.id';
+export const CLOUD_INSTANCE_NAME = 'cloud.instance.name';
+export const CLOUD_SERVICE_NAME = 'cloud.service.name';
+export const CLOUD_PROJECT_NAME = 'cloud.project.name';
+
+export const EVENT_SUCCESS_COUNT = 'event.success_count';
+
+export const SERVICE = 'service';
+export const SERVICE_NAME = 'service.name';
+export const SERVICE_ENVIRONMENT = 'service.environment';
+export const SERVICE_FRAMEWORK_NAME = 'service.framework.name';
+export const SERVICE_FRAMEWORK_VERSION = 'service.framework.version';
+export const SERVICE_LANGUAGE_NAME = 'service.language.name';
+export const SERVICE_LANGUAGE_VERSION = 'service.language.version';
+export const SERVICE_RUNTIME_NAME = 'service.runtime.name';
+export const SERVICE_RUNTIME_VERSION = 'service.runtime.version';
+export const SERVICE_NODE_NAME = 'service.node.name';
+export const SERVICE_VERSION = 'service.version';
+export const SERVICE_TARGET_TYPE = 'service.target.type';
+export const SERVICE_OVERFLOW_COUNT = 'service_transaction.aggregation.overflow_count';
+
+export const URL_FULL = 'url.full';
+export const HTTP_REQUEST_METHOD = 'http.request.method';
+export const HTTP_RESPONSE_STATUS_CODE = 'http.response.status_code';
+export const USER_ID = 'user.id';
+export const USER_AGENT_ORIGINAL = 'user_agent.original';
+export const USER_AGENT_NAME = 'user_agent.name';
+export const USER_AGENT_VERSION = 'user_agent.version';
+
+export const OBSERVER_VERSION = 'observer.version';
+export const OBSERVER_VERSION_MAJOR = 'observer.version_major';
+export const OBSERVER_HOSTNAME = 'observer.hostname';
+export const OBSERVER_LISTENING = 'observer.listening';
+export const PROCESSOR_EVENT = 'processor.event';
+export const PROCESSOR_NAME = 'processor.name';
+
+export const TRANSACTION_MARKS_AGENT = 'transaction.marks.agent';
+export const TRANSACTION_DURATION = 'transaction.duration.us';
+export const TRANSACTION_DURATION_HISTOGRAM = 'transaction.duration.histogram';
+export const TRANSACTION_DURATION_SUMMARY = 'transaction.duration.summary';
+export const TRANSACTION_TYPE = 'transaction.type';
+export const TRANSACTION_RESULT = 'transaction.result';
+export const TRANSACTION_NAME = 'transaction.name';
+export const TRANSACTION_ID = 'transaction.id';
+export const TRANSACTION_SAMPLED = 'transaction.sampled';
+export const TRANSACTION_PAGE_URL = 'transaction.page.url';
+export const TRANSACTION_FAILURE_COUNT = 'transaction.failure_count';
+export const TRANSACTION_SUCCESS_COUNT = 'transaction.success_count';
+export const TRANSACTION_OVERFLOW_COUNT = 'transaction.aggregation.overflow_count';
+// for transaction metrics
+export const TRANSACTION_ROOT = 'transaction.root';
+export const TRANSACTION_PROFILER_STACK_TRACE_IDS = 'transaction.profiler_stack_trace_ids';
+
+export const EVENT_OUTCOME = 'event.outcome';
+
+export const TRACE_ID = 'trace.id';
+
+export const SPAN_DURATION = 'span.duration.us';
+export const SPAN_TYPE = 'span.type';
+export const SPAN_SUBTYPE = 'span.subtype';
+export const SPAN_SELF_TIME_SUM = 'span.self_time.sum.us';
+export const SPAN_ACTION = 'span.action';
+export const SPAN_NAME = 'span.name';
+export const SPAN_ID = 'span.id';
+export const SPAN_DESTINATION_SERVICE_RESOURCE = 'span.destination.service.resource';
+export const SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT =
+  'span.destination.service.response_time.count';
+
+export const SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM =
+  'span.destination.service.response_time.sum.us';
+
+export const SPAN_LINKS = 'span.links';
+export const SPAN_LINKS_TRACE_ID = 'span.links.trace.id';
+export const SPAN_LINKS_SPAN_ID = 'span.links.span.id';
+
+export const SPAN_COMPOSITE_COUNT = 'span.composite.count';
+export const SPAN_COMPOSITE_SUM = 'span.composite.sum.us';
+export const SPAN_COMPOSITE_COMPRESSION_STRATEGY = 'span.composite.compression_strategy';
+
+export const SPAN_SYNC = 'span.sync';
+export const SPAN_STACKTRACE = 'span.stacktrace';
+
+// Parent ID for a transaction or span
+export const PARENT_ID = 'parent.id';
+
+export const ERROR_ID = 'error.id';
+export const ERROR_GROUP_ID = 'error.grouping_key';
+export const ERROR_GROUP_NAME = 'error.grouping_name';
+export const ERROR_CULPRIT = 'error.culprit';
+export const ERROR_LOG_LEVEL = 'error.log.level';
+export const ERROR_LOG_MESSAGE = 'error.log.message';
+export const ERROR_EXCEPTION = 'error.exception';
+export const ERROR_EXC_MESSAGE = 'error.exception.message'; // only to be used in es queries, since error.exception is now an array
+export const ERROR_EXC_HANDLED = 'error.exception.handled'; // only to be used in es queries, since error.exception is now an array
+export const ERROR_EXC_TYPE = 'error.exception.type';
+export const ERROR_PAGE_URL = 'error.page.url';
+export const ERROR_STACK_TRACE = 'error.stack_trace';
+export const ERROR_TYPE = 'error.type';
+
+// METRICS
+export const METRIC_SYSTEM_FREE_MEMORY = 'system.memory.actual.free';
+export const METRIC_SYSTEM_TOTAL_MEMORY = 'system.memory.total';
+export const METRIC_SYSTEM_CPU_PERCENT = 'system.cpu.total.norm.pct';
+export const METRIC_PROCESS_CPU_PERCENT = 'system.process.cpu.total.norm.pct';
+export const METRIC_CGROUP_MEMORY_LIMIT_BYTES = 'system.process.cgroup.memory.mem.limit.bytes';
+export const METRIC_CGROUP_MEMORY_USAGE_BYTES = 'system.process.cgroup.memory.mem.usage.bytes';
+
+export const METRIC_JAVA_HEAP_MEMORY_MAX = 'jvm.memory.heap.max';
+export const METRIC_JAVA_HEAP_MEMORY_COMMITTED = 'jvm.memory.heap.committed';
+export const METRIC_JAVA_HEAP_MEMORY_USED = 'jvm.memory.heap.used';
+export const METRIC_JAVA_NON_HEAP_MEMORY_MAX = 'jvm.memory.non_heap.max';
+export const METRIC_JAVA_NON_HEAP_MEMORY_COMMITTED = 'jvm.memory.non_heap.committed';
+export const METRIC_JAVA_NON_HEAP_MEMORY_USED = 'jvm.memory.non_heap.used';
+export const METRIC_JAVA_THREAD_COUNT = 'jvm.thread.count';
+export const METRIC_JAVA_GC_COUNT = 'jvm.gc.count';
+export const METRIC_JAVA_GC_TIME = 'jvm.gc.time';
+
+export const METRICSET_NAME = 'metricset.name';
+export const METRICSET_INTERVAL = 'metricset.interval';
+
+export const LABEL_NAME = 'labels.name';
+export const LABEL_GC = 'labels.gc';
+export const LABEL_TYPE = 'labels.type';
+export const LABEL_TELEMETRY_AUTO_VERSION = 'labels.telemetry_auto_version';
+export const LABEL_LIFECYCLE_STATE = 'labels.lifecycle_state';
+
+export const HOST = 'host';
+export const HOST_HOSTNAME = 'host.hostname'; // Do not use. Please use `HOST_NAME` instead.
+export const HOST_NAME = 'host.name';
+export const HOST_OS_PLATFORM = 'host.os.platform';
+export const HOST_ARCHITECTURE = 'host.architecture';
+export const HOST_OS_VERSION = 'host.os.version';
+
+export const CONTAINER_ID = 'container.id';
+export const CONTAINER = 'container';
+export const CONTAINER_IMAGE = 'container.image.name';
+
+export const KUBERNETES = 'kubernetes';
+export const KUBERNETES_POD_NAME = 'kubernetes.pod.name';
+export const KUBERNETES_POD_UID = 'kubernetes.pod.uid';
+export const KUBERNETES_NAMESPACE = 'kubernetes.namespace';
+export const KUBERNETES_NODE_NAME = 'kubernetes.node.name';
+export const KUBERNETES_CONTAINER_NAME = 'kubernetes.container.name';
+export const KUBERNETES_CONTAINER_ID = 'kubernetes.container.id';
+export const KUBERNETES_DEPLOYMENT_NAME = 'kubernetes.deployment.name';
+export const KUBERNETES_REPLICASET_NAME = 'kubernetes.replicaset.name';
+
+export const FAAS_ID = 'faas.id';
+export const FAAS_NAME = 'faas.name';
+export const FAAS_COLDSTART = 'faas.coldstart';
+export const FAAS_TRIGGER_TYPE = 'faas.trigger.type';
+export const FAAS_DURATION = 'faas.duration';
+export const FAAS_COLDSTART_DURATION = 'faas.coldstart_duration';
+export const FAAS_BILLED_DURATION = 'faas.billed_duration';
+
+// OpenTelemetry Metrics
+export const METRIC_OTEL_SYSTEM_CPU_UTILIZATION = 'system.cpu.utilization';
+export const METRIC_OTEL_SYSTEM_MEMORY_UTILIZATION = 'system.memory.utilization';
+
+export const METRIC_OTEL_JVM_PROCESS_CPU_PERCENT = 'process.runtime.jvm.cpu.utilization';
+export const METRIC_OTEL_JVM_PROCESS_MEMORY_USAGE = 'process.runtime.jvm.memory.usage';
+export const METRIC_OTEL_JVM_PROCESS_MEMORY_COMMITTED = 'process.runtime.jvm.memory.committed';
+export const METRIC_OTEL_JVM_PROCESS_MEMORY_LIMIT = 'process.runtime.jvm.memory.limit';
+export const METRIC_OTEL_JVM_PROCESS_THREADS_COUNT = 'process.runtime.jvm.threads.count';
+export const METRIC_OTEL_JVM_SYSTEM_CPU_PERCENT = 'process.runtime.jvm.system.cpu.utilization';
+export const METRIC_OTEL_JVM_GC_DURATION = 'process.runtime.jvm.gc.duration';
+export const VALUE_OTEL_JVM_PROCESS_MEMORY_HEAP = 'heap';
+export const VALUE_OTEL_JVM_PROCESS_MEMORY_NON_HEAP = 'non_heap';
+
+// OpenTelemetry semconv fields for AgentName https://opentelemetry.io/docs/specs/semconv/resource/#telemetry-sdk
+export const TELEMETRY_SDK_NAME = 'telemetry.sdk.name';
+export const TELEMETRY_SDK_LANGUAGE = 'telemetry.sdk.language';
+export const TELEMETRY_SDK_VERSION = 'telemetry.sdk.version';
+
+// OpenTelemetry semconv fields for HTTP server https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-semantic-conventions
+export const URL_PATH = 'url.path';
+export const URL_SCHEME = 'url.scheme';
+export const SERVER_ADDRESS = 'server.address';
+export const SERVER_PORT = 'server.port';
+
+// OpenTelemetry span links
+export const LINKS_SPAN_ID = 'links.span_id';
+export const LINKS_TRACE_ID = 'links.trace_id';
+
+// Metadata
+export const TIER = '_tier';
+export const INDEX = '_index';
+export const DATA_STEAM_TYPE = 'data_stream.type';
+
+// Mobile
+export const NETWORK_CONNECTION_TYPE = 'network.connection.type';
+export const DEVICE_MODEL_IDENTIFIER = 'device.model.identifier';
+export const SESSION_ID = 'session.id';
+export const APP_LAUNCH_TIME = 'application.launch.time';
+export const EVENT_NAME = 'event.name';
+
+// Location
+export const CLIENT_GEO_COUNTRY_ISO_CODE = 'client.geo.country_iso_code';
+export const CLIENT_GEO_REGION_ISO_CODE = 'client.geo.region_iso_code';
+export const CLIENT_GEO_COUNTRY_NAME = 'client.geo.country_name';
+export const CLIENT_GEO_CITY_NAME = 'client.geo.city_name';
+export const CLIENT_GEO_REGION_NAME = 'client.geo.region_name';
+
+export const CHILD_ID = 'child.id';
+
+export const LOG_LEVEL = 'log.level';
+
+// Process
+export const PROCESS_ARGS = 'process.args';
+export const PROCESS_PID = 'process.pid';

--- a/x-pack/plugins/observability_solution/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/observability_solution/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
@@ -1,0 +1,406 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transaction queries fetches a transaction 1`] = `
+Object {
+  "apm": Object {
+    "sources": Array [
+      Object {
+        "documentType": "transactionEvent",
+        "rollupInterval": "none",
+      },
+    ],
+  },
+  "body": Object {
+    "_source": Array [
+      "span.links",
+      "transaction.marks.agent",
+    ],
+    "fields": Array [
+      "trace.id",
+      "agent.name",
+      "processor.event",
+      "@timestamp",
+      "timestamp.us",
+      "service.name",
+      "transaction.id",
+      "transaction.duration.us",
+      "transaction.name",
+      "transaction.sampled",
+      "transaction.type",
+      "processor.name",
+      "service.language.name",
+      "url.full",
+      "transaction.page.url",
+      "http.response.status_code",
+      "http.request.method",
+      "user_agent.name",
+    ],
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "transaction.id": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "trace.id": "bar",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 0,
+                "lte": 50000,
+              },
+            },
+          },
+        ],
+      },
+    },
+    "size": 1,
+    "terminate_after": 1,
+    "track_total_hits": false,
+  },
+}
+`;
+
+exports[`transaction queries fetches breakdown data for transactions 1`] = `
+Object {
+  "apm": Object {
+    "events": Array [
+      "metric",
+    ],
+  },
+  "body": Object {
+    "aggs": Object {
+      "by_date": Object {
+        "aggs": Object {
+          "sum_all_self_times": Object {
+            "sum": Object {
+              "field": "span.self_time.sum.us",
+            },
+          },
+          "types": Object {
+            "aggs": Object {
+              "subtypes": Object {
+                "aggs": Object {
+                  "total_self_time_per_subtype": Object {
+                    "sum": Object {
+                      "field": "span.self_time.sum.us",
+                    },
+                  },
+                },
+                "terms": Object {
+                  "field": "span.subtype",
+                  "missing": "",
+                  "order": Object {
+                    "_count": "desc",
+                  },
+                  "size": 20,
+                },
+              },
+            },
+            "terms": Object {
+              "field": "span.type",
+              "order": Object {
+                "_count": "desc",
+              },
+              "size": 20,
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 50000,
+            "min": 0,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "30s",
+          "min_doc_count": 0,
+        },
+      },
+      "sum_all_self_times": Object {
+        "sum": Object {
+          "field": "span.self_time.sum.us",
+        },
+      },
+      "types": Object {
+        "aggs": Object {
+          "subtypes": Object {
+            "aggs": Object {
+              "total_self_time_per_subtype": Object {
+                "sum": Object {
+                  "field": "span.self_time.sum.us",
+                },
+              },
+            },
+            "terms": Object {
+              "field": "span.subtype",
+              "missing": "",
+              "order": Object {
+                "_count": "desc",
+              },
+              "size": 20,
+            },
+          },
+        },
+        "terms": Object {
+          "field": "span.type",
+          "order": Object {
+            "_count": "desc",
+          },
+          "size": 20,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "transaction.type": "bar",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 0,
+                "lte": 50000,
+              },
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "span.self_time.sum.us",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+    "track_total_hits": false,
+  },
+}
+`;
+
+exports[`transaction queries fetches breakdown data for transactions for a transaction name 1`] = `
+Object {
+  "apm": Object {
+    "events": Array [
+      "metric",
+    ],
+  },
+  "body": Object {
+    "aggs": Object {
+      "by_date": Object {
+        "aggs": Object {
+          "sum_all_self_times": Object {
+            "sum": Object {
+              "field": "span.self_time.sum.us",
+            },
+          },
+          "types": Object {
+            "aggs": Object {
+              "subtypes": Object {
+                "aggs": Object {
+                  "total_self_time_per_subtype": Object {
+                    "sum": Object {
+                      "field": "span.self_time.sum.us",
+                    },
+                  },
+                },
+                "terms": Object {
+                  "field": "span.subtype",
+                  "missing": "",
+                  "order": Object {
+                    "_count": "desc",
+                  },
+                  "size": 20,
+                },
+              },
+            },
+            "terms": Object {
+              "field": "span.type",
+              "order": Object {
+                "_count": "desc",
+              },
+              "size": 20,
+            },
+          },
+        },
+        "date_histogram": Object {
+          "extended_bounds": Object {
+            "max": 50000,
+            "min": 0,
+          },
+          "field": "@timestamp",
+          "fixed_interval": "30s",
+          "min_doc_count": 0,
+        },
+      },
+      "sum_all_self_times": Object {
+        "sum": Object {
+          "field": "span.self_time.sum.us",
+        },
+      },
+      "types": Object {
+        "aggs": Object {
+          "subtypes": Object {
+            "aggs": Object {
+              "total_self_time_per_subtype": Object {
+                "sum": Object {
+                  "field": "span.self_time.sum.us",
+                },
+              },
+            },
+            "terms": Object {
+              "field": "span.subtype",
+              "missing": "",
+              "order": Object {
+                "_count": "desc",
+              },
+              "size": 20,
+            },
+          },
+        },
+        "terms": Object {
+          "field": "span.type",
+          "order": Object {
+            "_count": "desc",
+          },
+          "size": 20,
+        },
+      },
+    },
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "transaction.type": "bar",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 0,
+                "lte": 50000,
+              },
+            },
+          },
+          Object {
+            "exists": Object {
+              "field": "span.self_time.sum.us",
+            },
+          },
+          Object {
+            "term": Object {
+              "transaction.name": "baz",
+            },
+          },
+        ],
+      },
+    },
+    "size": 0,
+    "track_total_hits": false,
+  },
+}
+`;
+
+exports[`transaction queries fetches transaction trace samples 1`] = `
+Object {
+  "_source": Array [
+    "transaction.id",
+    "trace.id",
+    "@timestamp",
+  ],
+  "apm": Object {
+    "events": Array [
+      "transaction",
+    ],
+  },
+  "body": Object {
+    "fields": Array [
+      "transaction.id",
+      "trace.id",
+      "@timestamp",
+    ],
+    "query": Object {
+      "bool": Object {
+        "filter": Array [
+          Object {
+            "term": Object {
+              "service.name": "foo",
+            },
+          },
+          Object {
+            "term": Object {
+              "transaction.type": "baz",
+            },
+          },
+          Object {
+            "term": Object {
+              "transaction.name": "bar",
+            },
+          },
+          Object {
+            "range": Object {
+              "@timestamp": Object {
+                "format": "epoch_millis",
+                "gte": 0,
+                "lte": 50000,
+              },
+            },
+          },
+          Object {
+            "term": Object {
+              "transaction.sampled": true,
+            },
+          },
+        ],
+        "should": Array [
+          Object {
+            "term": Object {
+              "trace.id": "qux",
+            },
+          },
+          Object {
+            "term": Object {
+              "transaction.id": "quz",
+            },
+          },
+        ],
+      },
+    },
+    "size": 500,
+    "sort": Array [
+      Object {
+        "_score": Object {
+          "order": "desc",
+        },
+      },
+      Object {
+        "@timestamp": Object {
+          "order": "desc",
+        },
+      },
+    ],
+    "track_total_hits": false,
+  },
+}
+`;

--- a/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
@@ -1,0 +1,1161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Error AGENT 1`] = `
+Object {
+  "name": "java",
+  "version": "agent version",
+}
+`;
+
+exports[`Error AGENT_ACTIVATION_METHOD 1`] = `undefined`;
+
+exports[`Error AGENT_NAME 1`] = `"java"`;
+
+exports[`Error AGENT_VERSION 1`] = `"agent version"`;
+
+exports[`Error APP_LAUNCH_TIME 1`] = `undefined`;
+
+exports[`Error CHILD_ID 1`] = `undefined`;
+
+exports[`Error CLIENT_GEO_CITY_NAME 1`] = `undefined`;
+
+exports[`Error CLIENT_GEO_COUNTRY_ISO_CODE 1`] = `undefined`;
+
+exports[`Error CLIENT_GEO_COUNTRY_NAME 1`] = `undefined`;
+
+exports[`Error CLIENT_GEO_REGION_ISO_CODE 1`] = `undefined`;
+
+exports[`Error CLIENT_GEO_REGION_NAME 1`] = `undefined`;
+
+exports[`Error CLOUD 1`] = `
+Object {
+  "availability_zone": "europe-west1-c",
+  "provider": "gcp",
+  "region": "europe-west1",
+}
+`;
+
+exports[`Error CLOUD_ACCOUNT_ID 1`] = `undefined`;
+
+exports[`Error CLOUD_ACCOUNT_NAME 1`] = `undefined`;
+
+exports[`Error CLOUD_AVAILABILITY_ZONE 1`] = `"europe-west1-c"`;
+
+exports[`Error CLOUD_INSTANCE_ID 1`] = `undefined`;
+
+exports[`Error CLOUD_INSTANCE_NAME 1`] = `undefined`;
+
+exports[`Error CLOUD_MACHINE_TYPE 1`] = `undefined`;
+
+exports[`Error CLOUD_PROJECT_NAME 1`] = `undefined`;
+
+exports[`Error CLOUD_PROVIDER 1`] = `"gcp"`;
+
+exports[`Error CLOUD_REGION 1`] = `"europe-west1"`;
+
+exports[`Error CLOUD_SERVICE_NAME 1`] = `undefined`;
+
+exports[`Error CONTAINER 1`] = `undefined`;
+
+exports[`Error CONTAINER_ID 1`] = `undefined`;
+
+exports[`Error CONTAINER_IMAGE 1`] = `undefined`;
+
+exports[`Error DATA_STEAM_TYPE 1`] = `undefined`;
+
+exports[`Error DESTINATION_ADDRESS 1`] = `undefined`;
+
+exports[`Error DEVICE_MODEL_IDENTIFIER 1`] = `undefined`;
+
+exports[`Error ERROR_CULPRIT 1`] = `"handleOopsie"`;
+
+exports[`Error ERROR_EXC_HANDLED 1`] = `undefined`;
+
+exports[`Error ERROR_EXC_MESSAGE 1`] = `undefined`;
+
+exports[`Error ERROR_EXC_TYPE 1`] = `undefined`;
+
+exports[`Error ERROR_EXCEPTION 1`] = `
+Array [
+  Object {
+    "handled": false,
+    "message": "sonic boom",
+    "module": "errors",
+    "type": "errorString",
+  },
+]
+`;
+
+exports[`Error ERROR_GROUP_ID 1`] = `"grouping key"`;
+
+exports[`Error ERROR_GROUP_NAME 1`] = `undefined`;
+
+exports[`Error ERROR_ID 1`] = `"error id"`;
+
+exports[`Error ERROR_LOG_LEVEL 1`] = `undefined`;
+
+exports[`Error ERROR_LOG_MESSAGE 1`] = `undefined`;
+
+exports[`Error ERROR_PAGE_URL 1`] = `undefined`;
+
+exports[`Error ERROR_STACK_TRACE 1`] = `undefined`;
+
+exports[`Error ERROR_TYPE 1`] = `undefined`;
+
+exports[`Error EVENT_NAME 1`] = `undefined`;
+
+exports[`Error EVENT_OUTCOME 1`] = `undefined`;
+
+exports[`Error EVENT_SUCCESS_COUNT 1`] = `undefined`;
+
+exports[`Error FAAS_BILLED_DURATION 1`] = `undefined`;
+
+exports[`Error FAAS_COLDSTART 1`] = `undefined`;
+
+exports[`Error FAAS_COLDSTART_DURATION 1`] = `undefined`;
+
+exports[`Error FAAS_DURATION 1`] = `undefined`;
+
+exports[`Error FAAS_ID 1`] = `undefined`;
+
+exports[`Error FAAS_NAME 1`] = `undefined`;
+
+exports[`Error FAAS_TRIGGER_TYPE 1`] = `undefined`;
+
+exports[`Error HOST 1`] = `
+Object {
+  "hostname": "my hostname",
+}
+`;
+
+exports[`Error HOST_ARCHITECTURE 1`] = `undefined`;
+
+exports[`Error HOST_HOSTNAME 1`] = `"my hostname"`;
+
+exports[`Error HOST_NAME 1`] = `undefined`;
+
+exports[`Error HOST_OS_PLATFORM 1`] = `undefined`;
+
+exports[`Error HOST_OS_VERSION 1`] = `undefined`;
+
+exports[`Error HTTP_REQUEST_METHOD 1`] = `undefined`;
+
+exports[`Error HTTP_RESPONSE_STATUS_CODE 1`] = `undefined`;
+
+exports[`Error INDEX 1`] = `undefined`;
+
+exports[`Error KUBERNETES 1`] = `undefined`;
+
+exports[`Error KUBERNETES_CONTAINER_ID 1`] = `undefined`;
+
+exports[`Error KUBERNETES_CONTAINER_NAME 1`] = `undefined`;
+
+exports[`Error KUBERNETES_DEPLOYMENT 1`] = `undefined`;
+
+exports[`Error KUBERNETES_DEPLOYMENT_NAME 1`] = `undefined`;
+
+exports[`Error KUBERNETES_NAMESPACE 1`] = `undefined`;
+
+exports[`Error KUBERNETES_NAMESPACE_NAME 1`] = `undefined`;
+
+exports[`Error KUBERNETES_NODE_NAME 1`] = `undefined`;
+
+exports[`Error KUBERNETES_POD_NAME 1`] = `undefined`;
+
+exports[`Error KUBERNETES_POD_UID 1`] = `undefined`;
+
+exports[`Error KUBERNETES_REPLICASET 1`] = `undefined`;
+
+exports[`Error KUBERNETES_REPLICASET_NAME 1`] = `undefined`;
+
+exports[`Error LABEL_GC 1`] = `undefined`;
+
+exports[`Error LABEL_LIFECYCLE_STATE 1`] = `undefined`;
+
+exports[`Error LABEL_NAME 1`] = `undefined`;
+
+exports[`Error LABEL_TELEMETRY_AUTO_VERSION 1`] = `undefined`;
+
+exports[`Error LABEL_TYPE 1`] = `undefined`;
+
+exports[`Error LINKS_SPAN_ID 1`] = `undefined`;
+
+exports[`Error LINKS_TRACE_ID 1`] = `undefined`;
+
+exports[`Error LOG_LEVEL 1`] = `undefined`;
+
+exports[`Error METRIC_CGROUP_MEMORY_LIMIT_BYTES 1`] = `undefined`;
+
+exports[`Error METRIC_CGROUP_MEMORY_USAGE_BYTES 1`] = `undefined`;
+
+exports[`Error METRIC_JAVA_GC_COUNT 1`] = `undefined`;
+
+exports[`Error METRIC_JAVA_GC_TIME 1`] = `undefined`;
+
+exports[`Error METRIC_JAVA_HEAP_MEMORY_COMMITTED 1`] = `undefined`;
+
+exports[`Error METRIC_JAVA_HEAP_MEMORY_MAX 1`] = `undefined`;
+
+exports[`Error METRIC_JAVA_HEAP_MEMORY_USED 1`] = `undefined`;
+
+exports[`Error METRIC_JAVA_NON_HEAP_MEMORY_COMMITTED 1`] = `undefined`;
+
+exports[`Error METRIC_JAVA_NON_HEAP_MEMORY_MAX 1`] = `undefined`;
+
+exports[`Error METRIC_JAVA_NON_HEAP_MEMORY_USED 1`] = `undefined`;
+
+exports[`Error METRIC_JAVA_THREAD_COUNT 1`] = `undefined`;
+
+exports[`Error METRIC_OTEL_JVM_GC_DURATION 1`] = `undefined`;
+
+exports[`Error METRIC_OTEL_JVM_PROCESS_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Error METRIC_OTEL_JVM_PROCESS_MEMORY_COMMITTED 1`] = `undefined`;
+
+exports[`Error METRIC_OTEL_JVM_PROCESS_MEMORY_LIMIT 1`] = `undefined`;
+
+exports[`Error METRIC_OTEL_JVM_PROCESS_MEMORY_USAGE 1`] = `undefined`;
+
+exports[`Error METRIC_OTEL_JVM_PROCESS_THREADS_COUNT 1`] = `undefined`;
+
+exports[`Error METRIC_OTEL_JVM_SYSTEM_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Error METRIC_OTEL_SYSTEM_CPU_UTILIZATION 1`] = `undefined`;
+
+exports[`Error METRIC_OTEL_SYSTEM_MEMORY_UTILIZATION 1`] = `undefined`;
+
+exports[`Error METRIC_PROCESS_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Error METRIC_SYSTEM_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Error METRIC_SYSTEM_FREE_MEMORY 1`] = `undefined`;
+
+exports[`Error METRIC_SYSTEM_TOTAL_MEMORY 1`] = `undefined`;
+
+exports[`Error METRICSET_INTERVAL 1`] = `undefined`;
+
+exports[`Error METRICSET_NAME 1`] = `undefined`;
+
+exports[`Error NETWORK_CONNECTION_TYPE 1`] = `undefined`;
+
+exports[`Error OBSERVER_HOSTNAME 1`] = `undefined`;
+
+exports[`Error OBSERVER_LISTENING 1`] = `undefined`;
+
+exports[`Error OBSERVER_VERSION 1`] = `"whatever"`;
+
+exports[`Error OBSERVER_VERSION_MAJOR 1`] = `8`;
+
+exports[`Error PARENT_ID 1`] = `"parentId"`;
+
+exports[`Error PROCESS_ARGS 1`] = `undefined`;
+
+exports[`Error PROCESS_PID 1`] = `undefined`;
+
+exports[`Error PROCESSOR_EVENT 1`] = `"error"`;
+
+exports[`Error PROCESSOR_NAME 1`] = `"error"`;
+
+exports[`Error SERVER_ADDRESS 1`] = `undefined`;
+
+exports[`Error SERVER_PORT 1`] = `undefined`;
+
+exports[`Error SERVICE 1`] = `
+Object {
+  "language": Object {
+    "name": "nodejs",
+    "version": "v1337",
+  },
+  "name": "service name",
+}
+`;
+
+exports[`Error SERVICE_ENVIRONMENT 1`] = `undefined`;
+
+exports[`Error SERVICE_FRAMEWORK_NAME 1`] = `undefined`;
+
+exports[`Error SERVICE_FRAMEWORK_VERSION 1`] = `undefined`;
+
+exports[`Error SERVICE_LANGUAGE_NAME 1`] = `"nodejs"`;
+
+exports[`Error SERVICE_LANGUAGE_VERSION 1`] = `"v1337"`;
+
+exports[`Error SERVICE_NAME 1`] = `"service name"`;
+
+exports[`Error SERVICE_NODE_NAME 1`] = `undefined`;
+
+exports[`Error SERVICE_OVERFLOW_COUNT 1`] = `undefined`;
+
+exports[`Error SERVICE_RUNTIME_NAME 1`] = `undefined`;
+
+exports[`Error SERVICE_RUNTIME_VERSION 1`] = `undefined`;
+
+exports[`Error SERVICE_TARGET_TYPE 1`] = `undefined`;
+
+exports[`Error SERVICE_VERSION 1`] = `undefined`;
+
+exports[`Error SESSION_ID 1`] = `undefined`;
+
+exports[`Error SPAN_ACTION 1`] = `undefined`;
+
+exports[`Error SPAN_COMPOSITE_COMPRESSION_STRATEGY 1`] = `undefined`;
+
+exports[`Error SPAN_COMPOSITE_COUNT 1`] = `undefined`;
+
+exports[`Error SPAN_COMPOSITE_SUM 1`] = `undefined`;
+
+exports[`Error SPAN_DESTINATION_SERVICE_RESOURCE 1`] = `undefined`;
+
+exports[`Error SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT 1`] = `undefined`;
+
+exports[`Error SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM 1`] = `undefined`;
+
+exports[`Error SPAN_DURATION 1`] = `undefined`;
+
+exports[`Error SPAN_ID 1`] = `undefined`;
+
+exports[`Error SPAN_LINKS 1`] = `undefined`;
+
+exports[`Error SPAN_LINKS_SPAN_ID 1`] = `undefined`;
+
+exports[`Error SPAN_LINKS_TRACE_ID 1`] = `undefined`;
+
+exports[`Error SPAN_NAME 1`] = `undefined`;
+
+exports[`Error SPAN_SELF_TIME_SUM 1`] = `undefined`;
+
+exports[`Error SPAN_STACKTRACE 1`] = `undefined`;
+
+exports[`Error SPAN_SUBTYPE 1`] = `undefined`;
+
+exports[`Error SPAN_SYNC 1`] = `undefined`;
+
+exports[`Error SPAN_TYPE 1`] = `undefined`;
+
+exports[`Error TELEMETRY_SDK_LANGUAGE 1`] = `undefined`;
+
+exports[`Error TELEMETRY_SDK_NAME 1`] = `undefined`;
+
+exports[`Error TELEMETRY_SDK_VERSION 1`] = `undefined`;
+
+exports[`Error TIER 1`] = `undefined`;
+
+exports[`Error TIMESTAMP_US 1`] = `1337`;
+
+exports[`Error TRACE_ID 1`] = `"trace id"`;
+
+exports[`Error TRANSACTION_MARKS_AGENT 1`] = `undefined`;
+
+exports[`Error TRANSACTION_DURATION 1`] = `undefined`;
+
+exports[`Error TRANSACTION_DURATION_HISTOGRAM 1`] = `undefined`;
+
+exports[`Error TRANSACTION_DURATION_SUMMARY 1`] = `undefined`;
+
+exports[`Error TRANSACTION_FAILURE_COUNT 1`] = `undefined`;
+
+exports[`Error TRANSACTION_ID 1`] = `"transaction id"`;
+
+exports[`Error TRANSACTION_NAME 1`] = `undefined`;
+
+exports[`Error TRANSACTION_OVERFLOW_COUNT 1`] = `undefined`;
+
+exports[`Error TRANSACTION_PAGE_URL 1`] = `undefined`;
+
+exports[`Error TRANSACTION_PROFILER_STACK_TRACE_IDS 1`] = `undefined`;
+
+exports[`Error TRANSACTION_RESULT 1`] = `undefined`;
+
+exports[`Error TRANSACTION_ROOT 1`] = `undefined`;
+
+exports[`Error TRANSACTION_SAMPLED 1`] = `undefined`;
+
+exports[`Error TRANSACTION_SUCCESS_COUNT 1`] = `undefined`;
+
+exports[`Error TRANSACTION_TYPE 1`] = `"request"`;
+
+exports[`Error URL_FULL 1`] = `undefined`;
+
+exports[`Error URL_PATH 1`] = `undefined`;
+
+exports[`Error URL_SCHEME 1`] = `undefined`;
+
+exports[`Error USER_AGENT_NAME 1`] = `undefined`;
+
+exports[`Error USER_AGENT_ORIGINAL 1`] = `undefined`;
+
+exports[`Error USER_AGENT_VERSION 1`] = `undefined`;
+
+exports[`Error USER_ID 1`] = `undefined`;
+
+exports[`Error VALUE_OTEL_JVM_PROCESS_MEMORY_HEAP 1`] = `undefined`;
+
+exports[`Error VALUE_OTEL_JVM_PROCESS_MEMORY_NON_HEAP 1`] = `undefined`;
+
+exports[`Span AGENT 1`] = `
+Object {
+  "name": "java",
+  "version": "agent version",
+}
+`;
+
+exports[`Span AGENT_ACTIVATION_METHOD 1`] = `undefined`;
+
+exports[`Span AGENT_NAME 1`] = `"java"`;
+
+exports[`Span AGENT_VERSION 1`] = `"agent version"`;
+
+exports[`Span APP_LAUNCH_TIME 1`] = `undefined`;
+
+exports[`Span CHILD_ID 1`] = `undefined`;
+
+exports[`Span CLIENT_GEO_CITY_NAME 1`] = `undefined`;
+
+exports[`Span CLIENT_GEO_COUNTRY_ISO_CODE 1`] = `undefined`;
+
+exports[`Span CLIENT_GEO_COUNTRY_NAME 1`] = `undefined`;
+
+exports[`Span CLIENT_GEO_REGION_ISO_CODE 1`] = `undefined`;
+
+exports[`Span CLIENT_GEO_REGION_NAME 1`] = `undefined`;
+
+exports[`Span CLOUD 1`] = `
+Object {
+  "availability_zone": "europe-west1-c",
+  "provider": "gcp",
+  "region": "europe-west1",
+}
+`;
+
+exports[`Span CLOUD_ACCOUNT_ID 1`] = `undefined`;
+
+exports[`Span CLOUD_ACCOUNT_NAME 1`] = `undefined`;
+
+exports[`Span CLOUD_AVAILABILITY_ZONE 1`] = `"europe-west1-c"`;
+
+exports[`Span CLOUD_INSTANCE_ID 1`] = `undefined`;
+
+exports[`Span CLOUD_INSTANCE_NAME 1`] = `undefined`;
+
+exports[`Span CLOUD_MACHINE_TYPE 1`] = `undefined`;
+
+exports[`Span CLOUD_PROJECT_NAME 1`] = `undefined`;
+
+exports[`Span CLOUD_PROVIDER 1`] = `"gcp"`;
+
+exports[`Span CLOUD_REGION 1`] = `"europe-west1"`;
+
+exports[`Span CLOUD_SERVICE_NAME 1`] = `undefined`;
+
+exports[`Span CONTAINER 1`] = `undefined`;
+
+exports[`Span CONTAINER_ID 1`] = `undefined`;
+
+exports[`Span CONTAINER_IMAGE 1`] = `undefined`;
+
+exports[`Span DATA_STEAM_TYPE 1`] = `undefined`;
+
+exports[`Span DESTINATION_ADDRESS 1`] = `undefined`;
+
+exports[`Span DEVICE_MODEL_IDENTIFIER 1`] = `undefined`;
+
+exports[`Span ERROR_CULPRIT 1`] = `undefined`;
+
+exports[`Span ERROR_EXC_HANDLED 1`] = `undefined`;
+
+exports[`Span ERROR_EXC_MESSAGE 1`] = `undefined`;
+
+exports[`Span ERROR_EXC_TYPE 1`] = `undefined`;
+
+exports[`Span ERROR_EXCEPTION 1`] = `undefined`;
+
+exports[`Span ERROR_GROUP_ID 1`] = `undefined`;
+
+exports[`Span ERROR_GROUP_NAME 1`] = `undefined`;
+
+exports[`Span ERROR_ID 1`] = `undefined`;
+
+exports[`Span ERROR_LOG_LEVEL 1`] = `undefined`;
+
+exports[`Span ERROR_LOG_MESSAGE 1`] = `undefined`;
+
+exports[`Span ERROR_PAGE_URL 1`] = `undefined`;
+
+exports[`Span ERROR_STACK_TRACE 1`] = `undefined`;
+
+exports[`Span ERROR_TYPE 1`] = `undefined`;
+
+exports[`Span EVENT_NAME 1`] = `undefined`;
+
+exports[`Span EVENT_OUTCOME 1`] = `"unknown"`;
+
+exports[`Span EVENT_SUCCESS_COUNT 1`] = `undefined`;
+
+exports[`Span FAAS_BILLED_DURATION 1`] = `undefined`;
+
+exports[`Span FAAS_COLDSTART 1`] = `undefined`;
+
+exports[`Span FAAS_COLDSTART_DURATION 1`] = `undefined`;
+
+exports[`Span FAAS_DURATION 1`] = `undefined`;
+
+exports[`Span FAAS_ID 1`] = `undefined`;
+
+exports[`Span FAAS_NAME 1`] = `undefined`;
+
+exports[`Span FAAS_TRIGGER_TYPE 1`] = `undefined`;
+
+exports[`Span HOST 1`] = `undefined`;
+
+exports[`Span HOST_ARCHITECTURE 1`] = `undefined`;
+
+exports[`Span HOST_HOSTNAME 1`] = `undefined`;
+
+exports[`Span HOST_NAME 1`] = `undefined`;
+
+exports[`Span HOST_OS_PLATFORM 1`] = `undefined`;
+
+exports[`Span HOST_OS_VERSION 1`] = `undefined`;
+
+exports[`Span HTTP_REQUEST_METHOD 1`] = `undefined`;
+
+exports[`Span HTTP_RESPONSE_STATUS_CODE 1`] = `undefined`;
+
+exports[`Span INDEX 1`] = `undefined`;
+
+exports[`Span KUBERNETES 1`] = `undefined`;
+
+exports[`Span KUBERNETES_CONTAINER_ID 1`] = `undefined`;
+
+exports[`Span KUBERNETES_CONTAINER_NAME 1`] = `undefined`;
+
+exports[`Span KUBERNETES_DEPLOYMENT 1`] = `undefined`;
+
+exports[`Span KUBERNETES_DEPLOYMENT_NAME 1`] = `undefined`;
+
+exports[`Span KUBERNETES_NAMESPACE 1`] = `undefined`;
+
+exports[`Span KUBERNETES_NAMESPACE_NAME 1`] = `undefined`;
+
+exports[`Span KUBERNETES_NODE_NAME 1`] = `undefined`;
+
+exports[`Span KUBERNETES_POD_NAME 1`] = `undefined`;
+
+exports[`Span KUBERNETES_POD_UID 1`] = `undefined`;
+
+exports[`Span KUBERNETES_REPLICASET 1`] = `undefined`;
+
+exports[`Span KUBERNETES_REPLICASET_NAME 1`] = `undefined`;
+
+exports[`Span LABEL_GC 1`] = `undefined`;
+
+exports[`Span LABEL_LIFECYCLE_STATE 1`] = `undefined`;
+
+exports[`Span LABEL_NAME 1`] = `undefined`;
+
+exports[`Span LABEL_TELEMETRY_AUTO_VERSION 1`] = `undefined`;
+
+exports[`Span LABEL_TYPE 1`] = `undefined`;
+
+exports[`Span LINKS_SPAN_ID 1`] = `undefined`;
+
+exports[`Span LINKS_TRACE_ID 1`] = `undefined`;
+
+exports[`Span LOG_LEVEL 1`] = `undefined`;
+
+exports[`Span METRIC_CGROUP_MEMORY_LIMIT_BYTES 1`] = `undefined`;
+
+exports[`Span METRIC_CGROUP_MEMORY_USAGE_BYTES 1`] = `undefined`;
+
+exports[`Span METRIC_JAVA_GC_COUNT 1`] = `undefined`;
+
+exports[`Span METRIC_JAVA_GC_TIME 1`] = `undefined`;
+
+exports[`Span METRIC_JAVA_HEAP_MEMORY_COMMITTED 1`] = `undefined`;
+
+exports[`Span METRIC_JAVA_HEAP_MEMORY_MAX 1`] = `undefined`;
+
+exports[`Span METRIC_JAVA_HEAP_MEMORY_USED 1`] = `undefined`;
+
+exports[`Span METRIC_JAVA_NON_HEAP_MEMORY_COMMITTED 1`] = `undefined`;
+
+exports[`Span METRIC_JAVA_NON_HEAP_MEMORY_MAX 1`] = `undefined`;
+
+exports[`Span METRIC_JAVA_NON_HEAP_MEMORY_USED 1`] = `undefined`;
+
+exports[`Span METRIC_JAVA_THREAD_COUNT 1`] = `undefined`;
+
+exports[`Span METRIC_OTEL_JVM_GC_DURATION 1`] = `undefined`;
+
+exports[`Span METRIC_OTEL_JVM_PROCESS_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Span METRIC_OTEL_JVM_PROCESS_MEMORY_COMMITTED 1`] = `undefined`;
+
+exports[`Span METRIC_OTEL_JVM_PROCESS_MEMORY_LIMIT 1`] = `undefined`;
+
+exports[`Span METRIC_OTEL_JVM_PROCESS_MEMORY_USAGE 1`] = `undefined`;
+
+exports[`Span METRIC_OTEL_JVM_PROCESS_THREADS_COUNT 1`] = `undefined`;
+
+exports[`Span METRIC_OTEL_JVM_SYSTEM_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Span METRIC_OTEL_SYSTEM_CPU_UTILIZATION 1`] = `undefined`;
+
+exports[`Span METRIC_OTEL_SYSTEM_MEMORY_UTILIZATION 1`] = `undefined`;
+
+exports[`Span METRIC_PROCESS_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Span METRIC_SYSTEM_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Span METRIC_SYSTEM_FREE_MEMORY 1`] = `undefined`;
+
+exports[`Span METRIC_SYSTEM_TOTAL_MEMORY 1`] = `undefined`;
+
+exports[`Span METRICSET_INTERVAL 1`] = `undefined`;
+
+exports[`Span METRICSET_NAME 1`] = `undefined`;
+
+exports[`Span NETWORK_CONNECTION_TYPE 1`] = `undefined`;
+
+exports[`Span OBSERVER_HOSTNAME 1`] = `undefined`;
+
+exports[`Span OBSERVER_LISTENING 1`] = `undefined`;
+
+exports[`Span OBSERVER_VERSION 1`] = `"whatever"`;
+
+exports[`Span OBSERVER_VERSION_MAJOR 1`] = `8`;
+
+exports[`Span PARENT_ID 1`] = `"parentId"`;
+
+exports[`Span PROCESS_ARGS 1`] = `undefined`;
+
+exports[`Span PROCESS_PID 1`] = `undefined`;
+
+exports[`Span PROCESSOR_EVENT 1`] = `"span"`;
+
+exports[`Span PROCESSOR_NAME 1`] = `"transaction"`;
+
+exports[`Span SERVER_ADDRESS 1`] = `undefined`;
+
+exports[`Span SERVER_PORT 1`] = `undefined`;
+
+exports[`Span SERVICE 1`] = `
+Object {
+  "name": "service name",
+}
+`;
+
+exports[`Span SERVICE_ENVIRONMENT 1`] = `undefined`;
+
+exports[`Span SERVICE_FRAMEWORK_NAME 1`] = `undefined`;
+
+exports[`Span SERVICE_FRAMEWORK_VERSION 1`] = `undefined`;
+
+exports[`Span SERVICE_LANGUAGE_NAME 1`] = `undefined`;
+
+exports[`Span SERVICE_LANGUAGE_VERSION 1`] = `undefined`;
+
+exports[`Span SERVICE_NAME 1`] = `"service name"`;
+
+exports[`Span SERVICE_NODE_NAME 1`] = `undefined`;
+
+exports[`Span SERVICE_OVERFLOW_COUNT 1`] = `undefined`;
+
+exports[`Span SERVICE_RUNTIME_NAME 1`] = `undefined`;
+
+exports[`Span SERVICE_RUNTIME_VERSION 1`] = `undefined`;
+
+exports[`Span SERVICE_TARGET_TYPE 1`] = `undefined`;
+
+exports[`Span SERVICE_VERSION 1`] = `undefined`;
+
+exports[`Span SESSION_ID 1`] = `undefined`;
+
+exports[`Span SPAN_ACTION 1`] = `"my action"`;
+
+exports[`Span SPAN_COMPOSITE_COMPRESSION_STRATEGY 1`] = `undefined`;
+
+exports[`Span SPAN_COMPOSITE_COUNT 1`] = `undefined`;
+
+exports[`Span SPAN_COMPOSITE_SUM 1`] = `undefined`;
+
+exports[`Span SPAN_DESTINATION_SERVICE_RESOURCE 1`] = `undefined`;
+
+exports[`Span SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT 1`] = `undefined`;
+
+exports[`Span SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM 1`] = `undefined`;
+
+exports[`Span SPAN_DURATION 1`] = `1337`;
+
+exports[`Span SPAN_ID 1`] = `"span id"`;
+
+exports[`Span SPAN_LINKS 1`] = `undefined`;
+
+exports[`Span SPAN_LINKS_SPAN_ID 1`] = `undefined`;
+
+exports[`Span SPAN_LINKS_TRACE_ID 1`] = `undefined`;
+
+exports[`Span SPAN_NAME 1`] = `"span name"`;
+
+exports[`Span SPAN_SELF_TIME_SUM 1`] = `undefined`;
+
+exports[`Span SPAN_STACKTRACE 1`] = `undefined`;
+
+exports[`Span SPAN_SUBTYPE 1`] = `"my subtype"`;
+
+exports[`Span SPAN_SYNC 1`] = `false`;
+
+exports[`Span SPAN_TYPE 1`] = `"span type"`;
+
+exports[`Span TELEMETRY_SDK_LANGUAGE 1`] = `undefined`;
+
+exports[`Span TELEMETRY_SDK_NAME 1`] = `undefined`;
+
+exports[`Span TELEMETRY_SDK_VERSION 1`] = `undefined`;
+
+exports[`Span TIER 1`] = `undefined`;
+
+exports[`Span TIMESTAMP_US 1`] = `1337`;
+
+exports[`Span TRACE_ID 1`] = `"trace id"`;
+
+exports[`Span TRANSACTION_MARKS_AGENT 1`] = `undefined`;
+
+exports[`Span TRANSACTION_DURATION 1`] = `undefined`;
+
+exports[`Span TRANSACTION_DURATION_HISTOGRAM 1`] = `undefined`;
+
+exports[`Span TRANSACTION_DURATION_SUMMARY 1`] = `undefined`;
+
+exports[`Span TRANSACTION_FAILURE_COUNT 1`] = `undefined`;
+
+exports[`Span TRANSACTION_ID 1`] = `"transaction id"`;
+
+exports[`Span TRANSACTION_NAME 1`] = `undefined`;
+
+exports[`Span TRANSACTION_OVERFLOW_COUNT 1`] = `undefined`;
+
+exports[`Span TRANSACTION_PAGE_URL 1`] = `undefined`;
+
+exports[`Span TRANSACTION_PROFILER_STACK_TRACE_IDS 1`] = `undefined`;
+
+exports[`Span TRANSACTION_RESULT 1`] = `undefined`;
+
+exports[`Span TRANSACTION_ROOT 1`] = `undefined`;
+
+exports[`Span TRANSACTION_SAMPLED 1`] = `undefined`;
+
+exports[`Span TRANSACTION_SUCCESS_COUNT 1`] = `undefined`;
+
+exports[`Span TRANSACTION_TYPE 1`] = `undefined`;
+
+exports[`Span URL_FULL 1`] = `undefined`;
+
+exports[`Span URL_PATH 1`] = `undefined`;
+
+exports[`Span URL_SCHEME 1`] = `undefined`;
+
+exports[`Span USER_AGENT_NAME 1`] = `undefined`;
+
+exports[`Span USER_AGENT_ORIGINAL 1`] = `undefined`;
+
+exports[`Span USER_AGENT_VERSION 1`] = `undefined`;
+
+exports[`Span USER_ID 1`] = `undefined`;
+
+exports[`Span VALUE_OTEL_JVM_PROCESS_MEMORY_HEAP 1`] = `undefined`;
+
+exports[`Span VALUE_OTEL_JVM_PROCESS_MEMORY_NON_HEAP 1`] = `undefined`;
+
+exports[`Transaction AGENT 1`] = `
+Object {
+  "name": "java",
+  "version": "agent version",
+}
+`;
+
+exports[`Transaction AGENT_ACTIVATION_METHOD 1`] = `undefined`;
+
+exports[`Transaction AGENT_NAME 1`] = `"java"`;
+
+exports[`Transaction AGENT_VERSION 1`] = `"agent version"`;
+
+exports[`Transaction APP_LAUNCH_TIME 1`] = `undefined`;
+
+exports[`Transaction CHILD_ID 1`] = `undefined`;
+
+exports[`Transaction CLIENT_GEO_CITY_NAME 1`] = `undefined`;
+
+exports[`Transaction CLIENT_GEO_COUNTRY_ISO_CODE 1`] = `undefined`;
+
+exports[`Transaction CLIENT_GEO_COUNTRY_NAME 1`] = `undefined`;
+
+exports[`Transaction CLIENT_GEO_REGION_ISO_CODE 1`] = `undefined`;
+
+exports[`Transaction CLIENT_GEO_REGION_NAME 1`] = `undefined`;
+
+exports[`Transaction CLOUD 1`] = `
+Object {
+  "availability_zone": "europe-west1-c",
+  "provider": "gcp",
+  "region": "europe-west1",
+}
+`;
+
+exports[`Transaction CLOUD_ACCOUNT_ID 1`] = `undefined`;
+
+exports[`Transaction CLOUD_ACCOUNT_NAME 1`] = `undefined`;
+
+exports[`Transaction CLOUD_AVAILABILITY_ZONE 1`] = `"europe-west1-c"`;
+
+exports[`Transaction CLOUD_INSTANCE_ID 1`] = `undefined`;
+
+exports[`Transaction CLOUD_INSTANCE_NAME 1`] = `undefined`;
+
+exports[`Transaction CLOUD_MACHINE_TYPE 1`] = `undefined`;
+
+exports[`Transaction CLOUD_PROJECT_NAME 1`] = `undefined`;
+
+exports[`Transaction CLOUD_PROVIDER 1`] = `"gcp"`;
+
+exports[`Transaction CLOUD_REGION 1`] = `"europe-west1"`;
+
+exports[`Transaction CLOUD_SERVICE_NAME 1`] = `undefined`;
+
+exports[`Transaction CONTAINER 1`] = `
+Object {
+  "id": "container1234567890abcdef",
+}
+`;
+
+exports[`Transaction CONTAINER_ID 1`] = `"container1234567890abcdef"`;
+
+exports[`Transaction CONTAINER_IMAGE 1`] = `undefined`;
+
+exports[`Transaction DATA_STEAM_TYPE 1`] = `undefined`;
+
+exports[`Transaction DESTINATION_ADDRESS 1`] = `undefined`;
+
+exports[`Transaction DEVICE_MODEL_IDENTIFIER 1`] = `undefined`;
+
+exports[`Transaction ERROR_CULPRIT 1`] = `undefined`;
+
+exports[`Transaction ERROR_EXC_HANDLED 1`] = `undefined`;
+
+exports[`Transaction ERROR_EXC_MESSAGE 1`] = `undefined`;
+
+exports[`Transaction ERROR_EXC_TYPE 1`] = `undefined`;
+
+exports[`Transaction ERROR_EXCEPTION 1`] = `undefined`;
+
+exports[`Transaction ERROR_GROUP_ID 1`] = `undefined`;
+
+exports[`Transaction ERROR_GROUP_NAME 1`] = `undefined`;
+
+exports[`Transaction ERROR_ID 1`] = `undefined`;
+
+exports[`Transaction ERROR_LOG_LEVEL 1`] = `undefined`;
+
+exports[`Transaction ERROR_LOG_MESSAGE 1`] = `undefined`;
+
+exports[`Transaction ERROR_PAGE_URL 1`] = `undefined`;
+
+exports[`Transaction ERROR_STACK_TRACE 1`] = `undefined`;
+
+exports[`Transaction ERROR_TYPE 1`] = `undefined`;
+
+exports[`Transaction EVENT_NAME 1`] = `undefined`;
+
+exports[`Transaction EVENT_OUTCOME 1`] = `"unknown"`;
+
+exports[`Transaction EVENT_SUCCESS_COUNT 1`] = `undefined`;
+
+exports[`Transaction FAAS_BILLED_DURATION 1`] = `undefined`;
+
+exports[`Transaction FAAS_COLDSTART 1`] = `undefined`;
+
+exports[`Transaction FAAS_COLDSTART_DURATION 1`] = `undefined`;
+
+exports[`Transaction FAAS_DURATION 1`] = `undefined`;
+
+exports[`Transaction FAAS_ID 1`] = `undefined`;
+
+exports[`Transaction FAAS_NAME 1`] = `undefined`;
+
+exports[`Transaction FAAS_TRIGGER_TYPE 1`] = `undefined`;
+
+exports[`Transaction HOST 1`] = `
+Object {
+  "hostname": "my hostname",
+}
+`;
+
+exports[`Transaction HOST_ARCHITECTURE 1`] = `undefined`;
+
+exports[`Transaction HOST_HOSTNAME 1`] = `"my hostname"`;
+
+exports[`Transaction HOST_NAME 1`] = `undefined`;
+
+exports[`Transaction HOST_OS_PLATFORM 1`] = `undefined`;
+
+exports[`Transaction HOST_OS_VERSION 1`] = `undefined`;
+
+exports[`Transaction HTTP_REQUEST_METHOD 1`] = `"GET"`;
+
+exports[`Transaction HTTP_RESPONSE_STATUS_CODE 1`] = `200`;
+
+exports[`Transaction INDEX 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES 1`] = `
+Object {
+  "pod": Object {
+    "uid": "pod1234567890abcdef",
+  },
+}
+`;
+
+exports[`Transaction KUBERNETES_CONTAINER_ID 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_CONTAINER_NAME 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_DEPLOYMENT 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_DEPLOYMENT_NAME 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_NAMESPACE 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_NAMESPACE_NAME 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_NODE_NAME 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_POD_NAME 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_POD_UID 1`] = `"pod1234567890abcdef"`;
+
+exports[`Transaction KUBERNETES_REPLICASET 1`] = `undefined`;
+
+exports[`Transaction KUBERNETES_REPLICASET_NAME 1`] = `undefined`;
+
+exports[`Transaction LABEL_GC 1`] = `undefined`;
+
+exports[`Transaction LABEL_LIFECYCLE_STATE 1`] = `undefined`;
+
+exports[`Transaction LABEL_NAME 1`] = `undefined`;
+
+exports[`Transaction LABEL_TELEMETRY_AUTO_VERSION 1`] = `undefined`;
+
+exports[`Transaction LABEL_TYPE 1`] = `undefined`;
+
+exports[`Transaction LINKS_SPAN_ID 1`] = `undefined`;
+
+exports[`Transaction LINKS_TRACE_ID 1`] = `undefined`;
+
+exports[`Transaction LOG_LEVEL 1`] = `undefined`;
+
+exports[`Transaction METRIC_CGROUP_MEMORY_LIMIT_BYTES 1`] = `undefined`;
+
+exports[`Transaction METRIC_CGROUP_MEMORY_USAGE_BYTES 1`] = `undefined`;
+
+exports[`Transaction METRIC_JAVA_GC_COUNT 1`] = `undefined`;
+
+exports[`Transaction METRIC_JAVA_GC_TIME 1`] = `undefined`;
+
+exports[`Transaction METRIC_JAVA_HEAP_MEMORY_COMMITTED 1`] = `undefined`;
+
+exports[`Transaction METRIC_JAVA_HEAP_MEMORY_MAX 1`] = `undefined`;
+
+exports[`Transaction METRIC_JAVA_HEAP_MEMORY_USED 1`] = `undefined`;
+
+exports[`Transaction METRIC_JAVA_NON_HEAP_MEMORY_COMMITTED 1`] = `undefined`;
+
+exports[`Transaction METRIC_JAVA_NON_HEAP_MEMORY_MAX 1`] = `undefined`;
+
+exports[`Transaction METRIC_JAVA_NON_HEAP_MEMORY_USED 1`] = `undefined`;
+
+exports[`Transaction METRIC_JAVA_THREAD_COUNT 1`] = `undefined`;
+
+exports[`Transaction METRIC_OTEL_JVM_GC_DURATION 1`] = `undefined`;
+
+exports[`Transaction METRIC_OTEL_JVM_PROCESS_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Transaction METRIC_OTEL_JVM_PROCESS_MEMORY_COMMITTED 1`] = `undefined`;
+
+exports[`Transaction METRIC_OTEL_JVM_PROCESS_MEMORY_LIMIT 1`] = `undefined`;
+
+exports[`Transaction METRIC_OTEL_JVM_PROCESS_MEMORY_USAGE 1`] = `undefined`;
+
+exports[`Transaction METRIC_OTEL_JVM_PROCESS_THREADS_COUNT 1`] = `undefined`;
+
+exports[`Transaction METRIC_OTEL_JVM_SYSTEM_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Transaction METRIC_OTEL_SYSTEM_CPU_UTILIZATION 1`] = `undefined`;
+
+exports[`Transaction METRIC_OTEL_SYSTEM_MEMORY_UTILIZATION 1`] = `undefined`;
+
+exports[`Transaction METRIC_PROCESS_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Transaction METRIC_SYSTEM_CPU_PERCENT 1`] = `undefined`;
+
+exports[`Transaction METRIC_SYSTEM_FREE_MEMORY 1`] = `undefined`;
+
+exports[`Transaction METRIC_SYSTEM_TOTAL_MEMORY 1`] = `undefined`;
+
+exports[`Transaction METRICSET_INTERVAL 1`] = `undefined`;
+
+exports[`Transaction METRICSET_NAME 1`] = `undefined`;
+
+exports[`Transaction NETWORK_CONNECTION_TYPE 1`] = `undefined`;
+
+exports[`Transaction OBSERVER_HOSTNAME 1`] = `undefined`;
+
+exports[`Transaction OBSERVER_LISTENING 1`] = `undefined`;
+
+exports[`Transaction OBSERVER_VERSION 1`] = `"whatever"`;
+
+exports[`Transaction OBSERVER_VERSION_MAJOR 1`] = `8`;
+
+exports[`Transaction PARENT_ID 1`] = `"parentId"`;
+
+exports[`Transaction PROCESS_ARGS 1`] = `undefined`;
+
+exports[`Transaction PROCESS_PID 1`] = `undefined`;
+
+exports[`Transaction PROCESSOR_EVENT 1`] = `"transaction"`;
+
+exports[`Transaction PROCESSOR_NAME 1`] = `"transaction"`;
+
+exports[`Transaction SERVER_ADDRESS 1`] = `undefined`;
+
+exports[`Transaction SERVER_PORT 1`] = `undefined`;
+
+exports[`Transaction SERVICE 1`] = `
+Object {
+  "language": Object {
+    "name": "nodejs",
+    "version": "v1337",
+  },
+  "name": "service name",
+}
+`;
+
+exports[`Transaction SERVICE_ENVIRONMENT 1`] = `undefined`;
+
+exports[`Transaction SERVICE_FRAMEWORK_NAME 1`] = `undefined`;
+
+exports[`Transaction SERVICE_FRAMEWORK_VERSION 1`] = `undefined`;
+
+exports[`Transaction SERVICE_LANGUAGE_NAME 1`] = `"nodejs"`;
+
+exports[`Transaction SERVICE_LANGUAGE_VERSION 1`] = `"v1337"`;
+
+exports[`Transaction SERVICE_NAME 1`] = `"service name"`;
+
+exports[`Transaction SERVICE_NODE_NAME 1`] = `undefined`;
+
+exports[`Transaction SERVICE_OVERFLOW_COUNT 1`] = `undefined`;
+
+exports[`Transaction SERVICE_RUNTIME_NAME 1`] = `undefined`;
+
+exports[`Transaction SERVICE_RUNTIME_VERSION 1`] = `undefined`;
+
+exports[`Transaction SERVICE_TARGET_TYPE 1`] = `undefined`;
+
+exports[`Transaction SERVICE_VERSION 1`] = `undefined`;
+
+exports[`Transaction SESSION_ID 1`] = `undefined`;
+
+exports[`Transaction SPAN_ACTION 1`] = `undefined`;
+
+exports[`Transaction SPAN_COMPOSITE_COMPRESSION_STRATEGY 1`] = `undefined`;
+
+exports[`Transaction SPAN_COMPOSITE_COUNT 1`] = `undefined`;
+
+exports[`Transaction SPAN_COMPOSITE_SUM 1`] = `undefined`;
+
+exports[`Transaction SPAN_DESTINATION_SERVICE_RESOURCE 1`] = `undefined`;
+
+exports[`Transaction SPAN_DESTINATION_SERVICE_RESPONSE_TIME_COUNT 1`] = `undefined`;
+
+exports[`Transaction SPAN_DESTINATION_SERVICE_RESPONSE_TIME_SUM 1`] = `undefined`;
+
+exports[`Transaction SPAN_DURATION 1`] = `undefined`;
+
+exports[`Transaction SPAN_ID 1`] = `undefined`;
+
+exports[`Transaction SPAN_LINKS 1`] = `undefined`;
+
+exports[`Transaction SPAN_LINKS_SPAN_ID 1`] = `undefined`;
+
+exports[`Transaction SPAN_LINKS_TRACE_ID 1`] = `undefined`;
+
+exports[`Transaction SPAN_NAME 1`] = `undefined`;
+
+exports[`Transaction SPAN_SELF_TIME_SUM 1`] = `undefined`;
+
+exports[`Transaction SPAN_STACKTRACE 1`] = `undefined`;
+
+exports[`Transaction SPAN_SUBTYPE 1`] = `undefined`;
+
+exports[`Transaction SPAN_SYNC 1`] = `undefined`;
+
+exports[`Transaction SPAN_TYPE 1`] = `undefined`;
+
+exports[`Transaction TELEMETRY_SDK_LANGUAGE 1`] = `undefined`;
+
+exports[`Transaction TELEMETRY_SDK_NAME 1`] = `undefined`;
+
+exports[`Transaction TELEMETRY_SDK_VERSION 1`] = `undefined`;
+
+exports[`Transaction TIER 1`] = `undefined`;
+
+exports[`Transaction TIMESTAMP_US 1`] = `1337`;
+
+exports[`Transaction TRACE_ID 1`] = `"trace id"`;
+
+exports[`Transaction TRANSACTION_MARKS_AGENT 1`] = `undefined`;
+
+exports[`Transaction TRANSACTION_DURATION 1`] = `1337`;
+
+exports[`Transaction TRANSACTION_DURATION_HISTOGRAM 1`] = `undefined`;
+
+exports[`Transaction TRANSACTION_DURATION_SUMMARY 1`] = `undefined`;
+
+exports[`Transaction TRANSACTION_FAILURE_COUNT 1`] = `undefined`;
+
+exports[`Transaction TRANSACTION_ID 1`] = `"transaction id"`;
+
+exports[`Transaction TRANSACTION_NAME 1`] = `"transaction name"`;
+
+exports[`Transaction TRANSACTION_OVERFLOW_COUNT 1`] = `undefined`;
+
+exports[`Transaction TRANSACTION_PAGE_URL 1`] = `undefined`;
+
+exports[`Transaction TRANSACTION_PROFILER_STACK_TRACE_IDS 1`] = `undefined`;
+
+exports[`Transaction TRANSACTION_RESULT 1`] = `"transaction result"`;
+
+exports[`Transaction TRANSACTION_ROOT 1`] = `undefined`;
+
+exports[`Transaction TRANSACTION_SAMPLED 1`] = `true`;
+
+exports[`Transaction TRANSACTION_SUCCESS_COUNT 1`] = `undefined`;
+
+exports[`Transaction TRANSACTION_TYPE 1`] = `"transaction type"`;
+
+exports[`Transaction URL_FULL 1`] = `"http://www.elastic.co"`;
+
+exports[`Transaction URL_PATH 1`] = `undefined`;
+
+exports[`Transaction URL_SCHEME 1`] = `undefined`;
+
+exports[`Transaction USER_AGENT_NAME 1`] = `"Other"`;
+
+exports[`Transaction USER_AGENT_ORIGINAL 1`] = `"test original"`;
+
+exports[`Transaction USER_AGENT_VERSION 1`] = `undefined`;
+
+exports[`Transaction USER_ID 1`] = `"1337"`;
+
+exports[`Transaction VALUE_OTEL_JVM_PROCESS_MEMORY_HEAP 1`] = `undefined`;
+
+exports[`Transaction VALUE_OTEL_JVM_PROCESS_MEMORY_NON_HEAP 1`] = `undefined`;

--- a/x-pack/solutions/observability/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/transactions/__snapshots__/queries.test.ts.snap
@@ -1,0 +1,403 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transaction queries fetches a transaction 1`] = `
+Object {
+  "_source": Array [
+    "span.links",
+    "transaction.marks.agent",
+  ],
+  "apm": Object {
+    "sources": Array [
+      Object {
+        "documentType": "transactionEvent",
+        "rollupInterval": "none",
+      },
+    ],
+  },
+  "fields": Array [
+    "trace.id",
+    "agent.name",
+    "processor.event",
+    "@timestamp",
+    "timestamp.us",
+    "service.name",
+    "transaction.id",
+    "transaction.duration.us",
+    "transaction.name",
+    "transaction.sampled",
+    "transaction.type",
+    "processor.name",
+    "service.language.name",
+    "url.full",
+    "transaction.page.url",
+    "http.response.status_code",
+    "http.request.method",
+    "user_agent.name",
+    "url.path",
+    "url.scheme",
+    "server.address",
+    "server.port",
+    "user_agent.version",
+  ],
+  "query": Object {
+    "bool": Object {
+      "filter": Array [
+        Object {
+          "term": Object {
+            "transaction.id": "foo",
+          },
+        },
+        Object {
+          "term": Object {
+            "trace.id": "bar",
+          },
+        },
+        Object {
+          "range": Object {
+            "@timestamp": Object {
+              "format": "epoch_millis",
+              "gte": 0,
+              "lte": 50000,
+            },
+          },
+        },
+      ],
+    },
+  },
+  "size": 1,
+  "terminate_after": 1,
+  "track_total_hits": false,
+}
+`;
+
+exports[`transaction queries fetches breakdown data for transactions 1`] = `
+Object {
+  "aggs": Object {
+    "by_date": Object {
+      "aggs": Object {
+        "sum_all_self_times": Object {
+          "sum": Object {
+            "field": "span.self_time.sum.us",
+          },
+        },
+        "types": Object {
+          "aggs": Object {
+            "subtypes": Object {
+              "aggs": Object {
+                "total_self_time_per_subtype": Object {
+                  "sum": Object {
+                    "field": "span.self_time.sum.us",
+                  },
+                },
+              },
+              "terms": Object {
+                "field": "span.subtype",
+                "missing": "",
+                "order": Object {
+                  "_count": "desc",
+                },
+                "size": 20,
+              },
+            },
+          },
+          "terms": Object {
+            "field": "span.type",
+            "order": Object {
+              "_count": "desc",
+            },
+            "size": 20,
+          },
+        },
+      },
+      "date_histogram": Object {
+        "extended_bounds": Object {
+          "max": 50000,
+          "min": 0,
+        },
+        "field": "@timestamp",
+        "fixed_interval": "30s",
+        "min_doc_count": 0,
+      },
+    },
+    "sum_all_self_times": Object {
+      "sum": Object {
+        "field": "span.self_time.sum.us",
+      },
+    },
+    "types": Object {
+      "aggs": Object {
+        "subtypes": Object {
+          "aggs": Object {
+            "total_self_time_per_subtype": Object {
+              "sum": Object {
+                "field": "span.self_time.sum.us",
+              },
+            },
+          },
+          "terms": Object {
+            "field": "span.subtype",
+            "missing": "",
+            "order": Object {
+              "_count": "desc",
+            },
+            "size": 20,
+          },
+        },
+      },
+      "terms": Object {
+        "field": "span.type",
+        "order": Object {
+          "_count": "desc",
+        },
+        "size": 20,
+      },
+    },
+  },
+  "apm": Object {
+    "events": Array [
+      "metric",
+    ],
+  },
+  "query": Object {
+    "bool": Object {
+      "filter": Array [
+        Object {
+          "term": Object {
+            "service.name": "foo",
+          },
+        },
+        Object {
+          "term": Object {
+            "transaction.type": "bar",
+          },
+        },
+        Object {
+          "range": Object {
+            "@timestamp": Object {
+              "format": "epoch_millis",
+              "gte": 0,
+              "lte": 50000,
+            },
+          },
+        },
+        Object {
+          "exists": Object {
+            "field": "span.self_time.sum.us",
+          },
+        },
+      ],
+    },
+  },
+  "size": 0,
+  "track_total_hits": false,
+}
+`;
+
+exports[`transaction queries fetches breakdown data for transactions for a transaction name 1`] = `
+Object {
+  "aggs": Object {
+    "by_date": Object {
+      "aggs": Object {
+        "sum_all_self_times": Object {
+          "sum": Object {
+            "field": "span.self_time.sum.us",
+          },
+        },
+        "types": Object {
+          "aggs": Object {
+            "subtypes": Object {
+              "aggs": Object {
+                "total_self_time_per_subtype": Object {
+                  "sum": Object {
+                    "field": "span.self_time.sum.us",
+                  },
+                },
+              },
+              "terms": Object {
+                "field": "span.subtype",
+                "missing": "",
+                "order": Object {
+                  "_count": "desc",
+                },
+                "size": 20,
+              },
+            },
+          },
+          "terms": Object {
+            "field": "span.type",
+            "order": Object {
+              "_count": "desc",
+            },
+            "size": 20,
+          },
+        },
+      },
+      "date_histogram": Object {
+        "extended_bounds": Object {
+          "max": 50000,
+          "min": 0,
+        },
+        "field": "@timestamp",
+        "fixed_interval": "30s",
+        "min_doc_count": 0,
+      },
+    },
+    "sum_all_self_times": Object {
+      "sum": Object {
+        "field": "span.self_time.sum.us",
+      },
+    },
+    "types": Object {
+      "aggs": Object {
+        "subtypes": Object {
+          "aggs": Object {
+            "total_self_time_per_subtype": Object {
+              "sum": Object {
+                "field": "span.self_time.sum.us",
+              },
+            },
+          },
+          "terms": Object {
+            "field": "span.subtype",
+            "missing": "",
+            "order": Object {
+              "_count": "desc",
+            },
+            "size": 20,
+          },
+        },
+      },
+      "terms": Object {
+        "field": "span.type",
+        "order": Object {
+          "_count": "desc",
+        },
+        "size": 20,
+      },
+    },
+  },
+  "apm": Object {
+    "events": Array [
+      "metric",
+    ],
+  },
+  "query": Object {
+    "bool": Object {
+      "filter": Array [
+        Object {
+          "term": Object {
+            "service.name": "foo",
+          },
+        },
+        Object {
+          "term": Object {
+            "transaction.type": "bar",
+          },
+        },
+        Object {
+          "range": Object {
+            "@timestamp": Object {
+              "format": "epoch_millis",
+              "gte": 0,
+              "lte": 50000,
+            },
+          },
+        },
+        Object {
+          "exists": Object {
+            "field": "span.self_time.sum.us",
+          },
+        },
+        Object {
+          "term": Object {
+            "transaction.name": "baz",
+          },
+        },
+      ],
+    },
+  },
+  "size": 0,
+  "track_total_hits": false,
+}
+`;
+
+exports[`transaction queries fetches transaction trace samples 1`] = `
+Object {
+  "_source": Array [
+    "transaction.id",
+    "trace.id",
+    "@timestamp",
+  ],
+  "apm": Object {
+    "events": Array [
+      "transaction",
+    ],
+  },
+  "fields": Array [
+    "transaction.id",
+    "trace.id",
+    "@timestamp",
+  ],
+  "query": Object {
+    "bool": Object {
+      "filter": Array [
+        Object {
+          "term": Object {
+            "service.name": "foo",
+          },
+        },
+        Object {
+          "term": Object {
+            "transaction.type": "baz",
+          },
+        },
+        Object {
+          "term": Object {
+            "transaction.name": "bar",
+          },
+        },
+        Object {
+          "range": Object {
+            "@timestamp": Object {
+              "format": "epoch_millis",
+              "gte": 0,
+              "lte": 50000,
+            },
+          },
+        },
+        Object {
+          "term": Object {
+            "transaction.sampled": true,
+          },
+        },
+      ],
+      "should": Array [
+        Object {
+          "term": Object {
+            "trace.id": "qux",
+          },
+        },
+        Object {
+          "term": Object {
+            "transaction.id": "quz",
+          },
+        },
+      ],
+    },
+  },
+  "size": 500,
+  "sort": Array [
+    Object {
+      "_score": Object {
+        "order": "desc",
+      },
+    },
+    Object {
+      "@timestamp": Object {
+        "order": "desc",
+      },
+    },
+  ],
+  "track_total_hits": false,
+}
+`;

--- a/x-pack/solutions/observability/plugins/apm/server/routes/transactions/get_transaction/index.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/transactions/get_transaction/index.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { rangeQuery, termQuery } from '@kbn/observability-plugin/server';
+import { unflattenKnownApmEventFields } from '@kbn/apm-data-access-plugin/server/utils';
+import type { Transaction } from '@kbn/apm-types';
+import { maybe } from '../../../../common/utils/maybe';
+import {
+  AGENT_NAME,
+  PROCESSOR_EVENT,
+  SERVICE_NAME,
+  TIMESTAMP_US,
+  TRACE_ID,
+  TRANSACTION_DURATION,
+  TRANSACTION_ID,
+  TRANSACTION_NAME,
+  TRANSACTION_SAMPLED,
+  TRANSACTION_TYPE,
+  AT_TIMESTAMP,
+  PROCESSOR_NAME,
+  SPAN_LINKS,
+  TRANSACTION_MARKS_AGENT,
+  SERVICE_LANGUAGE_NAME,
+  URL_FULL,
+  HTTP_REQUEST_METHOD,
+  HTTP_RESPONSE_STATUS_CODE,
+  TRANSACTION_PAGE_URL,
+  USER_AGENT_NAME,
+  URL_PATH,
+  URL_SCHEME,
+  SERVER_ADDRESS,
+  SERVER_PORT,
+  USER_AGENT_VERSION,
+} from '../../../../common/es_fields/apm';
+import { asMutableArray } from '../../../../common/utils/as_mutable_array';
+import type { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
+import { ApmDocumentType } from '../../../../common/document_type';
+import { RollupInterval } from '../../../../common/rollup';
+
+export async function getTransaction({
+  transactionId,
+  traceId,
+  apmEventClient,
+  start,
+  end,
+}: {
+  transactionId: string;
+  traceId?: string;
+  apmEventClient: APMEventClient;
+  start: number;
+  end: number;
+}): Promise<Transaction | undefined> {
+  const requiredFields = asMutableArray([
+    TRACE_ID,
+    AGENT_NAME,
+    PROCESSOR_EVENT,
+    AT_TIMESTAMP,
+    TIMESTAMP_US,
+    SERVICE_NAME,
+    TRANSACTION_ID,
+    TRANSACTION_DURATION,
+    TRANSACTION_NAME,
+    TRANSACTION_SAMPLED,
+    TRANSACTION_TYPE,
+  ] as const);
+
+  const optionalFields = asMutableArray([
+    PROCESSOR_NAME,
+    SERVICE_LANGUAGE_NAME,
+    URL_FULL,
+    TRANSACTION_PAGE_URL,
+    HTTP_RESPONSE_STATUS_CODE,
+    HTTP_REQUEST_METHOD,
+    USER_AGENT_NAME,
+    URL_PATH,
+    URL_SCHEME,
+    SERVER_ADDRESS,
+    SERVER_PORT,
+    USER_AGENT_VERSION,
+  ] as const);
+
+  const resp = await apmEventClient.search('get_transaction', {
+    apm: {
+      sources: [
+        {
+          documentType: ApmDocumentType.TransactionEvent,
+          rollupInterval: RollupInterval.None,
+        },
+      ],
+    },
+    track_total_hits: false,
+    size: 1,
+    terminate_after: 1,
+    query: {
+      bool: {
+        filter: asMutableArray([
+          { term: { [TRANSACTION_ID]: transactionId } },
+          ...termQuery(TRACE_ID, traceId),
+          ...rangeQuery(start, end),
+        ]),
+      },
+    },
+    fields: [...requiredFields, ...optionalFields],
+    _source: [SPAN_LINKS, TRANSACTION_MARKS_AGENT],
+  });
+
+  const hit = maybe(resp.hits.hits[0]);
+
+  if (!hit) {
+    return undefined;
+  }
+
+  const event = unflattenKnownApmEventFields(hit.fields, requiredFields);
+
+  const source =
+    'span' in hit._source || 'transaction' in hit._source
+      ? (hit._source as {
+          transaction?: Pick<Required<Transaction>['transaction'], 'marks'>;
+          span?: Pick<Required<Transaction>['span'], 'links'>;
+        })
+      : undefined;
+
+  return {
+    ...event,
+    transaction: {
+      ...event.transaction,
+      marks: source?.transaction?.marks,
+    },
+    processor: {
+      name: 'transaction',
+      event: 'transaction',
+    },
+    span: source?.span,
+  };
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[APM] Fix query for transaction marks (#215819)](https://github.com/elastic/kibana/pull/215819)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sunghyun Kim","email":"cqbqdd11519@gmail.com"},"sourceCommit":{"committedDate":"2025-04-01T15:05:42Z","message":"[APM] Fix query for transaction marks (#215819)\n\n## Summary\n\nThere is a bug in kibana 8.17, where no transaction marks are shown in\nthe APM's transaction waterfall ui.\nThe marks are stored in the field `transaction.marks.agent` of\ndocuments, but kibana apm server is querying `transaction.agent.marks`.\n\nThis PR fixes the field name.\n\n\nI also added `span.id` in the query source to include the marks in the\nresponse, even if there is no `span.links` in the transaction info.\n(I found the case from RUM data with `transaction.marks.agent` but\nwithout `span.links`, so that the response does not include marks\nbecause there is no `source` field in the query result)\n\nI am not sure if it's the right way to fix it, as i have no\nunderstanding about the relationsip between `transaction.marks.agent`\nand `span.links`, so this PR is more like a bug report.\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\nNone","sha":"d4d1c2b6ddf98859e5d36654eab0ca71cefc8808","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","💝community","backport:all-open","ci:project-deploy-observability","Team:obs-ux-infra_services","v9.1.0"],"title":"[APM] Fix query for transaction marks","number":215819,"url":"https://github.com/elastic/kibana/pull/215819","mergeCommit":{"message":"[APM] Fix query for transaction marks (#215819)\n\n## Summary\n\nThere is a bug in kibana 8.17, where no transaction marks are shown in\nthe APM's transaction waterfall ui.\nThe marks are stored in the field `transaction.marks.agent` of\ndocuments, but kibana apm server is querying `transaction.agent.marks`.\n\nThis PR fixes the field name.\n\n\nI also added `span.id` in the query source to include the marks in the\nresponse, even if there is no `span.links` in the transaction info.\n(I found the case from RUM data with `transaction.marks.agent` but\nwithout `span.links`, so that the response does not include marks\nbecause there is no `source` field in the query result)\n\nI am not sure if it's the right way to fix it, as i have no\nunderstanding about the relationsip between `transaction.marks.agent`\nand `span.links`, so this PR is more like a bug report.\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\nNone","sha":"d4d1c2b6ddf98859e5d36654eab0ca71cefc8808"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215819","number":215819,"mergeCommit":{"message":"[APM] Fix query for transaction marks (#215819)\n\n## Summary\n\nThere is a bug in kibana 8.17, where no transaction marks are shown in\nthe APM's transaction waterfall ui.\nThe marks are stored in the field `transaction.marks.agent` of\ndocuments, but kibana apm server is querying `transaction.agent.marks`.\n\nThis PR fixes the field name.\n\n\nI also added `span.id` in the query source to include the marks in the\nresponse, even if there is no `span.links` in the transaction info.\n(I found the case from RUM data with `transaction.marks.agent` but\nwithout `span.links`, so that the response does not include marks\nbecause there is no `source` field in the query result)\n\nI am not sure if it's the right way to fix it, as i have no\nunderstanding about the relationsip between `transaction.marks.agent`\nand `span.links`, so this PR is more like a bug report.\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\nNone","sha":"d4d1c2b6ddf98859e5d36654eab0ca71cefc8808"}}]}] BACKPORT-->