### PR TITLE
Handle ELASTIC_PROFILER_STACK_TRACE_IDS for apm-profiler integration

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-types/src/es_fields/apm.ts
@@ -74,6 +74,8 @@ export const TRANSACTION_OVERFLOW_COUNT = 'transaction.aggregation.overflow_coun
 export const TRANSACTION_ROOT = 'transaction.root';
 export const TRANSACTION_PROFILER_STACK_TRACE_IDS = 'transaction.profiler_stack_trace_ids';
 
+export const ELASTIC_PROFILER_STACK_TRACE_IDS = 'elastic.profiler_stack_trace_ids';
+
 export const EVENT_OUTCOME = 'event.outcome';
 
 export const TRACE_ID = 'trace.id';

--- a/x-pack/solutions/observability/plugins/apm/server/routes/profiling/route.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/profiling/route.ts
@@ -15,6 +15,7 @@ import { environmentRt, kueryRt } from '../default_api_types';
 import { fetchFlamegraph } from './fetch_flamegraph';
 import { fetchFunctions } from './fetch_functions';
 import { TRANSACTION_PROFILER_STACK_TRACE_IDS } from '../../../common/es_fields/apm';
+import { ELASTIC_PROFILER_STACK_TRACE_IDS } from '../../../common/es_fields/apm';
 
 const servicesFlamegraphRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/services/{serviceName}/profiling/flamegraph',
@@ -47,6 +48,9 @@ const servicesFlamegraphRoute = createApmServerRoute({
       const { start, end, kuery, transactionName, transactionType, environment } = params.query;
 
       const indices = apmEventClient.getIndicesFromProcessorEvent(ProcessorEvent.transaction);
+      const stacktraceIdsField = indices.includes(TRANSACTION_PROFILER_STACK_TRACE_IDS)
+        ? TRANSACTION_PROFILER_STACK_TRACE_IDS
+        : ELASTIC_PROFILER_STACK_TRACE_IDS;
 
       return fetchFlamegraph({
         profilingDataAccessStart,
@@ -60,7 +64,7 @@ const servicesFlamegraphRoute = createApmServerRoute({
         environment,
         transactionType,
         indices,
-        stacktraceIdsField: TRANSACTION_PROFILER_STACK_TRACE_IDS,
+        stacktraceIdsField: stacktraceIdsField
       });
     }
 
@@ -112,6 +116,10 @@ const servicesFunctionsRoute = createApmServerRoute({
 
       const indices = apmEventClient.getIndicesFromProcessorEvent(ProcessorEvent.transaction);
 
+      const stacktraceIdsField = indices.includes(TRANSACTION_PROFILER_STACK_TRACE_IDS)
+        ? TRANSACTION_PROFILER_STACK_TRACE_IDS
+        : ELASTIC_PROFILER_STACK_TRACE_IDS;
+
       return fetchFunctions({
         profilingDataAccessStart,
         core,
@@ -119,7 +127,7 @@ const servicesFunctionsRoute = createApmServerRoute({
         startIndex,
         endIndex,
         indices,
-        stacktraceIdsField: TRANSACTION_PROFILER_STACK_TRACE_IDS,
+        stacktraceIdsField: stacktraceIdsField,
         start,
         end,
         kuery,


### PR DESCRIPTION
## Summary

`ELASTIC_PROFILER_STACK_TRACE_IDS` is introduced for OTel based data streams. The same information is stored in `TRANSACTION_PROFILER_STACK_TRACE_IDS` in the classic APM data streams.

Prior to this PR apm<->profiling integration did not work for OTel SDKs. This PR adds handling for the new field name.

Tested with a local setup:

<img width="1654" alt="Screenshot 2025-04-02 at 14 28 08" src="https://github.com/user-attachments/assets/9024c546-b773-4655-b60c-48de8317bf54" />

<img width="1472" alt="Screenshot 2025-04-02 at 14 28 18" src="https://github.com/user-attachments/assets/05bf53b3-05f7-4565-87d5-a0a78b47d8d5" />

Corresponding PR in es: https://github.com/elastic/elasticsearch/pull/125608


Questions:
- [ ] How do we test this? Is there any test I could extend here? - sorry for the noob question, I don't work much on Kibana and have not found anything.

@cauemarcondes: Since this PR is basically the same functionality which you added in https://github.com/elastic/kibana/pull/176922, I'm adding you here as reviewer. 