### PR TITLE
[Security solution] Read `config` from preconfigured connectors in Assistant/Attack Discovery

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/helpers.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/helpers.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  getGenAiConfig,
+  getActionTypeTitle,
+  getConnectorTypeTitle,
+  GenAiConfig,
+  OpenAiProviderType,
+} from './helpers';
+import { PRECONFIGURED_CONNECTOR } from './translations';
+import {
+  type ActionConnector,
+  type ActionTypeModel,
+  type ActionTypeRegistryContract,
+} from '@kbn/alerts-ui-shared';
+
+const mockConnector = (config: GenAiConfig, isPreconfigured = false) => ({
+  isPreconfigured,
+  config,
+  actionTypeId: 'test-action',
+});
+
+describe('getGenAiConfig', () => {
+  test('returns empty object when connector is undefined', () => {
+    expect(getGenAiConfig(undefined)).toEqual({});
+  });
+
+  test('extracts apiProvider, apiUrl, and defaultModel from connector config', () => {
+    const connector = mockConnector({
+      apiProvider: OpenAiProviderType.OpenAi,
+      apiUrl: 'https://api.openai.com',
+      defaultModel: 'gpt-4',
+    }) as ActionConnector;
+    expect(getGenAiConfig(connector)).toEqual({
+      apiProvider: OpenAiProviderType.OpenAi,
+      apiUrl: 'https://api.openai.com',
+      defaultModel: 'gpt-4',
+    });
+  });
+
+  test('extracts api-version from Azure API URL', () => {
+    const connector = mockConnector({
+      apiProvider: OpenAiProviderType.AzureAi,
+      apiUrl: 'https://api.azure.com?api-version=2024-01-01',
+    }) as ActionConnector;
+    expect(getGenAiConfig(connector)).toEqual({
+      apiProvider: OpenAiProviderType.AzureAi,
+      apiUrl: 'https://api.azure.com?api-version=2024-01-01',
+      defaultModel: '2024-01-01',
+    });
+  });
+});
+
+describe('getActionTypeTitle', () => {
+  test('returns actionTypeTitle if defined', () => {
+    expect(getActionTypeTitle({ actionTypeTitle: 'Test Action' } as ActionTypeModel)).toBe(
+      'Test Action'
+    );
+  });
+
+  test('returns id if actionTypeTitle is undefined', () => {
+    expect(getActionTypeTitle({ id: 'test-id' } as ActionTypeModel)).toBe('test-id');
+  });
+});
+
+describe('getConnectorTypeTitle', () => {
+  const mockActionTypeRegistry = {
+    get: jest.fn().mockReturnValue({ actionTypeTitle: 'Fallback Action' }),
+  } as unknown as ActionTypeRegistryContract;
+
+  test('returns null when connector is undefined', () => {
+    expect(getConnectorTypeTitle(undefined, mockActionTypeRegistry)).toBeNull();
+  });
+
+  test('returns PRECONFIGURED_CONNECTOR for preconfigured connectors', () => {
+    const connector = mockConnector({}, true) as ActionConnector;
+    expect(getConnectorTypeTitle(connector, mockActionTypeRegistry)).toBe(PRECONFIGURED_CONNECTOR);
+  });
+
+  test('returns apiProvider if defined in config', () => {
+    const connector = mockConnector({ apiProvider: OpenAiProviderType.OpenAi }) as ActionConnector;
+    expect(getConnectorTypeTitle(connector, mockActionTypeRegistry)).toBe('OpenAI');
+  });
+
+  test('returns action type title from registry if apiProvider is undefined', () => {
+    const connector = mockConnector({}) as ActionConnector;
+    expect(getConnectorTypeTitle(connector, mockActionTypeRegistry)).toBe('Fallback Action');
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/helpers.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/connectorland/helpers.tsx
@@ -15,13 +15,13 @@ import { ActionConnectorProps } from '@kbn/triggers-actions-ui-plugin/public/typ
 import { PRECONFIGURED_CONNECTOR } from './translations';
 
 // aligns with OpenAiProviderType from '@kbn/stack-connectors-plugin/common/openai/types'
-enum OpenAiProviderType {
+export enum OpenAiProviderType {
   OpenAi = 'OpenAI',
   AzureAi = 'Azure OpenAI',
   Other = 'Other',
 }
 
-interface GenAiConfig {
+export interface GenAiConfig {
   apiProvider?: OpenAiProviderType;
   apiUrl?: string;
   defaultModel?: string;
@@ -29,26 +29,21 @@ interface GenAiConfig {
 
 /**
  * Returns the GenAiConfig for a given ActionConnector. Note that if the connector is preconfigured,
- * the config will be undefined as the connector is neither available nor editable.
+ * the config MAY be undefined if exposeConfig: true is absent
  *
  * @param connector
  */
-export const getGenAiConfig = (connector: ActionConnector | undefined): GenAiConfig | undefined => {
-  if (!connector?.isPreconfigured) {
-    const config = (connector as ActionConnectorProps<GenAiConfig, unknown>)?.config;
-    const { apiProvider, apiUrl, defaultModel } = config ?? {};
-
-    return {
-      apiProvider,
-      apiUrl,
-      defaultModel:
-        apiProvider === OpenAiProviderType.AzureAi
-          ? getAzureApiVersionParameter(apiUrl ?? '')
-          : defaultModel,
-    };
-  }
-
-  return undefined; // the connector is neither available nor editable
+export const getGenAiConfig = (connector: ActionConnector | undefined): GenAiConfig => {
+  const config = (connector as ActionConnectorProps<GenAiConfig, unknown>)?.config;
+  const { apiProvider, apiUrl, defaultModel } = config ?? {};
+  return {
+    apiProvider,
+    apiUrl,
+    defaultModel:
+      apiProvider === OpenAiProviderType.AzureAi
+        ? getAzureApiVersionParameter(apiUrl ?? '')
+        : defaultModel,
+  };
 };
 
 export const getActionTypeTitle = (actionType: ActionTypeModel): string => {

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/tsconfig.json
@@ -43,5 +43,6 @@
     "@kbn/shared-ux-router",
     "@kbn/inference-endpoint-ui-common",
     "@kbn/datemath",
+    "@kbn/alerts-ui-shared",
   ]
 }


### PR DESCRIPTION
## Summary

We had some code that assumed we could not get `config` from preconfigured connectors. With [the addition of ](https://github.com/elastic/kibana/pull/207654)`exposeConfig`, we can no longer make this assumption. This PR allows for config to be read from preconfigured connectors if it exists.


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->