### PR TITLE
[CI] Allow using `elastic-images-qa` through PR label or env var

### DIFF
--- a/.buildkite/pipeline-utils/buildkite/client.ts
+++ b/.buildkite/pipeline-utils/buildkite/client.ts
@@ -38,6 +38,19 @@ export type BuildkiteStep =
   | BuildkiteTriggerStep
   | BuildkiteWaitStep;
 
+export interface BuildkiteAgentQueue {
+  queue: string;
+}
+
+export interface BuildkiteAgentTargetingRule {
+  provider?: string;
+  image?: string;
+  imageProject?: string;
+  machineType?: string;
+  minCpuPlatform?: string;
+  preemptible?: boolean;
+}
+
 export interface BuildkiteCommandStep {
   command: string;
   label: string;
@@ -45,18 +58,7 @@ export interface BuildkiteCommandStep {
   concurrency?: number;
   concurrency_group?: string;
   concurrency_method?: 'eager' | 'ordered';
-  agents:
-    | {
-        queue: string;
-      }
-    | {
-        provider?: string;
-        image?: string;
-        imageProject?: string;
-        machineType?: string;
-        minCpuPlatform?: string;
-        preemptible?: boolean;
-      };
+  agents: BuildkiteAgentQueue | BuildkiteAgentTargetingRule;
   timeout_in_minutes?: number;
   key?: string;
   cancel_on_build_failing?: boolean;


### PR DESCRIPTION
## Summary
Currently, if you'd like to test something on Kibana's VM image, you'd have to build a VM image to -qa, then rewrite all references to `elastic-images-qa` for the PR jobs; once done with testing, we'd undo the changes to `elastic-images-prod`.

This is a helpful tool for us to test with WIP VM images, we'd be able to add a label to the PR, and it would automatically grab the QA images, without any temporary commits.

Jobs in https://buildkite.com/elastic/kibana-pull-request/builds/289599 have ran with an elastic-qa image. ✅

<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x","9.0"]} ONMERGE-->