### PR TITLE
chore(): change telemetry codeowner from @elastic/platform-analytics to @elastic/kibana-telemetry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1911,8 +1911,8 @@ packages/kbn-monaco/src/esql @elastic/kibana-esql
 # Kibana Telemetry
 /.telemetryrc.json @elastic/kibana-core
 /x-pack/.telemetryrc.json @elastic/kibana-core
-/src/platform/plugins/shared/telemetry/schema/ @elastic/kibana-core @elastic/platform-analytics
-/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/ @elastic/kibana-core @elastic/platform-analytics
+/src/platform/plugins/shared/telemetry/schema/ @elastic/kibana-core @elastic/kibana-telemetry
+/x-pack/platform/plugins/private/telemetry_collection_xpack/schema/ @elastic/kibana-core @elastic/kibana-telemetry
 x-pack/platform/plugins/private/cloud_integrations/cloud_full_story/server/config.ts @elastic/kibana-core @shahinakmal
 
 # Kibana Localization


### PR DESCRIPTION
## Summary

Change telemetry codeowners entry from platform-analytics to kibana-telemetry. This somewhat expanded github team will notify correctly while including more reviewers across orgs. Expands on change from #214572

cc @elastic/platform-analytics 