### PR TITLE
[Synthetics] Fixed alert count in monitor details

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_fetch_active_alerts.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_fetch_active_alerts.ts
@@ -52,6 +52,11 @@ export function useFetchActiveAlerts() {
                   'location.id': selectedLocation?.id,
                 },
               },
+              {
+                term: {
+                  'kibana.alert.status': 'active',
+                },
+              },
             ],
           },
         },
@@ -62,6 +67,6 @@ export function useFetchActiveAlerts() {
   return {
     loading,
     data,
-    numberOfAlerts: data?.hits?.total.value ?? 0,
+    numberOfActiveAlerts: data?.hits?.total.value ?? 0,
   };
 }

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_alerts/alerts_icon.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_alerts/alerts_icon.tsx
@@ -9,7 +9,9 @@ import { EuiBadge } from '@elastic/eui';
 import { useFetchActiveAlerts } from '../hooks/use_fetch_active_alerts';
 
 export const MonitorAlertsIcon = () => {
-  const { numberOfAlerts } = useFetchActiveAlerts();
+  const { numberOfActiveAlerts } = useFetchActiveAlerts();
 
-  return numberOfAlerts > 0 ? <EuiBadge color="danger">{numberOfAlerts}</EuiBadge> : null;
+  return numberOfActiveAlerts > 0 ? (
+    <EuiBadge color="danger">{numberOfActiveAlerts}</EuiBadge>
+  ) : null;
 };


### PR DESCRIPTION
This PR closes #191328 

Before:
<img width="1512" alt="Screenshot 2025-04-02 at 10 38 42" src="https://github.com/user-attachments/assets/d4c9c744-afdf-4d1b-8bd9-9447c0945258" />

After:
<img width="758" alt="Screenshot 2025-04-02 at 10 38 21" src="https://github.com/user-attachments/assets/c2692a44-db8c-461b-803c-d1834646d514" />


<!--ONMERGE {"backportTargets":["8.17","8.18","8.x","9.0"]} ONMERGE-->