### PR TITLE
[8.x] [ObsUX][A11y] Add announcement keyboard elements improvements (#216592)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/group_name.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/group_name.tsx
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import { EuiLink, EuiToolTip } from '@elastic/eui';
-import React from 'react';
-
+import { EuiButtonEmpty, EuiScreenReaderOnly, EuiToolTip } from '@elastic/eui';
+import React, { useCallback, useState } from 'react';
+import { i18n } from '@kbn/i18n';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
+
 import type {
   InfraWaffleMapGroup,
   InfraWaffleMapOptions,
@@ -21,43 +22,72 @@ interface Props {
   options: InfraWaffleMapOptions;
 }
 
-export class GroupName extends React.PureComponent<Props, {}> {
-  public render() {
-    const { group, isChild } = this.props;
-    const linkStyle = {
-      fontSize: isChild ? '0.85em' : '1em',
-    };
-    return (
+export const GroupName: React.FC<Props> = ({ onDrilldown, group, isChild, options }) => {
+  const [a11yAnnouncement, setA11yAnnouncement] = useState('');
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+
+      if (options.groupBy.length === 0) {
+        setA11yAnnouncement(
+          i18n.translate('xpack.infra.inventory.groupBy.noChangeMessage', {
+            defaultMessage: 'No changes were made when selecting {group}.',
+            values: { group: group.name },
+          })
+        );
+        return;
+      }
+
+      setA11yAnnouncement(
+        i18n.translate('xpack.infra.inventory.groupBy.groupingByMessage', {
+          defaultMessage: 'Grouping by {group}...',
+          values: { group: group.name },
+        })
+      );
+
+      const currentPath =
+        isChild && options.groupBy.length > 1 ? options.groupBy[1] : options.groupBy[0];
+      onDrilldown(`${currentPath.field}: "${group.name}"`);
+    },
+    [group.name, isChild, onDrilldown, options.groupBy]
+  );
+
+  const buttonStyle = {
+    fontSize: isChild ? '0.85em' : '1em',
+  };
+
+  return (
+    <>
+      <EuiScreenReaderOnly>
+        <div aria-live="polite" role="status">
+          {a11yAnnouncement}
+        </div>
+      </EuiScreenReaderOnly>
+
       <GroupNameContainer>
         <Inner isChild={isChild}>
           <Name>
             <EuiToolTip position="top" content={group.name}>
-              <EuiLink
-                style={linkStyle}
-                onClickCapture={this.handleClick}
-                data-test-subj="groupNameLink"
+              <EuiButtonEmpty
+                aria-label={i18n.translate('xpack.infra.inventory.groupBySelectorButtonLabel', {
+                  defaultMessage: 'Group by {group}',
+                  values: { group: group.name },
+                })}
+                style={buttonStyle}
+                onClick={handleClick}
+                data-test-subj="groupNameButton"
               >
                 {group.name}
-              </EuiLink>
+              </EuiButtonEmpty>
             </EuiToolTip>
           </Name>
           <Count>{group.count}</Count>
         </Inner>
       </GroupNameContainer>
-    );
-  }
-
-  private handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    const { groupBy } = this.props.options;
-    // When groupBy is empty that means there is nothing todo so let's just do nothing.
-    if (groupBy.length === 0) {
-      return;
-    }
-    const currentPath = this.props.isChild && groupBy.length > 1 ? groupBy[1] : groupBy[0];
-    this.props.onDrilldown(`${currentPath.field}: "${this.props.group.name}"`);
-  };
-}
+    </>
+  );
+};
 
 const GroupNameContainer = euiStyled.div`
   position: relative;

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/legend_controls.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/legend_controls.tsx
@@ -259,10 +259,6 @@ export const LegendControls = ({
             checked={draftLegend.reverseColors}
             onChange={handleReverseColors}
             compressed
-            style={{
-              position: 'relative',
-              top: '8px',
-            }}
           />
         </EuiFormRow>
         <EuiFormRow
@@ -281,10 +277,6 @@ export const LegendControls = ({
             checked={draftAuto}
             onChange={handleAutoChange}
             compressed
-            style={{
-              position: 'relative',
-              top: '8px',
-            }}
           />
         </EuiFormRow>
         <EuiFormRow

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/swatch_label.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/swatch_label.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import { EuiColorPickerSwatch, EuiText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiText, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import React from 'react';
 
 export interface Props {
@@ -17,7 +18,15 @@ export const SwatchLabel = ({ label, color }: Props) => {
   return (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
       <EuiFlexItem grow={false}>
-        <EuiColorPickerSwatch color={color} />
+        <EuiIcon
+          type="stopFilled"
+          color={color}
+          size="xl"
+          aria-label={i18n.translate('xpack.infra.legendControls.iconColorLabel', {
+            defaultMessage: '{label} color',
+            values: { label },
+          })}
+        />
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiText size="xs">

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -129,8 +129,8 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       await comboBox.setElement(groupByCustomField, field);
       await testSubjects.click('groupByCustomFieldAddButton');
       await this.waitForLoading();
-      const groupNameLinks = await testSubjects.findAll('groupNameLink');
-      return Promise.all(groupNameLinks.map(async (link) => link.getVisibleText()));
+      const groupNameButtons = await testSubjects.findAll('groupNameButton');
+      return Promise.all(groupNameButtons.map((link) => link.getVisibleText()));
     },
 
     async enterSearchTerm(query: string) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[ObsUX][A11y] Add announcement keyboard elements improvements (#216592)](https://github.com/elastic/kibana/pull/216592)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miriam","email":"31922082+MiriamAparicio@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-02T11:24:26Z","message":"[ObsUX][A11y] Add announcement keyboard elements improvements (#216592)\n\nCloses https://github.com/elastic/kibana/issues/216029\n\n## Summary\n\nSome elements on the Infrastructure Inventory were not accessible or\ntheir interaction with the keyboard was not properly announced to the\nusers, see issue for steps to reproduce, use a screen reader to test.\n\n### What was done\n\n#### Groupby buttons \n\n- Replace link element by button\n- Add announcement when interacting with the button, i.e., when\nclicking/selecting the `All` button nothing changes\n\n\nhttps://github.com/user-attachments/assets/da7a973d-26a4-4288-8aea-e1dd7a43ea6f\n\n#### Legend options\n\n- Replace `EuiColorPickerSwatch` button by and icon, the button didn't\nhave any action, it only shows the selected color for minimum and\nmaximum for the selected color palette\n- Fix ui alignment of checkbox elements\n\nBefore\n\n<img width=\"452\" alt=\"Screenshot 2025-04-01 at 08 58 40\"\nsrc=\"https://github.com/user-attachments/assets/66d7e733-8f95-4d76-9eb2-549b8421b888\"\n/>\n\nAfter\n\n<img width=\"585\" alt=\"Screenshot 2025-04-01 at 08 54 31\"\nsrc=\"https://github.com/user-attachments/assets/825a9f84-ddaf-43dc-b136-e268592818c1\"\n/>","sha":"ecd83ce211cdf2dd9bca43c8e6c15473dc8e1c44","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:obs-ux-infra_services","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[ObsUX][A11y] Add announcement keyboard elements improvements","number":216592,"url":"https://github.com/elastic/kibana/pull/216592","mergeCommit":{"message":"[ObsUX][A11y] Add announcement keyboard elements improvements (#216592)\n\nCloses https://github.com/elastic/kibana/issues/216029\n\n## Summary\n\nSome elements on the Infrastructure Inventory were not accessible or\ntheir interaction with the keyboard was not properly announced to the\nusers, see issue for steps to reproduce, use a screen reader to test.\n\n### What was done\n\n#### Groupby buttons \n\n- Replace link element by button\n- Add announcement when interacting with the button, i.e., when\nclicking/selecting the `All` button nothing changes\n\n\nhttps://github.com/user-attachments/assets/da7a973d-26a4-4288-8aea-e1dd7a43ea6f\n\n#### Legend options\n\n- Replace `EuiColorPickerSwatch` button by and icon, the button didn't\nhave any action, it only shows the selected color for minimum and\nmaximum for the selected color palette\n- Fix ui alignment of checkbox elements\n\nBefore\n\n<img width=\"452\" alt=\"Screenshot 2025-04-01 at 08 58 40\"\nsrc=\"https://github.com/user-attachments/assets/66d7e733-8f95-4d76-9eb2-549b8421b888\"\n/>\n\nAfter\n\n<img width=\"585\" alt=\"Screenshot 2025-04-01 at 08 54 31\"\nsrc=\"https://github.com/user-attachments/assets/825a9f84-ddaf-43dc-b136-e268592818c1\"\n/>","sha":"ecd83ce211cdf2dd9bca43c8e6c15473dc8e1c44"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216800","number":216800,"state":"MERGED","mergeCommit":{"sha":"ae0c91447de0f4cc021be66dbd66751d3d0ead48","message":"[9.0] [ObsUX][A11y] Add announcement keyboard elements improvements (#216592) (#216800)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[ObsUX][A11y] Add announcement keyboard elements improvements\n(#216592)](https://github.com/elastic/kibana/pull/216592)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Miriam <31922082+MiriamAparicio@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216987","number":216987,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216592","number":216592,"mergeCommit":{"message":"[ObsUX][A11y] Add announcement keyboard elements improvements (#216592)\n\nCloses https://github.com/elastic/kibana/issues/216029\n\n## Summary\n\nSome elements on the Infrastructure Inventory were not accessible or\ntheir interaction with the keyboard was not properly announced to the\nusers, see issue for steps to reproduce, use a screen reader to test.\n\n### What was done\n\n#### Groupby buttons \n\n- Replace link element by button\n- Add announcement when interacting with the button, i.e., when\nclicking/selecting the `All` button nothing changes\n\n\nhttps://github.com/user-attachments/assets/da7a973d-26a4-4288-8aea-e1dd7a43ea6f\n\n#### Legend options\n\n- Replace `EuiColorPickerSwatch` button by and icon, the button didn't\nhave any action, it only shows the selected color for minimum and\nmaximum for the selected color palette\n- Fix ui alignment of checkbox elements\n\nBefore\n\n<img width=\"452\" alt=\"Screenshot 2025-04-01 at 08 58 40\"\nsrc=\"https://github.com/user-attachments/assets/66d7e733-8f95-4d76-9eb2-549b8421b888\"\n/>\n\nAfter\n\n<img width=\"585\" alt=\"Screenshot 2025-04-01 at 08 54 31\"\nsrc=\"https://github.com/user-attachments/assets/825a9f84-ddaf-43dc-b136-e268592818c1\"\n/>","sha":"ecd83ce211cdf2dd9bca43c8e6c15473dc8e1c44"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->