### PR TITLE
Retry "lock release" to fix flaky tests

### DIFF
--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/distributed_lock_manager/lock_manager_client.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/distributed_lock_manager/lock_manager_client.ts
@@ -140,6 +140,7 @@ export class LockManager {
       const response = await this.esClient.update<LockDocument>({
         index: LOCKS_CONCRETE_INDEX_NAME,
         id: this.lockId,
+        retry_on_conflict: 3, // Retry on version conflict. This can necessary if `extendTtl` is called at the same time.
         scripted_upsert: false,
         script: {
           lang: 'painless',


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/216397
Closes https://github.com/elastic/kibana/issues/216763

This change ensures that we do not send the `release` request and `extendTtl` request simultaneously in `withLock`. This caused a conflict causing tests to fail:

```
           └-> "before all" hook for "should return the result of the callback"
             │ERROR Failed to release lock "my_lock_with_ttl_extension": version_conflict_engine_exception
             │      	Root causes:
             │      		version_conflict_engine_exception: [my_lock_with_ttl_extension]: version conflict, required seqNo [43], primary term [1]. current document has seqNo [44] and primary term [1]
```

Flaky tests:
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8142


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->