### PR TITLE
[7.17] [Vega] Fix update vega spec in functional tests (#216620)

### DIFF
--- a/test/functional/apps/visualize/_vega_chart.ts
+++ b/test/functional/apps/visualize/_vega_chart.ts
@@ -85,7 +85,11 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         });
 
         it('should render different data in response to filter change', async function () {
-          await PageObjects.vegaChart.typeInSpec('"config": { "kibana": {"renderer": "svg"} },');
+          const { spec, isValid } = await PageObjects.vegaChart.getSpecAsJSON();
+          expect(isValid).to.be(true);
+          // add SVG renderer to read the Y axis labels
+          const updatedSpec = { ...spec, config: { kibana: { renderer: 'svg' } } };
+          await PageObjects.vegaChart.fillSpec(JSON.stringify(updatedSpec, null, 2));
           await PageObjects.visEditor.clickGo();
           await PageObjects.visChart.waitForVisualizationRenderingStabilized();
           const fullDataLabels = await PageObjects.vegaChart.getYAxisLabels();

--- a/test/functional/page_objects/vega_chart_page.ts
+++ b/test/functional/page_objects/vega_chart_page.ts
@@ -7,6 +7,7 @@
  */
 
 import expect from '@kbn/expect';
+import hjson from 'hjson';
 import { FtrService } from '../ftr_provider_context';
 
 const compareSpecs = (first: string, second: string) => {
@@ -74,14 +75,17 @@ export class VegaChartPageObject extends FtrService {
     });
   }
 
-  public async typeInSpec(text: string) {
-    const aceGutter = await this.getAceGutterContainer();
-
-    await aceGutter.doubleClick();
-    await this.browser.pressKeys(this.browser.keys.RIGHT);
-    await this.browser.pressKeys(this.browser.keys.LEFT);
-    await this.browser.pressKeys(this.browser.keys.LEFT);
-    await this.browser.pressKeys(text);
+  public async getSpecAsJSON() {
+    const text = await this.getSpec();
+    try {
+      const spec = hjson.parse(text, { legacyRoot: false, keepWsc: true });
+      return {
+        spec,
+        isValid: true,
+      };
+    } catch (err) {
+      return { spec: text, isValid: false };
+    }
   }
 
   public async cleanSpec() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Vega] Fix update vega spec in functional tests (#216620)](https://github.com/elastic/kibana/pull/216620)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2025-04-01T15:26:17Z","message":"[Vega] Fix update vega spec in functional tests (#216620)\n\n## Summary\n\nThis PR fixes a flaky test practice that was causing issues in 7.17\nbranch.\nThe flakiness was introduced long ago when the choosen method to\nupdate/add more content to the Vega Spec was done by manually clicking\nin the Vega spec editor the left border (where the editor shows the line\nnumbers) to select all the text in the editor and go to the last line\nbut a char before the end of the text (right before the closing\nbracket).\n\nThe failure highlighted by\nhttps://github.com/elastic/kibana/issues/213646 where caused the added\n`config` text positioned in the wrong line/column due to the Konami Code\nlike type of functional test operation.\n\n\nThe fix instead provides a more robust method: it takes the written text\nin the editor, parse it to JSON, update the JSON and write it back again\nto the editor.\n\nWill fix the issue https://github.com/elastic/kibana/issues/213646 when\nbackported to 7.17.","sha":"200ec10593480edc3ef7b0d0ea77b29c787d1382","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","Team:Visualizations","release_note:skip","v9.0.0","backport:all-open","v9.1.0"],"title":"[Vega] Fix update vega spec in functional tests","number":216620,"url":"https://github.com/elastic/kibana/pull/216620","mergeCommit":{"message":"[Vega] Fix update vega spec in functional tests (#216620)\n\n## Summary\n\nThis PR fixes a flaky test practice that was causing issues in 7.17\nbranch.\nThe flakiness was introduced long ago when the choosen method to\nupdate/add more content to the Vega Spec was done by manually clicking\nin the Vega spec editor the left border (where the editor shows the line\nnumbers) to select all the text in the editor and go to the last line\nbut a char before the end of the text (right before the closing\nbracket).\n\nThe failure highlighted by\nhttps://github.com/elastic/kibana/issues/213646 where caused the added\n`config` text positioned in the wrong line/column due to the Konami Code\nlike type of functional test operation.\n\n\nThe fix instead provides a more robust method: it takes the written text\nin the editor, parse it to JSON, update the JSON and write it back again\nto the editor.\n\nWill fix the issue https://github.com/elastic/kibana/issues/213646 when\nbackported to 7.17.","sha":"200ec10593480edc3ef7b0d0ea77b29c787d1382"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216676","number":216676,"state":"MERGED","mergeCommit":{"sha":"6c6c7c5077a8f73bcaf9db8f039f079e89f4e787","message":"[9.0] [Vega] Fix update vega spec in functional tests (#216620) (#216676)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Vega] Fix update vega spec in functional tests\n(#216620)](https://github.com/elastic/kibana/pull/216620)\n\n<!--- Backport version: 9.6.6 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Marco\nVettorello\",\"email\":\"marco.vettorello@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2025-04-01T15:26:17Z\",\"message\":\"[Vega]\nFix update vega spec in functional tests (#216620)\\n\\n## Summary\\n\\nThis\nPR fixes a flaky test practice that was causing issues in\n7.17\\nbranch.\\nThe flakiness was introduced long ago when the choosen\nmethod to\\nupdate/add more content to the Vega Spec was done by manually\nclicking\\nin the Vega spec editor the left border (where the editor\nshows the line\\nnumbers) to select all the text in the editor and go to\nthe last line\\nbut a char before the end of the text (right before the\nclosing\\nbracket).\\n\\nThe failure highlighted\nby\\nhttps://github.com/elastic/kibana/issues/213646 where caused the\nadded\\n`config` text positioned in the wrong line/column due to the\nKonami Code\\nlike type of functional test operation.\\n\\n\\nThe fix\ninstead provides a more robust method: it takes the written text\\nin the\neditor, parse it to JSON, update the JSON and write it back again\\nto\nthe editor.\\n\\nWill fix the issue\nhttps://github.com/elastic/kibana/issues/213646 when\\nbackported to\n7.17.\",\"sha\":\"200ec10593480edc3ef7b0d0ea77b29c787d1382\",\"branchLabelMapping\":{\"^v9.1.0$\":\"main\",\"^v8.19.0$\":\"8.x\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"test\",\"Team:Visualizations\",\"release_note:skip\",\"backport:all-open\",\"v9.1.0\"],\"title\":\"[Vega]\nFix update vega spec in functional\ntests\",\"number\":216620,\"url\":\"https://github.com/elastic/kibana/pull/216620\",\"mergeCommit\":{\"message\":\"[Vega]\nFix update vega spec in functional tests (#216620)\\n\\n## Summary\\n\\nThis\nPR fixes a flaky test practice that was causing issues in\n7.17\\nbranch.\\nThe flakiness was introduced long ago when the choosen\nmethod to\\nupdate/add more content to the Vega Spec was done by manually\nclicking\\nin the Vega spec editor the left border (where the editor\nshows the line\\nnumbers) to select all the text in the editor and go to\nthe last line\\nbut a char before the end of the text (right before the\nclosing\\nbracket).\\n\\nThe failure highlighted\nby\\nhttps://github.com/elastic/kibana/issues/213646 where caused the\nadded\\n`config` text positioned in the wrong line/column due to the\nKonami Code\\nlike type of functional test operation.\\n\\n\\nThe fix\ninstead provides a more robust method: it takes the written text\\nin the\neditor, parse it to JSON, update the JSON and write it back again\\nto\nthe editor.\\n\\nWill fix the issue\nhttps://github.com/elastic/kibana/issues/213646 when\\nbackported to\n7.17.\",\"sha\":\"200ec10593480edc3ef7b0d0ea77b29c787d1382\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v9.1.0\",\"branchLabelMappingKey\":\"^v9.1.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/216620\",\"number\":216620,\"mergeCommit\":{\"message\":\"[Vega]\nFix update vega spec in functional tests (#216620)\\n\\n## Summary\\n\\nThis\nPR fixes a flaky test practice that was causing issues in\n7.17\\nbranch.\\nThe flakiness was introduced long ago when the choosen\nmethod to\\nupdate/add more content to the Vega Spec was done by manually\nclicking\\nin the Vega spec editor the left border (where the editor\nshows the line\\nnumbers) to select all the text in the editor and go to\nthe last line\\nbut a char before the end of the text (right before the\nclosing\\nbracket).\\n\\nThe failure highlighted\nby\\nhttps://github.com/elastic/kibana/issues/213646 where caused the\nadded\\n`config` text positioned in the wrong line/column due to the\nKonami Code\\nlike type of functional test operation.\\n\\n\\nThe fix\ninstead provides a more robust method: it takes the written text\\nin the\neditor, parse it to JSON, update the JSON and write it back again\\nto\nthe editor.\\n\\nWill fix the issue\nhttps://github.com/elastic/kibana/issues/213646 when\\nbackported to\n7.17.\",\"sha\":\"200ec10593480edc3ef7b0d0ea77b29c787d1382\"}}]}] BACKPORT-->\n\nCo-authored-by: Marco Vettorello <marco.vettorello@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216620","number":216620,"mergeCommit":{"message":"[Vega] Fix update vega spec in functional tests (#216620)\n\n## Summary\n\nThis PR fixes a flaky test practice that was causing issues in 7.17\nbranch.\nThe flakiness was introduced long ago when the choosen method to\nupdate/add more content to the Vega Spec was done by manually clicking\nin the Vega spec editor the left border (where the editor shows the line\nnumbers) to select all the text in the editor and go to the last line\nbut a char before the end of the text (right before the closing\nbracket).\n\nThe failure highlighted by\nhttps://github.com/elastic/kibana/issues/213646 where caused the added\n`config` text positioned in the wrong line/column due to the Konami Code\nlike type of functional test operation.\n\n\nThe fix instead provides a more robust method: it takes the written text\nin the editor, parse it to JSON, update the JSON and write it back again\nto the editor.\n\nWill fix the issue https://github.com/elastic/kibana/issues/213646 when\nbackported to 7.17.","sha":"200ec10593480edc3ef7b0d0ea77b29c787d1382"}},{"url":"https://github.com/elastic/kibana/pull/216670","number":216670,"branch":"8.16","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/216672","number":216672,"branch":"8.17","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/216673","number":216673,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/216675","number":216675,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->