### PR TITLE
[Obs AI Assistant] Skip lock tests in MKI temporarily

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/distributed_lock_manager/distributed_lock_manager.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/distributed_lock_manager/distributed_lock_manager.spec.ts
@@ -28,6 +28,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const logger = getLoggerMock(log);
 
   describe('LockManager', function () {
+    this.tags(['failsOnMKI']);
     before(async () => {
       await clearAllLocks(es);
       await ensureTemplatesAndIndexCreated(es);


### PR DESCRIPTION
Tests added in https://github.com/elastic/kibana/pull/216397 are failing on MKI. Skipping temporarily in the affected environment

### CI Failure

```
Serverless Observability - Deployment-agnostic API integration tests observability AI Assistant LockManager "before all" hook in "LockManager"
```

### Root cause

```
           └- ✖ fail: Serverless Observability - Deployment-agnostic API integration tests observability AI Assistant LockManager Basic lock operations acquires the lock when not held
           │      ResponseError: security_exception
           │ 	Root causes:
           │ 		security_exception: action [indices:admin/create] is unauthorized for user [testing-internal] with effective roles [superuser] on restricted indices [.kibana_locks-000001], this action is granted by the index privileges [create_index,manage,all]
```

### Root cause
```ts
const es = getService('es');
es.deleteByQuery({ index: '.kibana_locks-000001', query: { match_all: {} }});
```

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->