### PR TITLE
Dev console - improve autocomplete for ES|QL _query API

### DIFF
--- a/src/platform/plugins/shared/console/server/lib/spec_definitions/json/overrides/esql.query.json
+++ b/src/platform/plugins/shared/console/server/lib/spec_definitions/json/overrides/esql.query.json
@@ -4,7 +4,11 @@
       "columnar": false,
       "locale": "",
       "params": [],
-      "query": ""
+      "query": "",
+      "profile": true,
+      "filter":  {
+        "__scope_link": "GLOBAL.query"
+      }
     }
   }
 }


### PR DESCRIPTION
Adds 2 missing options we have for the `_query` API: `profile` and `filter`.

### Before:

`profile` and `filter` are not listed as options:

<img width="228" alt="Screenshot 2025-04-02 at 13 07 57" src="https://github.com/user-attachments/assets/2d3ba39d-e7de-4818-8255-0481091d0bed" />


### After:
`profile` is an autocomplete option and has a default value of `true`:

<img width="318" alt="Screenshot 2025-04-02 at 13 02 58" src="https://github.com/user-attachments/assets/81092578-08a7-4b58-9500-f0c37b83a511" />

`filter` is also an option - filter allows passing a DSL query, so `filter` should have all the autocomplete options that we have available for DSL queries:

<img width="240" alt="Screenshot 2025-04-02 at 13 09 04" src="https://github.com/user-attachments/assets/809c1ae7-2324-46de-a1a6-b2f92c4811b6" />

<img width="295" alt="Screenshot 2025-04-02 at 13 09 49" src="https://github.com/user-attachments/assets/05bbd63a-ee34-45de-a9aa-f751b77a29ea" />
<img width="221" alt="Screenshot 2025-04-02 at 13 10 02" src="https://github.com/user-attachments/assets/8e95cf79-2944-40ae-bcd4-146a0467180d" />


### Documentation:

`profile` docs: https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-query-api.html#esql-query-api-request-body

`filter` docs https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-rest.html#esql-rest-filtering


<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->