### PR TITLE
[Fleet] Do not allow to edit anything else than namespace for managed policies

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -125,7 +125,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
   const [isUninstallCommandFlyoutOpen, setIsUninstallCommandFlyoutOpen] = useState(false);
   const policyHasElasticDefend = useMemo(() => hasElasticDefend(agentPolicy), [agentPolicy]);
   const isManagedPolicy = agentPolicy.is_managed === true;
-  const isManagedorAgentlessPolicy = isManagedPolicy || agentPolicy?.supports_agentless === true;
+  const isManagedOrAgentlessPolicy = isManagedPolicy || agentPolicy?.supports_agentless === true;
 
   const userHasAccessToAllPolicySpaces = useMemo(
     () => ('space_ids' in agentPolicy ? !agentPolicy.space_ids?.includes(UNKNOWN_SPACE) : true),
@@ -439,7 +439,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
       >
         <EuiSpacer size="l" />
         <EuiCheckboxGroup
-          disabled={disabled || isManagedorAgentlessPolicy}
+          disabled={disabled || isManagedOrAgentlessPolicy}
           options={[
             {
               id: `${dataTypes.Logs}_${monitoringCheckboxIdSuffix}`,
@@ -575,7 +575,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
         >
           <EuiFieldNumber
             fullWidth
-            disabled={disabled || isManagedorAgentlessPolicy}
+            disabled={disabled || isManagedOrAgentlessPolicy}
             value={agentPolicy.inactivity_timeout || ''}
             min={0}
             onChange={(e) => {
@@ -616,7 +616,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
           isInvalid={Boolean(touchedFields.fleet_server_host_id && validation.fleet_server_host_id)}
         >
           <EuiSuperSelect
-            disabled={disabled || isManagedorAgentlessPolicy}
+            disabled={disabled || isManagedOrAgentlessPolicy}
             valueOfSelected={agentPolicy.fleet_server_host_id || DEFAULT_SELECT_VALUE}
             fullWidth
             isLoading={isLoadingFleetServerHostsOption}
@@ -698,7 +698,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
           isDisabled={disabled}
         >
           <EuiSuperSelect
-            disabled={disabled || isManagedorAgentlessPolicy}
+            disabled={disabled || isManagedOrAgentlessPolicy}
             valueOfSelected={agentPolicy.monitoring_output_id || DEFAULT_SELECT_VALUE}
             fullWidth
             isLoading={isLoadingOptions}
@@ -737,10 +737,10 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
               : null
           }
           isInvalid={Boolean(touchedFields.download_source_id && validation.download_source_id)}
-          isDisabled={disabled || isManagedorAgentlessPolicy}
+          isDisabled={disabled || isManagedOrAgentlessPolicy}
         >
           <EuiSuperSelect
-            disabled={disabled || isManagedorAgentlessPolicy}
+            disabled={disabled || isManagedOrAgentlessPolicy}
             valueOfSelected={agentPolicy.download_source_id || DEFAULT_SELECT_VALUE}
             fullWidth
             isLoading={isLoadingDownloadSources}
@@ -771,9 +771,9 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
           />
         }
       >
-        <EuiFormRow fullWidth isDisabled={disabled || isManagedorAgentlessPolicy}>
+        <EuiFormRow fullWidth isDisabled={disabled || isManagedOrAgentlessPolicy}>
           <EuiRadioGroup
-            disabled={disabled || isManagedorAgentlessPolicy}
+            disabled={disabled || isManagedOrAgentlessPolicy}
             options={[
               {
                 id: 'hostname',
@@ -864,11 +864,11 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
               : null
           }
           isInvalid={Boolean(touchedFields.unenroll_timeout && validation.unenroll_timeout)}
-          isDisabled={disabled || isManagedorAgentlessPolicy}
+          isDisabled={disabled || isManagedOrAgentlessPolicy}
         >
           <EuiFieldNumber
             fullWidth
-            disabled={disabled || isManagedorAgentlessPolicy}
+            disabled={disabled || isManagedOrAgentlessPolicy}
             value={agentPolicy.unenroll_timeout || ''}
             min={0}
             onChange={(e) => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_advanced_fields/index.tsx
@@ -737,10 +737,10 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
               : null
           }
           isInvalid={Boolean(touchedFields.download_source_id && validation.download_source_id)}
-          isDisabled={disabled}
+          isDisabled={disabled || isManagedorAgentlessPolicy}
         >
           <EuiSuperSelect
-            disabled={disabled || agentPolicy?.supports_agentless === true}
+            disabled={disabled || isManagedorAgentlessPolicy}
             valueOfSelected={agentPolicy.download_source_id || DEFAULT_SELECT_VALUE}
             fullWidth
             isLoading={isLoadingDownloadSources}
@@ -771,9 +771,9 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
           />
         }
       >
-        <EuiFormRow fullWidth isDisabled={disabled}>
+        <EuiFormRow fullWidth isDisabled={disabled || isManagedorAgentlessPolicy}>
           <EuiRadioGroup
-            disabled={disabled || agentPolicy?.supports_agentless === true}
+            disabled={disabled || isManagedorAgentlessPolicy}
             options={[
               {
                 id: 'hostname',
@@ -864,7 +864,7 @@ export const AgentPolicyAdvancedOptionsContent: React.FunctionComponent<Props> =
               : null
           }
           isInvalid={Boolean(touchedFields.unenroll_timeout && validation.unenroll_timeout)}
-          isDisabled={disabled}
+          isDisabled={disabled || isManagedorAgentlessPolicy}
         >
           <EuiFieldNumber
             fullWidth

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_form.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_form.tsx
@@ -189,7 +189,9 @@ export const AgentPolicyForm: React.FunctionComponent<Props> = ({
               <EuiSpacer size="m" />
               <ConfiguredSettings
                 configuredSettings={AGENT_POLICY_ADVANCED_SETTINGS}
-                disabled={isDisabled || !!agentPolicy?.supports_agentless}
+                disabled={
+                  isDisabled || !!agentPolicy?.supports_agentless || !!agentPolicy?.is_managed
+                }
               />
             </>
             <EuiSpacer size="xl" />


### PR DESCRIPTION
## Description 

Resolve #205358

Disable all inputs expect `namespace` for managed policies

## UI Changes

![localhost_5601_app_fleet_policies_test-policy_settings](https://github.com/user-attachments/assets/a08ac78b-81f9-41c1-9d96-778ab5dc998e)


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->