### PR TITLE
Offer Mark as read-only after reindexing an index fails

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/container.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/container.tsx
@@ -182,6 +182,8 @@ export const IndexFlyout: React.FunctionComponent<IndexFlyoutProps> = ({
             startReindex={startReindexWithWarnings}
             reindexState={reindexState}
             cancelReindex={onStopReindex}
+            startReadonly={onMakeReadonly}
+            deprecation={deprecation}
           />
         );
       case 'unfreeze':

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/__snapshots__/reindex_step.test.tsx.snap
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/__snapshots__/reindex_step.test.tsx.snap
@@ -70,23 +70,28 @@ exports[`ReindexStep renders 1`] = `
           />
         </EuiButtonEmpty>
       </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
+      <EuiFlexGroup
+        gutterSize="s"
+        justifyContent="flexEnd"
       >
-        <EuiButton
-          color="primary"
-          data-test-subj="startReindexingButton"
-          disabled={false}
-          fill={true}
-          isLoading={false}
-          onClick={[MockFunction]}
+        <EuiFlexItem
+          grow={false}
         >
-          <MemoizedFormattedMessage
-            defaultMessage="Start reindexing"
-            id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.reindexStep.reindexButton.runReindexLabel"
-          />
-        </EuiButton>
-      </EuiFlexItem>
+          <EuiButton
+            color="primary"
+            data-test-subj="startReindexingButton"
+            disabled={false}
+            fill={true}
+            isLoading={false}
+            onClick={[MockFunction]}
+          >
+            <MemoizedFormattedMessage
+              defaultMessage="Start reindexing"
+              id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.reindexStep.reindexButton.runReindexLabel"
+            />
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiFlexGroup>
   </EuiFlyoutFooter>
 </Fragment>
@@ -163,23 +168,28 @@ exports[`ReindexStep renders for frozen indices 1`] = `
           />
         </EuiButtonEmpty>
       </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
+      <EuiFlexGroup
+        gutterSize="s"
+        justifyContent="flexEnd"
       >
-        <EuiButton
-          color="primary"
-          data-test-subj="startReindexingButton"
-          disabled={false}
-          fill={true}
-          isLoading={false}
-          onClick={[MockFunction]}
+        <EuiFlexItem
+          grow={false}
         >
-          <MemoizedFormattedMessage
-            defaultMessage="Start reindexing"
-            id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.reindexStep.reindexButton.runReindexLabel"
-          />
-        </EuiButton>
-      </EuiFlexItem>
+          <EuiButton
+            color="primary"
+            data-test-subj="startReindexingButton"
+            disabled={false}
+            fill={true}
+            isLoading={false}
+            onClick={[MockFunction]}
+          >
+            <MemoizedFormattedMessage
+              defaultMessage="Start reindexing"
+              id="xpack.upgradeAssistant.esDeprecations.indices.indexFlyout.reindexStep.reindexButton.runReindexLabel"
+            />
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiFlexGroup>
   </EuiFlyoutFooter>
 </Fragment>

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/reindex_step.test.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecations/deprecation_types/indices/flyout/steps/reindex/reindex_step.test.tsx
@@ -9,7 +9,11 @@ import { shallow } from 'enzyme';
 import { cloneDeep } from 'lodash';
 import React from 'react';
 
-import { ReindexStatus } from '../../../../../../../../../common/types';
+import {
+  EnrichedDeprecationInfo,
+  ReindexAction,
+  ReindexStatus,
+} from '../../../../../../../../../common/types';
 import { LoadingState } from '../../../../../../types';
 import type { ReindexState } from '../../../use_reindex';
 import { ReindexFlyoutStep } from './reindex_step';
@@ -41,6 +45,7 @@ describe('ReindexStep', () => {
     onConfirmInputChange: jest.fn(),
     startReindex: jest.fn(),
     cancelReindex: jest.fn(),
+    startReadonly: jest.fn(),
     http: {
       basePath: {
         prepend: jest.fn(),
@@ -65,6 +70,18 @@ describe('ReindexStep', () => {
         isClosedIndex: false,
       },
     } as ReindexState,
+    deprecation: {
+      isCritical: true,
+      resolveDuringUpgrade: false,
+      type: 'index_settings',
+      message: 'Index created before 7.0',
+      details: 'deprecation details',
+      url: 'doc_url',
+      index: 'myIndex',
+      correctiveAction: {
+        type: 'reindex',
+      },
+    } as EnrichedDeprecationInfo,
   };
 
   it('renders', () => {
@@ -134,5 +151,59 @@ describe('ReindexStep', () => {
 
     wrapper.find('EuiButton').simulate('click');
     expect(props.startReindex).toHaveBeenCalled();
+  });
+
+  it('shows read-only button when reindexing fails', () => {
+    const props = cloneDeep(defaultProps);
+    props.reindexState.status = ReindexStatus.failed;
+    props.reindexState.errorMessage = 'Reindex failed';
+    const wrapper = shallow(<ReindexFlyoutStep {...props} />);
+    expect(wrapper.find('[data-test-subj="startIndexReadonlyButton"]').exists()).toBe(true);
+  });
+
+  it('only shows read-only button when status is failed', () => {
+    const statuses = [
+      ReindexStatus.cancelled,
+      ReindexStatus.completed,
+      ReindexStatus.fetchFailed,
+      ReindexStatus.inProgress,
+      ReindexStatus.paused,
+    ];
+
+    statuses.forEach((status) => {
+      const props = cloneDeep(defaultProps);
+      props.reindexState.status = status;
+      const wrapper = shallow(<ReindexFlyoutStep {...props} />);
+      expect(wrapper.find('[data-test-subj="startIndexReadonlyButton"]').exists()).toBe(false);
+    });
+  });
+
+  it('does not show read-only button when the index is already read-only', () => {
+    const props = cloneDeep(defaultProps);
+    props.reindexState.status = ReindexStatus.failed;
+    props.reindexState.errorMessage = 'Reindex failed';
+    props.reindexState.meta.isReadonly = true;
+    const wrapper = shallow(<ReindexFlyoutStep {...props} />);
+    expect(wrapper.find('[data-test-subj="startIndexReadonlyButton"]').exists()).toBe(false);
+  });
+
+  it('does not show read-only button when read-only is excluded', () => {
+    const props = {
+      ...defaultProps,
+      reindexState: {
+        ...defaultProps.reindexState,
+        status: ReindexStatus.failed,
+        errorMessage: 'Reindex failed',
+      },
+      deprecation: {
+        ...defaultProps.deprecation,
+        correctiveAction: {
+          ...defaultProps.deprecation.correctiveAction,
+          excludedActions: ['readOnly'],
+        } as ReindexAction,
+      },
+    };
+    const wrapper = shallow(<ReindexFlyoutStep {...props} />);
+    expect(wrapper.find('[data-test-subj="startIndexReadonlyButton"]').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/213349
(Data Streams will be addressed in a separated PR)

## Summary
When a user wanted to mark as read-only an index that had previously failed to be reindexed, it was hard to find the Mark as read-only button. They needed to click Try again >  Back and then they can see the button. This PR adds the button when reindexing fails for indices and read-only option is available.

<img width="1506" alt="Screenshot 2025-04-02 at 10 23 27" src="https://github.com/user-attachments/assets/9e114629-ca61-4117-a3f2-413f2ccbcc66" />

### How to test

* Follow the instructions in https://github.com/elastic/kibana-team/issues/1521. Use the data folder called `[04/02] Failed reindexing`.
* Go to "Stack Management > Upgrade Assistant"
    * Verify that indexes that have failed to reindex offer the Mark as read-only option.
    * Verify the button is not displayed if the index has already been marked as read-only.
  

### Demo
<details>
<summary>Video</summary>


https://github.com/user-attachments/assets/1ec6a20a-8ec8-4f57-aa99-3b5c08402d28



</details>