### PR TITLE
[8.x] [Security Solution] Migrate legacy Detections API docs to OpenAPI specs (#212367)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -113,7 +113,22 @@ tags:
   - description: Manage and interact with Security Assistant resources.
     name: Security AI Assistant API
     x-displayName: Security AI assistant
-  - description: You can create rules that automatically turn events and external alerts sent to Elastic Security into detection alerts. These alerts are displayed on the Detections page.
+  - description: |
+      Use the detections APIs to create and manage detection rules. Detection rules search events and external alerts sent to Elastic Security and generate detection alerts from any hits. Alerts are displayed on the **Alerts** page and can be assigned and triaged, using the alert status to mark them as open, closed, or acknowledged.
+
+      This API supports both key-based authentication and basic authentication.
+
+      To use key-based authentication, create an API key, then specify the key in the header of your API calls.
+
+      To use basic authentication, provide a username and password; this automatically creates an API key that matches the current user’s privileges.
+
+      In both cases, the API key is subsequently used for authorization when the rule runs.
+      > warn
+      > If the API key used for authorization has different privileges than the key that created or most recently updated a rule, the rule behavior might change.
+
+      > If the API key that created a rule is deleted, or the user that created the rule becomes inactive, the rule will stop running.
+
+      To create and run rules, the user must meet specific requirements for the Kibana space. Refer to the [Detections requirements](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html) for a complete list of requirements.
     name: Security Detections API
     x-displayName: Security detections
   - description: Endpoint Exceptions API allows you to manage detection rule endpoint exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.
@@ -8309,7 +8324,15 @@ paths:
         - Security Detections API
   /api/detection_engine/rules:
     delete:
-      description: Delete a detection rule using the `rule_id` or `id` field.
+      description: |
+        Delete a detection rule using the `rule_id` or `id` field.
+
+        The URL query must include one of the following:
+
+        * `id` - `DELETE /api/detection_engine/rules?id=<id>`
+        * `rule_id`- `DELETE /api/detection_engine/rules?rule_id=<rule_id>`
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
       operationId: DeleteRule
       parameters:
         - description: The rule's `id` value.
@@ -8334,8 +8357,22 @@ paths:
       summary: Delete a detection rule
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request DELETE https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
     get:
-      description: Retrieve a detection rule using the `rule_id` or `id` field.
+      description: |
+        Retrieve a detection rule using the `rule_id` or `id` field.
+
+        The URL query must include one of the following:
+
+        * `id` - `GET /api/detection_engine/rules?id=<id>`
+        * `rule_id` - `GET /api/detection_engine/rules?rule_id=<rule_id>`
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
       operationId: ReadRule
       parameters:
         - description: The rule's `id` value.
@@ -8354,25 +8391,205 @@ paths:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
+              examples:
+                example1:
+                  summary: Example response for a retrieved rule
+                  value:
+                    created_at: '2020-02-03T11:19:04.259Z'
+                    created_by: elastic
+                    description: Process started by MS Office program in user folder
+                    enabled: false
+                    execution_summary:
+                      last_execution:
+                        date: '2022-03-23T16:06:12.787Z'
+                        message: This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.
+                        metrics:
+                          execution_gap_duration_s: 0
+                          total_indexing_duration_ms: 15
+                          total_search_duration_ms: 135
+                        status: partial failure
+                        status_order: 20
+                    false_positives: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-4200s
+                    id: c41d170b-8ba6-4de6-b8ec-76440a35ace3
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: MS Office child process
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: process.name
+                        type: keyword
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    risk_score: 21
+                    rule_id: process_started_by_ms_office_user_folder
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat:
+                      - framework: MITRE ATT&CK
+                        tactic:
+                          id: TA0001
+                          name: Initial Access
+                          reference: https://attack.mitre.org/tactics/TA0001
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: https://attack.mitre.org/techniques/T1193
+                    to: now-300s
+                    type: query
+                    updated_at: '2020-02-03T11:19:04.462Z'
+                    updated_by: elastic
+                    version: 1
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
-          description: Indicates a successful call.
+          description: |
+            Indicates a successful call.
+            > info
+            > These fields are under development and their usage or schema may change: execution_summary.
       summary: Retrieve a detection rule
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request GET https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
     patch:
-      description: Update specific fields of an existing detection rule using the `rule_id` or `id` field.
+      description: |
+        Update specific fields of an existing detection rule using the `rule_id` or `id` field.
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       operationId: PatchRule
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
+            examples:
+              example1:
+                summary: Patch query rule
+                value:
+                  id: 14b7b513-3d8d-4b22-b7da-a7ae632f7e76
+                  name: New name
+              example2:
+                summary: Patch EQL rule
+                value:
+                  rule_id: process_started_by_ms_office_program_possible_payload
+                  threat:
+                    - framework: MITRE ATT&CK
+                      tactic:
+                        id: TA0001
+                        name: Initial Access
+                        reference: https://attack.mitre.org/tactics/TA0001
+                      technique:
+                        - id: T1193
+                          name: Spearphishing Attachment
+                          reference: https://attack.mitre.org/techniques/T1193
+              example3:
+                summary: Patch threshold rule
+                value:
+                  id: 005d2c4f-51ca-493d-a2bd-20ef076339b1
+                  query: 'agent.version : * and agent.id : "243d9b4f-ca01-4311-8e5c-9abbee91afd8"'
+                  threshold:
+                    cardinality: []
+                    field: []
+                    value: 600
+              example4:
+                summary: Patch new terms rule
+                value:
+                  history_window_start: now-3d
+                  id: 569aac91-40dc-4807-a8ae-a2c8698089c4
+                  new_terms_fields:
+                    - Endpoint.policy.applied.artifacts.global.identifiers.name
+              example5:
+                summary: Patch esql rule
+                value:
+                  id: 0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd
+                  query: |
+                    FROM logs-abc*
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp)
+                    | EVAL event_rate = count / DATE_DIFF("seconds", min_timestamp, NOW()) 
+                    | KEEP event_rate
+              example6:
+                summary: Patch indicator match rule
+                value:
+                  id: 462f1986-10fe-40a3-a22c-2b1c9c4c48fd
+                  threat_query: '@timestamp >= "now-30d/d" and event.module:(threatintel or ti_*) and threat.indicator.ip:* and not labels.is_ioc_transform_source:"false"'
+              example7:
+                summary: Patch machine learning rule
+                value:
+                  anomaly_threshold: 50
+                  id: 60b13926-289b-41b1-a537-197ef1fa5059
+                  machine_learning_job_id:
+                    - auth_high_count_logon_events
             schema:
               $ref: '#/components/schemas/Security_Detections_API_RulePatchProps'
+        description: |
+          > info
+          > You cannot modify the `id` or `rule_id` values.
         required: true
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Updated description for the rule.
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query: null
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: Updated Rule Name
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                    required_fields:
+                      - name: process.parent.name
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 2
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
@@ -8380,11 +8597,304 @@ paths:
       tags:
         - Security Detections API
     post:
-      description: Create a new detection rule.
+      description: |
+        Create a new detection rule.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
+        You can create the following types of rules:
+
+        * **Custom query**: Searches the defined indices and creates an alert when a document matches the rule's KQL query.
+        * **Event correlation**: Searches the defined indices and creates an alert when results match an [Event Query Language (EQL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html) query.
+        * **Threshold**: Searches the defined indices and creates an alert when the number of times the specified field's value meets the threshold during a single execution. When there are multiple values that meet the threshold, an alert is generated for each value.
+          For example, if the threshold `field` is `source.ip` and its `value` is `10`, an alert is generated for every source IP address that appears in at least 10 of the rule's search results. If you're interested, see [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) for more information.
+        * **Indicator match**: Creates an alert when fields match values defined in the specified [Elasticsearch index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). For example, you can create an index for IP addresses and use this index to create an alert whenever an event's `destination.ip` equals a value in the index. The index's field mappings should be [ECS-compliant](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html).
+        * **New terms**: Generates an alert for each new term detected in source documents within a specified time range.
+        * **ES|QL**: Uses [Elasticsearch Query Language (ES|QL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html) to find events and aggregate search results.
+        * **Machine learning rules**: Creates an alert when a machine learning job discovers an anomaly above the defined threshold.
+        > info
+        > To create machine learning rules, you must have the [appropriate license](https://www.elastic.co/subscriptions) or use a [cloud deployment](https://cloud.elastic.co/registration). Additionally, for the machine learning rule to function correctly, the associated machine learning job must be running.
+
+        To retrieve machine learning job IDs, which are required to create machine learning jobs, call the [Elasticsearch Get jobs API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html). Machine learning jobs that contain `siem` in the `groups` field can be used to create rules:
+
+        ```json
+        ...
+        "job_id": "linux_anomalous_network_activity_ecs",
+        "job_type": "anomaly_detector",
+        "job_version": "7.7.0",
+        "groups": [
+          "auditbeat",
+          "process",
+          "siem"
+        ],
+        ...
+        ```
+
+        Additionally, you can set up notifications for when rules create alerts. The notifications use the [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html). Each action type requires a connector. Connectors store the information required to send notifications via external systems. The following connector types are supported for rule notifications:
+
+        * Slack
+        * Email
+        * PagerDuty
+        * Webhook
+        * Microsoft Teams
+        * IBM Resilient
+        * Jira
+        * ServiceNow ITSM
+        > info
+        > For more information on PagerDuty fields, see [Send a v2 Event](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/).
+
+        To retrieve connector IDs, which are required to configure rule notifications, call the [Find objects API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-find.html) with `"type": "action"` in the request payload.
+
+        For detailed information on Kibana actions and alerting, and additional API calls, see:
+
+        * [Alerting API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-alerting)
+        * [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html)
+        * [Connectors API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-connectors)
       operationId: CreateRule
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
+            examples:
+              example1:
+                description: Query rule that searches for processes started by MS Office
+                summary: Query rule
+                value:
+                  description: Process started by MS Office program - possible payload
+                  enabled: false
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: phrase
+                  from: now-70m
+                  interval: 1h
+                  language: kuery
+                  name: MS Office child process
+                  query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                  related_integrations:
+                    - package: o365
+                      version: ^2.3.2
+                  required_fields:
+                    - name: process.parent.name
+                      type: keyword
+                  risk_score: 50
+                  rule_id: process_started_by_ms_office_program
+                  severity: low
+                  tags:
+                    - child process
+                    - ms office
+                  type: query
+              example2:
+                description: Threshold rule that detects multiple failed login attempts to a Windows host from the same external source IP address
+                summary: Threshold rule
+                value:
+                  description: Detects when there are 20 or more failed login attempts from the same IP address with a 2 minute time frame.
+                  enabled: true
+                  exceptions_list:
+                    - id: int-ips
+                      namespace_type: single
+                      type: detection
+                  from: now-180s
+                  index:
+                    - winlogbeat-*
+                  interval: 2m
+                  name: Windows server prml-19
+                  query: host.name:prml-19 and event.category:authentication and event.outcome:failure
+                  required_fields:
+                    - name: source.ip
+                      type: ip
+                  risk_score: 30
+                  rule_id: liv-win-ser-logins
+                  severity: low
+                  severity_mapping:
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: low
+                      value: Manchester
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: medium
+                      value: London
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: high
+                      value: Birmingham
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: critical
+                      value: Wallingford
+                  tags:
+                    - Brute force
+                  threshold:
+                    field: source.ip
+                    value: 20
+                  type: threshold
+              example3:
+                description: Machine learning rule that creates alerts, and sends Slack notifications, when the linux_anomalous_network_activity_ecs machine learning job discovers anomalies with a threshold of 70 or above.
+                summary: Machine learning rule
+                value:
+                  actions:
+                    - action_type_id: .slack
+                      group: default
+                      id: 5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5
+                      params:
+                        message: 'Urgent: {{context.rule.description}}'
+                  anomaly_threshold: 70
+                  description: Generates alerts when the job discovers anomalies over 70
+                  enabled: true
+                  from: now-6m
+                  interval: 5m
+                  machine_learning_job_id: linux_anomalous_network_activity_ecs
+                  name: Anomalous Linux network activity
+                  note: Shut down the internet.
+                  risk_score: 70
+                  rule_id: ml_linux_network_high_threshold
+                  setup: This rule requires data coming in from Elastic Defend.
+                  severity: high
+                  tags:
+                    - machine learning
+                    - Linux
+                  type: machine_learning
+              example4:
+                description: Event correlation rule that creates alerts when the Windows rundll32.exe process makes unusual network connections
+                summary: EQL rule
+                value:
+                  description: Unusual rundll32.exe network connection
+                  language: eql
+                  name: rundll32.exe network connection
+                  query: sequence by process.entity_id with maxspan=2h [process where event.type in ("start", "process_started") and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe") and ((process.args == "rundll32.exe" and process.args_count == 1) or (process.args != "rundll32.exe" and process.args_count == 0))] [network where event.type == "connection" and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe")]
+                  required_fields:
+                    - name: event.type
+                      type: keyword
+                    - name: process.args
+                      type: keyword
+                    - name: process.args_count
+                      type: long
+                    - name: process.entity_id
+                      type: keyword
+                    - name: process.name
+                      type: keyword
+                    - name: process.pe.original_file_name
+                      type: keyword
+                  risk_score: 21
+                  rule_id: eql-outbound-rundll32-connections
+                  severity: low
+                  tags:
+                    - EQL
+                    - Windows
+                    - rundll32.exe
+                  type: eql
+              example5:
+                description: |
+                  Indicator match rule that creates an alert when one of the following is true: The event's destination IP address and port number matches destination IP and port values in the threat_index index; The event's source IP address matches a host IP address value in the threat_index index.
+                summary: Indicator match rule
+                value:
+                  actions: []
+                  description: Checks for bad IP addresses listed in the ip-threat-list index
+                  index:
+                    - packetbeat-*
+                  name: Bad IP threat match
+                  query: destination.ip:* or host.ip:*
+                  required_fields:
+                    - name: destination.ip
+                      type: ip
+                    - name: destination.port
+                      type: long
+                    - name: host.ip
+                      type: ip
+                  risk_score: 50
+                  severity: medium
+                  threat_index:
+                    - ip-threat-list
+                  threat_mapping:
+                    - entries:
+                        - field: destination.ip
+                          type: mapping
+                          value: destination.ip
+                        - field: destination.port
+                          type: mapping
+                          value: destination.port
+                    - entries:
+                        - field: source.ip
+                          type: mapping
+                          value: host.ip
+                  threat_query: '*:*'
+                  type: threat_match
+              example6:
+                description: New terms rule that creates alerts a new IP address is detected for a user
+                summary: New terms rule
+                value:
+                  description: Detects a user associated with a new IP address
+                  history_window_start: now-30d
+                  index:
+                    - auditbeat*
+                  language: kuery
+                  name: New User IP Detected
+                  new_terms_fields:
+                    - user.id
+                    - source.ip
+                  query: '*'
+                  required_fields:
+                    - name: user.id
+                      type: keyword
+                    - name: source.ip
+                      type: ip
+                  risk_score: 21
+                  severity: medium
+                  type: new_terms
+              example7:
+                description: esql rule that creates alerts from events that match an Excel parent process
+                summary: Esql rule
+                value:
+                  description: Find Excel events
+                  enabled: false
+                  from: now-360s
+                  interval: 5m
+                  language: esql
+                  name: Find Excel events
+                  query: from auditbeat-8.10.2 METADATA _id, _version, _index | where process.parent.name == "EXCEL.EXE"
+                  required_fields:
+                    - name: process.parent.name
+                      type: keyword
+                  risk_score: 21
+                  severity: low
+                  tags: []
+                  to: now
+                  type: esql
+              example8:
+                description: Query rule that searches for processes started by MS Office and suppresses alerts by the process.parent.name field within a 5-hour time period
+                summary: Query rule 2
+                value:
+                  alert_suppression:
+                    duration:
+                      unit: h
+                      value: 5
+                    group_by:
+                      - process.parent.name
+                    missing_fields_strategy: suppress
+                  description: Process started by MS Office program - possible payload
+                  enabled: false
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: phrase
+                  from: now-70m
+                  interval: 1h
+                  language: kuery
+                  name: MS Office child process
+                  query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                  risk_score: 50
+                  rule_id: process_started_by_ms_office_program
+                  severity: low
+                  tags:
+                    - child process
+                    - ms office
+                  type: query
             schema:
               $ref: '#/components/schemas/Security_Detections_API_RuleCreateProps'
         required: true
@@ -8392,6 +8902,381 @@ paths:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
+              examples:
+                example1:
+                  description: Example response for a query rule
+                  summary: Query rule response
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Process started by MS Office program - possible payload
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: MS Office child process
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                      - integration: graphactivitylogs
+                        package: azure
+                        version: ^1.11.4
+                    required_fields:
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 1
+                example2:
+                  description: Example response for a machine learning job rule
+                  summary: Machine learning response
+                  value:
+                    actions:
+                      - action_type_id: .slack
+                        frequency:
+                          notifyWhen: onActiveAlert
+                          summary: true
+                          throttle: null
+                        group: default
+                        id: 5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5
+                        params:
+                          message: 'Urgent: {{context.rule.description}}'
+                    anomaly_threshold: 70
+                    created_at: '2020-04-07T14:45:15.679Z'
+                    created_by: elastic
+                    description: Generates alerts when the job discovers anomalies over 70
+                    enabled: true
+                    false_positives: []
+                    from: now-6m
+                    id: 83876f66-3a57-4a99-bf37-416494c80f3b
+                    immutable: false
+                    interval: 5m
+                    machine_learning_job_id: linux_anomalous_network_activity_ecs
+                    max_signals: 100
+                    name: Anomalous Linux network activity
+                    note: Shut down the internet.
+                    references: []
+                    related_integrations: []
+                    required_fields: []
+                    risk_score: 70
+                    rule_id: ml_linux_network_high_threshold
+                    setup: ''
+                    severity: high
+                    status: going to run
+                    status_date: '2020-04-07T14:45:21.685Z'
+                    tags:
+                      - machine learning
+                      - Linux
+                    threat: []
+                    to: now
+                    type: machine_learning
+                    updated_at: '2020-04-07T14:45:15.892Z'
+                    updated_by: elastic
+                    version: 1
+                example3:
+                  description: Example response for a threshold rule
+                  summary: Threshold rule response
+                  value:
+                    actions: []
+                    author: []
+                    created_at: '2020-07-22T10:27:23.486Z'
+                    created_by: elastic
+                    description: Detects when there are 20 or more failed login attempts from the same IP address with a 2 minute time frame.
+                    enabled: true
+                    exceptions_list:
+                      - id: int-ips
+                        namespace_type: single
+                        type: detection
+                    false_positives: []
+                    from: now-180s
+                    id: 15dbde26-b627-4d74-bb1f-a5e0ed9e4993
+                    immutable: false
+                    index:
+                      - winlogbeat-*
+                    interval: 2m
+                    language: kuery
+                    max_signals: 100
+                    name: Windows server prml-19
+                    query: host.name:prml-19 and event.category:authentication and event.outcome:failure
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: source.ip
+                        type: ip
+                    risk_score: 30
+                    risk_score_mapping: []
+                    rule_id: liv-win-ser-logins
+                    setup: ''
+                    severity: low
+                    severity_mapping:
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: low
+                        value: Manchester
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: medium
+                        value: London
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: high
+                        value: Birmingham
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: critical
+                        value: Wallingford
+                    tags:
+                      - Brute force
+                    threat: []
+                    threshold:
+                      field: source.ip
+                      value: 20
+                    to: now
+                    type: threshold
+                    updated_at: '2020-07-22T10:27:23.673Z'
+                    updated_by: elastic
+                    version: 1
+                example4:
+                  description: Example response for an EQL rule
+                  summary: EQL rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-05T09:06:16.392Z'
+                    created_by: elastic
+                    description: Unusual rundll32.exe network connection
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    id: 93808cae-b05b-4dc9-8479-73574b50f8b1
+                    immutable: false
+                    interval: 5m
+                    language: eql
+                    max_signals: 100
+                    name: rundll32.exe network connection
+                    query: sequence by process.entity_id with maxspan=2h [process where event.type in ("start", "process_started") and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe") and ((process.args == "rundll32.exe" and process.args_count == 1) or (process.args != "rundll32.exe" and process.args_count == 0))] [network where event.type == "connection" and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe")]
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: event.type
+                        type: keyword
+                      - ecs: true
+                        name: process.args
+                        type: keyword
+                      - ecs: true
+                        name: process.args_count
+                        type: long
+                      - ecs: true
+                        name: process.entity_id
+                        type: keyword
+                      - ecs: true
+                        name: process.name
+                        type: keyword
+                      - ecs: true
+                        name: process.pe.original_file_name
+                        type: keyword
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: eql-outbound-rundll32-connections
+                    setup: ''
+                    severity: low
+                    severity_mapping: []
+                    tags:
+                      - EQL
+                      - Windows
+                      - rundll32.exe
+                    threat: []
+                    throttle: no_actions
+                    to: now
+                    type: eql
+                    updated_at: '2020-10-05T09:06:16.403Z'
+                    updated_by: elastic
+                    version: 1
+                example5:
+                  description: Example response for an indicator match rule
+                  summary: Indicator match rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    created_by: elastic
+                    description: Checks for bad IP addresses listed in the ip-threat-list index
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    id: d5daa13f-81fb-4b13-be2f-31011e1d9ae1
+                    immutable: false
+                    index:
+                      - packetbeat-*
+                    interval: 5m
+                    language: kuery
+                    max_signals: 100
+                    name: Bad IP threat match
+                    query: destination.ip:* or host.ip:*
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: destination.ip
+                        type: ip
+                      - ecs: true
+                        name: destination.port
+                        type: long
+                      - ecs: true
+                        name: host.ip
+                        type: ip
+                    risk_score: 50
+                    risk_score_mapping: []
+                    rule_id: 608501e4-c768-4f64-9326-cec55b5d439b
+                    setup: ''
+                    severity: medium
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    threat_index:
+                      - ip-threat-list
+                    threat_mapping:
+                      - entries:
+                          - field: destination.ip
+                            type: mapping
+                            value: destination.ip
+                          - field: destination.port
+                            type: mapping
+                            value: destination.port
+                      - entries:
+                          - field: source.ip
+                            type: mapping
+                            value: host.ip
+                    threat_query: '*:*'
+                    to: now
+                    type: threat_match
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    updated_by: elastic
+                    version: 1
+                example6:
+                  description: Example response for a new terms rule
+                  summary: New terms rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    created_by: elastic
+                    description: Detects a user associated with a new IP address
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    history_window_start: now-30d
+                    id: eb7225c0-566b-11ee-8b4f-bbf3afdeb9f4
+                    immutable: false
+                    index:
+                      - auditbeat*
+                    interval: 5m
+                    language: kuery
+                    max_signals: 100
+                    name: New User IP Detected
+                    new_terms_fields:
+                      - user.id
+                      - source.ip
+                    query: '*'
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: user.id
+                        type: keyword
+                      - ecs: true
+                        name: source.ip
+                        type: ip
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: c6f5d0bc-7be9-47d4-b2f3-073d22641e30
+                    setup: ''
+                    severity: medium
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    to: now
+                    type: new_terms
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    updated_by: elastic
+                    version: 1
+                example7:
+                  description: Example response for an Esql rule
+                  summary: Esql rule response
+                  value:
+                    actions: []
+                    author: []
+                    created_at: '2023-10-18T10:55:14.269Z'
+                    created_by: elastic
+                    description: Find Excel events
+                    enabled: false
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-360s
+                    id: d0f20490-6da4-11ee-b85e-09e9b661f2e2
+                    immutable: false
+                    interval: 5m
+                    language: esql
+                    max_signals: 100
+                    name: Find Excel events
+                    output_index: ''
+                    query: from auditbeat-8.10.2 METADATA _id | where process.parent.name == "EXCEL.EXE"
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    revision: 0
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: e4b53a89-debd-4a0d-a3e3-20606952e589
+                    setup: ''
+                    severity: low
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    to: now
+                    type: esql
+                    updated_at: '2023-10-18T10:55:14.269Z'
+                    updated_by: elastic
+                    version: 1
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
@@ -8401,19 +9286,168 @@ paths:
     put:
       description: |
         Update a detection rule using the `rule_id` or `id` field. The original rule is replaced, and all unspecified fields are deleted.
-        > info
-        > You cannot modify the `id` or `rule_id` values.
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       operationId: UpdateRule
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
+            examples:
+              example1:
+                summary: Update query rule
+                value:
+                  description: A new description
+                  id: 14b7b513-3d8d-4b22-b7da-a7ae632f7e76
+                  name: A new name for the rule
+                  risk_score: 22
+                  severity: medium
+                  type: query
+              example2:
+                summary: Update EQL rule
+                value:
+                  description: eql rule test
+                  id: 9b684efb-acf9-4323-9bff-8335b3867d14
+                  index:
+                    - apm-*-transaction*
+                  language: eql
+                  name: New name for EQL rule
+                  query: process where process.name == "regsvr32.exe"
+                  risk_score: 21
+                  severity: low
+                  type: eql
+              example3:
+                summary: Update threshold rule
+                value:
+                  description: Description of threat rule test
+                  id: 005d2c4f-51ca-493d-a2bd-20ef076339b1
+                  language: kuery
+                  name: New name for threat rule
+                  query: 'agent.version : * and agent.id : "243d9b4f-ca01-4311-8e5c-9abbee91afd8"'
+                  risk_score: 21
+                  severity: low
+                  tags:
+                    - new_tag
+                  threshold:
+                    cardinality: []
+                    field: []
+                    value: 400
+                  type: threshold
+              example4:
+                summary: Update new terms rule
+                value:
+                  description: New description
+                  history_window_start: now-7d
+                  id: 569aac91-40dc-4807-a8ae-a2c8698089c4
+                  interval: 5m
+                  name: New terms rule name
+                  new_terms_fields:
+                    - Endpoint.policy.applied.artifacts.global.identifiers.name
+                  query: 'agent.version : "9.1.0"'
+                  risk_score: 21
+                  severity: low
+                  type: new_terms
+              example5:
+                summary: Update esql rule
+                value:
+                  description: New description for esql rule
+                  id: 0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd
+                  language: esql
+                  name: New name for esql rule
+                  query: |
+                    FROM logs*
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp) /* MIN(dateField) finds the earliest timestamp in the dataset. */
+                    | EVAL event_rate = count / DATE_DIFF("seconds", min_timestamp, NOW()) /* Calculates the event rate by dividing the total count of events by the time difference (in seconds) between the earliest event and the current time. */
+                    | KEEP event_rate
+                  risk_score: 21
+                  severity: low
+                  type: esql
+              example6:
+                summary: Update indicator match rule
+                value:
+                  description: New description
+                  id: 462f1986-10fe-40a3-a22c-2b1c9c4c48fd
+                  name: New name for Indicator Match rule
+                  query: source.ip:* or destination.ip:*\n
+                  risk_score: 99
+                  severity: critical
+                  threat_index:
+                    - filebeat-*
+                    - logs-ti_*
+                  threat_mapping:
+                    - entries:
+                        - field: source.ip
+                          type: mapping
+                          value: threat.indicator.ip
+                    - entries:
+                        - field: destination.ip
+                          type: mapping
+                          value: threat.indicator.ip
+                  threat_query: '@timestamp >= "now-30d/d" and event.module:(threatintel or ti_*) and threat.indicator.ip:* and not labels.is_ioc_transform_source:"true"'
+                  type: threat_match
+              example7:
+                summary: Update machine learning rule
+                value:
+                  anomaly_threshold: 50
+                  description: New description of ml rule
+                  id: 60b13926-289b-41b1-a537-197ef1fa5059
+                  machine_learning_job_id:
+                    - auth_high_count_logon_events
+                  name: New name of ml rule
+                  risk_score: 21
+                  severity: low
+                  type: machine_learning
             schema:
               $ref: '#/components/schemas/Security_Detections_API_RuleUpdateProps'
+        description: |
+          > info
+          > All unspecified fields are deleted. You cannot modify the `id` or `rule_id` values.
         required: true
       responses:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Updated description for the rule.
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query: null
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: Updated Rule Name
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                    required_fields:
+                      - name: process.parent.name
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 2
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
@@ -8422,10 +9456,22 @@ paths:
         - Security Detections API
   /api/detection_engine/rules/_bulk_action:
     post:
-      description: Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
+      description: |
+        Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
+        > warn
+        > When used with  [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       operationId: PerformRulesBulkAction
       parameters:
-        - description: Enables dry run mode for the request call.
+        - description: |
+            Enables dry run mode for the request call.
+
+            Enable dry run mode to verify that bulk actions can be applied to specified rules. Certain rules, such as prebuilt Elastic rules on a Basic subscription, can’t be edited and will return errors in the request response. Error details will contain an explanation, the rule name and/or ID, and additional troubleshooting information.
+
+            To enable dry run mode on a request, add the query parameter `dry_run=true` to the end of the request URL. Rules specified in the request will be temporarily updated. These updates won’t be written to Elasticsearch.
+            > info
+            > Dry run mode is not supported for the `export` bulk action. A 400 error will be returned in the request response.
           in: query
           name: dry_run
           required: false
@@ -8434,6 +9480,89 @@ paths:
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:
+            examples:
+              example1:
+                description: The following request activates all rules with the test tag
+                summary: Enable all rules with the test tag
+                value:
+                  action: enable
+                  query: 'alert.attributes.tags: "test"'
+              example2:
+                description: The following request enables the rule with the specified ID.
+                summary: Enable a specific rule by ID
+                value:
+                  action: enable
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+              example3:
+                description: The following request disables the rule with the specified ID.
+                summary: Disable a specific rule by ID
+                value:
+                  action: disable
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+              example4:
+                description: The following request adds tags tag-1 and tag-2 to the rules that have the IDs sent in the payload
+                summary: Add tags to rules
+                value:
+                  action: edit
+                  edit:
+                    - type: add_tags
+                      value:
+                        - tag-1
+                        - tag-2
+                  ids:
+                    - 8bc7dad0-9320-11ec-9265-8b772383a08d
+                    - 8e5c1a40-9320-11ec-9265-8b772383a08d
+              example5:
+                description: The following request will validate that the add_index_patterns bulk action can be successfully applied to three rules. The dry_run parameter is specified in query parameters, e.g. POST api/detection_engine/rules/_bulk_action?dry_run=true
+                summary: Dry run - Validate add_index_patterns bulk action
+                value:
+                  action: edit
+                  edit:
+                    - type: add_index_patterns
+                      value:
+                        - test-*
+                  ids:
+                    - 81aa0480-06af-11ed-94fb-dd1a0597d8d2
+                    - dc015d10-0831-11ed-ac8b-05a222bd8d4a
+                    - de8f5af0-0831-11ed-ac8b-05a222bd8d4a
+              example6:
+                description: The following request duplicates rules with the specified IDs, including exceptions but not expired exceptions.
+                summary: Duplicate rules with specific IDs
+                value:
+                  action: duplicate
+                  duplicate:
+                    include_exceptions: true
+                    include_expired_exceptions: false
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                    - 461a4c22-416e-4009-a9a7-cf79656454bf
+              example7:
+                description: The following request deletes the rule with the specified ID.
+                summary: Delete a specific rule by ID
+                value:
+                  action: delete
+                  ids:
+                    - cf4abfd1-7c37-4519-ab0f-5ea5c75fac60
+              example8:
+                description: The following request runs the rule with the specified ID within the given date range.
+                summary: Run a specific rule by ID
+                value:
+                  action: run
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                  run:
+                    end_date: '2025-03-10T23:59:59.999Z'
+                    start_date: '2025-03-01T00:00:00.000Z'
+              example9:
+                description: The following request exports the rules with the specified IDs.
+                summary: Export specific rules by ID
+                value:
+                  action: export
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                    - 13199674-aff1-418a-9e93-04f585fe36d1
             schema:
               oneOf:
                 - $ref: '#/components/schemas/Security_Detections_API_BulkDeleteRules'
@@ -8447,6 +9576,214 @@ paths:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
+              examples:
+                example1:
+                  description: In this response one rule was updated and one was skipped. Objects returned in attributes.results.skipped will only include rules' id, name, and skip_reason.
+                  summary: Successful response
+                  value:
+                    attributes:
+                      results:
+                        created: []
+                        deleted: []
+                        skipped:
+                          - id: 51658332-a15e-4c9e-912a-67214e2e2359
+                            name: Skipped rule
+                            skip_reason: RULE_NOT_MODIFIED
+                        updated:
+                          - anomaly_threshold: 50
+                            author:
+                              - Elastic
+                            created_at: '2022-02-21T14:14:13.801Z'
+                            created_by: elastic
+                            description: A machine learning job detected unusually large numbers of DNS queries for a single top-level DNS domain, which is often used for DNS tunneling. DNS tunneling can be used for command-and-control, persistence, or data exfiltration activity. For example, dnscat tends to generate many DNS questions for a top-level domain as it uses the DNS protocol to tunnel data.
+                            enabled: true
+                            exceptions_list: []
+                            execution_summary:
+                              last_execution:
+                                date: '2022-03-23T16:06:12.787Z'
+                                message: This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.
+                                metrics:
+                                  execution_gap_duration_s: 0
+                                  total_indexing_duration_ms: 15
+                                  total_search_duration_ms: 135
+                                status: partial failure
+                                status_order: 20
+                            false_positives:
+                              - DNS domains that use large numbers of child domains, such as software or content distribution networks, can trigger this alert and such parent domains can be excluded.
+                            from: now-45m
+                            id: 8bc7dad0-9320-11ec-9265-8b772383a08d
+                            immutable: false
+                            interval: 15m
+                            license: Elastic License v2
+                            machine_learning_job_id:
+                              - packetbeat_dns_tunneling
+                            max_signals: 100
+                            name: DNS Tunneling [Duplicate]
+                            references:
+                              - https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html
+                            related_integrations: []
+                            required_fields: []
+                            risk_score: 21
+                            risk_score_mapping: []
+                            rule_id: 7289bf08-4e91-4c70-bf01-e04c4c5d7756
+                            setup: ''
+                            severity: low
+                            severity_mapping: []
+                            tags:
+                              - Elastic
+                              - Network
+                              - Threat Detection
+                              - ML
+                            threat: []
+                            to: now
+                            type: machine_learning
+                            updated_at: '2022-02-21T17:05:50.883Z'
+                            updated_by: elastic
+                            version: 6
+                      summary:
+                        failed: 0
+                        skipped: 1
+                        succeeded: 1
+                        total: 2
+                    rules_count: 1
+                    success: true
+                example2:
+                  description: If processing of any rule fails, a partial error outputs the ID and/or name of the affected rule and the corresponding error, as well as successfully processed rules (in the same format as a successful 200 request).
+                  summary: Partial failure
+                  value:
+                    value:
+                      attributes:
+                        errors:
+                          - message: Index patterns can't be added. Machine learning rule doesn't have index patterns property
+                            rules:
+                              - id: 8bc7dad0-9320-11ec-9265-8b772383a08d
+                                name: DNS Tunneling [Duplicate]
+                            status_code: 500
+                        results:
+                          created: []
+                          deleted: []
+                          skipped: []
+                          updated:
+                            - actions: []
+                              author:
+                                - Elastic
+                              created_at: '2022-02-21T14:14:17.883Z'
+                              created_by: elastic
+                              description: Generates a detection alert for each external alert written to the configured indices. Enabling this rule allows you to immediately begin investigating external alerts in the app.
+                              enabled: true
+                              exceptions_list: []
+                              execution_summary:
+                                last_execution:
+                                  date: '2022-03-23T16:06:12.787Z'
+                                  message: This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.
+                                  metrics:
+                                    execution_gap_duration_s: 0
+                                    total_indexing_duration_ms: 15
+                                    total_search_duration_ms: 135
+                                  status: partial failure
+                                  status_order: 20
+                              false_positives: []
+                              from: now-6m
+                              id: 8e5c1a40-9320-11ec-9265-8b772383a08d
+                              immutable: false
+                              index:
+                                - apm-*-transaction*
+                                - traces-apm*
+                                - auditbeat-*
+                                - filebeat-*
+                                - logs-*
+                                - packetbeat-*
+                                - winlogbeat-*
+                                - added-by-id-*
+                              interval: 5m
+                              language: kuery
+                              license: Elastic License v2
+                              max_signals: 10000
+                              name: External Alerts [Duplicate]
+                              query: |
+                                event.kind:alert and not event.module:(endgame or endpoint)
+                              references: []
+                              related_integrations: []
+                              required_fields: []
+                              risk_score: 47
+                              risk_score_mapping:
+                                - field: event.risk_score
+                                  operator: equals
+                                  value: ''
+                              rule_id: 941faf98-0cdc-4569-b16d-4af962914d61
+                              rule_name_override: message
+                              setup: ''
+                              severity: medium
+                              severity_mapping:
+                                - field: event.severity
+                                  operator: equals
+                                  severity: low
+                                  value: '21'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: medium
+                                  value: '47'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: high
+                                  value: '73'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: critical
+                                  value: '99'
+                              tags:
+                                - Elastic
+                                - Network
+                                - Windows
+                                - APM
+                                - macOS
+                                - Linux
+                              threat: []
+                              timestamp_override: event.ingested
+                              to: now
+                              type: query
+                              updated_at: '2022-02-21T16:56:22.818Z'
+                              updated_by: elastic
+                              version: 5
+                        summary:
+                          failed: 1
+                          skipped: 0
+                          succeeded: 1
+                          total: 2
+                      message: Bulk edit partially failed
+                      rules_count: 2
+                      status_code: 500
+                      success: false
+                example3:
+                  description: The attributes.errors section of the response shows that two rules failed to update and one succeeded. The same results would be returned if you ran the request without dry run mode enabled. Notice that there are no arrays in attributes.results. In dry run mode, rule updates are not applied and saved to Elasticsearch, so the endpoint wouldn’t return results for rules that have been updated, created, or deleted.
+                  summary: Dry run
+                  value:
+                    attributes:
+                      errors:
+                        - err_code: IMMUTABLE
+                          message: Elastic rule can't be edited
+                          rules:
+                            - id: 81aa0480-06af-11ed-94fb-dd1a0597d8d2
+                              name: Unusual AWS Command for a User
+                          status_code: 500
+                        - err_code: MACHINE_LEARNING_INDEX_PATTERN
+                          message: Machine learning rule doesn't have index patterns
+                          rules:
+                            - id: dc015d10-0831-11ed-ac8b-05a222bd8d4a
+                              name: Suspicious Powershell Script [Duplicate]
+                          status_code: 500
+                      results:
+                        created: []
+                        deleted: []
+                        skipped: []
+                        updated: []
+                      summary:
+                        failed: 2
+                        skipped: 0
+                        succeeded: 1
+                        total: 3
+                    message: Bulk edit partially failed
+                    status_code: 500
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/Security_Detections_API_BulkEditActionResponse'
@@ -8462,7 +9799,11 @@ paths:
         - Actions
         - Exception lists
         > info
-        > You cannot export prebuilt rules.
+        > Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+        > You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+        > Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
       operationId: ExportRules
       parameters:
         - description: Determines whether a summary of the exported rules is returned.
@@ -8472,7 +9813,10 @@ paths:
           schema:
             default: false
             type: boolean
-        - description: File name for saving the exported rules.
+        - description: |
+            File name for saving the exported rules.
+            > info
+            > When using cURL to export rules to a file, use the -O and -J options to save the rules to the file name specified in the URL.
           in: query
           name: file_name
           required: false
@@ -8504,13 +9848,30 @@ paths:
           content:
             application/ndjson; Elastic-Api-Version=2023-10-31:
               schema:
-                description: An `.ndjson` file containing the returned rules.
+                description: |
+                  An `.ndjson` file containing the returned rules.
+
+                  Each line in the file represents an object (a rule, exception list parent container, or exception list item), and the last line includes a summary of what was exported.
                 format: binary
                 type: string
           description: Indicates a successful call.
       summary: Export detection rules
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST "localhost:5601/api/detection_engine/rules/_export?exclude_export_details=true&file_name=exported_rules.ndjson" -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d'
+            {
+              "objects": [
+                {
+                  "rule_id":"343580b5-c811-447c-8d2d-2ccf052c6900"
+                },
+                {
+                  "rule_id":"2938c9fa-53eb-4c04-b79c-33cbf041b18d"
+                }
+              ]
+            }
   /api/detection_engine/rules/_find:
     get:
       description: Retrieve a paginated list of detection rules. By default, the first page is returned, with 20 results per page.
@@ -8523,7 +9884,18 @@ paths:
             items:
               type: string
             type: array
-        - description: Search query
+        - description: |
+            Search query
+
+            Filters the returned results according to the value of the specified field, using the alert.attributes.<field name>:<field value> syntax, where <field name> can be:
+            - name
+            - enabled
+            - tags
+            - createdBy
+            - interval
+            - updatedBy
+            > info
+            > Even though the JSON rule object uses created_by and updated_by fields, you must use createdBy and updatedBy fields in the filter.
           in: query
           name: filter
           required: false
@@ -8573,6 +9945,73 @@ paths:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
+              examples:
+                example1:
+                  value:
+                    data:
+                      - created_at: '2020-02-02T10:05:19.613Z'
+                        created_by: elastic
+                        description: Identifies a PowerShell process launched by either cscript.exe or wscript.exe. Observing Windows scripting processes executing a PowerShell script, may be indicative of malicious activity.
+                        enabled: false
+                        execution_summary:
+                          last_execution:
+                            date: '2022-03-23T16:06:12.787Z'
+                            message: This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.
+                            metrics:
+                              execution_gap_duration_s: 0
+                              total_indexing_duration_ms: 15
+                              total_search_duration_ms: 135
+                            status: partial failure
+                            status_order: 20
+                        false_positives: []
+                        from: now-6m
+                        id: 89761517-fdb0-4223-b67b-7621acc48f9e
+                        immutable: true
+                        index:
+                          - winlogbeat-*
+                        interval: 5m
+                        language: kuery
+                        max_signals: 33
+                        name: Windows Script Executing PowerShell
+                        query: 'event.action:"Process Create (rule: ProcessCreate)" and process.parent.name:("wscript.exe" or "cscript.exe") and process.name:"powershell.exe"'
+                        references: []
+                        related_integrations:
+                          - package: o365
+                            version: ^2.3.2
+                        required_fields:
+                          - ecs: true
+                            name: event.action
+                            type: keyword
+                          - ecs: true
+                            name: process.name
+                            type: keyword
+                          - ecs: true
+                            name: process.parent.name
+                            type: keyword
+                        risk_score: 21
+                        rule_id: f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc
+                        setup: ''
+                        severity: low
+                        tags:
+                          - Elastic
+                          - Windows
+                        threat:
+                          - framework: MITRE ATT&CK
+                            tactic:
+                              id: TA0002
+                              name: Execution
+                              reference: https://attack.mitre.org/tactics/TA0002/
+                            technique:
+                              - id: T1193
+                                name: Spearphishing Attachment
+                                reference: https://attack.mitre.org/techniques/T1193/
+                        to: now
+                        type: query
+                        updated_at: '2020-02-02T10:05:19.830Z'
+                        updated_by: elastic
+                    page: 1
+                    perPage: 5
+                    total: 4
               schema:
                 type: object
                 properties:
@@ -8591,16 +10030,36 @@ paths:
                   - perPage
                   - total
                   - data
-          description: Successful response
+          description: |
+            Successful response
+            > info
+            > These fields are under development and their usage or schema may change: execution_summary.
       summary: List all detection rules
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X GET "localhost:5601/api/detection_engine/rules/_find?page=1&per_page=5&sort_field=enabled&sort_order=asc&filter=alert.attributes.name:windows" -H 'kbn-xsrf: true'
   /api/detection_engine/rules/_import:
     post:
       description: |
         Import detection rules from an `.ndjson` file, including actions and exception lists. The request must include:
         - The `Content-Type: multipart/form-data` HTTP header.
         - A link to the `.ndjson` file containing the rules.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+        > info
+        > To import rules with actions, you need at least Read privileges for the Action and Connectors feature. To overwrite or add new connectors, you need All privileges for the Actions and Connectors feature. To import rules without actions, you don’t need Actions and Connectors privileges. Refer to [Enable and access detections](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui) for more information.
+
+        > info
+        > Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+        > You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+        > Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
       operationId: ImportRules
       parameters:
         - description: Determines whether existing rules with the same `rule_id` are overwritten.
@@ -8610,7 +10069,7 @@ paths:
           schema:
             default: false
             type: boolean
-        - description: Determines whether existing exception lists with the same `list_id` are overwritten.
+        - description: Determines whether existing exception lists with the same `list_id` are overwritten. Both the exception list container and its items are overwritten.
           in: query
           name: overwrite_exceptions
           required: false
@@ -8646,6 +10105,17 @@ paths:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
+              examples:
+                example1:
+                  summary: Import rules with success
+                  value:
+                    errors: []
+                    exceptions_errors: []
+                    exceptions_success: true
+                    exceptions_success_count: 0
+                    rules_count: 1
+                    success: true
+                    success_count: 1
               schema:
                 additionalProperties: false
                 type: object
@@ -8700,6 +10170,13 @@ paths:
       summary: Import detection rules
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST "<KibanaURL>/api/detection_engine/rules/_import"
+            -u <username>:<password> -H 'kbn-xsrf: true'
+            -H 'Content-Type: multipart/form-data'
+            --form "file=@<link to file>"
   /api/detection_engine/rules/{id}/exceptions:
     post:
       description: Create exception items that apply to a single detection rule.
@@ -9057,6 +10534,17 @@ paths:
         '200':
           content:
             application/json; Elastic-Api-Version=2023-10-31:
+              examples:
+                example1:
+                  value:
+                    - zeek
+                    - suricata
+                    - windows
+                    - linux
+                    - network
+                    - initial access
+                    - remote access
+                    - phishing
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
           description: Indicates a successful call
@@ -46959,6 +48447,7 @@ components:
         - in-progress
       type: string
     Security_Detections_API_AlertSuppression:
+      description: Defines alert suppression configuration.
       type: object
       properties:
         duration:
@@ -46981,6 +48470,7 @@ components:
         - value
         - unit
     Security_Detections_API_AlertSuppressionDurationUnit:
+      description: Time unit
       enum:
         - s
         - m
@@ -47008,11 +48498,14 @@ components:
         $ref: '#/components/schemas/Security_Detections_API_AlertTag'
       type: array
     Security_Detections_API_AnomalyThreshold:
-      description: Anomaly threshold
+      description: Anomaly score threshold above which the rule creates an alert. Valid values are from 0 to 100.
       minimum: 0
       type: integer
     Security_Detections_API_BuildingBlockType:
-      description: Determines if the rule acts as a building block. By default, building-block alerts are not displayed in the UI. These rules are used as a foundation for other rules that do generate alerts. Its value must be default.
+      description: |
+        Determines if the rule acts as a building block. If yes, the value must be `default`.
+        By default, building-block alerts are not displayed in the UI. These rules are used as a foundation for other rules that do generate alerts.
+        For more information, refer to [About building block rules](https://www.elastic.co/guide/en/security/current/building-block-rule.html).
       type: string
     Security_Detections_API_BulkActionEditPayload:
       anyOf:
@@ -47164,13 +48657,13 @@ components:
             - delete
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -47182,13 +48675,13 @@ components:
             - disable
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -47200,6 +48693,7 @@ components:
             - duplicate
           type: string
         duplicate:
+          description: Duplicate object that describes applying an update action.
           type: object
           properties:
             include_exceptions:
@@ -47212,13 +48706,13 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -47274,6 +48768,7 @@ components:
         - deleted
         - skipped
     Security_Detections_API_BulkEditActionSummary:
+      description: A rule can only be skipped when the bulk action to be performed on it results in nothing being done. For example, if the `edit` action is used to add a tag to a rule that already has that tag, or to delete an index pattern that is not specified in a rule. Objects returned in `attributes.results.skipped` will only include rules' `id`, `name`, and `skip_reason`.
       type: object
       properties:
         failed:
@@ -47303,13 +48798,13 @@ components:
           minItems: 1
           type: array
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -47326,13 +48821,13 @@ components:
             - enable
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -47346,13 +48841,13 @@ components:
             - export
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -47364,15 +48859,16 @@ components:
             - run
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
         run:
+          description: Object that describes applying a manual rule run action.
           type: object
           properties:
             end_date:
@@ -47414,6 +48910,7 @@ components:
               - items:
                   type: string
                 type: array
+      description: 'Map Osquery results columns or static values to Elastic Common Schema (ECS) fields. Example: "ecs_mapping": {"process.pid": {"field": "pid"}}'
       type: object
     Security_Detections_API_EndpointResponseAction:
       type: object
@@ -47458,7 +48955,6 @@ components:
           description: Query language to use
         query:
           $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
-          description: EQL query to execute
         type:
           description: Rule type
           enum:
@@ -47473,6 +48969,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -47521,6 +49018,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -47592,6 +49093,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -47640,6 +49142,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -47694,7 +49200,6 @@ components:
               description: Query language to use
             query:
               $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
-              description: EQL query to execute
             type:
               description: Rule type
               enum:
@@ -47706,6 +49211,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -47756,6 +49262,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -47805,6 +49315,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -47855,6 +49366,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -47936,6 +49451,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -47984,6 +49500,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -48055,6 +49575,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -48103,6 +49624,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -48158,6 +49683,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -48207,12 +49733,15 @@ components:
               $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             query:
               $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
-              description: ESQL query to execute
             references:
               $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -48265,7 +49794,6 @@ components:
           $ref: '#/components/schemas/Security_Detections_API_EsqlQueryLanguage'
         query:
           $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
-          description: ESQL query to execute
         type:
           description: Rule type
           enum:
@@ -48284,6 +49812,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -48334,6 +49863,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -48423,8 +49956,15 @@ components:
         - updatedAt
       type: string
     Security_Detections_API_HistoryWindowStart:
-      $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
+      description: Start date to use when checking if a term has been seen before. Supports relative dates – for example, now-30d will search the last 30 days of data when checking if a term is new. We do not recommend using absolute dates, which can cause issues with rule performance due to querying increasing amounts of data over time.
+      format: nonempty
+      minLength: 1
+      type: string
     Security_Detections_API_IndexPatternArray:
+      description: |
+        Indices on which the rule functions. Defaults to the Security Solution indices defined on the Kibana Advanced Settings page (Kibana → Stack Management → Advanced Settings → `securitySolution:defaultIndex`).
+        > info
+        > This field is not supported for ES|QL rules.
       items:
         type: string
       type: array
@@ -48442,17 +49982,6 @@ components:
       description: |
         Schema for fields relating to investigation fields. These are user defined fields we use to highlight
         in various features in the UI such as alert details flyout and exceptions auto-population from alert.
-        Added in PR #163235
-        Right now we only have a single field but anticipate adding more related fields to store various
-        configuration states such as `override` - where a user might say if they want only these fields to
-        display, or if they want these fields + the fields we select. When expanding this field, it may look
-        something like:
-        ```typescript
-        const investigationFields = z.object({
-          field_names: NonEmptyArray(NonEmptyString),
-          override: z.boolean().optional(),
-        });
-        ```
       type: object
       properties:
         field_names:
@@ -48469,7 +49998,7 @@ components:
       description: Determines whether an external/prebuilt rule has been customized by the user (i.e. any of its fields have been modified and diverged from the base value).
       type: boolean
     Security_Detections_API_IsRuleEnabled:
-      description: Determines whether the rule is enabled.
+      description: Determines whether the rule is enabled. Defaults to true.
       type: boolean
     Security_Detections_API_IsRuleImmutable:
       deprecated: true
@@ -48484,7 +50013,7 @@ components:
         - lucene
       type: string
     Security_Detections_API_MachineLearningJobId:
-      description: Machine learning job ID
+      description: Machine learning job ID(s) the rule monitors for anomaly scores.
       oneOf:
         - type: string
         - items:
@@ -48496,6 +50025,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -48544,6 +50074,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -48615,6 +50149,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -48663,6 +50198,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -48732,6 +50271,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -48782,6 +50322,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -48847,6 +50391,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -48897,6 +50442,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -48943,9 +50492,15 @@ components:
             - severity
         - $ref: '#/components/schemas/Security_Detections_API_MachineLearningRuleCreateFields'
     Security_Detections_API_MaxSignals:
+      default: 100
+      description: |
+        Maximum number of alerts the rule can create during a single run (the rule’s Max alerts per run [advanced setting](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#rule-ui-advanced-params) value).
+        > info
+        > This setting can be superseded by the [Kibana configuration setting](https://www.elastic.co/guide/en/kibana/current/alert-action-settings-kb.html#alert-settings) `xpack.alerting.rules.run.alerts.max`, which determines the maximum alerts generated by any rule in the Kibana alerting framework. For example, if `xpack.alerting.rules.run.alerts.max` is set to 1000, the rule can generate no more than 1000 alerts even if `max_signals` is set higher.
       minimum: 1
       type: integer
     Security_Detections_API_NewTermsFields:
+      description: Fields to monitor for new values.
       items:
         type: string
       maxItems: 3
@@ -48956,6 +50511,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -49004,6 +50560,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -49076,6 +50636,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -49124,6 +50685,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -49207,6 +50772,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -49257,6 +50823,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -49331,6 +50901,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -49381,6 +50952,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -49471,16 +51046,20 @@ components:
         ecs_mapping:
           $ref: '#/components/schemas/Security_Detections_API_EcsMapping'
         pack_id:
+          description: 'To specify a query pack, use the packId field. Example: "packId": "processes_elastic"'
           type: string
         queries:
           items:
             $ref: '#/components/schemas/Security_Detections_API_OsqueryQuery'
           type: array
         query:
+          description: 'To run a single query, use the query field and enter a SQL query. Example: "query": "SELECT * FROM processes;"'
           type: string
         saved_query_id:
+          description: 'To run a saved query, use the saved_query_id field and specify the saved query ID. Example: "saved_query_id": "processes_elastic"'
           type: string
         timeout:
+          description: 'A timeout period, in seconds, after which the query will stop running. Overwriting the default timeout allows you to support queries that require more time to complete. The default and minimum supported value is 60. The maximum supported value is 900. Example: "timeout": 120.'
           type: number
     Security_Detections_API_OsqueryQuery:
       type: object
@@ -49534,11 +51113,13 @@ components:
       type: object
       properties:
         command:
+          description: 'To run an endpoint response action, specify a value for the command field. Example: "command": "isolate"'
           enum:
             - kill-process
             - suspend-process
           type: string
         comment:
+          description: 'Add a note that explains or describes the action. You can find your comment in the response actions history log. Example: "comment": "Check processes"'
           type: string
         config:
           type: object
@@ -49560,6 +51141,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -49608,6 +51190,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -49680,6 +51266,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -49728,6 +51315,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -49809,6 +51400,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -49859,6 +51451,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -49927,6 +51523,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -49977,6 +51574,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -50041,19 +51642,10 @@ components:
         There are Fleet packages like `windows` that contain only one integration; in this case,
         `integration` should be unspecified. There are also packages like `aws` and `azure` that contain
         several integrations; in this case, `integration` should be specified.
-
-        @example
-        const x: RelatedIntegration = {
-          package: 'windows',
-          version: '1.5.x',
-        };
-
-        @example
-        const x: RelatedIntegration = {
-          package: 'azure',
-          version: '~1.1.6',
-          integration: 'activitylogs',
-        };
+      example:
+        integration: activitylogs
+        package: azure
+        version: ~1.1.6
       type: object
       properties:
         integration:
@@ -50095,14 +51687,18 @@ components:
       type: object
       properties:
         ecs:
-          description: Whether the field is an ECS field
+          description: Indicates whether the field is ECS-compliant. This property is only present in responses. Its value is computed based on field’s name and type.
           type: boolean
         name:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Name of an Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
         type:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Type of the Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
       required:
         - name
         - type
@@ -50116,11 +51712,15 @@ components:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Name of an Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
         type:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
-          description: Type of an Elasticsearch field
+          description: Type of the Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
       required:
         - name
         - type
@@ -50168,7 +51768,12 @@ components:
         - related_integrations
         - required_fields
     Security_Detections_API_RiskScore:
-      description: Risk score (0 to 100)
+      description: |
+        A numerical representation of the alert's severity from 0 to 100, where:
+        * `0` - `21` represents low severity
+        * `22` - `47` represents medium severity
+        * `48` - `73` represents high severity
+        * `74` - `100` represents critical severity
       maximum: 100
       minimum: 0
       type: integer
@@ -50178,6 +51783,7 @@ components:
         type: object
         properties:
           field:
+            description: Source event field used to override the default `risk_score`.
             type: string
           operator:
             enum:
@@ -50196,7 +51802,26 @@ components:
       type: object
       properties:
         action_type_id:
-          description: The action type used for sending notifications.
+          description: |
+            The action type used for sending notifications, can be:
+
+              - `.slack`
+              - `.slack_api`
+              - `.email`
+              - `.index`
+              - `.pagerduty`
+              - `.swimlane`
+              - `.webhook`
+              - `.servicenow`
+              - `.servicenow-itom`
+              - `.servicenow-sir`
+              - `.jira`
+              - `.resilient`
+              - `.opsgenie`
+              - `.teams`
+              - `.torq`
+              - `.tines`
+              - `.d3security`
           type: string
         alerts_filter:
           $ref: '#/components/schemas/Security_Detections_API_RuleActionAlertsFilter'
@@ -50216,6 +51841,19 @@ components:
         - params
     Security_Detections_API_RuleActionAlertsFilter:
       additionalProperties: true
+      description: |
+        Object containing an action’s conditional filters.
+
+        - `timeframe` (object, optional): Object containing the time frame for when this action can be run.
+            - `days` (array of integers, required): List of days of the week on which this action will be run. Days of the week are expressed as numbers between `1-7`, where `1` is Monday and `7` is Sunday. To select all days of the week, enter an empty array.
+            - `hours` (object, required): The hours of the day during which this action will run. Hours of the day are expressed as two strings in the format `hh:mm` in `24` hour time. A start of `00:00` and an end of `24:00` means the action can run all day.
+                - start (string, required): Start time in `hh:mm` format.
+                - end (string, required): End time in `hh:mm` format.
+            - `timezone` (string, required): An ISO timezone name, such as `Europe/Madrid` or `America/New_York`. Specific offsets such as `UTC` or `UTC+1` will also work, but lack built-in DST.
+        - `query` (object, optional): Object containing a query filter which gets applied to an action and determines whether the action should run.
+            - `kql` (string, required): A KQL string.
+            - `filters` (array of objects, required): Array of filter objects, as defined in the `kbn-es-query` package.
+              
       type: object
     Security_Detections_API_RuleActionFrequency:
       description: The action frequency defines when the action runs (for example, only on rule execution or at specific time intervals).
@@ -50240,7 +51878,7 @@ components:
       description: The connector ID.
       type: string
     Security_Detections_API_RuleActionNotifyWhen:
-      description: 'The condition for throttling the notification: `onActionGroupChange`, `onActiveAlert`,  or `onThrottleInterval`'
+      description: Defines how often rules run actions.
       enum:
         - onActiveAlert
         - onThrottleInterval
@@ -50248,7 +51886,34 @@ components:
       type: string
     Security_Detections_API_RuleActionParams:
       additionalProperties: true
-      description: Object containing the allowed connector fields, which varies according to the connector type.
+      description: |
+        Object containing the allowed connector fields, which varies according to the connector type.
+
+        For Slack:
+
+          - `message` (string, required): The notification message.
+
+        For email:
+
+          - `to`, `cc`, `bcc` (string): Email addresses to which the notifications are sent. At least one field must have a value.
+          - `subject` (string, optional): Email subject line.
+          - `message` (string, required): Email body text.
+
+        For Webhook:
+
+          - `body` (string, required): JSON payload.
+
+        For PagerDuty:
+
+          - `severity` (string, required): Severity of on the alert notification, can be: `Critical`, `Error`, `Warning` or `Info`.
+          - `eventAction` (string, required): Event [action type](https://v2.developer.pagerduty.com/docs/events-api-v2#event-action), which can be `trigger`, `resolve`, or `acknowledge`.
+          - `dedupKey` (string, optional): Groups alert notifications with the same PagerDuty alert.
+          - `timestamp` (DateTime, optional): ISO-8601 format [timestamp](https://v2.developer.pagerduty.com/docs/types#datetime).
+          - `component` (string, optional): Source machine component responsible for the event, for example `security-solution`.
+          - `group` (string, optional): Enables logical grouping of service components.
+          - `source` (string, optional): The affected system. Defaults to the Kibana saved object ID of the action.
+          - `summary` (string, options): Summary of the event. Defaults to `No summary provided`. Maximum length is 1024 characters.
+          - `class` (string, optional): Value indicating the class/type of the event.
       type: object
     Security_Detections_API_RuleActionThrottle:
       description: Defines how often rule actions are taken.
@@ -50262,6 +51927,7 @@ components:
           pattern: ^[1-9]\d*[smhd]$
           type: string
     Security_Detections_API_RuleAuthorArray:
+      description: The rule’s author.
       items:
         type: string
       type: array
@@ -50278,6 +51944,8 @@ components:
       discriminator:
         propertyName: type
     Security_Detections_API_RuleDescription:
+      description: The rule’s description.
+      example: Detects anomalous Windows process creation events.
       minLength: 1
       type: string
     Security_Detections_API_RuleDetailsInError:
@@ -50290,14 +51958,20 @@ components:
       required:
         - id
     Security_Detections_API_RuleExceptionList:
+      description: |
+        Array of [exception containers](https://www.elastic.co/guide/en/security/current/exceptions-api-overview.html), which define exceptions that prevent the rule from generating alerts even when its other criteria are met.
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: ID of the exception container
+          format: nonempty
+          minLength: 1
+          type: string
         list_id:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: List ID of the exception container
+          format: nonempty
+          minLength: 1
+          type: string
         namespace_type:
           description: Determines the exceptions validity in rule's Kibana space
           enum:
@@ -50361,6 +52035,10 @@ components:
     Security_Detections_API_RuleExecutionStatusOrder:
       type: integer
     Security_Detections_API_RuleExecutionSummary:
+      description: |
+        Summary of the last execution of a rule.
+        > info
+        > This field is under development and its usage or schema may change
       type: object
       properties:
         last_execution:
@@ -50388,10 +52066,15 @@ components:
       required:
         - last_execution
     Security_Detections_API_RuleFalsePositiveArray:
+      description: String array used to describe common reasons why the rule may issue false-positive alerts. Defaults to an empty array.
       items:
         type: string
       type: array
     Security_Detections_API_RuleFilterArray:
+      description: |
+        The query and filter context array used to define the conditions for when alerts are created from events. Defaults to an empty array.
+        > info
+        > This field is not supported for ES|QL rules.
       items: {}
       type: array
     Security_Detections_API_RuleInterval:
@@ -50408,15 +52091,22 @@ components:
       type: string
     Security_Detections_API_RuleMetadata:
       additionalProperties: true
+      description: |
+        Placeholder for metadata about the rule.
+        > info
+        > This field is overwritten when you save changes to the rule’s settings.
       type: object
     Security_Detections_API_RuleName:
+      description: A human-readable name for the rule.
+      example: Anomalous Windows Process Creation
       minLength: 1
       type: string
     Security_Detections_API_RuleNameOverride:
-      description: Sets the source field for the alert's signal.rule.name value
+      description: Sets which field in the source event is used to populate the alert's `signal.rule.name` value (in the UI, this value is displayed on the Rules page in the Rule column). When unspecified, the rule’s `name` value is used. The source field must be a string data type.
       type: string
     Security_Detections_API_RuleObjectId:
       $ref: '#/components/schemas/Security_Detections_API_UUID'
+      description: A dynamic unique identifier for the rule object. It is randomly generated when a rule is created and cannot be changed after that. It is always a UUID. It is unique within a given Kibana space. The same prebuilt Elastic rule, when installed in two different Kibana spaces or two different Elastic environments, will have different object `id`s.
     Security_Detections_API_RulePatchProps:
       anyOf:
         - $ref: '#/components/schemas/Security_Detections_API_EqlRulePatchProps'
@@ -50474,8 +52164,14 @@ components:
         - invocationCount
         - timeframeEnd
     Security_Detections_API_RuleQuery:
+      description: |
+        [Query](https://www.elastic.co/guide/en/kibana/8.17/search.html) used by the rule to create alerts.
+
+        - For indicator match rules, only the query’s results are used to determine whether an alert is generated.
+        - ES|QL rules have additional query requirements. Refer to [Create ES|QL](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-esql-rule) rules for more information.
       type: string
     Security_Detections_API_RuleReferenceArray:
+      description: Array containing notes about or references to relevant information about the rule. Defaults to an empty array.
       items:
         type: string
       type: array
@@ -50501,7 +52197,7 @@ components:
       minimum: 0
       type: integer
     Security_Detections_API_RuleSignatureId:
-      description: Could be any string, not necessarily a UUID
+      description: A stable unique identifier for the rule object. It can be assigned during rule creation. It can be any string, but often is a UUID. It should be unique not only within a given Kibana space, but also across spaces and Elastic environments. The same prebuilt Elastic rule, when installed in two different Kibana spaces or two different Elastic environments, will have the same `rule_id`s.
       type: string
     Security_Detections_API_RuleSource:
       description: Discriminated union that determines whether the rule is internally sourced (created within the Kibana app) or has an external source, such as the Elastic Prebuilt rules repo.
@@ -50551,12 +52247,14 @@ components:
         - conflict
       type: string
     Security_Detections_API_SavedQueryId:
+      description: Kibana [saved search](https://www.elastic.co/guide/en/kibana/current/save-open-search.html) used by the rule to create alerts.
       type: string
     Security_Detections_API_SavedQueryRule:
       allOf:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -50605,6 +52303,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -50677,6 +52379,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -50725,6 +52428,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -50806,6 +52513,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -50856,6 +52564,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -50924,6 +52636,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -50974,6 +52687,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -51060,9 +52777,15 @@ components:
         - tags_to_add
         - tags_to_remove
     Security_Detections_API_SetupGuide:
+      description: Populates the rule’s setup guide with instructions on rule prerequisites such as required integrations, configuration steps, and anything else needed for the rule to work correctly.
       type: string
     Security_Detections_API_Severity:
-      description: Severity of the rule
+      description: |
+        Severity level of alerts produced by the rule, which must be one of the following:
+        * `low`: Alerts that are of interest but generally not considered to be security incidents
+        * `medium`: Alerts that require investigation
+        * `high`: Alerts that require immediate investigation
+        * `critical`: Alerts that indicate it is highly likely a security incident has occurred
       enum:
         - low
         - medium
@@ -51075,6 +52798,7 @@ components:
         type: object
         properties:
           field:
+            description: Source event field used to override the default `severity`.
             type: string
           operator:
             enum:
@@ -51106,6 +52830,9 @@ components:
         - desc
       type: string
     Security_Detections_API_Threat:
+      description: |
+        > info
+        > Currently, only threats described using the MITRE ATT&CK&trade; framework are supported.
       type: object
       properties:
         framework:
@@ -51130,6 +52857,7 @@ components:
         description: Query and filter context array used to filter documents from the Elasticsearch index containing the threat values
       type: array
     Security_Detections_API_ThreatIndex:
+      description: Elasticsearch indices used to check which field values generate alerts.
       items:
         type: string
       type: array
@@ -51137,6 +52865,14 @@ components:
       description: Defines the path to the threat indicator in the indicator documents (optional)
       type: string
     Security_Detections_API_ThreatMapping:
+      description: |
+        Array of entries objects that define mappings between the source event fields and the values in the Elasticsearch threat index. Each entries object must contain these fields:
+
+        - field: field from the event indices on which the rule runs
+        - type: must be mapping
+        - value: field from the Elasticsearch threat index
+          
+        You can use Boolean and and or logic to define the conditions for when matching fields and values generate alerts. Sibling entries objects are evaluated using or logic, whereas multiple entries in a single entries object use and logic. See Example of Threat Match rule which uses both `and` and `or` logic.
       items:
         type: object
         properties:
@@ -51166,6 +52902,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -51214,6 +52951,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -51286,6 +53027,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -51334,6 +53076,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -51431,6 +53177,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -51481,6 +53228,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -51558,6 +53309,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -51608,6 +53360,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -51654,7 +53410,7 @@ components:
             - severity
         - $ref: '#/components/schemas/Security_Detections_API_ThreatMatchRuleCreateFields'
     Security_Detections_API_ThreatQuery:
-      description: Query to run
+      description: Query used to determine which fields in the Elasticsearch index are used for generating alerts.
       type: string
     Security_Detections_API_ThreatSubtechnique:
       type: object
@@ -51673,6 +53429,8 @@ components:
         - name
         - reference
     Security_Detections_API_ThreatTactic:
+      description: |
+        Object containing information on the attack type
       type: object
       properties:
         id:
@@ -51701,7 +53459,8 @@ components:
           description: Technique reference
           type: string
         subtechnique:
-          description: Array containing more specific information on the attack technique
+          description: |
+            Array containing more specific information on the attack technique.
           items:
             $ref: '#/components/schemas/Security_Detections_API_ThreatSubtechnique'
           type: array
@@ -51722,6 +53481,7 @@ components:
         - field
         - value
     Security_Detections_API_ThresholdAlertSuppression:
+      description: Defines alert suppression configuration.
       type: object
       properties:
         duration:
@@ -51729,12 +53489,15 @@ components:
       required:
         - duration
     Security_Detections_API_ThresholdCardinality:
+      description: The field on which the cardinality is applied.
       items:
         type: object
         properties:
           field:
+            description: The field on which to calculate and compare the cardinality.
             type: string
           value:
+            description: The threshold value from which an alert is generated based on unique number of values of cardinality.field.
             minimum: 0
             type: integer
         required:
@@ -51742,7 +53505,7 @@ components:
           - value
       type: array
     Security_Detections_API_ThresholdField:
-      description: Field to aggregate on
+      description: The field on which the threshold is applied. If you specify an empty array ([]), alerts are generated when the query returns at least the number of results specified in the value field.
       oneOf:
         - type: string
         - items:
@@ -51753,6 +53516,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -51801,6 +53565,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -51873,6 +53641,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -51921,6 +53690,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -52004,6 +53777,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -52054,6 +53828,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -52125,6 +53903,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -52175,6 +53954,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -52221,11 +54004,15 @@ components:
             - severity
         - $ref: '#/components/schemas/Security_Detections_API_ThresholdRuleCreateFields'
     Security_Detections_API_ThresholdValue:
-      description: Threshold value
+      description: The threshold value from which an alert is generated.
       minimum: 1
       type: integer
     Security_Detections_API_ThrottleForBulkActions:
-      description: 'The condition for throttling the notification: ''rule'', ''no_actions'', or time duration'
+      description: |
+        Defines the maximum interval in which a rule’s actions are executed.
+        > info
+        > The rule level `throttle` field is deprecated in Elastic Security 8.8 and will remain active for at least the next 12 months.
+        > In Elastic Security 8.8 and later, you can use the `frequency` field to define frequencies for individual actions. Actions without frequencies will acquire a converted version of the rule’s `throttle` field. In the response, the converted `throttle` setting appears in the individual actions' `frequency` field.
       enum:
         - rule
         - 1h
@@ -52242,10 +54029,10 @@ components:
       description: Timeline template title
       type: string
     Security_Detections_API_TimestampField:
-      description: Contains the event timestamp used for sorting a sequence of events
+      description: Specifies the name of the event timestamp field used for sorting a sequence of events. Not to be confused with `timestamp_override`, which specifies the more general field used for querying events within a range. Defaults to the @timestamp ECS field.
       type: string
     Security_Detections_API_TimestampOverride:
-      description: Sets the time field used to query indices
+      description: Sets the time field used to query indices. When unspecified, rules query the `@timestamp` field. The source field must be an Elasticsearch date data type.
       type: string
     Security_Detections_API_TimestampOverrideFallbackDisabled:
       description: Disables the fallback to the event's @timestamp field

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -123,10 +123,20 @@ tags:
     x-displayName: Security AI assistant
   - description: |
       Use the detections APIs to create and manage detection rules. Detection rules search events and external alerts sent to Elastic Security and generate detection alerts from any hits. Alerts are displayed on the **Alerts** page and can be assigned and triaged, using the alert status to mark them as open, closed, or acknowledged.
+
+      This API supports both key-based authentication and basic authentication.
+
+      To use key-based authentication, create an API key, then specify the key in the header of your API calls.
+
+      To use basic authentication, provide a username and password; this automatically creates an API key that matches the current user’s privileges.
+
+      In both cases, the API key is subsequently used for authorization when the rule runs.
       > warn
       > If the API key used for authorization has different privileges than the key that created or most recently updated a rule, the rule behavior might change.
 
       > If the API key that created a rule is deleted, or the user that created the rule becomes inactive, the rule will stop running.
+
+      To create and run rules, the user must meet specific requirements for the Kibana space. Refer to the [Detections requirements](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html) for a complete list of requirements.
     name: Security Detections API
     x-displayName: Security detections
   - description: Endpoint Exceptions API allows you to manage detection rule endpoint exceptions to prevent a rule from generating an alert from incoming events even when the rule's other criteria are met.
@@ -10958,7 +10968,15 @@ paths:
         - Security Detections API
   /api/detection_engine/rules:
     delete:
-      description: Delete a detection rule using the `rule_id` or `id` field.
+      description: |
+        Delete a detection rule using the `rule_id` or `id` field.
+
+        The URL query must include one of the following:
+
+        * `id` - `DELETE /api/detection_engine/rules?id=<id>`
+        * `rule_id`- `DELETE /api/detection_engine/rules?rule_id=<rule_id>`
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
       operationId: DeleteRule
       parameters:
         - description: The rule's `id` value.
@@ -10983,8 +11001,22 @@ paths:
       summary: Delete a detection rule
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request DELETE https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
     get:
-      description: Retrieve a detection rule using the `rule_id` or `id` field.
+      description: |
+        Retrieve a detection rule using the `rule_id` or `id` field.
+
+        The URL query must include one of the following:
+
+        * `id` - `GET /api/detection_engine/rules?id=<id>`
+        * `rule_id` - `GET /api/detection_engine/rules?rule_id=<rule_id>`
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
       operationId: ReadRule
       parameters:
         - description: The rule's `id` value.
@@ -11003,25 +11035,205 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Example response for a retrieved rule
+                  value:
+                    created_at: '2020-02-03T11:19:04.259Z'
+                    created_by: elastic
+                    description: Process started by MS Office program in user folder
+                    enabled: false
+                    execution_summary:
+                      last_execution:
+                        date: '2022-03-23T16:06:12.787Z'
+                        message: This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.
+                        metrics:
+                          execution_gap_duration_s: 0
+                          total_indexing_duration_ms: 15
+                          total_search_duration_ms: 135
+                        status: partial failure
+                        status_order: 20
+                    false_positives: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-4200s
+                    id: c41d170b-8ba6-4de6-b8ec-76440a35ace3
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: MS Office child process
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: process.name
+                        type: keyword
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    risk_score: 21
+                    rule_id: process_started_by_ms_office_user_folder
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat:
+                      - framework: MITRE ATT&CK
+                        tactic:
+                          id: TA0001
+                          name: Initial Access
+                          reference: https://attack.mitre.org/tactics/TA0001
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: https://attack.mitre.org/techniques/T1193
+                    to: now-300s
+                    type: query
+                    updated_at: '2020-02-03T11:19:04.462Z'
+                    updated_by: elastic
+                    version: 1
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
-          description: Indicates a successful call.
+          description: |
+            Indicates a successful call.
+            > info
+            > These fields are under development and their usage or schema may change: execution_summary.
       summary: Retrieve a detection rule
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request GET https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
     patch:
-      description: Update specific fields of an existing detection rule using the `rule_id` or `id` field.
+      description: |
+        Update specific fields of an existing detection rule using the `rule_id` or `id` field.
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       operationId: PatchRule
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                summary: Patch query rule
+                value:
+                  id: 14b7b513-3d8d-4b22-b7da-a7ae632f7e76
+                  name: New name
+              example2:
+                summary: Patch EQL rule
+                value:
+                  rule_id: process_started_by_ms_office_program_possible_payload
+                  threat:
+                    - framework: MITRE ATT&CK
+                      tactic:
+                        id: TA0001
+                        name: Initial Access
+                        reference: https://attack.mitre.org/tactics/TA0001
+                      technique:
+                        - id: T1193
+                          name: Spearphishing Attachment
+                          reference: https://attack.mitre.org/techniques/T1193
+              example3:
+                summary: Patch threshold rule
+                value:
+                  id: 005d2c4f-51ca-493d-a2bd-20ef076339b1
+                  query: 'agent.version : * and agent.id : "243d9b4f-ca01-4311-8e5c-9abbee91afd8"'
+                  threshold:
+                    cardinality: []
+                    field: []
+                    value: 600
+              example4:
+                summary: Patch new terms rule
+                value:
+                  history_window_start: now-3d
+                  id: 569aac91-40dc-4807-a8ae-a2c8698089c4
+                  new_terms_fields:
+                    - Endpoint.policy.applied.artifacts.global.identifiers.name
+              example5:
+                summary: Patch esql rule
+                value:
+                  id: 0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd
+                  query: |
+                    FROM logs-abc*
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp)
+                    | EVAL event_rate = count / DATE_DIFF("seconds", min_timestamp, NOW()) 
+                    | KEEP event_rate
+              example6:
+                summary: Patch indicator match rule
+                value:
+                  id: 462f1986-10fe-40a3-a22c-2b1c9c4c48fd
+                  threat_query: '@timestamp >= "now-30d/d" and event.module:(threatintel or ti_*) and threat.indicator.ip:* and not labels.is_ioc_transform_source:"false"'
+              example7:
+                summary: Patch machine learning rule
+                value:
+                  anomaly_threshold: 50
+                  id: 60b13926-289b-41b1-a537-197ef1fa5059
+                  machine_learning_job_id:
+                    - auth_high_count_logon_events
             schema:
               $ref: '#/components/schemas/Security_Detections_API_RulePatchProps'
+        description: |
+          > info
+          > You cannot modify the `id` or `rule_id` values.
         required: true
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Updated description for the rule.
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query: null
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: Updated Rule Name
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                    required_fields:
+                      - name: process.parent.name
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 2
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
@@ -11029,11 +11241,304 @@ paths:
       tags:
         - Security Detections API
     post:
-      description: Create a new detection rule.
+      description: |
+        Create a new detection rule.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
+        You can create the following types of rules:
+
+        * **Custom query**: Searches the defined indices and creates an alert when a document matches the rule's KQL query.
+        * **Event correlation**: Searches the defined indices and creates an alert when results match an [Event Query Language (EQL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html) query.
+        * **Threshold**: Searches the defined indices and creates an alert when the number of times the specified field's value meets the threshold during a single execution. When there are multiple values that meet the threshold, an alert is generated for each value.
+          For example, if the threshold `field` is `source.ip` and its `value` is `10`, an alert is generated for every source IP address that appears in at least 10 of the rule's search results. If you're interested, see [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) for more information.
+        * **Indicator match**: Creates an alert when fields match values defined in the specified [Elasticsearch index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). For example, you can create an index for IP addresses and use this index to create an alert whenever an event's `destination.ip` equals a value in the index. The index's field mappings should be [ECS-compliant](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html).
+        * **New terms**: Generates an alert for each new term detected in source documents within a specified time range.
+        * **ES|QL**: Uses [Elasticsearch Query Language (ES|QL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html) to find events and aggregate search results.
+        * **Machine learning rules**: Creates an alert when a machine learning job discovers an anomaly above the defined threshold.
+        > info
+        > To create machine learning rules, you must have the [appropriate license](https://www.elastic.co/subscriptions) or use a [cloud deployment](https://cloud.elastic.co/registration). Additionally, for the machine learning rule to function correctly, the associated machine learning job must be running.
+
+        To retrieve machine learning job IDs, which are required to create machine learning jobs, call the [Elasticsearch Get jobs API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html). Machine learning jobs that contain `siem` in the `groups` field can be used to create rules:
+
+        ```json
+        ...
+        "job_id": "linux_anomalous_network_activity_ecs",
+        "job_type": "anomaly_detector",
+        "job_version": "7.7.0",
+        "groups": [
+          "auditbeat",
+          "process",
+          "siem"
+        ],
+        ...
+        ```
+
+        Additionally, you can set up notifications for when rules create alerts. The notifications use the [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html). Each action type requires a connector. Connectors store the information required to send notifications via external systems. The following connector types are supported for rule notifications:
+
+        * Slack
+        * Email
+        * PagerDuty
+        * Webhook
+        * Microsoft Teams
+        * IBM Resilient
+        * Jira
+        * ServiceNow ITSM
+        > info
+        > For more information on PagerDuty fields, see [Send a v2 Event](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/).
+
+        To retrieve connector IDs, which are required to configure rule notifications, call the [Find objects API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-find.html) with `"type": "action"` in the request payload.
+
+        For detailed information on Kibana actions and alerting, and additional API calls, see:
+
+        * [Alerting API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-alerting)
+        * [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html)
+        * [Connectors API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-connectors)
       operationId: CreateRule
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                description: Query rule that searches for processes started by MS Office
+                summary: Query rule
+                value:
+                  description: Process started by MS Office program - possible payload
+                  enabled: false
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: phrase
+                  from: now-70m
+                  interval: 1h
+                  language: kuery
+                  name: MS Office child process
+                  query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                  related_integrations:
+                    - package: o365
+                      version: ^2.3.2
+                  required_fields:
+                    - name: process.parent.name
+                      type: keyword
+                  risk_score: 50
+                  rule_id: process_started_by_ms_office_program
+                  severity: low
+                  tags:
+                    - child process
+                    - ms office
+                  type: query
+              example2:
+                description: Threshold rule that detects multiple failed login attempts to a Windows host from the same external source IP address
+                summary: Threshold rule
+                value:
+                  description: Detects when there are 20 or more failed login attempts from the same IP address with a 2 minute time frame.
+                  enabled: true
+                  exceptions_list:
+                    - id: int-ips
+                      namespace_type: single
+                      type: detection
+                  from: now-180s
+                  index:
+                    - winlogbeat-*
+                  interval: 2m
+                  name: Windows server prml-19
+                  query: host.name:prml-19 and event.category:authentication and event.outcome:failure
+                  required_fields:
+                    - name: source.ip
+                      type: ip
+                  risk_score: 30
+                  rule_id: liv-win-ser-logins
+                  severity: low
+                  severity_mapping:
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: low
+                      value: Manchester
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: medium
+                      value: London
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: high
+                      value: Birmingham
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: critical
+                      value: Wallingford
+                  tags:
+                    - Brute force
+                  threshold:
+                    field: source.ip
+                    value: 20
+                  type: threshold
+              example3:
+                description: Machine learning rule that creates alerts, and sends Slack notifications, when the linux_anomalous_network_activity_ecs machine learning job discovers anomalies with a threshold of 70 or above.
+                summary: Machine learning rule
+                value:
+                  actions:
+                    - action_type_id: .slack
+                      group: default
+                      id: 5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5
+                      params:
+                        message: 'Urgent: {{context.rule.description}}'
+                  anomaly_threshold: 70
+                  description: Generates alerts when the job discovers anomalies over 70
+                  enabled: true
+                  from: now-6m
+                  interval: 5m
+                  machine_learning_job_id: linux_anomalous_network_activity_ecs
+                  name: Anomalous Linux network activity
+                  note: Shut down the internet.
+                  risk_score: 70
+                  rule_id: ml_linux_network_high_threshold
+                  setup: This rule requires data coming in from Elastic Defend.
+                  severity: high
+                  tags:
+                    - machine learning
+                    - Linux
+                  type: machine_learning
+              example4:
+                description: Event correlation rule that creates alerts when the Windows rundll32.exe process makes unusual network connections
+                summary: EQL rule
+                value:
+                  description: Unusual rundll32.exe network connection
+                  language: eql
+                  name: rundll32.exe network connection
+                  query: sequence by process.entity_id with maxspan=2h [process where event.type in ("start", "process_started") and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe") and ((process.args == "rundll32.exe" and process.args_count == 1) or (process.args != "rundll32.exe" and process.args_count == 0))] [network where event.type == "connection" and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe")]
+                  required_fields:
+                    - name: event.type
+                      type: keyword
+                    - name: process.args
+                      type: keyword
+                    - name: process.args_count
+                      type: long
+                    - name: process.entity_id
+                      type: keyword
+                    - name: process.name
+                      type: keyword
+                    - name: process.pe.original_file_name
+                      type: keyword
+                  risk_score: 21
+                  rule_id: eql-outbound-rundll32-connections
+                  severity: low
+                  tags:
+                    - EQL
+                    - Windows
+                    - rundll32.exe
+                  type: eql
+              example5:
+                description: |
+                  Indicator match rule that creates an alert when one of the following is true: The event's destination IP address and port number matches destination IP and port values in the threat_index index; The event's source IP address matches a host IP address value in the threat_index index.
+                summary: Indicator match rule
+                value:
+                  actions: []
+                  description: Checks for bad IP addresses listed in the ip-threat-list index
+                  index:
+                    - packetbeat-*
+                  name: Bad IP threat match
+                  query: destination.ip:* or host.ip:*
+                  required_fields:
+                    - name: destination.ip
+                      type: ip
+                    - name: destination.port
+                      type: long
+                    - name: host.ip
+                      type: ip
+                  risk_score: 50
+                  severity: medium
+                  threat_index:
+                    - ip-threat-list
+                  threat_mapping:
+                    - entries:
+                        - field: destination.ip
+                          type: mapping
+                          value: destination.ip
+                        - field: destination.port
+                          type: mapping
+                          value: destination.port
+                    - entries:
+                        - field: source.ip
+                          type: mapping
+                          value: host.ip
+                  threat_query: '*:*'
+                  type: threat_match
+              example6:
+                description: New terms rule that creates alerts a new IP address is detected for a user
+                summary: New terms rule
+                value:
+                  description: Detects a user associated with a new IP address
+                  history_window_start: now-30d
+                  index:
+                    - auditbeat*
+                  language: kuery
+                  name: New User IP Detected
+                  new_terms_fields:
+                    - user.id
+                    - source.ip
+                  query: '*'
+                  required_fields:
+                    - name: user.id
+                      type: keyword
+                    - name: source.ip
+                      type: ip
+                  risk_score: 21
+                  severity: medium
+                  type: new_terms
+              example7:
+                description: esql rule that creates alerts from events that match an Excel parent process
+                summary: Esql rule
+                value:
+                  description: Find Excel events
+                  enabled: false
+                  from: now-360s
+                  interval: 5m
+                  language: esql
+                  name: Find Excel events
+                  query: from auditbeat-8.10.2 METADATA _id, _version, _index | where process.parent.name == "EXCEL.EXE"
+                  required_fields:
+                    - name: process.parent.name
+                      type: keyword
+                  risk_score: 21
+                  severity: low
+                  tags: []
+                  to: now
+                  type: esql
+              example8:
+                description: Query rule that searches for processes started by MS Office and suppresses alerts by the process.parent.name field within a 5-hour time period
+                summary: Query rule 2
+                value:
+                  alert_suppression:
+                    duration:
+                      unit: h
+                      value: 5
+                    group_by:
+                      - process.parent.name
+                    missing_fields_strategy: suppress
+                  description: Process started by MS Office program - possible payload
+                  enabled: false
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: phrase
+                  from: now-70m
+                  interval: 1h
+                  language: kuery
+                  name: MS Office child process
+                  query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                  risk_score: 50
+                  rule_id: process_started_by_ms_office_program
+                  severity: low
+                  tags:
+                    - child process
+                    - ms office
+                  type: query
             schema:
               $ref: '#/components/schemas/Security_Detections_API_RuleCreateProps'
         required: true
@@ -11041,6 +11546,381 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  description: Example response for a query rule
+                  summary: Query rule response
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Process started by MS Office program - possible payload
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: MS Office child process
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                      - integration: graphactivitylogs
+                        package: azure
+                        version: ^1.11.4
+                    required_fields:
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 1
+                example2:
+                  description: Example response for a machine learning job rule
+                  summary: Machine learning response
+                  value:
+                    actions:
+                      - action_type_id: .slack
+                        frequency:
+                          notifyWhen: onActiveAlert
+                          summary: true
+                          throttle: null
+                        group: default
+                        id: 5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5
+                        params:
+                          message: 'Urgent: {{context.rule.description}}'
+                    anomaly_threshold: 70
+                    created_at: '2020-04-07T14:45:15.679Z'
+                    created_by: elastic
+                    description: Generates alerts when the job discovers anomalies over 70
+                    enabled: true
+                    false_positives: []
+                    from: now-6m
+                    id: 83876f66-3a57-4a99-bf37-416494c80f3b
+                    immutable: false
+                    interval: 5m
+                    machine_learning_job_id: linux_anomalous_network_activity_ecs
+                    max_signals: 100
+                    name: Anomalous Linux network activity
+                    note: Shut down the internet.
+                    references: []
+                    related_integrations: []
+                    required_fields: []
+                    risk_score: 70
+                    rule_id: ml_linux_network_high_threshold
+                    setup: ''
+                    severity: high
+                    status: going to run
+                    status_date: '2020-04-07T14:45:21.685Z'
+                    tags:
+                      - machine learning
+                      - Linux
+                    threat: []
+                    to: now
+                    type: machine_learning
+                    updated_at: '2020-04-07T14:45:15.892Z'
+                    updated_by: elastic
+                    version: 1
+                example3:
+                  description: Example response for a threshold rule
+                  summary: Threshold rule response
+                  value:
+                    actions: []
+                    author: []
+                    created_at: '2020-07-22T10:27:23.486Z'
+                    created_by: elastic
+                    description: Detects when there are 20 or more failed login attempts from the same IP address with a 2 minute time frame.
+                    enabled: true
+                    exceptions_list:
+                      - id: int-ips
+                        namespace_type: single
+                        type: detection
+                    false_positives: []
+                    from: now-180s
+                    id: 15dbde26-b627-4d74-bb1f-a5e0ed9e4993
+                    immutable: false
+                    index:
+                      - winlogbeat-*
+                    interval: 2m
+                    language: kuery
+                    max_signals: 100
+                    name: Windows server prml-19
+                    query: host.name:prml-19 and event.category:authentication and event.outcome:failure
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: source.ip
+                        type: ip
+                    risk_score: 30
+                    risk_score_mapping: []
+                    rule_id: liv-win-ser-logins
+                    setup: ''
+                    severity: low
+                    severity_mapping:
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: low
+                        value: Manchester
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: medium
+                        value: London
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: high
+                        value: Birmingham
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: critical
+                        value: Wallingford
+                    tags:
+                      - Brute force
+                    threat: []
+                    threshold:
+                      field: source.ip
+                      value: 20
+                    to: now
+                    type: threshold
+                    updated_at: '2020-07-22T10:27:23.673Z'
+                    updated_by: elastic
+                    version: 1
+                example4:
+                  description: Example response for an EQL rule
+                  summary: EQL rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-05T09:06:16.392Z'
+                    created_by: elastic
+                    description: Unusual rundll32.exe network connection
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    id: 93808cae-b05b-4dc9-8479-73574b50f8b1
+                    immutable: false
+                    interval: 5m
+                    language: eql
+                    max_signals: 100
+                    name: rundll32.exe network connection
+                    query: sequence by process.entity_id with maxspan=2h [process where event.type in ("start", "process_started") and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe") and ((process.args == "rundll32.exe" and process.args_count == 1) or (process.args != "rundll32.exe" and process.args_count == 0))] [network where event.type == "connection" and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe")]
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: event.type
+                        type: keyword
+                      - ecs: true
+                        name: process.args
+                        type: keyword
+                      - ecs: true
+                        name: process.args_count
+                        type: long
+                      - ecs: true
+                        name: process.entity_id
+                        type: keyword
+                      - ecs: true
+                        name: process.name
+                        type: keyword
+                      - ecs: true
+                        name: process.pe.original_file_name
+                        type: keyword
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: eql-outbound-rundll32-connections
+                    setup: ''
+                    severity: low
+                    severity_mapping: []
+                    tags:
+                      - EQL
+                      - Windows
+                      - rundll32.exe
+                    threat: []
+                    throttle: no_actions
+                    to: now
+                    type: eql
+                    updated_at: '2020-10-05T09:06:16.403Z'
+                    updated_by: elastic
+                    version: 1
+                example5:
+                  description: Example response for an indicator match rule
+                  summary: Indicator match rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    created_by: elastic
+                    description: Checks for bad IP addresses listed in the ip-threat-list index
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    id: d5daa13f-81fb-4b13-be2f-31011e1d9ae1
+                    immutable: false
+                    index:
+                      - packetbeat-*
+                    interval: 5m
+                    language: kuery
+                    max_signals: 100
+                    name: Bad IP threat match
+                    query: destination.ip:* or host.ip:*
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: destination.ip
+                        type: ip
+                      - ecs: true
+                        name: destination.port
+                        type: long
+                      - ecs: true
+                        name: host.ip
+                        type: ip
+                    risk_score: 50
+                    risk_score_mapping: []
+                    rule_id: 608501e4-c768-4f64-9326-cec55b5d439b
+                    setup: ''
+                    severity: medium
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    threat_index:
+                      - ip-threat-list
+                    threat_mapping:
+                      - entries:
+                          - field: destination.ip
+                            type: mapping
+                            value: destination.ip
+                          - field: destination.port
+                            type: mapping
+                            value: destination.port
+                      - entries:
+                          - field: source.ip
+                            type: mapping
+                            value: host.ip
+                    threat_query: '*:*'
+                    to: now
+                    type: threat_match
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    updated_by: elastic
+                    version: 1
+                example6:
+                  description: Example response for a new terms rule
+                  summary: New terms rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    created_by: elastic
+                    description: Detects a user associated with a new IP address
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    history_window_start: now-30d
+                    id: eb7225c0-566b-11ee-8b4f-bbf3afdeb9f4
+                    immutable: false
+                    index:
+                      - auditbeat*
+                    interval: 5m
+                    language: kuery
+                    max_signals: 100
+                    name: New User IP Detected
+                    new_terms_fields:
+                      - user.id
+                      - source.ip
+                    query: '*'
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: user.id
+                        type: keyword
+                      - ecs: true
+                        name: source.ip
+                        type: ip
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: c6f5d0bc-7be9-47d4-b2f3-073d22641e30
+                    setup: ''
+                    severity: medium
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    to: now
+                    type: new_terms
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    updated_by: elastic
+                    version: 1
+                example7:
+                  description: Example response for an Esql rule
+                  summary: Esql rule response
+                  value:
+                    actions: []
+                    author: []
+                    created_at: '2023-10-18T10:55:14.269Z'
+                    created_by: elastic
+                    description: Find Excel events
+                    enabled: false
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-360s
+                    id: d0f20490-6da4-11ee-b85e-09e9b661f2e2
+                    immutable: false
+                    interval: 5m
+                    language: esql
+                    max_signals: 100
+                    name: Find Excel events
+                    output_index: ''
+                    query: from auditbeat-8.10.2 METADATA _id | where process.parent.name == "EXCEL.EXE"
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    revision: 0
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: e4b53a89-debd-4a0d-a3e3-20606952e589
+                    setup: ''
+                    severity: low
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    to: now
+                    type: esql
+                    updated_at: '2023-10-18T10:55:14.269Z'
+                    updated_by: elastic
+                    version: 1
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
@@ -11050,19 +11930,168 @@ paths:
     put:
       description: |
         Update a detection rule using the `rule_id` or `id` field. The original rule is replaced, and all unspecified fields are deleted.
-        > info
-        > You cannot modify the `id` or `rule_id` values.
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       operationId: UpdateRule
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                summary: Update query rule
+                value:
+                  description: A new description
+                  id: 14b7b513-3d8d-4b22-b7da-a7ae632f7e76
+                  name: A new name for the rule
+                  risk_score: 22
+                  severity: medium
+                  type: query
+              example2:
+                summary: Update EQL rule
+                value:
+                  description: eql rule test
+                  id: 9b684efb-acf9-4323-9bff-8335b3867d14
+                  index:
+                    - apm-*-transaction*
+                  language: eql
+                  name: New name for EQL rule
+                  query: process where process.name == "regsvr32.exe"
+                  risk_score: 21
+                  severity: low
+                  type: eql
+              example3:
+                summary: Update threshold rule
+                value:
+                  description: Description of threat rule test
+                  id: 005d2c4f-51ca-493d-a2bd-20ef076339b1
+                  language: kuery
+                  name: New name for threat rule
+                  query: 'agent.version : * and agent.id : "243d9b4f-ca01-4311-8e5c-9abbee91afd8"'
+                  risk_score: 21
+                  severity: low
+                  tags:
+                    - new_tag
+                  threshold:
+                    cardinality: []
+                    field: []
+                    value: 400
+                  type: threshold
+              example4:
+                summary: Update new terms rule
+                value:
+                  description: New description
+                  history_window_start: now-7d
+                  id: 569aac91-40dc-4807-a8ae-a2c8698089c4
+                  interval: 5m
+                  name: New terms rule name
+                  new_terms_fields:
+                    - Endpoint.policy.applied.artifacts.global.identifiers.name
+                  query: 'agent.version : "9.1.0"'
+                  risk_score: 21
+                  severity: low
+                  type: new_terms
+              example5:
+                summary: Update esql rule
+                value:
+                  description: New description for esql rule
+                  id: 0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd
+                  language: esql
+                  name: New name for esql rule
+                  query: |
+                    FROM logs*
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp) /* MIN(dateField) finds the earliest timestamp in the dataset. */
+                    | EVAL event_rate = count / DATE_DIFF("seconds", min_timestamp, NOW()) /* Calculates the event rate by dividing the total count of events by the time difference (in seconds) between the earliest event and the current time. */
+                    | KEEP event_rate
+                  risk_score: 21
+                  severity: low
+                  type: esql
+              example6:
+                summary: Update indicator match rule
+                value:
+                  description: New description
+                  id: 462f1986-10fe-40a3-a22c-2b1c9c4c48fd
+                  name: New name for Indicator Match rule
+                  query: source.ip:* or destination.ip:*\n
+                  risk_score: 99
+                  severity: critical
+                  threat_index:
+                    - filebeat-*
+                    - logs-ti_*
+                  threat_mapping:
+                    - entries:
+                        - field: source.ip
+                          type: mapping
+                          value: threat.indicator.ip
+                    - entries:
+                        - field: destination.ip
+                          type: mapping
+                          value: threat.indicator.ip
+                  threat_query: '@timestamp >= "now-30d/d" and event.module:(threatintel or ti_*) and threat.indicator.ip:* and not labels.is_ioc_transform_source:"true"'
+                  type: threat_match
+              example7:
+                summary: Update machine learning rule
+                value:
+                  anomaly_threshold: 50
+                  description: New description of ml rule
+                  id: 60b13926-289b-41b1-a537-197ef1fa5059
+                  machine_learning_job_id:
+                    - auth_high_count_logon_events
+                  name: New name of ml rule
+                  risk_score: 21
+                  severity: low
+                  type: machine_learning
             schema:
               $ref: '#/components/schemas/Security_Detections_API_RuleUpdateProps'
+        description: |
+          > info
+          > All unspecified fields are deleted. You cannot modify the `id` or `rule_id` values.
         required: true
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Updated description for the rule.
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query: null
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: Updated Rule Name
+                    query: process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                    required_fields:
+                      - name: process.parent.name
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 2
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleResponse'
           description: Indicates a successful call.
@@ -11071,10 +12100,22 @@ paths:
         - Security Detections API
   /api/detection_engine/rules/_bulk_action:
     post:
-      description: Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
+      description: |
+        Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
+        > warn
+        > When used with  [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       operationId: PerformRulesBulkAction
       parameters:
-        - description: Enables dry run mode for the request call.
+        - description: |
+            Enables dry run mode for the request call.
+
+            Enable dry run mode to verify that bulk actions can be applied to specified rules. Certain rules, such as prebuilt Elastic rules on a Basic subscription, can’t be edited and will return errors in the request response. Error details will contain an explanation, the rule name and/or ID, and additional troubleshooting information.
+
+            To enable dry run mode on a request, add the query parameter `dry_run=true` to the end of the request URL. Rules specified in the request will be temporarily updated. These updates won’t be written to Elasticsearch.
+            > info
+            > Dry run mode is not supported for the `export` bulk action. A 400 error will be returned in the request response.
           in: query
           name: dry_run
           required: false
@@ -11083,6 +12124,89 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                description: The following request activates all rules with the test tag
+                summary: Enable all rules with the test tag
+                value:
+                  action: enable
+                  query: 'alert.attributes.tags: "test"'
+              example2:
+                description: The following request enables the rule with the specified ID.
+                summary: Enable a specific rule by ID
+                value:
+                  action: enable
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+              example3:
+                description: The following request disables the rule with the specified ID.
+                summary: Disable a specific rule by ID
+                value:
+                  action: disable
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+              example4:
+                description: The following request adds tags tag-1 and tag-2 to the rules that have the IDs sent in the payload
+                summary: Add tags to rules
+                value:
+                  action: edit
+                  edit:
+                    - type: add_tags
+                      value:
+                        - tag-1
+                        - tag-2
+                  ids:
+                    - 8bc7dad0-9320-11ec-9265-8b772383a08d
+                    - 8e5c1a40-9320-11ec-9265-8b772383a08d
+              example5:
+                description: The following request will validate that the add_index_patterns bulk action can be successfully applied to three rules. The dry_run parameter is specified in query parameters, e.g. POST api/detection_engine/rules/_bulk_action?dry_run=true
+                summary: Dry run - Validate add_index_patterns bulk action
+                value:
+                  action: edit
+                  edit:
+                    - type: add_index_patterns
+                      value:
+                        - test-*
+                  ids:
+                    - 81aa0480-06af-11ed-94fb-dd1a0597d8d2
+                    - dc015d10-0831-11ed-ac8b-05a222bd8d4a
+                    - de8f5af0-0831-11ed-ac8b-05a222bd8d4a
+              example6:
+                description: The following request duplicates rules with the specified IDs, including exceptions but not expired exceptions.
+                summary: Duplicate rules with specific IDs
+                value:
+                  action: duplicate
+                  duplicate:
+                    include_exceptions: true
+                    include_expired_exceptions: false
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                    - 461a4c22-416e-4009-a9a7-cf79656454bf
+              example7:
+                description: The following request deletes the rule with the specified ID.
+                summary: Delete a specific rule by ID
+                value:
+                  action: delete
+                  ids:
+                    - cf4abfd1-7c37-4519-ab0f-5ea5c75fac60
+              example8:
+                description: The following request runs the rule with the specified ID within the given date range.
+                summary: Run a specific rule by ID
+                value:
+                  action: run
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                  run:
+                    end_date: '2025-03-10T23:59:59.999Z'
+                    start_date: '2025-03-01T00:00:00.000Z'
+              example9:
+                description: The following request exports the rules with the specified IDs.
+                summary: Export specific rules by ID
+                value:
+                  action: export
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                    - 13199674-aff1-418a-9e93-04f585fe36d1
             schema:
               oneOf:
                 - $ref: '#/components/schemas/Security_Detections_API_BulkDeleteRules'
@@ -11096,6 +12220,214 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  description: In this response one rule was updated and one was skipped. Objects returned in attributes.results.skipped will only include rules' id, name, and skip_reason.
+                  summary: Successful response
+                  value:
+                    attributes:
+                      results:
+                        created: []
+                        deleted: []
+                        skipped:
+                          - id: 51658332-a15e-4c9e-912a-67214e2e2359
+                            name: Skipped rule
+                            skip_reason: RULE_NOT_MODIFIED
+                        updated:
+                          - anomaly_threshold: 50
+                            author:
+                              - Elastic
+                            created_at: '2022-02-21T14:14:13.801Z'
+                            created_by: elastic
+                            description: A machine learning job detected unusually large numbers of DNS queries for a single top-level DNS domain, which is often used for DNS tunneling. DNS tunneling can be used for command-and-control, persistence, or data exfiltration activity. For example, dnscat tends to generate many DNS questions for a top-level domain as it uses the DNS protocol to tunnel data.
+                            enabled: true
+                            exceptions_list: []
+                            execution_summary:
+                              last_execution:
+                                date: '2022-03-23T16:06:12.787Z'
+                                message: This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.
+                                metrics:
+                                  execution_gap_duration_s: 0
+                                  total_indexing_duration_ms: 15
+                                  total_search_duration_ms: 135
+                                status: partial failure
+                                status_order: 20
+                            false_positives:
+                              - DNS domains that use large numbers of child domains, such as software or content distribution networks, can trigger this alert and such parent domains can be excluded.
+                            from: now-45m
+                            id: 8bc7dad0-9320-11ec-9265-8b772383a08d
+                            immutable: false
+                            interval: 15m
+                            license: Elastic License v2
+                            machine_learning_job_id:
+                              - packetbeat_dns_tunneling
+                            max_signals: 100
+                            name: DNS Tunneling [Duplicate]
+                            references:
+                              - https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html
+                            related_integrations: []
+                            required_fields: []
+                            risk_score: 21
+                            risk_score_mapping: []
+                            rule_id: 7289bf08-4e91-4c70-bf01-e04c4c5d7756
+                            setup: ''
+                            severity: low
+                            severity_mapping: []
+                            tags:
+                              - Elastic
+                              - Network
+                              - Threat Detection
+                              - ML
+                            threat: []
+                            to: now
+                            type: machine_learning
+                            updated_at: '2022-02-21T17:05:50.883Z'
+                            updated_by: elastic
+                            version: 6
+                      summary:
+                        failed: 0
+                        skipped: 1
+                        succeeded: 1
+                        total: 2
+                    rules_count: 1
+                    success: true
+                example2:
+                  description: If processing of any rule fails, a partial error outputs the ID and/or name of the affected rule and the corresponding error, as well as successfully processed rules (in the same format as a successful 200 request).
+                  summary: Partial failure
+                  value:
+                    value:
+                      attributes:
+                        errors:
+                          - message: Index patterns can't be added. Machine learning rule doesn't have index patterns property
+                            rules:
+                              - id: 8bc7dad0-9320-11ec-9265-8b772383a08d
+                                name: DNS Tunneling [Duplicate]
+                            status_code: 500
+                        results:
+                          created: []
+                          deleted: []
+                          skipped: []
+                          updated:
+                            - actions: []
+                              author:
+                                - Elastic
+                              created_at: '2022-02-21T14:14:17.883Z'
+                              created_by: elastic
+                              description: Generates a detection alert for each external alert written to the configured indices. Enabling this rule allows you to immediately begin investigating external alerts in the app.
+                              enabled: true
+                              exceptions_list: []
+                              execution_summary:
+                                last_execution:
+                                  date: '2022-03-23T16:06:12.787Z'
+                                  message: This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.
+                                  metrics:
+                                    execution_gap_duration_s: 0
+                                    total_indexing_duration_ms: 15
+                                    total_search_duration_ms: 135
+                                  status: partial failure
+                                  status_order: 20
+                              false_positives: []
+                              from: now-6m
+                              id: 8e5c1a40-9320-11ec-9265-8b772383a08d
+                              immutable: false
+                              index:
+                                - apm-*-transaction*
+                                - traces-apm*
+                                - auditbeat-*
+                                - filebeat-*
+                                - logs-*
+                                - packetbeat-*
+                                - winlogbeat-*
+                                - added-by-id-*
+                              interval: 5m
+                              language: kuery
+                              license: Elastic License v2
+                              max_signals: 10000
+                              name: External Alerts [Duplicate]
+                              query: |
+                                event.kind:alert and not event.module:(endgame or endpoint)
+                              references: []
+                              related_integrations: []
+                              required_fields: []
+                              risk_score: 47
+                              risk_score_mapping:
+                                - field: event.risk_score
+                                  operator: equals
+                                  value: ''
+                              rule_id: 941faf98-0cdc-4569-b16d-4af962914d61
+                              rule_name_override: message
+                              setup: ''
+                              severity: medium
+                              severity_mapping:
+                                - field: event.severity
+                                  operator: equals
+                                  severity: low
+                                  value: '21'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: medium
+                                  value: '47'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: high
+                                  value: '73'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: critical
+                                  value: '99'
+                              tags:
+                                - Elastic
+                                - Network
+                                - Windows
+                                - APM
+                                - macOS
+                                - Linux
+                              threat: []
+                              timestamp_override: event.ingested
+                              to: now
+                              type: query
+                              updated_at: '2022-02-21T16:56:22.818Z'
+                              updated_by: elastic
+                              version: 5
+                        summary:
+                          failed: 1
+                          skipped: 0
+                          succeeded: 1
+                          total: 2
+                      message: Bulk edit partially failed
+                      rules_count: 2
+                      status_code: 500
+                      success: false
+                example3:
+                  description: The attributes.errors section of the response shows that two rules failed to update and one succeeded. The same results would be returned if you ran the request without dry run mode enabled. Notice that there are no arrays in attributes.results. In dry run mode, rule updates are not applied and saved to Elasticsearch, so the endpoint wouldn’t return results for rules that have been updated, created, or deleted.
+                  summary: Dry run
+                  value:
+                    attributes:
+                      errors:
+                        - err_code: IMMUTABLE
+                          message: Elastic rule can't be edited
+                          rules:
+                            - id: 81aa0480-06af-11ed-94fb-dd1a0597d8d2
+                              name: Unusual AWS Command for a User
+                          status_code: 500
+                        - err_code: MACHINE_LEARNING_INDEX_PATTERN
+                          message: Machine learning rule doesn't have index patterns
+                          rules:
+                            - id: dc015d10-0831-11ed-ac8b-05a222bd8d4a
+                              name: Suspicious Powershell Script [Duplicate]
+                          status_code: 500
+                      results:
+                        created: []
+                        deleted: []
+                        skipped: []
+                        updated: []
+                      summary:
+                        failed: 2
+                        skipped: 0
+                        succeeded: 1
+                        total: 3
+                    message: Bulk edit partially failed
+                    status_code: 500
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/Security_Detections_API_BulkEditActionResponse'
@@ -11388,7 +12720,11 @@ paths:
         - Actions
         - Exception lists
         > info
-        > You cannot export prebuilt rules.
+        > Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+        > You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+        > Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
       operationId: ExportRules
       parameters:
         - description: Determines whether a summary of the exported rules is returned.
@@ -11398,7 +12734,10 @@ paths:
           schema:
             default: false
             type: boolean
-        - description: File name for saving the exported rules.
+        - description: |
+            File name for saving the exported rules.
+            > info
+            > When using cURL to export rules to a file, use the -O and -J options to save the rules to the file name specified in the URL.
           in: query
           name: file_name
           required: false
@@ -11430,13 +12769,30 @@ paths:
           content:
             application/ndjson:
               schema:
-                description: An `.ndjson` file containing the returned rules.
+                description: |
+                  An `.ndjson` file containing the returned rules.
+
+                  Each line in the file represents an object (a rule, exception list parent container, or exception list item), and the last line includes a summary of what was exported.
                 format: binary
                 type: string
           description: Indicates a successful call.
       summary: Export detection rules
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST "localhost:5601/api/detection_engine/rules/_export?exclude_export_details=true&file_name=exported_rules.ndjson" -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d'
+            {
+              "objects": [
+                {
+                  "rule_id":"343580b5-c811-447c-8d2d-2ccf052c6900"
+                },
+                {
+                  "rule_id":"2938c9fa-53eb-4c04-b79c-33cbf041b18d"
+                }
+              ]
+            }
   /api/detection_engine/rules/_find:
     get:
       description: Retrieve a paginated list of detection rules. By default, the first page is returned, with 20 results per page.
@@ -11449,7 +12805,18 @@ paths:
             items:
               type: string
             type: array
-        - description: Search query
+        - description: |
+            Search query
+
+            Filters the returned results according to the value of the specified field, using the alert.attributes.<field name>:<field value> syntax, where <field name> can be:
+            - name
+            - enabled
+            - tags
+            - createdBy
+            - interval
+            - updatedBy
+            > info
+            > Even though the JSON rule object uses created_by and updated_by fields, you must use createdBy and updatedBy fields in the filter.
           in: query
           name: filter
           required: false
@@ -11499,6 +12866,73 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    data:
+                      - created_at: '2020-02-02T10:05:19.613Z'
+                        created_by: elastic
+                        description: Identifies a PowerShell process launched by either cscript.exe or wscript.exe. Observing Windows scripting processes executing a PowerShell script, may be indicative of malicious activity.
+                        enabled: false
+                        execution_summary:
+                          last_execution:
+                            date: '2022-03-23T16:06:12.787Z'
+                            message: This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.
+                            metrics:
+                              execution_gap_duration_s: 0
+                              total_indexing_duration_ms: 15
+                              total_search_duration_ms: 135
+                            status: partial failure
+                            status_order: 20
+                        false_positives: []
+                        from: now-6m
+                        id: 89761517-fdb0-4223-b67b-7621acc48f9e
+                        immutable: true
+                        index:
+                          - winlogbeat-*
+                        interval: 5m
+                        language: kuery
+                        max_signals: 33
+                        name: Windows Script Executing PowerShell
+                        query: 'event.action:"Process Create (rule: ProcessCreate)" and process.parent.name:("wscript.exe" or "cscript.exe") and process.name:"powershell.exe"'
+                        references: []
+                        related_integrations:
+                          - package: o365
+                            version: ^2.3.2
+                        required_fields:
+                          - ecs: true
+                            name: event.action
+                            type: keyword
+                          - ecs: true
+                            name: process.name
+                            type: keyword
+                          - ecs: true
+                            name: process.parent.name
+                            type: keyword
+                        risk_score: 21
+                        rule_id: f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc
+                        setup: ''
+                        severity: low
+                        tags:
+                          - Elastic
+                          - Windows
+                        threat:
+                          - framework: MITRE ATT&CK
+                            tactic:
+                              id: TA0002
+                              name: Execution
+                              reference: https://attack.mitre.org/tactics/TA0002/
+                            technique:
+                              - id: T1193
+                                name: Spearphishing Attachment
+                                reference: https://attack.mitre.org/techniques/T1193/
+                        to: now
+                        type: query
+                        updated_at: '2020-02-02T10:05:19.830Z'
+                        updated_by: elastic
+                    page: 1
+                    perPage: 5
+                    total: 4
               schema:
                 type: object
                 properties:
@@ -11517,16 +12951,36 @@ paths:
                   - perPage
                   - total
                   - data
-          description: Successful response
+          description: |
+            Successful response
+            > info
+            > These fields are under development and their usage or schema may change: execution_summary.
       summary: List all detection rules
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X GET "localhost:5601/api/detection_engine/rules/_find?page=1&per_page=5&sort_field=enabled&sort_order=asc&filter=alert.attributes.name:windows" -H 'kbn-xsrf: true'
   /api/detection_engine/rules/_import:
     post:
       description: |
         Import detection rules from an `.ndjson` file, including actions and exception lists. The request must include:
         - The `Content-Type: multipart/form-data` HTTP header.
         - A link to the `.ndjson` file containing the rules.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+        > info
+        > To import rules with actions, you need at least Read privileges for the Action and Connectors feature. To overwrite or add new connectors, you need All privileges for the Actions and Connectors feature. To import rules without actions, you don’t need Actions and Connectors privileges. Refer to [Enable and access detections](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui) for more information.
+
+        > info
+        > Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+        > You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+        > Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
       operationId: ImportRules
       parameters:
         - description: Determines whether existing rules with the same `rule_id` are overwritten.
@@ -11536,7 +12990,7 @@ paths:
           schema:
             default: false
             type: boolean
-        - description: Determines whether existing exception lists with the same `list_id` are overwritten.
+        - description: Determines whether existing exception lists with the same `list_id` are overwritten. Both the exception list container and its items are overwritten.
           in: query
           name: overwrite_exceptions
           required: false
@@ -11572,6 +13026,17 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Import rules with success
+                  value:
+                    errors: []
+                    exceptions_errors: []
+                    exceptions_success: true
+                    exceptions_success_count: 0
+                    rules_count: 1
+                    success: true
+                    success_count: 1
               schema:
                 additionalProperties: false
                 type: object
@@ -11626,6 +13091,13 @@ paths:
       summary: Import detection rules
       tags:
         - Security Detections API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST "<KibanaURL>/api/detection_engine/rules/_import"
+            -u <username>:<password> -H 'kbn-xsrf: true'
+            -H 'Content-Type: multipart/form-data'
+            --form "file=@<link to file>"
   /api/detection_engine/rules/{id}/exceptions:
     post:
       description: Create exception items that apply to a single detection rule.
@@ -11691,12 +13163,30 @@ paths:
         - Security Exceptions API
   /api/detection_engine/rules/prepackaged:
     put:
-      description: Install and update all Elastic prebuilt detection rules and Timelines.
+      description: |
+        Install and update all Elastic prebuilt detection rules and Timelines.
+
+        This endpoint allows you to install and update prebuilt detection rules and Timelines provided by Elastic. 
+        When you call this endpoint, it will:
+        - Install any new prebuilt detection rules that are not currently installed in your system.
+        - Update any existing prebuilt detection rules that have been modified or improved by Elastic.
+        - Install any new prebuilt Timelines that are not currently installed in your system.
+        - Update any existing prebuilt Timelines that have been modified or improved by Elastic.
+
+        This ensures that your detection engine is always up-to-date with the latest rules and Timelines, 
+        providing you with the most current and effective threat detection capabilities.
       operationId: InstallPrebuiltRulesAndTimelines
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    rules_installed: 112
+                    rules_updated: 0
+                    timelines_installed: 5
+                    timelines_updated: 2
               schema:
                 additionalProperties: false
                 type: object
@@ -11728,12 +13218,25 @@ paths:
         - Security Detections API
   /api/detection_engine/rules/prepackaged/_status:
     get:
-      description: Retrieve the status of all Elastic prebuilt detection rules and Timelines.
+      description: |
+        Retrieve the status of all Elastic prebuilt detection rules and Timelines. 
+
+        This endpoint provides detailed information about the number of custom rules, installed prebuilt rules, available prebuilt rules that are not installed, outdated prebuilt rules, installed prebuilt timelines, available prebuilt timelines that are not installed, and outdated prebuilt timelines.
       operationId: ReadPrebuiltRulesAndTimelinesStatus
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    rules_custom_installed: 0
+                    rules_installed: 0
+                    rules_not_installed: 112
+                    rules_not_updated: 0
+                    timelines_installed: 0
+                    timelines_not_installed: 0
+                    timelines_not_updated: 0
               schema:
                 additionalProperties: false
                 type: object
@@ -12302,6 +13805,17 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    - zeek
+                    - suricata
+                    - windows
+                    - linux
+                    - network
+                    - initial access
+                    - remote access
+                    - phishing
               schema:
                 $ref: '#/components/schemas/Security_Detections_API_RuleTagArray'
           description: Indicates a successful call
@@ -32352,6 +33866,7 @@ components:
         - in-progress
       type: string
     Security_Detections_API_AlertSuppression:
+      description: Defines alert suppression configuration.
       type: object
       properties:
         duration:
@@ -32374,6 +33889,7 @@ components:
         - value
         - unit
     Security_Detections_API_AlertSuppressionDurationUnit:
+      description: Time unit
       enum:
         - s
         - m
@@ -32411,11 +33927,14 @@ components:
         - version
         - count
     Security_Detections_API_AnomalyThreshold:
-      description: Anomaly threshold
+      description: Anomaly score threshold above which the rule creates an alert. Valid values are from 0 to 100.
       minimum: 0
       type: integer
     Security_Detections_API_BuildingBlockType:
-      description: Determines if the rule acts as a building block. By default, building-block alerts are not displayed in the UI. These rules are used as a foundation for other rules that do generate alerts. Its value must be default.
+      description: |
+        Determines if the rule acts as a building block. If yes, the value must be `default`.
+        By default, building-block alerts are not displayed in the UI. These rules are used as a foundation for other rules that do generate alerts.
+        For more information, refer to [About building block rules](https://www.elastic.co/guide/en/security/current/building-block-rule.html).
       type: string
     Security_Detections_API_BulkActionEditPayload:
       anyOf:
@@ -32573,13 +34092,13 @@ components:
             - delete
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -32591,13 +34110,13 @@ components:
             - disable
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -32609,6 +34128,7 @@ components:
             - duplicate
           type: string
         duplicate:
+          description: Duplicate object that describes applying an update action.
           type: object
           properties:
             include_exceptions:
@@ -32621,13 +34141,13 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -32683,6 +34203,7 @@ components:
         - deleted
         - skipped
     Security_Detections_API_BulkEditActionSummary:
+      description: A rule can only be skipped when the bulk action to be performed on it results in nothing being done. For example, if the `edit` action is used to add a tag to a rule that already has that tag, or to delete an index pattern that is not specified in a rule. Objects returned in `attributes.results.skipped` will only include rules' `id`, `name`, and `skip_reason`.
       type: object
       properties:
         failed:
@@ -32712,13 +34233,13 @@ components:
           minItems: 1
           type: array
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -32735,13 +34256,13 @@ components:
             - enable
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -32755,13 +34276,13 @@ components:
             - export
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -32773,15 +34294,16 @@ components:
             - run
           type: string
         ids:
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
         run:
+          description: Object that describes applying a manual rule run action.
           type: object
           properties:
             end_date:
@@ -32823,6 +34345,7 @@ components:
               - items:
                   type: string
                 type: array
+      description: 'Map Osquery results columns or static values to Elastic Common Schema (ECS) fields. Example: "ecs_mapping": {"process.pid": {"field": "pid"}}'
       type: object
     Security_Detections_API_EndpointResponseAction:
       type: object
@@ -32867,7 +34390,6 @@ components:
           description: Query language to use
         query:
           $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
-          description: EQL query to execute
         type:
           description: Rule type
           enum:
@@ -32882,6 +34404,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -32930,6 +34453,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -33001,6 +34528,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -33049,6 +34577,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -33103,7 +34635,6 @@ components:
               description: Query language to use
             query:
               $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
-              description: EQL query to execute
             type:
               description: Rule type
               enum:
@@ -33115,6 +34646,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -33165,6 +34697,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -33214,6 +34750,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -33264,6 +34801,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -33345,6 +34886,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -33393,6 +34935,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -33464,6 +35010,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -33512,6 +35059,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -33567,6 +35118,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -33616,12 +35168,15 @@ components:
               $ref: '#/components/schemas/Security_Detections_API_AlertsIndex'
             query:
               $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
-              description: ESQL query to execute
             references:
               $ref: '#/components/schemas/Security_Detections_API_RuleReferenceArray'
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -33674,7 +35229,6 @@ components:
           $ref: '#/components/schemas/Security_Detections_API_EsqlQueryLanguage'
         query:
           $ref: '#/components/schemas/Security_Detections_API_RuleQuery'
-          description: ESQL query to execute
         type:
           description: Rule type
           enum:
@@ -33693,6 +35247,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -33743,6 +35298,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -33832,7 +35391,10 @@ components:
         - updatedAt
       type: string
     Security_Detections_API_HistoryWindowStart:
-      $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
+      description: Start date to use when checking if a term has been seen before. Supports relative dates – for example, now-30d will search the last 30 days of data when checking if a term is new. We do not recommend using absolute dates, which can cause issues with rule performance due to querying increasing amounts of data over time.
+      format: nonempty
+      minLength: 1
+      type: string
     Security_Detections_API_IndexMigrationStatus:
       type: object
       properties:
@@ -33857,6 +35419,10 @@ components:
         - migrations
         - is_outdated
     Security_Detections_API_IndexPatternArray:
+      description: |
+        Indices on which the rule functions. Defaults to the Security Solution indices defined on the Kibana Advanced Settings page (Kibana → Stack Management → Advanced Settings → `securitySolution:defaultIndex`).
+        > info
+        > This field is not supported for ES|QL rules.
       items:
         type: string
       type: array
@@ -33874,17 +35440,6 @@ components:
       description: |
         Schema for fields relating to investigation fields. These are user defined fields we use to highlight
         in various features in the UI such as alert details flyout and exceptions auto-population from alert.
-        Added in PR #163235
-        Right now we only have a single field but anticipate adding more related fields to store various
-        configuration states such as `override` - where a user might say if they want only these fields to
-        display, or if they want these fields + the fields we select. When expanding this field, it may look
-        something like:
-        ```typescript
-        const investigationFields = z.object({
-          field_names: NonEmptyArray(NonEmptyString),
-          override: z.boolean().optional(),
-        });
-        ```
       type: object
       properties:
         field_names:
@@ -33901,7 +35456,7 @@ components:
       description: Determines whether an external/prebuilt rule has been customized by the user (i.e. any of its fields have been modified and diverged from the base value).
       type: boolean
     Security_Detections_API_IsRuleEnabled:
-      description: Determines whether the rule is enabled.
+      description: Determines whether the rule is enabled. Defaults to true.
       type: boolean
     Security_Detections_API_IsRuleImmutable:
       deprecated: true
@@ -33916,7 +35471,7 @@ components:
         - lucene
       type: string
     Security_Detections_API_MachineLearningJobId:
-      description: Machine learning job ID
+      description: Machine learning job ID(s) the rule monitors for anomaly scores.
       oneOf:
         - type: string
         - items:
@@ -33928,6 +35483,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -33976,6 +35532,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -34047,6 +35607,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -34095,6 +35656,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -34164,6 +35729,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -34214,6 +35780,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -34279,6 +35849,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -34329,6 +35900,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -34375,6 +35950,11 @@ components:
             - severity
         - $ref: '#/components/schemas/Security_Detections_API_MachineLearningRuleCreateFields'
     Security_Detections_API_MaxSignals:
+      default: 100
+      description: |
+        Maximum number of alerts the rule can create during a single run (the rule’s Max alerts per run [advanced setting](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#rule-ui-advanced-params) value).
+        > info
+        > This setting can be superseded by the [Kibana configuration setting](https://www.elastic.co/guide/en/kibana/current/alert-action-settings-kb.html#alert-settings) `xpack.alerting.rules.run.alerts.max`, which determines the maximum alerts generated by any rule in the Kibana alerting framework. For example, if `xpack.alerting.rules.run.alerts.max` is set to 1000, the rule can generate no more than 1000 alerts even if `max_signals` is set higher.
       minimum: 1
       type: integer
     Security_Detections_API_MigrationCleanupResult:
@@ -34476,6 +36056,7 @@ components:
         - version
         - updated
     Security_Detections_API_NewTermsFields:
+      description: Fields to monitor for new values.
       items:
         type: string
       maxItems: 3
@@ -34486,6 +36067,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -34534,6 +36116,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -34606,6 +36192,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -34654,6 +36241,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -34737,6 +36328,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -34787,6 +36379,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -34861,6 +36457,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -34911,6 +36508,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -35001,16 +36602,20 @@ components:
         ecs_mapping:
           $ref: '#/components/schemas/Security_Detections_API_EcsMapping'
         pack_id:
+          description: 'To specify a query pack, use the packId field. Example: "packId": "processes_elastic"'
           type: string
         queries:
           items:
             $ref: '#/components/schemas/Security_Detections_API_OsqueryQuery'
           type: array
         query:
+          description: 'To run a single query, use the query field and enter a SQL query. Example: "query": "SELECT * FROM processes;"'
           type: string
         saved_query_id:
+          description: 'To run a saved query, use the saved_query_id field and specify the saved query ID. Example: "saved_query_id": "processes_elastic"'
           type: string
         timeout:
+          description: 'A timeout period, in seconds, after which the query will stop running. Overwriting the default timeout allows you to support queries that require more time to complete. The default and minimum supported value is 60. The maximum supported value is 900. Example: "timeout": 120.'
           type: number
     Security_Detections_API_OsqueryQuery:
       type: object
@@ -35064,11 +36669,13 @@ components:
       type: object
       properties:
         command:
+          description: 'To run an endpoint response action, specify a value for the command field. Example: "command": "isolate"'
           enum:
             - kill-process
             - suspend-process
           type: string
         comment:
+          description: 'Add a note that explains or describes the action. You can find your comment in the response actions history log. Example: "comment": "Check processes"'
           type: string
         config:
           type: object
@@ -35090,6 +36697,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -35138,6 +36746,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -35210,6 +36822,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -35258,6 +36871,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -35339,6 +36956,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -35389,6 +37007,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -35457,6 +37079,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -35507,6 +37130,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -35571,19 +37198,10 @@ components:
         There are Fleet packages like `windows` that contain only one integration; in this case,
         `integration` should be unspecified. There are also packages like `aws` and `azure` that contain
         several integrations; in this case, `integration` should be specified.
-
-        @example
-        const x: RelatedIntegration = {
-          package: 'windows',
-          version: '1.5.x',
-        };
-
-        @example
-        const x: RelatedIntegration = {
-          package: 'azure',
-          version: '~1.1.6',
-          integration: 'activitylogs',
-        };
+      example:
+        integration: activitylogs
+        package: azure
+        version: ~1.1.6
       type: object
       properties:
         integration:
@@ -35625,14 +37243,18 @@ components:
       type: object
       properties:
         ecs:
-          description: Whether the field is an ECS field
+          description: Indicates whether the field is ECS-compliant. This property is only present in responses. Its value is computed based on field’s name and type.
           type: boolean
         name:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Name of an Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
         type:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Type of the Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
       required:
         - name
         - type
@@ -35646,11 +37268,15 @@ components:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: Name of an Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
         type:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
-          description: Type of an Elasticsearch field
+          description: Type of the Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
       required:
         - name
         - type
@@ -35698,7 +37324,12 @@ components:
         - related_integrations
         - required_fields
     Security_Detections_API_RiskScore:
-      description: Risk score (0 to 100)
+      description: |
+        A numerical representation of the alert's severity from 0 to 100, where:
+        * `0` - `21` represents low severity
+        * `22` - `47` represents medium severity
+        * `48` - `73` represents high severity
+        * `74` - `100` represents critical severity
       maximum: 100
       minimum: 0
       type: integer
@@ -35708,6 +37339,7 @@ components:
         type: object
         properties:
           field:
+            description: Source event field used to override the default `risk_score`.
             type: string
           operator:
             enum:
@@ -35726,7 +37358,26 @@ components:
       type: object
       properties:
         action_type_id:
-          description: The action type used for sending notifications.
+          description: |
+            The action type used for sending notifications, can be:
+
+              - `.slack`
+              - `.slack_api`
+              - `.email`
+              - `.index`
+              - `.pagerduty`
+              - `.swimlane`
+              - `.webhook`
+              - `.servicenow`
+              - `.servicenow-itom`
+              - `.servicenow-sir`
+              - `.jira`
+              - `.resilient`
+              - `.opsgenie`
+              - `.teams`
+              - `.torq`
+              - `.tines`
+              - `.d3security`
           type: string
         alerts_filter:
           $ref: '#/components/schemas/Security_Detections_API_RuleActionAlertsFilter'
@@ -35746,6 +37397,19 @@ components:
         - params
     Security_Detections_API_RuleActionAlertsFilter:
       additionalProperties: true
+      description: |
+        Object containing an action’s conditional filters.
+
+        - `timeframe` (object, optional): Object containing the time frame for when this action can be run.
+            - `days` (array of integers, required): List of days of the week on which this action will be run. Days of the week are expressed as numbers between `1-7`, where `1` is Monday and `7` is Sunday. To select all days of the week, enter an empty array.
+            - `hours` (object, required): The hours of the day during which this action will run. Hours of the day are expressed as two strings in the format `hh:mm` in `24` hour time. A start of `00:00` and an end of `24:00` means the action can run all day.
+                - start (string, required): Start time in `hh:mm` format.
+                - end (string, required): End time in `hh:mm` format.
+            - `timezone` (string, required): An ISO timezone name, such as `Europe/Madrid` or `America/New_York`. Specific offsets such as `UTC` or `UTC+1` will also work, but lack built-in DST.
+        - `query` (object, optional): Object containing a query filter which gets applied to an action and determines whether the action should run.
+            - `kql` (string, required): A KQL string.
+            - `filters` (array of objects, required): Array of filter objects, as defined in the `kbn-es-query` package.
+              
       type: object
     Security_Detections_API_RuleActionFrequency:
       description: The action frequency defines when the action runs (for example, only on rule execution or at specific time intervals).
@@ -35770,7 +37434,7 @@ components:
       description: The connector ID.
       type: string
     Security_Detections_API_RuleActionNotifyWhen:
-      description: 'The condition for throttling the notification: `onActionGroupChange`, `onActiveAlert`,  or `onThrottleInterval`'
+      description: Defines how often rules run actions.
       enum:
         - onActiveAlert
         - onThrottleInterval
@@ -35778,7 +37442,34 @@ components:
       type: string
     Security_Detections_API_RuleActionParams:
       additionalProperties: true
-      description: Object containing the allowed connector fields, which varies according to the connector type.
+      description: |
+        Object containing the allowed connector fields, which varies according to the connector type.
+
+        For Slack:
+
+          - `message` (string, required): The notification message.
+
+        For email:
+
+          - `to`, `cc`, `bcc` (string): Email addresses to which the notifications are sent. At least one field must have a value.
+          - `subject` (string, optional): Email subject line.
+          - `message` (string, required): Email body text.
+
+        For Webhook:
+
+          - `body` (string, required): JSON payload.
+
+        For PagerDuty:
+
+          - `severity` (string, required): Severity of on the alert notification, can be: `Critical`, `Error`, `Warning` or `Info`.
+          - `eventAction` (string, required): Event [action type](https://v2.developer.pagerduty.com/docs/events-api-v2#event-action), which can be `trigger`, `resolve`, or `acknowledge`.
+          - `dedupKey` (string, optional): Groups alert notifications with the same PagerDuty alert.
+          - `timestamp` (DateTime, optional): ISO-8601 format [timestamp](https://v2.developer.pagerduty.com/docs/types#datetime).
+          - `component` (string, optional): Source machine component responsible for the event, for example `security-solution`.
+          - `group` (string, optional): Enables logical grouping of service components.
+          - `source` (string, optional): The affected system. Defaults to the Kibana saved object ID of the action.
+          - `summary` (string, options): Summary of the event. Defaults to `No summary provided`. Maximum length is 1024 characters.
+          - `class` (string, optional): Value indicating the class/type of the event.
       type: object
     Security_Detections_API_RuleActionThrottle:
       description: Defines how often rule actions are taken.
@@ -35792,6 +37483,7 @@ components:
           pattern: ^[1-9]\d*[smhd]$
           type: string
     Security_Detections_API_RuleAuthorArray:
+      description: The rule’s author.
       items:
         type: string
       type: array
@@ -35808,6 +37500,8 @@ components:
       discriminator:
         propertyName: type
     Security_Detections_API_RuleDescription:
+      description: The rule’s description.
+      example: Detects anomalous Windows process creation events.
       minLength: 1
       type: string
     Security_Detections_API_RuleDetailsInError:
@@ -35820,14 +37514,20 @@ components:
       required:
         - id
     Security_Detections_API_RuleExceptionList:
+      description: |
+        Array of [exception containers](https://www.elastic.co/guide/en/security/current/exceptions-api-overview.html), which define exceptions that prevent the rule from generating alerts even when its other criteria are met.
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: ID of the exception container
+          format: nonempty
+          minLength: 1
+          type: string
         list_id:
-          $ref: '#/components/schemas/Security_Detections_API_NonEmptyString'
           description: List ID of the exception container
+          format: nonempty
+          minLength: 1
+          type: string
         namespace_type:
           description: Determines the exceptions validity in rule's Kibana space
           enum:
@@ -35891,6 +37591,10 @@ components:
     Security_Detections_API_RuleExecutionStatusOrder:
       type: integer
     Security_Detections_API_RuleExecutionSummary:
+      description: |
+        Summary of the last execution of a rule.
+        > info
+        > This field is under development and its usage or schema may change
       type: object
       properties:
         last_execution:
@@ -35918,10 +37622,15 @@ components:
       required:
         - last_execution
     Security_Detections_API_RuleFalsePositiveArray:
+      description: String array used to describe common reasons why the rule may issue false-positive alerts. Defaults to an empty array.
       items:
         type: string
       type: array
     Security_Detections_API_RuleFilterArray:
+      description: |
+        The query and filter context array used to define the conditions for when alerts are created from events. Defaults to an empty array.
+        > info
+        > This field is not supported for ES|QL rules.
       items: {}
       type: array
     Security_Detections_API_RuleInterval:
@@ -35938,15 +37647,22 @@ components:
       type: string
     Security_Detections_API_RuleMetadata:
       additionalProperties: true
+      description: |
+        Placeholder for metadata about the rule.
+        > info
+        > This field is overwritten when you save changes to the rule’s settings.
       type: object
     Security_Detections_API_RuleName:
+      description: A human-readable name for the rule.
+      example: Anomalous Windows Process Creation
       minLength: 1
       type: string
     Security_Detections_API_RuleNameOverride:
-      description: Sets the source field for the alert's signal.rule.name value
+      description: Sets which field in the source event is used to populate the alert's `signal.rule.name` value (in the UI, this value is displayed on the Rules page in the Rule column). When unspecified, the rule’s `name` value is used. The source field must be a string data type.
       type: string
     Security_Detections_API_RuleObjectId:
       $ref: '#/components/schemas/Security_Detections_API_UUID'
+      description: A dynamic unique identifier for the rule object. It is randomly generated when a rule is created and cannot be changed after that. It is always a UUID. It is unique within a given Kibana space. The same prebuilt Elastic rule, when installed in two different Kibana spaces or two different Elastic environments, will have different object `id`s.
     Security_Detections_API_RulePatchProps:
       anyOf:
         - $ref: '#/components/schemas/Security_Detections_API_EqlRulePatchProps'
@@ -36004,8 +37720,14 @@ components:
         - invocationCount
         - timeframeEnd
     Security_Detections_API_RuleQuery:
+      description: |
+        [Query](https://www.elastic.co/guide/en/kibana/8.17/search.html) used by the rule to create alerts.
+
+        - For indicator match rules, only the query’s results are used to determine whether an alert is generated.
+        - ES|QL rules have additional query requirements. Refer to [Create ES|QL](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-esql-rule) rules for more information.
       type: string
     Security_Detections_API_RuleReferenceArray:
+      description: Array containing notes about or references to relevant information about the rule. Defaults to an empty array.
       items:
         type: string
       type: array
@@ -36031,7 +37753,7 @@ components:
       minimum: 0
       type: integer
     Security_Detections_API_RuleSignatureId:
-      description: Could be any string, not necessarily a UUID
+      description: A stable unique identifier for the rule object. It can be assigned during rule creation. It can be any string, but often is a UUID. It should be unique not only within a given Kibana space, but also across spaces and Elastic environments. The same prebuilt Elastic rule, when installed in two different Kibana spaces or two different Elastic environments, will have the same `rule_id`s.
       type: string
     Security_Detections_API_RuleSource:
       description: Discriminated union that determines whether the rule is internally sourced (created within the Kibana app) or has an external source, such as the Elastic Prebuilt rules repo.
@@ -36081,12 +37803,14 @@ components:
         - conflict
       type: string
     Security_Detections_API_SavedQueryId:
+      description: Kibana [saved search](https://www.elastic.co/guide/en/kibana/current/save-open-search.html) used by the rule to create alerts.
       type: string
     Security_Detections_API_SavedQueryRule:
       allOf:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -36135,6 +37859,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -36207,6 +37935,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -36255,6 +37984,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -36336,6 +38069,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -36386,6 +38120,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -36454,6 +38192,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -36504,6 +38243,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -36590,9 +38333,15 @@ components:
         - tags_to_add
         - tags_to_remove
     Security_Detections_API_SetupGuide:
+      description: Populates the rule’s setup guide with instructions on rule prerequisites such as required integrations, configuration steps, and anything else needed for the rule to work correctly.
       type: string
     Security_Detections_API_Severity:
-      description: Severity of the rule
+      description: |
+        Severity level of alerts produced by the rule, which must be one of the following:
+        * `low`: Alerts that are of interest but generally not considered to be security incidents
+        * `medium`: Alerts that require investigation
+        * `high`: Alerts that require immediate investigation
+        * `critical`: Alerts that indicate it is highly likely a security incident has occurred
       enum:
         - low
         - medium
@@ -36605,6 +38354,7 @@ components:
         type: object
         properties:
           field:
+            description: Source event field used to override the default `severity`.
             type: string
           operator:
             enum:
@@ -36643,6 +38393,9 @@ components:
         - desc
       type: string
     Security_Detections_API_Threat:
+      description: |
+        > info
+        > Currently, only threats described using the MITRE ATT&CK&trade; framework are supported.
       type: object
       properties:
         framework:
@@ -36667,6 +38420,7 @@ components:
         description: Query and filter context array used to filter documents from the Elasticsearch index containing the threat values
       type: array
     Security_Detections_API_ThreatIndex:
+      description: Elasticsearch indices used to check which field values generate alerts.
       items:
         type: string
       type: array
@@ -36674,6 +38428,14 @@ components:
       description: Defines the path to the threat indicator in the indicator documents (optional)
       type: string
     Security_Detections_API_ThreatMapping:
+      description: |
+        Array of entries objects that define mappings between the source event fields and the values in the Elasticsearch threat index. Each entries object must contain these fields:
+
+        - field: field from the event indices on which the rule runs
+        - type: must be mapping
+        - value: field from the Elasticsearch threat index
+          
+        You can use Boolean and and or logic to define the conditions for when matching fields and values generate alerts. Sibling entries objects are evaluated using or logic, whereas multiple entries in a single entries object use and logic. See Example of Threat Match rule which uses both `and` and `or` logic.
       items:
         type: object
         properties:
@@ -36703,6 +38465,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -36751,6 +38514,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -36823,6 +38590,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -36871,6 +38639,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -36968,6 +38740,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -37018,6 +38791,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -37095,6 +38872,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -37145,6 +38923,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -37191,7 +38973,7 @@ components:
             - severity
         - $ref: '#/components/schemas/Security_Detections_API_ThreatMatchRuleCreateFields'
     Security_Detections_API_ThreatQuery:
-      description: Query to run
+      description: Query used to determine which fields in the Elasticsearch index are used for generating alerts.
       type: string
     Security_Detections_API_ThreatSubtechnique:
       type: object
@@ -37210,6 +38992,8 @@ components:
         - name
         - reference
     Security_Detections_API_ThreatTactic:
+      description: |
+        Object containing information on the attack type
       type: object
       properties:
         id:
@@ -37238,7 +39022,8 @@ components:
           description: Technique reference
           type: string
         subtechnique:
-          description: Array containing more specific information on the attack technique
+          description: |
+            Array containing more specific information on the attack technique.
           items:
             $ref: '#/components/schemas/Security_Detections_API_ThreatSubtechnique'
           type: array
@@ -37259,6 +39044,7 @@ components:
         - field
         - value
     Security_Detections_API_ThresholdAlertSuppression:
+      description: Defines alert suppression configuration.
       type: object
       properties:
         duration:
@@ -37266,12 +39052,15 @@ components:
       required:
         - duration
     Security_Detections_API_ThresholdCardinality:
+      description: The field on which the cardinality is applied.
       items:
         type: object
         properties:
           field:
+            description: The field on which to calculate and compare the cardinality.
             type: string
           value:
+            description: The threshold value from which an alert is generated based on unique number of values of cardinality.field.
             minimum: 0
             type: integer
         required:
@@ -37279,7 +39068,7 @@ components:
           - value
       type: array
     Security_Detections_API_ThresholdField:
-      description: Field to aggregate on
+      description: The field on which the threshold is applied. If you specify an empty array ([]), alerts are generated when the query returns at least the number of results specified in the value field.
       oneOf:
         - type: string
         - items:
@@ -37290,6 +39079,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -37338,6 +39128,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -37410,6 +39204,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -37458,6 +39253,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -37541,6 +39340,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -37591,6 +39391,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -37662,6 +39466,7 @@ components:
         - type: object
           properties:
             actions:
+              description: Array defining the automated actions (notifications) taken when alerts are generated.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RuleAction'
               type: array
@@ -37712,6 +39517,10 @@ components:
             related_integrations:
               $ref: '#/components/schemas/Security_Detections_API_RelatedIntegrationArray'
             required_fields:
+              description: |
+                Elasticsearch fields and their types that need to be present for the rule to function.
+                > info
+                > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
               items:
                 $ref: '#/components/schemas/Security_Detections_API_RequiredFieldInput'
               type: array
@@ -37758,11 +39567,15 @@ components:
             - severity
         - $ref: '#/components/schemas/Security_Detections_API_ThresholdRuleCreateFields'
     Security_Detections_API_ThresholdValue:
-      description: Threshold value
+      description: The threshold value from which an alert is generated.
       minimum: 1
       type: integer
     Security_Detections_API_ThrottleForBulkActions:
-      description: 'The condition for throttling the notification: ''rule'', ''no_actions'', or time duration'
+      description: |
+        Defines the maximum interval in which a rule’s actions are executed.
+        > info
+        > The rule level `throttle` field is deprecated in Elastic Security 8.8 and will remain active for at least the next 12 months.
+        > In Elastic Security 8.8 and later, you can use the `frequency` field to define frequencies for individual actions. Actions without frequencies will acquire a converted version of the rule’s `throttle` field. In the response, the converted `throttle` setting appears in the individual actions' `frequency` field.
       enum:
         - rule
         - 1h
@@ -37779,10 +39592,10 @@ components:
       description: Timeline template title
       type: string
     Security_Detections_API_TimestampField:
-      description: Contains the event timestamp used for sorting a sequence of events
+      description: Specifies the name of the event timestamp field used for sorting a sequence of events. Not to be confused with `timestamp_override`, which specifies the more general field used for querying events within a range. Defaults to the @timestamp ECS field.
       type: string
     Security_Detections_API_TimestampOverride:
-      description: Sets the time field used to query indices
+      description: Sets the time field used to query indices. When unspecified, rules query the `@timestamp` field. The source field must be an Elasticsearch date data type.
       type: string
     Security_Detections_API_TimestampOverrideFallbackDisabled:
       description: Disables the fallback to the event's @timestamp field

--- a/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
+++ b/x-pack/platform/plugins/shared/alerting/server/integration_tests/__snapshots__/serverless_upgrade_and_rollback_checks.test.ts.snap
@@ -5709,10 +5709,12 @@ Object {
             "additionalProperties": false,
             "properties": Object {
               "id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "list_id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "namespace_type": Object {
                 "enum": Array [
@@ -5787,6 +5789,7 @@ Object {
           "type": "string",
         },
         "maxSignals": Object {
+          "default": 100,
           "minimum": 1,
           "type": "integer",
         },
@@ -5840,10 +5843,12 @@ Object {
                 "type": "boolean",
               },
               "name": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "type": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
             },
             "required": Array [
@@ -6246,7 +6251,6 @@ Object {
         "ruleId",
         "immutable",
         "outputIndex",
-        "maxSignals",
         "riskScore",
         "riskScoreMapping",
         "severity",
@@ -6376,10 +6380,12 @@ Object {
             "additionalProperties": false,
             "properties": Object {
               "id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "list_id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "namespace_type": Object {
                 "enum": Array [
@@ -6454,6 +6460,7 @@ Object {
           "type": "string",
         },
         "maxSignals": Object {
+          "default": 100,
           "minimum": 1,
           "type": "integer",
         },
@@ -6507,10 +6514,12 @@ Object {
                 "type": "boolean",
               },
               "name": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "type": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
             },
             "required": Array [
@@ -6913,7 +6922,6 @@ Object {
         "ruleId",
         "immutable",
         "outputIndex",
-        "maxSignals",
         "riskScore",
         "riskScoreMapping",
         "severity",
@@ -7106,10 +7114,12 @@ Object {
             "additionalProperties": false,
             "properties": Object {
               "id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "list_id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "namespace_type": Object {
                 "enum": Array [
@@ -7184,6 +7194,7 @@ Object {
           "type": "string",
         },
         "maxSignals": Object {
+          "default": 100,
           "minimum": 1,
           "type": "integer",
         },
@@ -7237,10 +7248,12 @@ Object {
                 "type": "boolean",
               },
               "name": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "type": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
             },
             "required": Array [
@@ -7643,7 +7656,6 @@ Object {
         "ruleId",
         "immutable",
         "outputIndex",
-        "maxSignals",
         "riskScore",
         "riskScoreMapping",
         "severity",
@@ -7754,10 +7766,12 @@ Object {
             "additionalProperties": false,
             "properties": Object {
               "id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "list_id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "namespace_type": Object {
                 "enum": Array [
@@ -7832,6 +7846,7 @@ Object {
           "type": "string",
         },
         "maxSignals": Object {
+          "default": 100,
           "minimum": 1,
           "type": "integer",
         },
@@ -7885,10 +7900,12 @@ Object {
                 "type": "boolean",
               },
               "name": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "type": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
             },
             "required": Array [
@@ -8291,7 +8308,6 @@ Object {
         "ruleId",
         "immutable",
         "outputIndex",
-        "maxSignals",
         "riskScore",
         "riskScoreMapping",
         "severity",
@@ -8360,7 +8376,8 @@ Object {
           "type": "array",
         },
         "historyWindowStart": Object {
-          "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+          "minLength": 1,
+          "type": "string",
         },
         "index": Object {
           "items": Object {
@@ -8457,10 +8474,12 @@ Object {
             "additionalProperties": false,
             "properties": Object {
               "id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "list_id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "namespace_type": Object {
                 "enum": Array [
@@ -8535,6 +8554,7 @@ Object {
           "type": "string",
         },
         "maxSignals": Object {
+          "default": 100,
           "minimum": 1,
           "type": "integer",
         },
@@ -8588,10 +8608,12 @@ Object {
                 "type": "boolean",
               },
               "name": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "type": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
             },
             "required": Array [
@@ -8994,7 +9016,6 @@ Object {
         "ruleId",
         "immutable",
         "outputIndex",
-        "maxSignals",
         "riskScore",
         "riskScoreMapping",
         "severity",
@@ -9162,10 +9183,12 @@ Object {
             "additionalProperties": false,
             "properties": Object {
               "id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "list_id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "namespace_type": Object {
                 "enum": Array [
@@ -9240,6 +9263,7 @@ Object {
           "type": "string",
         },
         "maxSignals": Object {
+          "default": 100,
           "minimum": 1,
           "type": "integer",
         },
@@ -9293,10 +9317,12 @@ Object {
                 "type": "boolean",
               },
               "name": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "type": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
             },
             "required": Array [
@@ -9699,7 +9725,6 @@ Object {
         "ruleId",
         "immutable",
         "outputIndex",
-        "maxSignals",
         "riskScore",
         "riskScoreMapping",
         "severity",
@@ -9867,10 +9892,12 @@ Object {
             "additionalProperties": false,
             "properties": Object {
               "id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "list_id": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "namespace_type": Object {
                 "enum": Array [
@@ -9945,6 +9972,7 @@ Object {
           "type": "string",
         },
         "maxSignals": Object {
+          "default": 100,
           "minimum": 1,
           "type": "integer",
         },
@@ -9998,10 +10026,12 @@ Object {
                 "type": "boolean",
               },
               "name": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
               "type": Object {
-                "$ref": "#/allOf/0/properties/investigationFields/anyOf/0/properties/field_names/items",
+                "minLength": 1,
+                "type": "string",
               },
             },
             "required": Array [
@@ -10404,7 +10434,6 @@ Object {
         "ruleId",
         "immutable",
         "outputIndex",
-        "maxSignals",
         "riskScore",
         "riskScoreMapping",
         "severity",

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_response_actions/response_actions.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_response_actions/response_actions.gen.ts
@@ -21,6 +21,9 @@ export const ResponseActionTypes = z.enum(['.osquery', '.endpoint']);
 export type ResponseActionTypesEnum = typeof ResponseActionTypes.enum;
 export const ResponseActionTypesEnum = ResponseActionTypes.enum;
 
+/**
+ * Map Osquery results columns or static values to Elastic Common Schema (ECS) fields. Example: "ecs_mapping": {"process.pid": {"field": "pid"}}
+ */
 export type EcsMapping = z.infer<typeof EcsMapping>;
 export const EcsMapping = z.object({}).catchall(
   z.object({
@@ -51,11 +54,23 @@ export const OsqueryQuery = z.object({
 
 export type OsqueryParams = z.infer<typeof OsqueryParams>;
 export const OsqueryParams = z.object({
+  /**
+   * To run a single query, use the query field and enter a SQL query. Example: "query": "SELECT * FROM processes;"
+   */
   query: z.string().optional(),
   ecs_mapping: EcsMapping.optional(),
   queries: z.array(OsqueryQuery).optional(),
+  /**
+   * To specify a query pack, use the packId field. Example: "packId": "processes_elastic"
+   */
   pack_id: z.string().optional(),
+  /**
+   * To run a saved query, use the saved_query_id field and specify the saved query ID. Example: "saved_query_id": "processes_elastic"
+   */
   saved_query_id: z.string().optional(),
+  /**
+   * A timeout period, in seconds, after which the query will stop running. Overwriting the default timeout allows you to support queries that require more time to complete. The default and minimum supported value is 60. The maximum supported value is 900. Example: "timeout": 120.
+   */
   timeout: z.number().optional(),
 });
 
@@ -89,7 +104,13 @@ export const DefaultParams = z.object({
 
 export type ProcessesParams = z.infer<typeof ProcessesParams>;
 export const ProcessesParams = z.object({
+  /**
+   * To run an endpoint response action, specify a value for the command field. Example: "command": "isolate"
+   */
   command: z.enum(['kill-process', 'suspend-process']),
+  /**
+   * Add a note that explains or describes the action. You can find your comment in the response actions history log. Example: "comment": "Check processes"
+   */
   comment: z.string().optional(),
   config: z.object({
     /**

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_response_actions/response_actions.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_response_actions/response_actions.schema.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Response Actions Schema
   version: 'not applicable'
-paths: { }
+paths: {}
 components:
   x-codegen-enabled: true
   schemas:
@@ -14,6 +14,7 @@ components:
 
     EcsMapping:
       type: object
+      description: 'Map Osquery results columns or static values to Elastic Common Schema (ECS) fields. Example: "ecs_mapping": {"process.pid": {"field": "pid"}}'
       additionalProperties:
         type: object
         properties:
@@ -55,6 +56,7 @@ components:
       properties:
         query:
           type: string
+          description: 'To run a single query, use the query field and enter a SQL query. Example: "query": "SELECT * FROM processes;"'
         ecs_mapping:
           $ref: '#/components/schemas/EcsMapping'
         queries:
@@ -63,10 +65,13 @@ components:
             $ref: '#/components/schemas/OsqueryQuery'
         pack_id:
           type: string
+          description: 'To specify a query pack, use the packId field. Example: "packId": "processes_elastic"'
         saved_query_id:
           type: string
+          description: 'To run a saved query, use the saved_query_id field and specify the saved query ID. Example: "saved_query_id": "processes_elastic"'
         timeout:
           type: number
+          description: 'A timeout period, in seconds, after which the query will stop running. Overwriting the default timeout allows you to support queries that require more time to complete. The default and minimum supported value is 60. The maximum supported value is 900. Example: "timeout": 120.'
 
     OsqueryParamsCamelCase:
       type: object
@@ -133,8 +138,10 @@ components:
           enum:
             - kill-process
             - suspend-process
+          description: 'To run an endpoint response action, specify a value for the command field. Example: "command": "isolate"'
         comment:
           type: string
+          description: 'Add a note that explains or describes the action. You can find your comment in the response actions history log. Example: "comment": "Check processes"'
         config:
           required:
             - field

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.gen.ts
@@ -15,22 +15,31 @@
  */
 
 import { z } from '@kbn/zod';
-import { isValidDateMath } from '@kbn/zod-helpers';
+import { isValidDateMath, isNonEmptyString } from '@kbn/zod-helpers';
 
 import { UUID, NonEmptyString } from '../../../model/primitives.gen';
 
+/**
+ * A dynamic unique identifier for the rule object. It is randomly generated when a rule is created and cannot be changed after that. It is always a UUID. It is unique within a given Kibana space. The same prebuilt Elastic rule, when installed in two different Kibana spaces or two different Elastic environments, will have different object `id`s.
+ */
 export type RuleObjectId = z.infer<typeof RuleObjectId>;
 export const RuleObjectId = UUID;
 
 /**
- * Could be any string, not necessarily a UUID
+ * A stable unique identifier for the rule object. It can be assigned during rule creation. It can be any string, but often is a UUID. It should be unique not only within a given Kibana space, but also across spaces and Elastic environments. The same prebuilt Elastic rule, when installed in two different Kibana spaces or two different Elastic environments, will have the same `rule_id`s.
  */
 export type RuleSignatureId = z.infer<typeof RuleSignatureId>;
 export const RuleSignatureId = z.string();
 
+/**
+ * A human-readable name for the rule.
+ */
 export type RuleName = z.infer<typeof RuleName>;
 export const RuleName = z.string().min(1);
 
+/**
+ * The rule’s description.
+ */
 export type RuleDescription = z.infer<typeof RuleDescription>;
 export const RuleDescription = z.string().min(1);
 
@@ -104,7 +113,7 @@ export type RuleSource = z.infer<typeof RuleSource>;
 export const RuleSource = z.discriminatedUnion('type', [ExternalRuleSource, InternalRuleSource]);
 
 /**
- * Determines whether the rule is enabled.
+ * Determines whether the rule is enabled. Defaults to true.
  */
 export type IsRuleEnabled = z.infer<typeof IsRuleEnabled>;
 export const IsRuleEnabled = z.boolean();
@@ -125,8 +134,13 @@ export type RuleIntervalTo = z.infer<typeof RuleIntervalTo>;
 export const RuleIntervalTo = z.string();
 
 /**
- * Risk score (0 to 100)
- */
+  * A numerical representation of the alert's severity from 0 to 100, where:
+* `0` - `21` represents low severity
+* `22` - `47` represents medium severity
+* `48` - `73` represents high severity
+* `74` - `100` represents critical severity
+
+  */
 export type RiskScore = z.infer<typeof RiskScore>;
 export const RiskScore = z.number().int().min(0).max(100);
 
@@ -136,6 +150,9 @@ export const RiskScore = z.number().int().min(0).max(100);
 export type RiskScoreMapping = z.infer<typeof RiskScoreMapping>;
 export const RiskScoreMapping = z.array(
   z.object({
+    /**
+     * Source event field used to override the default `risk_score`.
+     */
     field: z.string(),
     operator: z.literal('equals'),
     value: z.string(),
@@ -144,8 +161,13 @@ export const RiskScoreMapping = z.array(
 );
 
 /**
- * Severity of the rule
- */
+  * Severity level of alerts produced by the rule, which must be one of the following:
+* `low`: Alerts that are of interest but generally not considered to be security incidents
+* `medium`: Alerts that require investigation
+* `high`: Alerts that require immediate investigation
+* `critical`: Alerts that indicate it is highly likely a security incident has occurred
+
+  */
 export type Severity = z.infer<typeof Severity>;
 export const Severity = z.enum(['low', 'medium', 'high', 'critical']);
 export type SeverityEnum = typeof Severity.enum;
@@ -157,6 +179,9 @@ export const SeverityEnum = Severity.enum;
 export type SeverityMapping = z.infer<typeof SeverityMapping>;
 export const SeverityMapping = z.array(
   z.object({
+    /**
+     * Source event field used to override the default `severity`.
+     */
     field: z.string(),
     operator: z.literal('equals'),
     severity: Severity,
@@ -170,6 +195,12 @@ export const SeverityMapping = z.array(
 export type RuleTagArray = z.infer<typeof RuleTagArray>;
 export const RuleTagArray = z.array(z.string());
 
+/**
+  * Placeholder for metadata about the rule.
+> info
+> This field is overwritten when you save changes to the rule’s settings.
+
+  */
 export type RuleMetadata = z.infer<typeof RuleMetadata>;
 export const RuleMetadata = z.object({}).catchall(z.unknown());
 
@@ -179,12 +210,21 @@ export const RuleMetadata = z.object({}).catchall(z.unknown());
 export type RuleLicense = z.infer<typeof RuleLicense>;
 export const RuleLicense = z.string();
 
+/**
+ * The rule’s author.
+ */
 export type RuleAuthorArray = z.infer<typeof RuleAuthorArray>;
 export const RuleAuthorArray = z.array(z.string());
 
+/**
+ * String array used to describe common reasons why the rule may issue false-positive alerts. Defaults to an empty array.
+ */
 export type RuleFalsePositiveArray = z.infer<typeof RuleFalsePositiveArray>;
 export const RuleFalsePositiveArray = z.array(z.string());
 
+/**
+ * Array containing notes about or references to relevant information about the rule. Defaults to an empty array.
+ */
 export type RuleReferenceArray = z.infer<typeof RuleReferenceArray>;
 export const RuleReferenceArray = z.array(z.string());
 
@@ -194,12 +234,18 @@ export const RuleReferenceArray = z.array(z.string());
 export type InvestigationGuide = z.infer<typeof InvestigationGuide>;
 export const InvestigationGuide = z.string();
 
+/**
+ * Populates the rule’s setup guide with instructions on rule prerequisites such as required integrations, configuration steps, and anything else needed for the rule to work correctly.
+ */
 export type SetupGuide = z.infer<typeof SetupGuide>;
 export const SetupGuide = z.string();
 
 /**
- * Determines if the rule acts as a building block. By default, building-block alerts are not displayed in the UI. These rules are used as a foundation for other rules that do generate alerts. Its value must be default.
- */
+  * Determines if the rule acts as a building block. If yes, the value must be `default`.
+By default, building-block alerts are not displayed in the UI. These rules are used as a foundation for other rules that do generate alerts.
+For more information, refer to [About building block rules](https://www.elastic.co/guide/en/security/current/building-block-rule.html).
+
+  */
 export type BuildingBlockType = z.infer<typeof BuildingBlockType>;
 export const BuildingBlockType = z.string();
 
@@ -216,8 +262,14 @@ export const AlertsIndex = z.string();
 export type AlertsIndexNamespace = z.infer<typeof AlertsIndexNamespace>;
 export const AlertsIndexNamespace = z.string();
 
+/**
+  * Maximum number of alerts the rule can create during a single run (the rule’s Max alerts per run [advanced setting](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#rule-ui-advanced-params) value).
+> info
+> This setting can be superseded by the [Kibana configuration setting](https://www.elastic.co/guide/en/kibana/current/alert-action-settings-kb.html#alert-settings) `xpack.alerting.rules.run.alerts.max`, which determines the maximum alerts generated by any rule in the Kibana alerting framework. For example, if `xpack.alerting.rules.run.alerts.max` is set to 1000, the rule can generate no more than 1000 alerts even if `max_signals` is set higher.
+
+  */
 export type MaxSignals = z.infer<typeof MaxSignals>;
-export const MaxSignals = z.number().int().min(1);
+export const MaxSignals = z.number().int().min(1).default(100);
 
 export type ThreatSubtechnique = z.infer<typeof ThreatSubtechnique>;
 export const ThreatSubtechnique = z.object({
@@ -249,12 +301,17 @@ export const ThreatTechnique = z.object({
    * Technique reference
    */
   reference: z.string(),
-  /**
-   * Array containing more specific information on the attack technique
-   */
+  /** 
+      * Array containing more specific information on the attack technique.
+ 
+      */
   subtechnique: z.array(ThreatSubtechnique).optional(),
 });
 
+/**
+  * Object containing information on the attack type
+
+  */
 export type ThreatTactic = z.infer<typeof ThreatTactic>;
 export const ThreatTactic = z.object({
   /**
@@ -271,6 +328,11 @@ export const ThreatTactic = z.object({
   reference: z.string(),
 });
 
+/**
+  * > info
+> Currently, only threats described using the MITRE ATT&CK&trade; framework are supported.
+
+  */
 export type Threat = z.infer<typeof Threat>;
 export const Threat = z.object({
   /**
@@ -287,29 +349,51 @@ export const Threat = z.object({
 export type ThreatArray = z.infer<typeof ThreatArray>;
 export const ThreatArray = z.array(Threat);
 
+/**
+  * Indices on which the rule functions. Defaults to the Security Solution indices defined on the Kibana Advanced Settings page (Kibana → Stack Management → Advanced Settings → `securitySolution:defaultIndex`).
+> info
+> This field is not supported for ES|QL rules.
+
+  */
 export type IndexPatternArray = z.infer<typeof IndexPatternArray>;
 export const IndexPatternArray = z.array(z.string());
 
 export type DataViewId = z.infer<typeof DataViewId>;
 export const DataViewId = z.string();
 
+/**
+ * Kibana [saved search](https://www.elastic.co/guide/en/kibana/current/save-open-search.html) used by the rule to create alerts.
+ */
 export type SavedQueryId = z.infer<typeof SavedQueryId>;
 export const SavedQueryId = z.string();
 
+/**
+  * [Query](https://www.elastic.co/guide/en/kibana/8.17/search.html) used by the rule to create alerts.
+
+- For indicator match rules, only the query’s results are used to determine whether an alert is generated.
+- ES|QL rules have additional query requirements. Refer to [Create ES|QL](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-esql-rule) rules for more information.
+
+  */
 export type RuleQuery = z.infer<typeof RuleQuery>;
 export const RuleQuery = z.string();
 
+/**
+  * The query and filter context array used to define the conditions for when alerts are created from events. Defaults to an empty array.
+> info
+> This field is not supported for ES|QL rules.
+
+  */
 export type RuleFilterArray = z.infer<typeof RuleFilterArray>;
 export const RuleFilterArray = z.array(z.unknown());
 
 /**
- * Sets the source field for the alert's signal.rule.name value
+ * Sets which field in the source event is used to populate the alert's `signal.rule.name` value (in the UI, this value is displayed on the Rules page in the Rule column). When unspecified, the rule’s `name` value is used. The source field must be a string data type.
  */
 export type RuleNameOverride = z.infer<typeof RuleNameOverride>;
 export const RuleNameOverride = z.string();
 
 /**
- * Sets the time field used to query indices
+ * Sets the time field used to query indices. When unspecified, rules query the `@timestamp` field. The source field must be an Elasticsearch date data type.
  */
 export type TimestampOverride = z.infer<typeof TimestampOverride>;
 export const TimestampOverride = z.string();
@@ -349,13 +433,13 @@ export const RequiredField = z.object({
   /**
    * Name of an Elasticsearch field
    */
-  name: NonEmptyString,
+  name: z.string().min(1).superRefine(isNonEmptyString),
   /**
    * Type of the Elasticsearch field
    */
-  type: NonEmptyString,
+  type: z.string().min(1).superRefine(isNonEmptyString),
   /**
-   * Whether the field is an ECS field
+   * Indicates whether the field is ECS-compliant. This property is only present in responses. Its value is computed based on field’s name and type.
    */
   ecs: z.boolean(),
 });
@@ -368,11 +452,11 @@ export const RequiredFieldInput = z.object({
   /**
    * Name of an Elasticsearch field
    */
-  name: NonEmptyString,
+  name: z.string().min(1).superRefine(isNonEmptyString),
   /**
-   * Type of an Elasticsearch field
+   * Type of the Elasticsearch field
    */
-  type: NonEmptyString,
+  type: z.string().min(1).superRefine(isNonEmptyString),
 });
 
 export type RequiredFieldArray = z.infer<typeof RequiredFieldArray>;
@@ -425,19 +509,6 @@ There are Fleet packages like `windows` that contain only one integration; in th
 `integration` should be unspecified. There are also packages like `aws` and `azure` that contain
 several integrations; in this case, `integration` should be specified.
 
-@example
-const x: RelatedIntegration = {
-  package: 'windows',
-  version: '1.5.x',
-};
-
-@example
-const x: RelatedIntegration = {
-  package: 'azure',
-  version: '~1.1.6',
-  integration: 'activitylogs',
-};
-
   */
 export type RelatedIntegration = z.infer<typeof RelatedIntegration>;
 export const RelatedIntegration = z.object({
@@ -452,17 +523,6 @@ export const RelatedIntegrationArray = z.array(RelatedIntegration);
 /**
   * Schema for fields relating to investigation fields. These are user defined fields we use to highlight
 in various features in the UI such as alert details flyout and exceptions auto-population from alert.
-Added in PR #163235
-Right now we only have a single field but anticipate adding more related fields to store various
-configuration states such as `override` - where a user might say if they want only these fields to
-display, or if they want these fields + the fields we select. When expanding this field, it may look
-something like:
-```typescript
-const investigationFields = z.object({
-  field_names: NonEmptyArray(NonEmptyString),
-  override: z.boolean().optional(),
-});
-```
 
   */
 export type InvestigationFields = z.infer<typeof InvestigationFields>;
@@ -480,7 +540,7 @@ export const RuleActionThrottle = z.union([
 ]);
 
 /**
- * The condition for throttling the notification: `onActionGroupChange`, `onActiveAlert`,  or `onThrottleInterval`
+ * Defines how often rules run actions.
  */
 export type RuleActionNotifyWhen = z.infer<typeof RuleActionNotifyWhen>;
 export const RuleActionNotifyWhen = z.enum([
@@ -504,12 +564,54 @@ export const RuleActionFrequency = z.object({
   throttle: RuleActionThrottle.nullable(),
 });
 
+/**
+  * Object containing an action’s conditional filters.
+
+- `timeframe` (object, optional): Object containing the time frame for when this action can be run.
+    - `days` (array of integers, required): List of days of the week on which this action will be run. Days of the week are expressed as numbers between `1-7`, where `1` is Monday and `7` is Sunday. To select all days of the week, enter an empty array.
+    - `hours` (object, required): The hours of the day during which this action will run. Hours of the day are expressed as two strings in the format `hh:mm` in `24` hour time. A start of `00:00` and an end of `24:00` means the action can run all day.
+        - start (string, required): Start time in `hh:mm` format.
+        - end (string, required): End time in `hh:mm` format.
+    - `timezone` (string, required): An ISO timezone name, such as `Europe/Madrid` or `America/New_York`. Specific offsets such as `UTC` or `UTC+1` will also work, but lack built-in DST.
+- `query` (object, optional): Object containing a query filter which gets applied to an action and determines whether the action should run.
+    - `kql` (string, required): A KQL string.
+    - `filters` (array of objects, required): Array of filter objects, as defined in the `kbn-es-query` package.
+      
+
+  */
 export type RuleActionAlertsFilter = z.infer<typeof RuleActionAlertsFilter>;
 export const RuleActionAlertsFilter = z.object({}).catchall(z.unknown());
 
 /**
- * Object containing the allowed connector fields, which varies according to the connector type.
- */
+  * Object containing the allowed connector fields, which varies according to the connector type.
+
+For Slack:
+
+  - `message` (string, required): The notification message.
+
+For email:
+
+  - `to`, `cc`, `bcc` (string): Email addresses to which the notifications are sent. At least one field must have a value.
+  - `subject` (string, optional): Email subject line.
+  - `message` (string, required): Email body text.
+
+For Webhook:
+
+  - `body` (string, required): JSON payload.
+
+For PagerDuty:
+
+  - `severity` (string, required): Severity of on the alert notification, can be: `Critical`, `Error`, `Warning` or `Info`.
+  - `eventAction` (string, required): Event [action type](https://v2.developer.pagerduty.com/docs/events-api-v2#event-action), which can be `trigger`, `resolve`, or `acknowledge`.
+  - `dedupKey` (string, optional): Groups alert notifications with the same PagerDuty alert.
+  - `timestamp` (DateTime, optional): ISO-8601 format [timestamp](https://v2.developer.pagerduty.com/docs/types#datetime).
+  - `component` (string, optional): Source machine component responsible for the event, for example `security-solution`.
+  - `group` (string, optional): Enables logical grouping of service components.
+  - `source` (string, optional): The affected system. Defaults to the Kibana saved object ID of the action.
+  - `summary` (string, options): Summary of the event. Defaults to `No summary provided`. Maximum length is 1024 characters.
+  - `class` (string, optional): Value indicating the class/type of the event.
+
+  */
 export type RuleActionParams = z.infer<typeof RuleActionParams>;
 export const RuleActionParams = z.object({}).catchall(z.unknown());
 
@@ -527,9 +629,28 @@ export const RuleActionId = z.string();
 
 export type RuleAction = z.infer<typeof RuleAction>;
 export const RuleAction = z.object({
-  /**
-   * The action type used for sending notifications.
-   */
+  /** 
+      * The action type used for sending notifications, can be:
+
+  - `.slack`
+  - `.slack_api`
+  - `.email`
+  - `.index`
+  - `.pagerduty`
+  - `.swimlane`
+  - `.webhook`
+  - `.servicenow`
+  - `.servicenow-itom`
+  - `.servicenow-sir`
+  - `.jira`
+  - `.resilient`
+  - `.opsgenie`
+  - `.teams`
+  - `.torq`
+  - `.tines`
+  - `.d3security`
+ 
+      */
   action_type_id: z.string(),
   group: RuleActionGroup.optional(),
   id: RuleActionId,
@@ -555,16 +676,20 @@ export const ExceptionListType = z.enum([
 export type ExceptionListTypeEnum = typeof ExceptionListType.enum;
 export const ExceptionListTypeEnum = ExceptionListType.enum;
 
+/**
+  * Array of [exception containers](https://www.elastic.co/guide/en/security/current/exceptions-api-overview.html), which define exceptions that prevent the rule from generating alerts even when its other criteria are met.
+
+  */
 export type RuleExceptionList = z.infer<typeof RuleExceptionList>;
 export const RuleExceptionList = z.object({
   /**
    * ID of the exception container
    */
-  id: NonEmptyString,
+  id: z.string().min(1).superRefine(isNonEmptyString),
   /**
    * List ID of the exception container
    */
-  list_id: NonEmptyString,
+  list_id: z.string().min(1).superRefine(isNonEmptyString),
   type: ExceptionListType,
   /**
    * Determines the exceptions validity in rule's Kibana space
@@ -572,6 +697,9 @@ export const RuleExceptionList = z.object({
   namespace_type: z.enum(['agnostic', 'single']),
 });
 
+/**
+ * Time unit
+ */
 export type AlertSuppressionDurationUnit = z.infer<typeof AlertSuppressionDurationUnit>;
 export const AlertSuppressionDurationUnit = z.enum(['s', 'm', 'h']);
 export type AlertSuppressionDurationUnitEnum = typeof AlertSuppressionDurationUnit.enum;
@@ -599,6 +727,9 @@ export const AlertSuppressionMissingFieldsStrategyEnum = AlertSuppressionMissing
 export type AlertSuppressionGroupBy = z.infer<typeof AlertSuppressionGroupBy>;
 export const AlertSuppressionGroupBy = z.array(z.string()).min(1).max(3);
 
+/**
+ * Defines alert suppression configuration.
+ */
 export type AlertSuppression = z.infer<typeof AlertSuppression>;
 export const AlertSuppression = z.object({
   group_by: AlertSuppressionGroupBy,

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/common_attributes.schema.yaml
@@ -8,18 +8,23 @@ components:
   schemas:
     RuleObjectId:
       $ref: '../../../model/primitives.schema.yaml#/components/schemas/UUID'
+      description: A dynamic unique identifier for the rule object. It is randomly generated when a rule is created and cannot be changed after that. It is always a UUID. It is unique within a given Kibana space. The same prebuilt Elastic rule, when installed in two different Kibana spaces or two different Elastic environments, will have different object `id`s.
 
     RuleSignatureId:
       type: string
-      description: Could be any string, not necessarily a UUID
+      description: A stable unique identifier for the rule object. It can be assigned during rule creation. It can be any string, but often is a UUID. It should be unique not only within a given Kibana space, but also across spaces and Elastic environments. The same prebuilt Elastic rule, when installed in two different Kibana spaces or two different Elastic environments, will have the same `rule_id`s.
 
     RuleName:
       type: string
+      description: A human-readable name for the rule.
       minLength: 1
+      example: Anomalous Windows Process Creation
 
     RuleDescription:
       type: string
+      description: The rule’s description.
       minLength: 1
+      example: Detects anomalous Windows process creation events.
 
     RuleVersion:
       type: integer
@@ -100,7 +105,7 @@ components:
 
     IsRuleEnabled:
       type: boolean
-      description: Determines whether the rule is enabled.
+      description: Determines whether the rule is enabled. Defaults to true.
 
     RuleInterval:
       type: string
@@ -116,7 +121,12 @@ components:
 
     RiskScore:
       type: integer
-      description: Risk score (0 to 100)
+      description: |
+        A numerical representation of the alert's severity from 0 to 100, where:
+        * `0` - `21` represents low severity
+        * `22` - `47` represents medium severity
+        * `48` - `73` represents high severity
+        * `74` - `100` represents critical severity
       minimum: 0
       maximum: 100
 
@@ -127,6 +137,7 @@ components:
         properties:
           field:
             type: string
+            description: Source event field used to override the default `risk_score`.
           operator:
             type: string
             enum:
@@ -140,11 +151,15 @@ components:
           - operator
           - value
       description: Overrides generated alerts' risk_score with a value from the source event
-
     Severity:
       type: string
       enum: [low, medium, high, critical]
-      description: Severity of the rule
+      description: |
+        Severity level of alerts produced by the rule, which must be one of the following:
+        * `low`: Alerts that are of interest but generally not considered to be security incidents
+        * `medium`: Alerts that require investigation
+        * `high`: Alerts that require immediate investigation
+        * `critical`: Alerts that indicate it is highly likely a security incident has occurred
 
     SeverityMapping:
       type: array
@@ -153,6 +168,7 @@ components:
         properties:
           field:
             type: string
+            description: Source event field used to override the default `severity`.
           operator:
             type: string
             enum:
@@ -176,6 +192,11 @@ components:
 
     RuleMetadata:
       type: object
+      description: |
+        Placeholder for metadata about the rule.
+        > info
+        > This field is overwritten when you save changes to the rule’s settings.
+
       additionalProperties: true
 
     RuleLicense:
@@ -184,16 +205,19 @@ components:
 
     RuleAuthorArray:
       type: array
+      description: The rule’s author.
       items:
         type: string
 
     RuleFalsePositiveArray:
       type: array
+      description: String array used to describe common reasons why the rule may issue false-positive alerts. Defaults to an empty array.
       items:
         type: string
 
     RuleReferenceArray:
       type: array
+      description: Array containing notes about or references to relevant information about the rule. Defaults to an empty array.
       items:
         type: string
 
@@ -203,10 +227,14 @@ components:
 
     SetupGuide:
       type: string
+      description: Populates the rule’s setup guide with instructions on rule prerequisites such as required integrations, configuration steps, and anything else needed for the rule to work correctly.
 
     BuildingBlockType:
       type: string
-      description: Determines if the rule acts as a building block. By default, building-block alerts are not displayed in the UI. These rules are used as a foundation for other rules that do generate alerts. Its value must be default.
+      description: |
+        Determines if the rule acts as a building block. If yes, the value must be `default`.
+        By default, building-block alerts are not displayed in the UI. These rules are used as a foundation for other rules that do generate alerts.
+        For more information, refer to [About building block rules](https://www.elastic.co/guide/en/security/current/building-block-rule.html).
 
     AlertsIndex:
       type: string
@@ -219,6 +247,11 @@ components:
 
     MaxSignals:
       type: integer
+      default: 100
+      description: |
+        Maximum number of alerts the rule can create during a single run (the rule’s Max alerts per run [advanced setting](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#rule-ui-advanced-params) value).
+        > info
+        > This setting can be superseded by the [Kibana configuration setting](https://www.elastic.co/guide/en/kibana/current/alert-action-settings-kb.html#alert-settings) `xpack.alerting.rules.run.alerts.max`, which determines the maximum alerts generated by any rule in the Kibana alerting framework. For example, if `xpack.alerting.rules.run.alerts.max` is set to 1000, the rule can generate no more than 1000 alerts even if `max_signals` is set higher.
       minimum: 1
 
     ThreatSubtechnique:
@@ -252,9 +285,10 @@ components:
           description: Technique reference
         subtechnique:
           type: array
+          description: |
+            Array containing more specific information on the attack technique.
           items:
             $ref: '#/components/schemas/ThreatSubtechnique'
-          description: Array containing more specific information on the attack technique
       required:
         - id
         - name
@@ -262,6 +296,8 @@ components:
 
     ThreatTactic:
       type: object
+      description: |
+        Object containing information on the attack type
       properties:
         id:
           type: string
@@ -279,6 +315,9 @@ components:
 
     Threat:
       type: object
+      description: |
+        > info
+        > Currently, only threats described using the MITRE ATT&CK&trade; framework are supported.
       properties:
         framework:
           type: string
@@ -300,6 +339,10 @@ components:
         $ref: '#/components/schemas/Threat'
 
     IndexPatternArray:
+      description: |
+        Indices on which the rule functions. Defaults to the Security Solution indices defined on the Kibana Advanced Settings page (Kibana → Stack Management → Advanced Settings → `securitySolution:defaultIndex`).
+        > info
+        > This field is not supported for ES|QL rules.
       type: array
       items:
         type: string
@@ -309,21 +352,31 @@ components:
 
     SavedQueryId:
       type: string
+      description: Kibana [saved search](https://www.elastic.co/guide/en/kibana/current/save-open-search.html) used by the rule to create alerts.
 
     RuleQuery:
       type: string
+      description: |
+        [Query](https://www.elastic.co/guide/en/kibana/8.17/search.html) used by the rule to create alerts.
+
+        - For indicator match rules, only the query’s results are used to determine whether an alert is generated.
+        - ES|QL rules have additional query requirements. Refer to [Create ES|QL](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-esql-rule) rules for more information.
 
     RuleFilterArray:
       type: array
+      description: |
+        The query and filter context array used to define the conditions for when alerts are created from events. Defaults to an empty array.
+        > info
+        > This field is not supported for ES|QL rules.
       items: {} # unknown
 
     RuleNameOverride:
       type: string
-      description: Sets the source field for the alert's signal.rule.name value
+      description: Sets which field in the source event is used to populate the alert's `signal.rule.name` value (in the UI, this value is displayed on the Rules page in the Rule column). When unspecified, the rule’s `name` value is used. The source field must be a string data type.
 
     TimestampOverride:
       type: string
-      description: Sets the time field used to query indices
+      description: Sets the time field used to query indices. When unspecified, rules query the `@timestamp` field. The source field must be an Elasticsearch date data type.
 
     TimestampOverrideFallbackDisabled:
       type: boolean
@@ -355,14 +408,18 @@ components:
         };
       properties:
         name:
-          $ref: '../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
+          type: string
+          format: nonempty
+          minLength: 1
           description: Name of an Elasticsearch field
         type:
-          $ref: '../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
+          type: string
+          format: nonempty
+          minLength: 1
           description: Type of the Elasticsearch field
         ecs:
           type: boolean
-          description: Whether the field is an ECS field
+          description: Indicates whether the field is ECS-compliant. This property is only present in responses. Its value is computed based on field’s name and type.
       required:
         - name
         - type
@@ -373,11 +430,15 @@ components:
       description: Input parameters to create a RequiredField. Does not include the `ecs` field, because `ecs` is calculated on the backend based on the field name and type.
       properties:
         name:
-          $ref: '../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
+          type: string
+          format: nonempty
+          minLength: 1
           description: Name of an Elasticsearch field
         type:
-          $ref: '../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
-          description: Type of an Elasticsearch field
+          type: string
+          format: nonempty
+          minLength: 1
+          description: Type of the Elasticsearch field
       required:
         - name
         - type
@@ -414,36 +475,23 @@ components:
     RelatedIntegration:
       type: object
       description: |
-        Related integration is a potential dependency of a rule. It's assumed that if the user installs
-        one of the related integrations of a rule, the rule might start to work properly because it will
-        have source events (generated by this integration) potentially matching the rule's query.
+            Related integration is a potential dependency of a rule. It's assumed that if the user installs
+            one of the related integrations of a rule, the rule might start to work properly because it will
+            have source events (generated by this integration) potentially matching the rule's query.
 
-        NOTE: Proper work is not guaranteed, because a related integration, if installed, can be
-        configured differently or generate data that is not necessarily relevant for this rule.
+            NOTE: Proper work is not guaranteed, because a related integration, if installed, can be
+            configured differently or generate data that is not necessarily relevant for this rule.
 
-        Related integration is a combination of a Fleet package and (optionally) one of the
-        package's "integrations" that this package contains. It is represented by 3 properties:
+            Related integration is a combination of a Fleet package and (optionally) one of the
+            package's "integrations" that this package contains. It is represented by 3 properties:
 
-        - `package`: name of the package (required, unique id)
-        - `version`: version of the package (required, semver-compatible)
-        - `integration`: name of the integration of this package (optional, id within the package)
+            - `package`: name of the package (required, unique id)
+            - `version`: version of the package (required, semver-compatible)
+            - `integration`: name of the integration of this package (optional, id within the package)
 
-        There are Fleet packages like `windows` that contain only one integration; in this case,
-        `integration` should be unspecified. There are also packages like `aws` and `azure` that contain
-        several integrations; in this case, `integration` should be specified.
-
-        @example
-        const x: RelatedIntegration = {
-          package: 'windows',
-          version: '1.5.x',
-        };
-
-        @example
-        const x: RelatedIntegration = {
-          package: 'azure',
-          version: '~1.1.6',
-          integration: 'activitylogs',
-        };
+            There are Fleet packages like `windows` that contain only one integration; in this case,
+            `integration` should be unspecified. There are also packages like `aws` and `azure` that contain
+            several integrations; in this case, `integration` should be specified.
       properties:
         package:
           $ref: '../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
@@ -451,6 +499,10 @@ components:
           $ref: '../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
         integration:
           $ref: '../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
+      example:
+        package: 'azure'
+        version: '~1.1.6'
+        integration: 'activitylogs'
       required:
         - package
         - version
@@ -465,17 +517,6 @@ components:
       description: |
         Schema for fields relating to investigation fields. These are user defined fields we use to highlight
         in various features in the UI such as alert details flyout and exceptions auto-population from alert.
-        Added in PR #163235
-        Right now we only have a single field but anticipate adding more related fields to store various
-        configuration states such as `override` - where a user might say if they want only these fields to
-        display, or if they want these fields + the fields we select. When expanding this field, it may look
-        something like:
-        ```typescript
-        const investigationFields = z.object({
-          field_names: NonEmptyArray(NonEmptyString),
-          override: z.boolean().optional(),
-        });
-        ```
       properties:
         field_names:
           type: array
@@ -503,7 +544,7 @@ components:
         - 'onActiveAlert'
         - 'onThrottleInterval'
         - 'onActionGroupChange'
-      description: 'The condition for throttling the notification: `onActionGroupChange`, `onActiveAlert`,  or `onThrottleInterval`'
+      description: Defines how often rules run actions.
 
     RuleActionFrequency:
       type: object
@@ -525,10 +566,49 @@ components:
     RuleActionAlertsFilter:
       type: object
       additionalProperties: true
+      description: |
+        Object containing an action’s conditional filters.
 
+        - `timeframe` (object, optional): Object containing the time frame for when this action can be run.
+            - `days` (array of integers, required): List of days of the week on which this action will be run. Days of the week are expressed as numbers between `1-7`, where `1` is Monday and `7` is Sunday. To select all days of the week, enter an empty array.
+            - `hours` (object, required): The hours of the day during which this action will run. Hours of the day are expressed as two strings in the format `hh:mm` in `24` hour time. A start of `00:00` and an end of `24:00` means the action can run all day.
+                - start (string, required): Start time in `hh:mm` format.
+                - end (string, required): End time in `hh:mm` format.
+            - `timezone` (string, required): An ISO timezone name, such as `Europe/Madrid` or `America/New_York`. Specific offsets such as `UTC` or `UTC+1` will also work, but lack built-in DST.
+        - `query` (object, optional): Object containing a query filter which gets applied to an action and determines whether the action should run.
+            - `kql` (string, required): A KQL string.
+            - `filters` (array of objects, required): Array of filter objects, as defined in the `kbn-es-query` package.
+              
     RuleActionParams:
       type: object
-      description: Object containing the allowed connector fields, which varies according to the connector type.
+      description: |
+        Object containing the allowed connector fields, which varies according to the connector type.
+
+        For Slack:
+
+          - `message` (string, required): The notification message.
+
+        For email:
+
+          - `to`, `cc`, `bcc` (string): Email addresses to which the notifications are sent. At least one field must have a value.
+          - `subject` (string, optional): Email subject line.
+          - `message` (string, required): Email body text.
+
+        For Webhook:
+
+          - `body` (string, required): JSON payload.
+
+        For PagerDuty:
+
+          - `severity` (string, required): Severity of on the alert notification, can be: `Critical`, `Error`, `Warning` or `Info`.
+          - `eventAction` (string, required): Event [action type](https://v2.developer.pagerduty.com/docs/events-api-v2#event-action), which can be `trigger`, `resolve`, or `acknowledge`.
+          - `dedupKey` (string, optional): Groups alert notifications with the same PagerDuty alert.
+          - `timestamp` (DateTime, optional): ISO-8601 format [timestamp](https://v2.developer.pagerduty.com/docs/types#datetime).
+          - `component` (string, optional): Source machine component responsible for the event, for example `security-solution`.
+          - `group` (string, optional): Enables logical grouping of service components.
+          - `source` (string, optional): The affected system. Defaults to the Kibana saved object ID of the action.
+          - `summary` (string, options): Summary of the event. Defaults to `No summary provided`. Maximum length is 1024 characters.
+          - `class` (string, optional): Value indicating the class/type of the event.
       additionalProperties: true
 
     RuleActionGroup:
@@ -544,7 +624,26 @@ components:
       properties:
         action_type_id:
           type: string
-          description: The action type used for sending notifications.
+          description: |
+            The action type used for sending notifications, can be:
+
+              - `.slack`
+              - `.slack_api`
+              - `.email`
+              - `.index`
+              - `.pagerduty`
+              - `.swimlane`
+              - `.webhook`
+              - `.servicenow`
+              - `.servicenow-itom`
+              - `.servicenow-sir`
+              - `.jira`
+              - `.resilient`
+              - `.opsgenie`
+              - `.teams`
+              - `.torq`
+              - `.tines`
+              - `.d3security`
         group:
           $ref: '#/components/schemas/RuleActionGroup'
         id:
@@ -576,12 +675,18 @@ components:
 
     RuleExceptionList:
       type: object
+      description: |
+        Array of [exception containers](https://www.elastic.co/guide/en/security/current/exceptions-api-overview.html), which define exceptions that prevent the rule from generating alerts even when its other criteria are met.
       properties:
         id:
-          $ref: '../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
+          type: string
+          format: nonempty
+          minLength: 1
           description: ID of the exception container
         list_id:
-          $ref: '../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
+          type: string
+          format: nonempty
+          minLength: 1
           description: List ID of the exception container
         type:
           $ref: '#/components/schemas/ExceptionListType'
@@ -599,6 +704,7 @@ components:
 
     AlertSuppressionDurationUnit:
       type: string
+      description: Time unit
       enum:
         - s
         - m
@@ -635,6 +741,7 @@ components:
 
     AlertSuppression:
       type: object
+      description: Defines alert suppression configuration.
       properties:
         group_by:
           $ref: '#/components/schemas/AlertSuppressionGroupBy'

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/rule_schemas.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/rule_schemas.gen.ts
@@ -131,6 +131,9 @@ export const BaseDefaultableFields = z.object({
   interval: RuleInterval.optional(),
   from: RuleIntervalFrom.optional(),
   to: RuleIntervalTo.optional(),
+  /**
+   * Array defining the automated actions (notifications) taken when alerts are generated.
+   */
   actions: z.array(RuleAction).optional(),
   exceptions_list: z.array(RuleExceptionList).optional(),
   author: RuleAuthorArray.optional(),
@@ -140,6 +143,12 @@ export const BaseDefaultableFields = z.object({
   threat: ThreatArray.optional(),
   setup: SetupGuide.optional(),
   related_integrations: RelatedIntegrationArray.optional(),
+  /** 
+      * Elasticsearch fields and their types that need to be present for the rule to function.
+> info
+> The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
+ 
+      */
   required_fields: z.array(RequiredFieldInput).optional(),
 });
 
@@ -207,9 +216,6 @@ export const EqlRequiredFields = z.object({
    * Rule type
    */
   type: z.literal('eql'),
-  /**
-   * EQL query to execute
-   */
   query: RuleQuery,
   /**
    * Query language to use
@@ -565,9 +571,6 @@ export const EsqlRuleRequiredFields = z.object({
    */
   type: z.literal('esql'),
   language: EsqlQueryLanguage,
-  /**
-   * ESQL query to execute
-   */
   query: RuleQuery,
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/rule_schemas.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/rule_schemas.schema.yaml
@@ -109,6 +109,7 @@ components:
         # Rule actions
         actions:
           type: array
+          description: Array defining the automated actions (notifications) taken when alerts are generated.
           items:
             $ref: './common_attributes.schema.yaml#/components/schemas/RuleAction'
 
@@ -141,10 +142,13 @@ components:
         # Related integrations
         related_integrations:
           $ref: './common_attributes.schema.yaml#/components/schemas/RelatedIntegrationArray'
-
         # Required fields
         required_fields:
           type: array
+          description: |
+            Elasticsearch fields and their types that need to be present for the rule to function.
+            > info
+            > The value of `required_fields` does not affect the rule’s behavior, and specifying it incorrectly won’t cause the rule to fail. Use `required_fields` as an informational property to document the fields that the rule expects to be present in the data.
           items:
             $ref: './common_attributes.schema.yaml#/components/schemas/RequiredFieldInput'
 
@@ -271,7 +275,6 @@ components:
           description: Rule type
         query:
           $ref: './common_attributes.schema.yaml#/components/schemas/RuleQuery'
-          description: EQL query to execute
         language:
           $ref: '#/components/schemas/EqlQueryLanguage'
           description: Query language to use
@@ -826,7 +829,6 @@ components:
           $ref: '#/components/schemas/EsqlQueryLanguage'
         query:
           $ref: './common_attributes.schema.yaml#/components/schemas/RuleQuery'
-          description: ESQL query to execute
       required:
         - type
         - language

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/eql_attributes.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/eql_attributes.gen.ts
@@ -20,7 +20,7 @@ export type EventCategoryOverride = z.infer<typeof EventCategoryOverride>;
 export const EventCategoryOverride = z.string();
 
 /**
- * Contains the event timestamp used for sorting a sequence of events
+ * Specifies the name of the event timestamp field used for sorting a sequence of events. Not to be confused with `timestamp_override`, which specifies the more general field used for querying events within a range. Defaults to the @timestamp ECS field.
  */
 export type TimestampField = z.infer<typeof TimestampField>;
 export const TimestampField = z.string();

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/eql_attributes.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/eql_attributes.schema.yaml
@@ -10,7 +10,7 @@ components:
       type: string
     TimestampField:
       type: string
-      description: Contains the event timestamp used for sorting a sequence of events
+      description: Specifies the name of the event timestamp field used for sorting a sequence of events. Not to be confused with `timestamp_override`, which specifies the more general field used for querying events within a range. Defaults to the @timestamp ECS field.
     TiebreakerField:
       type: string
       description: Sets a secondary field for sorting events

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/ml_attributes.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/ml_attributes.gen.ts
@@ -17,13 +17,13 @@
 import { z } from '@kbn/zod';
 
 /**
- * Anomaly threshold
+ * Anomaly score threshold above which the rule creates an alert. Valid values are from 0 to 100.
  */
 export type AnomalyThreshold = z.infer<typeof AnomalyThreshold>;
 export const AnomalyThreshold = z.number().int().min(0);
 
 /**
- * Machine learning job ID
+ * Machine learning job ID(s) the rule monitors for anomaly scores.
  */
 export type MachineLearningJobId = z.infer<typeof MachineLearningJobId>;
 export const MachineLearningJobId = z.union([z.string(), z.array(z.string()).min(1)]);

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/ml_attributes.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/ml_attributes.schema.yaml
@@ -9,7 +9,7 @@ components:
     AnomalyThreshold:
       type: integer
       minimum: 0
-      description: Anomaly threshold
+      description: Anomaly score threshold above which the rule creates an alert. Valid values are from 0 to 100.
     MachineLearningJobId:
       oneOf:
         - type: string
@@ -17,4 +17,4 @@ components:
           items:
             type: string
           minItems: 1
-      description: Machine learning job ID
+      description: Machine learning job ID(s) the rule monitors for anomaly scores.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/new_terms_attributes.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/new_terms_attributes.gen.ts
@@ -15,11 +15,16 @@
  */
 
 import { z } from '@kbn/zod';
+import { isNonEmptyString } from '@kbn/zod-helpers';
 
-import { NonEmptyString } from '../../../../model/primitives.gen';
-
+/**
+ * Fields to monitor for new values.
+ */
 export type NewTermsFields = z.infer<typeof NewTermsFields>;
 export const NewTermsFields = z.array(z.string()).min(1).max(3);
 
+/**
+ * Start date to use when checking if a term has been seen before. Supports relative dates – for example, now-30d will search the last 30 days of data when checking if a term is new. We do not recommend using absolute dates, which can cause issues with rule performance due to querying increasing amounts of data over time.
+ */
 export type HistoryWindowStart = z.infer<typeof HistoryWindowStart>;
-export const HistoryWindowStart = NonEmptyString;
+export const HistoryWindowStart = z.string().min(1).superRefine(isNonEmptyString);

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/new_terms_attributes.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/new_terms_attributes.schema.yaml
@@ -10,7 +10,11 @@ components:
       type: array
       items:
         type: string
+      description: Fields to monitor for new values.
       minItems: 1
       maxItems: 3
     HistoryWindowStart:
-      $ref: '../../../../model/primitives.schema.yaml#/components/schemas/NonEmptyString'
+      type: string
+      format: nonempty
+      minLength: 1
+      description: Start date to use when checking if a term has been seen before. Supports relative dates – for example, now-30d will search the last 30 days of data when checking if a term is new. We do not recommend using absolute dates, which can cause issues with rule performance due to querying increasing amounts of data over time.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/threat_match_attributes.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/threat_match_attributes.gen.ts
@@ -19,11 +19,21 @@ import { z } from '@kbn/zod';
 import { NonEmptyString } from '../../../../model/primitives.gen';
 
 /**
- * Query to run
+ * Query used to determine which fields in the Elasticsearch index are used for generating alerts.
  */
 export type ThreatQuery = z.infer<typeof ThreatQuery>;
 export const ThreatQuery = z.string();
 
+/**
+  * Array of entries objects that define mappings between the source event fields and the values in the Elasticsearch threat index. Each entries object must contain these fields:
+
+- field: field from the event indices on which the rule runs
+- type: must be mapping
+- value: field from the Elasticsearch threat index
+  
+You can use Boolean and and or logic to define the conditions for when matching fields and values generate alerts. Sibling entries objects are evaluated using or logic, whereas multiple entries in a single entries object use and logic. See Example of Threat Match rule which uses both `and` and `or` logic.
+
+  */
 export type ThreatMapping = z.infer<typeof ThreatMapping>;
 export const ThreatMapping = z
   .array(
@@ -39,6 +49,9 @@ export const ThreatMapping = z
   )
   .min(1);
 
+/**
+ * Elasticsearch indices used to check which field values generate alerts.
+ */
 export type ThreatIndex = z.infer<typeof ThreatIndex>;
 export const ThreatIndex = z.array(z.string());
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/threat_match_attributes.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/threat_match_attributes.schema.yaml
@@ -8,10 +8,18 @@ components:
   schemas:
     ThreatQuery:
       type: string
-      description: Query to run
+      description: Query used to determine which fields in the Elasticsearch index are used for generating alerts.
 
     ThreatMapping:
       type: array
+      description: |
+        Array of entries objects that define mappings between the source event fields and the values in the Elasticsearch threat index. Each entries object must contain these fields:
+
+        - field: field from the event indices on which the rule runs
+        - type: must be mapping
+        - value: field from the Elasticsearch threat index
+          
+        You can use Boolean and and or logic to define the conditions for when matching fields and values generate alerts. Sibling entries objects are evaluated using or logic, whereas multiple entries in a single entries object use and logic. See Example of Threat Match rule which uses both `and` and `or` logic.
       minItems: 1
       items:
         type: object
@@ -38,6 +46,7 @@ components:
 
     ThreatIndex:
       type: array
+      description: Elasticsearch indices used to check which field values generate alerts.
       items:
         type: string
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/threshold_attributes.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/threshold_attributes.gen.ts
@@ -18,22 +18,31 @@ import { z } from '@kbn/zod';
 
 import { AlertSuppressionDuration } from '../common_attributes.gen';
 
+/**
+ * The field on which the cardinality is applied.
+ */
 export type ThresholdCardinality = z.infer<typeof ThresholdCardinality>;
 export const ThresholdCardinality = z.array(
   z.object({
+    /**
+     * The field on which to calculate and compare the cardinality.
+     */
     field: z.string(),
+    /**
+     * The threshold value from which an alert is generated based on unique number of values of cardinality.field.
+     */
     value: z.number().int().min(0),
   })
 );
 
 /**
- * Threshold value
+ * The threshold value from which an alert is generated.
  */
 export type ThresholdValue = z.infer<typeof ThresholdValue>;
 export const ThresholdValue = z.number().int().min(1);
 
 /**
- * Field to aggregate on
+ * The field on which the threshold is applied. If you specify an empty array ([]), alerts are generated when the query returns at least the number of results specified in the value field.
  */
 export type ThresholdField = z.infer<typeof ThresholdField>;
 export const ThresholdField = z.union([z.string(), z.array(z.string())]);
@@ -65,6 +74,9 @@ export const ThresholdWithCardinality = z.object({
   cardinality: ThresholdCardinality,
 });
 
+/**
+ * Defines alert suppression configuration.
+ */
 export type ThresholdAlertSuppression = z.infer<typeof ThresholdAlertSuppression>;
 export const ThresholdAlertSuppression = z.object({
   duration: AlertSuppressionDuration,

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/threshold_attributes.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/model/rule_schema/specific_attributes/threshold_attributes.schema.yaml
@@ -8,13 +8,16 @@ components:
   schemas:
     ThresholdCardinality:
       type: array
+      description: The field on which the cardinality is applied.
       items:
         type: object
         properties:
           field:
             type: string
+            description: The field on which to calculate and compare the cardinality.
           value:
             type: integer
+            description: The threshold value from which an alert is generated based on unique number of values of cardinality.field.
             minimum: 0
         required:
           - field
@@ -23,7 +26,7 @@ components:
     ThresholdValue:
       type: integer
       minimum: 1
-      description: Threshold value
+      description: The threshold value from which an alert is generated.
 
     ThresholdField:
       oneOf:
@@ -31,7 +34,7 @@ components:
         - type: array
           items:
             type: string
-      description: Field to aggregate on
+      description: The field on which the threshold is applied. If you specify an empty array ([]), alerts are generated when the query returns at least the number of results specified in the value field.
 
     ThresholdFieldNormalized:
       type: array
@@ -81,8 +84,9 @@ components:
 
     ThresholdAlertSuppression:
       type: object
+      description: Defines alert suppression configuration.
       properties:
-        duration: 
+        duration:
           $ref: '../common_attributes.schema.yaml#/components/schemas/AlertSuppressionDuration'
       required:
         - duration

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/install_prebuilt_rules_and_timelines/install_prebuilt_rules_and_timelines_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/install_prebuilt_rules_and_timelines/install_prebuilt_rules_and_timelines_route.schema.yaml
@@ -9,7 +9,18 @@ paths:
       x-codegen-enabled: true
       operationId: InstallPrebuiltRulesAndTimelines
       summary: Install prebuilt detection rules and Timelines
-      description: Install and update all Elastic prebuilt detection rules and Timelines.
+      description: |
+        Install and update all Elastic prebuilt detection rules and Timelines.
+
+        This endpoint allows you to install and update prebuilt detection rules and Timelines provided by Elastic. 
+        When you call this endpoint, it will:
+        - Install any new prebuilt detection rules that are not currently installed in your system.
+        - Update any existing prebuilt detection rules that have been modified or improved by Elastic.
+        - Install any new prebuilt Timelines that are not currently installed in your system.
+        - Update any existing prebuilt Timelines that have been modified or improved by Elastic.
+
+        This ensures that your detection engine is always up-to-date with the latest rules and Timelines, 
+        providing you with the most current and effective threat detection capabilities.
       tags:
         - Prebuilt Rules API
       responses:
@@ -42,3 +53,10 @@ paths:
                   - rules_updated
                   - timelines_installed
                   - timelines_updated
+              examples:
+                example1:
+                  value: 
+                    rules_installed: 112
+                    rules_updated: 0
+                    timelines_installed: 5
+                    timelines_updated: 2

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/read_prebuilt_rules_and_timelines_status/read_prebuilt_rules_and_timelines_status_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/prebuilt_rules/read_prebuilt_rules_and_timelines_status/read_prebuilt_rules_and_timelines_status_route.schema.yaml
@@ -9,7 +9,10 @@ paths:
       x-codegen-enabled: true
       operationId: ReadPrebuiltRulesAndTimelinesStatus
       summary: Retrieve the status of prebuilt detection rules and Timelines
-      description: Retrieve the status of all Elastic prebuilt detection rules and Timelines.
+      description: |
+        Retrieve the status of all Elastic prebuilt detection rules and Timelines. 
+      
+        This endpoint provides detailed information about the number of custom rules, installed prebuilt rules, available prebuilt rules that are not installed, outdated prebuilt rules, installed prebuilt timelines, available prebuilt timelines that are not installed, and outdated prebuilt timelines.
       tags:
         - Prebuilt Rules API
       responses:
@@ -57,3 +60,13 @@ paths:
                   - timelines_installed
                   - timelines_not_installed
                   - timelines_not_updated
+              examples:
+                example1:
+                  value:
+                    rules_custom_installed: 0
+                    rules_installed: 0
+                    rules_not_installed: 112
+                    rules_not_updated: 0
+                    timelines_installed: 0
+                    timelines_not_installed: 0
+                    timelines_not_updated: 0

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.gen.ts
@@ -76,6 +76,9 @@ export const BulkEditActionResults = z.object({
   skipped: z.array(BulkActionSkipResult),
 });
 
+/**
+ * A rule can only be skipped when the bulk action to be performed on it results in nothing being done. For example, if the `edit` action is used to add a tag to a rule that already has that tag, or to delete an index pattern that is not specified in a rule. Objects returned in `attributes.results.skipped` will only include rules' `id`, `name`, and `skip_reason`.
+ */
 export type BulkEditActionSummary = z.infer<typeof BulkEditActionSummary>;
 export const BulkEditActionSummary = z.object({
   failed: z.number().int(),
@@ -103,11 +106,11 @@ export const BulkExportActionResponse = z.string();
 export type BulkActionBase = z.infer<typeof BulkActionBase>;
 export const BulkActionBase = z.object({
   /**
-   * Query to filter rules
+   * Query to filter rules.
    */
   query: z.string().optional(),
   /**
-   * Array of rule IDs
+   * Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
    */
   ids: z.array(z.string()).min(1).optional(),
 });
@@ -144,6 +147,9 @@ export type BulkDuplicateRules = z.infer<typeof BulkDuplicateRules>;
 export const BulkDuplicateRules = BulkActionBase.merge(
   z.object({
     action: z.literal('duplicate'),
+    /**
+     * Duplicate object that describes applying an update action.
+     */
     duplicate: z
       .object({
         /**
@@ -163,6 +169,9 @@ export type BulkManualRuleRun = z.infer<typeof BulkManualRuleRun>;
 export const BulkManualRuleRun = BulkActionBase.merge(
   z.object({
     action: z.literal('run'),
+    /**
+     * Object that describes applying a manual rule run action.
+     */
     run: z.object({
       /**
        * Start date of the manual rule run
@@ -177,8 +186,12 @@ export const BulkManualRuleRun = BulkActionBase.merge(
 );
 
 /**
- * The condition for throttling the notification: 'rule', 'no_actions', or time duration
- */
+  * Defines the maximum interval in which a rule’s actions are executed.
+> info
+> The rule level `throttle` field is deprecated in Elastic Security 8.8 and will remain active for at least the next 12 months.
+> In Elastic Security 8.8 and later, you can use the `frequency` field to define frequencies for individual actions. Actions without frequencies will acquire a converted version of the rule’s `throttle` field. In the response, the converted `throttle` setting appears in the individual actions' `frequency` field.
+
+  */
 export type ThrottleForBulkActions = z.infer<typeof ThrottleForBulkActions>;
 export const ThrottleForBulkActions = z.enum(['rule', '1h', '1d', '7d']);
 export type ThrottleForBulkActionsEnum = typeof ThrottleForBulkActions.enum;
@@ -311,9 +324,16 @@ export const BulkEditRules = BulkActionBase.merge(
 
 export type PerformRulesBulkActionRequestQuery = z.infer<typeof PerformRulesBulkActionRequestQuery>;
 export const PerformRulesBulkActionRequestQuery = z.object({
-  /**
-   * Enables dry run mode for the request call.
-   */
+  /** 
+      * Enables dry run mode for the request call.
+
+Enable dry run mode to verify that bulk actions can be applied to specified rules. Certain rules, such as prebuilt Elastic rules on a Basic subscription, can’t be edited and will return errors in the request response. Error details will contain an explanation, the rule name and/or ID, and additional troubleshooting information.
+
+To enable dry run mode on a request, add the query parameter `dry_run=true` to the end of the request URL. Rules specified in the request will be temporarily updated. These updates won’t be written to Elasticsearch.
+> info
+> Dry run mode is not supported for the `export` bulk action. A 400 error will be returned in the request response.
+ 
+      */
   dry_run: BooleanFromString.optional(),
 });
 export type PerformRulesBulkActionRequestQueryInput = z.input<

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml
@@ -9,13 +9,25 @@ paths:
       x-codegen-enabled: true
       operationId: PerformRulesBulkAction
       summary: Apply a bulk action to detection rules
-      description: Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
+      description: |
+        Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
+        > warn
+        > When used with  [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       tags:
         - Bulk API
       parameters:
         - name: dry_run
           in: query
-          description: Enables dry run mode for the request call.
+          description: |
+            Enables dry run mode for the request call.
+
+            Enable dry run mode to verify that bulk actions can be applied to specified rules. Certain rules, such as prebuilt Elastic rules on a Basic subscription, can’t be edited and will return errors in the request response. Error details will contain an explanation, the rule name and/or ID, and additional troubleshooting information.
+
+            To enable dry run mode on a request, add the query parameter `dry_run=true` to the end of the request URL. Rules specified in the request will be temporarily updated. These updates won’t be written to Elasticsearch.
+            > info
+            > Dry run mode is not supported for the `export` bulk action. A 400 error will be returned in the request response.
           required: false
           schema:
             type: boolean
@@ -31,6 +43,90 @@ paths:
                 - $ref: '#/components/schemas/BulkDuplicateRules'
                 - $ref: '#/components/schemas/BulkManualRuleRun'
                 - $ref: '#/components/schemas/BulkEditRules'
+            examples:
+              example1:
+                summary: Enable all rules with the test tag
+                description: The following request activates all rules with the test tag
+                value:
+                  query: 'alert.attributes.tags: "test"'
+                  action: 'enable'
+              example2:
+                summary: Enable a specific rule by ID
+                description: The following request enables the rule with the specified ID.
+                value:
+                  action: 'enable'
+                  ids:
+                    - '748694f0-6977-4ea5-8384-cd2e39730779'
+              example3:
+                summary: Disable a specific rule by ID
+                description: The following request disables the rule with the specified ID.
+                value:
+                  action: 'disable'
+                  ids:
+                    - '748694f0-6977-4ea5-8384-cd2e39730779'
+              example4:
+                summary: Add tags to rules
+                description: The following request adds tags tag-1 and tag-2 to the rules that have the IDs sent in the payload
+                value:
+                  ids:
+                    - '8bc7dad0-9320-11ec-9265-8b772383a08d'
+                    - '8e5c1a40-9320-11ec-9265-8b772383a08d'
+                  action: 'edit'
+                  edit:
+                    - type: 'add_tags'
+                      value:
+                        - 'tag-1'
+                        - 'tag-2'
+              example5:
+                summary: Dry run - Validate add_index_patterns bulk action
+                description: The following request will validate that the add_index_patterns bulk action can be successfully applied to three rules. The dry_run parameter is specified in query parameters, e.g. POST api/detection_engine/rules/_bulk_action?dry_run=true
+                value:
+                  action: 'edit'
+                  edit:
+                    - value:
+                        - 'test-*'
+                      type: 'add_index_patterns'
+                  ids:
+                    - '81aa0480-06af-11ed-94fb-dd1a0597d8d2'
+                    - 'dc015d10-0831-11ed-ac8b-05a222bd8d4a'
+                    - 'de8f5af0-0831-11ed-ac8b-05a222bd8d4a'
+              example6:
+                summary: Duplicate rules with specific IDs
+                description: The following request duplicates rules with the specified IDs, including exceptions but not expired exceptions.
+                value:
+                  action: 'duplicate'
+                  ids:
+                    - '748694f0-6977-4ea5-8384-cd2e39730779'
+                    - '461a4c22-416e-4009-a9a7-cf79656454bf'
+                  duplicate:
+                    include_exceptions: true
+                    include_expired_exceptions: false
+              example7:
+                summary: Delete a specific rule by ID
+                description: The following request deletes the rule with the specified ID.
+                value:
+                  action: 'delete'
+                  ids:
+                    - 'cf4abfd1-7c37-4519-ab0f-5ea5c75fac60'
+              example8:
+                summary: Run a specific rule by ID
+                description: The following request runs the rule with the specified ID within the given date range.
+                value:
+                  action: 'run'
+                  ids:
+                    - '748694f0-6977-4ea5-8384-cd2e39730779'
+                  run:
+                    start_date: '2025-03-01T00:00:00.000Z'
+                    end_date: '2025-03-10T23:59:59.999Z'
+              example9:
+                summary: Export specific rules by ID
+                description: The following request exports the rules with the specified IDs.
+                value:
+                  action: 'export'
+                  ids:
+                    - '748694f0-6977-4ea5-8384-cd2e39730779'
+                    - '13199674-aff1-418a-9e93-04f585fe36d1'
+
       responses:
         200:
           description: OK
@@ -40,7 +136,213 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/BulkEditActionResponse'
                   - $ref: '#/components/schemas/BulkExportActionResponse'
-
+              examples:
+                example1:
+                  summary: Successful response
+                  description: In this response one rule was updated and one was skipped. Objects returned in attributes.results.skipped will only include rules' id, name, and skip_reason.
+                  value:
+                    success: true
+                    rules_count: 1
+                    attributes:
+                      results:
+                        updated:
+                          - id: '8bc7dad0-9320-11ec-9265-8b772383a08d'
+                            updated_at: '2022-02-21T17:05:50.883Z'
+                            updated_by: 'elastic'
+                            created_at: '2022-02-21T14:14:13.801Z'
+                            created_by: 'elastic'
+                            name: 'DNS Tunneling [Duplicate]'
+                            tags:
+                              - 'Elastic'
+                              - 'Network'
+                              - 'Threat Detection'
+                              - 'ML'
+                            interval: '15m'
+                            enabled: true
+                            description: 'A machine learning job detected unusually large numbers of DNS queries for a single top-level DNS domain, which is often used for DNS tunneling. DNS tunneling can be used for command-and-control, persistence, or data exfiltration activity. For example, dnscat tends to generate many DNS questions for a top-level domain as it uses the DNS protocol to tunnel data.'
+                            risk_score: 21
+                            severity: 'low'
+                            license: 'Elastic License v2'
+                            author:
+                              - 'Elastic'
+                            false_positives:
+                              - 'DNS domains that use large numbers of child domains, such as software or content distribution networks, can trigger this alert and such parent domains can be excluded.'
+                            from: 'now-45m'
+                            rule_id: '7289bf08-4e91-4c70-bf01-e04c4c5d7756'
+                            max_signals: 100
+                            risk_score_mapping: []
+                            severity_mapping: []
+                            threat: []
+                            to: 'now'
+                            references:
+                              - 'https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html'
+                            version: 6
+                            exceptions_list: []
+                            immutable: false
+                            related_integrations: []
+                            required_fields: []
+                            setup: ''
+                            type: 'machine_learning'
+                            anomaly_threshold: 50
+                            machine_learning_job_id:
+                              - 'packetbeat_dns_tunneling'
+                            execution_summary:
+                              last_execution:
+                                date: '2022-03-23T16:06:12.787Z'
+                                status: 'partial failure'
+                                status_order: 20
+                                message: 'This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.'
+                                metrics:
+                                  total_search_duration_ms: 135
+                                  total_indexing_duration_ms: 15
+                                  execution_gap_duration_s: 0
+                        created: []
+                        deleted: []
+                        skipped:
+                          - id: '51658332-a15e-4c9e-912a-67214e2e2359'
+                            name: 'Skipped rule'
+                            skip_reason: 'RULE_NOT_MODIFIED'
+                      summary:
+                        failed: 0
+                        skipped: 1
+                        succeeded: 1
+                        total: 2
+                example2:
+                  summary: Partial failure
+                  description: If processing of any rule fails, a partial error outputs the ID and/or name of the affected rule and the corresponding error, as well as successfully processed rules (in the same format as a successful 200 request).
+                  value:
+                    value:
+                      success: false
+                      status_code: 500
+                      message: 'Bulk edit partially failed'
+                      rules_count: 2
+                      attributes:
+                        results:
+                          updated:
+                            - id: '8e5c1a40-9320-11ec-9265-8b772383a08d'
+                              updated_at: '2022-02-21T16:56:22.818Z'
+                              updated_by: 'elastic'
+                              created_at: '2022-02-21T14:14:17.883Z'
+                              created_by: 'elastic'
+                              name: 'External Alerts [Duplicate]'
+                              tags:
+                                - 'Elastic'
+                                - 'Network'
+                                - 'Windows'
+                                - 'APM'
+                                - 'macOS'
+                                - 'Linux'
+                              interval: '5m'
+                              enabled: true
+                              description: 'Generates a detection alert for each external alert written to the configured indices. Enabling this rule allows you to immediately begin investigating external alerts in the app.'
+                              risk_score: 47
+                              severity: 'medium'
+                              license: 'Elastic License v2'
+                              rule_name_override: 'message'
+                              timestamp_override: 'event.ingested'
+                              author:
+                                - 'Elastic'
+                              false_positives: []
+                              from: 'now-6m'
+                              rule_id: '941faf98-0cdc-4569-b16d-4af962914d61'
+                              max_signals: 10000
+                              risk_score_mapping:
+                                - field: 'event.risk_score'
+                                  value: ''
+                                  operator: 'equals'
+                              severity_mapping:
+                                - severity: 'low'
+                                  field: 'event.severity'
+                                  value: '21'
+                                  operator: 'equals'
+                                - severity: 'medium'
+                                  field: 'event.severity'
+                                  value: '47'
+                                  operator: 'equals'
+                                - severity: 'high'
+                                  field: 'event.severity'
+                                  value: '73'
+                                  operator: 'equals'
+                                - severity: 'critical'
+                                  field: 'event.severity'
+                                  value: '99'
+                                  operator: 'equals'
+                              threat: []
+                              to: 'now'
+                              references: []
+                              version: 5
+                              exceptions_list: []
+                              immutable: false
+                              related_integrations: []
+                              required_fields: []
+                              setup: ''
+                              type: 'query'
+                              language: 'kuery'
+                              index:
+                                - 'apm-*-transaction*'
+                                - 'traces-apm*'
+                                - 'auditbeat-*'
+                                - 'filebeat-*'
+                                - 'logs-*'
+                                - 'packetbeat-*'
+                                - 'winlogbeat-*'
+                                - 'added-by-id-*'
+                              query: "event.kind:alert and not event.module:(endgame or endpoint)\n"
+                              actions: []
+                              execution_summary:
+                                last_execution:
+                                  date: '2022-03-23T16:06:12.787Z'
+                                  status: 'partial failure'
+                                  status_order: 20
+                                  message: 'This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.'
+                                  metrics:
+                                    total_search_duration_ms: 135
+                                    total_indexing_duration_ms: 15
+                                    execution_gap_duration_s: 0
+                          created: []
+                          deleted: []
+                          skipped: []
+                        summary:
+                          failed: 1
+                          succeeded: 1
+                          skipped: 0
+                          total: 2
+                        errors:
+                          - message: "Index patterns can't be added. Machine learning rule doesn't have index patterns property"
+                            status_code: 500
+                            rules:
+                              - id: '8bc7dad0-9320-11ec-9265-8b772383a08d'
+                                name: 'DNS Tunneling [Duplicate]'
+                example3:
+                  summary: Dry run
+                  description: The attributes.errors section of the response shows that two rules failed to update and one succeeded. The same results would be returned if you ran the request without dry run mode enabled. Notice that there are no arrays in attributes.results. In dry run mode, rule updates are not applied and saved to Elasticsearch, so the endpoint wouldn’t return results for rules that have been updated, created, or deleted.
+                  value:
+                    message: 'Bulk edit partially failed'
+                    status_code: 500
+                    attributes:
+                      errors:
+                        - message: "Elastic rule can't be edited"
+                          status_code: 500
+                          err_code: 'IMMUTABLE'
+                          rules:
+                            - id: '81aa0480-06af-11ed-94fb-dd1a0597d8d2'
+                              name: 'Unusual AWS Command for a User'
+                        - message: "Machine learning rule doesn't have index patterns"
+                          status_code: 500
+                          err_code: 'MACHINE_LEARNING_INDEX_PATTERN'
+                          rules:
+                            - id: 'dc015d10-0831-11ed-ac8b-05a222bd8d4a'
+                              name: 'Suspicious Powershell Script [Duplicate]'
+                      results:
+                        updated: []
+                        created: []
+                        deleted: []
+                        skipped: []
+                      summary:
+                        failed: 2
+                        succeeded: 1
+                        skipped: 0
+                        total: 3
 components:
   schemas:
     BulkEditSkipReason:
@@ -127,6 +429,7 @@ components:
 
     BulkEditActionSummary:
       type: object
+      description: A rule can only be skipped when the bulk action to be performed on it results in nothing being done. For example, if the `edit` action is used to add a tag to a rule that already has that tag, or to delete an index pattern that is not specified in a rule. Objects returned in `attributes.results.skipped` will only include rules' `id`, `name`, and `skip_reason`.
       properties:
         failed:
           type: integer
@@ -179,10 +482,10 @@ components:
       properties:
         query:
           type: string
-          description: Query to filter rules
+          description: Query to filter rules.
         ids:
           type: array
-          description: Array of rule IDs
+          description: Array of rule IDs. Array of rule IDs to which a bulk action will be applied. Only valid when query property is undefined.
           minItems: 1
           items:
             type: string
@@ -241,6 +544,7 @@ components:
               enum: [duplicate]
             duplicate:
               type: object
+              description: Duplicate object that describes applying an update action.
               properties:
                 include_exceptions:
                   type: boolean
@@ -264,6 +568,7 @@ components:
               enum: [run]
             run:
               type: object
+              description: Object that describes applying a manual rule run action.
               properties:
                 start_date:
                   type: string
@@ -279,7 +584,11 @@ components:
 
     ThrottleForBulkActions:
       type: string
-      description: "The condition for throttling the notification: 'rule', 'no_actions', or time duration"
+      description: |
+        Defines the maximum interval in which a rule’s actions are executed.
+        > info
+        > The rule level `throttle` field is deprecated in Elastic Security 8.8 and will remain active for at least the next 12 months.
+        > In Elastic Security 8.8 and later, you can use the `frequency` field to define frequencies for individual actions. Actions without frequencies will acquire a converted version of the rule’s `throttle` field. In the response, the converted `throttle` setting appears in the individual actions' `frequency` field.
       enum:
         - rule
         - 1h

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/create_rule/create_rule_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/create_rule/create_rule_route.schema.yaml
@@ -9,15 +9,306 @@ paths:
       x-codegen-enabled: true
       operationId: CreateRule
       summary: Create a detection rule
-      description: Create a new detection rule.
-      tags:
-        - Rules API
+      description: |
+        Create a new detection rule.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+        
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
+        You can create the following types of rules:
+
+        * **Custom query**: Searches the defined indices and creates an alert when a document matches the rule's KQL query.
+        * **Event correlation**: Searches the defined indices and creates an alert when results match an [Event Query Language (EQL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html) query.
+        * **Threshold**: Searches the defined indices and creates an alert when the number of times the specified field's value meets the threshold during a single execution. When there are multiple values that meet the threshold, an alert is generated for each value.
+          For example, if the threshold `field` is `source.ip` and its `value` is `10`, an alert is generated for every source IP address that appears in at least 10 of the rule's search results. If you're interested, see [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) for more information.
+        * **Indicator match**: Creates an alert when fields match values defined in the specified [Elasticsearch index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). For example, you can create an index for IP addresses and use this index to create an alert whenever an event's `destination.ip` equals a value in the index. The index's field mappings should be [ECS-compliant](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html).
+        * **New terms**: Generates an alert for each new term detected in source documents within a specified time range.
+        * **ES|QL**: Uses [Elasticsearch Query Language (ES|QL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html) to find events and aggregate search results.
+        * **Machine learning rules**: Creates an alert when a machine learning job discovers an anomaly above the defined threshold.
+        > info
+        > To create machine learning rules, you must have the [appropriate license](https://www.elastic.co/subscriptions) or use a [cloud deployment](https://cloud.elastic.co/registration). Additionally, for the machine learning rule to function correctly, the associated machine learning job must be running.
+
+        To retrieve machine learning job IDs, which are required to create machine learning jobs, call the [Elasticsearch Get jobs API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html). Machine learning jobs that contain `siem` in the `groups` field can be used to create rules:
+
+        ```json
+        ...
+        "job_id": "linux_anomalous_network_activity_ecs",
+        "job_type": "anomaly_detector",
+        "job_version": "7.7.0",
+        "groups": [
+          "auditbeat",
+          "process",
+          "siem"
+        ],
+        ...
+        ```
+
+        Additionally, you can set up notifications for when rules create alerts. The notifications use the [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html). Each action type requires a connector. Connectors store the information required to send notifications via external systems. The following connector types are supported for rule notifications:
+
+        * Slack
+        * Email
+        * PagerDuty
+        * Webhook
+        * Microsoft Teams
+        * IBM Resilient
+        * Jira
+        * ServiceNow ITSM
+        > info
+        > For more information on PagerDuty fields, see [Send a v2 Event](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/).
+
+        To retrieve connector IDs, which are required to configure rule notifications, call the [Find objects API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-find.html) with `"type": "action"` in the request payload.
+
+        For detailed information on Kibana actions and alerting, and additional API calls, see:
+
+        * [Alerting API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-alerting)
+        * [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html)
+        * [Connectors API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-connectors)
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RuleCreateProps'
+            examples:
+              example1:
+                summary: Query rule
+                description: Query rule that searches for processes started by MS Office
+                value:
+                  rule_id: 'process_started_by_ms_office_program'
+                  risk_score: 50
+                  description: 'Process started by MS Office program - possible payload'
+                  interval: '1h'
+                  name: 'MS Office child process'
+                  severity: 'low'
+                  tags:
+                    - 'child process'
+                    - 'ms office'
+                  type: 'query'
+                  from: 'now-70m'
+                  query: 'process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE'
+                  language: 'kuery'
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: 'phrase'
+                  required_fields:
+                    - name: 'process.parent.name'
+                      type: 'keyword'
+                  related_integrations:
+                    - package: 'o365'
+                      version: '^2.3.2'
+                  enabled: false
+              example2:
+                summary: Threshold rule
+                description: Threshold rule that detects multiple failed login attempts to a Windows host from the same external source IP address
+                value:
+                  description: 'Detects when there are 20 or more failed login attempts from the same IP address with a 2 minute time frame.'
+                  enabled: true
+                  exceptions_list:
+                    - id: 'int-ips'
+                      namespace_type: 'single'
+                      type: 'detection'
+                  from: 'now-180s'
+                  index:
+                    - 'winlogbeat-*'
+                  interval: '2m'
+                  name: 'Windows server prml-19'
+                  query: 'host.name:prml-19 and event.category:authentication and event.outcome:failure'
+                  required_fields:
+                    - name: 'source.ip'
+                      type: 'ip'
+                  risk_score: 30
+                  rule_id: 'liv-win-ser-logins'
+                  severity: 'low'
+                  severity_mapping:
+                    - field: 'source.geo.city_name'
+                      operator: 'equals'
+                      severity: 'low'
+                      value: 'Manchester'
+                    - field: 'source.geo.city_name'
+                      operator: 'equals'
+                      severity: 'medium'
+                      value: 'London'
+                    - field: 'source.geo.city_name'
+                      operator: 'equals'
+                      severity: 'high'
+                      value: 'Birmingham'
+                    - field: 'source.geo.city_name'
+                      operator: 'equals'
+                      severity: 'critical'
+                      value: 'Wallingford'
+                  tags:
+                    - 'Brute force'
+                  threshold:
+                    field: 'source.ip'
+                    value: 20
+                  type: 'threshold'
+              example3:
+                summary: Machine learning rule
+                description: Machine learning rule that creates alerts, and sends Slack notifications, when the linux_anomalous_network_activity_ecs machine learning job discovers anomalies with a threshold of 70 or above.
+                value:
+                  anomaly_threshold: 70
+                  rule_id: 'ml_linux_network_high_threshold'
+                  risk_score: 70
+                  machine_learning_job_id: 'linux_anomalous_network_activity_ecs'
+                  description: 'Generates alerts when the job discovers anomalies over 70'
+                  interval: '5m'
+                  name: 'Anomalous Linux network activity'
+                  note: 'Shut down the internet.'
+                  setup: 'This rule requires data coming in from Elastic Defend.'
+                  severity: 'high'
+                  tags:
+                    - 'machine learning'
+                    - 'Linux'
+                  type: 'machine_learning'
+                  from: 'now-6m'
+                  enabled: true
+                  actions:
+                    - action_type_id: '.slack'
+                      group: 'default'
+                      id: '5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5'
+                      params:
+                        message: 'Urgent: {{context.rule.description}}'
+              example4:
+                summary: EQL rule
+                description: Event correlation rule that creates alerts when the Windows rundll32.exe process makes unusual network connections
+                value:
+                  rule_id: 'eql-outbound-rundll32-connections'
+                  risk_score: 21
+                  description: 'Unusual rundll32.exe network connection'
+                  name: 'rundll32.exe network connection'
+                  severity: 'low'
+                  tags:
+                    - 'EQL'
+                    - 'Windows'
+                    - 'rundll32.exe'
+                  type: 'eql'
+                  language: 'eql'
+                  query: 'sequence by process.entity_id with maxspan=2h [process where event.type in ("start", "process_started") and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe") and ((process.args == "rundll32.exe" and process.args_count == 1) or (process.args != "rundll32.exe" and process.args_count == 0))] [network where event.type == "connection" and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe")]'
+                  required_fields:
+                    - name: 'event.type'
+                      type: 'keyword'
+                    - name: 'process.args'
+                      type: 'keyword'
+                    - name: 'process.args_count'
+                      type: 'long'
+                    - name: 'process.entity_id'
+                      type: 'keyword'
+                    - name: 'process.name'
+                      type: 'keyword'
+                    - name: 'process.pe.original_file_name'
+                      type: 'keyword'
+              example5:
+                summary: Indicator match rule
+                description: |
+                  Indicator match rule that creates an alert when one of the following is true: The event's destination IP address and port number matches destination IP and port values in the threat_index index; The event's source IP address matches a host IP address value in the threat_index index.
+                value:
+                  type: 'threat_match'
+                  actions: []
+                  index:
+                    - 'packetbeat-*'
+                  query: 'destination.ip:* or host.ip:*'
+                  threat_index:
+                    - 'ip-threat-list'
+                  threat_query: '*:*'
+                  threat_mapping:
+                    - entries:
+                        - field: 'destination.ip'
+                          type: 'mapping'
+                          value: 'destination.ip'
+                        - field: 'destination.port'
+                          type: 'mapping'
+                          value: 'destination.port'
+                    - entries:
+                        - field: 'source.ip'
+                          type: 'mapping'
+                          value: 'host.ip'
+                  required_fields:
+                    - name: 'destination.ip'
+                      type: 'ip'
+                    - name: 'destination.port'
+                      type: 'long'
+                    - name: 'host.ip'
+                      type: 'ip'
+                  risk_score: 50
+                  severity: 'medium'
+                  name: 'Bad IP threat match'
+                  description: 'Checks for bad IP addresses listed in the ip-threat-list index'
+              example6:
+                summary: New terms rule
+                description: New terms rule that creates alerts a new IP address is detected for a user
+                value:
+                  risk_score: 21
+                  description: 'Detects a user associated with a new IP address'
+                  name: 'New User IP Detected'
+                  severity: 'medium'
+                  type: 'new_terms'
+                  language: 'kuery'
+                  query: '*'
+                  new_terms_fields:
+                    - 'user.id'
+                    - 'source.ip'
+                  history_window_start: 'now-30d'
+                  index:
+                    - 'auditbeat*'
+                  required_fields:
+                    - name: 'user.id'
+                      type: 'keyword'
+                    - name: 'source.ip'
+                      type: 'ip'
+              example7:
+                summary: Esql rule
+                description: esql rule that creates alerts from events that match an Excel parent process
+                value:
+                  type: 'esql'
+                  language: 'esql'
+                  query: 'from auditbeat-8.10.2 METADATA _id, _version, _index | where process.parent.name == "EXCEL.EXE"'
+                  name: 'Find Excel events'
+                  description: 'Find Excel events'
+                  tags: []
+                  interval: '5m'
+                  from: 'now-360s'
+                  to: 'now'
+                  enabled: false
+                  risk_score: 21
+                  severity: 'low'
+                  required_fields:
+                    - name: 'process.parent.name'
+                      type: 'keyword'
+              example8:
+                summary: Query rule 2
+                description: Query rule that searches for processes started by MS Office and suppresses alerts by the process.parent.name field within a 5-hour time period
+                value:
+                  rule_id: 'process_started_by_ms_office_program'
+                  risk_score: 50
+                  description: 'Process started by MS Office program - possible payload'
+                  interval: '1h'
+                  name: 'MS Office child process'
+                  severity: 'low'
+                  tags:
+                    - 'child process'
+                    - 'ms office'
+                  type: 'query'
+                  from: 'now-70m'
+                  query: 'process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE'
+                  language: 'kuery'
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: 'phrase'
+                  enabled: false
+                  alert_suppression:
+                    duration:
+                      unit: 'h'
+                      value: 5
+                    group_by:
+                      - 'process.parent.name'
+                    missing_fields_strategy: 'suppress'
       responses:
         200:
           description: Indicates a successful call.
@@ -25,3 +316,378 @@ paths:
             application/json:
               schema:
                 $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RuleResponse'
+              examples:
+                example1:
+                  summary: Query rule response
+                  description: Example response for a query rule
+                  value:
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    created_by: 'elastic'
+                    description: 'Process started by MS Office program - possible payload'
+                    enabled: false
+                    false_positives: []
+                    from: 'now-70m'
+                    id: '6541b99a-dee9-4f6d-a86d-dbd1869d73b1'
+                    immutable: false
+                    interval: '1h'
+                    rule_id: 'process_started_by_ms_office_program'
+                    max_signals: 100
+                    risk_score: 50
+                    name: 'MS Office child process'
+                    references: []
+                    severity: 'low'
+                    updated_by: 'elastic'
+                    tags:
+                      - 'child process'
+                      - 'ms office'
+                    to: 'now'
+                    type: 'query'
+                    threat: []
+                    version: 1
+                    actions: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: 'phrase'
+                    query: 'process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE'
+                    language: 'kuery'
+                    related_integrations:
+                      - package: 'o365'
+                        version: '^2.3.2'
+                      - package: 'azure'
+                        version: '^1.11.4'
+                        integration: 'graphactivitylogs'
+                    required_fields:
+                      - name: 'process.parent.name'
+                        type: 'keyword'
+                        ecs: true
+                    setup: ''
+                example2:
+                  summary: Machine learning response
+                  description: Example response for a machine learning job rule
+                  value:
+                    created_at: '2020-04-07T14:45:15.679Z'
+                    updated_at: '2020-04-07T14:45:15.892Z'
+                    created_by: 'elastic'
+                    description: 'Generates alerts when the job discovers anomalies over 70'
+                    enabled: true
+                    false_positives: []
+                    from: 'now-6m'
+                    id: '83876f66-3a57-4a99-bf37-416494c80f3b'
+                    immutable: false
+                    interval: '5m'
+                    rule_id: 'ml_linux_network_high_threshold'
+                    max_signals: 100
+                    risk_score: 70
+                    name: 'Anomalous Linux network activity'
+                    references: []
+                    severity: 'high'
+                    updated_by: 'elastic'
+                    tags:
+                      - 'machine learning'
+                      - 'Linux'
+                    to: 'now'
+                    type: 'machine_learning'
+                    threat: []
+                    version: 1
+                    actions:
+                      - action_type_id: '.slack'
+                        group: 'default'
+                        id: '5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5'
+                        params:
+                          message: 'Urgent: {{context.rule.description}}'
+                        frequency:
+                          summary: true
+                          notifyWhen: 'onActiveAlert'
+                          throttle: null
+                    note: 'Shut down the internet.'
+                    status: 'going to run'
+                    status_date: '2020-04-07T14:45:21.685Z'
+                    anomaly_threshold: 70
+                    machine_learning_job_id: 'linux_anomalous_network_activity_ecs'
+                    related_integrations: []
+                    required_fields: []
+                    setup: ''
+                example3:
+                  summary: Threshold rule response
+                  description: Example response for a threshold rule
+                  value:
+                    author: []
+                    created_at: '2020-07-22T10:27:23.486Z'
+                    updated_at: '2020-07-22T10:27:23.673Z'
+                    created_by: 'elastic'
+                    description: 'Detects when there are 20 or more failed login attempts from the same IP address with a 2 minute time frame.'
+                    enabled: true
+                    false_positives: []
+                    from: 'now-180s'
+                    id: '15dbde26-b627-4d74-bb1f-a5e0ed9e4993'
+                    immutable: false
+                    interval: '2m'
+                    rule_id: 'liv-win-ser-logins'
+                    max_signals: 100
+                    risk_score: 30
+                    risk_score_mapping: []
+                    name: 'Windows server prml-19'
+                    references: []
+                    severity: 'low'
+                    severity_mapping:
+                      - field: 'source.geo.city_name'
+                        operator: 'equals'
+                        severity: 'low'
+                        value: 'Manchester'
+                      - field: 'source.geo.city_name'
+                        operator: 'equals'
+                        severity: 'medium'
+                        value: 'London'
+                      - field: 'source.geo.city_name'
+                        operator: 'equals'
+                        severity: 'high'
+                        value: 'Birmingham'
+                      - field: 'source.geo.city_name'
+                        operator: 'equals'
+                        severity: 'critical'
+                        value: 'Wallingford'
+                    updated_by: 'elastic'
+                    tags:
+                      - 'Brute force'
+                    to: 'now'
+                    type: 'threshold'
+                    threat: []
+                    version: 1
+                    exceptions_list:
+                      - id: 'int-ips'
+                        namespace_type: 'single'
+                        type: 'detection'
+                    actions: []
+                    index:
+                      - 'winlogbeat-*'
+                    query: 'host.name:prml-19 and event.category:authentication and event.outcome:failure'
+                    language: 'kuery'
+                    threshold:
+                      field: 'source.ip'
+                      value: 20
+                    related_integrations:
+                      - package: 'o365'
+                        version: '^2.3.2'
+                    required_fields:
+                      - name: 'source.ip'
+                        type: 'ip'
+                        ecs: true
+                    setup: ''
+                example4:
+                  summary: EQL rule response
+                  description: Example response for an EQL rule
+                  value:
+                    author: []
+                    created_at: '2020-10-05T09:06:16.392Z'
+                    updated_at: '2020-10-05T09:06:16.403Z'
+                    created_by: 'elastic'
+                    description: 'Unusual rundll32.exe network connection'
+                    enabled: true
+                    false_positives: []
+                    from: 'now-6m'
+                    id: '93808cae-b05b-4dc9-8479-73574b50f8b1'
+                    immutable: false
+                    interval: '5m'
+                    rule_id: 'eql-outbound-rundll32-connections'
+                    max_signals: 100
+                    risk_score: 21
+                    risk_score_mapping: []
+                    name: 'rundll32.exe network connection'
+                    references: []
+                    severity: 'low'
+                    severity_mapping: []
+                    updated_by: 'elastic'
+                    tags:
+                      - 'EQL'
+                      - 'Windows'
+                      - 'rundll32.exe'
+                    to: 'now'
+                    type: 'eql'
+                    threat: []
+                    version: 1
+                    exceptions_list: []
+                    throttle: 'no_actions'
+                    query: 'sequence by process.entity_id with maxspan=2h [process where event.type in ("start", "process_started") and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe") and ((process.args == "rundll32.exe" and process.args_count == 1) or (process.args != "rundll32.exe" and process.args_count == 0))] [network where event.type == "connection" and (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe")]'
+                    language: 'eql'
+                    related_integrations:
+                      - package: 'o365'
+                        version: '^2.3.2'
+                    required_fields:
+                      - name: 'event.type'
+                        type: 'keyword'
+                        ecs: true
+                      - name: 'process.args'
+                        type: 'keyword'
+                        ecs: true
+                      - name: 'process.args_count'
+                        type: 'long'
+                        ecs: true
+                      - name: 'process.entity_id'
+                        type: 'keyword'
+                        ecs: true
+                      - name: 'process.name'
+                        type: 'keyword'
+                        ecs: true
+                      - name: 'process.pe.original_file_name'
+                        type: 'keyword'
+                        ecs: true
+                    setup: ''
+                example5:
+                  summary: Indicator match rule response
+                  description: Example response for an indicator match rule
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    created_by: 'elastic'
+                    description: 'Checks for bad IP addresses listed in the ip-threat-list index'
+                    enabled: true
+                    false_positives: []
+                    from: 'now-6m'
+                    id: 'd5daa13f-81fb-4b13-be2f-31011e1d9ae1'
+                    immutable: false
+                    interval: '5m'
+                    rule_id: '608501e4-c768-4f64-9326-cec55b5d439b'
+                    max_signals: 100
+                    risk_score: 50
+                    risk_score_mapping: []
+                    name: 'Bad IP threat match'
+                    references: []
+                    severity: 'medium'
+                    severity_mapping: []
+                    updated_by: 'elastic'
+                    tags: []
+                    to: 'now'
+                    type: 'threat_match'
+                    threat: []
+                    version: 1
+                    exceptions_list: []
+                    index:
+                      - 'packetbeat-*'
+                    query: 'destination.ip:* or host.ip:*'
+                    language: 'kuery'
+                    threat_query: '*:*'
+                    threat_index:
+                      - 'ip-threat-list'
+                    threat_mapping:
+                      - entries:
+                          - field: 'destination.ip'
+                            type: 'mapping'
+                            value: 'destination.ip'
+                          - field: 'destination.port'
+                            type: 'mapping'
+                            value: 'destination.port'
+                      - entries:
+                          - field: 'source.ip'
+                            type: 'mapping'
+                            value: 'host.ip'
+                    related_integrations:
+                      - package: 'o365'
+                        version: '^2.3.2'
+                    required_fields:
+                      - name: 'destination.ip'
+                        type: 'ip'
+                        ecs: true
+                      - name: 'destination.port'
+                        type: 'long'
+                        ecs: true
+                      - name: 'host.ip'
+                        type: 'ip'
+                        ecs: true
+                    setup: ''
+                example6:
+                  summary: New terms rule response
+                  description: Example response for a new terms rule
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    created_by: 'elastic'
+                    description: 'Detects a user associated with a new IP address'
+                    enabled: true
+                    false_positives: []
+                    from: 'now-6m'
+                    id: 'eb7225c0-566b-11ee-8b4f-bbf3afdeb9f4'
+                    immutable: false
+                    interval: '5m'
+                    rule_id: 'c6f5d0bc-7be9-47d4-b2f3-073d22641e30'
+                    max_signals: 100
+                    risk_score: 21
+                    risk_score_mapping: []
+                    name: 'New User IP Detected'
+                    references: []
+                    severity: 'medium'
+                    severity_mapping: []
+                    updated_by: 'elastic'
+                    tags: []
+                    to: 'now'
+                    type: 'new_terms'
+                    threat: []
+                    version: 1
+                    exceptions_list: []
+                    index:
+                      - 'auditbeat*'
+                    query: '*'
+                    language: 'kuery'
+                    new_terms_fields:
+                      - 'user.id'
+                      - 'source.ip'
+                    history_window_start: 'now-30d'
+                    related_integrations:
+                      - package: 'o365'
+                        version: '^2.3.2'
+                    required_fields:
+                      - name: 'user.id'
+                        type: 'keyword'
+                        ecs: true
+                      - name: 'source.ip'
+                        type: 'ip'
+                        ecs: true
+                    setup: ''
+                example7:
+                  summary: Esql rule response
+                  description: Example response for an Esql rule
+                  value:
+                    name: 'Find Excel events'
+                    description: 'Find Excel events'
+                    risk_score: 21
+                    severity: 'low'
+                    output_index: ''
+                    tags: []
+                    interval: '5m'
+                    enabled: false
+                    author: []
+                    false_positives: []
+                    from: 'now-360s'
+                    max_signals: 100
+                    risk_score_mapping: []
+                    severity_mapping: []
+                    threat: []
+                    to: 'now'
+                    references: []
+                    version: 1
+                    exceptions_list: []
+                    actions: []
+                    id: 'd0f20490-6da4-11ee-b85e-09e9b661f2e2'
+                    updated_at: '2023-10-18T10:55:14.269Z'
+                    updated_by: 'elastic'
+                    created_at: '2023-10-18T10:55:14.269Z'
+                    created_by: 'elastic'
+                    revision: 0
+                    rule_id: 'e4b53a89-debd-4a0d-a3e3-20606952e589'
+                    immutable: false
+                    related_integrations:
+                      - package: 'o365'
+                        version: '^2.3.2'
+                    required_fields:
+                      - name: 'process.parent.name'
+                        type: 'keyword'
+                        ecs: true
+                    setup: ''
+                    type: 'esql'
+                    language: 'esql'
+                    query: 'from auditbeat-8.10.2 METADATA _id | where process.parent.name == "EXCEL.EXE"'

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/delete_rule/delete_rule_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/delete_rule/delete_rule_route.schema.yaml
@@ -9,7 +9,15 @@ paths:
       x-codegen-enabled: true
       operationId: DeleteRule
       summary: Delete a detection rule
-      description: Delete a detection rule using the `rule_id` or `id` field.
+      description: |
+        Delete a detection rule using the `rule_id` or `id` field.
+
+        The URL query must include one of the following:
+
+        * `id` - `DELETE /api/detection_engine/rules?id=<id>`
+        * `rule_id`- `DELETE /api/detection_engine/rules?rule_id=<rule_id>`
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
       tags:
         - Rules API
       parameters:
@@ -25,6 +33,12 @@ paths:
           description: The rule's `rule_id` value.
           schema:
             $ref: '../../../model/rule_schema/common_attributes.schema.yaml#/components/schemas/RuleSignatureId'
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request DELETE https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
       responses:
         200:
           description: Indicates a successful call.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/patch_rule/patch_rule_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/patch_rule/patch_rule_route.schema.yaml
@@ -9,15 +9,82 @@ paths:
       x-codegen-enabled: true
       operationId: PatchRule
       summary: Patch a detection rule
-      description: Update specific fields of an existing detection rule using the `rule_id` or `id` field.
+      description: |
+        Update specific fields of an existing detection rule using the `rule_id` or `id` field.
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       tags:
         - Rules API
       requestBody:
         required: true
+        description: |
+          > info
+          > You cannot modify the `id` or `rule_id` values.
         content:
           application/json:
             schema:
               $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RulePatchProps'
+            examples:
+              example1:
+                summary: Patch query rule
+                value:
+                  id: '14b7b513-3d8d-4b22-b7da-a7ae632f7e76'
+                  name: 'New name'
+              example2:
+                summary: Patch EQL rule
+                value:
+                  rule_id: 'process_started_by_ms_office_program_possible_payload'
+                  threat:
+                    - framework: 'MITRE ATT&CK'
+                      tactic:
+                        id: 'TA0001'
+                        reference: 'https://attack.mitre.org/tactics/TA0001'
+                        name: 'Initial Access'
+                      technique:
+                        - id: 'T1193'
+                          name: 'Spearphishing Attachment'
+                          reference: 'https://attack.mitre.org/techniques/T1193'
+              example3:
+                summary: Patch threshold rule
+                value:
+                  id: '005d2c4f-51ca-493d-a2bd-20ef076339b1'
+                  query: 'agent.version : * and agent.id : "243d9b4f-ca01-4311-8e5c-9abbee91afd8"'
+                  threshold:
+                    field: []
+                    value: 600
+                    cardinality: []
+              example4:
+                summary: Patch new terms rule
+                value:
+                  id: '569aac91-40dc-4807-a8ae-a2c8698089c4'
+                  new_terms_fields:
+                    - 'Endpoint.policy.applied.artifacts.global.identifiers.name'
+                  history_window_start: 'now-3d'
+              example5:
+                summary: Patch esql rule
+                value:
+                  id: '0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd'
+                  query: |
+                    FROM logs-abc*
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp)
+                    | EVAL event_rate = count / DATE_DIFF("seconds", min_timestamp, NOW()) 
+                    | KEEP event_rate
+              example6:
+                summary: Patch indicator match rule
+                value:
+                  id: '462f1986-10fe-40a3-a22c-2b1c9c4c48fd'
+                  threat_query: '@timestamp >= "now-30d/d" and event.module:(threatintel or ti_*) and threat.indicator.ip:* and not labels.is_ioc_transform_source:"false"'
+              example7:
+                summary: Patch machine learning rule
+                value:
+                  id: '60b13926-289b-41b1-a537-197ef1fa5059'
+                  anomaly_threshold: 50
+                  machine_learning_job_id:
+                    - 'auth_high_count_logon_events'
       responses:
         200:
           description: Indicates a successful call.
@@ -25,3 +92,41 @@ paths:
             application/json:
               schema:
                 $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RuleResponse'
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    created_by: 'elastic'
+                    description: 'Updated description for the rule.'
+                    enabled: false
+                    false_positives: []
+                    from: 'now-70m'
+                    id: '6541b99a-dee9-4f6d-a86d-dbd1869d73b1'
+                    immutable: false
+                    interval: '1h'
+                    rule_id: 'process_started_by_ms_office_program'
+                    max_signals: 100
+                    risk_score: 50
+                    name: 'Updated Rule Name'
+                    references: []
+                    severity: 'low'
+                    updated_by: 'elastic'
+                    tags:
+                      - 'child process'
+                      - 'ms office'
+                    to: 'now'
+                    type: 'query'
+                    threat: []
+                    version: 2
+                    actions: []
+                    filters:
+                      - query:
+                    query: 'process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE'
+                    language: 'kuery'
+                    related_integrations:
+                      - package: 'o365'
+                    required_fields:
+                      - name: 'process.parent.name'
+                    setup: ''

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/read_rule/read_rule_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/read_rule/read_rule_route.schema.yaml
@@ -9,7 +9,15 @@ paths:
       x-codegen-enabled: true
       operationId: ReadRule
       summary: Retrieve a detection rule
-      description: Retrieve a detection rule using the `rule_id` or `id` field.
+      description: |
+        Retrieve a detection rule using the `rule_id` or `id` field.
+
+        The URL query must include one of the following:
+
+        * `id` - `GET /api/detection_engine/rules?id=<id>`
+        * `rule_id` - `GET /api/detection_engine/rules?rule_id=<rule_id>`
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
       tags:
         - Rules API
       parameters:
@@ -25,10 +33,85 @@ paths:
           description: The rule's `rule_id` value.
           schema:
             $ref: '../../../model/rule_schema/common_attributes.schema.yaml#/components/schemas/RuleSignatureId'
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request GET https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
       responses:
         200:
-          description: Indicates a successful call.
+          description: |
+            Indicates a successful call.
+            > info
+            > These fields are under development and their usage or schema may change: execution_summary.
           content:
             application/json:
               schema:
                 $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RuleResponse'
+              examples:
+                example1:
+                  summary: Example response for a retrieved rule
+                  value:
+                    created_at: '2020-02-03T11:19:04.259Z'
+                    updated_at: '2020-02-03T11:19:04.462Z'
+                    created_by: 'elastic'
+                    description: 'Process started by MS Office program in user folder'
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: 'phrase'
+                    from: 'now-4200s'
+                    id: 'c41d170b-8ba6-4de6-b8ec-76440a35ace3'
+                    immutable: false
+                    interval: '1h'
+                    rule_id: 'process_started_by_ms_office_user_folder'
+                    related_integrations:
+                      - package: 'o365'
+                        version: '^2.3.2'
+                    required_fields:
+                      - name: 'process.name'
+                        type: 'keyword'
+                        ecs: true
+                      - name: 'process.parent.name'
+                        type: 'keyword'
+                        ecs: true
+                    setup: ''
+                    language: 'kuery'
+                    max_signals: 100
+                    risk_score: 21
+                    name: 'MS Office child process'
+                    query: 'process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE'
+                    references: []
+                    severity: 'low'
+                    updated_by: 'elastic'
+                    tags:
+                      - 'child process'
+                      - 'ms office'
+                    to: 'now-300s'
+                    type: 'query'
+                    threat:
+                      - framework: 'MITRE ATT&CK'
+                        tactic:
+                          id: 'TA0001'
+                          reference: 'https://attack.mitre.org/tactics/TA0001'
+                          name: 'Initial Access'
+                        technique:
+                          - id: 'T1193'
+                            name: 'Spearphishing Attachment'
+                            reference: 'https://attack.mitre.org/techniques/T1193'
+                    execution_summary:
+                      last_execution:
+                        date: '2022-03-23T16:06:12.787Z'
+                        status: 'partial failure'
+                        status_order: 20
+                        message: 'This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.'
+                        metrics:
+                          total_search_duration_ms: 135
+                          total_indexing_duration_ms: 15
+                          execution_gap_duration_s: 0
+                    version: 1

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/update_rule/update_rule_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/crud/update_rule/update_rule_route.schema.yaml
@@ -11,16 +11,126 @@ paths:
       summary: Update a detection rule
       description: |
         Update a detection rule using the `rule_id` or `id` field. The original rule is replaced, and all unspecified fields are deleted.
-        > info
-        > You cannot modify the `id` or `rule_id` values.
+
+        The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
       tags:
         - Rules API
       requestBody:
         required: true
+        description: |
+          > info
+          > All unspecified fields are deleted. You cannot modify the `id` or `rule_id` values.
         content:
           application/json:
             schema:
               $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RuleUpdateProps'
+            examples:
+              example1:
+                summary: Update query rule
+                value:
+                  id: '14b7b513-3d8d-4b22-b7da-a7ae632f7e76'
+                  type: 'query'
+                  name: 'A new name for the rule'
+                  description: 'A new description'
+                  risk_score: 22
+                  severity: 'medium'
+              example2:
+                summary: Update EQL rule
+                value:
+                  id: '9b684efb-acf9-4323-9bff-8335b3867d14'
+                  name: 'New name for EQL rule'
+                  description: 'eql rule test'
+                  risk_score: 21
+                  severity: 'low'
+                  type: 'eql'
+                  language: 'eql'
+                  index:
+                    - 'apm-*-transaction*'
+                  query: 'process where process.name == "regsvr32.exe"'
+              example3:
+                summary: Update threshold rule
+                value:
+                  id: '005d2c4f-51ca-493d-a2bd-20ef076339b1'
+                  name: 'New name for threat rule'
+                  tags: ['new_tag']
+                  description: 'Description of threat rule test'
+                  risk_score: 21
+                  severity: 'low'
+                  type: 'threshold'
+                  language: 'kuery'
+                  query: 'agent.version : * and agent.id : "243d9b4f-ca01-4311-8e5c-9abbee91afd8"'
+                  threshold:
+                    field: []
+                    value: 400
+                    cardinality: []
+              example4:
+                summary: Update new terms rule
+                value:
+                  id: '569aac91-40dc-4807-a8ae-a2c8698089c4'
+                  name: 'New terms rule name'
+                  description: 'New description'
+                  type: 'new_terms'
+                  interval: '5m'
+                  risk_score: 21
+                  severity: 'low'
+                  query: 'agent.version : "9.1.0"'
+                  new_terms_fields:
+                    - 'Endpoint.policy.applied.artifacts.global.identifiers.name'
+                  history_window_start: 'now-7d'
+              example5:
+                summary: Update esql rule
+                value:
+                  id: '0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd'
+                  name: 'New name for esql rule'
+                  description: 'New description for esql rule'
+                  risk_score: 21
+                  severity: 'low'
+                  type: 'esql'
+                  language: 'esql'
+                  query: |
+                    FROM logs*
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp) /* MIN(dateField) finds the earliest timestamp in the dataset. */
+                    | EVAL event_rate = count / DATE_DIFF("seconds", min_timestamp, NOW()) /* Calculates the event rate by dividing the total count of events by the time difference (in seconds) between the earliest event and the current time. */
+                    | KEEP event_rate
+              example6:
+                summary: Update indicator match rule
+                value:
+                  id: '462f1986-10fe-40a3-a22c-2b1c9c4c48fd'
+                  name: 'New name for Indicator Match rule'
+                  description: 'New description'
+                  risk_score: 99
+                  severity: 'critical'
+                  type: 'threat_match'
+                  query: 'source.ip:* or destination.ip:*\n'
+                  threat_query: '@timestamp >= "now-30d/d" and event.module:(threatintel or ti_*) and threat.indicator.ip:* and not labels.is_ioc_transform_source:"true"'
+                  threat_mapping:
+                    - entries:
+                        - field: 'source.ip'
+                          type: 'mapping'
+                          value: 'threat.indicator.ip'
+                    - entries:
+                        - field: 'destination.ip'
+                          type: 'mapping'
+                          value: 'threat.indicator.ip'
+                  threat_index:
+                    - 'filebeat-*'
+                    - 'logs-ti_*'
+              example7:
+                summary: Update machine learning rule
+                value:
+                  id: '60b13926-289b-41b1-a537-197ef1fa5059'
+                  name: 'New name of ml rule'
+                  description: 'New description of ml rule'
+                  risk_score: 21
+                  severity: 'low'
+                  type: 'machine_learning'
+                  anomaly_threshold: 50
+                  machine_learning_job_id:
+                    - 'auth_high_count_logon_events'
       responses:
         200:
           description: Indicates a successful call.
@@ -28,3 +138,41 @@ paths:
             application/json:
               schema:
                 $ref: '../../../model/rule_schema/rule_schemas.schema.yaml#/components/schemas/RuleResponse'
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    created_by: 'elastic'
+                    description: 'Updated description for the rule.'
+                    enabled: false
+                    false_positives: []
+                    from: 'now-70m'
+                    id: '6541b99a-dee9-4f6d-a86d-dbd1869d73b1'
+                    immutable: false
+                    interval: '1h'
+                    rule_id: 'process_started_by_ms_office_program'
+                    max_signals: 100
+                    risk_score: 50
+                    name: 'Updated Rule Name'
+                    references: []
+                    severity: 'low'
+                    updated_by: 'elastic'
+                    tags:
+                      - 'child process'
+                      - 'ms office'
+                    to: 'now'
+                    type: 'query'
+                    threat: []
+                    version: 2
+                    actions: []
+                    filters:
+                      - query:
+                    query: 'process.parent.name:EXCEL.EXE or process.parent.name:MSPUB.EXE or process.parent.name:OUTLOOK.EXE or process.parent.name:POWERPNT.EXE or process.parent.name:VISIO.EXE or process.parent.name:WINWORD.EXE'
+                    language: 'kuery'
+                    related_integrations:
+                      - package: 'o365'
+                    required_fields:
+                      - name: 'process.parent.name'
+                    setup: ''

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.gen.ts
@@ -25,9 +25,12 @@ export const ExportRulesRequestQuery = z.object({
    * Determines whether a summary of the exported rules is returned.
    */
   exclude_export_details: BooleanFromString.optional().default(false),
-  /**
-   * File name for saving the exported rules.
-   */
+  /** 
+      * File name for saving the exported rules.
+> info
+> When using cURL to export rules to a file, use the -O and -J options to save the rules to the file name specified in the URL.
+ 
+      */
   file_name: z.string().optional().default('export.ndjson'),
 });
 export type ExportRulesRequestQueryInput = z.input<typeof ExportRulesRequestQuery>;

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/export_rules/export_rules_route.schema.yaml
@@ -14,7 +14,11 @@ paths:
         - Actions
         - Exception lists
         > info
-        > You cannot export prebuilt rules.
+        > Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+        > You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+        > Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
       tags:
         - Import/Export API
       parameters:
@@ -28,10 +32,27 @@ paths:
         - name: file_name
           in: query
           required: false
-          description: File name for saving the exported rules.
+          description: |
+            File name for saving the exported rules.
+            > info
+            > When using cURL to export rules to a file, use the -O and -J options to save the rules to the file name specified in the URL.
           schema:
             type: string
             default: export.ndjson
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST "localhost:5601/api/detection_engine/rules/_export?exclude_export_details=true&file_name=exported_rules.ndjson" -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d'
+            {
+              "objects": [
+                {
+                  "rule_id":"343580b5-c811-447c-8d2d-2ccf052c6900"
+                },
+                {
+                  "rule_id":"2938c9fa-53eb-4c04-b79c-33cbf041b18d"
+                }
+              ]
+            }
       requestBody:
         required: false
         content:
@@ -60,4 +81,7 @@ paths:
               schema:
                 type: string
                 format: binary
-                description: An `.ndjson` file containing the returned rules.
+                description: |
+                  An `.ndjson` file containing the returned rules.
+
+                  Each line in the file represents an object (a rule, exception list parent container, or exception list item), and the last line includes a summary of what was exported.

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/find_rules/find_rules_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/find_rules/find_rules_route.gen.ts
@@ -43,9 +43,20 @@ export const FindRulesSortFieldEnum = FindRulesSortField.enum;
 export type FindRulesRequestQuery = z.infer<typeof FindRulesRequestQuery>;
 export const FindRulesRequestQuery = z.object({
   fields: ArrayFromString(z.string()).optional(),
-  /**
-   * Search query
-   */
+  /** 
+      * Search query
+
+Filters the returned results according to the value of the specified field, using the alert.attributes.<field name>:<field value> syntax, where <field name> can be:
+- name
+- enabled
+- tags
+- createdBy
+- interval
+- updatedBy
+> info
+> Even though the JSON rule object uses created_by and updated_by fields, you must use createdBy and updatedBy fields in the filter.
+ 
+      */
   filter: z.string().optional(),
   /**
    * Field to sort by

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/find_rules/find_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/find_rules/find_rules_route.schema.yaml
@@ -22,7 +22,18 @@ paths:
               type: string
         - name: 'filter'
           in: query
-          description: Search query
+          description: |
+            Search query
+
+            Filters the returned results according to the value of the specified field, using the alert.attributes.<field name>:<field value> syntax, where <field name> can be:
+            - name
+            - enabled
+            - tags
+            - createdBy
+            - interval
+            - updatedBy
+            > info
+            > Even though the JSON rule object uses created_by and updated_by fields, you must use createdBy and updatedBy fields in the filter.
           required: false
           schema:
             type: string
@@ -66,10 +77,16 @@ paths:
           required: false
           schema:
             type: string
-
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X GET "localhost:5601/api/detection_engine/rules/_find?page=1&per_page=5&sort_field=enabled&sort_order=asc&filter=alert.attributes.name:windows" -H 'kbn-xsrf: true'
       responses:
         '200':
-          description: Successful response
+          description: |
+            Successful response
+            > info
+            > These fields are under development and their usage or schema may change: execution_summary.
           content:
             application/json:
               schema:
@@ -90,6 +107,73 @@ paths:
                   - perPage
                   - total
                   - data
+              examples:
+                example1:
+                  value:
+                    page: 1
+                    perPage: 5
+                    total: 4
+                    data:
+                      - created_at: '2020-02-02T10:05:19.613Z'
+                        updated_at: '2020-02-02T10:05:19.830Z'
+                        created_by: 'elastic'
+                        description: 'Identifies a PowerShell process launched by either cscript.exe or wscript.exe. Observing Windows scripting processes executing a PowerShell script, may be indicative of malicious activity.'
+                        enabled: false
+                        false_positives: []
+                        from: 'now-6m'
+                        id: '89761517-fdb0-4223-b67b-7621acc48f9e'
+                        immutable: true
+                        index:
+                          - 'winlogbeat-*'
+                        interval: '5m'
+                        rule_id: 'f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc'
+                        language: 'kuery'
+                        max_signals: 33
+                        risk_score: 21
+                        name: 'Windows Script Executing PowerShell'
+                        query: 'event.action:"Process Create (rule: ProcessCreate)" and process.parent.name:("wscript.exe" or "cscript.exe") and process.name:"powershell.exe"'
+                        references: []
+                        severity: 'low'
+                        updated_by: 'elastic'
+                        tags:
+                          - 'Elastic'
+                          - 'Windows'
+                        to: 'now'
+                        related_integrations:
+                          - package: 'o365'
+                            version: '^2.3.2'
+                        required_fields:
+                          - name: 'event.action'
+                            type: 'keyword'
+                            ecs: true
+                          - name: 'process.name'
+                            type: 'keyword'
+                            ecs: true
+                          - name: 'process.parent.name'
+                            type: 'keyword'
+                            ecs: true
+                        setup: ''
+                        type: 'query'
+                        threat:
+                          - framework: 'MITRE ATT&CK'
+                            tactic:
+                              id: 'TA0002'
+                              name: 'Execution'
+                              reference: 'https://attack.mitre.org/tactics/TA0002/'
+                            technique:
+                              - id: 'T1193'
+                                name: 'Spearphishing Attachment'
+                                reference: 'https://attack.mitre.org/techniques/T1193/'
+                        execution_summary:
+                          last_execution:
+                            date: '2022-03-23T16:06:12.787Z'
+                            status: 'partial failure'
+                            status_order: 20
+                            message: 'This rule attempted to query data from Elasticsearch indices listed in the "Index pattern" section of the rule definition, but no matching index was found.'
+                            metrics:
+                              total_search_duration_ms: 135
+                              total_indexing_duration_ms: 15
+                              execution_gap_duration_s: 0
 
 components:
   schemas:

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/import_rules/import_rules_route.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/import_rules/import_rules_route.gen.ts
@@ -27,7 +27,7 @@ export const ImportRulesRequestQuery = z.object({
    */
   overwrite: BooleanFromString.optional().default(false),
   /**
-   * Determines whether existing exception lists with the same `list_id` are overwritten.
+   * Determines whether existing exception lists with the same `list_id` are overwritten. Both the exception list container and its items are overwritten.
    */
   overwrite_exceptions: BooleanFromString.optional().default(false),
   /**

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/import_rules/import_rules_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/import_rules/import_rules_route.schema.yaml
@@ -13,8 +13,28 @@ paths:
         Import detection rules from an `.ndjson` file, including actions and exception lists. The request must include:
         - The `Content-Type: multipart/form-data` HTTP header.
         - A link to the `.ndjson` file containing the rules.
+        > warn
+        > When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+        > If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+        > info
+        > To import rules with actions, you need at least Read privileges for the Action and Connectors feature. To overwrite or add new connectors, you need All privileges for the Actions and Connectors feature. To import rules without actions, you don’t need Actions and Connectors privileges. Refer to [Enable and access detections](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui) for more information.
+
+        > info
+        > Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+        > You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+        > Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
       tags:
         - Import/Export API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST "<KibanaURL>/api/detection_engine/rules/_import"
+            -u <username>:<password> -H 'kbn-xsrf: true'
+            -H 'Content-Type: multipart/form-data'
+            --form "file=@<link to file>"
       requestBody:
         required: true
         content:
@@ -37,7 +57,7 @@ paths:
         - name: overwrite_exceptions
           in: query
           required: false
-          description: Determines whether existing exception lists with the same `list_id` are overwritten.
+          description: Determines whether existing exception lists with the same `list_id` are overwritten. Both the exception list container and its items are overwritten.
           schema:
             type: boolean
             default: false
@@ -110,3 +130,14 @@ paths:
                   action_connectors_success_count:
                     type: integer
                     minimum: 0
+              examples:
+                example1:
+                  summary: Import rules with success
+                  value:
+                    success: true
+                    success_count: 1
+                    rules_count: 1
+                    errors: []
+                    exceptions_errors: []
+                    exceptions_success: true
+                    exceptions_success_count: 0

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/read_tags/read_tags_route.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_management/read_tags/read_tags_route.schema.yaml
@@ -19,3 +19,14 @@ paths:
             application/json:
               schema:
                 $ref: '../../model/rule_schema/common_attributes.schema.yaml#/components/schemas/RuleTagArray'
+              examples:
+                example1:
+                  value:
+                    - "zeek"
+                    - "suricata"
+                    - "windows"
+                    - "linux"
+                    - "network"
+                    - "initial access"
+                    - "remote access"
+                    - "phishing"

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/model/execution_summary.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/model/execution_summary.gen.ts
@@ -19,6 +19,12 @@ import { z } from '@kbn/zod';
 import { RuleExecutionStatus, RuleExecutionStatusOrder } from './execution_status.gen';
 import { RuleExecutionMetrics } from './execution_metrics.gen';
 
+/**
+  * Summary of the last execution of a rule.
+> info
+> This field is under development and its usage or schema may change
+
+  */
 export type RuleExecutionSummary = z.infer<typeof RuleExecutionSummary>;
 export const RuleExecutionSummary = z.object({
   last_execution: z.object({

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/model/execution_summary.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/model/execution_summary.schema.yaml
@@ -8,6 +8,10 @@ components:
   schemas:
     RuleExecutionSummary:
       type: object
+      description: |
+        Summary of the last execution of a rule.
+        > info
+        > This field is under development and its usage or schema may change
       properties:
         last_execution:
           type: object

--- a/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/quickstart_client.gen.ts
@@ -736,8 +736,62 @@ If a record already exists for the specified entity, that record is overwritten 
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Create a new detection rule.
-   */
+    * Create a new detection rule.
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
+You can create the following types of rules:
+
+* **Custom query**: Searches the defined indices and creates an alert when a document matches the rule's KQL query.
+* **Event correlation**: Searches the defined indices and creates an alert when results match an [Event Query Language (EQL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html) query.
+* **Threshold**: Searches the defined indices and creates an alert when the number of times the specified field's value meets the threshold during a single execution. When there are multiple values that meet the threshold, an alert is generated for each value.
+  For example, if the threshold `field` is `source.ip` and its `value` is `10`, an alert is generated for every source IP address that appears in at least 10 of the rule's search results. If you're interested, see [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) for more information.
+* **Indicator match**: Creates an alert when fields match values defined in the specified [Elasticsearch index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). For example, you can create an index for IP addresses and use this index to create an alert whenever an event's `destination.ip` equals a value in the index. The index's field mappings should be [ECS-compliant](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html).
+* **New terms**: Generates an alert for each new term detected in source documents within a specified time range.
+* **ES|QL**: Uses [Elasticsearch Query Language (ES|QL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html) to find events and aggregate search results.
+* **Machine learning rules**: Creates an alert when a machine learning job discovers an anomaly above the defined threshold.
+> info
+> To create machine learning rules, you must have the [appropriate license](https://www.elastic.co/subscriptions) or use a [cloud deployment](https://cloud.elastic.co/registration). Additionally, for the machine learning rule to function correctly, the associated machine learning job must be running.
+
+To retrieve machine learning job IDs, which are required to create machine learning jobs, call the [Elasticsearch Get jobs API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html). Machine learning jobs that contain `siem` in the `groups` field can be used to create rules:
+
+```json
+...
+"job_id": "linux_anomalous_network_activity_ecs",
+"job_type": "anomaly_detector",
+"job_version": "7.7.0",
+"groups": [
+  "auditbeat",
+  "process",
+  "siem"
+],
+...
+```
+
+Additionally, you can set up notifications for when rules create alerts. The notifications use the [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html). Each action type requires a connector. Connectors store the information required to send notifications via external systems. The following connector types are supported for rule notifications:
+
+* Slack
+* Email
+* PagerDuty
+* Webhook
+* Microsoft Teams
+* IBM Resilient
+* Jira
+* ServiceNow ITSM
+> info
+> For more information on PagerDuty fields, see [Send a v2 Event](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/).
+
+To retrieve connector IDs, which are required to configure rule notifications, call the [Find objects API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-find.html) with `"type": "action"` in the request payload.
+
+For detailed information on Kibana actions and alerting, and additional API calls, see:
+
+* [Alerting API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-alerting)
+* [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html)
+* [Connectors API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-connectors)
+
+    */
   async createRule(props: CreateRuleProps) {
     this.log.info(`${new Date().toISOString()} Calling API CreateRule`);
     return this.kbnClient
@@ -859,8 +913,16 @@ If a record already exists for the specified entity, that record is overwritten 
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Delete a detection rule using the `rule_id` or `id` field.
-   */
+    * Delete a detection rule using the `rule_id` or `id` field.
+
+The URL query must include one of the following:
+
+* `id` - `DELETE /api/detection_engine/rules?id=<id>`
+* `rule_id`- `DELETE /api/detection_engine/rules?rule_id=<rule_id>`
+
+The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+
+    */
   async deleteRule(props: DeleteRuleProps) {
     this.log.info(`${new Date().toISOString()} Calling API DeleteRule`);
     return this.kbnClient
@@ -1227,7 +1289,11 @@ If a record already exists for the specified entity, that record is overwritten 
 - Actions
 - Exception lists
 > info
-> You cannot export prebuilt rules.
+> Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+> You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+> Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
 
     */
   async exportRules(props: ExportRulesProps) {
@@ -1725,6 +1791,19 @@ finalize it.
     * Import detection rules from an `.ndjson` file, including actions and exception lists. The request must include:
 - The `Content-Type: multipart/form-data` HTTP header.
 - A link to the `.ndjson` file containing the rules.
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+> info
+> To import rules with actions, you need at least Read privileges for the Action and Connectors feature. To overwrite or add new connectors, you need All privileges for the Actions and Connectors feature. To import rules without actions, you don’t need Actions and Connectors privileges. Refer to [Enable and access detections](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui) for more information.
+
+> info
+> Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+> You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+> Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
 
     */
   async importRules(props: ImportRulesProps) {
@@ -1815,8 +1894,19 @@ finalize it.
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Install and update all Elastic prebuilt detection rules and Timelines.
-   */
+    * Install and update all Elastic prebuilt detection rules and Timelines.
+
+This endpoint allows you to install and update prebuilt detection rules and Timelines provided by Elastic. 
+When you call this endpoint, it will:
+- Install any new prebuilt detection rules that are not currently installed in your system.
+- Update any existing prebuilt detection rules that have been modified or improved by Elastic.
+- Install any new prebuilt Timelines that are not currently installed in your system.
+- Update any existing prebuilt Timelines that have been modified or improved by Elastic.
+
+This ensures that your detection engine is always up-to-date with the latest rules and Timelines, 
+providing you with the most current and effective threat detection capabilities.
+
+    */
   async installPrebuiltRulesAndTimelines() {
     this.log.info(`${new Date().toISOString()} Calling API InstallPrebuiltRulesAndTimelines`);
     return this.kbnClient
@@ -1888,8 +1978,15 @@ finalize it.
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Update specific fields of an existing detection rule using the `rule_id` or `id` field.
-   */
+    * Update specific fields of an existing detection rule using the `rule_id` or `id` field.
+
+The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
+    */
   async patchRule(props: PatchRuleProps) {
     this.log.info(`${new Date().toISOString()} Calling API PatchRule`);
     return this.kbnClient
@@ -1920,8 +2017,13 @@ finalize it.
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
-   */
+    * Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
+> warn
+> When used with  [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
+    */
   async performRulesBulkAction(props: PerformRulesBulkActionProps) {
     this.log.info(`${new Date().toISOString()} Calling API PerformRulesBulkAction`);
     return this.kbnClient
@@ -2030,8 +2132,11 @@ finalize it.
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Retrieve the status of all Elastic prebuilt detection rules and Timelines.
-   */
+    * Retrieve the status of all Elastic prebuilt detection rules and Timelines. 
+
+This endpoint provides detailed information about the number of custom rules, installed prebuilt rules, available prebuilt rules that are not installed, outdated prebuilt rules, installed prebuilt timelines, available prebuilt timelines that are not installed, and outdated prebuilt timelines.
+
+    */
   async readPrebuiltRulesAndTimelinesStatus() {
     this.log.info(`${new Date().toISOString()} Calling API ReadPrebuiltRulesAndTimelinesStatus`);
     return this.kbnClient
@@ -2076,8 +2181,16 @@ detection engine rules.
       .catch(catchAxiosErrorFormatAndThrow);
   }
   /**
-   * Retrieve a detection rule using the `rule_id` or `id` field.
-   */
+    * Retrieve a detection rule using the `rule_id` or `id` field.
+
+The URL query must include one of the following:
+
+* `id` - `GET /api/detection_engine/rules?id=<id>`
+* `rule_id` - `GET /api/detection_engine/rules?rule_id=<rule_id>`
+
+The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+
+    */
   async readRule(props: ReadRuleProps) {
     this.log.info(`${new Date().toISOString()} Calling API ReadRule`);
     return this.kbnClient
@@ -2338,8 +2451,12 @@ detection engine rules.
   }
   /**
     * Update a detection rule using the `rule_id` or `id` field. The original rule is replaced, and all unspecified fields are deleted.
-> info
-> You cannot modify the `id` or `rule_id` values.
+
+The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
 
     */
   async updateRule(props: UpdateRuleProps) {

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -192,7 +192,22 @@ paths:
         - Privileges API
   /api/detection_engine/rules:
     delete:
-      description: Delete a detection rule using the `rule_id` or `id` field.
+      description: >
+        Delete a detection rule using the `rule_id` or `id` field.
+
+
+        The URL query must include one of the following:
+
+
+        * `id` - `DELETE /api/detection_engine/rules?id=<id>`
+
+        * `rule_id`- `DELETE /api/detection_engine/rules?rule_id=<rule_id>`
+
+
+        The difference between the `id` and `rule_id` is that the `id` is a
+        unique rule identifier that is randomly generated when a rule is created
+        and cannot be set, whereas `rule_id` is a stable rule identifier that
+        can be assigned during rule creation.
       operationId: DeleteRule
       parameters:
         - description: The rule's `id` value.
@@ -218,8 +233,29 @@ paths:
       tags:
         - Security Detections API
         - Rules API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request DELETE https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
     get:
-      description: Retrieve a detection rule using the `rule_id` or `id` field.
+      description: >
+        Retrieve a detection rule using the `rule_id` or `id` field.
+
+
+        The URL query must include one of the following:
+
+
+        * `id` - `GET /api/detection_engine/rules?id=<id>`
+
+        * `rule_id` - `GET /api/detection_engine/rules?rule_id=<rule_id>`
+
+
+        The difference between the `id` and `rule_id` is that the `id` is a
+        unique rule identifier that is randomly generated when a rule is created
+        and cannot be set, whereas `rule_id` is a stable rule identifier that
+        can be assigned during rule creation.
       operationId: ReadRule
       parameters:
         - description: The rule's `id` value.
@@ -238,28 +274,247 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Example response for a retrieved rule
+                  value:
+                    created_at: '2020-02-03T11:19:04.259Z'
+                    created_by: elastic
+                    description: Process started by MS Office program in user folder
+                    enabled: false
+                    execution_summary:
+                      last_execution:
+                        date: '2022-03-23T16:06:12.787Z'
+                        message: >-
+                          This rule attempted to query data from Elasticsearch
+                          indices listed in the "Index pattern" section of the
+                          rule definition, but no matching index was found.
+                        metrics:
+                          execution_gap_duration_s: 0
+                          total_indexing_duration_ms: 15
+                          total_search_duration_ms: 135
+                        status: partial failure
+                        status_order: 20
+                    false_positives: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-4200s
+                    id: c41d170b-8ba6-4de6-b8ec-76440a35ace3
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: MS Office child process
+                    query: >-
+                      process.parent.name:EXCEL.EXE or
+                      process.parent.name:MSPUB.EXE or
+                      process.parent.name:OUTLOOK.EXE or
+                      process.parent.name:POWERPNT.EXE or
+                      process.parent.name:VISIO.EXE or
+                      process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: process.name
+                        type: keyword
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    risk_score: 21
+                    rule_id: process_started_by_ms_office_user_folder
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat:
+                      - framework: MITRE ATT&CK
+                        tactic:
+                          id: TA0001
+                          name: Initial Access
+                          reference: 'https://attack.mitre.org/tactics/TA0001'
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: 'https://attack.mitre.org/techniques/T1193'
+                    to: now-300s
+                    type: query
+                    updated_at: '2020-02-03T11:19:04.462Z'
+                    updated_by: elastic
+                    version: 1
               schema:
                 $ref: '#/components/schemas/RuleResponse'
-          description: Indicates a successful call.
+          description: >
+            Indicates a successful call.
+
+            > info
+
+            > These fields are under development and their usage or schema may
+            change: execution_summary.
       summary: Retrieve a detection rule
       tags:
         - Security Detections API
         - Rules API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request GET https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
     patch:
-      description: >-
+      description: >
         Update specific fields of an existing detection rule using the `rule_id`
         or `id` field.
+
+
+        The difference between the `id` and `rule_id` is that the `id` is a
+        unique rule identifier that is randomly generated when a rule is created
+        and cannot be set, whereas `rule_id` is a stable rule identifier that
+        can be assigned during rule creation.
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
       operationId: PatchRule
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                summary: Patch query rule
+                value:
+                  id: 14b7b513-3d8d-4b22-b7da-a7ae632f7e76
+                  name: New name
+              example2:
+                summary: Patch EQL rule
+                value:
+                  rule_id: process_started_by_ms_office_program_possible_payload
+                  threat:
+                    - framework: MITRE ATT&CK
+                      tactic:
+                        id: TA0001
+                        name: Initial Access
+                        reference: 'https://attack.mitre.org/tactics/TA0001'
+                      technique:
+                        - id: T1193
+                          name: Spearphishing Attachment
+                          reference: 'https://attack.mitre.org/techniques/T1193'
+              example3:
+                summary: Patch threshold rule
+                value:
+                  id: 005d2c4f-51ca-493d-a2bd-20ef076339b1
+                  query: >-
+                    agent.version : * and agent.id :
+                    "243d9b4f-ca01-4311-8e5c-9abbee91afd8"
+                  threshold:
+                    cardinality: []
+                    field: []
+                    value: 600
+              example4:
+                summary: Patch new terms rule
+                value:
+                  history_window_start: now-3d
+                  id: 569aac91-40dc-4807-a8ae-a2c8698089c4
+                  new_terms_fields:
+                    - Endpoint.policy.applied.artifacts.global.identifiers.name
+              example5:
+                summary: Patch esql rule
+                value:
+                  id: 0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd
+                  query: >
+                    FROM logs-abc*
+
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp)
+
+                    | EVAL event_rate = count / DATE_DIFF("seconds",
+                    min_timestamp, NOW()) 
+
+                    | KEEP event_rate
+              example6:
+                summary: Patch indicator match rule
+                value:
+                  id: 462f1986-10fe-40a3-a22c-2b1c9c4c48fd
+                  threat_query: >-
+                    @timestamp >= "now-30d/d" and event.module:(threatintel or
+                    ti_*) and threat.indicator.ip:* and not
+                    labels.is_ioc_transform_source:"false"
+              example7:
+                summary: Patch machine learning rule
+                value:
+                  anomaly_threshold: 50
+                  id: 60b13926-289b-41b1-a537-197ef1fa5059
+                  machine_learning_job_id:
+                    - auth_high_count_logon_events
             schema:
               $ref: '#/components/schemas/RulePatchProps'
+        description: |
+          > info
+          > You cannot modify the `id` or `rule_id` values.
         required: true
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Updated description for the rule.
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query: null
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: Updated Rule Name
+                    query: >-
+                      process.parent.name:EXCEL.EXE or
+                      process.parent.name:MSPUB.EXE or
+                      process.parent.name:OUTLOOK.EXE or
+                      process.parent.name:POWERPNT.EXE or
+                      process.parent.name:VISIO.EXE or
+                      process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                    required_fields:
+                      - name: process.parent.name
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 2
               schema:
                 $ref: '#/components/schemas/RuleResponse'
           description: Indicates a successful call.
@@ -268,11 +523,432 @@ paths:
         - Security Detections API
         - Rules API
     post:
-      description: Create a new detection rule.
+      description: >
+        Create a new detection rule.
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
+
+
+        You can create the following types of rules:
+
+
+        * **Custom query**: Searches the defined indices and creates an alert
+        when a document matches the rule's KQL query.
+
+        * **Event correlation**: Searches the defined indices and creates an
+        alert when results match an [Event Query Language
+        (EQL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html)
+        query.
+
+        * **Threshold**: Searches the defined indices and creates an alert when
+        the number of times the specified field's value meets the threshold
+        during a single execution. When there are multiple values that meet the
+        threshold, an alert is generated for each value.
+          For example, if the threshold `field` is `source.ip` and its `value` is `10`, an alert is generated for every source IP address that appears in at least 10 of the rule's search results. If you're interested, see [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) for more information.
+        * **Indicator match**: Creates an alert when fields match values defined
+        in the specified [Elasticsearch
+        index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html).
+        For example, you can create an index for IP addresses and use this index
+        to create an alert whenever an event's `destination.ip` equals a value
+        in the index. The index's field mappings should be
+        [ECS-compliant](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html).
+
+        * **New terms**: Generates an alert for each new term detected in source
+        documents within a specified time range.
+
+        * **ES|QL**: Uses [Elasticsearch Query Language
+        (ES|QL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html)
+        to find events and aggregate search results.
+
+        * **Machine learning rules**: Creates an alert when a machine learning
+        job discovers an anomaly above the defined threshold.
+
+        > info
+
+        > To create machine learning rules, you must have the [appropriate
+        license](https://www.elastic.co/subscriptions) or use a [cloud
+        deployment](https://cloud.elastic.co/registration). Additionally, for
+        the machine learning rule to function correctly, the associated machine
+        learning job must be running.
+
+
+        To retrieve machine learning job IDs, which are required to create
+        machine learning jobs, call the [Elasticsearch Get jobs
+        API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html).
+        Machine learning jobs that contain `siem` in the `groups` field can be
+        used to create rules:
+
+
+        ```json
+
+        ...
+
+        "job_id": "linux_anomalous_network_activity_ecs",
+
+        "job_type": "anomaly_detector",
+
+        "job_version": "7.7.0",
+
+        "groups": [
+          "auditbeat",
+          "process",
+          "siem"
+        ],
+
+        ...
+
+        ```
+
+
+        Additionally, you can set up notifications for when rules create alerts.
+        The notifications use the [Alerting and Actions
+        framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html).
+        Each action type requires a connector. Connectors store the information
+        required to send notifications via external systems. The following
+        connector types are supported for rule notifications:
+
+
+        * Slack
+
+        * Email
+
+        * PagerDuty
+
+        * Webhook
+
+        * Microsoft Teams
+
+        * IBM Resilient
+
+        * Jira
+
+        * ServiceNow ITSM
+
+        > info
+
+        > For more information on PagerDuty fields, see [Send a v2
+        Event](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/).
+
+
+        To retrieve connector IDs, which are required to configure rule
+        notifications, call the [Find objects
+        API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-find.html)
+        with `"type": "action"` in the request payload.
+
+
+        For detailed information on Kibana actions and alerting, and additional
+        API calls, see:
+
+
+        * [Alerting
+        API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-alerting)
+
+        * [Alerting and Actions
+        framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html)
+
+        * [Connectors
+        API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-connectors)
       operationId: CreateRule
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                description: Query rule that searches for processes started by MS Office
+                summary: Query rule
+                value:
+                  description: Process started by MS Office program - possible payload
+                  enabled: false
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: phrase
+                  from: now-70m
+                  interval: 1h
+                  language: kuery
+                  name: MS Office child process
+                  query: >-
+                    process.parent.name:EXCEL.EXE or
+                    process.parent.name:MSPUB.EXE or
+                    process.parent.name:OUTLOOK.EXE or
+                    process.parent.name:POWERPNT.EXE or
+                    process.parent.name:VISIO.EXE or
+                    process.parent.name:WINWORD.EXE
+                  related_integrations:
+                    - package: o365
+                      version: ^2.3.2
+                  required_fields:
+                    - name: process.parent.name
+                      type: keyword
+                  risk_score: 50
+                  rule_id: process_started_by_ms_office_program
+                  severity: low
+                  tags:
+                    - child process
+                    - ms office
+                  type: query
+              example2:
+                description: >-
+                  Threshold rule that detects multiple failed login attempts to
+                  a Windows host from the same external source IP address
+                summary: Threshold rule
+                value:
+                  description: >-
+                    Detects when there are 20 or more failed login attempts from
+                    the same IP address with a 2 minute time frame.
+                  enabled: true
+                  exceptions_list:
+                    - id: int-ips
+                      namespace_type: single
+                      type: detection
+                  from: now-180s
+                  index:
+                    - winlogbeat-*
+                  interval: 2m
+                  name: Windows server prml-19
+                  query: >-
+                    host.name:prml-19 and event.category:authentication and
+                    event.outcome:failure
+                  required_fields:
+                    - name: source.ip
+                      type: ip
+                  risk_score: 30
+                  rule_id: liv-win-ser-logins
+                  severity: low
+                  severity_mapping:
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: low
+                      value: Manchester
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: medium
+                      value: London
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: high
+                      value: Birmingham
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: critical
+                      value: Wallingford
+                  tags:
+                    - Brute force
+                  threshold:
+                    field: source.ip
+                    value: 20
+                  type: threshold
+              example3:
+                description: >-
+                  Machine learning rule that creates alerts, and sends Slack
+                  notifications, when the linux_anomalous_network_activity_ecs
+                  machine learning job discovers anomalies with a threshold of
+                  70 or above.
+                summary: Machine learning rule
+                value:
+                  actions:
+                    - action_type_id: .slack
+                      group: default
+                      id: 5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5
+                      params:
+                        message: 'Urgent: {{context.rule.description}}'
+                  anomaly_threshold: 70
+                  description: Generates alerts when the job discovers anomalies over 70
+                  enabled: true
+                  from: now-6m
+                  interval: 5m
+                  machine_learning_job_id: linux_anomalous_network_activity_ecs
+                  name: Anomalous Linux network activity
+                  note: Shut down the internet.
+                  risk_score: 70
+                  rule_id: ml_linux_network_high_threshold
+                  setup: This rule requires data coming in from Elastic Defend.
+                  severity: high
+                  tags:
+                    - machine learning
+                    - Linux
+                  type: machine_learning
+              example4:
+                description: >-
+                  Event correlation rule that creates alerts when the Windows
+                  rundll32.exe process makes unusual network connections
+                summary: EQL rule
+                value:
+                  description: Unusual rundll32.exe network connection
+                  language: eql
+                  name: rundll32.exe network connection
+                  query: >-
+                    sequence by process.entity_id with maxspan=2h [process where
+                    event.type in ("start", "process_started") and (process.name
+                    == "rundll32.exe" or process.pe.original_file_name ==
+                    "rundll32.exe") and ((process.args == "rundll32.exe" and
+                    process.args_count == 1) or (process.args != "rundll32.exe"
+                    and process.args_count == 0))] [network where event.type ==
+                    "connection" and (process.name == "rundll32.exe" or
+                    process.pe.original_file_name == "rundll32.exe")]
+                  required_fields:
+                    - name: event.type
+                      type: keyword
+                    - name: process.args
+                      type: keyword
+                    - name: process.args_count
+                      type: long
+                    - name: process.entity_id
+                      type: keyword
+                    - name: process.name
+                      type: keyword
+                    - name: process.pe.original_file_name
+                      type: keyword
+                  risk_score: 21
+                  rule_id: eql-outbound-rundll32-connections
+                  severity: low
+                  tags:
+                    - EQL
+                    - Windows
+                    - rundll32.exe
+                  type: eql
+              example5:
+                description: >
+                  Indicator match rule that creates an alert when one of the
+                  following is true: The event's destination IP address and port
+                  number matches destination IP and port values in the
+                  threat_index index; The event's source IP address matches a
+                  host IP address value in the threat_index index.
+                summary: Indicator match rule
+                value:
+                  actions: []
+                  description: >-
+                    Checks for bad IP addresses listed in the ip-threat-list
+                    index
+                  index:
+                    - packetbeat-*
+                  name: Bad IP threat match
+                  query: 'destination.ip:* or host.ip:*'
+                  required_fields:
+                    - name: destination.ip
+                      type: ip
+                    - name: destination.port
+                      type: long
+                    - name: host.ip
+                      type: ip
+                  risk_score: 50
+                  severity: medium
+                  threat_index:
+                    - ip-threat-list
+                  threat_mapping:
+                    - entries:
+                        - field: destination.ip
+                          type: mapping
+                          value: destination.ip
+                        - field: destination.port
+                          type: mapping
+                          value: destination.port
+                    - entries:
+                        - field: source.ip
+                          type: mapping
+                          value: host.ip
+                  threat_query: '*:*'
+                  type: threat_match
+              example6:
+                description: >-
+                  New terms rule that creates alerts a new IP address is
+                  detected for a user
+                summary: New terms rule
+                value:
+                  description: Detects a user associated with a new IP address
+                  history_window_start: now-30d
+                  index:
+                    - auditbeat*
+                  language: kuery
+                  name: New User IP Detected
+                  new_terms_fields:
+                    - user.id
+                    - source.ip
+                  query: '*'
+                  required_fields:
+                    - name: user.id
+                      type: keyword
+                    - name: source.ip
+                      type: ip
+                  risk_score: 21
+                  severity: medium
+                  type: new_terms
+              example7:
+                description: >-
+                  esql rule that creates alerts from events that match an Excel
+                  parent process
+                summary: Esql rule
+                value:
+                  description: Find Excel events
+                  enabled: false
+                  from: now-360s
+                  interval: 5m
+                  language: esql
+                  name: Find Excel events
+                  query: >-
+                    from auditbeat-8.10.2 METADATA _id, _version, _index | where
+                    process.parent.name == "EXCEL.EXE"
+                  required_fields:
+                    - name: process.parent.name
+                      type: keyword
+                  risk_score: 21
+                  severity: low
+                  tags: []
+                  to: now
+                  type: esql
+              example8:
+                description: >-
+                  Query rule that searches for processes started by MS Office
+                  and suppresses alerts by the process.parent.name field within
+                  a 5-hour time period
+                summary: Query rule 2
+                value:
+                  alert_suppression:
+                    duration:
+                      unit: h
+                      value: 5
+                    group_by:
+                      - process.parent.name
+                    missing_fields_strategy: suppress
+                  description: Process started by MS Office program - possible payload
+                  enabled: false
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: phrase
+                  from: now-70m
+                  interval: 1h
+                  language: kuery
+                  name: MS Office child process
+                  query: >-
+                    process.parent.name:EXCEL.EXE or
+                    process.parent.name:MSPUB.EXE or
+                    process.parent.name:OUTLOOK.EXE or
+                    process.parent.name:POWERPNT.EXE or
+                    process.parent.name:VISIO.EXE or
+                    process.parent.name:WINWORD.EXE
+                  risk_score: 50
+                  rule_id: process_started_by_ms_office_program
+                  severity: low
+                  tags:
+                    - child process
+                    - ms office
+                  type: query
             schema:
               $ref: '#/components/schemas/RuleCreateProps'
         required: true
@@ -280,32 +956,611 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  description: Example response for a query rule
+                  summary: Query rule response
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Process started by MS Office program - possible payload
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: MS Office child process
+                    query: >-
+                      process.parent.name:EXCEL.EXE or
+                      process.parent.name:MSPUB.EXE or
+                      process.parent.name:OUTLOOK.EXE or
+                      process.parent.name:POWERPNT.EXE or
+                      process.parent.name:VISIO.EXE or
+                      process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                      - integration: graphactivitylogs
+                        package: azure
+                        version: ^1.11.4
+                    required_fields:
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 1
+                example2:
+                  description: Example response for a machine learning job rule
+                  summary: Machine learning response
+                  value:
+                    actions:
+                      - action_type_id: .slack
+                        frequency:
+                          notifyWhen: onActiveAlert
+                          summary: true
+                          throttle: null
+                        group: default
+                        id: 5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5
+                        params:
+                          message: 'Urgent: {{context.rule.description}}'
+                    anomaly_threshold: 70
+                    created_at: '2020-04-07T14:45:15.679Z'
+                    created_by: elastic
+                    description: Generates alerts when the job discovers anomalies over 70
+                    enabled: true
+                    false_positives: []
+                    from: now-6m
+                    id: 83876f66-3a57-4a99-bf37-416494c80f3b
+                    immutable: false
+                    interval: 5m
+                    machine_learning_job_id: linux_anomalous_network_activity_ecs
+                    max_signals: 100
+                    name: Anomalous Linux network activity
+                    note: Shut down the internet.
+                    references: []
+                    related_integrations: []
+                    required_fields: []
+                    risk_score: 70
+                    rule_id: ml_linux_network_high_threshold
+                    setup: ''
+                    severity: high
+                    status: going to run
+                    status_date: '2020-04-07T14:45:21.685Z'
+                    tags:
+                      - machine learning
+                      - Linux
+                    threat: []
+                    to: now
+                    type: machine_learning
+                    updated_at: '2020-04-07T14:45:15.892Z'
+                    updated_by: elastic
+                    version: 1
+                example3:
+                  description: Example response for a threshold rule
+                  summary: Threshold rule response
+                  value:
+                    actions: []
+                    author: []
+                    created_at: '2020-07-22T10:27:23.486Z'
+                    created_by: elastic
+                    description: >-
+                      Detects when there are 20 or more failed login attempts
+                      from the same IP address with a 2 minute time frame.
+                    enabled: true
+                    exceptions_list:
+                      - id: int-ips
+                        namespace_type: single
+                        type: detection
+                    false_positives: []
+                    from: now-180s
+                    id: 15dbde26-b627-4d74-bb1f-a5e0ed9e4993
+                    immutable: false
+                    index:
+                      - winlogbeat-*
+                    interval: 2m
+                    language: kuery
+                    max_signals: 100
+                    name: Windows server prml-19
+                    query: >-
+                      host.name:prml-19 and event.category:authentication and
+                      event.outcome:failure
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: source.ip
+                        type: ip
+                    risk_score: 30
+                    risk_score_mapping: []
+                    rule_id: liv-win-ser-logins
+                    setup: ''
+                    severity: low
+                    severity_mapping:
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: low
+                        value: Manchester
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: medium
+                        value: London
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: high
+                        value: Birmingham
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: critical
+                        value: Wallingford
+                    tags:
+                      - Brute force
+                    threat: []
+                    threshold:
+                      field: source.ip
+                      value: 20
+                    to: now
+                    type: threshold
+                    updated_at: '2020-07-22T10:27:23.673Z'
+                    updated_by: elastic
+                    version: 1
+                example4:
+                  description: Example response for an EQL rule
+                  summary: EQL rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-05T09:06:16.392Z'
+                    created_by: elastic
+                    description: Unusual rundll32.exe network connection
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    id: 93808cae-b05b-4dc9-8479-73574b50f8b1
+                    immutable: false
+                    interval: 5m
+                    language: eql
+                    max_signals: 100
+                    name: rundll32.exe network connection
+                    query: >-
+                      sequence by process.entity_id with maxspan=2h [process
+                      where event.type in ("start", "process_started") and
+                      (process.name == "rundll32.exe" or
+                      process.pe.original_file_name == "rundll32.exe") and
+                      ((process.args == "rundll32.exe" and process.args_count ==
+                      1) or (process.args != "rundll32.exe" and
+                      process.args_count == 0))] [network where event.type ==
+                      "connection" and (process.name == "rundll32.exe" or
+                      process.pe.original_file_name == "rundll32.exe")]
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: event.type
+                        type: keyword
+                      - ecs: true
+                        name: process.args
+                        type: keyword
+                      - ecs: true
+                        name: process.args_count
+                        type: long
+                      - ecs: true
+                        name: process.entity_id
+                        type: keyword
+                      - ecs: true
+                        name: process.name
+                        type: keyword
+                      - ecs: true
+                        name: process.pe.original_file_name
+                        type: keyword
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: eql-outbound-rundll32-connections
+                    setup: ''
+                    severity: low
+                    severity_mapping: []
+                    tags:
+                      - EQL
+                      - Windows
+                      - rundll32.exe
+                    threat: []
+                    throttle: no_actions
+                    to: now
+                    type: eql
+                    updated_at: '2020-10-05T09:06:16.403Z'
+                    updated_by: elastic
+                    version: 1
+                example5:
+                  description: Example response for an indicator match rule
+                  summary: Indicator match rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    created_by: elastic
+                    description: >-
+                      Checks for bad IP addresses listed in the ip-threat-list
+                      index
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    id: d5daa13f-81fb-4b13-be2f-31011e1d9ae1
+                    immutable: false
+                    index:
+                      - packetbeat-*
+                    interval: 5m
+                    language: kuery
+                    max_signals: 100
+                    name: Bad IP threat match
+                    query: 'destination.ip:* or host.ip:*'
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: destination.ip
+                        type: ip
+                      - ecs: true
+                        name: destination.port
+                        type: long
+                      - ecs: true
+                        name: host.ip
+                        type: ip
+                    risk_score: 50
+                    risk_score_mapping: []
+                    rule_id: 608501e4-c768-4f64-9326-cec55b5d439b
+                    setup: ''
+                    severity: medium
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    threat_index:
+                      - ip-threat-list
+                    threat_mapping:
+                      - entries:
+                          - field: destination.ip
+                            type: mapping
+                            value: destination.ip
+                          - field: destination.port
+                            type: mapping
+                            value: destination.port
+                      - entries:
+                          - field: source.ip
+                            type: mapping
+                            value: host.ip
+                    threat_query: '*:*'
+                    to: now
+                    type: threat_match
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    updated_by: elastic
+                    version: 1
+                example6:
+                  description: Example response for a new terms rule
+                  summary: New terms rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    created_by: elastic
+                    description: Detects a user associated with a new IP address
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    history_window_start: now-30d
+                    id: eb7225c0-566b-11ee-8b4f-bbf3afdeb9f4
+                    immutable: false
+                    index:
+                      - auditbeat*
+                    interval: 5m
+                    language: kuery
+                    max_signals: 100
+                    name: New User IP Detected
+                    new_terms_fields:
+                      - user.id
+                      - source.ip
+                    query: '*'
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: user.id
+                        type: keyword
+                      - ecs: true
+                        name: source.ip
+                        type: ip
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: c6f5d0bc-7be9-47d4-b2f3-073d22641e30
+                    setup: ''
+                    severity: medium
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    to: now
+                    type: new_terms
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    updated_by: elastic
+                    version: 1
+                example7:
+                  description: Example response for an Esql rule
+                  summary: Esql rule response
+                  value:
+                    actions: []
+                    author: []
+                    created_at: '2023-10-18T10:55:14.269Z'
+                    created_by: elastic
+                    description: Find Excel events
+                    enabled: false
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-360s
+                    id: d0f20490-6da4-11ee-b85e-09e9b661f2e2
+                    immutable: false
+                    interval: 5m
+                    language: esql
+                    max_signals: 100
+                    name: Find Excel events
+                    output_index: ''
+                    query: >-
+                      from auditbeat-8.10.2 METADATA _id | where
+                      process.parent.name == "EXCEL.EXE"
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    revision: 0
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: e4b53a89-debd-4a0d-a3e3-20606952e589
+                    setup: ''
+                    severity: low
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    to: now
+                    type: esql
+                    updated_at: '2023-10-18T10:55:14.269Z'
+                    updated_by: elastic
+                    version: 1
               schema:
                 $ref: '#/components/schemas/RuleResponse'
           description: Indicates a successful call.
       summary: Create a detection rule
       tags:
         - Security Detections API
-        - Rules API
     put:
       description: >
         Update a detection rule using the `rule_id` or `id` field. The original
         rule is replaced, and all unspecified fields are deleted.
 
-        > info
 
-        > You cannot modify the `id` or `rule_id` values.
+        The difference between the `id` and `rule_id` is that the `id` is a
+        unique rule identifier that is randomly generated when a rule is created
+        and cannot be set, whereas `rule_id` is a stable rule identifier that
+        can be assigned during rule creation.
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
       operationId: UpdateRule
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                summary: Update query rule
+                value:
+                  description: A new description
+                  id: 14b7b513-3d8d-4b22-b7da-a7ae632f7e76
+                  name: A new name for the rule
+                  risk_score: 22
+                  severity: medium
+                  type: query
+              example2:
+                summary: Update EQL rule
+                value:
+                  description: eql rule test
+                  id: 9b684efb-acf9-4323-9bff-8335b3867d14
+                  index:
+                    - apm-*-transaction*
+                  language: eql
+                  name: New name for EQL rule
+                  query: process where process.name == "regsvr32.exe"
+                  risk_score: 21
+                  severity: low
+                  type: eql
+              example3:
+                summary: Update threshold rule
+                value:
+                  description: Description of threat rule test
+                  id: 005d2c4f-51ca-493d-a2bd-20ef076339b1
+                  language: kuery
+                  name: New name for threat rule
+                  query: >-
+                    agent.version : * and agent.id :
+                    "243d9b4f-ca01-4311-8e5c-9abbee91afd8"
+                  risk_score: 21
+                  severity: low
+                  tags:
+                    - new_tag
+                  threshold:
+                    cardinality: []
+                    field: []
+                    value: 400
+                  type: threshold
+              example4:
+                summary: Update new terms rule
+                value:
+                  description: New description
+                  history_window_start: now-7d
+                  id: 569aac91-40dc-4807-a8ae-a2c8698089c4
+                  interval: 5m
+                  name: New terms rule name
+                  new_terms_fields:
+                    - Endpoint.policy.applied.artifacts.global.identifiers.name
+                  query: 'agent.version : "9.1.0"'
+                  risk_score: 21
+                  severity: low
+                  type: new_terms
+              example5:
+                summary: Update esql rule
+                value:
+                  description: New description for esql rule
+                  id: 0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd
+                  language: esql
+                  name: New name for esql rule
+                  query: >
+                    FROM logs*
+
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp) /*
+                    MIN(dateField) finds the earliest timestamp in the dataset.
+                    */
+
+                    | EVAL event_rate = count / DATE_DIFF("seconds",
+                    min_timestamp, NOW()) /* Calculates the event rate by
+                    dividing the total count of events by the time difference
+                    (in seconds) between the earliest event and the current
+                    time. */
+
+                    | KEEP event_rate
+                  risk_score: 21
+                  severity: low
+                  type: esql
+              example6:
+                summary: Update indicator match rule
+                value:
+                  description: New description
+                  id: 462f1986-10fe-40a3-a22c-2b1c9c4c48fd
+                  name: New name for Indicator Match rule
+                  query: 'source.ip:* or destination.ip:*\n'
+                  risk_score: 99
+                  severity: critical
+                  threat_index:
+                    - filebeat-*
+                    - logs-ti_*
+                  threat_mapping:
+                    - entries:
+                        - field: source.ip
+                          type: mapping
+                          value: threat.indicator.ip
+                    - entries:
+                        - field: destination.ip
+                          type: mapping
+                          value: threat.indicator.ip
+                  threat_query: >-
+                    @timestamp >= "now-30d/d" and event.module:(threatintel or
+                    ti_*) and threat.indicator.ip:* and not
+                    labels.is_ioc_transform_source:"true"
+                  type: threat_match
+              example7:
+                summary: Update machine learning rule
+                value:
+                  anomaly_threshold: 50
+                  description: New description of ml rule
+                  id: 60b13926-289b-41b1-a537-197ef1fa5059
+                  machine_learning_job_id:
+                    - auth_high_count_logon_events
+                  name: New name of ml rule
+                  risk_score: 21
+                  severity: low
+                  type: machine_learning
             schema:
               $ref: '#/components/schemas/RuleUpdateProps'
+        description: >
+          > info
+
+          > All unspecified fields are deleted. You cannot modify the `id` or
+          `rule_id` values.
         required: true
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Updated description for the rule.
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query: null
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: Updated Rule Name
+                    query: >-
+                      process.parent.name:EXCEL.EXE or
+                      process.parent.name:MSPUB.EXE or
+                      process.parent.name:OUTLOOK.EXE or
+                      process.parent.name:POWERPNT.EXE or
+                      process.parent.name:VISIO.EXE or
+                      process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                    required_fields:
+                      - name: process.parent.name
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 2
               schema:
                 $ref: '#/components/schemas/RuleResponse'
           description: Indicates a successful call.
@@ -315,13 +1570,45 @@ paths:
         - Rules API
   /api/detection_engine/rules/_bulk_action:
     post:
-      description: >-
+      description: >
         Apply a bulk action, such as bulk edit, duplicate, or delete, to
         multiple detection rules. The bulk action is applied to all rules that
         match the query or to the rules listed by their IDs.
+
+        > warn
+
+        > When used with  [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
       operationId: PerformRulesBulkAction
       parameters:
-        - description: Enables dry run mode for the request call.
+        - description: >
+            Enables dry run mode for the request call.
+
+
+            Enable dry run mode to verify that bulk actions can be applied to
+            specified rules. Certain rules, such as prebuilt Elastic rules on a
+            Basic subscription, can’t be edited and will return errors in the
+            request response. Error details will contain an explanation, the
+            rule name and/or ID, and additional troubleshooting information.
+
+
+            To enable dry run mode on a request, add the query parameter
+            `dry_run=true` to the end of the request URL. Rules specified in the
+            request will be temporarily updated. These updates won’t be written
+            to Elasticsearch.
+
+            > info
+
+            > Dry run mode is not supported for the `export` bulk action. A 400
+            error will be returned in the request response.
           in: query
           name: dry_run
           required: false
@@ -330,6 +1617,102 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                description: The following request activates all rules with the test tag
+                summary: Enable all rules with the test tag
+                value:
+                  action: enable
+                  query: 'alert.attributes.tags: "test"'
+              example2:
+                description: The following request enables the rule with the specified ID.
+                summary: Enable a specific rule by ID
+                value:
+                  action: enable
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+              example3:
+                description: The following request disables the rule with the specified ID.
+                summary: Disable a specific rule by ID
+                value:
+                  action: disable
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+              example4:
+                description: >-
+                  The following request adds tags tag-1 and tag-2 to the rules
+                  that have the IDs sent in the payload
+                summary: Add tags to rules
+                value:
+                  action: edit
+                  edit:
+                    - type: add_tags
+                      value:
+                        - tag-1
+                        - tag-2
+                  ids:
+                    - 8bc7dad0-9320-11ec-9265-8b772383a08d
+                    - 8e5c1a40-9320-11ec-9265-8b772383a08d
+              example5:
+                description: >-
+                  The following request will validate that the
+                  add_index_patterns bulk action can be successfully applied to
+                  three rules. The dry_run parameter is specified in query
+                  parameters, e.g. POST
+                  api/detection_engine/rules/_bulk_action?dry_run=true
+                summary: Dry run - Validate add_index_patterns bulk action
+                value:
+                  action: edit
+                  edit:
+                    - type: add_index_patterns
+                      value:
+                        - test-*
+                  ids:
+                    - 81aa0480-06af-11ed-94fb-dd1a0597d8d2
+                    - dc015d10-0831-11ed-ac8b-05a222bd8d4a
+                    - de8f5af0-0831-11ed-ac8b-05a222bd8d4a
+              example6:
+                description: >-
+                  The following request duplicates rules with the specified IDs,
+                  including exceptions but not expired exceptions.
+                summary: Duplicate rules with specific IDs
+                value:
+                  action: duplicate
+                  duplicate:
+                    include_exceptions: true
+                    include_expired_exceptions: false
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                    - 461a4c22-416e-4009-a9a7-cf79656454bf
+              example7:
+                description: The following request deletes the rule with the specified ID.
+                summary: Delete a specific rule by ID
+                value:
+                  action: delete
+                  ids:
+                    - cf4abfd1-7c37-4519-ab0f-5ea5c75fac60
+              example8:
+                description: >-
+                  The following request runs the rule with the specified ID
+                  within the given date range.
+                summary: Run a specific rule by ID
+                value:
+                  action: run
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                  run:
+                    end_date: '2025-03-10T23:59:59.999Z'
+                    start_date: '2025-03-01T00:00:00.000Z'
+              example9:
+                description: >-
+                  The following request exports the rules with the specified
+                  IDs.
+                summary: Export specific rules by ID
+                value:
+                  action: export
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                    - 13199674-aff1-418a-9e93-04f585fe36d1
             schema:
               oneOf:
                 - $ref: '#/components/schemas/BulkDeleteRules'
@@ -343,6 +1726,257 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  description: >-
+                    In this response one rule was updated and one was skipped.
+                    Objects returned in attributes.results.skipped will only
+                    include rules' id, name, and skip_reason.
+                  summary: Successful response
+                  value:
+                    attributes:
+                      results:
+                        created: []
+                        deleted: []
+                        skipped:
+                          - id: 51658332-a15e-4c9e-912a-67214e2e2359
+                            name: Skipped rule
+                            skip_reason: RULE_NOT_MODIFIED
+                        updated:
+                          - anomaly_threshold: 50
+                            author:
+                              - Elastic
+                            created_at: '2022-02-21T14:14:13.801Z'
+                            created_by: elastic
+                            description: >-
+                              A machine learning job detected unusually large
+                              numbers of DNS queries for a single top-level DNS
+                              domain, which is often used for DNS tunneling. DNS
+                              tunneling can be used for command-and-control,
+                              persistence, or data exfiltration activity. For
+                              example, dnscat tends to generate many DNS
+                              questions for a top-level domain as it uses the
+                              DNS protocol to tunnel data.
+                            enabled: true
+                            exceptions_list: []
+                            execution_summary:
+                              last_execution:
+                                date: '2022-03-23T16:06:12.787Z'
+                                message: >-
+                                  This rule attempted to query data from
+                                  Elasticsearch indices listed in the "Index
+                                  pattern" section of the rule definition, but
+                                  no matching index was found.
+                                metrics:
+                                  execution_gap_duration_s: 0
+                                  total_indexing_duration_ms: 15
+                                  total_search_duration_ms: 135
+                                status: partial failure
+                                status_order: 20
+                            false_positives:
+                              - >-
+                                DNS domains that use large numbers of child
+                                domains, such as software or content
+                                distribution networks, can trigger this alert
+                                and such parent domains can be excluded.
+                            from: now-45m
+                            id: 8bc7dad0-9320-11ec-9265-8b772383a08d
+                            immutable: false
+                            interval: 15m
+                            license: Elastic License v2
+                            machine_learning_job_id:
+                              - packetbeat_dns_tunneling
+                            max_signals: 100
+                            name: 'DNS Tunneling [Duplicate]'
+                            references:
+                              - >-
+                                https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html
+                            related_integrations: []
+                            required_fields: []
+                            risk_score: 21
+                            risk_score_mapping: []
+                            rule_id: 7289bf08-4e91-4c70-bf01-e04c4c5d7756
+                            setup: ''
+                            severity: low
+                            severity_mapping: []
+                            tags:
+                              - Elastic
+                              - Network
+                              - Threat Detection
+                              - ML
+                            threat: []
+                            to: now
+                            type: machine_learning
+                            updated_at: '2022-02-21T17:05:50.883Z'
+                            updated_by: elastic
+                            version: 6
+                      summary:
+                        failed: 0
+                        skipped: 1
+                        succeeded: 1
+                        total: 2
+                    rules_count: 1
+                    success: true
+                example2:
+                  description: >-
+                    If processing of any rule fails, a partial error outputs the
+                    ID and/or name of the affected rule and the corresponding
+                    error, as well as successfully processed rules (in the same
+                    format as a successful 200 request).
+                  summary: Partial failure
+                  value:
+                    value:
+                      attributes:
+                        errors:
+                          - message: >-
+                              Index patterns can't be added. Machine learning
+                              rule doesn't have index patterns property
+                            rules:
+                              - id: 8bc7dad0-9320-11ec-9265-8b772383a08d
+                                name: 'DNS Tunneling [Duplicate]'
+                            status_code: 500
+                        results:
+                          created: []
+                          deleted: []
+                          skipped: []
+                          updated:
+                            - actions: []
+                              author:
+                                - Elastic
+                              created_at: '2022-02-21T14:14:17.883Z'
+                              created_by: elastic
+                              description: >-
+                                Generates a detection alert for each external
+                                alert written to the configured indices.
+                                Enabling this rule allows you to immediately
+                                begin investigating external alerts in the app.
+                              enabled: true
+                              exceptions_list: []
+                              execution_summary:
+                                last_execution:
+                                  date: '2022-03-23T16:06:12.787Z'
+                                  message: >-
+                                    This rule attempted to query data from
+                                    Elasticsearch indices listed in the "Index
+                                    pattern" section of the rule definition, but
+                                    no matching index was found.
+                                  metrics:
+                                    execution_gap_duration_s: 0
+                                    total_indexing_duration_ms: 15
+                                    total_search_duration_ms: 135
+                                  status: partial failure
+                                  status_order: 20
+                              false_positives: []
+                              from: now-6m
+                              id: 8e5c1a40-9320-11ec-9265-8b772383a08d
+                              immutable: false
+                              index:
+                                - apm-*-transaction*
+                                - traces-apm*
+                                - auditbeat-*
+                                - filebeat-*
+                                - logs-*
+                                - packetbeat-*
+                                - winlogbeat-*
+                                - added-by-id-*
+                              interval: 5m
+                              language: kuery
+                              license: Elastic License v2
+                              max_signals: 10000
+                              name: 'External Alerts [Duplicate]'
+                              query: >
+                                event.kind:alert and not event.module:(endgame
+                                or endpoint)
+                              references: []
+                              related_integrations: []
+                              required_fields: []
+                              risk_score: 47
+                              risk_score_mapping:
+                                - field: event.risk_score
+                                  operator: equals
+                                  value: ''
+                              rule_id: 941faf98-0cdc-4569-b16d-4af962914d61
+                              rule_name_override: message
+                              setup: ''
+                              severity: medium
+                              severity_mapping:
+                                - field: event.severity
+                                  operator: equals
+                                  severity: low
+                                  value: '21'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: medium
+                                  value: '47'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: high
+                                  value: '73'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: critical
+                                  value: '99'
+                              tags:
+                                - Elastic
+                                - Network
+                                - Windows
+                                - APM
+                                - macOS
+                                - Linux
+                              threat: []
+                              timestamp_override: event.ingested
+                              to: now
+                              type: query
+                              updated_at: '2022-02-21T16:56:22.818Z'
+                              updated_by: elastic
+                              version: 5
+                        summary:
+                          failed: 1
+                          skipped: 0
+                          succeeded: 1
+                          total: 2
+                      message: Bulk edit partially failed
+                      rules_count: 2
+                      status_code: 500
+                      success: false
+                example3:
+                  description: >-
+                    The attributes.errors section of the response shows that two
+                    rules failed to update and one succeeded. The same results
+                    would be returned if you ran the request without dry run
+                    mode enabled. Notice that there are no arrays in
+                    attributes.results. In dry run mode, rule updates are not
+                    applied and saved to Elasticsearch, so the endpoint wouldn’t
+                    return results for rules that have been updated, created, or
+                    deleted.
+                  summary: Dry run
+                  value:
+                    attributes:
+                      errors:
+                        - err_code: IMMUTABLE
+                          message: Elastic rule can't be edited
+                          rules:
+                            - id: 81aa0480-06af-11ed-94fb-dd1a0597d8d2
+                              name: Unusual AWS Command for a User
+                          status_code: 500
+                        - err_code: MACHINE_LEARNING_INDEX_PATTERN
+                          message: Machine learning rule doesn't have index patterns
+                          rules:
+                            - id: dc015d10-0831-11ed-ac8b-05a222bd8d4a
+                              name: 'Suspicious Powershell Script [Duplicate]'
+                          status_code: 500
+                      results:
+                        created: []
+                        deleted: []
+                        skipped: []
+                        updated: []
+                      summary:
+                        failed: 2
+                        skipped: 0
+                        succeeded: 1
+                        total: 3
+                    message: Bulk edit partially failed
+                    status_code: 500
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/BulkEditActionResponse'
@@ -706,7 +2340,27 @@ paths:
 
         > info
 
-        > You cannot export prebuilt rules.
+        > Rule actions and connectors are included in the exported file, but
+        sensitive information about the connector (such as authentication
+        credentials) is not included. You must re-add missing connector details
+        after importing detection rules.
+
+
+        > You can use Kibana’s [Saved
+        Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html)
+        UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs
+        (experimental) to
+        [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault)
+        and
+        [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault)
+        any necessary connectors before importing detection rules.
+
+
+        > Similarly, any value lists used for rule exceptions are not included
+        in rule exports or imports. Use the [Manage value
+        lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists)
+        UI (Rules → Detection rules (SIEM) → Manage value lists) to export and
+        import value lists separately.
       operationId: ExportRules
       parameters:
         - description: Determines whether a summary of the exported rules is returned.
@@ -716,7 +2370,13 @@ paths:
           schema:
             default: false
             type: boolean
-        - description: File name for saving the exported rules.
+        - description: >
+            File name for saving the exported rules.
+
+            > info
+
+            > When using cURL to export rules to a file, use the -O and -J
+            options to save the rules to the file name specified in the URL.
           in: query
           name: file_name
           required: false
@@ -750,7 +2410,13 @@ paths:
           content:
             application/ndjson:
               schema:
-                description: An `.ndjson` file containing the returned rules.
+                description: >
+                  An `.ndjson` file containing the returned rules.
+
+
+                  Each line in the file represents an object (a rule, exception
+                  list parent container, or exception list item), and the last
+                  line includes a summary of what was exported.
                 format: binary
                 type: string
           description: Indicates a successful call.
@@ -758,6 +2424,23 @@ paths:
       tags:
         - Security Detections API
         - Import/Export API
+      x-codeSamples:
+        - lang: cURL
+          source: >
+            curl -X POST
+            "localhost:5601/api/detection_engine/rules/_export?exclude_export_details=true&file_name=exported_rules.ndjson"
+            -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d'
+
+            {
+              "objects": [
+                {
+                  "rule_id":"343580b5-c811-447c-8d2d-2ccf052c6900"
+                },
+                {
+                  "rule_id":"2938c9fa-53eb-4c04-b79c-33cbf041b18d"
+                }
+              ]
+            }
   /api/detection_engine/rules/_find:
     get:
       description: >-
@@ -772,7 +2455,30 @@ paths:
             items:
               type: string
             type: array
-        - description: Search query
+        - description: >
+            Search query
+
+
+            Filters the returned results according to the value of the specified
+            field, using the alert.attributes.<field name>:<field value> syntax,
+            where <field name> can be:
+
+            - name
+
+            - enabled
+
+            - tags
+
+            - createdBy
+
+            - interval
+
+            - updatedBy
+
+            > info
+
+            > Even though the JSON rule object uses created_by and updated_by
+            fields, you must use createdBy and updatedBy fields in the filter.
           in: query
           name: filter
           required: false
@@ -822,6 +2528,84 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    data:
+                      - created_at: '2020-02-02T10:05:19.613Z'
+                        created_by: elastic
+                        description: >-
+                          Identifies a PowerShell process launched by either
+                          cscript.exe or wscript.exe. Observing Windows
+                          scripting processes executing a PowerShell script, may
+                          be indicative of malicious activity.
+                        enabled: false
+                        execution_summary:
+                          last_execution:
+                            date: '2022-03-23T16:06:12.787Z'
+                            message: >-
+                              This rule attempted to query data from
+                              Elasticsearch indices listed in the "Index
+                              pattern" section of the rule definition, but no
+                              matching index was found.
+                            metrics:
+                              execution_gap_duration_s: 0
+                              total_indexing_duration_ms: 15
+                              total_search_duration_ms: 135
+                            status: partial failure
+                            status_order: 20
+                        false_positives: []
+                        from: now-6m
+                        id: 89761517-fdb0-4223-b67b-7621acc48f9e
+                        immutable: true
+                        index:
+                          - winlogbeat-*
+                        interval: 5m
+                        language: kuery
+                        max_signals: 33
+                        name: Windows Script Executing PowerShell
+                        query: >-
+                          event.action:"Process Create (rule: ProcessCreate)"
+                          and process.parent.name:("wscript.exe" or
+                          "cscript.exe") and process.name:"powershell.exe"
+                        references: []
+                        related_integrations:
+                          - package: o365
+                            version: ^2.3.2
+                        required_fields:
+                          - ecs: true
+                            name: event.action
+                            type: keyword
+                          - ecs: true
+                            name: process.name
+                            type: keyword
+                          - ecs: true
+                            name: process.parent.name
+                            type: keyword
+                        risk_score: 21
+                        rule_id: f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc
+                        setup: ''
+                        severity: low
+                        tags:
+                          - Elastic
+                          - Windows
+                        threat:
+                          - framework: MITRE ATT&CK
+                            tactic:
+                              id: TA0002
+                              name: Execution
+                              reference: 'https://attack.mitre.org/tactics/TA0002/'
+                            technique:
+                              - id: T1193
+                                name: Spearphishing Attachment
+                                reference: 'https://attack.mitre.org/techniques/T1193/'
+                        to: now
+                        type: query
+                        updated_at: '2020-02-02T10:05:19.830Z'
+                        updated_by: elastic
+                    page: 1
+                    perPage: 5
+                    total: 4
               schema:
                 type: object
                 properties:
@@ -840,11 +2624,23 @@ paths:
                   - perPage
                   - total
                   - data
-          description: Successful response
+          description: >
+            Successful response
+
+            > info
+
+            > These fields are under development and their usage or schema may
+            change: execution_summary.
       summary: List all detection rules
       tags:
         - Security Detections API
         - Rules API
+      x-codeSamples:
+        - lang: cURL
+          source: >
+            curl -X GET
+            "localhost:5601/api/detection_engine/rules/_find?page=1&per_page=5&sort_field=enabled&sort_order=asc&filter=alert.attributes.name:windows"
+            -H 'kbn-xsrf: true'
   /api/detection_engine/rules/_import:
     post:
       description: >
@@ -854,6 +2650,54 @@ paths:
         - The `Content-Type: multipart/form-data` HTTP header.
 
         - A link to the `.ndjson` file containing the rules.
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
+
+        > info
+
+        > To import rules with actions, you need at least Read privileges for
+        the Action and Connectors feature. To overwrite or add new connectors,
+        you need All privileges for the Actions and Connectors feature. To
+        import rules without actions, you don’t need Actions and Connectors
+        privileges. Refer to [Enable and access
+        detections](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui)
+        for more information.
+
+
+        > info
+
+        > Rule actions and connectors are included in the exported file, but
+        sensitive information about the connector (such as authentication
+        credentials) is not included. You must re-add missing connector details
+        after importing detection rules.
+
+
+        > You can use Kibana’s [Saved
+        Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html)
+        UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs
+        (experimental) to
+        [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault)
+        and
+        [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault)
+        any necessary connectors before importing detection rules.
+
+
+        > Similarly, any value lists used for rule exceptions are not included
+        in rule exports or imports. Use the [Manage value
+        lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists)
+        UI (Rules → Detection rules (SIEM) → Manage value lists) to export and
+        import value lists separately.
       operationId: ImportRules
       parameters:
         - description: >-
@@ -867,7 +2711,8 @@ paths:
             type: boolean
         - description: >-
             Determines whether existing exception lists with the same `list_id`
-            are overwritten.
+            are overwritten. Both the exception list container and its items are
+            overwritten.
           in: query
           name: overwrite_exceptions
           required: false
@@ -905,6 +2750,17 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Import rules with success
+                  value:
+                    errors: []
+                    exceptions_errors: []
+                    exceptions_success: true
+                    exceptions_success_count: 0
+                    rules_count: 1
+                    success: true
+                    success_count: 1
               schema:
                 additionalProperties: false
                 type: object
@@ -960,14 +2816,54 @@ paths:
       tags:
         - Security Detections API
         - Import/Export API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST "<KibanaURL>/api/detection_engine/rules/_import"
+            -u <username>:<password> -H 'kbn-xsrf: true'
+            -H 'Content-Type: multipart/form-data'
+            --form "file=@<link to file>"
   /api/detection_engine/rules/prepackaged:
     put:
-      description: Install and update all Elastic prebuilt detection rules and Timelines.
+      description: >
+        Install and update all Elastic prebuilt detection rules and Timelines.
+
+
+        This endpoint allows you to install and update prebuilt detection rules
+        and Timelines provided by Elastic. 
+
+        When you call this endpoint, it will:
+
+        - Install any new prebuilt detection rules that are not currently
+        installed in your system.
+
+        - Update any existing prebuilt detection rules that have been modified
+        or improved by Elastic.
+
+        - Install any new prebuilt Timelines that are not currently installed in
+        your system.
+
+        - Update any existing prebuilt Timelines that have been modified or
+        improved by Elastic.
+
+
+        This ensures that your detection engine is always up-to-date with the
+        latest rules and Timelines, 
+
+        providing you with the most current and effective threat detection
+        capabilities.
       operationId: InstallPrebuiltRulesAndTimelines
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    rules_installed: 112
+                    rules_updated: 0
+                    timelines_installed: 5
+                    timelines_updated: 2
               schema:
                 additionalProperties: false
                 type: object
@@ -1000,14 +2896,31 @@ paths:
         - Prebuilt Rules API
   /api/detection_engine/rules/prepackaged/_status:
     get:
-      description: >-
+      description: >
         Retrieve the status of all Elastic prebuilt detection rules and
-        Timelines.
+        Timelines. 
+
+
+        This endpoint provides detailed information about the number of custom
+        rules, installed prebuilt rules, available prebuilt rules that are not
+        installed, outdated prebuilt rules, installed prebuilt timelines,
+        available prebuilt timelines that are not installed, and outdated
+        prebuilt timelines.
       operationId: ReadPrebuiltRulesAndTimelinesStatus
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    rules_custom_installed: 0
+                    rules_installed: 0
+                    rules_not_installed: 112
+                    rules_not_updated: 0
+                    timelines_installed: 0
+                    timelines_not_installed: 0
+                    timelines_not_updated: 0
               schema:
                 additionalProperties: false
                 type: object
@@ -1619,6 +3532,17 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    - zeek
+                    - suricata
+                    - windows
+                    - linux
+                    - network
+                    - initial access
+                    - remote access
+                    - phishing
               schema:
                 $ref: '#/components/schemas/RuleTagArray'
           description: Indicates a successful call
@@ -1719,6 +3643,7 @@ components:
         - in-progress
       type: string
     AlertSuppression:
+      description: Defines alert suppression configuration.
       type: object
       properties:
         duration:
@@ -1741,6 +3666,7 @@ components:
         - value
         - unit
     AlertSuppressionDurationUnit:
+      description: Time unit
       enum:
         - s
         - m
@@ -1781,15 +3707,21 @@ components:
         - version
         - count
     AnomalyThreshold:
-      description: Anomaly threshold
+      description: >-
+        Anomaly score threshold above which the rule creates an alert. Valid
+        values are from 0 to 100.
       minimum: 0
       type: integer
     BuildingBlockType:
-      description: >-
-        Determines if the rule acts as a building block. By default,
-        building-block alerts are not displayed in the UI. These rules are used
-        as a foundation for other rules that do generate alerts. Its value must
-        be default.
+      description: >
+        Determines if the rule acts as a building block. If yes, the value must
+        be `default`.
+
+        By default, building-block alerts are not displayed in the UI. These
+        rules are used as a foundation for other rules that do generate alerts.
+
+        For more information, refer to [About building block
+        rules](https://www.elastic.co/guide/en/security/current/building-block-rule.html).
       type: string
     BulkActionEditPayload:
       anyOf:
@@ -1949,13 +3881,15 @@ components:
             - delete
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -1967,13 +3901,15 @@ components:
             - disable
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -1985,6 +3921,7 @@ components:
             - duplicate
           type: string
         duplicate:
+          description: Duplicate object that describes applying an update action.
           type: object
           properties:
             include_exceptions:
@@ -1997,13 +3934,15 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -2059,6 +3998,13 @@ components:
         - deleted
         - skipped
     BulkEditActionSummary:
+      description: >-
+        A rule can only be skipped when the bulk action to be performed on it
+        results in nothing being done. For example, if the `edit` action is used
+        to add a tag to a rule that already has that tag, or to delete an index
+        pattern that is not specified in a rule. Objects returned in
+        `attributes.results.skipped` will only include rules' `id`, `name`, and
+        `skip_reason`.
       type: object
       properties:
         failed:
@@ -2088,13 +4034,15 @@ components:
           minItems: 1
           type: array
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -2111,13 +4059,15 @@ components:
             - enable
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -2131,13 +4081,15 @@ components:
             - export
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -2149,15 +4101,18 @@ components:
             - run
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
         run:
+          description: Object that describes applying a manual rule run action.
           type: object
           properties:
             end_date:
@@ -2199,6 +4154,9 @@ components:
               - items:
                   type: string
                 type: array
+      description: >-
+        Map Osquery results columns or static values to Elastic Common Schema
+        (ECS) fields. Example: "ecs_mapping": {"process.pid": {"field": "pid"}}
       type: object
     EndpointResponseAction:
       type: object
@@ -2243,7 +4201,6 @@ components:
           description: Query language to use
         query:
           $ref: '#/components/schemas/RuleQuery'
-          description: EQL query to execute
         type:
           description: Rule type
           enum:
@@ -2258,6 +4215,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2306,6 +4266,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2377,6 +4348,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2425,6 +4399,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2479,7 +4464,6 @@ components:
               description: Query language to use
             query:
               $ref: '#/components/schemas/RuleQuery'
-              description: EQL query to execute
             type:
               description: Rule type
               enum:
@@ -2491,6 +4475,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2541,6 +4528,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2590,6 +4588,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2640,6 +4641,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2721,6 +4733,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2769,6 +4784,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2840,6 +4866,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2888,6 +4917,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2943,6 +4983,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2992,12 +5035,22 @@ components:
               $ref: '#/components/schemas/AlertsIndex'
             query:
               $ref: '#/components/schemas/RuleQuery'
-              description: ESQL query to execute
             references:
               $ref: '#/components/schemas/RuleReferenceArray'
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3050,7 +5103,6 @@ components:
           $ref: '#/components/schemas/EsqlQueryLanguage'
         query:
           $ref: '#/components/schemas/RuleQuery'
-          description: ESQL query to execute
         type:
           description: Rule type
           enum:
@@ -3069,6 +5121,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3119,6 +5174,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3210,7 +5276,15 @@ components:
         - updatedAt
       type: string
     HistoryWindowStart:
-      $ref: '#/components/schemas/NonEmptyString'
+      description: >-
+        Start date to use when checking if a term has been seen before. Supports
+        relative dates – for example, now-30d will search the last 30 days of
+        data when checking if a term is new. We do not recommend using absolute
+        dates, which can cause issues with rule performance due to querying
+        increasing amounts of data over time.
+      format: nonempty
+      minLength: 1
+      type: string
     IndexMigrationStatus:
       type: object
       properties:
@@ -3235,6 +5309,14 @@ components:
         - migrations
         - is_outdated
     IndexPatternArray:
+      description: >
+        Indices on which the rule functions. Defaults to the Security Solution
+        indices defined on the Kibana Advanced Settings page (Kibana → Stack
+        Management → Advanced Settings → `securitySolution:defaultIndex`).
+
+        > info
+
+        > This field is not supported for ES|QL rules.
       items:
         type: string
       type: array
@@ -3257,28 +5339,6 @@ components:
 
         in various features in the UI such as alert details flyout and
         exceptions auto-population from alert.
-
-        Added in PR #163235
-
-        Right now we only have a single field but anticipate adding more related
-        fields to store various
-
-        configuration states such as `override` - where a user might say if they
-        want only these fields to
-
-        display, or if they want these fields + the fields we select. When
-        expanding this field, it may look
-
-        something like:
-
-        ```typescript
-
-        const investigationFields = z.object({
-          field_names: NonEmptyArray(NonEmptyString),
-          override: z.boolean().optional(),
-        });
-
-        ```
       type: object
       properties:
         field_names:
@@ -3298,7 +5358,7 @@ components:
         base value).
       type: boolean
     IsRuleEnabled:
-      description: Determines whether the rule is enabled.
+      description: Determines whether the rule is enabled. Defaults to true.
       type: boolean
     IsRuleImmutable:
       deprecated: true
@@ -3315,7 +5375,7 @@ components:
         - lucene
       type: string
     MachineLearningJobId:
-      description: Machine learning job ID
+      description: Machine learning job ID(s) the rule monitors for anomaly scores.
       oneOf:
         - type: string
         - items:
@@ -3327,6 +5387,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3375,6 +5438,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3446,6 +5520,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3494,6 +5571,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3563,6 +5651,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3613,6 +5704,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3678,6 +5780,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3728,6 +5833,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3774,6 +5890,22 @@ components:
             - severity
         - $ref: '#/components/schemas/MachineLearningRuleCreateFields'
     MaxSignals:
+      default: 100
+      description: >
+        Maximum number of alerts the rule can create during a single run (the
+        rule’s Max alerts per run [advanced
+        setting](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#rule-ui-advanced-params)
+        value).
+
+        > info
+
+        > This setting can be superseded by the [Kibana configuration
+        setting](https://www.elastic.co/guide/en/kibana/current/alert-action-settings-kb.html#alert-settings)
+        `xpack.alerting.rules.run.alerts.max`, which determines the maximum
+        alerts generated by any rule in the Kibana alerting framework. For
+        example, if `xpack.alerting.rules.run.alerts.max` is set to 1000, the
+        rule can generate no more than 1000 alerts even if `max_signals` is set
+        higher.
       minimum: 1
       type: integer
     MigrationCleanupResult:
@@ -3875,6 +6007,7 @@ components:
         - version
         - updated
     NewTermsFields:
+      description: Fields to monitor for new values.
       items:
         type: string
       maxItems: 3
@@ -3885,6 +6018,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3933,6 +6069,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4005,6 +6152,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4053,6 +6203,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4136,6 +6297,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4186,6 +6350,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4260,6 +6435,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4310,6 +6488,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4400,16 +6589,31 @@ components:
         ecs_mapping:
           $ref: '#/components/schemas/EcsMapping'
         pack_id:
+          description: >-
+            To specify a query pack, use the packId field. Example: "packId":
+            "processes_elastic"
           type: string
         queries:
           items:
             $ref: '#/components/schemas/OsqueryQuery'
           type: array
         query:
+          description: >-
+            To run a single query, use the query field and enter a SQL query.
+            Example: "query": "SELECT * FROM processes;"
           type: string
         saved_query_id:
+          description: >-
+            To run a saved query, use the saved_query_id field and specify the
+            saved query ID. Example: "saved_query_id": "processes_elastic"
           type: string
         timeout:
+          description: >-
+            A timeout period, in seconds, after which the query will stop
+            running. Overwriting the default timeout allows you to support
+            queries that require more time to complete. The default and minimum
+            supported value is 60. The maximum supported value is 900. Example:
+            "timeout": 120.
           type: number
     OsqueryQuery:
       type: object
@@ -4463,11 +6667,18 @@ components:
       type: object
       properties:
         command:
+          description: >-
+            To run an endpoint response action, specify a value for the command
+            field. Example: "command": "isolate"
           enum:
             - kill-process
             - suspend-process
           type: string
         comment:
+          description: >-
+            Add a note that explains or describes the action. You can find your
+            comment in the response actions history log. Example: "comment":
+            "Check processes"
           type: string
         config:
           type: object
@@ -4489,6 +6700,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4537,6 +6751,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4609,6 +6834,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4657,6 +6885,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4738,6 +6977,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4788,6 +7030,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4856,6 +7109,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4906,6 +7162,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4992,23 +7259,10 @@ components:
         and `azure` that contain
 
         several integrations; in this case, `integration` should be specified.
-
-
-        @example
-
-        const x: RelatedIntegration = {
-          package: 'windows',
-          version: '1.5.x',
-        };
-
-
-        @example
-
-        const x: RelatedIntegration = {
-          package: 'azure',
-          version: '~1.1.6',
-          integration: 'activitylogs',
-        };
+      example:
+        integration: activitylogs
+        package: azure
+        version: ~1.1.6
       type: object
       properties:
         integration:
@@ -5062,14 +7316,21 @@ components:
       type: object
       properties:
         ecs:
-          description: Whether the field is an ECS field
+          description: >-
+            Indicates whether the field is ECS-compliant. This property is only
+            present in responses. Its value is computed based on field’s name
+            and type.
           type: boolean
         name:
-          $ref: '#/components/schemas/NonEmptyString'
           description: Name of an Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
         type:
-          $ref: '#/components/schemas/NonEmptyString'
           description: Type of the Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
       required:
         - name
         - type
@@ -5086,11 +7347,15 @@ components:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/NonEmptyString'
           description: Name of an Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
         type:
-          $ref: '#/components/schemas/NonEmptyString'
-          description: Type of an Elasticsearch field
+          description: Type of the Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
       required:
         - name
         - type
@@ -5138,7 +7403,12 @@ components:
         - related_integrations
         - required_fields
     RiskScore:
-      description: Risk score (0 to 100)
+      description: |
+        A numerical representation of the alert's severity from 0 to 100, where:
+        * `0` - `21` represents low severity
+        * `22` - `47` represents medium severity
+        * `48` - `73` represents high severity
+        * `74` - `100` represents critical severity
       maximum: 100
       minimum: 0
       type: integer
@@ -5150,6 +7420,7 @@ components:
         type: object
         properties:
           field:
+            description: Source event field used to override the default `risk_score`.
             type: string
           operator:
             enum:
@@ -5168,7 +7439,26 @@ components:
       type: object
       properties:
         action_type_id:
-          description: The action type used for sending notifications.
+          description: |
+            The action type used for sending notifications, can be:
+
+              - `.slack`
+              - `.slack_api`
+              - `.email`
+              - `.index`
+              - `.pagerduty`
+              - `.swimlane`
+              - `.webhook`
+              - `.servicenow`
+              - `.servicenow-itom`
+              - `.servicenow-sir`
+              - `.jira`
+              - `.resilient`
+              - `.opsgenie`
+              - `.teams`
+              - `.torq`
+              - `.tines`
+              - `.d3security`
           type: string
         alerts_filter:
           $ref: '#/components/schemas/RuleActionAlertsFilter'
@@ -5188,6 +7478,22 @@ components:
         - params
     RuleActionAlertsFilter:
       additionalProperties: true
+      description: >
+        Object containing an action’s conditional filters.
+
+
+        - `timeframe` (object, optional): Object containing the time frame for
+        when this action can be run.
+            - `days` (array of integers, required): List of days of the week on which this action will be run. Days of the week are expressed as numbers between `1-7`, where `1` is Monday and `7` is Sunday. To select all days of the week, enter an empty array.
+            - `hours` (object, required): The hours of the day during which this action will run. Hours of the day are expressed as two strings in the format `hh:mm` in `24` hour time. A start of `00:00` and an end of `24:00` means the action can run all day.
+                - start (string, required): Start time in `hh:mm` format.
+                - end (string, required): End time in `hh:mm` format.
+            - `timezone` (string, required): An ISO timezone name, such as `Europe/Madrid` or `America/New_York`. Specific offsets such as `UTC` or `UTC+1` will also work, but lack built-in DST.
+        - `query` (object, optional): Object containing a query filter which
+        gets applied to an action and determines whether the action should run.
+            - `kql` (string, required): A KQL string.
+            - `filters` (array of objects, required): Array of filter objects, as defined in the `kbn-es-query` package.
+              
       type: object
     RuleActionFrequency:
       description: >-
@@ -5218,9 +7524,7 @@ components:
       description: The connector ID.
       type: string
     RuleActionNotifyWhen:
-      description: >-
-        The condition for throttling the notification: `onActionGroupChange`,
-        `onActiveAlert`,  or `onThrottleInterval`
+      description: Defines how often rules run actions.
       enum:
         - onActiveAlert
         - onThrottleInterval
@@ -5228,9 +7532,36 @@ components:
       type: string
     RuleActionParams:
       additionalProperties: true
-      description: >-
+      description: >
         Object containing the allowed connector fields, which varies according
         to the connector type.
+
+
+        For Slack:
+
+          - `message` (string, required): The notification message.
+
+        For email:
+
+          - `to`, `cc`, `bcc` (string): Email addresses to which the notifications are sent. At least one field must have a value.
+          - `subject` (string, optional): Email subject line.
+          - `message` (string, required): Email body text.
+
+        For Webhook:
+
+          - `body` (string, required): JSON payload.
+
+        For PagerDuty:
+
+          - `severity` (string, required): Severity of on the alert notification, can be: `Critical`, `Error`, `Warning` or `Info`.
+          - `eventAction` (string, required): Event [action type](https://v2.developer.pagerduty.com/docs/events-api-v2#event-action), which can be `trigger`, `resolve`, or `acknowledge`.
+          - `dedupKey` (string, optional): Groups alert notifications with the same PagerDuty alert.
+          - `timestamp` (DateTime, optional): ISO-8601 format [timestamp](https://v2.developer.pagerduty.com/docs/types#datetime).
+          - `component` (string, optional): Source machine component responsible for the event, for example `security-solution`.
+          - `group` (string, optional): Enables logical grouping of service components.
+          - `source` (string, optional): The affected system. Defaults to the Kibana saved object ID of the action.
+          - `summary` (string, options): Summary of the event. Defaults to `No summary provided`. Maximum length is 1024 characters.
+          - `class` (string, optional): Value indicating the class/type of the event.
       type: object
     RuleActionThrottle:
       description: Defines how often rule actions are taken.
@@ -5244,6 +7575,7 @@ components:
           pattern: '^[1-9]\d*[smhd]$'
           type: string
     RuleAuthorArray:
+      description: The rule’s author.
       items:
         type: string
       type: array
@@ -5260,6 +7592,8 @@ components:
       discriminator:
         propertyName: type
     RuleDescription:
+      description: The rule’s description.
+      example: Detects anomalous Windows process creation events.
       minLength: 1
       type: string
     RuleDetailsInError:
@@ -5272,14 +7606,23 @@ components:
       required:
         - id
     RuleExceptionList:
+      description: >
+        Array of [exception
+        containers](https://www.elastic.co/guide/en/security/current/exceptions-api-overview.html),
+        which define exceptions that prevent the rule from generating alerts
+        even when its other criteria are met.
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/NonEmptyString'
           description: ID of the exception container
+          format: nonempty
+          minLength: 1
+          type: string
         list_id:
-          $ref: '#/components/schemas/NonEmptyString'
           description: List ID of the exception container
+          format: nonempty
+          minLength: 1
+          type: string
         namespace_type:
           description: Determines the exceptions validity in rule's Kibana space
           enum:
@@ -5368,6 +7711,10 @@ components:
     RuleExecutionStatusOrder:
       type: integer
     RuleExecutionSummary:
+      description: |
+        Summary of the last execution of a rule.
+        > info
+        > This field is under development and its usage or schema may change
       type: object
       properties:
         last_execution:
@@ -5395,10 +7742,20 @@ components:
       required:
         - last_execution
     RuleFalsePositiveArray:
+      description: >-
+        String array used to describe common reasons why the rule may issue
+        false-positive alerts. Defaults to an empty array.
       items:
         type: string
       type: array
     RuleFilterArray:
+      description: >
+        The query and filter context array used to define the conditions for
+        when alerts are created from events. Defaults to an empty array.
+
+        > info
+
+        > This field is not supported for ES|QL rules.
       items: {}
       type: array
     RuleInterval:
@@ -5421,15 +7778,34 @@ components:
       type: string
     RuleMetadata:
       additionalProperties: true
+      description: >
+        Placeholder for metadata about the rule.
+
+        > info
+
+        > This field is overwritten when you save changes to the rule’s
+        settings.
       type: object
     RuleName:
+      description: A human-readable name for the rule.
+      example: Anomalous Windows Process Creation
       minLength: 1
       type: string
     RuleNameOverride:
-      description: Sets the source field for the alert's signal.rule.name value
+      description: >-
+        Sets which field in the source event is used to populate the alert's
+        `signal.rule.name` value (in the UI, this value is displayed on the
+        Rules page in the Rule column). When unspecified, the rule’s `name`
+        value is used. The source field must be a string data type.
       type: string
     RuleObjectId:
       $ref: '#/components/schemas/UUID'
+      description: >-
+        A dynamic unique identifier for the rule object. It is randomly
+        generated when a rule is created and cannot be changed after that. It is
+        always a UUID. It is unique within a given Kibana space. The same
+        prebuilt Elastic rule, when installed in two different Kibana spaces or
+        two different Elastic environments, will have different object `id`s.
     RulePatchProps:
       anyOf:
         - $ref: '#/components/schemas/EqlRulePatchProps'
@@ -5487,8 +7863,22 @@ components:
         - invocationCount
         - timeframeEnd
     RuleQuery:
+      description: >
+        [Query](https://www.elastic.co/guide/en/kibana/8.17/search.html) used by
+        the rule to create alerts.
+
+
+        - For indicator match rules, only the query’s results are used to
+        determine whether an alert is generated.
+
+        - ES|QL rules have additional query requirements. Refer to [Create
+        ES|QL](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-esql-rule)
+        rules for more information.
       type: string
     RuleReferenceArray:
+      description: >-
+        Array containing notes about or references to relevant information about
+        the rule. Defaults to an empty array.
       items:
         type: string
       type: array
@@ -5524,7 +7914,13 @@ components:
       minimum: 0
       type: integer
     RuleSignatureId:
-      description: 'Could be any string, not necessarily a UUID'
+      description: >-
+        A stable unique identifier for the rule object. It can be assigned
+        during rule creation. It can be any string, but often is a UUID. It
+        should be unique not only within a given Kibana space, but also across
+        spaces and Elastic environments. The same prebuilt Elastic rule, when
+        installed in two different Kibana spaces or two different Elastic
+        environments, will have the same `rule_id`s.
       type: string
     RuleSource:
       description: >-
@@ -5587,12 +7983,19 @@ components:
         - conflict
       type: string
     SavedQueryId:
+      description: >-
+        Kibana [saved
+        search](https://www.elastic.co/guide/en/kibana/current/save-open-search.html)
+        used by the rule to create alerts.
       type: string
     SavedQueryRule:
       allOf:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5641,6 +8044,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -5713,6 +8127,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5761,6 +8178,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -5842,6 +8270,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5892,6 +8323,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -5960,6 +8402,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -6010,6 +8455,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -6096,9 +8552,25 @@ components:
         - tags_to_add
         - tags_to_remove
     SetupGuide:
+      description: >-
+        Populates the rule’s setup guide with instructions on rule prerequisites
+        such as required integrations, configuration steps, and anything else
+        needed for the rule to work correctly.
       type: string
     Severity:
-      description: Severity of the rule
+      description: >
+        Severity level of alerts produced by the rule, which must be one of the
+        following:
+
+        * `low`: Alerts that are of interest but generally not considered to be
+        security incidents
+
+        * `medium`: Alerts that require investigation
+
+        * `high`: Alerts that require immediate investigation
+
+        * `critical`: Alerts that indicate it is highly likely a security
+        incident has occurred
       enum:
         - low
         - medium
@@ -6111,6 +8583,7 @@ components:
         type: object
         properties:
           field:
+            description: Source event field used to override the default `severity`.
             type: string
           operator:
             enum:
@@ -6149,6 +8622,11 @@ components:
         - desc
       type: string
     Threat:
+      description: >
+        > info
+
+        > Currently, only threats described using the MITRE ATT&CK&trade;
+        framework are supported.
       type: object
       properties:
         framework:
@@ -6175,6 +8653,7 @@ components:
           Elasticsearch index containing the threat values
       type: array
     ThreatIndex:
+      description: Elasticsearch indices used to check which field values generate alerts.
       items:
         type: string
       type: array
@@ -6184,6 +8663,23 @@ components:
         (optional)
       type: string
     ThreatMapping:
+      description: >
+        Array of entries objects that define mappings between the source event
+        fields and the values in the Elasticsearch threat index. Each entries
+        object must contain these fields:
+
+
+        - field: field from the event indices on which the rule runs
+
+        - type: must be mapping
+
+        - value: field from the Elasticsearch threat index
+          
+        You can use Boolean and and or logic to define the conditions for when
+        matching fields and values generate alerts. Sibling entries objects are
+        evaluated using or logic, whereas multiple entries in a single entries
+        object use and logic. See Example of Threat Match rule which uses both
+        `and` and `or` logic.
       items:
         type: object
         properties:
@@ -6213,6 +8709,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -6261,6 +8760,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -6333,6 +8843,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -6381,6 +8894,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -6478,6 +9002,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -6528,6 +9055,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -6605,6 +9143,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -6655,6 +9196,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -6701,7 +9253,9 @@ components:
             - severity
         - $ref: '#/components/schemas/ThreatMatchRuleCreateFields'
     ThreatQuery:
-      description: Query to run
+      description: >-
+        Query used to determine which fields in the Elasticsearch index are used
+        for generating alerts.
       type: string
     ThreatSubtechnique:
       type: object
@@ -6720,6 +9274,8 @@ components:
         - name
         - reference
     ThreatTactic:
+      description: |
+        Object containing information on the attack type
       type: object
       properties:
         id:
@@ -6748,7 +9304,8 @@ components:
           description: Technique reference
           type: string
         subtechnique:
-          description: Array containing more specific information on the attack technique
+          description: |
+            Array containing more specific information on the attack technique.
           items:
             $ref: '#/components/schemas/ThreatSubtechnique'
           type: array
@@ -6769,6 +9326,7 @@ components:
         - field
         - value
     ThresholdAlertSuppression:
+      description: Defines alert suppression configuration.
       type: object
       properties:
         duration:
@@ -6776,12 +9334,17 @@ components:
       required:
         - duration
     ThresholdCardinality:
+      description: The field on which the cardinality is applied.
       items:
         type: object
         properties:
           field:
+            description: The field on which to calculate and compare the cardinality.
             type: string
           value:
+            description: >-
+              The threshold value from which an alert is generated based on
+              unique number of values of cardinality.field.
             minimum: 0
             type: integer
         required:
@@ -6789,7 +9352,10 @@ components:
           - value
       type: array
     ThresholdField:
-      description: Field to aggregate on
+      description: >-
+        The field on which the threshold is applied. If you specify an empty
+        array ([]), alerts are generated when the query returns at least the
+        number of results specified in the value field.
       oneOf:
         - type: string
         - items:
@@ -6800,6 +9366,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -6848,6 +9417,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -6920,6 +9500,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -6968,6 +9551,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -7051,6 +9645,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -7101,6 +9698,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -7172,6 +9780,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -7222,6 +9833,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -7268,13 +9890,23 @@ components:
             - severity
         - $ref: '#/components/schemas/ThresholdRuleCreateFields'
     ThresholdValue:
-      description: Threshold value
+      description: The threshold value from which an alert is generated.
       minimum: 1
       type: integer
     ThrottleForBulkActions:
-      description: >-
-        The condition for throttling the notification: 'rule', 'no_actions', or
-        time duration
+      description: >
+        Defines the maximum interval in which a rule’s actions are executed.
+
+        > info
+
+        > The rule level `throttle` field is deprecated in Elastic Security 8.8
+        and will remain active for at least the next 12 months.
+
+        > In Elastic Security 8.8 and later, you can use the `frequency` field
+        to define frequencies for individual actions. Actions without
+        frequencies will acquire a converted version of the rule’s `throttle`
+        field. In the response, the converted `throttle` setting appears in the
+        individual actions' `frequency` field.
       enum:
         - rule
         - 1h
@@ -7291,10 +9923,17 @@ components:
       description: Timeline template title
       type: string
     TimestampField:
-      description: Contains the event timestamp used for sorting a sequence of events
+      description: >-
+        Specifies the name of the event timestamp field used for sorting a
+        sequence of events. Not to be confused with `timestamp_override`, which
+        specifies the more general field used for querying events within a
+        range. Defaults to the @timestamp ECS field.
       type: string
     TimestampOverride:
-      description: Sets the time field used to query indices
+      description: >-
+        Sets the time field used to query indices. When unspecified, rules query
+        the `@timestamp` field. The source field must be an Elasticsearch date
+        data type.
       type: string
     TimestampOverrideFallbackDisabled:
       description: Disables the fallback to the event's @timestamp field
@@ -7332,6 +9971,22 @@ tags:
       **Alerts** page and can be assigned and triaged, using the alert status to
       mark them as open, closed, or acknowledged.
 
+
+      This API supports both key-based authentication and basic authentication.
+
+
+      To use key-based authentication, create an API key, then specify the key
+      in the header of your API calls.
+
+
+      To use basic authentication, provide a username and password; this
+      automatically creates an API key that matches the current user’s
+      privileges.
+
+
+      In both cases, the API key is subsequently used for authorization when the
+      rule runs.
+
       > warn
 
       > If the API key used for authorization has different privileges than the
@@ -7341,5 +9996,11 @@ tags:
 
       > If the API key that created a rule is deleted, or the user that created
       the rule becomes inactive, the rule will stop running.
+
+
+      To create and run rules, the user must meet specific requirements for the
+      Kibana space. Refer to the [Detections
+      requirements](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html)
+      for a complete list of requirements.
     name: Security Detections API
     x-displayName: Security detections

--- a/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/docs/openapi/serverless/security_solution_detections_api_2023_10_31.bundled.schema.yaml
@@ -61,7 +61,22 @@ paths:
         - Privileges API
   /api/detection_engine/rules:
     delete:
-      description: Delete a detection rule using the `rule_id` or `id` field.
+      description: >
+        Delete a detection rule using the `rule_id` or `id` field.
+
+
+        The URL query must include one of the following:
+
+
+        * `id` - `DELETE /api/detection_engine/rules?id=<id>`
+
+        * `rule_id`- `DELETE /api/detection_engine/rules?rule_id=<rule_id>`
+
+
+        The difference between the `id` and `rule_id` is that the `id` is a
+        unique rule identifier that is randomly generated when a rule is created
+        and cannot be set, whereas `rule_id` is a stable rule identifier that
+        can be assigned during rule creation.
       operationId: DeleteRule
       parameters:
         - description: The rule's `id` value.
@@ -87,8 +102,29 @@ paths:
       tags:
         - Security Detections API
         - Rules API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request DELETE https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
     get:
-      description: Retrieve a detection rule using the `rule_id` or `id` field.
+      description: >
+        Retrieve a detection rule using the `rule_id` or `id` field.
+
+
+        The URL query must include one of the following:
+
+
+        * `id` - `GET /api/detection_engine/rules?id=<id>`
+
+        * `rule_id` - `GET /api/detection_engine/rules?rule_id=<rule_id>`
+
+
+        The difference between the `id` and `rule_id` is that the `id` is a
+        unique rule identifier that is randomly generated when a rule is created
+        and cannot be set, whereas `rule_id` is a stable rule identifier that
+        can be assigned during rule creation.
       operationId: ReadRule
       parameters:
         - description: The rule's `id` value.
@@ -107,28 +143,247 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Example response for a retrieved rule
+                  value:
+                    created_at: '2020-02-03T11:19:04.259Z'
+                    created_by: elastic
+                    description: Process started by MS Office program in user folder
+                    enabled: false
+                    execution_summary:
+                      last_execution:
+                        date: '2022-03-23T16:06:12.787Z'
+                        message: >-
+                          This rule attempted to query data from Elasticsearch
+                          indices listed in the "Index pattern" section of the
+                          rule definition, but no matching index was found.
+                        metrics:
+                          execution_gap_duration_s: 0
+                          total_indexing_duration_ms: 15
+                          total_search_duration_ms: 135
+                        status: partial failure
+                        status_order: 20
+                    false_positives: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-4200s
+                    id: c41d170b-8ba6-4de6-b8ec-76440a35ace3
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: MS Office child process
+                    query: >-
+                      process.parent.name:EXCEL.EXE or
+                      process.parent.name:MSPUB.EXE or
+                      process.parent.name:OUTLOOK.EXE or
+                      process.parent.name:POWERPNT.EXE or
+                      process.parent.name:VISIO.EXE or
+                      process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: process.name
+                        type: keyword
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    risk_score: 21
+                    rule_id: process_started_by_ms_office_user_folder
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat:
+                      - framework: MITRE ATT&CK
+                        tactic:
+                          id: TA0001
+                          name: Initial Access
+                          reference: 'https://attack.mitre.org/tactics/TA0001'
+                        technique:
+                          - id: T1193
+                            name: Spearphishing Attachment
+                            reference: 'https://attack.mitre.org/techniques/T1193'
+                    to: now-300s
+                    type: query
+                    updated_at: '2020-02-03T11:19:04.462Z'
+                    updated_by: elastic
+                    version: 1
               schema:
                 $ref: '#/components/schemas/RuleResponse'
-          description: Indicates a successful call.
+          description: >
+            Indicates a successful call.
+
+            > info
+
+            > These fields are under development and their usage or schema may
+            change: execution_summary.
       summary: Retrieve a detection rule
       tags:
         - Security Detections API
         - Rules API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl \
+              --request GET https://localhost:5601/api/detection_engine/rules?rule_id=bfeaf89b-a2a7-48a3-817f-e41829dc61ee \
+              --header "Content-Type: application/json; Elastic-Api-Version=2023-10-31"
     patch:
-      description: >-
+      description: >
         Update specific fields of an existing detection rule using the `rule_id`
         or `id` field.
+
+
+        The difference between the `id` and `rule_id` is that the `id` is a
+        unique rule identifier that is randomly generated when a rule is created
+        and cannot be set, whereas `rule_id` is a stable rule identifier that
+        can be assigned during rule creation.
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
       operationId: PatchRule
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                summary: Patch query rule
+                value:
+                  id: 14b7b513-3d8d-4b22-b7da-a7ae632f7e76
+                  name: New name
+              example2:
+                summary: Patch EQL rule
+                value:
+                  rule_id: process_started_by_ms_office_program_possible_payload
+                  threat:
+                    - framework: MITRE ATT&CK
+                      tactic:
+                        id: TA0001
+                        name: Initial Access
+                        reference: 'https://attack.mitre.org/tactics/TA0001'
+                      technique:
+                        - id: T1193
+                          name: Spearphishing Attachment
+                          reference: 'https://attack.mitre.org/techniques/T1193'
+              example3:
+                summary: Patch threshold rule
+                value:
+                  id: 005d2c4f-51ca-493d-a2bd-20ef076339b1
+                  query: >-
+                    agent.version : * and agent.id :
+                    "243d9b4f-ca01-4311-8e5c-9abbee91afd8"
+                  threshold:
+                    cardinality: []
+                    field: []
+                    value: 600
+              example4:
+                summary: Patch new terms rule
+                value:
+                  history_window_start: now-3d
+                  id: 569aac91-40dc-4807-a8ae-a2c8698089c4
+                  new_terms_fields:
+                    - Endpoint.policy.applied.artifacts.global.identifiers.name
+              example5:
+                summary: Patch esql rule
+                value:
+                  id: 0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd
+                  query: >
+                    FROM logs-abc*
+
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp)
+
+                    | EVAL event_rate = count / DATE_DIFF("seconds",
+                    min_timestamp, NOW()) 
+
+                    | KEEP event_rate
+              example6:
+                summary: Patch indicator match rule
+                value:
+                  id: 462f1986-10fe-40a3-a22c-2b1c9c4c48fd
+                  threat_query: >-
+                    @timestamp >= "now-30d/d" and event.module:(threatintel or
+                    ti_*) and threat.indicator.ip:* and not
+                    labels.is_ioc_transform_source:"false"
+              example7:
+                summary: Patch machine learning rule
+                value:
+                  anomaly_threshold: 50
+                  id: 60b13926-289b-41b1-a537-197ef1fa5059
+                  machine_learning_job_id:
+                    - auth_high_count_logon_events
             schema:
               $ref: '#/components/schemas/RulePatchProps'
+        description: |
+          > info
+          > You cannot modify the `id` or `rule_id` values.
         required: true
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Updated description for the rule.
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query: null
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: Updated Rule Name
+                    query: >-
+                      process.parent.name:EXCEL.EXE or
+                      process.parent.name:MSPUB.EXE or
+                      process.parent.name:OUTLOOK.EXE or
+                      process.parent.name:POWERPNT.EXE or
+                      process.parent.name:VISIO.EXE or
+                      process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                    required_fields:
+                      - name: process.parent.name
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 2
               schema:
                 $ref: '#/components/schemas/RuleResponse'
           description: Indicates a successful call.
@@ -137,11 +392,432 @@ paths:
         - Security Detections API
         - Rules API
     post:
-      description: Create a new detection rule.
+      description: >
+        Create a new detection rule.
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
+
+
+        You can create the following types of rules:
+
+
+        * **Custom query**: Searches the defined indices and creates an alert
+        when a document matches the rule's KQL query.
+
+        * **Event correlation**: Searches the defined indices and creates an
+        alert when results match an [Event Query Language
+        (EQL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html)
+        query.
+
+        * **Threshold**: Searches the defined indices and creates an alert when
+        the number of times the specified field's value meets the threshold
+        during a single execution. When there are multiple values that meet the
+        threshold, an alert is generated for each value.
+          For example, if the threshold `field` is `source.ip` and its `value` is `10`, an alert is generated for every source IP address that appears in at least 10 of the rule's search results. If you're interested, see [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) for more information.
+        * **Indicator match**: Creates an alert when fields match values defined
+        in the specified [Elasticsearch
+        index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html).
+        For example, you can create an index for IP addresses and use this index
+        to create an alert whenever an event's `destination.ip` equals a value
+        in the index. The index's field mappings should be
+        [ECS-compliant](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html).
+
+        * **New terms**: Generates an alert for each new term detected in source
+        documents within a specified time range.
+
+        * **ES|QL**: Uses [Elasticsearch Query Language
+        (ES|QL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html)
+        to find events and aggregate search results.
+
+        * **Machine learning rules**: Creates an alert when a machine learning
+        job discovers an anomaly above the defined threshold.
+
+        > info
+
+        > To create machine learning rules, you must have the [appropriate
+        license](https://www.elastic.co/subscriptions) or use a [cloud
+        deployment](https://cloud.elastic.co/registration). Additionally, for
+        the machine learning rule to function correctly, the associated machine
+        learning job must be running.
+
+
+        To retrieve machine learning job IDs, which are required to create
+        machine learning jobs, call the [Elasticsearch Get jobs
+        API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html).
+        Machine learning jobs that contain `siem` in the `groups` field can be
+        used to create rules:
+
+
+        ```json
+
+        ...
+
+        "job_id": "linux_anomalous_network_activity_ecs",
+
+        "job_type": "anomaly_detector",
+
+        "job_version": "7.7.0",
+
+        "groups": [
+          "auditbeat",
+          "process",
+          "siem"
+        ],
+
+        ...
+
+        ```
+
+
+        Additionally, you can set up notifications for when rules create alerts.
+        The notifications use the [Alerting and Actions
+        framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html).
+        Each action type requires a connector. Connectors store the information
+        required to send notifications via external systems. The following
+        connector types are supported for rule notifications:
+
+
+        * Slack
+
+        * Email
+
+        * PagerDuty
+
+        * Webhook
+
+        * Microsoft Teams
+
+        * IBM Resilient
+
+        * Jira
+
+        * ServiceNow ITSM
+
+        > info
+
+        > For more information on PagerDuty fields, see [Send a v2
+        Event](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/).
+
+
+        To retrieve connector IDs, which are required to configure rule
+        notifications, call the [Find objects
+        API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-find.html)
+        with `"type": "action"` in the request payload.
+
+
+        For detailed information on Kibana actions and alerting, and additional
+        API calls, see:
+
+
+        * [Alerting
+        API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-alerting)
+
+        * [Alerting and Actions
+        framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html)
+
+        * [Connectors
+        API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-connectors)
       operationId: CreateRule
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                description: Query rule that searches for processes started by MS Office
+                summary: Query rule
+                value:
+                  description: Process started by MS Office program - possible payload
+                  enabled: false
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: phrase
+                  from: now-70m
+                  interval: 1h
+                  language: kuery
+                  name: MS Office child process
+                  query: >-
+                    process.parent.name:EXCEL.EXE or
+                    process.parent.name:MSPUB.EXE or
+                    process.parent.name:OUTLOOK.EXE or
+                    process.parent.name:POWERPNT.EXE or
+                    process.parent.name:VISIO.EXE or
+                    process.parent.name:WINWORD.EXE
+                  related_integrations:
+                    - package: o365
+                      version: ^2.3.2
+                  required_fields:
+                    - name: process.parent.name
+                      type: keyword
+                  risk_score: 50
+                  rule_id: process_started_by_ms_office_program
+                  severity: low
+                  tags:
+                    - child process
+                    - ms office
+                  type: query
+              example2:
+                description: >-
+                  Threshold rule that detects multiple failed login attempts to
+                  a Windows host from the same external source IP address
+                summary: Threshold rule
+                value:
+                  description: >-
+                    Detects when there are 20 or more failed login attempts from
+                    the same IP address with a 2 minute time frame.
+                  enabled: true
+                  exceptions_list:
+                    - id: int-ips
+                      namespace_type: single
+                      type: detection
+                  from: now-180s
+                  index:
+                    - winlogbeat-*
+                  interval: 2m
+                  name: Windows server prml-19
+                  query: >-
+                    host.name:prml-19 and event.category:authentication and
+                    event.outcome:failure
+                  required_fields:
+                    - name: source.ip
+                      type: ip
+                  risk_score: 30
+                  rule_id: liv-win-ser-logins
+                  severity: low
+                  severity_mapping:
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: low
+                      value: Manchester
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: medium
+                      value: London
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: high
+                      value: Birmingham
+                    - field: source.geo.city_name
+                      operator: equals
+                      severity: critical
+                      value: Wallingford
+                  tags:
+                    - Brute force
+                  threshold:
+                    field: source.ip
+                    value: 20
+                  type: threshold
+              example3:
+                description: >-
+                  Machine learning rule that creates alerts, and sends Slack
+                  notifications, when the linux_anomalous_network_activity_ecs
+                  machine learning job discovers anomalies with a threshold of
+                  70 or above.
+                summary: Machine learning rule
+                value:
+                  actions:
+                    - action_type_id: .slack
+                      group: default
+                      id: 5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5
+                      params:
+                        message: 'Urgent: {{context.rule.description}}'
+                  anomaly_threshold: 70
+                  description: Generates alerts when the job discovers anomalies over 70
+                  enabled: true
+                  from: now-6m
+                  interval: 5m
+                  machine_learning_job_id: linux_anomalous_network_activity_ecs
+                  name: Anomalous Linux network activity
+                  note: Shut down the internet.
+                  risk_score: 70
+                  rule_id: ml_linux_network_high_threshold
+                  setup: This rule requires data coming in from Elastic Defend.
+                  severity: high
+                  tags:
+                    - machine learning
+                    - Linux
+                  type: machine_learning
+              example4:
+                description: >-
+                  Event correlation rule that creates alerts when the Windows
+                  rundll32.exe process makes unusual network connections
+                summary: EQL rule
+                value:
+                  description: Unusual rundll32.exe network connection
+                  language: eql
+                  name: rundll32.exe network connection
+                  query: >-
+                    sequence by process.entity_id with maxspan=2h [process where
+                    event.type in ("start", "process_started") and (process.name
+                    == "rundll32.exe" or process.pe.original_file_name ==
+                    "rundll32.exe") and ((process.args == "rundll32.exe" and
+                    process.args_count == 1) or (process.args != "rundll32.exe"
+                    and process.args_count == 0))] [network where event.type ==
+                    "connection" and (process.name == "rundll32.exe" or
+                    process.pe.original_file_name == "rundll32.exe")]
+                  required_fields:
+                    - name: event.type
+                      type: keyword
+                    - name: process.args
+                      type: keyword
+                    - name: process.args_count
+                      type: long
+                    - name: process.entity_id
+                      type: keyword
+                    - name: process.name
+                      type: keyword
+                    - name: process.pe.original_file_name
+                      type: keyword
+                  risk_score: 21
+                  rule_id: eql-outbound-rundll32-connections
+                  severity: low
+                  tags:
+                    - EQL
+                    - Windows
+                    - rundll32.exe
+                  type: eql
+              example5:
+                description: >
+                  Indicator match rule that creates an alert when one of the
+                  following is true: The event's destination IP address and port
+                  number matches destination IP and port values in the
+                  threat_index index; The event's source IP address matches a
+                  host IP address value in the threat_index index.
+                summary: Indicator match rule
+                value:
+                  actions: []
+                  description: >-
+                    Checks for bad IP addresses listed in the ip-threat-list
+                    index
+                  index:
+                    - packetbeat-*
+                  name: Bad IP threat match
+                  query: 'destination.ip:* or host.ip:*'
+                  required_fields:
+                    - name: destination.ip
+                      type: ip
+                    - name: destination.port
+                      type: long
+                    - name: host.ip
+                      type: ip
+                  risk_score: 50
+                  severity: medium
+                  threat_index:
+                    - ip-threat-list
+                  threat_mapping:
+                    - entries:
+                        - field: destination.ip
+                          type: mapping
+                          value: destination.ip
+                        - field: destination.port
+                          type: mapping
+                          value: destination.port
+                    - entries:
+                        - field: source.ip
+                          type: mapping
+                          value: host.ip
+                  threat_query: '*:*'
+                  type: threat_match
+              example6:
+                description: >-
+                  New terms rule that creates alerts a new IP address is
+                  detected for a user
+                summary: New terms rule
+                value:
+                  description: Detects a user associated with a new IP address
+                  history_window_start: now-30d
+                  index:
+                    - auditbeat*
+                  language: kuery
+                  name: New User IP Detected
+                  new_terms_fields:
+                    - user.id
+                    - source.ip
+                  query: '*'
+                  required_fields:
+                    - name: user.id
+                      type: keyword
+                    - name: source.ip
+                      type: ip
+                  risk_score: 21
+                  severity: medium
+                  type: new_terms
+              example7:
+                description: >-
+                  esql rule that creates alerts from events that match an Excel
+                  parent process
+                summary: Esql rule
+                value:
+                  description: Find Excel events
+                  enabled: false
+                  from: now-360s
+                  interval: 5m
+                  language: esql
+                  name: Find Excel events
+                  query: >-
+                    from auditbeat-8.10.2 METADATA _id, _version, _index | where
+                    process.parent.name == "EXCEL.EXE"
+                  required_fields:
+                    - name: process.parent.name
+                      type: keyword
+                  risk_score: 21
+                  severity: low
+                  tags: []
+                  to: now
+                  type: esql
+              example8:
+                description: >-
+                  Query rule that searches for processes started by MS Office
+                  and suppresses alerts by the process.parent.name field within
+                  a 5-hour time period
+                summary: Query rule 2
+                value:
+                  alert_suppression:
+                    duration:
+                      unit: h
+                      value: 5
+                    group_by:
+                      - process.parent.name
+                    missing_fields_strategy: suppress
+                  description: Process started by MS Office program - possible payload
+                  enabled: false
+                  filters:
+                    - query:
+                        match:
+                          event.action:
+                            query: 'Process Create (rule: ProcessCreate)'
+                            type: phrase
+                  from: now-70m
+                  interval: 1h
+                  language: kuery
+                  name: MS Office child process
+                  query: >-
+                    process.parent.name:EXCEL.EXE or
+                    process.parent.name:MSPUB.EXE or
+                    process.parent.name:OUTLOOK.EXE or
+                    process.parent.name:POWERPNT.EXE or
+                    process.parent.name:VISIO.EXE or
+                    process.parent.name:WINWORD.EXE
+                  risk_score: 50
+                  rule_id: process_started_by_ms_office_program
+                  severity: low
+                  tags:
+                    - child process
+                    - ms office
+                  type: query
             schema:
               $ref: '#/components/schemas/RuleCreateProps'
         required: true
@@ -149,32 +825,611 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  description: Example response for a query rule
+                  summary: Query rule response
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Process started by MS Office program - possible payload
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query:
+                          match:
+                            event.action:
+                              query: 'Process Create (rule: ProcessCreate)'
+                              type: phrase
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: MS Office child process
+                    query: >-
+                      process.parent.name:EXCEL.EXE or
+                      process.parent.name:MSPUB.EXE or
+                      process.parent.name:OUTLOOK.EXE or
+                      process.parent.name:POWERPNT.EXE or
+                      process.parent.name:VISIO.EXE or
+                      process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                      - integration: graphactivitylogs
+                        package: azure
+                        version: ^1.11.4
+                    required_fields:
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 1
+                example2:
+                  description: Example response for a machine learning job rule
+                  summary: Machine learning response
+                  value:
+                    actions:
+                      - action_type_id: .slack
+                        frequency:
+                          notifyWhen: onActiveAlert
+                          summary: true
+                          throttle: null
+                        group: default
+                        id: 5ad22cd5-5e6e-4c6c-a81a-54b626a4cec5
+                        params:
+                          message: 'Urgent: {{context.rule.description}}'
+                    anomaly_threshold: 70
+                    created_at: '2020-04-07T14:45:15.679Z'
+                    created_by: elastic
+                    description: Generates alerts when the job discovers anomalies over 70
+                    enabled: true
+                    false_positives: []
+                    from: now-6m
+                    id: 83876f66-3a57-4a99-bf37-416494c80f3b
+                    immutable: false
+                    interval: 5m
+                    machine_learning_job_id: linux_anomalous_network_activity_ecs
+                    max_signals: 100
+                    name: Anomalous Linux network activity
+                    note: Shut down the internet.
+                    references: []
+                    related_integrations: []
+                    required_fields: []
+                    risk_score: 70
+                    rule_id: ml_linux_network_high_threshold
+                    setup: ''
+                    severity: high
+                    status: going to run
+                    status_date: '2020-04-07T14:45:21.685Z'
+                    tags:
+                      - machine learning
+                      - Linux
+                    threat: []
+                    to: now
+                    type: machine_learning
+                    updated_at: '2020-04-07T14:45:15.892Z'
+                    updated_by: elastic
+                    version: 1
+                example3:
+                  description: Example response for a threshold rule
+                  summary: Threshold rule response
+                  value:
+                    actions: []
+                    author: []
+                    created_at: '2020-07-22T10:27:23.486Z'
+                    created_by: elastic
+                    description: >-
+                      Detects when there are 20 or more failed login attempts
+                      from the same IP address with a 2 minute time frame.
+                    enabled: true
+                    exceptions_list:
+                      - id: int-ips
+                        namespace_type: single
+                        type: detection
+                    false_positives: []
+                    from: now-180s
+                    id: 15dbde26-b627-4d74-bb1f-a5e0ed9e4993
+                    immutable: false
+                    index:
+                      - winlogbeat-*
+                    interval: 2m
+                    language: kuery
+                    max_signals: 100
+                    name: Windows server prml-19
+                    query: >-
+                      host.name:prml-19 and event.category:authentication and
+                      event.outcome:failure
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: source.ip
+                        type: ip
+                    risk_score: 30
+                    risk_score_mapping: []
+                    rule_id: liv-win-ser-logins
+                    setup: ''
+                    severity: low
+                    severity_mapping:
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: low
+                        value: Manchester
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: medium
+                        value: London
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: high
+                        value: Birmingham
+                      - field: source.geo.city_name
+                        operator: equals
+                        severity: critical
+                        value: Wallingford
+                    tags:
+                      - Brute force
+                    threat: []
+                    threshold:
+                      field: source.ip
+                      value: 20
+                    to: now
+                    type: threshold
+                    updated_at: '2020-07-22T10:27:23.673Z'
+                    updated_by: elastic
+                    version: 1
+                example4:
+                  description: Example response for an EQL rule
+                  summary: EQL rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-05T09:06:16.392Z'
+                    created_by: elastic
+                    description: Unusual rundll32.exe network connection
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    id: 93808cae-b05b-4dc9-8479-73574b50f8b1
+                    immutable: false
+                    interval: 5m
+                    language: eql
+                    max_signals: 100
+                    name: rundll32.exe network connection
+                    query: >-
+                      sequence by process.entity_id with maxspan=2h [process
+                      where event.type in ("start", "process_started") and
+                      (process.name == "rundll32.exe" or
+                      process.pe.original_file_name == "rundll32.exe") and
+                      ((process.args == "rundll32.exe" and process.args_count ==
+                      1) or (process.args != "rundll32.exe" and
+                      process.args_count == 0))] [network where event.type ==
+                      "connection" and (process.name == "rundll32.exe" or
+                      process.pe.original_file_name == "rundll32.exe")]
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: event.type
+                        type: keyword
+                      - ecs: true
+                        name: process.args
+                        type: keyword
+                      - ecs: true
+                        name: process.args_count
+                        type: long
+                      - ecs: true
+                        name: process.entity_id
+                        type: keyword
+                      - ecs: true
+                        name: process.name
+                        type: keyword
+                      - ecs: true
+                        name: process.pe.original_file_name
+                        type: keyword
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: eql-outbound-rundll32-connections
+                    setup: ''
+                    severity: low
+                    severity_mapping: []
+                    tags:
+                      - EQL
+                      - Windows
+                      - rundll32.exe
+                    threat: []
+                    throttle: no_actions
+                    to: now
+                    type: eql
+                    updated_at: '2020-10-05T09:06:16.403Z'
+                    updated_by: elastic
+                    version: 1
+                example5:
+                  description: Example response for an indicator match rule
+                  summary: Indicator match rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    created_by: elastic
+                    description: >-
+                      Checks for bad IP addresses listed in the ip-threat-list
+                      index
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    id: d5daa13f-81fb-4b13-be2f-31011e1d9ae1
+                    immutable: false
+                    index:
+                      - packetbeat-*
+                    interval: 5m
+                    language: kuery
+                    max_signals: 100
+                    name: Bad IP threat match
+                    query: 'destination.ip:* or host.ip:*'
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: destination.ip
+                        type: ip
+                      - ecs: true
+                        name: destination.port
+                        type: long
+                      - ecs: true
+                        name: host.ip
+                        type: ip
+                    risk_score: 50
+                    risk_score_mapping: []
+                    rule_id: 608501e4-c768-4f64-9326-cec55b5d439b
+                    setup: ''
+                    severity: medium
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    threat_index:
+                      - ip-threat-list
+                    threat_mapping:
+                      - entries:
+                          - field: destination.ip
+                            type: mapping
+                            value: destination.ip
+                          - field: destination.port
+                            type: mapping
+                            value: destination.port
+                      - entries:
+                          - field: source.ip
+                            type: mapping
+                            value: host.ip
+                    threat_query: '*:*'
+                    to: now
+                    type: threat_match
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    updated_by: elastic
+                    version: 1
+                example6:
+                  description: Example response for a new terms rule
+                  summary: New terms rule response
+                  value:
+                    author: []
+                    created_at: '2020-10-06T07:07:58.227Z'
+                    created_by: elastic
+                    description: Detects a user associated with a new IP address
+                    enabled: true
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-6m
+                    history_window_start: now-30d
+                    id: eb7225c0-566b-11ee-8b4f-bbf3afdeb9f4
+                    immutable: false
+                    index:
+                      - auditbeat*
+                    interval: 5m
+                    language: kuery
+                    max_signals: 100
+                    name: New User IP Detected
+                    new_terms_fields:
+                      - user.id
+                      - source.ip
+                    query: '*'
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: user.id
+                        type: keyword
+                      - ecs: true
+                        name: source.ip
+                        type: ip
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: c6f5d0bc-7be9-47d4-b2f3-073d22641e30
+                    setup: ''
+                    severity: medium
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    to: now
+                    type: new_terms
+                    updated_at: '2020-10-06T07:07:58.237Z'
+                    updated_by: elastic
+                    version: 1
+                example7:
+                  description: Example response for an Esql rule
+                  summary: Esql rule response
+                  value:
+                    actions: []
+                    author: []
+                    created_at: '2023-10-18T10:55:14.269Z'
+                    created_by: elastic
+                    description: Find Excel events
+                    enabled: false
+                    exceptions_list: []
+                    false_positives: []
+                    from: now-360s
+                    id: d0f20490-6da4-11ee-b85e-09e9b661f2e2
+                    immutable: false
+                    interval: 5m
+                    language: esql
+                    max_signals: 100
+                    name: Find Excel events
+                    output_index: ''
+                    query: >-
+                      from auditbeat-8.10.2 METADATA _id | where
+                      process.parent.name == "EXCEL.EXE"
+                    references: []
+                    related_integrations:
+                      - package: o365
+                        version: ^2.3.2
+                    required_fields:
+                      - ecs: true
+                        name: process.parent.name
+                        type: keyword
+                    revision: 0
+                    risk_score: 21
+                    risk_score_mapping: []
+                    rule_id: e4b53a89-debd-4a0d-a3e3-20606952e589
+                    setup: ''
+                    severity: low
+                    severity_mapping: []
+                    tags: []
+                    threat: []
+                    to: now
+                    type: esql
+                    updated_at: '2023-10-18T10:55:14.269Z'
+                    updated_by: elastic
+                    version: 1
               schema:
                 $ref: '#/components/schemas/RuleResponse'
           description: Indicates a successful call.
       summary: Create a detection rule
       tags:
         - Security Detections API
-        - Rules API
     put:
       description: >
         Update a detection rule using the `rule_id` or `id` field. The original
         rule is replaced, and all unspecified fields are deleted.
 
-        > info
 
-        > You cannot modify the `id` or `rule_id` values.
+        The difference between the `id` and `rule_id` is that the `id` is a
+        unique rule identifier that is randomly generated when a rule is created
+        and cannot be set, whereas `rule_id` is a stable rule identifier that
+        can be assigned during rule creation.
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
       operationId: UpdateRule
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                summary: Update query rule
+                value:
+                  description: A new description
+                  id: 14b7b513-3d8d-4b22-b7da-a7ae632f7e76
+                  name: A new name for the rule
+                  risk_score: 22
+                  severity: medium
+                  type: query
+              example2:
+                summary: Update EQL rule
+                value:
+                  description: eql rule test
+                  id: 9b684efb-acf9-4323-9bff-8335b3867d14
+                  index:
+                    - apm-*-transaction*
+                  language: eql
+                  name: New name for EQL rule
+                  query: process where process.name == "regsvr32.exe"
+                  risk_score: 21
+                  severity: low
+                  type: eql
+              example3:
+                summary: Update threshold rule
+                value:
+                  description: Description of threat rule test
+                  id: 005d2c4f-51ca-493d-a2bd-20ef076339b1
+                  language: kuery
+                  name: New name for threat rule
+                  query: >-
+                    agent.version : * and agent.id :
+                    "243d9b4f-ca01-4311-8e5c-9abbee91afd8"
+                  risk_score: 21
+                  severity: low
+                  tags:
+                    - new_tag
+                  threshold:
+                    cardinality: []
+                    field: []
+                    value: 400
+                  type: threshold
+              example4:
+                summary: Update new terms rule
+                value:
+                  description: New description
+                  history_window_start: now-7d
+                  id: 569aac91-40dc-4807-a8ae-a2c8698089c4
+                  interval: 5m
+                  name: New terms rule name
+                  new_terms_fields:
+                    - Endpoint.policy.applied.artifacts.global.identifiers.name
+                  query: 'agent.version : "9.1.0"'
+                  risk_score: 21
+                  severity: low
+                  type: new_terms
+              example5:
+                summary: Update esql rule
+                value:
+                  description: New description for esql rule
+                  id: 0b15e8a2-49b6-47e0-a8e6-d63a6cc335bd
+                  language: esql
+                  name: New name for esql rule
+                  query: >
+                    FROM logs*
+
+                    | STATS count = COUNT(*), min_timestamp = MIN(@timestamp) /*
+                    MIN(dateField) finds the earliest timestamp in the dataset.
+                    */
+
+                    | EVAL event_rate = count / DATE_DIFF("seconds",
+                    min_timestamp, NOW()) /* Calculates the event rate by
+                    dividing the total count of events by the time difference
+                    (in seconds) between the earliest event and the current
+                    time. */
+
+                    | KEEP event_rate
+                  risk_score: 21
+                  severity: low
+                  type: esql
+              example6:
+                summary: Update indicator match rule
+                value:
+                  description: New description
+                  id: 462f1986-10fe-40a3-a22c-2b1c9c4c48fd
+                  name: New name for Indicator Match rule
+                  query: 'source.ip:* or destination.ip:*\n'
+                  risk_score: 99
+                  severity: critical
+                  threat_index:
+                    - filebeat-*
+                    - logs-ti_*
+                  threat_mapping:
+                    - entries:
+                        - field: source.ip
+                          type: mapping
+                          value: threat.indicator.ip
+                    - entries:
+                        - field: destination.ip
+                          type: mapping
+                          value: threat.indicator.ip
+                  threat_query: >-
+                    @timestamp >= "now-30d/d" and event.module:(threatintel or
+                    ti_*) and threat.indicator.ip:* and not
+                    labels.is_ioc_transform_source:"true"
+                  type: threat_match
+              example7:
+                summary: Update machine learning rule
+                value:
+                  anomaly_threshold: 50
+                  description: New description of ml rule
+                  id: 60b13926-289b-41b1-a537-197ef1fa5059
+                  machine_learning_job_id:
+                    - auth_high_count_logon_events
+                  name: New name of ml rule
+                  risk_score: 21
+                  severity: low
+                  type: machine_learning
             schema:
               $ref: '#/components/schemas/RuleUpdateProps'
+        description: >
+          > info
+
+          > All unspecified fields are deleted. You cannot modify the `id` or
+          `rule_id` values.
         required: true
       responses:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Example response for an updated rule
+                  value:
+                    actions: []
+                    created_at: '2020-04-07T14:51:09.755Z'
+                    created_by: elastic
+                    description: Updated description for the rule.
+                    enabled: false
+                    false_positives: []
+                    filters:
+                      - query: null
+                    from: now-70m
+                    id: 6541b99a-dee9-4f6d-a86d-dbd1869d73b1
+                    immutable: false
+                    interval: 1h
+                    language: kuery
+                    max_signals: 100
+                    name: Updated Rule Name
+                    query: >-
+                      process.parent.name:EXCEL.EXE or
+                      process.parent.name:MSPUB.EXE or
+                      process.parent.name:OUTLOOK.EXE or
+                      process.parent.name:POWERPNT.EXE or
+                      process.parent.name:VISIO.EXE or
+                      process.parent.name:WINWORD.EXE
+                    references: []
+                    related_integrations:
+                      - package: o365
+                    required_fields:
+                      - name: process.parent.name
+                    risk_score: 50
+                    rule_id: process_started_by_ms_office_program
+                    setup: ''
+                    severity: low
+                    tags:
+                      - child process
+                      - ms office
+                    threat: []
+                    to: now
+                    type: query
+                    updated_at: '2020-04-07T14:51:09.970Z'
+                    updated_by: elastic
+                    version: 2
               schema:
                 $ref: '#/components/schemas/RuleResponse'
           description: Indicates a successful call.
@@ -184,13 +1439,45 @@ paths:
         - Rules API
   /api/detection_engine/rules/_bulk_action:
     post:
-      description: >-
+      description: >
         Apply a bulk action, such as bulk edit, duplicate, or delete, to
         multiple detection rules. The bulk action is applied to all rules that
         match the query or to the rules listed by their IDs.
+
+        > warn
+
+        > When used with  [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
       operationId: PerformRulesBulkAction
       parameters:
-        - description: Enables dry run mode for the request call.
+        - description: >
+            Enables dry run mode for the request call.
+
+
+            Enable dry run mode to verify that bulk actions can be applied to
+            specified rules. Certain rules, such as prebuilt Elastic rules on a
+            Basic subscription, can’t be edited and will return errors in the
+            request response. Error details will contain an explanation, the
+            rule name and/or ID, and additional troubleshooting information.
+
+
+            To enable dry run mode on a request, add the query parameter
+            `dry_run=true` to the end of the request URL. Rules specified in the
+            request will be temporarily updated. These updates won’t be written
+            to Elasticsearch.
+
+            > info
+
+            > Dry run mode is not supported for the `export` bulk action. A 400
+            error will be returned in the request response.
           in: query
           name: dry_run
           required: false
@@ -199,6 +1486,102 @@ paths:
       requestBody:
         content:
           application/json:
+            examples:
+              example1:
+                description: The following request activates all rules with the test tag
+                summary: Enable all rules with the test tag
+                value:
+                  action: enable
+                  query: 'alert.attributes.tags: "test"'
+              example2:
+                description: The following request enables the rule with the specified ID.
+                summary: Enable a specific rule by ID
+                value:
+                  action: enable
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+              example3:
+                description: The following request disables the rule with the specified ID.
+                summary: Disable a specific rule by ID
+                value:
+                  action: disable
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+              example4:
+                description: >-
+                  The following request adds tags tag-1 and tag-2 to the rules
+                  that have the IDs sent in the payload
+                summary: Add tags to rules
+                value:
+                  action: edit
+                  edit:
+                    - type: add_tags
+                      value:
+                        - tag-1
+                        - tag-2
+                  ids:
+                    - 8bc7dad0-9320-11ec-9265-8b772383a08d
+                    - 8e5c1a40-9320-11ec-9265-8b772383a08d
+              example5:
+                description: >-
+                  The following request will validate that the
+                  add_index_patterns bulk action can be successfully applied to
+                  three rules. The dry_run parameter is specified in query
+                  parameters, e.g. POST
+                  api/detection_engine/rules/_bulk_action?dry_run=true
+                summary: Dry run - Validate add_index_patterns bulk action
+                value:
+                  action: edit
+                  edit:
+                    - type: add_index_patterns
+                      value:
+                        - test-*
+                  ids:
+                    - 81aa0480-06af-11ed-94fb-dd1a0597d8d2
+                    - dc015d10-0831-11ed-ac8b-05a222bd8d4a
+                    - de8f5af0-0831-11ed-ac8b-05a222bd8d4a
+              example6:
+                description: >-
+                  The following request duplicates rules with the specified IDs,
+                  including exceptions but not expired exceptions.
+                summary: Duplicate rules with specific IDs
+                value:
+                  action: duplicate
+                  duplicate:
+                    include_exceptions: true
+                    include_expired_exceptions: false
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                    - 461a4c22-416e-4009-a9a7-cf79656454bf
+              example7:
+                description: The following request deletes the rule with the specified ID.
+                summary: Delete a specific rule by ID
+                value:
+                  action: delete
+                  ids:
+                    - cf4abfd1-7c37-4519-ab0f-5ea5c75fac60
+              example8:
+                description: >-
+                  The following request runs the rule with the specified ID
+                  within the given date range.
+                summary: Run a specific rule by ID
+                value:
+                  action: run
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                  run:
+                    end_date: '2025-03-10T23:59:59.999Z'
+                    start_date: '2025-03-01T00:00:00.000Z'
+              example9:
+                description: >-
+                  The following request exports the rules with the specified
+                  IDs.
+                summary: Export specific rules by ID
+                value:
+                  action: export
+                  ids:
+                    - 748694f0-6977-4ea5-8384-cd2e39730779
+                    - 13199674-aff1-418a-9e93-04f585fe36d1
             schema:
               oneOf:
                 - $ref: '#/components/schemas/BulkDeleteRules'
@@ -212,6 +1595,257 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  description: >-
+                    In this response one rule was updated and one was skipped.
+                    Objects returned in attributes.results.skipped will only
+                    include rules' id, name, and skip_reason.
+                  summary: Successful response
+                  value:
+                    attributes:
+                      results:
+                        created: []
+                        deleted: []
+                        skipped:
+                          - id: 51658332-a15e-4c9e-912a-67214e2e2359
+                            name: Skipped rule
+                            skip_reason: RULE_NOT_MODIFIED
+                        updated:
+                          - anomaly_threshold: 50
+                            author:
+                              - Elastic
+                            created_at: '2022-02-21T14:14:13.801Z'
+                            created_by: elastic
+                            description: >-
+                              A machine learning job detected unusually large
+                              numbers of DNS queries for a single top-level DNS
+                              domain, which is often used for DNS tunneling. DNS
+                              tunneling can be used for command-and-control,
+                              persistence, or data exfiltration activity. For
+                              example, dnscat tends to generate many DNS
+                              questions for a top-level domain as it uses the
+                              DNS protocol to tunnel data.
+                            enabled: true
+                            exceptions_list: []
+                            execution_summary:
+                              last_execution:
+                                date: '2022-03-23T16:06:12.787Z'
+                                message: >-
+                                  This rule attempted to query data from
+                                  Elasticsearch indices listed in the "Index
+                                  pattern" section of the rule definition, but
+                                  no matching index was found.
+                                metrics:
+                                  execution_gap_duration_s: 0
+                                  total_indexing_duration_ms: 15
+                                  total_search_duration_ms: 135
+                                status: partial failure
+                                status_order: 20
+                            false_positives:
+                              - >-
+                                DNS domains that use large numbers of child
+                                domains, such as software or content
+                                distribution networks, can trigger this alert
+                                and such parent domains can be excluded.
+                            from: now-45m
+                            id: 8bc7dad0-9320-11ec-9265-8b772383a08d
+                            immutable: false
+                            interval: 15m
+                            license: Elastic License v2
+                            machine_learning_job_id:
+                              - packetbeat_dns_tunneling
+                            max_signals: 100
+                            name: 'DNS Tunneling [Duplicate]'
+                            references:
+                              - >-
+                                https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html
+                            related_integrations: []
+                            required_fields: []
+                            risk_score: 21
+                            risk_score_mapping: []
+                            rule_id: 7289bf08-4e91-4c70-bf01-e04c4c5d7756
+                            setup: ''
+                            severity: low
+                            severity_mapping: []
+                            tags:
+                              - Elastic
+                              - Network
+                              - Threat Detection
+                              - ML
+                            threat: []
+                            to: now
+                            type: machine_learning
+                            updated_at: '2022-02-21T17:05:50.883Z'
+                            updated_by: elastic
+                            version: 6
+                      summary:
+                        failed: 0
+                        skipped: 1
+                        succeeded: 1
+                        total: 2
+                    rules_count: 1
+                    success: true
+                example2:
+                  description: >-
+                    If processing of any rule fails, a partial error outputs the
+                    ID and/or name of the affected rule and the corresponding
+                    error, as well as successfully processed rules (in the same
+                    format as a successful 200 request).
+                  summary: Partial failure
+                  value:
+                    value:
+                      attributes:
+                        errors:
+                          - message: >-
+                              Index patterns can't be added. Machine learning
+                              rule doesn't have index patterns property
+                            rules:
+                              - id: 8bc7dad0-9320-11ec-9265-8b772383a08d
+                                name: 'DNS Tunneling [Duplicate]'
+                            status_code: 500
+                        results:
+                          created: []
+                          deleted: []
+                          skipped: []
+                          updated:
+                            - actions: []
+                              author:
+                                - Elastic
+                              created_at: '2022-02-21T14:14:17.883Z'
+                              created_by: elastic
+                              description: >-
+                                Generates a detection alert for each external
+                                alert written to the configured indices.
+                                Enabling this rule allows you to immediately
+                                begin investigating external alerts in the app.
+                              enabled: true
+                              exceptions_list: []
+                              execution_summary:
+                                last_execution:
+                                  date: '2022-03-23T16:06:12.787Z'
+                                  message: >-
+                                    This rule attempted to query data from
+                                    Elasticsearch indices listed in the "Index
+                                    pattern" section of the rule definition, but
+                                    no matching index was found.
+                                  metrics:
+                                    execution_gap_duration_s: 0
+                                    total_indexing_duration_ms: 15
+                                    total_search_duration_ms: 135
+                                  status: partial failure
+                                  status_order: 20
+                              false_positives: []
+                              from: now-6m
+                              id: 8e5c1a40-9320-11ec-9265-8b772383a08d
+                              immutable: false
+                              index:
+                                - apm-*-transaction*
+                                - traces-apm*
+                                - auditbeat-*
+                                - filebeat-*
+                                - logs-*
+                                - packetbeat-*
+                                - winlogbeat-*
+                                - added-by-id-*
+                              interval: 5m
+                              language: kuery
+                              license: Elastic License v2
+                              max_signals: 10000
+                              name: 'External Alerts [Duplicate]'
+                              query: >
+                                event.kind:alert and not event.module:(endgame
+                                or endpoint)
+                              references: []
+                              related_integrations: []
+                              required_fields: []
+                              risk_score: 47
+                              risk_score_mapping:
+                                - field: event.risk_score
+                                  operator: equals
+                                  value: ''
+                              rule_id: 941faf98-0cdc-4569-b16d-4af962914d61
+                              rule_name_override: message
+                              setup: ''
+                              severity: medium
+                              severity_mapping:
+                                - field: event.severity
+                                  operator: equals
+                                  severity: low
+                                  value: '21'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: medium
+                                  value: '47'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: high
+                                  value: '73'
+                                - field: event.severity
+                                  operator: equals
+                                  severity: critical
+                                  value: '99'
+                              tags:
+                                - Elastic
+                                - Network
+                                - Windows
+                                - APM
+                                - macOS
+                                - Linux
+                              threat: []
+                              timestamp_override: event.ingested
+                              to: now
+                              type: query
+                              updated_at: '2022-02-21T16:56:22.818Z'
+                              updated_by: elastic
+                              version: 5
+                        summary:
+                          failed: 1
+                          skipped: 0
+                          succeeded: 1
+                          total: 2
+                      message: Bulk edit partially failed
+                      rules_count: 2
+                      status_code: 500
+                      success: false
+                example3:
+                  description: >-
+                    The attributes.errors section of the response shows that two
+                    rules failed to update and one succeeded. The same results
+                    would be returned if you ran the request without dry run
+                    mode enabled. Notice that there are no arrays in
+                    attributes.results. In dry run mode, rule updates are not
+                    applied and saved to Elasticsearch, so the endpoint wouldn’t
+                    return results for rules that have been updated, created, or
+                    deleted.
+                  summary: Dry run
+                  value:
+                    attributes:
+                      errors:
+                        - err_code: IMMUTABLE
+                          message: Elastic rule can't be edited
+                          rules:
+                            - id: 81aa0480-06af-11ed-94fb-dd1a0597d8d2
+                              name: Unusual AWS Command for a User
+                          status_code: 500
+                        - err_code: MACHINE_LEARNING_INDEX_PATTERN
+                          message: Machine learning rule doesn't have index patterns
+                          rules:
+                            - id: dc015d10-0831-11ed-ac8b-05a222bd8d4a
+                              name: 'Suspicious Powershell Script [Duplicate]'
+                          status_code: 500
+                      results:
+                        created: []
+                        deleted: []
+                        skipped: []
+                        updated: []
+                      summary:
+                        failed: 2
+                        skipped: 0
+                        succeeded: 1
+                        total: 3
+                    message: Bulk edit partially failed
+                    status_code: 500
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/BulkEditActionResponse'
@@ -233,7 +1867,27 @@ paths:
 
         > info
 
-        > You cannot export prebuilt rules.
+        > Rule actions and connectors are included in the exported file, but
+        sensitive information about the connector (such as authentication
+        credentials) is not included. You must re-add missing connector details
+        after importing detection rules.
+
+
+        > You can use Kibana’s [Saved
+        Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html)
+        UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs
+        (experimental) to
+        [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault)
+        and
+        [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault)
+        any necessary connectors before importing detection rules.
+
+
+        > Similarly, any value lists used for rule exceptions are not included
+        in rule exports or imports. Use the [Manage value
+        lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists)
+        UI (Rules → Detection rules (SIEM) → Manage value lists) to export and
+        import value lists separately.
       operationId: ExportRules
       parameters:
         - description: Determines whether a summary of the exported rules is returned.
@@ -243,7 +1897,13 @@ paths:
           schema:
             default: false
             type: boolean
-        - description: File name for saving the exported rules.
+        - description: >
+            File name for saving the exported rules.
+
+            > info
+
+            > When using cURL to export rules to a file, use the -O and -J
+            options to save the rules to the file name specified in the URL.
           in: query
           name: file_name
           required: false
@@ -277,7 +1937,13 @@ paths:
           content:
             application/ndjson:
               schema:
-                description: An `.ndjson` file containing the returned rules.
+                description: >
+                  An `.ndjson` file containing the returned rules.
+
+
+                  Each line in the file represents an object (a rule, exception
+                  list parent container, or exception list item), and the last
+                  line includes a summary of what was exported.
                 format: binary
                 type: string
           description: Indicates a successful call.
@@ -285,6 +1951,23 @@ paths:
       tags:
         - Security Detections API
         - Import/Export API
+      x-codeSamples:
+        - lang: cURL
+          source: >
+            curl -X POST
+            "localhost:5601/api/detection_engine/rules/_export?exclude_export_details=true&file_name=exported_rules.ndjson"
+            -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d'
+
+            {
+              "objects": [
+                {
+                  "rule_id":"343580b5-c811-447c-8d2d-2ccf052c6900"
+                },
+                {
+                  "rule_id":"2938c9fa-53eb-4c04-b79c-33cbf041b18d"
+                }
+              ]
+            }
   /api/detection_engine/rules/_find:
     get:
       description: >-
@@ -299,7 +1982,30 @@ paths:
             items:
               type: string
             type: array
-        - description: Search query
+        - description: >
+            Search query
+
+
+            Filters the returned results according to the value of the specified
+            field, using the alert.attributes.<field name>:<field value> syntax,
+            where <field name> can be:
+
+            - name
+
+            - enabled
+
+            - tags
+
+            - createdBy
+
+            - interval
+
+            - updatedBy
+
+            > info
+
+            > Even though the JSON rule object uses created_by and updated_by
+            fields, you must use createdBy and updatedBy fields in the filter.
           in: query
           name: filter
           required: false
@@ -349,6 +2055,84 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    data:
+                      - created_at: '2020-02-02T10:05:19.613Z'
+                        created_by: elastic
+                        description: >-
+                          Identifies a PowerShell process launched by either
+                          cscript.exe or wscript.exe. Observing Windows
+                          scripting processes executing a PowerShell script, may
+                          be indicative of malicious activity.
+                        enabled: false
+                        execution_summary:
+                          last_execution:
+                            date: '2022-03-23T16:06:12.787Z'
+                            message: >-
+                              This rule attempted to query data from
+                              Elasticsearch indices listed in the "Index
+                              pattern" section of the rule definition, but no
+                              matching index was found.
+                            metrics:
+                              execution_gap_duration_s: 0
+                              total_indexing_duration_ms: 15
+                              total_search_duration_ms: 135
+                            status: partial failure
+                            status_order: 20
+                        false_positives: []
+                        from: now-6m
+                        id: 89761517-fdb0-4223-b67b-7621acc48f9e
+                        immutable: true
+                        index:
+                          - winlogbeat-*
+                        interval: 5m
+                        language: kuery
+                        max_signals: 33
+                        name: Windows Script Executing PowerShell
+                        query: >-
+                          event.action:"Process Create (rule: ProcessCreate)"
+                          and process.parent.name:("wscript.exe" or
+                          "cscript.exe") and process.name:"powershell.exe"
+                        references: []
+                        related_integrations:
+                          - package: o365
+                            version: ^2.3.2
+                        required_fields:
+                          - ecs: true
+                            name: event.action
+                            type: keyword
+                          - ecs: true
+                            name: process.name
+                            type: keyword
+                          - ecs: true
+                            name: process.parent.name
+                            type: keyword
+                        risk_score: 21
+                        rule_id: f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc
+                        setup: ''
+                        severity: low
+                        tags:
+                          - Elastic
+                          - Windows
+                        threat:
+                          - framework: MITRE ATT&CK
+                            tactic:
+                              id: TA0002
+                              name: Execution
+                              reference: 'https://attack.mitre.org/tactics/TA0002/'
+                            technique:
+                              - id: T1193
+                                name: Spearphishing Attachment
+                                reference: 'https://attack.mitre.org/techniques/T1193/'
+                        to: now
+                        type: query
+                        updated_at: '2020-02-02T10:05:19.830Z'
+                        updated_by: elastic
+                    page: 1
+                    perPage: 5
+                    total: 4
               schema:
                 type: object
                 properties:
@@ -367,11 +2151,23 @@ paths:
                   - perPage
                   - total
                   - data
-          description: Successful response
+          description: >
+            Successful response
+
+            > info
+
+            > These fields are under development and their usage or schema may
+            change: execution_summary.
       summary: List all detection rules
       tags:
         - Security Detections API
         - Rules API
+      x-codeSamples:
+        - lang: cURL
+          source: >
+            curl -X GET
+            "localhost:5601/api/detection_engine/rules/_find?page=1&per_page=5&sort_field=enabled&sort_order=asc&filter=alert.attributes.name:windows"
+            -H 'kbn-xsrf: true'
   /api/detection_engine/rules/_import:
     post:
       description: >
@@ -381,6 +2177,54 @@ paths:
         - The `Content-Type: multipart/form-data` HTTP header.
 
         - A link to the `.ndjson` file containing the rules.
+
+        > warn
+
+        > When used with [API
+        key](https://www.elastic.co/guide/en/kibana/current/api-keys.html)
+        authentication, the user's key gets assigned to the affected rules. If
+        the user's key gets deleted or the user becomes inactive, the rules will
+        stop running.
+
+
+        > If the API key that is used for authorization has different privileges
+        than the key that created or most recently updated the rule, the rule
+        behavior might change.
+
+        > info
+
+        > To import rules with actions, you need at least Read privileges for
+        the Action and Connectors feature. To overwrite or add new connectors,
+        you need All privileges for the Actions and Connectors feature. To
+        import rules without actions, you don’t need Actions and Connectors
+        privileges. Refer to [Enable and access
+        detections](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui)
+        for more information.
+
+
+        > info
+
+        > Rule actions and connectors are included in the exported file, but
+        sensitive information about the connector (such as authentication
+        credentials) is not included. You must re-add missing connector details
+        after importing detection rules.
+
+
+        > You can use Kibana’s [Saved
+        Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html)
+        UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs
+        (experimental) to
+        [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault)
+        and
+        [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault)
+        any necessary connectors before importing detection rules.
+
+
+        > Similarly, any value lists used for rule exceptions are not included
+        in rule exports or imports. Use the [Manage value
+        lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists)
+        UI (Rules → Detection rules (SIEM) → Manage value lists) to export and
+        import value lists separately.
       operationId: ImportRules
       parameters:
         - description: >-
@@ -394,7 +2238,8 @@ paths:
             type: boolean
         - description: >-
             Determines whether existing exception lists with the same `list_id`
-            are overwritten.
+            are overwritten. Both the exception list container and its items are
+            overwritten.
           in: query
           name: overwrite_exceptions
           required: false
@@ -432,6 +2277,17 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  summary: Import rules with success
+                  value:
+                    errors: []
+                    exceptions_errors: []
+                    exceptions_success: true
+                    exceptions_success_count: 0
+                    rules_count: 1
+                    success: true
+                    success_count: 1
               schema:
                 additionalProperties: false
                 type: object
@@ -487,6 +2343,13 @@ paths:
       tags:
         - Security Detections API
         - Import/Export API
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST "<KibanaURL>/api/detection_engine/rules/_import"
+            -u <username>:<password> -H 'kbn-xsrf: true'
+            -H 'Content-Type: multipart/form-data'
+            --form "file=@<link to file>"
   /api/detection_engine/rules/preview:
     post:
       operationId: RulePreview
@@ -793,6 +2656,17 @@ paths:
         '200':
           content:
             application/json:
+              examples:
+                example1:
+                  value:
+                    - zeek
+                    - suricata
+                    - windows
+                    - linux
+                    - network
+                    - initial access
+                    - remote access
+                    - phishing
               schema:
                 $ref: '#/components/schemas/RuleTagArray'
           description: Indicates a successful call
@@ -850,6 +2724,7 @@ components:
         - in-progress
       type: string
     AlertSuppression:
+      description: Defines alert suppression configuration.
       type: object
       properties:
         duration:
@@ -872,6 +2747,7 @@ components:
         - value
         - unit
     AlertSuppressionDurationUnit:
+      description: Time unit
       enum:
         - s
         - m
@@ -902,15 +2778,21 @@ components:
         $ref: '#/components/schemas/AlertTag'
       type: array
     AnomalyThreshold:
-      description: Anomaly threshold
+      description: >-
+        Anomaly score threshold above which the rule creates an alert. Valid
+        values are from 0 to 100.
       minimum: 0
       type: integer
     BuildingBlockType:
-      description: >-
-        Determines if the rule acts as a building block. By default,
-        building-block alerts are not displayed in the UI. These rules are used
-        as a foundation for other rules that do generate alerts. Its value must
-        be default.
+      description: >
+        Determines if the rule acts as a building block. If yes, the value must
+        be `default`.
+
+        By default, building-block alerts are not displayed in the UI. These
+        rules are used as a foundation for other rules that do generate alerts.
+
+        For more information, refer to [About building block
+        rules](https://www.elastic.co/guide/en/security/current/building-block-rule.html).
       type: string
     BulkActionEditPayload:
       anyOf:
@@ -1064,13 +2946,15 @@ components:
             - delete
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -1082,13 +2966,15 @@ components:
             - disable
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -1100,6 +2986,7 @@ components:
             - duplicate
           type: string
         duplicate:
+          description: Duplicate object that describes applying an update action.
           type: object
           properties:
             include_exceptions:
@@ -1112,13 +2999,15 @@ components:
             - include_exceptions
             - include_expired_exceptions
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -1174,6 +3063,13 @@ components:
         - deleted
         - skipped
     BulkEditActionSummary:
+      description: >-
+        A rule can only be skipped when the bulk action to be performed on it
+        results in nothing being done. For example, if the `edit` action is used
+        to add a tag to a rule that already has that tag, or to delete an index
+        pattern that is not specified in a rule. Objects returned in
+        `attributes.results.skipped` will only include rules' `id`, `name`, and
+        `skip_reason`.
       type: object
       properties:
         failed:
@@ -1203,13 +3099,15 @@ components:
           minItems: 1
           type: array
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -1226,13 +3124,15 @@ components:
             - enable
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -1246,13 +3146,15 @@ components:
             - export
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
       required:
         - action
@@ -1264,15 +3166,18 @@ components:
             - run
           type: string
         ids:
-          description: Array of rule IDs
+          description: >-
+            Array of rule IDs. Array of rule IDs to which a bulk action will be
+            applied. Only valid when query property is undefined.
           items:
             type: string
           minItems: 1
           type: array
         query:
-          description: Query to filter rules
+          description: Query to filter rules.
           type: string
         run:
+          description: Object that describes applying a manual rule run action.
           type: object
           properties:
             end_date:
@@ -1314,6 +3219,9 @@ components:
               - items:
                   type: string
                 type: array
+      description: >-
+        Map Osquery results columns or static values to Elastic Common Schema
+        (ECS) fields. Example: "ecs_mapping": {"process.pid": {"field": "pid"}}
       type: object
     EndpointResponseAction:
       type: object
@@ -1358,7 +3266,6 @@ components:
           description: Query language to use
         query:
           $ref: '#/components/schemas/RuleQuery'
-          description: EQL query to execute
         type:
           description: Rule type
           enum:
@@ -1373,6 +3280,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -1421,6 +3331,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -1492,6 +3413,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -1540,6 +3464,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -1594,7 +3529,6 @@ components:
               description: Query language to use
             query:
               $ref: '#/components/schemas/RuleQuery'
-              description: EQL query to execute
             type:
               description: Rule type
               enum:
@@ -1606,6 +3540,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -1656,6 +3593,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -1705,6 +3653,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -1755,6 +3706,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -1836,6 +3798,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -1884,6 +3849,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -1955,6 +3931,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2003,6 +3982,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2058,6 +4048,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2107,12 +4100,22 @@ components:
               $ref: '#/components/schemas/AlertsIndex'
             query:
               $ref: '#/components/schemas/RuleQuery'
-              description: ESQL query to execute
             references:
               $ref: '#/components/schemas/RuleReferenceArray'
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2165,7 +4168,6 @@ components:
           $ref: '#/components/schemas/EsqlQueryLanguage'
         query:
           $ref: '#/components/schemas/RuleQuery'
-          description: ESQL query to execute
         type:
           description: Rule type
           enum:
@@ -2184,6 +4186,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2234,6 +4239,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2325,8 +4341,24 @@ components:
         - updatedAt
       type: string
     HistoryWindowStart:
-      $ref: '#/components/schemas/NonEmptyString'
+      description: >-
+        Start date to use when checking if a term has been seen before. Supports
+        relative dates – for example, now-30d will search the last 30 days of
+        data when checking if a term is new. We do not recommend using absolute
+        dates, which can cause issues with rule performance due to querying
+        increasing amounts of data over time.
+      format: nonempty
+      minLength: 1
+      type: string
     IndexPatternArray:
+      description: >
+        Indices on which the rule functions. Defaults to the Security Solution
+        indices defined on the Kibana Advanced Settings page (Kibana → Stack
+        Management → Advanced Settings → `securitySolution:defaultIndex`).
+
+        > info
+
+        > This field is not supported for ES|QL rules.
       items:
         type: string
       type: array
@@ -2349,28 +4381,6 @@ components:
 
         in various features in the UI such as alert details flyout and
         exceptions auto-population from alert.
-
-        Added in PR #163235
-
-        Right now we only have a single field but anticipate adding more related
-        fields to store various
-
-        configuration states such as `override` - where a user might say if they
-        want only these fields to
-
-        display, or if they want these fields + the fields we select. When
-        expanding this field, it may look
-
-        something like:
-
-        ```typescript
-
-        const investigationFields = z.object({
-          field_names: NonEmptyArray(NonEmptyString),
-          override: z.boolean().optional(),
-        });
-
-        ```
       type: object
       properties:
         field_names:
@@ -2390,7 +4400,7 @@ components:
         base value).
       type: boolean
     IsRuleEnabled:
-      description: Determines whether the rule is enabled.
+      description: Determines whether the rule is enabled. Defaults to true.
       type: boolean
     IsRuleImmutable:
       deprecated: true
@@ -2407,7 +4417,7 @@ components:
         - lucene
       type: string
     MachineLearningJobId:
-      description: Machine learning job ID
+      description: Machine learning job ID(s) the rule monitors for anomaly scores.
       oneOf:
         - type: string
         - items:
@@ -2419,6 +4429,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2467,6 +4480,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2538,6 +4562,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2586,6 +4613,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2655,6 +4693,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2705,6 +4746,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2770,6 +4822,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2820,6 +4875,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2866,9 +4932,26 @@ components:
             - severity
         - $ref: '#/components/schemas/MachineLearningRuleCreateFields'
     MaxSignals:
+      default: 100
+      description: >
+        Maximum number of alerts the rule can create during a single run (the
+        rule’s Max alerts per run [advanced
+        setting](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#rule-ui-advanced-params)
+        value).
+
+        > info
+
+        > This setting can be superseded by the [Kibana configuration
+        setting](https://www.elastic.co/guide/en/kibana/current/alert-action-settings-kb.html#alert-settings)
+        `xpack.alerting.rules.run.alerts.max`, which determines the maximum
+        alerts generated by any rule in the Kibana alerting framework. For
+        example, if `xpack.alerting.rules.run.alerts.max` is set to 1000, the
+        rule can generate no more than 1000 alerts even if `max_signals` is set
+        higher.
       minimum: 1
       type: integer
     NewTermsFields:
+      description: Fields to monitor for new values.
       items:
         type: string
       maxItems: 3
@@ -2879,6 +4962,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -2927,6 +5013,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -2999,6 +5096,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3047,6 +5147,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3130,6 +5241,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3180,6 +5294,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3254,6 +5379,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3304,6 +5432,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3394,16 +5533,31 @@ components:
         ecs_mapping:
           $ref: '#/components/schemas/EcsMapping'
         pack_id:
+          description: >-
+            To specify a query pack, use the packId field. Example: "packId":
+            "processes_elastic"
           type: string
         queries:
           items:
             $ref: '#/components/schemas/OsqueryQuery'
           type: array
         query:
+          description: >-
+            To run a single query, use the query field and enter a SQL query.
+            Example: "query": "SELECT * FROM processes;"
           type: string
         saved_query_id:
+          description: >-
+            To run a saved query, use the saved_query_id field and specify the
+            saved query ID. Example: "saved_query_id": "processes_elastic"
           type: string
         timeout:
+          description: >-
+            A timeout period, in seconds, after which the query will stop
+            running. Overwriting the default timeout allows you to support
+            queries that require more time to complete. The default and minimum
+            supported value is 60. The maximum supported value is 900. Example:
+            "timeout": 120.
           type: number
     OsqueryQuery:
       type: object
@@ -3457,11 +5611,18 @@ components:
       type: object
       properties:
         command:
+          description: >-
+            To run an endpoint response action, specify a value for the command
+            field. Example: "command": "isolate"
           enum:
             - kill-process
             - suspend-process
           type: string
         comment:
+          description: >-
+            Add a note that explains or describes the action. You can find your
+            comment in the response actions history log. Example: "comment":
+            "Check processes"
           type: string
         config:
           type: object
@@ -3483,6 +5644,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3531,6 +5695,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3603,6 +5778,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3651,6 +5829,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3732,6 +5921,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3782,6 +5974,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3850,6 +6053,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -3900,6 +6106,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -3986,23 +6203,10 @@ components:
         and `azure` that contain
 
         several integrations; in this case, `integration` should be specified.
-
-
-        @example
-
-        const x: RelatedIntegration = {
-          package: 'windows',
-          version: '1.5.x',
-        };
-
-
-        @example
-
-        const x: RelatedIntegration = {
-          package: 'azure',
-          version: '~1.1.6',
-          integration: 'activitylogs',
-        };
+      example:
+        integration: activitylogs
+        package: azure
+        version: ~1.1.6
       type: object
       properties:
         integration:
@@ -4056,14 +6260,21 @@ components:
       type: object
       properties:
         ecs:
-          description: Whether the field is an ECS field
+          description: >-
+            Indicates whether the field is ECS-compliant. This property is only
+            present in responses. Its value is computed based on field’s name
+            and type.
           type: boolean
         name:
-          $ref: '#/components/schemas/NonEmptyString'
           description: Name of an Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
         type:
-          $ref: '#/components/schemas/NonEmptyString'
           description: Type of the Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
       required:
         - name
         - type
@@ -4080,11 +6291,15 @@ components:
       type: object
       properties:
         name:
-          $ref: '#/components/schemas/NonEmptyString'
           description: Name of an Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
         type:
-          $ref: '#/components/schemas/NonEmptyString'
-          description: Type of an Elasticsearch field
+          description: Type of the Elasticsearch field
+          format: nonempty
+          minLength: 1
+          type: string
       required:
         - name
         - type
@@ -4132,7 +6347,12 @@ components:
         - related_integrations
         - required_fields
     RiskScore:
-      description: Risk score (0 to 100)
+      description: |
+        A numerical representation of the alert's severity from 0 to 100, where:
+        * `0` - `21` represents low severity
+        * `22` - `47` represents medium severity
+        * `48` - `73` represents high severity
+        * `74` - `100` represents critical severity
       maximum: 100
       minimum: 0
       type: integer
@@ -4144,6 +6364,7 @@ components:
         type: object
         properties:
           field:
+            description: Source event field used to override the default `risk_score`.
             type: string
           operator:
             enum:
@@ -4162,7 +6383,26 @@ components:
       type: object
       properties:
         action_type_id:
-          description: The action type used for sending notifications.
+          description: |
+            The action type used for sending notifications, can be:
+
+              - `.slack`
+              - `.slack_api`
+              - `.email`
+              - `.index`
+              - `.pagerduty`
+              - `.swimlane`
+              - `.webhook`
+              - `.servicenow`
+              - `.servicenow-itom`
+              - `.servicenow-sir`
+              - `.jira`
+              - `.resilient`
+              - `.opsgenie`
+              - `.teams`
+              - `.torq`
+              - `.tines`
+              - `.d3security`
           type: string
         alerts_filter:
           $ref: '#/components/schemas/RuleActionAlertsFilter'
@@ -4182,6 +6422,22 @@ components:
         - params
     RuleActionAlertsFilter:
       additionalProperties: true
+      description: >
+        Object containing an action’s conditional filters.
+
+
+        - `timeframe` (object, optional): Object containing the time frame for
+        when this action can be run.
+            - `days` (array of integers, required): List of days of the week on which this action will be run. Days of the week are expressed as numbers between `1-7`, where `1` is Monday and `7` is Sunday. To select all days of the week, enter an empty array.
+            - `hours` (object, required): The hours of the day during which this action will run. Hours of the day are expressed as two strings in the format `hh:mm` in `24` hour time. A start of `00:00` and an end of `24:00` means the action can run all day.
+                - start (string, required): Start time in `hh:mm` format.
+                - end (string, required): End time in `hh:mm` format.
+            - `timezone` (string, required): An ISO timezone name, such as `Europe/Madrid` or `America/New_York`. Specific offsets such as `UTC` or `UTC+1` will also work, but lack built-in DST.
+        - `query` (object, optional): Object containing a query filter which
+        gets applied to an action and determines whether the action should run.
+            - `kql` (string, required): A KQL string.
+            - `filters` (array of objects, required): Array of filter objects, as defined in the `kbn-es-query` package.
+              
       type: object
     RuleActionFrequency:
       description: >-
@@ -4212,9 +6468,7 @@ components:
       description: The connector ID.
       type: string
     RuleActionNotifyWhen:
-      description: >-
-        The condition for throttling the notification: `onActionGroupChange`,
-        `onActiveAlert`,  or `onThrottleInterval`
+      description: Defines how often rules run actions.
       enum:
         - onActiveAlert
         - onThrottleInterval
@@ -4222,9 +6476,36 @@ components:
       type: string
     RuleActionParams:
       additionalProperties: true
-      description: >-
+      description: >
         Object containing the allowed connector fields, which varies according
         to the connector type.
+
+
+        For Slack:
+
+          - `message` (string, required): The notification message.
+
+        For email:
+
+          - `to`, `cc`, `bcc` (string): Email addresses to which the notifications are sent. At least one field must have a value.
+          - `subject` (string, optional): Email subject line.
+          - `message` (string, required): Email body text.
+
+        For Webhook:
+
+          - `body` (string, required): JSON payload.
+
+        For PagerDuty:
+
+          - `severity` (string, required): Severity of on the alert notification, can be: `Critical`, `Error`, `Warning` or `Info`.
+          - `eventAction` (string, required): Event [action type](https://v2.developer.pagerduty.com/docs/events-api-v2#event-action), which can be `trigger`, `resolve`, or `acknowledge`.
+          - `dedupKey` (string, optional): Groups alert notifications with the same PagerDuty alert.
+          - `timestamp` (DateTime, optional): ISO-8601 format [timestamp](https://v2.developer.pagerduty.com/docs/types#datetime).
+          - `component` (string, optional): Source machine component responsible for the event, for example `security-solution`.
+          - `group` (string, optional): Enables logical grouping of service components.
+          - `source` (string, optional): The affected system. Defaults to the Kibana saved object ID of the action.
+          - `summary` (string, options): Summary of the event. Defaults to `No summary provided`. Maximum length is 1024 characters.
+          - `class` (string, optional): Value indicating the class/type of the event.
       type: object
     RuleActionThrottle:
       description: Defines how often rule actions are taken.
@@ -4238,6 +6519,7 @@ components:
           pattern: '^[1-9]\d*[smhd]$'
           type: string
     RuleAuthorArray:
+      description: The rule’s author.
       items:
         type: string
       type: array
@@ -4254,6 +6536,8 @@ components:
       discriminator:
         propertyName: type
     RuleDescription:
+      description: The rule’s description.
+      example: Detects anomalous Windows process creation events.
       minLength: 1
       type: string
     RuleDetailsInError:
@@ -4266,14 +6550,23 @@ components:
       required:
         - id
     RuleExceptionList:
+      description: >
+        Array of [exception
+        containers](https://www.elastic.co/guide/en/security/current/exceptions-api-overview.html),
+        which define exceptions that prevent the rule from generating alerts
+        even when its other criteria are met.
       type: object
       properties:
         id:
-          $ref: '#/components/schemas/NonEmptyString'
           description: ID of the exception container
+          format: nonempty
+          minLength: 1
+          type: string
         list_id:
-          $ref: '#/components/schemas/NonEmptyString'
           description: List ID of the exception container
+          format: nonempty
+          minLength: 1
+          type: string
         namespace_type:
           description: Determines the exceptions validity in rule's Kibana space
           enum:
@@ -4362,6 +6655,10 @@ components:
     RuleExecutionStatusOrder:
       type: integer
     RuleExecutionSummary:
+      description: |
+        Summary of the last execution of a rule.
+        > info
+        > This field is under development and its usage or schema may change
       type: object
       properties:
         last_execution:
@@ -4389,10 +6686,20 @@ components:
       required:
         - last_execution
     RuleFalsePositiveArray:
+      description: >-
+        String array used to describe common reasons why the rule may issue
+        false-positive alerts. Defaults to an empty array.
       items:
         type: string
       type: array
     RuleFilterArray:
+      description: >
+        The query and filter context array used to define the conditions for
+        when alerts are created from events. Defaults to an empty array.
+
+        > info
+
+        > This field is not supported for ES|QL rules.
       items: {}
       type: array
     RuleInterval:
@@ -4415,15 +6722,34 @@ components:
       type: string
     RuleMetadata:
       additionalProperties: true
+      description: >
+        Placeholder for metadata about the rule.
+
+        > info
+
+        > This field is overwritten when you save changes to the rule’s
+        settings.
       type: object
     RuleName:
+      description: A human-readable name for the rule.
+      example: Anomalous Windows Process Creation
       minLength: 1
       type: string
     RuleNameOverride:
-      description: Sets the source field for the alert's signal.rule.name value
+      description: >-
+        Sets which field in the source event is used to populate the alert's
+        `signal.rule.name` value (in the UI, this value is displayed on the
+        Rules page in the Rule column). When unspecified, the rule’s `name`
+        value is used. The source field must be a string data type.
       type: string
     RuleObjectId:
       $ref: '#/components/schemas/UUID'
+      description: >-
+        A dynamic unique identifier for the rule object. It is randomly
+        generated when a rule is created and cannot be changed after that. It is
+        always a UUID. It is unique within a given Kibana space. The same
+        prebuilt Elastic rule, when installed in two different Kibana spaces or
+        two different Elastic environments, will have different object `id`s.
     RulePatchProps:
       anyOf:
         - $ref: '#/components/schemas/EqlRulePatchProps'
@@ -4481,8 +6807,22 @@ components:
         - invocationCount
         - timeframeEnd
     RuleQuery:
+      description: >
+        [Query](https://www.elastic.co/guide/en/kibana/8.17/search.html) used by
+        the rule to create alerts.
+
+
+        - For indicator match rules, only the query’s results are used to
+        determine whether an alert is generated.
+
+        - ES|QL rules have additional query requirements. Refer to [Create
+        ES|QL](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-esql-rule)
+        rules for more information.
       type: string
     RuleReferenceArray:
+      description: >-
+        Array containing notes about or references to relevant information about
+        the rule. Defaults to an empty array.
       items:
         type: string
       type: array
@@ -4518,7 +6858,13 @@ components:
       minimum: 0
       type: integer
     RuleSignatureId:
-      description: 'Could be any string, not necessarily a UUID'
+      description: >-
+        A stable unique identifier for the rule object. It can be assigned
+        during rule creation. It can be any string, but often is a UUID. It
+        should be unique not only within a given Kibana space, but also across
+        spaces and Elastic environments. The same prebuilt Elastic rule, when
+        installed in two different Kibana spaces or two different Elastic
+        environments, will have the same `rule_id`s.
       type: string
     RuleSource:
       description: >-
@@ -4581,12 +6927,19 @@ components:
         - conflict
       type: string
     SavedQueryId:
+      description: >-
+        Kibana [saved
+        search](https://www.elastic.co/guide/en/kibana/current/save-open-search.html)
+        used by the rule to create alerts.
       type: string
     SavedQueryRule:
       allOf:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4635,6 +6988,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4707,6 +7071,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4755,6 +7122,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4836,6 +7214,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -4886,6 +7267,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -4954,6 +7346,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5004,6 +7399,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -5090,9 +7496,25 @@ components:
         - tags_to_add
         - tags_to_remove
     SetupGuide:
+      description: >-
+        Populates the rule’s setup guide with instructions on rule prerequisites
+        such as required integrations, configuration steps, and anything else
+        needed for the rule to work correctly.
       type: string
     Severity:
-      description: Severity of the rule
+      description: >
+        Severity level of alerts produced by the rule, which must be one of the
+        following:
+
+        * `low`: Alerts that are of interest but generally not considered to be
+        security incidents
+
+        * `medium`: Alerts that require investigation
+
+        * `high`: Alerts that require immediate investigation
+
+        * `critical`: Alerts that indicate it is highly likely a security
+        incident has occurred
       enum:
         - low
         - medium
@@ -5105,6 +7527,7 @@ components:
         type: object
         properties:
           field:
+            description: Source event field used to override the default `severity`.
             type: string
           operator:
             enum:
@@ -5136,6 +7559,11 @@ components:
         - desc
       type: string
     Threat:
+      description: >
+        > info
+
+        > Currently, only threats described using the MITRE ATT&CK&trade;
+        framework are supported.
       type: object
       properties:
         framework:
@@ -5162,6 +7590,7 @@ components:
           Elasticsearch index containing the threat values
       type: array
     ThreatIndex:
+      description: Elasticsearch indices used to check which field values generate alerts.
       items:
         type: string
       type: array
@@ -5171,6 +7600,23 @@ components:
         (optional)
       type: string
     ThreatMapping:
+      description: >
+        Array of entries objects that define mappings between the source event
+        fields and the values in the Elasticsearch threat index. Each entries
+        object must contain these fields:
+
+
+        - field: field from the event indices on which the rule runs
+
+        - type: must be mapping
+
+        - value: field from the Elasticsearch threat index
+          
+        You can use Boolean and and or logic to define the conditions for when
+        matching fields and values generate alerts. Sibling entries objects are
+        evaluated using or logic, whereas multiple entries in a single entries
+        object use and logic. See Example of Threat Match rule which uses both
+        `and` and `or` logic.
       items:
         type: object
         properties:
@@ -5200,6 +7646,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5248,6 +7697,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -5320,6 +7780,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5368,6 +7831,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -5465,6 +7939,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5515,6 +7992,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -5592,6 +8080,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5642,6 +8133,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -5688,7 +8190,9 @@ components:
             - severity
         - $ref: '#/components/schemas/ThreatMatchRuleCreateFields'
     ThreatQuery:
-      description: Query to run
+      description: >-
+        Query used to determine which fields in the Elasticsearch index are used
+        for generating alerts.
       type: string
     ThreatSubtechnique:
       type: object
@@ -5707,6 +8211,8 @@ components:
         - name
         - reference
     ThreatTactic:
+      description: |
+        Object containing information on the attack type
       type: object
       properties:
         id:
@@ -5735,7 +8241,8 @@ components:
           description: Technique reference
           type: string
         subtechnique:
-          description: Array containing more specific information on the attack technique
+          description: |
+            Array containing more specific information on the attack technique.
           items:
             $ref: '#/components/schemas/ThreatSubtechnique'
           type: array
@@ -5756,6 +8263,7 @@ components:
         - field
         - value
     ThresholdAlertSuppression:
+      description: Defines alert suppression configuration.
       type: object
       properties:
         duration:
@@ -5763,12 +8271,17 @@ components:
       required:
         - duration
     ThresholdCardinality:
+      description: The field on which the cardinality is applied.
       items:
         type: object
         properties:
           field:
+            description: The field on which to calculate and compare the cardinality.
             type: string
           value:
+            description: >-
+              The threshold value from which an alert is generated based on
+              unique number of values of cardinality.field.
             minimum: 0
             type: integer
         required:
@@ -5776,7 +8289,10 @@ components:
           - value
       type: array
     ThresholdField:
-      description: Field to aggregate on
+      description: >-
+        The field on which the threshold is applied. If you specify an empty
+        array ([]), alerts are generated when the query returns at least the
+        number of results specified in the value field.
       oneOf:
         - type: string
         - items:
@@ -5787,6 +8303,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5835,6 +8354,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -5907,6 +8437,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -5955,6 +8488,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -6038,6 +8582,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -6088,6 +8635,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -6159,6 +8717,9 @@ components:
         - type: object
           properties:
             actions:
+              description: >-
+                Array defining the automated actions (notifications) taken when
+                alerts are generated.
               items:
                 $ref: '#/components/schemas/RuleAction'
               type: array
@@ -6209,6 +8770,17 @@ components:
             related_integrations:
               $ref: '#/components/schemas/RelatedIntegrationArray'
             required_fields:
+              description: >
+                Elasticsearch fields and their types that need to be present for
+                the rule to function.
+
+                > info
+
+                > The value of `required_fields` does not affect the rule’s
+                behavior, and specifying it incorrectly won’t cause the rule to
+                fail. Use `required_fields` as an informational property to
+                document the fields that the rule expects to be present in the
+                data.
               items:
                 $ref: '#/components/schemas/RequiredFieldInput'
               type: array
@@ -6255,13 +8827,23 @@ components:
             - severity
         - $ref: '#/components/schemas/ThresholdRuleCreateFields'
     ThresholdValue:
-      description: Threshold value
+      description: The threshold value from which an alert is generated.
       minimum: 1
       type: integer
     ThrottleForBulkActions:
-      description: >-
-        The condition for throttling the notification: 'rule', 'no_actions', or
-        time duration
+      description: >
+        Defines the maximum interval in which a rule’s actions are executed.
+
+        > info
+
+        > The rule level `throttle` field is deprecated in Elastic Security 8.8
+        and will remain active for at least the next 12 months.
+
+        > In Elastic Security 8.8 and later, you can use the `frequency` field
+        to define frequencies for individual actions. Actions without
+        frequencies will acquire a converted version of the rule’s `throttle`
+        field. In the response, the converted `throttle` setting appears in the
+        individual actions' `frequency` field.
       enum:
         - rule
         - 1h
@@ -6278,10 +8860,17 @@ components:
       description: Timeline template title
       type: string
     TimestampField:
-      description: Contains the event timestamp used for sorting a sequence of events
+      description: >-
+        Specifies the name of the event timestamp field used for sorting a
+        sequence of events. Not to be confused with `timestamp_override`, which
+        specifies the more general field used for querying events within a
+        range. Defaults to the @timestamp ECS field.
       type: string
     TimestampOverride:
-      description: Sets the time field used to query indices
+      description: >-
+        Sets the time field used to query indices. When unspecified, rules query
+        the `@timestamp` field. The source field must be an Elasticsearch date
+        data type.
       type: string
     TimestampOverrideFallbackDisabled:
       description: Disables the fallback to the event's @timestamp field
@@ -6319,6 +8908,22 @@ tags:
       **Alerts** page and can be assigned and triaged, using the alert status to
       mark them as open, closed, or acknowledged.
 
+
+      This API supports both key-based authentication and basic authentication.
+
+
+      To use key-based authentication, create an API key, then specify the key
+      in the header of your API calls.
+
+
+      To use basic authentication, provide a username and password; this
+      automatically creates an API key that matches the current user’s
+      privileges.
+
+
+      In both cases, the API key is subsequently used for authorization when the
+      rule runs.
+
       > warn
 
       > If the API key used for authorization has different privileges than the
@@ -6328,5 +8933,11 @@ tags:
 
       > If the API key that created a rule is deleted, or the user that created
       the rule becomes inactive, the rule will stop running.
+
+
+      To create and run rules, the user must meet specific requirements for the
+      Kibana space. Refer to the [Detections
+      requirements](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html)
+      for a complete list of requirements.
     name: Security Detections API
     x-displayName: Security detections

--- a/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_detections_info/detections_ess.info.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_detections_info/detections_ess.info.yaml
@@ -1,14 +1,24 @@
 openapi: 3.0.3
 info:
-  title: "Security Detections API (Elastic Cloud and self-hosted)"
-  description: "Use the detections APIs to create and manage detection rules. Detection rules search events and external alerts sent to Elastic Security and generate detection alerts from any hits. Alerts are displayed on the **Alerts** page and can be assigned and triaged, using the alert status to mark them as open, closed, or acknowledged."
+  title: 'Security Detections API (Elastic Cloud and self-hosted)'
+  description: 'Use the detections APIs to create and manage detection rules. Detection rules search events and external alerts sent to Elastic Security and generate detection alerts from any hits. Alerts are displayed on the **Alerts** page and can be assigned and triaged, using the alert status to mark them as open, closed, or acknowledged.'
 
 tags:
-  - name: "Security Detections API"
-    x-displayName: "Security detections"
+  - name: 'Security Detections API'
+    x-displayName: 'Security detections'
     description: |
       Use the detections APIs to create and manage detection rules. Detection rules search events and external alerts sent to Elastic Security and generate detection alerts from any hits. Alerts are displayed on the **Alerts** page and can be assigned and triaged, using the alert status to mark them as open, closed, or acknowledged.
+
+      This API supports both key-based authentication and basic authentication.
+
+      To use key-based authentication, create an API key, then specify the key in the header of your API calls.
+
+      To use basic authentication, provide a username and password; this automatically creates an API key that matches the current user’s privileges.
+
+      In both cases, the API key is subsequently used for authorization when the rule runs.
       > warn
       > If the API key used for authorization has different privileges than the key that created or most recently updated a rule, the rule behavior might change.
 
       > If the API key that created a rule is deleted, or the user that created the rule becomes inactive, the rule will stop running.
+
+      To create and run rules, the user must meet specific requirements for the Kibana space. Refer to the [Detections requirements](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html) for a complete list of requirements.

--- a/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_detections_info/detections_serverless.info.yaml
+++ b/x-pack/solutions/security/plugins/security_solution/scripts/openapi/bundle_detections_info/detections_serverless.info.yaml
@@ -1,14 +1,24 @@
 openapi: 3.0.3
 info:
-  title: "Security Detections API (Elastic Cloud Serverless)"
-  description: "Use the detections APIs to create and manage detection rules. Detection rules search events and external alerts sent to Elastic Security and generate detection alerts from any hits. Alerts are displayed on the **Alerts** page and can be assigned and triaged, using the alert status to mark them as open, closed, or acknowledged."
+  title: 'Security Detections API (Elastic Cloud Serverless)'
+  description: 'Use the detections APIs to create and manage detection rules. Detection rules search events and external alerts sent to Elastic Security and generate detection alerts from any hits. Alerts are displayed on the **Alerts** page and can be assigned and triaged, using the alert status to mark them as open, closed, or acknowledged.'
 
 tags:
-  - name: "Security Detections API"
-    x-displayName: "Security detections"
+  - name: 'Security Detections API'
+    x-displayName: 'Security detections'
     description: |
       Use the detections APIs to create and manage detection rules. Detection rules search events and external alerts sent to Elastic Security and generate detection alerts from any hits. Alerts are displayed on the **Alerts** page and can be assigned and triaged, using the alert status to mark them as open, closed, or acknowledged.
+
+      This API supports both key-based authentication and basic authentication.
+
+      To use key-based authentication, create an API key, then specify the key in the header of your API calls.
+
+      To use basic authentication, provide a username and password; this automatically creates an API key that matches the current user’s privileges.
+
+      In both cases, the API key is subsequently used for authorization when the rule runs.
       > warn
       > If the API key used for authorization has different privileges than the key that created or most recently updated a rule, the rule behavior might change.
 
       > If the API key that created a rule is deleted, or the user that created the rule becomes inactive, the rule will stop running.
+
+      To create and run rules, the user must meet specific requirements for the Kibana space. Refer to the [Detections requirements](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html) for a complete list of requirements.

--- a/x-pack/test/api_integration/services/security_solution_api.gen.ts
+++ b/x-pack/test/api_integration/services/security_solution_api.gen.ts
@@ -411,8 +411,62 @@ If a record already exists for the specified entity, that record is overwritten 
         .send(props.body as object);
     },
     /**
-     * Create a new detection rule.
-     */
+      * Create a new detection rule.
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
+You can create the following types of rules:
+
+* **Custom query**: Searches the defined indices and creates an alert when a document matches the rule's KQL query.
+* **Event correlation**: Searches the defined indices and creates an alert when results match an [Event Query Language (EQL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html) query.
+* **Threshold**: Searches the defined indices and creates an alert when the number of times the specified field's value meets the threshold during a single execution. When there are multiple values that meet the threshold, an alert is generated for each value.
+  For example, if the threshold `field` is `source.ip` and its `value` is `10`, an alert is generated for every source IP address that appears in at least 10 of the rule's search results. If you're interested, see [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) for more information.
+* **Indicator match**: Creates an alert when fields match values defined in the specified [Elasticsearch index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html). For example, you can create an index for IP addresses and use this index to create an alert whenever an event's `destination.ip` equals a value in the index. The index's field mappings should be [ECS-compliant](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html).
+* **New terms**: Generates an alert for each new term detected in source documents within a specified time range.
+* **ES|QL**: Uses [Elasticsearch Query Language (ES|QL)](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html) to find events and aggregate search results.
+* **Machine learning rules**: Creates an alert when a machine learning job discovers an anomaly above the defined threshold.
+> info
+> To create machine learning rules, you must have the [appropriate license](https://www.elastic.co/subscriptions) or use a [cloud deployment](https://cloud.elastic.co/registration). Additionally, for the machine learning rule to function correctly, the associated machine learning job must be running.
+
+To retrieve machine learning job IDs, which are required to create machine learning jobs, call the [Elasticsearch Get jobs API](https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html). Machine learning jobs that contain `siem` in the `groups` field can be used to create rules:
+
+```json
+...
+"job_id": "linux_anomalous_network_activity_ecs",
+"job_type": "anomaly_detector",
+"job_version": "7.7.0",
+"groups": [
+  "auditbeat",
+  "process",
+  "siem"
+],
+...
+```
+
+Additionally, you can set up notifications for when rules create alerts. The notifications use the [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html). Each action type requires a connector. Connectors store the information required to send notifications via external systems. The following connector types are supported for rule notifications:
+
+* Slack
+* Email
+* PagerDuty
+* Webhook
+* Microsoft Teams
+* IBM Resilient
+* Jira
+* ServiceNow ITSM
+> info
+> For more information on PagerDuty fields, see [Send a v2 Event](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/).
+
+To retrieve connector IDs, which are required to configure rule notifications, call the [Find objects API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-find.html) with `"type": "action"` in the request payload.
+
+For detailed information on Kibana actions and alerting, and additional API calls, see:
+
+* [Alerting API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-alerting)
+* [Alerting and Actions framework](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html)
+* [Connectors API](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-connectors)
+
+      */
     createRule(props: CreateRuleProps, kibanaSpace: string = 'default') {
       return supertest
         .post(routeWithNamespace('/api/detection_engine/rules', kibanaSpace))
@@ -513,8 +567,16 @@ If a record already exists for the specified entity, that record is overwritten 
         .send(props.body as object);
     },
     /**
-     * Delete a detection rule using the `rule_id` or `id` field.
-     */
+      * Delete a detection rule using the `rule_id` or `id` field.
+
+The URL query must include one of the following:
+
+* `id` - `DELETE /api/detection_engine/rules?id=<id>`
+* `rule_id`- `DELETE /api/detection_engine/rules?rule_id=<rule_id>`
+
+The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+
+      */
     deleteRule(props: DeleteRuleProps, kibanaSpace: string = 'default') {
       return supertest
         .delete(routeWithNamespace('/api/detection_engine/rules', kibanaSpace))
@@ -795,7 +857,11 @@ If a record already exists for the specified entity, that record is overwritten 
 - Actions
 - Exception lists
 > info
-> You cannot export prebuilt rules.
+> Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+> You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+> Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
 
       */
     exportRules(props: ExportRulesProps, kibanaSpace: string = 'default') {
@@ -1195,6 +1261,19 @@ finalize it.
       * Import detection rules from an `.ndjson` file, including actions and exception lists. The request must include:
 - The `Content-Type: multipart/form-data` HTTP header.
 - A link to the `.ndjson` file containing the rules.
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+> info
+> To import rules with actions, you need at least Read privileges for the Action and Connectors feature. To overwrite or add new connectors, you need All privileges for the Actions and Connectors feature. To import rules without actions, you don’t need Actions and Connectors privileges. Refer to [Enable and access detections](https://www.elastic.co/guide/en/security/current/detections-permissions-section.html#enable-detections-ui) for more information.
+
+> info
+> Rule actions and connectors are included in the exported file, but sensitive information about the connector (such as authentication credentials) is not included. You must re-add missing connector details after importing detection rules.
+
+> You can use Kibana’s [Saved Objects](https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html) UI (Stack Management → Kibana → Saved Objects) or the Saved Objects APIs (experimental) to [export](https://www.elastic.co/docs/api/doc/kibana/operation/operation-exportsavedobjectsdefault) and [import](https://www.elastic.co/docs/api/doc/kibana/operation/operation-importsavedobjectsdefault) any necessary connectors before importing detection rules.
+
+> Similarly, any value lists used for rule exceptions are not included in rule exports or imports. Use the [Manage value lists](https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html#manage-value-lists) UI (Rules → Detection rules (SIEM) → Manage value lists) to export and import value lists separately.
 
       */
     importRules(props: ImportRulesProps, kibanaSpace: string = 'default') {
@@ -1264,8 +1343,19 @@ finalize it.
         .send(props.body as object);
     },
     /**
-     * Install and update all Elastic prebuilt detection rules and Timelines.
-     */
+      * Install and update all Elastic prebuilt detection rules and Timelines.
+
+This endpoint allows you to install and update prebuilt detection rules and Timelines provided by Elastic. 
+When you call this endpoint, it will:
+- Install any new prebuilt detection rules that are not currently installed in your system.
+- Update any existing prebuilt detection rules that have been modified or improved by Elastic.
+- Install any new prebuilt Timelines that are not currently installed in your system.
+- Update any existing prebuilt Timelines that have been modified or improved by Elastic.
+
+This ensures that your detection engine is always up-to-date with the latest rules and Timelines, 
+providing you with the most current and effective threat detection capabilities.
+
+      */
     installPrebuiltRulesAndTimelines(kibanaSpace: string = 'default') {
       return supertest
         .put(routeWithNamespace('/api/detection_engine/rules/prepackaged', kibanaSpace))
@@ -1313,8 +1403,15 @@ finalize it.
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
     /**
-     * Update specific fields of an existing detection rule using the `rule_id` or `id` field.
-     */
+      * Update specific fields of an existing detection rule using the `rule_id` or `id` field.
+
+The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
+      */
     patchRule(props: PatchRuleProps, kibanaSpace: string = 'default') {
       return supertest
         .patch(routeWithNamespace('/api/detection_engine/rules', kibanaSpace))
@@ -1335,8 +1432,13 @@ finalize it.
         .send(props.body as object);
     },
     /**
-     * Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
-     */
+      * Apply a bulk action, such as bulk edit, duplicate, or delete, to multiple detection rules. The bulk action is applied to all rules that match the query or to the rules listed by their IDs.
+> warn
+> When used with  [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
+
+      */
     performRulesBulkAction(props: PerformRulesBulkActionProps, kibanaSpace: string = 'default') {
       return supertest
         .post(routeWithNamespace('/api/detection_engine/rules/_bulk_action', kibanaSpace))
@@ -1412,8 +1514,11 @@ finalize it.
         .query(props.query);
     },
     /**
-     * Retrieve the status of all Elastic prebuilt detection rules and Timelines.
-     */
+      * Retrieve the status of all Elastic prebuilt detection rules and Timelines. 
+
+This endpoint provides detailed information about the number of custom rules, installed prebuilt rules, available prebuilt rules that are not installed, outdated prebuilt rules, installed prebuilt timelines, available prebuilt timelines that are not installed, and outdated prebuilt timelines.
+
+      */
     readPrebuiltRulesAndTimelinesStatus(kibanaSpace: string = 'default') {
       return supertest
         .get(routeWithNamespace('/api/detection_engine/rules/prepackaged/_status', kibanaSpace))
@@ -1443,8 +1548,16 @@ detection engine rules.
         .set(X_ELASTIC_INTERNAL_ORIGIN_REQUEST, 'kibana');
     },
     /**
-     * Retrieve a detection rule using the `rule_id` or `id` field.
-     */
+      * Retrieve a detection rule using the `rule_id` or `id` field.
+
+The URL query must include one of the following:
+
+* `id` - `GET /api/detection_engine/rules?id=<id>`
+* `rule_id` - `GET /api/detection_engine/rules?rule_id=<rule_id>`
+
+The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+
+      */
     readRule(props: ReadRuleProps, kibanaSpace: string = 'default') {
       return supertest
         .get(routeWithNamespace('/api/detection_engine/rules', kibanaSpace))
@@ -1640,8 +1753,12 @@ detection engine rules.
     },
     /**
       * Update a detection rule using the `rule_id` or `id` field. The original rule is replaced, and all unspecified fields are deleted.
-> info
-> You cannot modify the `id` or `rule_id` values.
+
+The difference between the `id` and `rule_id` is that the `id` is a unique rule identifier that is randomly generated when a rule is created and cannot be set, whereas `rule_id` is a stable rule identifier that can be assigned during rule creation.
+> warn
+> When used with [API key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) authentication, the user's key gets assigned to the affected rules. If the user's key gets deleted or the user becomes inactive, the rules will stop running.
+
+> If the API key that is used for authorization has different privileges than the key that created or most recently updated the rule, the rule behavior might change.
 
       */
     updateRule(props: UpdateRuleProps, kibanaSpace: string = 'default') {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security Solution] Migrate legacy Detections API docs to OpenAPI specs (#212367)](https://github.com/elastic/kibana/pull/212367)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jacek Kolezynski","email":"jacek.kolezynski@elastic.co"},"sourceCommit":{"committedDate":"2025-04-01T13:43:02Z","message":"[Security Solution] Migrate legacy Detections API docs to OpenAPI specs (#212367)\n\n**Partially resolves: #211808**\n\n## Summary\n\nThis is the first part of the migration effort, containing changes for:\n- CRUD endpoints\n- BULK Actions\n- Export / Import Rule\n- Find Rule\n- List Tags\n- Get Status\n- Install Rule\n\nI migrated the examples and the description of the fields. Some of the\nfields contained description that was very similar to the legacy, then I\ndidn't change it. I only modified the descriptions where it was\nvaluable.\n\nI also discovered some problems. For example the value for the 'query'\nfield, always shows 'EQL query to execute'. I reported this to the docs\nteam, in the 'next-api-reference' channel.\n\nAnother issue was with 'related_integrations field', which also didn't\nshow the long description. I also wrote about it to the docs team\n[here](https://elastic.slack.com/archives/C05UL5YC06B/p1740137094701209).\nIn this PR I decided to try moving the description one level up, where\nit renders properly.\n\n\n# Testing\n1. cd x-pack/solutions/security/plugins/security_solution\n2. yarn openapi:bundle:detections \n3. Take the bundled file\n(docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml)\nand load it into bump.sh console to see the changes.\n4. Compare the changes with the [Legacy\ndocumentation](https://www.elastic.co/guide/en/security/current/rule-api-overview.html)\n\nYou can also use this [link](https://bump.sh/jkelas/doc/kibana_wip/)\nwhere I deployed the generated bundled doc.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2b01257343335ad7ea5d40577c7e10deb94db19b","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","APIDocs","Team:Detection Rule Management","backport:version","8.18 candidate","v9.1.0","v8.19.0"],"title":"[Security Solution] Migrate legacy Detections API docs to OpenAPI specs","number":212367,"url":"https://github.com/elastic/kibana/pull/212367","mergeCommit":{"message":"[Security Solution] Migrate legacy Detections API docs to OpenAPI specs (#212367)\n\n**Partially resolves: #211808**\n\n## Summary\n\nThis is the first part of the migration effort, containing changes for:\n- CRUD endpoints\n- BULK Actions\n- Export / Import Rule\n- Find Rule\n- List Tags\n- Get Status\n- Install Rule\n\nI migrated the examples and the description of the fields. Some of the\nfields contained description that was very similar to the legacy, then I\ndidn't change it. I only modified the descriptions where it was\nvaluable.\n\nI also discovered some problems. For example the value for the 'query'\nfield, always shows 'EQL query to execute'. I reported this to the docs\nteam, in the 'next-api-reference' channel.\n\nAnother issue was with 'related_integrations field', which also didn't\nshow the long description. I also wrote about it to the docs team\n[here](https://elastic.slack.com/archives/C05UL5YC06B/p1740137094701209).\nIn this PR I decided to try moving the description one level up, where\nit renders properly.\n\n\n# Testing\n1. cd x-pack/solutions/security/plugins/security_solution\n2. yarn openapi:bundle:detections \n3. Take the bundled file\n(docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml)\nand load it into bump.sh console to see the changes.\n4. Compare the changes with the [Legacy\ndocumentation](https://www.elastic.co/guide/en/security/current/rule-api-overview.html)\n\nYou can also use this [link](https://bump.sh/jkelas/doc/kibana_wip/)\nwhere I deployed the generated bundled doc.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2b01257343335ad7ea5d40577c7e10deb94db19b"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212367","number":212367,"mergeCommit":{"message":"[Security Solution] Migrate legacy Detections API docs to OpenAPI specs (#212367)\n\n**Partially resolves: #211808**\n\n## Summary\n\nThis is the first part of the migration effort, containing changes for:\n- CRUD endpoints\n- BULK Actions\n- Export / Import Rule\n- Find Rule\n- List Tags\n- Get Status\n- Install Rule\n\nI migrated the examples and the description of the fields. Some of the\nfields contained description that was very similar to the legacy, then I\ndidn't change it. I only modified the descriptions where it was\nvaluable.\n\nI also discovered some problems. For example the value for the 'query'\nfield, always shows 'EQL query to execute'. I reported this to the docs\nteam, in the 'next-api-reference' channel.\n\nAnother issue was with 'related_integrations field', which also didn't\nshow the long description. I also wrote about it to the docs team\n[here](https://elastic.slack.com/archives/C05UL5YC06B/p1740137094701209).\nIn this PR I decided to try moving the description one level up, where\nit renders properly.\n\n\n# Testing\n1. cd x-pack/solutions/security/plugins/security_solution\n2. yarn openapi:bundle:detections \n3. Take the bundled file\n(docs/openapi/ess/security_solution_detections_api_2023_10_31.bundled.schema.yaml)\nand load it into bump.sh console to see the changes.\n4. Compare the changes with the [Legacy\ndocumentation](https://www.elastic.co/guide/en/security/current/rule-api-overview.html)\n\nYou can also use this [link](https://bump.sh/jkelas/doc/kibana_wip/)\nwhere I deployed the generated bundled doc.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"2b01257343335ad7ea5d40577c7e10deb94db19b"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->