### PR TITLE
[Fleet] Add name to audit logs

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.test.ts
@@ -219,7 +219,9 @@ describe('Agent policy', () => {
       soClient.create.mockResolvedValueOnce({
         id: 'test-agent-policy',
         type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
-        attributes: {},
+        attributes: {
+          name: 'test',
+        },
         references: [],
       });
 
@@ -237,6 +239,7 @@ describe('Agent policy', () => {
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'create',
+        name: 'test',
         id: 'test-agent-policy',
         savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
@@ -280,6 +283,7 @@ describe('Agent policy', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'create',
         id: 'test-agent-policy',
+        name: 'test',
         savedObjectType: AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
@@ -491,7 +495,9 @@ describe('Agent policy', () => {
 
       soClient.get.mockResolvedValueOnce({
         id: 'test-agent-policy',
-        attributes: {},
+        attributes: {
+          name: 'Test',
+        },
         references: [],
         type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
@@ -501,6 +507,7 @@ describe('Agent policy', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toBeCalledWith({
         action: 'get',
         id: 'test-agent-policy',
+        name: 'Test',
         savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
@@ -514,13 +521,17 @@ describe('Agent policy', () => {
         saved_objects: [
           {
             id: 'test-agent-policy-1',
-            attributes: {},
+            attributes: {
+              name: 'Test 1',
+            },
             references: [],
             type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
           },
           {
             id: 'test-agent-policy-2',
-            attributes: {},
+            attributes: {
+              name: 'Test 2',
+            },
             references: [],
             type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
           },
@@ -532,12 +543,14 @@ describe('Agent policy', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(1, {
         action: 'get',
         id: 'test-agent-policy-1',
+        name: 'Test 1',
         savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(2, {
         action: 'get',
         id: 'test-agent-policy-2',
+        name: 'Test 2',
         savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
@@ -552,14 +565,18 @@ describe('Agent policy', () => {
         saved_objects: [
           {
             id: 'test-agent-policy-1',
-            attributes: {},
+            attributes: {
+              name: 'Test 1',
+            },
             references: [],
             type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
             score: 0,
           },
           {
             id: 'test-agent-policy-2',
-            attributes: {},
+            attributes: {
+              name: 'Test 2',
+            },
             references: [],
             type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
             score: 0,
@@ -578,12 +595,14 @@ describe('Agent policy', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(1, {
         action: 'find',
         id: 'test-agent-policy-1',
+        name: 'Test 1',
         savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(2, {
         action: 'find',
         id: 'test-agent-policy-2',
+        name: 'Test 2',
         savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
@@ -594,7 +613,7 @@ describe('Agent policy', () => {
     let esClient: ReturnType<typeof elasticsearchServiceMock.createClusterClient>['asInternalUser'];
 
     beforeEach(() => {
-      soClient = getSavedObjectMock({ revision: 1, package_policies: ['package-1'] });
+      soClient = getSavedObjectMock({ revision: 1, name: 'Test', package_policies: ['package-1'] });
       mockedPackagePolicyService.findAllForAgentPolicy.mockReturnValue([
         {
           id: 'package-1',
@@ -648,6 +667,7 @@ describe('Agent policy', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'delete',
         id: 'mocked',
+        name: 'Test',
         savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
     });
@@ -994,7 +1014,9 @@ describe('Agent policy', () => {
       const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
 
       soClient.get.mockResolvedValue({
-        attributes: {},
+        attributes: {
+          name: 'Test',
+        },
         references: [],
         id: 'test-agent-policy',
         type: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
@@ -1008,6 +1030,7 @@ describe('Agent policy', () => {
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'update',
+        name: 'Test',
         id: 'test-agent-policy',
         savedObjectType: LEGACY_AGENT_POLICY_SAVED_OBJECT_TYPE,
       });
@@ -1556,7 +1579,7 @@ describe('Agent policy', () => {
             perPage: 1000,
             sortField: 'created_at',
             sortOrder: 'asc',
-            fields: ['id'],
+            fields: ['id', 'name'],
             filter: undefined,
           })
         );
@@ -1576,7 +1599,7 @@ describe('Agent policy', () => {
             perPage: 13,
             sortField: 'created_at',
             sortOrder: 'asc',
-            fields: ['id'],
+            fields: ['id', 'name'],
             filter: 'one=two',
           })
         );

--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -189,15 +189,17 @@ class AgentPolicyService {
     }
   ): Promise<AgentPolicy> {
     const savedObjectType = await getAgentPolicySavedObjectType();
-    auditLoggingService.writeCustomSoAuditLog({
-      action: 'update',
-      id,
-      savedObjectType,
-    });
+
     const logger = appContextService.getLogger();
     logger.debug(`Starting update of agent policy ${id}`);
 
     const existingAgentPolicy = await this.get(soClient, id, true);
+    auditLoggingService.writeCustomSoAuditLog({
+      action: 'update',
+      id,
+      name: existingAgentPolicy?.name,
+      savedObjectType,
+    });
 
     if (!existingAgentPolicy) {
       throw new AgentPolicyNotFoundError('Agent policy not found');
@@ -392,6 +394,7 @@ class AgentPolicyService {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'create',
       id: options.id,
+      name: agentPolicy.name,
       savedObjectType,
     });
     await this.runExternalCallbacks('agentPolicyCreate', agentPolicy);
@@ -515,6 +518,7 @@ class AgentPolicyService {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'get',
       id,
+      name: agentPolicy.name,
       savedObjectType,
     });
 
@@ -580,6 +584,7 @@ class AgentPolicyService {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'get',
         id: agentPolicy.id,
+        name: agentPolicy.name,
         savedObjectType,
       });
     }
@@ -684,6 +689,7 @@ class AgentPolicyService {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'find',
         id: agentPolicy.id,
+        name: agentPolicy.name,
         savedObjectType,
       });
     }
@@ -1203,13 +1209,14 @@ class AgentPolicyService {
     const logger = appContextService.getLogger();
     logger.debug(`Deleting agent policy ${id}`);
     const savedObjectType = await getAgentPolicySavedObjectType();
+
+    const agentPolicy = await this.get(soClient, id, false);
     auditLoggingService.writeCustomSoAuditLog({
       action: 'delete',
       id,
+      name: agentPolicy?.name,
       savedObjectType,
     });
-
-    const agentPolicy = await this.get(soClient, id, false);
     if (!agentPolicy) {
       throw new AgentPolicyNotFoundError('Agent policy not found');
     }
@@ -1787,14 +1794,14 @@ class AgentPolicyService {
     { perPage = 1000, kuery = undefined, spaceId = undefined }: FetchAllAgentPolicyIdsOptions = {}
   ): Promise<AsyncIterable<string[]>> {
     const savedObjectType = await getAgentPolicySavedObjectType();
-    return createSoFindIterable<{}>({
+    return createSoFindIterable<{ name: string }>({
       soClient,
       findRequest: {
         type: savedObjectType,
         perPage,
         sortField: 'created_at',
         sortOrder: 'asc',
-        fields: ['id'],
+        fields: ['id', 'name'],
         filter: kuery ? normalizeKuery(savedObjectType, kuery) : undefined,
         namespaces: spaceId ? [spaceId] : undefined,
       },
@@ -1803,6 +1810,7 @@ class AgentPolicyService {
           auditLoggingService.writeCustomSoAuditLog({
             action: 'find',
             id: agentPolicySO.id,
+            name: agentPolicySO.attributes.name,
             savedObjectType,
           });
           return agentPolicySO.id;

--- a/x-pack/platform/plugins/shared/fleet/server/services/audit_logging.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/audit_logging.ts
@@ -52,10 +52,12 @@ class AuditLoggingService {
   public writeCustomSoAuditLog({
     action,
     id,
+    name,
     savedObjectType,
   }: {
     action: 'find' | 'get' | 'create' | 'update' | 'delete';
     id: string;
+    name?: string;
     savedObjectType: string;
   }) {
     this.writeCustomAuditLog({
@@ -71,6 +73,7 @@ class AuditLoggingService {
       kibana: {
         saved_object: {
           id,
+          name,
           type: savedObjectType,
         },
       },

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/custom_integrations/validation/check_naming_collision.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/custom_integrations/validation/check_naming_collision.ts
@@ -74,6 +74,7 @@ export const checkForInstallationNamingCollision = async (
     auditLoggingService.writeCustomSoAuditLog({
       action: 'find',
       id: savedObject.id,
+      name: savedObject.attributes.name,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
   }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/es_assets_reference.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/es_assets_reference.ts
@@ -56,6 +56,7 @@ export const updateEsAssetReferences = async (
   auditLoggingService.writeCustomSoAuditLog({
     action: 'update',
     id: pkgName,
+    name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
 
@@ -100,6 +101,7 @@ export const optimisticallyAddEsAssetReferences = async (
     auditLoggingService.writeCustomSoAuditLog({
       action: 'get',
       id: pkgName,
+      name: pkgName,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
 
@@ -119,6 +121,7 @@ export const optimisticallyAddEsAssetReferences = async (
     auditLoggingService.writeCustomSoAuditLog({
       action: 'update',
       id: pkgName,
+      name: pkgName,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.test.ts
@@ -509,6 +509,7 @@ owner: elastic`,
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'get',
         id: 'elasticsearch',
+        name: 'elasticsearch',
         savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
       });
     });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/get.ts
@@ -170,6 +170,7 @@ export async function getPackages(
     auditLoggingService.writeCustomSoAuditLog({
       action: 'get',
       id: pkg.id,
+      name: pkg.name,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
   }
@@ -286,6 +287,7 @@ export async function getLimitedPackages(options: {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'find',
       id: pkg.id,
+      name: pkg.name,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
   }
@@ -307,6 +309,7 @@ export async function getPackageSavedObjects(
     auditLoggingService.writeCustomSoAuditLog({
       action: 'find',
       id: savedObject.id,
+      name: savedObject.attributes.name,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
   }
@@ -360,6 +363,7 @@ export async function getInstalledPackageSavedObjects(
     auditLoggingService.writeCustomSoAuditLog({
       action: 'find',
       id: savedObject.id,
+      name: savedObject.attributes.name,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
   }
@@ -555,6 +559,7 @@ export const getPackageUsageStats = async ({
       auditLoggingService.writeCustomSoAuditLog({
         action: 'find',
         id: packagePolicy.id,
+        name: packagePolicy.attributes.name,
         savedObjectType: packagePolicySavedObjectType,
       });
     }
@@ -673,6 +678,7 @@ export async function getInstallationObject(options: {
   auditLoggingService.writeCustomSoAuditLog({
     action: 'find',
     id: installation.id,
+    name: installation.attributes.name,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
 
@@ -694,6 +700,7 @@ async function getInstallationObjects(options: {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'find',
       id: installation.id,
+      name: installation.attributes.name,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
   }

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.test.ts
@@ -139,6 +139,7 @@ describe('createInstallation', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'create',
         id: 'test-package',
+        name: 'test-package',
         savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
       });
     });
@@ -156,6 +157,7 @@ describe('createInstallation', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'create',
         id: 'test-package',
+        name: 'test-package',
         savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
       });
     });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install.ts
@@ -1061,6 +1061,7 @@ export const updateVersion = async (
   auditLoggingService.writeCustomSoAuditLog({
     action: 'update',
     id: pkgName,
+    name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
 
@@ -1085,6 +1086,7 @@ export const updateInstallStatusToFailed = async ({
   auditLoggingService.writeCustomSoAuditLog({
     action: 'update',
     id: pkgName,
+    name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
   try {
@@ -1126,6 +1128,7 @@ export async function restartInstallation(options: {
   auditLoggingService.writeCustomSoAuditLog({
     action: 'update',
     id: pkgName,
+    name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
 
@@ -1178,6 +1181,7 @@ export async function createInstallation(options: {
   auditLoggingService.writeCustomSoAuditLog({
     action: 'create',
     id: pkgName,
+    name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
 
@@ -1205,6 +1209,7 @@ export const saveKibanaAssetsRefs = async (
   auditLoggingService.writeCustomSoAuditLog({
     action: 'update',
     id: pkgName,
+    name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.test.ts
@@ -102,6 +102,7 @@ describe('updateLatestExecutedState', () => {
     ]);
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'update',
+      name: 'test-integration',
       id: 'test-integration',
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
@@ -169,6 +170,7 @@ describe('updateLatestExecutedState', () => {
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'update',
       id: 'test-integration',
+      name: 'test-integration',
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
     expect(packagePolicyService.bulkUpgrade).toHaveBeenCalledWith(

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/step_save_system_object.ts
@@ -38,6 +38,7 @@ export async function stepSaveSystemObject(context: InstallContext) {
   auditLoggingService.writeCustomSoAuditLog({
     action: 'update',
     id: pkgName,
+    name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/update_latest_executed_state.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/update_latest_executed_state.test.ts
@@ -105,6 +105,7 @@ describe('updateLatestExecutedState', () => {
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'update',
       id: 'xyz',
+      name: 'xyz',
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
   });
@@ -227,6 +228,7 @@ describe('updateLatestExecutedState', () => {
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'update',
       id: 'xyz',
+      name: 'xyz',
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
     expect(logger.error).toHaveBeenCalledWith(

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/update_latest_executed_state.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/install_state_machine/steps/update_latest_executed_state.ts
@@ -32,6 +32,7 @@ export const updateLatestExecutedState = async (context: InstallContext) => {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'update',
       id: pkgName,
+      name: pkgName,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
     return await withPackageSpan('Update latest executed state', () =>
@@ -55,6 +56,7 @@ export const cleanupLatestExecutedState = async (context: InstallContext) => {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'update',
       id: pkgName,
+      name: pkgName,
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
     logger.debug(`Cleaning up latest executed state`);

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/remove.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/remove.test.ts
@@ -108,6 +108,7 @@ describe('removeInstallation', () => {
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'delete',
       id: 'system',
+      name: 'system',
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/remove.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/remove.ts
@@ -106,6 +106,7 @@ export async function removeInstallation(options: {
   auditLoggingService.writeCustomSoAuditLog({
     action: 'delete',
     id: pkgName,
+    name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
   await savedObjectsClient.delete(PACKAGES_SAVED_OBJECT_TYPE, pkgName);

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/update.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/update.test.ts
@@ -59,7 +59,9 @@ describe('updatePackage', () => {
 
     mockGetInstallationObject.mockResolvedValueOnce({
       id: 'test-package',
-      attributes: {} as any,
+      attributes: {
+        name: 'test-package',
+      } as any,
       references: [],
       type: PACKAGES_SAVED_OBJECT_TYPE,
     });
@@ -73,6 +75,7 @@ describe('updatePackage', () => {
     expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
       action: 'update',
       id: 'test-package',
+      name: 'test-package',
       savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
     });
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/update.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/packages/update.ts
@@ -35,6 +35,7 @@ export async function updatePackage(
   auditLoggingService.writeCustomSoAuditLog({
     action: 'update',
     id: installedPackage.id,
+    name: installedPackage.attributes.name,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
 
@@ -62,6 +63,7 @@ export async function updateDatastreamExperimentalFeatures(
   auditLoggingService.writeCustomSoAuditLog({
     action: 'update',
     id: pkgName,
+    name: pkgName,
     savedObjectType: PACKAGES_SAVED_OBJECT_TYPE,
   });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/output.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/output.test.ts
@@ -83,6 +83,7 @@ function mockOutputSO(id: string, attributes: any = {}, updatedAt?: string) {
     type: 'ingest-outputs',
     references: [],
     attributes: {
+      name: 'Test',
       output_id: id,
       ...attributes,
     },
@@ -521,6 +522,7 @@ describe('Output Service', () => {
         expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
           action: 'create',
           id: outputIdToUuid('output-test'),
+          name: 'Test',
           savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
         });
       });
@@ -1817,6 +1819,7 @@ describe('Output Service', () => {
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'update',
+        name: 'Test',
         id: outputIdToUuid('existing-es-output'),
         savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
       });
@@ -2387,6 +2390,7 @@ describe('Output Service', () => {
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'delete',
+        name: 'Test',
         id: outputIdToUuid('existing-es-output'),
         savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
       });
@@ -2409,6 +2413,7 @@ describe('Output Service', () => {
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'get',
+        name: 'Test',
         id: outputIdToUuid('existing-es-output'),
         savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
       });

--- a/x-pack/platform/plugins/shared/fleet/server/services/output.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/output.ts
@@ -383,6 +383,7 @@ class OutputService {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'get',
         id: output.id,
+        name: output.attributes.name,
         savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
       });
     }
@@ -401,6 +402,7 @@ class OutputService {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'get',
         id: output.id,
+        name: output.attributes.name,
         savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
       });
     }
@@ -425,6 +427,7 @@ class OutputService {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'update',
       id: outputIdToUuid(defaultDataOutputId),
+      name: originalOutput.name,
       savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
     });
 
@@ -712,6 +715,7 @@ class OutputService {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'create',
       id,
+      name: data.name,
       savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
     });
     const newSo = await this.encryptedSoClient.create<OutputSOAttributes>(SAVED_OBJECT_TYPE, data, {
@@ -754,6 +758,7 @@ class OutputService {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'get',
         id: output.id,
+        name: output.attributes.name,
         savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
       });
     }
@@ -779,6 +784,7 @@ class OutputService {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'get',
         id: output.id,
+        name: output.attributes.name,
         savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
       });
     }
@@ -800,6 +806,7 @@ class OutputService {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'get',
       id: outputSO.id,
+      name: outputSO?.attributes?.name,
       savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
     });
 
@@ -851,6 +858,7 @@ class OutputService {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'delete',
       id: outputIdToUuid(id),
+      name: originalOutput.name,
       savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
     });
 
@@ -1136,6 +1144,7 @@ class OutputService {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'update',
       id: outputIdToUuid(id),
+      name: originalOutput.name,
       savedObjectType: OUTPUT_SAVED_OBJECT_TYPE,
     });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.test.ts
@@ -304,6 +304,7 @@ describe('Package policy service', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toBeCalledWith({
         action: 'create',
         id: 'test-package-policy',
+        name: 'Test Package Policy',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
     });
@@ -447,12 +448,14 @@ describe('Package policy service', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(1, {
         action: 'create',
         id: 'test-package-policy-1',
+        name: 'Test Package Policy 1',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(2, {
         action: 'create',
         id: 'test-package-policy-2',
+        name: 'Test Package Policy 2',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
     });
@@ -463,7 +466,7 @@ describe('Package policy service', () => {
       const soClient = savedObjectsClientMock.create();
       soClient.get.mockResolvedValueOnce({
         id: 'test-package-policy',
-        attributes: {},
+        attributes: { name: 'Test' },
         references: [],
         type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
@@ -473,6 +476,7 @@ describe('Package policy service', () => {
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toBeCalledWith({
         action: 'get',
         id: 'test-package-policy',
+        name: 'Test',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
     });
@@ -485,13 +489,13 @@ describe('Package policy service', () => {
         saved_objects: [
           {
             id: 'test-package-policy-1',
-            attributes: {},
+            attributes: { name: 'Test 1' },
             references: [],
             type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
           },
           {
             id: 'test-package-policy-2',
-            attributes: {},
+            attributes: { name: 'Test 2' },
             references: [],
             type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
           },
@@ -505,12 +509,14 @@ describe('Package policy service', () => {
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(1, {
         action: 'get',
+        name: 'Test 1',
         id: 'test-package-policy-1',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(2, {
         action: 'get',
+        name: 'Test 2',
         id: 'test-package-policy-2',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
@@ -527,14 +533,14 @@ describe('Package policy service', () => {
         saved_objects: [
           {
             id: 'test-package-policy-1',
-            attributes: {},
+            attributes: { name: 'Test 1' },
             references: [],
             type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
             score: 0,
           },
           {
             id: 'test-package-policy-2',
-            attributes: {},
+            attributes: { name: 'Test 2' },
             references: [],
             type: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
             score: 0,
@@ -550,12 +556,14 @@ describe('Package policy service', () => {
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(1, {
         action: 'find',
+        name: 'Test 1',
         id: 'test-package-policy-1',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenNthCalledWith(2, {
         action: 'find',
+        name: 'Test 2',
         id: 'test-package-policy-2',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });
@@ -1781,6 +1789,7 @@ describe('Package policy service', () => {
 
       expect(mockedAuditLoggingService.writeCustomSoAuditLog).toHaveBeenCalledWith({
         action: 'update',
+        name: 'endpoint-1',
         id: 'test-package-policy',
         savedObjectType: LEGACY_PACKAGE_POLICY_SAVED_OBJECT_TYPE,
       });

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -261,6 +261,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'create',
       id: packagePolicyId,
+      name: packagePolicy.name,
       savedObjectType,
     });
 
@@ -514,6 +515,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'create',
         id: packagePolicy.id,
+        name: packagePolicy.name,
         savedObjectType,
       });
 
@@ -772,6 +774,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'get',
       id,
+      name: response.name,
       savedObjectType,
     });
 
@@ -800,6 +803,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'find',
         id: packagePolicy.id,
+        name: packagePolicy.name,
         savedObjectType,
       });
     }
@@ -842,6 +846,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'get',
         id: packagePolicy.id,
+        name: packagePolicy.name,
         savedObjectType,
       });
     }
@@ -879,6 +884,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'find',
         id: packagePolicy.id,
+        name: packagePolicy.attributes.name,
         savedObjectType,
       });
     }
@@ -899,13 +905,13 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
   ): Promise<ListResult<string>> {
     const { page = 1, perPage = 20, sortField = 'updated_at', sortOrder = 'desc', kuery } = options;
     const savedObjectType = await getPackagePolicySavedObjectType();
-    const packagePolicies = await soClient.find<{}>({
+    const packagePolicies = await soClient.find<{ name: string }>({
       type: savedObjectType,
       sortField,
       sortOrder,
       page,
       perPage,
-      fields: [],
+      fields: ['name'],
       filter: kuery ? normalizeKuery(savedObjectType, kuery) : undefined,
     });
 
@@ -913,6 +919,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'find',
         id: packagePolicy.id,
+        name: packagePolicy.attributes.name,
         savedObjectType,
       });
     }
@@ -936,6 +943,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     auditLoggingService.writeCustomSoAuditLog({
       action: 'update',
       id,
+      name: packagePolicyUpdate.name,
       savedObjectType,
     });
     const logger = appContextService.getLogger();
@@ -1191,6 +1199,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       auditLoggingService.writeCustomSoAuditLog({
         action: 'update',
         id: packagePolicy.id,
+        name: packagePolicy.name,
         savedObjectType,
       });
     }
@@ -2126,6 +2135,7 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
           auditLoggingService.writeCustomSoAuditLog({
             action: 'find',
             id: packagePolicySO.id,
+            name: packagePolicySO.attributes.name,
             savedObjectType,
           });
 


### PR DESCRIPTION
## Summary



Resolve https://github.com/elastic/kibana/issues/208110

Add saved object name to audit logs, the original issue mentioned using `nameAttribute` but Fleet use custom audit logging making that property not usable. (also as we already have `name` attributes on our saved object there is no need to configure that property)


## How to test


Update your kibana config
```
xpack.security.audit.enabled: true
xpack.security.audit.include_saved_object_names: true
xpack.security.audit.appender.type: console
xpack.security.audit.appender.layout.type: json
```

Do some Fleet actions and check the saved object name is displayed when available: `"name":"Agent policy 1"`

```
{"event":{"action":"saved_object_get","category":["database"],"outcome":"unknown","type":["access"]},"kibana":{"space_id":"default","session_id":"3bbld5sk5HE5U80efoDzRHit02hAjC614137JmiEHb4=","saved_object":{"id":"388b641d-1000-4401-b9f4-461ae27f68ac","name":"Agent policy 1","type":"fleet-agent-policies"}},"labels":{"application":"elastic/fleet"},"user":{"id":"u_xENghUGkaA4PYBKxv1SX86Hhdnj2Yu5UPPEt9EjDL_g_0","name":"system_indices_superuser","roles":["system_indices_superuser"]},"trace":{"id":"370f7d64-337b-4ca7-a88f-f7e6b4927ff6"},"client":{"ip":"127.0.0.1"},"service":{"node":{"roles":["background_tasks","ui"]}},"ecs":{"version":"8.11.0"},"@timestamp":"2025-04-02T12:47:34.528-04:00","message":"User has accessed fleet-agent-policies [id=388b641d-1000-4401-b9f4-461ae27f68ac]","log":{"level":"INFO","logger":"plugins.security.audit.ecs"},"process":{"pid":83984,"uptime":689.358787917},"transaction":{"id":"221564c7519f47a8"}}
```




