### PR TITLE
[Stack connectors] Fix bedrock `modelId` encoding

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.test.ts
@@ -31,6 +31,7 @@ jest.mock('../lib/gen_ai/create_gen_ai_dashboard');
 // @ts-ignore
 const mockSigner = jest.spyOn(aws, 'sign').mockReturnValue({ signed: true });
 const mockSend = jest.fn();
+const encodedModel = encodeURIComponent(DEFAULT_BEDROCK_MODEL);
 describe('BedrockConnector', () => {
   let mockRequest: jest.Mock;
   let mockError: jest.Mock;
@@ -111,7 +112,7 @@ describe('BedrockConnector', () => {
               'Content-Type': 'application/json',
             },
             host: 'bedrock-runtime.us-east-1.amazonaws.com',
-            path: '/model/anthropic.claude-3-5-sonnet-20240620-v1:0/invoke',
+            path: `/model/${encodedModel}/invoke`,
             service: 'bedrock',
           },
           { accessKeyId: '123', secretAccessKey: 'secret' }
@@ -124,7 +125,7 @@ describe('BedrockConnector', () => {
           {
             signed: true,
             timeout: DEFAULT_TIMEOUT_MS,
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke`,
             method: 'post',
             responseSchema: RunApiLatestResponseSchema,
             data: DEFAULT_BODY,
@@ -154,7 +155,7 @@ describe('BedrockConnector', () => {
           {
             signed: true,
             timeout: DEFAULT_TIMEOUT_MS,
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke`,
             method: 'post',
             responseSchema: RunActionResponseSchema,
             data: v2Body,
@@ -212,7 +213,7 @@ describe('BedrockConnector', () => {
               'x-amzn-bedrock-accept': '*/*',
             },
             host: 'bedrock-runtime.us-east-1.amazonaws.com',
-            path: '/model/anthropic.claude-3-5-sonnet-20240620-v1:0/invoke-with-response-stream',
+            path: `/model/${encodedModel}/invoke-with-response-stream`,
             service: 'bedrock',
           },
           { accessKeyId: '123', secretAccessKey: 'secret' }
@@ -225,7 +226,7 @@ describe('BedrockConnector', () => {
         expect(mockRequest).toHaveBeenCalledWith(
           {
             signed: true,
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke-with-response-stream`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke-with-response-stream`,
             method: 'post',
             responseSchema: StreamingResponseSchema,
             responseType: 'stream',
@@ -246,7 +247,7 @@ describe('BedrockConnector', () => {
         expect(mockRequest).toHaveBeenCalledWith(
           {
             signed: true,
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke-with-response-stream`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke-with-response-stream`,
             method: 'post',
             responseSchema: StreamingResponseSchema,
             responseType: 'stream',
@@ -286,7 +287,7 @@ describe('BedrockConnector', () => {
           {
             signed: true,
             responseType: 'stream',
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke-with-response-stream`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke-with-response-stream`,
             method: 'post',
             responseSchema: StreamingResponseSchema,
             data: JSON.stringify({
@@ -341,7 +342,7 @@ describe('BedrockConnector', () => {
           {
             signed: true,
             responseType: 'stream',
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke-with-response-stream`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke-with-response-stream`,
             method: 'post',
             responseSchema: StreamingResponseSchema,
             data: JSON.stringify({
@@ -442,7 +443,7 @@ describe('BedrockConnector', () => {
           {
             signed: true,
             timeout: DEFAULT_TIMEOUT_MS,
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke`,
             method: 'post',
             responseSchema: RunApiLatestResponseSchema,
             data: JSON.stringify({
@@ -486,7 +487,7 @@ describe('BedrockConnector', () => {
           {
             signed: true,
             timeout: DEFAULT_TIMEOUT_MS,
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke`,
             method: 'post',
             responseSchema: RunApiLatestResponseSchema,
             data: JSON.stringify({
@@ -532,7 +533,7 @@ describe('BedrockConnector', () => {
           {
             signed: true,
             timeout: DEFAULT_TIMEOUT_MS,
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke`,
             method: 'post',
             responseSchema: RunApiLatestResponseSchema,
             data: JSON.stringify({
@@ -582,7 +583,7 @@ describe('BedrockConnector', () => {
           {
             signed: true,
             timeout: DEFAULT_TIMEOUT_MS,
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke`,
             method: 'post',
             responseSchema: RunApiLatestResponseSchema,
             data: JSON.stringify({
@@ -609,7 +610,7 @@ describe('BedrockConnector', () => {
         expect(mockRequest).toHaveBeenCalledWith(
           {
             signed: true,
-            url: `${DEFAULT_BEDROCK_URL}/model/${DEFAULT_BEDROCK_MODEL}/invoke`,
+            url: `${DEFAULT_BEDROCK_URL}/model/${encodedModel}/invoke`,
             method: 'post',
             responseSchema: RunApiLatestResponseSchema,
             data: JSON.stringify({

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/bedrock/bedrock.ts
@@ -254,7 +254,9 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
     connectorUsageCollector: ConnectorUsageCollector
   ): Promise<RunActionResponse | InvokeAIRawActionResponse> {
     // set model on per request basis
-    const currentModel = reqModel ?? this.model;
+    // Application Inference Profile IDs need to be encoded when using the API
+    // Decode first to ensure an existing encoded value is not double encoded
+    const currentModel = encodeURIComponent(decodeURIComponent(reqModel ?? this.model));
     const path = `/model/${currentModel}/invoke`;
     const signed = this.signRequest(body, path, false);
     const requestArgs = {
@@ -299,7 +301,10 @@ The Kibana Connector in use may need to be reconfigured with an updated Amazon B
     connectorUsageCollector: ConnectorUsageCollector
   ): Promise<StreamingResponse> {
     // set model on per request basis
-    const path = `/model/${reqModel ?? this.model}/invoke-with-response-stream`;
+    // Application Inference Profile IDs need to be encoded when using the API
+    // Decode first to ensure an existing encoded value is not double encoded
+    const currentModel = encodeURIComponent(decodeURIComponent(reqModel ?? this.model));
+    const path = `/model/${currentModel}/invoke-with-response-stream`;
     const signed = this.signRequest(body, path, true);
 
     const response = await this.request(

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/bedrock.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/actions/connector_types/bedrock.ts
@@ -332,7 +332,7 @@ export default function bedrockTest({ getService }: FtrProviderContext) {
 
             expect(simulator.requestData).to.eql(DEFAULT_BODY);
             expect(simulator.requestUrl).to.eql(
-              `${apiUrl}/model/${defaultConfig.defaultModel}/invoke`
+              `${apiUrl}/model/${encodeURIComponent(defaultConfig.defaultModel)}/invoke`
             );
             expect(body).to.eql({
               status: 'ok',
@@ -584,7 +584,7 @@ export default function bedrockTest({ getService }: FtrProviderContext) {
 
             expect(simulator.requestData).to.eql(DEFAULT_BODY);
             expect(simulator.requestUrl).to.eql(
-              `${apiUrl}/model/${defaultConfig.defaultModel}/invoke`
+              `${apiUrl}/model/${encodeURIComponent(defaultConfig.defaultModel)}/invoke`
             );
             expect(body).to.eql({
               status: 'ok',


### PR DESCRIPTION
## Summary

When using application inference profiles, we discovered that http requests require the ID to be encoded since the ID is part of the URL. The SDK does not require encoding and will fail with an encoded model. This PR encodes the model id in Bedrock http requests. It first decodes the id to prevent double encoding if a user already had a connector with an encoded ID.

### To test:

1. Create 2 connectors, one with an encoded and one with an unencoded application inference model id:
    ```
    arn%3Aaws%3Abedrock%3Aus-west-2%3A644184947617%3Aapplication-inference-profile%2F8sx6caye2nsi
    arn:aws:bedrock:us-west-2:644184947617:application-inference-profile/8sx6caye2nsi
    ```
2. Use the correct region URL: https://bedrock-runtime.us-west-2.amazonaws.com
3. Use these credentials: https://p.elstc.co/paste/pZPzDTo8#ymn8BazX0Y-DhQ2GFr/O+vW5fm296oMwNRa4/SxpFxH
4. Run the connector test tab for each connector, ensure it passes
5. Say "hello world" from security AI Assistant, ensure you get a nice hello back.

<!--ONMERGE {"backportTargets":["8.17","8.18","8.x","9.0"]} ONMERGE-->