### PR TITLE
[8.x] [Graph] Remove `transparentize` color function (#216072)

### DIFF
--- a/x-pack/platform/plugins/private/graph/public/components/graph_visualization/__snapshots__/graph_visualization.test.tsx.snap
+++ b/x-pack/platform/plugins/private/graph/public/components/graph_visualization/__snapshots__/graph_visualization.test.tsx.snap
@@ -110,11 +110,12 @@ exports[`graph_visualization should render to svg elements 1`] = `
             },
             Object {
               "map": undefined,
-              "name": "f3zvy5",
+              "name": "1m022vv",
               "next": undefined,
               "styles": "
                           stroke-width: 4px;
-                          stroke: rgba(0,119,204,0.25);
+                          stroke: #99c9eb;
+                          paint-order: stroke;
                         ",
               "toString": [Function],
             },

--- a/x-pack/platform/plugins/private/graph/public/components/graph_visualization/graph_visualization.tsx
+++ b/x-pack/platform/plugins/private/graph/public/components/graph_visualization/graph_visualization.tsx
@@ -8,7 +8,7 @@
 import React, { useRef } from 'react';
 import d3, { ZoomEvent } from 'd3';
 import { css } from '@emotion/react';
-import { type UseEuiTheme, euiTextTruncate, useEuiTheme, transparentize } from '@elastic/eui';
+import { type UseEuiTheme, euiTextTruncate, useEuiTheme } from '@elastic/eui';
 import { Workspace, WorkspaceNode, TermIntersect, ControlType, WorkspaceEdge } from '../../types';
 import { makeNodeId } from '../../services/persistence';
 import { getIconOffset, IconRenderer } from '../icon_renderer';
@@ -191,7 +191,8 @@ export function GraphVisualization({
                       node.isSelected &&
                         css`
                           stroke-width: ${euiThemeContext.euiTheme.size.xs};
-                          stroke: ${transparentize(euiThemeContext.euiTheme.colors.primary, 0.25)};
+                          stroke: ${euiThemeContext.euiTheme.colors.borderBasePrimary};
+                          paint-order: stroke;
                         `,
                     ]}
                   />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Graph] Remove `transparentize` color function (#216072)](https://github.com/elastic/kibana/pull/216072)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maria Iriarte","email":"106958839+mariairiartef@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-31T12:26:10Z","message":"[Graph] Remove `transparentize` color function (#216072)\n\n## Summary\n\nRemoves `Graph` usage of color functions in favor of color tokens as\nrequested in\nhttps://github.com/elastic/kibana/issues/199715#custom-colors.\n\nThe\n[guidelines](https://docs.google.com/document/d/1IAKbasq1nDfqd2IU3KdP8cwD3uCCAwkIekKRq7zgyWg/edit?tab=t.0#heading=h.5rebxirnvgy5)\nrecommend using opaque colors when possible.\n\n## Screenshots\n\n### Before\n\n<img width=\"1726\" alt=\"Screenshot 2025-03-26 at 12 12 00\"\nsrc=\"https://github.com/user-attachments/assets/ff9dc939-eb84-486c-b52e-9b5760e6d9a3\"\n/>\n\n### After\n\n<img width=\"649\" alt=\"Screenshot 2025-03-27 at 10 51 27\"\nsrc=\"https://github.com/user-attachments/assets/5471db37-95f4-43e8-b3f8-82652dde8b7f\"\n/>\n\n\n\n\n### Checklist\n\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>","sha":"c7218a3fdbcf54b13f6da32a27e8ea0e6003b768","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Graph","Team:Visualizations","release_note:skip","backport missing","backport:version","EUI Visual Refresh","v9.1.0","v8.19.0"],"title":"[Graph] Remove `transparentize` color function","number":216072,"url":"https://github.com/elastic/kibana/pull/216072","mergeCommit":{"message":"[Graph] Remove `transparentize` color function (#216072)\n\n## Summary\n\nRemoves `Graph` usage of color functions in favor of color tokens as\nrequested in\nhttps://github.com/elastic/kibana/issues/199715#custom-colors.\n\nThe\n[guidelines](https://docs.google.com/document/d/1IAKbasq1nDfqd2IU3KdP8cwD3uCCAwkIekKRq7zgyWg/edit?tab=t.0#heading=h.5rebxirnvgy5)\nrecommend using opaque colors when possible.\n\n## Screenshots\n\n### Before\n\n<img width=\"1726\" alt=\"Screenshot 2025-03-26 at 12 12 00\"\nsrc=\"https://github.com/user-attachments/assets/ff9dc939-eb84-486c-b52e-9b5760e6d9a3\"\n/>\n\n### After\n\n<img width=\"649\" alt=\"Screenshot 2025-03-27 at 10 51 27\"\nsrc=\"https://github.com/user-attachments/assets/5471db37-95f4-43e8-b3f8-82652dde8b7f\"\n/>\n\n\n\n\n### Checklist\n\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>","sha":"c7218a3fdbcf54b13f6da32a27e8ea0e6003b768"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216072","number":216072,"mergeCommit":{"message":"[Graph] Remove `transparentize` color function (#216072)\n\n## Summary\n\nRemoves `Graph` usage of color functions in favor of color tokens as\nrequested in\nhttps://github.com/elastic/kibana/issues/199715#custom-colors.\n\nThe\n[guidelines](https://docs.google.com/document/d/1IAKbasq1nDfqd2IU3KdP8cwD3uCCAwkIekKRq7zgyWg/edit?tab=t.0#heading=h.5rebxirnvgy5)\nrecommend using opaque colors when possible.\n\n## Screenshots\n\n### Before\n\n<img width=\"1726\" alt=\"Screenshot 2025-03-26 at 12 12 00\"\nsrc=\"https://github.com/user-attachments/assets/ff9dc939-eb84-486c-b52e-9b5760e6d9a3\"\n/>\n\n### After\n\n<img width=\"649\" alt=\"Screenshot 2025-03-27 at 10 51 27\"\nsrc=\"https://github.com/user-attachments/assets/5471db37-95f4-43e8-b3f8-82652dde8b7f\"\n/>\n\n\n\n\n### Checklist\n\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Nick Partridge <nicholas.partridge@elastic.co>","sha":"c7218a3fdbcf54b13f6da32a27e8ea0e6003b768"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->