### PR TITLE
[8.17] [Discover] Fix `getAdditionalCellActions` FTR tests (#216540)

### DIFF
--- a/test/functional/apps/discover/context_awareness/extensions/_get_additional_cell_actions.ts
+++ b/test/functional/apps/discover/context_awareness/extensions/_get_additional_cell_actions.ts
@@ -9,6 +9,7 @@
 
 import kbnRison from '@kbn/rison';
 import expect from '@kbn/expect';
+import { Alert } from 'selenium-webdriver';
 import type { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
@@ -16,9 +17,22 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataViews = getService('dataViews');
   const dataGrid = getService('dataGrid');
   const browser = getService('browser');
+  const retry = getService('retry');
 
-  // Failing: See https://github.com/elastic/kibana/issues/213300
-  describe.skip('extension getAdditionalCellActions', () => {
+  const checkAlert = async (text: string) => {
+    let alert: Alert | undefined;
+    try {
+      await retry.waitFor('alert to be present', async () => {
+        alert = (await browser.getAlert()) ?? undefined;
+        return Boolean(alert);
+      });
+      expect(await alert?.getText()).to.be(text);
+    } finally {
+      await alert?.dismiss();
+    }
+  };
+
+  describe('extension getAdditionalCellActions', () => {
     describe('ES|QL mode', () => {
       it('should render additional cell actions for logs data source', async () => {
         const state = kbnRison.encode({
@@ -32,20 +46,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('example-data-source-action');
-        let alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Example data source action executed');
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('another-example-data-source-action');
-        alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Another example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Another example data source action executed');
       });
 
       it('should not render incompatible cell action for message column', async () => {
@@ -97,20 +101,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('example-data-source-action');
-        let alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Example data source action executed');
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('another-example-data-source-action');
-        alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Another example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Another example data source action executed');
         // check Surrounding docs page
         await dataGrid.clickRowToggle();
         const [, surroundingActionEl] = await dataGrid.getRowActions();
@@ -121,20 +115,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('example-data-source-action');
-        alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Example data source action executed');
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('another-example-data-source-action');
-        alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Another example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Another example data source action executed');
       });
 
       it('should not render incompatible cell action for message column', async () => {

--- a/x-pack/test_serverless/functional/test_suites/common/discover/context_awareness/extensions/_get_additional_cell_actions.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/discover/context_awareness/extensions/_get_additional_cell_actions.ts
@@ -7,6 +7,7 @@
 
 import kbnRison from '@kbn/rison';
 import expect from '@kbn/expect';
+import { Alert } from 'selenium-webdriver';
 import type { FtrProviderContext } from '../../../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
@@ -20,6 +21,20 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const dataViews = getService('dataViews');
   const dataGrid = getService('dataGrid');
   const browser = getService('browser');
+  const retry = getService('retry');
+
+  const checkAlert = async (text: string) => {
+    let alert: Alert | undefined;
+    try {
+      await retry.waitFor('alert to be present', async () => {
+        alert = (await browser.getAlert()) ?? undefined;
+        return Boolean(alert);
+      });
+      expect(await alert?.getText()).to.be(text);
+    } finally {
+      await alert?.dismiss();
+    }
+  };
 
   describe('extension getAdditionalCellActions', () => {
     before(async () => {
@@ -39,20 +54,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('example-data-source-action');
-        let alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Example data source action executed');
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('another-example-data-source-action');
-        alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Another example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Another example data source action executed');
       });
 
       it('should not render incompatible cell action for message column', async () => {
@@ -104,20 +109,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('example-data-source-action');
-        let alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Example data source action executed');
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('another-example-data-source-action');
-        alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Another example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Another example data source action executed');
         // check Surrounding docs page
         await dataGrid.clickRowToggle();
         const [, surroundingActionEl] = await dataGrid.getRowActions();
@@ -128,20 +123,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.discover.waitUntilSearchingHasFinished();
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('example-data-source-action');
-        alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Example data source action executed');
         await dataGrid.clickCellExpandButtonExcludingControlColumns(0, 0);
         await dataGrid.clickCellExpandPopoverAction('another-example-data-source-action');
-        alert = await browser.getAlert();
-        try {
-          expect(await alert?.getText()).to.be('Another example data source action executed');
-        } finally {
-          await alert?.dismiss();
-        }
+        await checkAlert('Another example data source action executed');
       });
 
       it('should not render incompatible cell action for message column', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Discover] Fix `getAdditionalCellActions` FTR tests (#216540)](https://github.com/elastic/kibana/pull/216540)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2025-04-02T14:45:08Z","message":"[Discover] Fix `getAdditionalCellActions` FTR tests (#216540)\n\n## Summary\n\nThis PR fixes the `getAdditionalCellActions` FTR tests that started\nfailing due to an issue dismissing alerts.\n\nResolves #213300.\nResolves #213422.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"d08e5521f28f4459a76b7176b902efbaea023b06","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:prev-minor","backport:prev-major","v9.1.0"],"title":"[Discover] Fix `getAdditionalCellActions` FTR tests","number":216540,"url":"https://github.com/elastic/kibana/pull/216540","mergeCommit":{"message":"[Discover] Fix `getAdditionalCellActions` FTR tests (#216540)\n\n## Summary\n\nThis PR fixes the `getAdditionalCellActions` FTR tests that started\nfailing due to an issue dismissing alerts.\n\nResolves #213300.\nResolves #213422.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"d08e5521f28f4459a76b7176b902efbaea023b06"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216540","number":216540,"mergeCommit":{"message":"[Discover] Fix `getAdditionalCellActions` FTR tests (#216540)\n\n## Summary\n\nThis PR fixes the `getAdditionalCellActions` FTR tests that started\nfailing due to an issue dismissing alerts.\n\nResolves #213300.\nResolves #213422.\n\n### Checklist\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"d08e5521f28f4459a76b7176b902efbaea023b06"}},{"url":"https://github.com/elastic/kibana/pull/216858","number":216858,"branch":"8.18","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/216860","number":216860,"branch":"9.0","state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/216859","number":216859,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->