### PR TITLE
[8.x] [Authz] Added allOf and anyOf nested conditions (#215516)

### DIFF
--- a/dev_docs/key_concepts/api_authorization.mdx
+++ b/dev_docs/key_concepts/api_authorization.mdx
@@ -218,6 +218,48 @@ router.get({
 }, handler);
 ```
 
+**Example 4: Complex configuration with nested `allOf`.**
+Requires (`<privilege_1>` AND `<privilege_2>`) OR (`<privilege_3>` AND `<privilege_4>`) to access the route.
+```ts
+router.get({
+  path: '/api/path',
+  security: {
+    authz: {
+      requiredPrivileges: [
+        { 
+          anyRequired: [
+            { allOf: ['<privilege_1>', '<privilege_2>']}, 
+            { allOf: ['<privilege_3>', '<privilege_4>']}
+          ],
+        }
+      ],
+    },
+  },
+  ...
+}, handler);
+```
+
+**Example 5: Complex configuration with nested `anyOf`.**
+Requires (`<privilege_1>` OR `<privilege_2>`) AND (`<privilege_3>` OR `<privilege_4>`) to access the route.
+```ts
+router.get({
+  path: '/api/path',
+  security: {
+    authz: {
+      requiredPrivileges: [
+        { 
+          allRequired: [
+            { anyOf: ['<privilege_1>', '<privilege_2>']}, 
+            { anyOf: ['<privilege_3>', '<privilege_4>']}
+          ],
+        }
+      ],
+    },
+  },
+  ...
+}, handler);
+```
+
 ### Versioned router security configuration examples
 Different security configurations can be applied to each version when using the Versioned Router. This allows your authorization needs to evolve in lockstep with your API.
 

--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -10197,7 +10197,7 @@
     },
     "/api/spaces/_copy_saved_objects": {
       "post": {
-        "description": "It also allows you to automatically copy related objects, so when you copy a dashboard, this can automatically copy over the associated visualizations, data views, and saved Discover sessions, as required. You can request to overwrite any objects that already exist in the target space if they share an identifier or you can use the resolve copy saved objects conflicts API to do this on a per-object basis.<br/><br/>[Required authorization] Route required privileges: ALL of [copySavedObjectsToSpaces].",
+        "description": "It also allows you to automatically copy related objects, so when you copy a dashboard, this can automatically copy over the associated visualizations, data views, and saved Discover sessions, as required. You can request to overwrite any objects that already exist in the target space if they share an identifier or you can use the resolve copy saved objects conflicts API to do this on a per-object basis.<br/><br/>[Required authorization] Route required privileges: copySavedObjectsToSpaces.",
         "operationId": "post-spaces-copy-saved-objects",
         "parameters": [
           {
@@ -10404,7 +10404,7 @@
     },
     "/api/spaces/_resolve_copy_saved_objects_errors": {
       "post": {
-        "description": "Overwrite saved objects that are returned as errors from the copy saved objects to space API.<br/><br/>[Required authorization] Route required privileges: ALL of [copySavedObjectsToSpaces].",
+        "description": "Overwrite saved objects that are returned as errors from the copy saved objects to space API.<br/><br/>[Required authorization] Route required privileges: copySavedObjectsToSpaces.",
         "operationId": "post-spaces-resolve-copy-saved-objects-errors",
         "parameters": [
           {

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -21231,7 +21231,7 @@ paths:
       x-state: Technical Preview
   /api/spaces/_copy_saved_objects:
     post:
-      description: 'It also allows you to automatically copy related objects, so when you copy a dashboard, this can automatically copy over the associated visualizations, data views, and saved Discover sessions, as required. You can request to overwrite any objects that already exist in the target space if they share an identifier or you can use the resolve copy saved objects conflicts API to do this on a per-object basis.<br/><br/>[Required authorization] Route required privileges: ALL of [copySavedObjectsToSpaces].'
+      description: 'It also allows you to automatically copy related objects, so when you copy a dashboard, this can automatically copy over the associated visualizations, data views, and saved Discover sessions, as required. You can request to overwrite any objects that already exist in the target space if they share an identifier or you can use the resolve copy saved objects conflicts API to do this on a per-object basis.<br/><br/>[Required authorization] Route required privileges: copySavedObjectsToSpaces.'
       operationId: post-spaces-copy-saved-objects
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -21394,7 +21394,7 @@ paths:
         - spaces
   /api/spaces/_resolve_copy_saved_objects_errors:
     post:
-      description: 'Overwrite saved objects that are returned as errors from the copy saved objects to space API.<br/><br/>[Required authorization] Route required privileges: ALL of [copySavedObjectsToSpaces].'
+      description: 'Overwrite saved objects that are returned as errors from the copy saved objects to space API.<br/><br/>[Required authorization] Route required privileges: copySavedObjectsToSpaces.'
       operationId: post-spaces-resolve-copy-saved-objects-errors
       parameters:
         - description: A required header to protect against CSRF attacks

--- a/src/core/packages/http/router-server-internal/tsconfig.json
+++ b/src/core/packages/http/router-server-internal/tsconfig.json
@@ -19,7 +19,8 @@
     "@kbn/core-logging-server-mocks",
     "@kbn/logging",
     "@kbn/core-http-common",
-    "@kbn/logging-mocks"
+    "@kbn/logging-mocks",
+    "@kbn/core-security-server"
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/http/server/index.ts
+++ b/src/core/packages/http/server/index.ts
@@ -119,6 +119,8 @@ export type {
   AuthcEnabled,
   Privilege,
   PrivilegeSet,
+  AllRequiredCondition,
+  AnyRequiredCondition,
   RouteSecurity,
   RouteSecurityGetter,
   InternalRouteSecurity,

--- a/src/core/packages/http/server/src/router/index.ts
+++ b/src/core/packages/http/server/src/router/index.ts
@@ -63,6 +63,8 @@ export type {
   AuthcDisabled,
   AuthcEnabled,
   RouteSecurity,
+  AllRequiredCondition,
+  AnyRequiredCondition,
   Privilege,
   PrivilegeSet,
   RouteDeprecationInfo,

--- a/src/core/packages/http/server/src/router/route.ts
+++ b/src/core/packages/http/server/src/router/route.ts
@@ -196,6 +196,9 @@ interface DeprecateApiDeprecationType {
   type: 'deprecate';
 }
 
+export type AllRequiredCondition = Array<Privilege | { anyOf: Privilege[] }>;
+export type AnyRequiredCondition = Array<Privilege | { allOf: Privilege[] }>;
+
 /**
  * A set of privileges that can be used to define complex authorization requirements.
  *
@@ -203,14 +206,14 @@ interface DeprecateApiDeprecationType {
  * - `allRequired`: An array of privileges where all listed privileges must be satisfied to meet the authorization requirement.
  */
 export interface PrivilegeSet {
-  anyRequired?: Privilege[];
-  allRequired?: Privilege[];
+  anyRequired?: AnyRequiredCondition;
+  allRequired?: AllRequiredCondition;
 }
 
 /**
  * An array representing a combination of simple privileges or complex privilege sets.
  */
-type Privileges = Array<Privilege | PrivilegeSet>;
+export type Privileges = Array<Privilege | PrivilegeSet>;
 
 /**
  * Describes the authorization requirements when authorization is enabled.

--- a/src/core/packages/security/server/index.ts
+++ b/src/core/packages/security/server/index.ts
@@ -50,3 +50,4 @@ export type {
 export type { KibanaPrivilegesType, ElasticsearchPrivilegesType } from './src/roles';
 export { isCreateRestAPIKeyParams } from './src/authentication/api_keys';
 export type { CoreFipsService } from './src/fips';
+export { unwindNestedSecurityPrivileges } from './src/authz';

--- a/src/core/packages/security/server/src/authz.ts
+++ b/src/core/packages/security/server/src/authz.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const unwindNestedSecurityPrivileges = <
+  T extends Array<string | { allOf?: string[]; anyOf?: string[] }>
+>(
+  privileges: T
+): string[] =>
+  privileges.reduce((acc: string[], privilege) => {
+    if (typeof privilege === 'object') {
+      if (privilege.allOf?.length) {
+        acc.push(...privilege.allOf);
+      }
+
+      if (privilege?.anyOf?.length) {
+        acc.push(...privilege.anyOf);
+      }
+    } else if (typeof privilege === 'string') {
+      acc.push(privilege);
+    }
+
+    return acc;
+  }, []);

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -615,4 +615,6 @@ export type {
   RouteSecurityGetter,
   Privilege,
   PrivilegeSet,
+  AllRequiredCondition,
+  AnyRequiredCondition,
 } from '@kbn/core-http-server';

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
@@ -126,6 +126,7 @@ Object {
     "/bar": Object {
       "get": Object {
         "deprecated": true,
+        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "get-bar",
         "parameters": Array [],
         "requestBody": Object {
@@ -490,6 +491,7 @@ Object {
     "/no-xsrf/{id}/{path}": Object {
       "post": Object {
         "deprecated": true,
+        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "post-no-xsrf-id-path",
         "parameters": Array [],
         "requestBody": Object {
@@ -702,6 +704,7 @@ Object {
     },
     "/test": Object {
       "get": Object {
+        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "get-test",
         "parameters": Array [],
         "requestBody": Object {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
@@ -126,7 +126,6 @@ Object {
     "/bar": Object {
       "get": Object {
         "deprecated": true,
-        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "get-bar",
         "parameters": Array [],
         "requestBody": Object {
@@ -491,7 +490,6 @@ Object {
     "/no-xsrf/{id}/{path}": Object {
       "post": Object {
         "deprecated": true,
-        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "post-no-xsrf-id-path",
         "parameters": Array [],
         "requestBody": Object {
@@ -704,7 +702,6 @@ Object {
     },
     "/test": Object {
       "get": Object {
-        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "get-test",
         "parameters": Array [],
         "requestBody": Object {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/extract_authz_description.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/extract_authz_description.test.ts
@@ -33,9 +33,7 @@ describe('extractAuthzDescription', () => {
       },
     };
     const description = extractAuthzDescription(routeSecurity);
-    expect(description).toBe(
-      '[Required authorization] Route required privileges: ALL of [manage_spaces].'
-    );
+    expect(description).toBe('[Required authorization] Route required privileges: manage_spaces.');
   });
 
   it('should return route authz description for privilege groups', () => {
@@ -46,9 +44,7 @@ describe('extractAuthzDescription', () => {
         },
       };
       const description = extractAuthzDescription(routeSecurity);
-      expect(description).toBe(
-        '[Required authorization] Route required privileges: ALL of [console].'
-      );
+      expect(description).toBe('[Required authorization] Route required privileges: console.');
     }
     {
       const routeSecurity: RouteSecurity = {
@@ -62,7 +58,7 @@ describe('extractAuthzDescription', () => {
       };
       const description = extractAuthzDescription(routeSecurity);
       expect(description).toBe(
-        '[Required authorization] Route required privileges: ANY of [manage_spaces OR taskmanager].'
+        '[Required authorization] Route required privileges: manage_spaces OR taskmanager.'
       );
     }
     {
@@ -78,7 +74,25 @@ describe('extractAuthzDescription', () => {
       };
       const description = extractAuthzDescription(routeSecurity);
       expect(description).toBe(
-        '[Required authorization] Route required privileges: ALL of [console, filesManagement] AND ANY of [manage_spaces OR taskmanager].'
+        '[Required authorization] Route required privileges: (console AND filesManagement) AND (manage_spaces OR taskmanager).'
+      );
+    }
+    {
+      const routeSecurity: RouteSecurity = {
+        authz: {
+          requiredPrivileges: [
+            {
+              anyRequired: [
+                { allOf: ['manage_spaces', 'taskmanager'] },
+                { allOf: ['console', 'filesManagement'] },
+              ],
+            },
+          ],
+        },
+      };
+      const description = extractAuthzDescription(routeSecurity);
+      expect(description).toBe(
+        '[Required authorization] Route required privileges: (manage_spaces AND taskmanager) OR (console AND filesManagement).'
       );
     }
   });

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
@@ -36,6 +36,7 @@ export const sharedOas = {
         deprecated: true,
         'x-discontinued': 'route discontinued version or date',
         operationId: 'get-bar',
+        description: '[Required authorization] Route required privileges: foo.',
         parameters: [],
         requestBody: {
           content: {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
@@ -36,7 +36,6 @@ export const sharedOas = {
         deprecated: true,
         'x-discontinued': 'route discontinued version or date',
         operationId: 'get-bar',
-        description: '[Required authorization] Route required privileges: foo.',
         parameters: [],
         requestBody: {
           content: {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/process_router.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/process_router.test.ts
@@ -118,7 +118,7 @@ describe('processRouter', () => {
               'manage_spaces',
               {
                 allRequired: ['taskmanager'],
-                anyRequired: ['console'],
+                anyRequired: ['console', 'devtools'],
               },
             ],
           },
@@ -139,7 +139,7 @@ describe('processRouter', () => {
               'manage_spaces',
               {
                 allRequired: ['taskmanager'],
-                anyRequired: ['console'],
+                anyRequired: ['console', 'devtools'],
               },
             ],
           },
@@ -172,11 +172,11 @@ describe('processRouter', () => {
     expect(result.paths['/qux']?.post).toBeDefined();
 
     expect(result.paths['/qux']?.post?.description).toEqual(
-      '[Required authorization] Route required privileges: ALL of [manage_spaces, taskmanager] AND ANY of [console].'
+      '[Required authorization] Route required privileges: (manage_spaces AND taskmanager) AND (console OR devtools).'
     );
 
     expect(result.paths['/quux']?.post?.description).toEqual(
-      'This a test route description.<br/><br/>[Required authorization] Route required privileges: ALL of [manage_spaces, taskmanager] AND ANY of [console].'
+      'This a test route description.<br/><br/>[Required authorization] Route required privileges: (manage_spaces AND taskmanager) AND (console OR devtools).'
     );
   });
 });

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/process_versioned_router.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/process_versioned_router.test.ts
@@ -156,7 +156,7 @@ describe('processVersionedRouter', () => {
     expect(results.paths['/foo']!.get).toBeDefined();
 
     expect(results.paths['/foo']!.get!.description).toBe(
-      'This is a test route description.<br/><br/>[Required authorization] Route required privileges: ALL of [manage_spaces].'
+      'This is a test route description.<br/><br/>[Required authorization] Route required privileges: manage_spaces.'
     );
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/authorization/api_authorization.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authorization/api_authorization.test.ts
@@ -546,6 +546,255 @@ describe('initAPIAuthorization', () => {
       }
     );
 
+    testSecurityConfig(
+      `protected route returns "authzResult" if user has permissions with complex anyRequired config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                anyRequired: [
+                  { allOf: ['privilege1', 'privilege2'] },
+                  { allOf: ['privilege3', 'privilege4'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: true },
+              { privilege: 'api:privilege4', authorized: true },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: ['privilege1', 'privilege2', 'privilege3', 'privilege4'],
+        asserts: {
+          authzResult: {
+            privilege1: true,
+            privilege2: false,
+            privilege3: true,
+            privilege4: true,
+          },
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns "authzResult" if user has permissions  requested with complex allRequired config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                allRequired: [
+                  { anyOf: ['privilege1', 'privilege2'] },
+                  { anyOf: ['privilege3', 'privilege4'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: true },
+              { privilege: 'api:privilege4', authorized: false },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: ['privilege1', 'privilege2', 'privilege3', 'privilege4'],
+        asserts: {
+          authzResult: {
+            privilege1: true,
+            privilege2: false,
+            privilege3: true,
+            privilege4: false,
+          },
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns forbidden if user doesn't have required privileges requested with complex allRequired config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                allRequired: [
+                  { anyOf: ['privilege1', 'privilege2'] },
+                  { anyOf: ['privilege3', 'privilege4'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: false },
+              { privilege: 'api:privilege4', authorized: false },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: ['privilege1', 'privilege2', 'privilege3', 'privilege4'],
+        asserts: {
+          forbidden: true,
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns "authzResult" if user has permissions requested with complex config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                // (privilege1 OR privilege2) AND (privilege3 OR privilege4)
+                // AND ((privilege5 AND privilege6) OR (privilege7 AND privilege8))
+                allRequired: [
+                  { anyOf: ['privilege1', 'privilege2'] },
+                  { anyOf: ['privilege3', 'privilege4'] },
+                ],
+                anyRequired: [
+                  { allOf: ['privilege5', 'privilege6'] },
+                  { allOf: ['privilege7', 'privilege8'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: false },
+              { privilege: 'api:privilege4', authorized: true },
+              { privilege: 'api:privilege5', authorized: false },
+              { privilege: 'api:privilege6', authorized: false },
+              { privilege: 'api:privilege7', authorized: true },
+              { privilege: 'api:privilege8', authorized: true },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: [
+          'privilege1',
+          'privilege2',
+          'privilege3',
+          'privilege4',
+          'privilege5',
+          'privilege6',
+          'privilege7',
+          'privilege8',
+        ],
+        asserts: {
+          authzResult: {
+            privilege1: true,
+            privilege2: false,
+            privilege3: false,
+            privilege4: true,
+            privilege5: false,
+            privilege6: false,
+            privilege7: true,
+            privilege8: true,
+          },
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns forbidden if user doesn't have required privileges with complex config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                // (privilege1 OR privilege2) AND (privilege3 OR privilege4)
+                // AND ((privilege5 AND privilege6) OR (privilege7 AND privilege8))
+                allRequired: [
+                  { anyOf: ['privilege1', 'privilege2'] },
+                  { anyOf: ['privilege3', 'privilege4'] },
+                ],
+                anyRequired: [
+                  { allOf: ['privilege5', 'privilege6'] },
+                  { allOf: ['privilege7', 'privilege8'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: false },
+              { privilege: 'api:privilege4', authorized: true },
+              { privilege: 'api:privilege5', authorized: false },
+              { privilege: 'api:privilege6', authorized: false },
+              { privilege: 'api:privilege7', authorized: true },
+              { privilege: 'api:privilege8', authorized: false },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: [
+          'privilege1',
+          'privilege2',
+          'privilege3',
+          'privilege4',
+          'privilege5',
+          'privilege6',
+          'privilege7',
+          'privilege8',
+        ],
+        asserts: {
+          forbidden: true,
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns forbidden if user doesn't have required privileges requested with complex anyRequired config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                anyRequired: [
+                  { allOf: ['privilege1', 'privilege2'] },
+                  { allOf: ['privilege3', 'privilege4'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: false },
+              { privilege: 'api:privilege4', authorized: true },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: ['privilege1', 'privilege2', 'privilege3', 'privilege4'],
+        asserts: {
+          forbidden: true,
+        },
+      }
+    );
+
     testSecurityConfig(`route returns next if route has authz disabled`, {
       security: {
         authz: {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/product_features_service/product_features_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/product_features_service/product_features_service.ts
@@ -290,12 +290,24 @@ export class ProductFeaturesService {
         const disabled = authz.requiredPrivileges.some((privilegeEntry) => {
           if (typeof privilegeEntry === 'object') {
             if (privilegeEntry.allRequired) {
-              if (privilegeEntry.allRequired.some(isApiPrivilegeSecurityAndDisabled)) {
+              if (
+                privilegeEntry.allRequired.some((entry) =>
+                  typeof entry === 'string'
+                    ? isApiPrivilegeSecurityAndDisabled(entry)
+                    : entry.anyOf.every(isApiPrivilegeSecurityAndDisabled)
+                )
+              ) {
                 return true;
               }
             }
             if (privilegeEntry.anyRequired) {
-              if (privilegeEntry.anyRequired.every(isApiPrivilegeSecurityAndDisabled)) {
+              if (
+                privilegeEntry.anyRequired.every((entry) =>
+                  typeof entry === 'string'
+                    ? isApiPrivilegeSecurityAndDisabled(entry)
+                    : entry.allOf.some(isApiPrivilegeSecurityAndDisabled)
+                )
+              ) {
                 return true;
               }
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Authz] Added allOf and anyOf nested conditions (#215516)](https://github.com/elastic/kibana/pull/215516)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Shostak","email":"165678770+elena-shostak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-03T12:28:17Z","message":"[Authz] Added allOf and anyOf nested conditions (#215516)\n\n## Summary\n\nCurrently, our `requiredPrivileges` structure supports `allRequired` and\n`anyRequired` for defining authorization logic. However, there is [a\nneed to\nsupport](https://github.com/elastic/kibana/pull/205335#issuecomment-2569275302)\nmore complex scenarios as `(privilege1 AND privilege2) OR (privilege3\nAND privilege4)`\n\nTo achieve `anyRequired` has been extended to allow defining multiple\nAND conditions evaluated with OR logic:\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       anyRequired: [\n          { allOf: ['privilege1', 'privilege2'] }, \n          { allOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n`allRequired` now also supports scenarios `(privilege1 OR privilege2)\nAND (privilege3 OR privilege4)`\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       allRequired: [\n          { anyOf: ['privilege1', 'privilege2'] }, \n          { anyOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n> [!IMPORTANT]\n> We expect to have unique privileges in `anyOf` or `allOf` conditions,\nassuming that most complex conditions can be simplified by boolean\nalgebra laws (OR/AND distributive etc).\n\n\n### Checklist\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n__Closes: https://github.com/elastic/kibana/issues/210977__\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ed058086e27c2b6f5015647b446304608d6b14a9","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","enhancement","release_note:skip","Feature:Security/Authorization","backport:prev-minor","backport:version","v9.1.0","v8.19.0"],"title":"[Authz] Added allOf and anyOf nested conditions","number":215516,"url":"https://github.com/elastic/kibana/pull/215516","mergeCommit":{"message":"[Authz] Added allOf and anyOf nested conditions (#215516)\n\n## Summary\n\nCurrently, our `requiredPrivileges` structure supports `allRequired` and\n`anyRequired` for defining authorization logic. However, there is [a\nneed to\nsupport](https://github.com/elastic/kibana/pull/205335#issuecomment-2569275302)\nmore complex scenarios as `(privilege1 AND privilege2) OR (privilege3\nAND privilege4)`\n\nTo achieve `anyRequired` has been extended to allow defining multiple\nAND conditions evaluated with OR logic:\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       anyRequired: [\n          { allOf: ['privilege1', 'privilege2'] }, \n          { allOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n`allRequired` now also supports scenarios `(privilege1 OR privilege2)\nAND (privilege3 OR privilege4)`\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       allRequired: [\n          { anyOf: ['privilege1', 'privilege2'] }, \n          { anyOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n> [!IMPORTANT]\n> We expect to have unique privileges in `anyOf` or `allOf` conditions,\nassuming that most complex conditions can be simplified by boolean\nalgebra laws (OR/AND distributive etc).\n\n\n### Checklist\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n__Closes: https://github.com/elastic/kibana/issues/210977__\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ed058086e27c2b6f5015647b446304608d6b14a9"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215516","number":215516,"mergeCommit":{"message":"[Authz] Added allOf and anyOf nested conditions (#215516)\n\n## Summary\n\nCurrently, our `requiredPrivileges` structure supports `allRequired` and\n`anyRequired` for defining authorization logic. However, there is [a\nneed to\nsupport](https://github.com/elastic/kibana/pull/205335#issuecomment-2569275302)\nmore complex scenarios as `(privilege1 AND privilege2) OR (privilege3\nAND privilege4)`\n\nTo achieve `anyRequired` has been extended to allow defining multiple\nAND conditions evaluated with OR logic:\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       anyRequired: [\n          { allOf: ['privilege1', 'privilege2'] }, \n          { allOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n`allRequired` now also supports scenarios `(privilege1 OR privilege2)\nAND (privilege3 OR privilege4)`\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       allRequired: [\n          { anyOf: ['privilege1', 'privilege2'] }, \n          { anyOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n> [!IMPORTANT]\n> We expect to have unique privileges in `anyOf` or `allOf` conditions,\nassuming that most complex conditions can be simplified by boolean\nalgebra laws (OR/AND distributive etc).\n\n\n### Checklist\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n__Closes: https://github.com/elastic/kibana/issues/210977__\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ed058086e27c2b6f5015647b446304608d6b14a9"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->