### PR TITLE
[8.17] add filter to entity definitions schema (#208588)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/get_united_definition.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/get_united_definition.test.ts
@@ -15,6 +15,7 @@ describe('getUnitedEntityDefinition', () => {
       namespace: 'test',
       fieldHistoryLength: 10,
       indexPatterns,
+      filter: ' ',
       syncDelay: '1m',
       frequency: '1m',
     });
@@ -172,6 +173,7 @@ describe('getUnitedEntityDefinition', () => {
       expect(unitedDefinition.entityManagerDefinition).toMatchInlineSnapshot(`
         Object {
           "displayNameTemplate": "{{host.name}}",
+          "filter": " ",
           "id": "security_host_test",
           "identityFields": Array [
             Object {
@@ -328,6 +330,7 @@ describe('getUnitedEntityDefinition', () => {
       namespace: 'test',
       fieldHistoryLength: 10,
       indexPatterns,
+      filter: ' ',
       syncDelay: '1m',
       frequency: '1m',
     });
@@ -461,6 +464,7 @@ describe('getUnitedEntityDefinition', () => {
       expect(unitedDefinition.entityManagerDefinition).toMatchInlineSnapshot(`
         Object {
           "displayNameTemplate": "{{user.name}}",
+          "filter": " ",
           "id": "security_user_test",
           "identityFields": Array [
             Object {

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/get_united_definition.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/get_united_definition.ts
@@ -25,7 +25,7 @@ interface Options {
   namespace: string;
   fieldHistoryLength: number;
   indexPatterns: string[];
-  filter: string;
+  filter?: string;
   syncDelay: string;
   frequency: string;
 }
@@ -55,7 +55,7 @@ export const getUnitedEntityDefinition = memoize(
       indexPatterns,
       syncDelay,
       frequency,
-      filter,
+      filter: filter ?? '',
     });
   }
 );

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/get_united_definition.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/get_united_definition.ts
@@ -25,6 +25,7 @@ interface Options {
   namespace: string;
   fieldHistoryLength: number;
   indexPatterns: string[];
+  filter: string;
   syncDelay: string;
   frequency: string;
 }
@@ -37,6 +38,7 @@ export const getUnitedEntityDefinition = memoize(
     indexPatterns,
     syncDelay,
     frequency,
+    filter,
   }: Options): UnitedEntityDefinition => {
     const unitedDefinition = unitedDefinitionBuilders[entityType](fieldHistoryLength);
 
@@ -53,6 +55,7 @@ export const getUnitedEntityDefinition = memoize(
       indexPatterns,
       syncDelay,
       frequency,
+      filter,
     });
   }
 );

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/united_entity_definition.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/united_entity_definition.ts
@@ -66,7 +66,7 @@ export class UnitedEntityDefinition {
       indexPatterns,
       identityFields: [identityField],
       displayNameTemplate: `{{${identityField}}}`,
-      filter: filter,
+      filter,
       metadata,
       latest: {
         timestampField: '@timestamp',

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/united_entity_definition.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/entity_store/united_entity_definitions/united_entity_definition.ts
@@ -22,6 +22,7 @@ export class UnitedEntityDefinition {
   indexPatterns: string[];
   fields: UnitedDefinitionField[];
   namespace: string;
+  filter: string;
   entityManagerDefinition: EntityDefinition;
   fieldRetentionDefinition: FieldRetentionDefinition;
   indexMappings: MappingTypeMapping;
@@ -34,6 +35,7 @@ export class UnitedEntityDefinition {
     indexPatterns: string[];
     fields: UnitedDefinitionField[];
     namespace: string;
+    filter: string;
     syncDelay: string;
     frequency: string;
   }) {
@@ -44,13 +46,14 @@ export class UnitedEntityDefinition {
     this.frequency = opts.frequency;
     this.syncDelay = opts.syncDelay;
     this.namespace = opts.namespace;
+    this.filter = opts.filter;
     this.entityManagerDefinition = this.toEntityManagerDefinition();
     this.fieldRetentionDefinition = this.toFieldRetentionDefinition();
     this.indexMappings = this.toIndexMappings();
   }
 
   private toEntityManagerDefinition(): EntityDefinition {
-    const { entityType, namespace, indexPatterns, syncDelay, frequency } = this;
+    const { entityType, namespace, indexPatterns, syncDelay, frequency, filter } = this;
     const identityField = getIdentityFieldForEntityType(this.entityType);
     const metadata = this.fields
       .filter((field) => field.definition)
@@ -63,6 +66,7 @@ export class UnitedEntityDefinition {
       indexPatterns,
       identityFields: [identityField],
       displayNameTemplate: `{{${identityField}}}`,
+      filter: filter,
       metadata,
       latest: {
         timestampField: '@timestamp',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [add filter to entity definitions schema (#208588)](https://github.com/elastic/kibana/pull/208588)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Charlotte Alexandra Wilson","email":"CAWilson94@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-31T10:01:21Z","message":"add filter to entity definitions schema (#208588)\n\n## Summary\r\n\r\nAdds filter to the entity definition schema so it can be used to filter\r\nentity store data further.\r\n\r\n### Testing Steps \r\n1. Open Kibana and start the entity store.\r\n2. Initialise an engine (e.g., user) with a filter:\r\n``` \r\nPOST kbn:/api/entity_store/engines/user/init \r\n{\r\n   \"filter\": \"@timestamp < now-6w\"\r\n}\r\n```\r\n3. Once the transform has run, verify in Dev Tools:\r\n`GET _transform/entities-v1-latest-security_user_default`\r\nYou should see the applied filter in the results, alongside default\r\nfilters for user.name and timestamp from\r\n[generate_latest_transform.ts](https://github.com/elastic/kibana/blob/90d768be9b35ac26a3b938edac5c1af47cab980a/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/generate_latest_transform.ts#L29)\r\nExample output will include the added filter as part of a bool query.\r\n\r\n```\r\n\"query\": {\r\n          **\"bool\": {\r\n            \"filter\": [\r\n              {\r\n                \"bool\": {\r\n                  \"should\": [\r\n                    {\r\n                      \"range\": {\r\n                        \"@timestamp\": {\r\n                          \"lt\": \"now-6w\"\r\n                        }\r\n                      }\r\n                    }\r\n                  ],**\r\n                  \"minimum_should_match\": 1\r\n                }\r\n              },\r\n              {\r\n                \"exists\": {\r\n                  \"field\": \"user.name\"\r\n                }\r\n              },\r\n              {\r\n                \"range\": {\r\n                  \"@timestamp\": {\r\n                    \"gte\": \"now-24h\"\r\n                  }\r\n                }\r\n              }\r\n            ]\r\n          }\r\n        }\r\n      },\r\n```","sha":"b94475c642491383ce6efe2213446ba3dc6988d6","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team: SecuritySolution","Theme: entity_analytics","Team:Entity Analytics","backport:version","v8.18.0","backport:8.17","v9.1.0"],"title":"add filter to entity definitions schema","number":208588,"url":"https://github.com/elastic/kibana/pull/208588","mergeCommit":{"message":"add filter to entity definitions schema (#208588)\n\n## Summary\r\n\r\nAdds filter to the entity definition schema so it can be used to filter\r\nentity store data further.\r\n\r\n### Testing Steps \r\n1. Open Kibana and start the entity store.\r\n2. Initialise an engine (e.g., user) with a filter:\r\n``` \r\nPOST kbn:/api/entity_store/engines/user/init \r\n{\r\n   \"filter\": \"@timestamp < now-6w\"\r\n}\r\n```\r\n3. Once the transform has run, verify in Dev Tools:\r\n`GET _transform/entities-v1-latest-security_user_default`\r\nYou should see the applied filter in the results, alongside default\r\nfilters for user.name and timestamp from\r\n[generate_latest_transform.ts](https://github.com/elastic/kibana/blob/90d768be9b35ac26a3b938edac5c1af47cab980a/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/generate_latest_transform.ts#L29)\r\nExample output will include the added filter as part of a bool query.\r\n\r\n```\r\n\"query\": {\r\n          **\"bool\": {\r\n            \"filter\": [\r\n              {\r\n                \"bool\": {\r\n                  \"should\": [\r\n                    {\r\n                      \"range\": {\r\n                        \"@timestamp\": {\r\n                          \"lt\": \"now-6w\"\r\n                        }\r\n                      }\r\n                    }\r\n                  ],**\r\n                  \"minimum_should_match\": 1\r\n                }\r\n              },\r\n              {\r\n                \"exists\": {\r\n                  \"field\": \"user.name\"\r\n                }\r\n              },\r\n              {\r\n                \"range\": {\r\n                  \"@timestamp\": {\r\n                    \"gte\": \"now-24h\"\r\n                  }\r\n                }\r\n              }\r\n            ]\r\n          }\r\n        }\r\n      },\r\n```","sha":"b94475c642491383ce6efe2213446ba3dc6988d6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209077","number":209077,"state":"MERGED","mergeCommit":{"sha":"cd96cb15fcef1c03c074d4fed6e98071d2f60a24","message":"[9.0] add filter to entity definitions schema (#208588) (#209077)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [add filter to entity definitions schema\n(#208588)](https://github.com/elastic/kibana/pull/208588)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Charlotte Alexandra Wilson <CAWilson94@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209075","number":209075,"state":"MERGED","mergeCommit":{"sha":"79f37e274a147b8dcc169ffd2a1ae527cd483686","message":"[8.18] add filter to entity definitions schema (#208588) (#209075)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [add filter to entity definitions schema\n(#208588)](https://github.com/elastic/kibana/pull/208588)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Charlotte Alexandra Wilson <CAWilson94@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208588","number":208588,"mergeCommit":{"message":"add filter to entity definitions schema (#208588)\n\n## Summary\r\n\r\nAdds filter to the entity definition schema so it can be used to filter\r\nentity store data further.\r\n\r\n### Testing Steps \r\n1. Open Kibana and start the entity store.\r\n2. Initialise an engine (e.g., user) with a filter:\r\n``` \r\nPOST kbn:/api/entity_store/engines/user/init \r\n{\r\n   \"filter\": \"@timestamp < now-6w\"\r\n}\r\n```\r\n3. Once the transform has run, verify in Dev Tools:\r\n`GET _transform/entities-v1-latest-security_user_default`\r\nYou should see the applied filter in the results, alongside default\r\nfilters for user.name and timestamp from\r\n[generate_latest_transform.ts](https://github.com/elastic/kibana/blob/90d768be9b35ac26a3b938edac5c1af47cab980a/x-pack/platform/plugins/shared/entity_manager/server/lib/entities/transform/generate_latest_transform.ts#L29)\r\nExample output will include the added filter as part of a bool query.\r\n\r\n```\r\n\"query\": {\r\n          **\"bool\": {\r\n            \"filter\": [\r\n              {\r\n                \"bool\": {\r\n                  \"should\": [\r\n                    {\r\n                      \"range\": {\r\n                        \"@timestamp\": {\r\n                          \"lt\": \"now-6w\"\r\n                        }\r\n                      }\r\n                    }\r\n                  ],**\r\n                  \"minimum_should_match\": 1\r\n                }\r\n              },\r\n              {\r\n                \"exists\": {\r\n                  \"field\": \"user.name\"\r\n                }\r\n              },\r\n              {\r\n                \"range\": {\r\n                  \"@timestamp\": {\r\n                    \"gte\": \"now-24h\"\r\n                  }\r\n                }\r\n              }\r\n            ]\r\n          }\r\n        }\r\n      },\r\n```","sha":"b94475c642491383ce6efe2213446ba3dc6988d6"}}]}] BACKPORT-->