### PR TITLE
[APM] Simplify environment selector

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_filter/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_filter/index.tsx
@@ -28,8 +28,7 @@ function updateEnvironmentUrl(
 }
 
 export function ApmEnvironmentFilter() {
-  const { environment, environments, status, rangeFrom, rangeTo, serviceName } =
-    useEnvironmentsContext();
+  const { environment, environments, status, rangeFrom, rangeTo } = useEnvironmentsContext();
   const history = useHistory();
   const location = useLocation();
 
@@ -42,9 +41,6 @@ export function ApmEnvironmentFilter() {
       status={status}
       environment={environment}
       availableEnvironments={environments}
-      serviceName={serviceName}
-      rangeFrom={rangeFrom}
-      rangeTo={rangeTo}
       onChange={(changeValue: string) => updateEnvironmentUrl(history, location, changeValue)}
     />
   );

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
@@ -68,7 +68,7 @@ export function EnvironmentSelect({
     [searchValue, availableEnvironments]
   );
 
-  const isInvalid = environment !== searchValue && searchValue !== '';
+  const isInvalid = getEnvironmentLabel(environment) !== searchValue && searchValue !== '';
 
   const options: Array<EuiComboBoxOptionOption<string>> = [...getEnvironmentOptions(environments)];
 

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
@@ -72,8 +72,6 @@ export function EnvironmentSelect({
 
   const options: Array<EuiComboBoxOptionOption<string>> = [...getEnvironmentOptions(environments)];
 
-  const onSearch = useMemo(() => setSearchValue, []);
-
   return (
     <EuiFormRow
       error={i18n.translate('xpack.apm.filter.environment.error', {
@@ -99,7 +97,7 @@ export function EnvironmentSelect({
         options={options}
         selectedOptions={selectedOptions}
         onChange={(changedOptions) => onSelect(changedOptions)}
-        onSearchChange={onSearch}
+        onSearchChange={setSearchValue}
         isLoading={status === FETCH_STATUS.LOADING}
       />
     </EuiFormRow>

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
@@ -4,10 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { isEmpty } from 'lodash';
 import { i18n } from '@kbn/i18n';
+import { css } from '@emotion/react';
 import React, { useMemo, useState } from 'react';
-import { debounce } from 'lodash';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import { EuiComboBox } from '@elastic/eui';
 import {
@@ -15,9 +14,7 @@ import {
   ENVIRONMENT_NOT_DEFINED,
   ENVIRONMENT_ALL,
 } from '../../../../common/environment_filter_values';
-import { SERVICE_ENVIRONMENT } from '../../../../common/es_fields/apm';
-import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
-import { useTimeRange } from '../../../hooks/use_time_range';
+import { FETCH_STATUS } from '../../../hooks/use_fetcher';
 import type { Environment } from '../../../../common/environment_rt';
 
 function getEnvironmentOptions(environments: Environment[]) {
@@ -39,22 +36,14 @@ export function EnvironmentSelect({
   environment,
   availableEnvironments,
   status,
-  serviceName,
-  rangeFrom,
-  rangeTo,
   onChange,
 }: {
   environment: Environment;
   availableEnvironments: Environment[];
   status: FETCH_STATUS;
-  serviceName?: string;
-  rangeFrom: string;
-  rangeTo: string;
   onChange: (value: string) => void;
 }) {
   const [searchValue, setSearchValue] = useState('');
-
-  const { start, end } = useTimeRange({ rangeFrom, rangeTo });
 
   const selectedOptions: Array<EuiComboBoxOptionOption<string>> = [
     {
@@ -69,42 +58,27 @@ export function EnvironmentSelect({
     }
   };
 
-  const { data, status: searchStatus } = useFetcher(
-    (callApmApi) => {
-      return isEmpty(searchValue)
-        ? Promise.resolve({ terms: [] })
-        : callApmApi('GET /internal/apm/suggestions', {
-            params: {
-              query: {
-                fieldName: SERVICE_ENVIRONMENT,
-                fieldValue: searchValue,
-                serviceName,
-                start,
-                end,
-              },
-            },
-          });
-    },
-    [searchValue, start, end, serviceName]
+  const environments = useMemo(
+    () =>
+      searchValue !== ''
+        ? availableEnvironments.filter((env) =>
+            env.toLowerCase().includes(searchValue.toLowerCase())
+          )
+        : availableEnvironments,
+    [searchValue, availableEnvironments]
   );
-  const terms = data?.terms ?? [];
 
-  const options: Array<EuiComboBoxOptionOption<string>> = [
-    ...(searchValue === ''
-      ? getEnvironmentOptions(availableEnvironments)
-      : terms.map((name) => {
-          return { label: name, value: name };
-        })),
-  ];
+  const options: Array<EuiComboBoxOptionOption<string>> = [...getEnvironmentOptions(environments)];
 
-  const onSearch = useMemo(() => debounce(setSearchValue, 300), []);
+  const onSearch = useMemo(() => setSearchValue, []);
 
   return (
     <EuiComboBox
       data-test-subj="environmentFilter"
-      async
       isClearable={false}
-      style={{ minWidth: '256px' }}
+      css={css`
+        min-width: 256px;
+      `}
       placeholder={i18n.translate('xpack.apm.filter.environment.placeholder', {
         defaultMessage: 'Select environment',
       })}
@@ -116,7 +90,7 @@ export function EnvironmentSelect({
       selectedOptions={selectedOptions}
       onChange={(changedOptions) => onSelect(changedOptions)}
       onSearchChange={onSearch}
-      isLoading={status === FETCH_STATUS.LOADING || searchStatus === FETCH_STATUS.LOADING}
+      isLoading={status === FETCH_STATUS.LOADING}
     />
   );
 }

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/environment_select/index.tsx
@@ -70,7 +70,10 @@ export function EnvironmentSelect({
 
   const isInvalid = getEnvironmentLabel(environment) !== searchValue && searchValue !== '';
 
-  const options: Array<EuiComboBoxOptionOption<string>> = [...getEnvironmentOptions(environments)];
+  const options: Array<EuiComboBoxOptionOption<string>> = useMemo(
+    () => getEnvironmentOptions(environments),
+    [environments]
+  );
 
   return (
     <EuiFormRow


### PR DESCRIPTION
## Summary

Closes #216974

This PR changes the way the environment selector works in APM, from async to sync.
We will filter the values in the client instead of debouncing + calling the API constantly when we already have the values.


## Before

https://github.com/user-attachments/assets/09b088bd-6c48-43c7-8fb2-7bc38fb0c30b

## After

https://github.com/user-attachments/assets/cc00fb9a-248d-4192-9857-b871f6a76bda



