### PR TITLE
[dashboard][8.17][8.16] fix State being dropped when editing visualize embeddables

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -342,7 +342,10 @@ export class DashboardContainer
     this.hasOverlays$ = dashboardApi.hasOverlays$;
     this.openOverlay = dashboardApi.openOverlay;
     this.hasRunMigrations$ = dashboardApi.hasRunMigrations$;
-    this.setLastSavedInput = dashboardApi.setLastSavedInput;
+    this.setLastSavedInput = (lastSavedInput: DashboardContainerInput) => {
+      dashboardApi.setLastSavedInput(lastSavedInput);
+      this.setPanels(lastSavedInput.panels);
+    };
     this.lastSavedInput$ = dashboardApi.lastSavedInput$;
     this.savedObjectId = dashboardApi.savedObjectId;
     this.setSavedObjectId = dashboardApi.setSavedObjectId;


### PR DESCRIPTION
8.16 and 8.17 fix for https://github.com/elastic/kibana/issues/216886

See https://github.com/elastic/kibana/pull/216901 for details