### PR TITLE
[APM] Fix fold/unfold button in traces waterfall explorer not clickable

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonEmpty, EuiCallOut, useEuiTheme } from '@elastic/eui';
+import { EuiButtonIcon, EuiCallOut, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { i18n } from '@kbn/i18n';
@@ -122,16 +122,19 @@ export function Waterfall({
           display: flex;
           position: sticky;
           top: var(--euiFixedHeadersOffset, 0);
-          z-index: ${euiTheme.levels.content};
+          z-index: ${euiTheme.levels.menu};
           background-color: ${euiTheme.colors.emptyShade};
           border-bottom: 1px solid ${euiTheme.colors.mediumShade};
         `}
       >
-        <EuiButtonEmpty
+        <EuiButtonIcon
           data-test-subj="apmWaterfallButton"
+          size="m"
           css={css`
             position: absolute;
-            z-index: ${euiTheme.levels.content};
+            z-index: ${euiTheme.levels.menu};
+            padding: ${euiTheme.size.m};
+            width: auto;
           `}
           aria-label={i18n.translate('xpack.apm.waterfall.foldButton.ariaLabel', {
             defaultMessage: 'Click to {isAccordionOpen} the waterfall',


### PR DESCRIPTION
## Summary

Fixes #216790

This PR fixes the z-indexes changed in the [emotion migration PR](https://github.com/elastic/kibana/pull/204222/files#diff-1c8129b4d0bdfead8d9fef09ba4344527629cb71cb52e920739fa85f17b5b36e), using the same value (2000) as before.
Also it uses EuiButtonIcon instead of EuiButtonEmpty and aligns its content.

## Before
![image](https://github.com/user-attachments/assets/8742e9a6-0de3-4353-9f95-cf82feffe7c6)

## After
![image](https://github.com/user-attachments/assets/2b9765a1-d428-4198-a9d5-ae9064c51ed9)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->