### PR TITLE
[8.17] [Onboarding] Hide card labels in search results (#213417)

### DIFF
--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/packages_list/index.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/packages_list/index.tsx
@@ -22,6 +22,7 @@ interface Props {
    * list functionality.
    */
   customCards?: CustomCard[];
+  showCardLabels?: boolean;
   /**
    * Override the default `observability` option.
    */
@@ -69,6 +70,7 @@ const PackageListGridWrapper = ({
     selectedCategory,
     excludePackageIdList,
     customCards,
+    showCardLabels,
     flowCategory,
     flowSearch,
     joinCardLists
@@ -83,6 +85,8 @@ const PackageListGridWrapper = ({
   if (isLoading) return <Loading />;
 
   const showPackageList = (showSearchBar && !!searchQuery) || showSearchBar === false;
+  const shouldShowCardLabels =
+    showCardLabels ?? (!showSearchBar || (showSearchBar && !!searchQuery));
 
   return (
     <Suspense fallback={<Loading />}>
@@ -114,7 +118,7 @@ const PackageListGridWrapper = ({
             categories={[]}
             setUrlandReplaceHistory={() => {}}
             setUrlandPushHistory={() => {}}
-            showCardLabels={true}
+            showCardLabels={shouldShowCardLabels}
           />
         )}
       </div>

--- a/x-pack/plugins/observability_solution/observability_onboarding/public/application/packages_list/index.tsx
+++ b/x-pack/plugins/observability_solution/observability_onboarding/public/application/packages_list/index.tsx
@@ -55,6 +55,7 @@ const PackageListGridWrapper = ({
   searchQuery,
   setSearchQuery,
   customCards,
+  showCardLabels,
   flowCategory,
   flowSearch,
   joinCardLists = false,
@@ -70,7 +71,6 @@ const PackageListGridWrapper = ({
     selectedCategory,
     excludePackageIdList,
     customCards,
-    showCardLabels,
     flowCategory,
     flowSearch,
     joinCardLists


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Onboarding] Hide card labels in search results (#213417)](https://github.com/elastic/kibana/pull/213417)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mykola Harmash","email":"mykola.harmash@gmail.com"},"sourceCommit":{"committedDate":"2025-03-07T14:40:39Z","message":"[Onboarding] Hide card labels in search results (#213417)\n\nCloses https://github.com/elastic/kibana/issues/200917\n\nLooking at the code in Fleet search results screen, cards would also\nhave the `Unverified` badges. ([this\ncheck](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx#L101)\nwould return `true` because this specific page doesn't provides\n`packageVerificationKeyId` to the `isPackageUnverified()` function, this\nonly happens on the individual integration details page. Fleet search\njust [hides the\nbadges](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx#L188)\nfor cards in search results.\n\nThis change aligns Onboarding search results with Fleet search results\nand hides the card labels which fixes the issue with `Unverified` badge\nappearing for installed integrations.\n\n| Before | After |\n| --- | --- |\n|\n![388110694-bd6abaf4-15ac-4d56-b556-fddb11c85ba7](https://github.com/user-attachments/assets/751a6572-192c-45f6-bfa8-82433b73398d)\n| ![CleanShot 2025-03-07 at 14 35\n53@2x](https://github.com/user-attachments/assets/d1588d7d-eec8-4207-a1e6-9a53272bbddf)\n|","sha":"33f71ae678e833b4c91325e40f47d819e1edb08d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","ci:project-deploy-observability","Feature: Observability Onboarding","backport:version","v8.18.0","v9.1.0","v8.17.4"],"title":"[Onboarding] Hide card labels in search results","number":213417,"url":"https://github.com/elastic/kibana/pull/213417","mergeCommit":{"message":"[Onboarding] Hide card labels in search results (#213417)\n\nCloses https://github.com/elastic/kibana/issues/200917\n\nLooking at the code in Fleet search results screen, cards would also\nhave the `Unverified` badges. ([this\ncheck](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx#L101)\nwould return `true` because this specific page doesn't provides\n`packageVerificationKeyId` to the `isPackageUnverified()` function, this\nonly happens on the individual integration details page. Fleet search\njust [hides the\nbadges](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx#L188)\nfor cards in search results.\n\nThis change aligns Onboarding search results with Fleet search results\nand hides the card labels which fixes the issue with `Unverified` badge\nappearing for installed integrations.\n\n| Before | After |\n| --- | --- |\n|\n![388110694-bd6abaf4-15ac-4d56-b556-fddb11c85ba7](https://github.com/user-attachments/assets/751a6572-192c-45f6-bfa8-82433b73398d)\n| ![CleanShot 2025-03-07 at 14 35\n53@2x](https://github.com/user-attachments/assets/d1588d7d-eec8-4207-a1e6-9a53272bbddf)\n|","sha":"33f71ae678e833b4c91325e40f47d819e1edb08d"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/213579","number":213579,"state":"MERGED","mergeCommit":{"sha":"ff5042eb811c5eb1eb6bccc797feec06f52e1e32","message":"[9.0] [Onboarding] Hide card labels in search results (#213417) (#213579)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Onboarding] Hide card labels in search results\n(#213417)](https://github.com/elastic/kibana/pull/213417)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Mykola Harmash <mykola.harmash@gmail.com>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216666","number":216666,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213417","number":213417,"mergeCommit":{"message":"[Onboarding] Hide card labels in search results (#213417)\n\nCloses https://github.com/elastic/kibana/issues/200917\n\nLooking at the code in Fleet search results screen, cards would also\nhave the `Unverified` badges. ([this\ncheck](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx#L101)\nwould return `true` because this specific page doesn't provides\n`packageVerificationKeyId` to the `isPackageUnverified()` function, this\nonly happens on the individual integration details page. Fleet search\njust [hides the\nbadges](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx#L188)\nfor cards in search results.\n\nThis change aligns Onboarding search results with Fleet search results\nand hides the card labels which fixes the issue with `Unverified` badge\nappearing for installed integrations.\n\n| Before | After |\n| --- | --- |\n|\n![388110694-bd6abaf4-15ac-4d56-b556-fddb11c85ba7](https://github.com/user-attachments/assets/751a6572-192c-45f6-bfa8-82433b73398d)\n| ![CleanShot 2025-03-07 at 14 35\n53@2x](https://github.com/user-attachments/assets/d1588d7d-eec8-4207-a1e6-9a53272bbddf)\n|","sha":"33f71ae678e833b4c91325e40f47d819e1edb08d"}},{"branch":"8.17","label":"v8.17.4","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->