### PR TITLE
[8.18] [SLO]: Optional groupings for slo summary (#209910)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/common.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/schema/common.ts
@@ -77,12 +77,16 @@ const groupSummarySchema = t.type({
   worst: t.type({
     sliValue: t.number,
     status: t.string,
-    slo: t.type({
-      id: t.string,
-      instanceId: t.string,
-      name: t.string,
-      groupings: t.record(t.string, t.unknown),
-    }),
+    slo: t.intersection([
+      t.type({
+        id: t.string,
+        instanceId: t.string,
+        name: t.string,
+      }),
+      t.partial({
+        groupings: t.record(t.string, t.unknown),
+      }),
+    ]),
   }),
   violated: t.number,
   healthy: t.number,

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/grouped_slos/hooks/use_group_name.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/grouped_slos/hooks/use_group_name.ts
@@ -20,7 +20,7 @@ export function useGroupName(groupBy: GroupByField, group: string, summary?: Gro
     case 'status':
       return groupName;
     case 'slo.instanceId':
-      if (groupName === ALL_VALUE || !summary) {
+      if (groupName === ALL_VALUE || !summary?.worst?.slo?.groupings) {
         return i18n.translate('xpack.slo.group.ungroupedInstanceId', {
           defaultMessage: 'Ungrouped',
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[SLO]: Optional groupings for slo summary (#209910)](https://github.com/elastic/kibana/pull/209910)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2025-02-05T23:18:56Z","message":"[SLO]: Optional groupings for slo summary (#209910)\n\n## Summary\r\n\r\nResolves #209159\r\n\r\nMake groupings property in SLO summary optional to fix schema validation\r\nissues with SLOs without groups.\r\n\r\n## Release Notes\r\n\r\nFixed bug that caused issues with loading SLOs by status, SLI type, or\r\ninstance id.\r\n\r\n## Testing\r\n\r\nCreate a SLO without an entry in the \"group by\" field. All SLOs should\r\nstill be able to be grouped despite this distinction.","sha":"02fc0a725d24064f4b5da5a06440a5fb2ac04521","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","backport:prev-minor","Team:obs-ux-management","v9.1.0","v8.19.0"],"title":"[SLO]: Optional groupings for slo summary","number":209910,"url":"https://github.com/elastic/kibana/pull/209910","mergeCommit":{"message":"[SLO]: Optional groupings for slo summary (#209910)\n\n## Summary\r\n\r\nResolves #209159\r\n\r\nMake groupings property in SLO summary optional to fix schema validation\r\nissues with SLOs without groups.\r\n\r\n## Release Notes\r\n\r\nFixed bug that caused issues with loading SLOs by status, SLI type, or\r\ninstance id.\r\n\r\n## Testing\r\n\r\nCreate a SLO without an entry in the \"group by\" field. All SLOs should\r\nstill be able to be grouped despite this distinction.","sha":"02fc0a725d24064f4b5da5a06440a5fb2ac04521"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209934","number":209934,"state":"MERGED","mergeCommit":{"sha":"442136fc09962861c11ab8476813f6dccdf1fce7","message":"[9.0] [SLO]: Optional groupings for slo summary (#209910) (#209934)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[SLO]: Optional groupings for slo summary\n(#209910)](https://github.com/elastic/kibana/pull/209910)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Bailey Cash <bailey.cash@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209910","number":209910,"mergeCommit":{"message":"[SLO]: Optional groupings for slo summary (#209910)\n\n## Summary\r\n\r\nResolves #209159\r\n\r\nMake groupings property in SLO summary optional to fix schema validation\r\nissues with SLOs without groups.\r\n\r\n## Release Notes\r\n\r\nFixed bug that caused issues with loading SLOs by status, SLI type, or\r\ninstance id.\r\n\r\n## Testing\r\n\r\nCreate a SLO without an entry in the \"group by\" field. All SLOs should\r\nstill be able to be grouped despite this distinction.","sha":"02fc0a725d24064f4b5da5a06440a5fb2ac04521"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/209933","number":209933,"state":"MERGED","mergeCommit":{"sha":"a37d63bf115a8f408fd91e6ef2da84a81e7b9abe","message":"[8.x] [SLO]: Optional groupings for slo summary (#209910) (#209933)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[SLO]: Optional groupings for slo summary\n(#209910)](https://github.com/elastic/kibana/pull/209910)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Bailey Cash <bailey.cash@elastic.co>"}}]}] BACKPORT-->