### PR TITLE
[8.x] [Discover][ES|QL] Fix JSON view for ES|QL record in DocViewer (#216642)

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_source/source.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_source/source.test.tsx
@@ -16,8 +16,11 @@ import * as useUiSettingHook from '@kbn/kibana-react-plugin/public/ui_settings/u
 import { EuiButton, EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
 import { JsonCodeEditorCommon } from '../json_code_editor';
 import { buildDataTableRecord } from '@kbn/discover-utils';
+import { mockUnifiedDocViewerServices } from '../../__mocks__';
 import { setUnifiedDocViewerServices } from '../../plugin';
 import type { UnifiedDocViewerServices } from '../../types';
+
+setUnifiedDocViewerServices(mockUnifiedDocViewerServices);
 
 const mockDataView = {
   getComputedFields: () => [],
@@ -104,5 +107,36 @@ describe('Source Viewer component', () => {
     expect(jsonCodeEditor.props().jsonValue).not.toContain('_score');
     expect(jsonCodeEditor.props().hasLineNumbers).toBe(true);
     expect(jsonCodeEditor.props().enableFindAction).toBe(true);
+  });
+
+  test('renders json code editor for ES|QL record', () => {
+    const record = {
+      _index: 'logstash-2014.09.09',
+      _id: 'id123',
+      message: 'Lorem ipsum dolor sit amet',
+      extension: 'html',
+    };
+    const mockHit = {
+      id: '22',
+      raw: record,
+      flattened: record,
+    };
+    jest.spyOn(useUiSettingHook, 'useUiSetting').mockImplementation(() => {
+      return false;
+    });
+    const comp = mountWithIntl(
+      <DocViewerSource
+        id={mockHit.id}
+        index={'index1'}
+        dataView={mockDataView}
+        esqlHit={mockHit}
+        width={123}
+        onRefresh={() => {}}
+      />
+    );
+    const jsonCodeEditor = comp.find(JsonCodeEditorCommon);
+    expect(jsonCodeEditor).not.toBe(null);
+    expect(jsonCodeEditor.props().jsonValue).toContain('message');
+    expect(jsonCodeEditor.props().jsonValue).toContain('_id');
   });
 });

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
@@ -28,7 +28,7 @@ interface SourceViewerProps {
   id: string;
   index: string | undefined;
   dataView: DataView;
-  textBasedHits?: DataTableRecord[];
+  esqlHit?: DataTableRecord;
   width?: number;
   decreaseAvailableHeightBy?: number;
   onRefresh: () => void;
@@ -44,7 +44,7 @@ export const DocViewerSource = ({
   id,
   index,
   dataView,
-  textBasedHits,
+  esqlHit,
   width,
   decreaseAvailableHeightBy,
   onRefresh,
@@ -63,7 +63,7 @@ export const DocViewerSource = ({
     index,
     dataView,
     requestSource: useNewFieldsApi,
-    textBasedHits,
+    esqlHit,
   });
 
   useEffect(() => {

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_source/source.tsx
@@ -56,7 +56,7 @@ export const DocViewerSource = ({
   const useNewFieldsApi = !uiSettings.get(SEARCH_FIELDS_FROM_SOURCE);
   const useDocExplorer = !isLegacyTableEnabled({
     uiSettings,
-    isEsqlMode: Array.isArray(textBasedHits),
+    isEsqlMode: Boolean(esqlHit),
   });
   const [requestState, hit] = useEsDocSearch({
     id,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_es_doc_search.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_es_doc_search.test.tsx
@@ -15,6 +15,7 @@ import { ElasticRequestState } from '@kbn/unified-doc-viewer';
 import {
   SEARCH_FIELDS_FROM_SOURCE as mockSearchFieldsFromSource,
   buildDataTableRecord,
+  DataTableRecord,
 } from '@kbn/discover-utils';
 import { setUnifiedDocViewerServices } from '../plugin';
 import { UnifiedDocViewerServices } from '../types';
@@ -296,18 +297,16 @@ describe('Test of <Doc /> helper / hook', () => {
       getComputedFields: () => [],
       getIndexPattern: () => index,
     };
-    const props = {
+    const props: EsDocSearchProps = {
       id: '1',
       index: 'index1',
-      dataView,
-      textBasedHits: [
-        {
-          id: '1',
-          raw: { field1: 1, field2: 2 },
-          flattened: { field1: 1, field2: 2 },
-        },
-      ],
-    } as unknown as EsDocSearchProps;
+      dataView: dataView as unknown as EsDocSearchProps['dataView'],
+      esqlHit: {
+        id: '1',
+        raw: { field1: 1, field2: 2 },
+        flattened: { field1: 1, field2: 2 },
+      } as DataTableRecord,
+    };
 
     const hook = renderHook((p: EsDocSearchProps) => useEsDocSearch(p), {
       initialProps: props,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_es_doc_search.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/hooks/use_es_doc_search.ts
@@ -37,9 +37,9 @@ export interface EsDocSearchProps {
    */
   requestSource?: boolean;
   /**
-   * Records fetched from text based query
+   * Record fetched from ES|QL query
    */
-  textBasedHits?: DataTableRecord[];
+  esqlHit?: DataTableRecord;
   /**
    * An optional callback that will be called before fetching the doc
    */
@@ -59,7 +59,7 @@ export function useEsDocSearch({
   index,
   dataView,
   requestSource,
-  textBasedHits,
+  esqlHit,
   onBeforeFetch,
   onProcessRecord,
 }: EsDocSearchProps): [ElasticRequestState, DataTableRecord | null, () => void] {
@@ -127,16 +127,13 @@ export function useEsDocSearch({
   ]);
 
   useEffect(() => {
-    if (textBasedHits) {
-      const selectedHit = textBasedHits?.find((r) => r.id === id);
-      if (selectedHit) {
-        setStatus(ElasticRequestState.Found);
-        setHit(selectedHit);
-      }
+    if (esqlHit) {
+      setStatus(ElasticRequestState.Found);
+      setHit(esqlHit);
     } else {
       requestData();
     }
-  }, [id, requestData, textBasedHits]);
+  }, [id, requestData, esqlHit]);
 
   return [status, hit, requestData];
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
@@ -91,7 +91,10 @@ export class UnifiedDocViewerPublicPlugin
             index={hit.raw._index}
             id={hit.raw._id ?? hit.id}
             dataView={dataView}
-            textBasedHits={textBasedHits}
+            // If ES|QL query changes, then textBasedHits will update too.
+            // This is a workaround to reuse the previously referred hit
+            // so the doc viewer preserves the state even after the record disappears from hits list.
+            esqlHit={Array.isArray(textBasedHits) ? hit : undefined}
             decreaseAvailableHeightBy={decreaseAvailableHeightBy}
             onRefresh={() => {}}
           />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Discover][ES|QL] Fix JSON view for ES|QL record in DocViewer (#216642)](https://github.com/elastic/kibana/pull/216642)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2025-04-02T15:59:03Z","message":"[Discover][ES|QL] Fix JSON view for ES|QL record in DocViewer (#216642)\n\n- Closes https://github.com/elastic/kibana/issues/214805\n\n## Summary\n\nBy default ES|QL records don't have `_id` unless it's requested via the\nquery `METADATA`.\nThis PR fixes the JSON view inside DocViewer for ES|QL records.\nPreviously it was relying on `textBasedHits` which gets updated when\nquery changes hence there is a possibility of loosing the reference to\nthe last viewed record.\n\n## Testing\n\nExample queries:\n```\nFROM kibana_sample_data_ecommerce METADATA _index\nFROM kibana_sample_data_ecommerce METADATA _index, _id\n```\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"43b6cc4c1df1aee03f7d3a52fbab3133c459ea43","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:DataDiscovery","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[Discover][ES|QL] Fix JSON view for ES|QL record in DocViewer","number":216642,"url":"https://github.com/elastic/kibana/pull/216642","mergeCommit":{"message":"[Discover][ES|QL] Fix JSON view for ES|QL record in DocViewer (#216642)\n\n- Closes https://github.com/elastic/kibana/issues/214805\n\n## Summary\n\nBy default ES|QL records don't have `_id` unless it's requested via the\nquery `METADATA`.\nThis PR fixes the JSON view inside DocViewer for ES|QL records.\nPreviously it was relying on `textBasedHits` which gets updated when\nquery changes hence there is a possibility of loosing the reference to\nthe last viewed record.\n\n## Testing\n\nExample queries:\n```\nFROM kibana_sample_data_ecommerce METADATA _index\nFROM kibana_sample_data_ecommerce METADATA _index, _id\n```\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"43b6cc4c1df1aee03f7d3a52fbab3133c459ea43"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216885","number":216885,"state":"MERGED","mergeCommit":{"sha":"c46210f690903907c9addd3fcea567bbddf71c3c","message":"[9.0] [Discover][ES|QL] Fix JSON view for ES|QL record in DocViewer (#216642) (#216885)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Discover][ES|QL] Fix JSON view for ES|QL record in DocViewer\n(#216642)](https://github.com/elastic/kibana/pull/216642)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Julia Rechkunova <julia.rechkunova@elastic.co>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216642","number":216642,"mergeCommit":{"message":"[Discover][ES|QL] Fix JSON view for ES|QL record in DocViewer (#216642)\n\n- Closes https://github.com/elastic/kibana/issues/214805\n\n## Summary\n\nBy default ES|QL records don't have `_id` unless it's requested via the\nquery `METADATA`.\nThis PR fixes the JSON view inside DocViewer for ES|QL records.\nPreviously it was relying on `textBasedHits` which gets updated when\nquery changes hence there is a possibility of loosing the reference to\nthe last viewed record.\n\n## Testing\n\nExample queries:\n```\nFROM kibana_sample_data_ecommerce METADATA _index\nFROM kibana_sample_data_ecommerce METADATA _index, _id\n```\n\n### Checklist\n\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"43b6cc4c1df1aee03f7d3a52fbab3133c459ea43"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->