### PR TITLE
[8.18] [Fleet] allow alpha, beta, rc suffixes in agent versions (#211787)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.test.ts
@@ -230,12 +230,24 @@ describe('getAvailableVersions', () => {
         JSON.stringify([
           [
             {
+              title: 'Elastic Agent 9.0.0',
+              version_number: '9.0.0-rc1',
+            },
+            {
               title: 'Elastic Agent 8.0.0',
-              version_number: '8.0.0-rc1',
+              version_number: '8.0.0-rc2',
             },
             {
               title: 'Elastic Agent 8.0.0',
               version_number: '8.0.0-beta1',
+            },
+            {
+              title: 'Elastic Agent 8.0.0',
+              version_number: '8.0.0-alpha1',
+            },
+            {
+              title: 'Elastic Agent 8.0.0',
+              version_number: '8.0.0-unkown',
             },
           ],
         ])

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/versions.ts
@@ -15,7 +15,7 @@ import semverGte from 'semver/functions/gte';
 import semverGt from 'semver/functions/gt';
 import semverRcompare from 'semver/functions/rcompare';
 import semverLt from 'semver/functions/lt';
-import semverCoerce from 'semver/functions/coerce';
+import semverParse from 'semver/functions/parse';
 
 import { REPO_ROOT } from '@kbn/repo-info';
 
@@ -114,8 +114,18 @@ export const getAvailableVersions = async ({
   // only want support versions in the final result. We'll also sort by newest version first.
   availableVersions = uniq(
     [...availableVersions, ...apiVersions]
-      .map((item: any) => (item.includes('+build') ? item : semverCoerce(item)?.version || ''))
-      .filter((v: any) => semverGte(v, MINIMUM_SUPPORTED_VERSION))
+      .filter((v: any) => {
+        const parsedVersion = semverParse(v);
+        if (
+          parsedVersion?.prerelease?.length &&
+          !parsedVersion.prerelease.some(
+            (prerelease) => typeof prerelease === 'string' && prerelease.includes('+build')
+          )
+        ) {
+          return false;
+        }
+        return semverGte(v, MINIMUM_SUPPORTED_VERSION);
+      })
       .sort((a: any, b: any) => (semverGt(a, b) ? -1 : 1))
   );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Fleet] allow alpha, beta, rc suffixes in agent versions (#211787)](https://github.com/elastic/kibana/pull/211787)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Julia Bardi","email":"90178898+juliaElastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-19T20:37:28Z","message":"[Fleet] allow alpha, beta, rc suffixes in agent versions (#211787)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/211777\n\nAdd agent flyout should show `9.0.0-beta1` now:\n<img width=\"2540\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/86259eea-5858-4d06-8989-8fadb3a57f96\"\n/>\n\nWhen `9.0.0` comes out, that should show up as latest. For example,\n`8.0.0` versions come back in this order:\n<img width=\"462\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c5204806-3cf7-4c65-bb60-21d176f24f17\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"ba2caf92c6e70d94d9743ff7628400750cb35d51","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","v9.0.0","backport:prev-minor","backport:version","v9.1.0","v8.19.0","backport:8.18","v8.18.1"],"title":"[Fleet] Do not allow alpha, beta, rc suffixes in agent versions","number":211787,"url":"https://github.com/elastic/kibana/pull/211787","mergeCommit":{"message":"[Fleet] allow alpha, beta, rc suffixes in agent versions (#211787)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/211777\n\nAdd agent flyout should show `9.0.0-beta1` now:\n<img width=\"2540\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/86259eea-5858-4d06-8989-8fadb3a57f96\"\n/>\n\nWhen `9.0.0` comes out, that should show up as latest. For example,\n`8.0.0` versions come back in this order:\n<img width=\"462\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c5204806-3cf7-4c65-bb60-21d176f24f17\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"ba2caf92c6e70d94d9743ff7628400750cb35d51"}},"sourceBranch":"main","suggestedTargetBranches":["8.x","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/211849","number":211849,"state":"MERGED","mergeCommit":{"sha":"1f98cbfdb28c12848820484a5ad4d51156f70136","message":"[9.0] [Fleet] allow alpha, beta, rc suffixes in agent versions (#211787) (#211849)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Fleet] allow alpha, beta, rc suffixes in agent versions\n(#211787)](https://github.com/elastic/kibana/pull/211787)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Julia Bardi <90178898+juliaElastic@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211787","number":211787,"mergeCommit":{"message":"[Fleet] allow alpha, beta, rc suffixes in agent versions (#211787)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/211777\n\nAdd agent flyout should show `9.0.0-beta1` now:\n<img width=\"2540\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/86259eea-5858-4d06-8989-8fadb3a57f96\"\n/>\n\nWhen `9.0.0` comes out, that should show up as latest. For example,\n`8.0.0` versions come back in this order:\n<img width=\"462\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/c5204806-3cf7-4c65-bb60-21d176f24f17\"\n/>\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"ba2caf92c6e70d94d9743ff7628400750cb35d51"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->