### PR TITLE
[9.0] [Authz] Added allOf and anyOf nested conditions (#215516)

### DIFF
--- a/dev_docs/key_concepts/api_authorization.mdx
+++ b/dev_docs/key_concepts/api_authorization.mdx
@@ -218,6 +218,48 @@ router.get({
 }, handler);
 ```
 
+**Example 4: Complex configuration with nested `allOf`.**
+Requires (`<privilege_1>` AND `<privilege_2>`) OR (`<privilege_3>` AND `<privilege_4>`) to access the route.
+```ts
+router.get({
+  path: '/api/path',
+  security: {
+    authz: {
+      requiredPrivileges: [
+        { 
+          anyRequired: [
+            { allOf: ['<privilege_1>', '<privilege_2>']}, 
+            { allOf: ['<privilege_3>', '<privilege_4>']}
+          ],
+        }
+      ],
+    },
+  },
+  ...
+}, handler);
+```
+
+**Example 5: Complex configuration with nested `anyOf`.**
+Requires (`<privilege_1>` OR `<privilege_2>`) AND (`<privilege_3>` OR `<privilege_4>`) to access the route.
+```ts
+router.get({
+  path: '/api/path',
+  security: {
+    authz: {
+      requiredPrivileges: [
+        { 
+          allRequired: [
+            { anyOf: ['<privilege_1>', '<privilege_2>']}, 
+            { anyOf: ['<privilege_3>', '<privilege_4>']}
+          ],
+        }
+      ],
+    },
+  },
+  ...
+}, handler);
+```
+
 ### Versioned router security configuration examples
 Different security configurations can be applied to each version when using the Versioned Router. This allows your authorization needs to evolve in lockstep with your API.
 

--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -8671,7 +8671,7 @@
     },
     "/api/fleet/agent_download_sources": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-settings-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-settings-read.",
         "operationId": "get-fleet-agent-download-sources",
         "parameters": [],
         "responses": {
@@ -8767,7 +8767,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "post-fleet-agent-download-sources",
         "parameters": [
           {
@@ -8896,7 +8896,7 @@
     },
     "/api/fleet/agent_download_sources/{sourceId}": {
       "delete": {
-        "description": "Delete an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "Delete an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "delete-fleet-agent-download-sources-sourceid",
         "parameters": [
           {
@@ -8969,7 +8969,7 @@
         ]
       },
       "get": {
-        "description": "Get an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-settings-read].",
+        "description": "Get an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-settings-read.",
         "operationId": "get-fleet-agent-download-sources-sourceid",
         "parameters": [
           {
@@ -9059,7 +9059,7 @@
         ]
       },
       "put": {
-        "description": "Update an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "Update an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "put-fleet-agent-download-sources-sourceid",
         "parameters": [
           {
@@ -9196,7 +9196,7 @@
     },
     "/api/fleet/agent_policies": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-agents-read OR fleet-setup].",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-agents-read OR fleet-setup.",
         "operationId": "get-fleet-agent-policies",
         "parameters": [
           {
@@ -10267,7 +10267,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-all.",
         "operationId": "post-fleet-agent-policies",
         "parameters": [
           {
@@ -11549,7 +11549,7 @@
     },
     "/api/fleet/agent_policies/_bulk_get": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-agents-read OR fleet-setup].",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-agents-read OR fleet-setup.",
         "operationId": "post-fleet-agent-policies-bulk-get",
         "parameters": [
           {
@@ -12569,7 +12569,7 @@
     },
     "/api/fleet/agent_policies/delete": {
       "post": {
-        "description": "Delete an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all].",
+        "description": "Delete an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all.",
         "operationId": "post-fleet-agent-policies-delete",
         "parameters": [
           {
@@ -12662,7 +12662,7 @@
     },
     "/api/fleet/agent_policies/outputs": {
       "post": {
-        "description": "Get a list of outputs associated with agent policies.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-settings-read].",
+        "description": "Get a list of outputs associated with agent policies.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-settings-read.",
         "operationId": "post-fleet-agent-policies-outputs",
         "parameters": [
           {
@@ -12835,7 +12835,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}": {
       "get": {
-        "description": "Get an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-agents-read OR fleet-setup].",
+        "description": "Get an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-agents-read OR fleet-setup.",
         "operationId": "get-fleet-agent-policies-agentpolicyid",
         "parameters": [
           {
@@ -13819,7 +13819,7 @@
         ]
       },
       "put": {
-        "description": "Update an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all].",
+        "description": "Update an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all.",
         "operationId": "put-fleet-agent-policies-agentpolicyid",
         "parameters": [
           {
@@ -15113,7 +15113,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/copy": {
       "post": {
-        "description": "Copy an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all].",
+        "description": "Copy an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all.",
         "operationId": "post-fleet-agent-policies-agentpolicyid-copy",
         "parameters": [
           {
@@ -16131,7 +16131,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/download": {
       "get": {
-        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-setup].",
+        "description": "Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-download",
         "parameters": [
           {
@@ -16236,7 +16236,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/full": {
       "get": {
-        "description": "Get a full agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read].",
+        "description": "Get a full agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-full",
         "parameters": [
           {
@@ -16764,7 +16764,7 @@
     },
     "/api/fleet/agent_policies/{agentPolicyId}/outputs": {
       "get": {
-        "description": "Get a list of outputs associated with agent policy by policy id.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-settings-read].",
+        "description": "Get a list of outputs associated with agent policy by policy id.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-settings-read.",
         "operationId": "get-fleet-agent-policies-agentpolicyid-outputs",
         "parameters": [
           {
@@ -17051,7 +17051,7 @@
     },
     "/api/fleet/agent_status/data": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "get-fleet-agent-status-data",
         "parameters": [
           {
@@ -17171,7 +17171,7 @@
     },
     "/api/fleet/agents": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "get-fleet-agents",
         "parameters": [
           {
@@ -17716,7 +17716,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "post-fleet-agents",
         "parameters": [
           {
@@ -17807,7 +17807,7 @@
     },
     "/api/fleet/agents/action_status": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "get-fleet-agents-action-status",
         "parameters": [
           {
@@ -18031,7 +18031,7 @@
     },
     "/api/fleet/agents/actions/{actionId}/cancel": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-agents-actions-actionid-cancel",
         "parameters": [
           {
@@ -18160,7 +18160,7 @@
     },
     "/api/fleet/agents/available_versions": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "get-fleet-agents-available-versions",
         "parameters": [],
         "responses": {
@@ -18219,7 +18219,7 @@
     },
     "/api/fleet/agents/bulk_reassign": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-agents-bulk-reassign",
         "parameters": [
           {
@@ -18325,7 +18325,7 @@
     },
     "/api/fleet/agents/bulk_request_diagnostics": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "post-fleet-agents-bulk-request-diagnostics",
         "parameters": [
           {
@@ -18432,7 +18432,7 @@
     },
     "/api/fleet/agents/bulk_unenroll": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-agents-bulk-unenroll",
         "parameters": [
           {
@@ -18544,7 +18544,7 @@
     },
     "/api/fleet/agents/bulk_update_agent_tags": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-agents-bulk-update-agent-tags",
         "parameters": [
           {
@@ -18658,7 +18658,7 @@
     },
     "/api/fleet/agents/bulk_upgrade": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-agents-bulk-upgrade",
         "parameters": [
           {
@@ -18780,7 +18780,7 @@
     },
     "/api/fleet/agents/files/{fileId}": {
       "delete": {
-        "description": "Delete a file uploaded by an agent.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "Delete a file uploaded by an agent.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "delete-fleet-agents-files-fileid",
         "parameters": [
           {
@@ -18859,7 +18859,7 @@
     },
     "/api/fleet/agents/files/{fileId}/{fileName}": {
       "get": {
-        "description": "Get a file uploaded by an agent.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "Get a file uploaded by an agent.<br/><br/>[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "get-fleet-agents-files-fileid-filename",
         "parameters": [
           {
@@ -18923,7 +18923,7 @@
     },
     "/api/fleet/agents/setup": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup.",
         "operationId": "get-fleet-agents-setup",
         "parameters": [],
         "responses": {
@@ -19011,7 +19011,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ANY of [fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup.",
         "operationId": "post-fleet-agents-setup",
         "parameters": [
           {
@@ -19099,7 +19099,7 @@
     },
     "/api/fleet/agents/tags": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "get-fleet-agents-tags",
         "parameters": [
           {
@@ -19176,7 +19176,7 @@
     },
     "/api/fleet/agents/{agentId}": {
       "delete": {
-        "description": "Delete an agent by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "Delete an agent by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "delete-fleet-agents-agentid",
         "parameters": [
           {
@@ -19252,7 +19252,7 @@
         ]
       },
       "get": {
-        "description": "Get an agent by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "Get an agent by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "get-fleet-agents-agentid",
         "parameters": [
           {
@@ -19711,7 +19711,7 @@
         ]
       },
       "put": {
-        "description": "Update an agent by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "Update an agent by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "put-fleet-agents-agentid",
         "parameters": [
           {
@@ -20195,7 +20195,7 @@
     },
     "/api/fleet/agents/{agentId}/actions": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-agents-agentid-actions",
         "parameters": [
           {
@@ -20399,7 +20399,7 @@
     },
     "/api/fleet/agents/{agentId}/reassign": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-agents-agentid-reassign",
         "parameters": [
           {
@@ -20485,7 +20485,7 @@
     },
     "/api/fleet/agents/{agentId}/request_diagnostics": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "post-fleet-agents-agentid-request-diagnostics",
         "parameters": [
           {
@@ -20582,7 +20582,7 @@
     },
     "/api/fleet/agents/{agentId}/unenroll": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-agents-agentid-unenroll",
         "parameters": [
           {
@@ -20632,7 +20632,7 @@
     },
     "/api/fleet/agents/{agentId}/upgrade": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-agents-agentid-upgrade",
         "parameters": [
           {
@@ -20727,7 +20727,7 @@
     },
     "/api/fleet/agents/{agentId}/uploads": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read.",
         "operationId": "get-fleet-agents-agentid-uploads",
         "parameters": [
           {
@@ -20907,7 +20907,7 @@
     },
     "/api/fleet/data_streams": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all, fleet-agent-policies-all, fleet-settings-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all AND fleet-agent-policies-all AND fleet-settings-all.",
         "operationId": "get-fleet-data-streams",
         "parameters": [],
         "responses": {
@@ -21052,7 +21052,7 @@
     },
     "/api/fleet/enrollment_api_keys": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [fleet-agents-all OR fleet-setup].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all OR fleet-setup.",
         "operationId": "get-fleet-enrollment-api-keys",
         "parameters": [
           {
@@ -21228,7 +21228,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-enrollment-api-keys",
         "parameters": [
           {
@@ -21362,7 +21362,7 @@
     },
     "/api/fleet/enrollment_api_keys/{keyId}": {
       "delete": {
-        "description": "Revoke an enrollment API key by ID by marking it as inactive.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "Revoke an enrollment API key by ID by marking it as inactive.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "delete-fleet-enrollment-api-keys-keyid",
         "parameters": [
           {
@@ -21438,7 +21438,7 @@
         ]
       },
       "get": {
-        "description": "Get an enrollment API key by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-agents-all OR fleet-setup].",
+        "description": "Get an enrollment API key by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all OR fleet-setup.",
         "operationId": "get-fleet-enrollment-api-keys-keyid",
         "parameters": [
           {
@@ -21539,7 +21539,7 @@
     },
     "/api/fleet/epm/bulk_assets": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "post-fleet-epm-bulk-assets",
         "parameters": [
           {
@@ -21678,7 +21678,7 @@
     },
     "/api/fleet/epm/categories": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "get-fleet-epm-categories",
         "parameters": [
           {
@@ -21777,7 +21777,7 @@
     },
     "/api/fleet/epm/custom_integrations": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].",
+        "description": "[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.",
         "operationId": "post-fleet-epm-custom-integrations",
         "parameters": [
           {
@@ -21981,7 +21981,7 @@
     },
     "/api/fleet/epm/data_streams": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "get-fleet-epm-data-streams",
         "parameters": [
           {
@@ -22095,7 +22095,7 @@
     },
     "/api/fleet/epm/packages": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "get-fleet-epm-packages",
         "parameters": [
           {
@@ -22682,7 +22682,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].",
+        "description": "[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.",
         "operationId": "post-fleet-epm-packages",
         "parameters": [
           {
@@ -22866,7 +22866,7 @@
     },
     "/api/fleet/epm/packages/_bulk": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].",
+        "description": "[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.",
         "operationId": "post-fleet-epm-packages-bulk",
         "parameters": [
           {
@@ -23139,7 +23139,7 @@
     },
     "/api/fleet/epm/packages/installed": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "get-fleet-epm-packages-installed",
         "parameters": [
           {
@@ -23368,7 +23368,7 @@
     },
     "/api/fleet/epm/packages/limited": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "get-fleet-epm-packages-limited",
         "parameters": [],
         "responses": {
@@ -23427,7 +23427,7 @@
     },
     "/api/fleet/epm/packages/{pkgName}/stats": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "get-fleet-epm-packages-pkgname-stats",
         "parameters": [
           {
@@ -23501,7 +23501,7 @@
     },
     "/api/fleet/epm/packages/{pkgName}/{pkgVersion}": {
       "delete": {
-        "description": "[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].",
+        "description": "[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.",
         "operationId": "delete-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -24372,7 +24372,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].",
+        "description": "[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.",
         "operationId": "post-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -24589,7 +24589,7 @@
         ]
       },
       "put": {
-        "description": "[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].",
+        "description": "[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.",
         "operationId": "put-fleet-epm-packages-pkgname-pkgversion",
         "parameters": [
           {
@@ -25412,7 +25412,7 @@
     },
     "/api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath}": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "get-fleet-epm-packages-pkgname-pkgversion-filepath",
         "parameters": [
           {
@@ -25482,7 +25482,7 @@
     },
     "/api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "get-fleet-epm-templates-pkgname-pkgversion-inputs",
         "parameters": [
           {
@@ -25639,7 +25639,7 @@
     },
     "/api/fleet/epm/verification_key_id": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].",
+        "description": "[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.",
         "operationId": "get-fleet-epm-verification-key-id",
         "parameters": [],
         "responses": {
@@ -25696,7 +25696,7 @@
     },
     "/api/fleet/fleet_server_hosts": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [fleet-agents-all OR fleet-settings-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all OR fleet-settings-read.",
         "operationId": "get-fleet-fleet-server-hosts",
         "parameters": [],
         "responses": {
@@ -25801,7 +25801,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "post-fleet-fleet-server-hosts",
         "parameters": [
           {
@@ -25948,7 +25948,7 @@
     },
     "/api/fleet/fleet_server_hosts/{itemId}": {
       "delete": {
-        "description": "Delete a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "Delete a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "delete-fleet-fleet-server-hosts-itemid",
         "parameters": [
           {
@@ -26021,7 +26021,7 @@
         ]
       },
       "get": {
-        "description": "Get a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-read].",
+        "description": "Get a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-read.",
         "operationId": "get-fleet-fleet-server-hosts-itemid",
         "parameters": [
           {
@@ -26120,7 +26120,7 @@
         ]
       },
       "put": {
-        "description": "Update a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "Update a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "put-fleet-fleet-server-hosts-itemid",
         "parameters": [
           {
@@ -26266,7 +26266,7 @@
     },
     "/api/fleet/health_check": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "post-fleet-health-check",
         "parameters": [
           {
@@ -26382,7 +26382,7 @@
     },
     "/api/fleet/kubernetes": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-setup].",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
         "operationId": "get-fleet-kubernetes",
         "parameters": [
           {
@@ -26463,7 +26463,7 @@
     },
     "/api/fleet/kubernetes/download": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-setup].",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.",
         "operationId": "get-fleet-kubernetes-download",
         "parameters": [
           {
@@ -26560,7 +26560,7 @@
     },
     "/api/fleet/logstash_api_keys": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "post-fleet-logstash-api-keys",
         "parameters": [
           {
@@ -26627,7 +26627,7 @@
     },
     "/api/fleet/message_signing_service/rotate_key_pair": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all, fleet-agent-policies-all, fleet-settings-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all AND fleet-agent-policies-all AND fleet-settings-all.",
         "operationId": "post-fleet-message-signing-service-rotate-key-pair",
         "parameters": [
           {
@@ -26728,7 +26728,7 @@
     },
     "/api/fleet/outputs": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ANY of [fleet-settings-read OR fleet-agent-policies-read].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-read OR fleet-agent-policies-read.",
         "operationId": "get-fleet-outputs",
         "parameters": [],
         "responses": {
@@ -27812,7 +27812,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "post-fleet-outputs",
         "parameters": [
           {
@@ -29918,7 +29918,7 @@
     },
     "/api/fleet/outputs/{outputId}": {
       "delete": {
-        "description": "Delete output by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "Delete output by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "delete-fleet-outputs-outputid",
         "parameters": [
           {
@@ -30016,7 +30016,7 @@
         ]
       },
       "get": {
-        "description": "Get output by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-settings-read OR fleet-agent-policies-read].",
+        "description": "Get output by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-read OR fleet-agent-policies-read.",
         "operationId": "get-fleet-outputs-outputid",
         "parameters": [
           {
@@ -31094,7 +31094,7 @@
         ]
       },
       "put": {
-        "description": "Update output by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-settings-all OR fleet-agent-policies-all].",
+        "description": "Update output by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all OR fleet-agent-policies-all.",
         "operationId": "put-fleet-outputs-outputid",
         "parameters": [
           {
@@ -33184,7 +33184,7 @@
     },
     "/api/fleet/outputs/{outputId}/health": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-read].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-read.",
         "operationId": "get-fleet-outputs-outputid-health",
         "parameters": [
           {
@@ -35938,7 +35938,7 @@
     },
     "/api/fleet/package_policies/delete": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all, integrations-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-all AND integrations-all.",
         "operationId": "post-fleet-package-policies-delete",
         "parameters": [
           {
@@ -36130,7 +36130,7 @@
     },
     "/api/fleet/package_policies/upgrade": {
       "post": {
-        "description": "Upgrade a package policy to a newer package version.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all, integrations-all].",
+        "description": "Upgrade a package policy to a newer package version.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all AND integrations-all.",
         "operationId": "post-fleet-package-policies-upgrade",
         "parameters": [
           {
@@ -36243,7 +36243,7 @@
     },
     "/api/fleet/package_policies/upgrade/dryrun": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, integrations-read].",
+        "description": "[Required authorization] Route required privileges: fleet-agent-policies-read AND integrations-read.",
         "operationId": "post-fleet-package-policies-upgrade-dryrun",
         "parameters": [
           {
@@ -37429,7 +37429,7 @@
     },
     "/api/fleet/package_policies/{packagePolicyId}": {
       "delete": {
-        "description": "Delete a package policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all, integrations-all].",
+        "description": "Delete a package policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all AND integrations-all.",
         "operationId": "delete-fleet-package-policies-packagepolicyid",
         "parameters": [
           {
@@ -39450,7 +39450,7 @@
     },
     "/api/fleet/proxies": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-read].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-read.",
         "operationId": "get-fleet-proxies",
         "parameters": [],
         "responses": {
@@ -39569,7 +39569,7 @@
         ]
       },
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "post-fleet-proxies",
         "parameters": [
           {
@@ -39744,7 +39744,7 @@
     },
     "/api/fleet/proxies/{itemId}": {
       "delete": {
-        "description": "Delete a proxy by ID<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "Delete a proxy by ID<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "delete-fleet-proxies-itemid",
         "parameters": [
           {
@@ -39817,7 +39817,7 @@
         ]
       },
       "get": {
-        "description": "Get a proxy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-read].",
+        "description": "Get a proxy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-read.",
         "operationId": "get-fleet-proxies-itemid",
         "parameters": [
           {
@@ -39930,7 +39930,7 @@
         ]
       },
       "put": {
-        "description": "Update a proxy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "Update a proxy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "put-fleet-proxies-itemid",
         "parameters": [
           {
@@ -40108,7 +40108,7 @@
     },
     "/api/fleet/service_tokens": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "post-fleet-service-tokens",
         "parameters": [
           {
@@ -40196,7 +40196,7 @@
     },
     "/api/fleet/settings": {
       "get": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-read].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-read.",
         "operationId": "get-fleet-settings",
         "parameters": [],
         "responses": {
@@ -40329,7 +40329,7 @@
         ]
       },
       "put": {
-        "description": "[Required authorization] Route required privileges: ALL of [fleet-settings-all].",
+        "description": "[Required authorization] Route required privileges: fleet-settings-all.",
         "operationId": "put-fleet-settings",
         "parameters": [
           {
@@ -40522,7 +40522,7 @@
     },
     "/api/fleet/setup": {
       "post": {
-        "description": "[Required authorization] Route required privileges: ANY of [fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup].",
+        "description": "[Required authorization] Route required privileges: fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup.",
         "operationId": "post-fleet-setup",
         "parameters": [
           {
@@ -40629,7 +40629,7 @@
     },
     "/api/fleet/uninstall_tokens": {
       "get": {
-        "description": "List the metadata for the latest uninstall tokens per agent policy.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "List the metadata for the latest uninstall tokens per agent policy.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "get-fleet-uninstall-tokens",
         "parameters": [
           {
@@ -40766,7 +40766,7 @@
     },
     "/api/fleet/uninstall_tokens/{uninstallTokenId}": {
       "get": {
-        "description": "Get one decrypted uninstall token by its ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].",
+        "description": "Get one decrypted uninstall token by its ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.",
         "operationId": "get-fleet-uninstall-tokens-uninstalltokenid",
         "parameters": [
           {
@@ -41633,7 +41633,7 @@
     },
     "/api/spaces/_copy_saved_objects": {
       "post": {
-        "description": "It also allows you to automatically copy related objects, so when you copy a dashboard, this can automatically copy over the associated visualizations, data views, and saved Discover sessions, as required. You can request to overwrite any objects that already exist in the target space if they share an identifier or you can use the resolve copy saved objects conflicts API to do this on a per-object basis.<br/><br/>[Required authorization] Route required privileges: ALL of [copySavedObjectsToSpaces].",
+        "description": "It also allows you to automatically copy related objects, so when you copy a dashboard, this can automatically copy over the associated visualizations, data views, and saved Discover sessions, as required. You can request to overwrite any objects that already exist in the target space if they share an identifier or you can use the resolve copy saved objects conflicts API to do this on a per-object basis.<br/><br/>[Required authorization] Route required privileges: copySavedObjectsToSpaces.",
         "operationId": "post-spaces-copy-saved-objects",
         "parameters": [
           {
@@ -41840,7 +41840,7 @@
     },
     "/api/spaces/_resolve_copy_saved_objects_errors": {
       "post": {
-        "description": "Overwrite saved objects that are returned as errors from the copy saved objects to space API.<br/><br/>[Required authorization] Route required privileges: ALL of [copySavedObjectsToSpaces].",
+        "description": "Overwrite saved objects that are returned as errors from the copy saved objects to space API.<br/><br/>[Required authorization] Route required privileges: copySavedObjectsToSpaces.",
         "operationId": "post-spaces-resolve-copy-saved-objects-errors",
         "parameters": [
           {

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -15044,7 +15044,7 @@ paths:
       x-state: Technical Preview
   /api/fleet/agent_download_sources:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-settings-read].'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-settings-read.'
       operationId: get-fleet-agent-download-sources
       parameters: []
       responses:
@@ -15110,7 +15110,7 @@ paths:
       tags:
         - Elastic Agent binary download sources
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: '[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: post-fleet-agent-download-sources
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -15197,7 +15197,7 @@ paths:
         - Elastic Agent binary download sources
   /api/fleet/agent_download_sources/{sourceId}:
     delete:
-      description: 'Delete an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: 'Delete an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: delete-fleet-agent-download-sources-sourceid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -15244,7 +15244,7 @@ paths:
       tags:
         - Elastic Agent binary download sources
     get:
-      description: 'Get an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-settings-read].'
+      description: 'Get an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-settings-read.'
       operationId: get-fleet-agent-download-sources-sourceid
       parameters:
         - in: path
@@ -15304,7 +15304,7 @@ paths:
       tags:
         - Elastic Agent binary download sources
     put:
-      description: 'Update an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: 'Update an agent binary download source by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: put-fleet-agent-download-sources-sourceid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -15396,7 +15396,7 @@ paths:
         - Elastic Agent binary download sources
   /api/fleet/agent_policies:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-agents-read OR fleet-setup].'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-agents-read OR fleet-setup.'
       operationId: get-fleet-agent-policies
       parameters:
         - in: query
@@ -16112,7 +16112,7 @@ paths:
       tags:
         - Elastic Agent policies
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all].'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-all.'
       operationId: post-fleet-agent-policies
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -16976,7 +16976,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/agent_policies/_bulk_get:
     post:
-      description: '[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-agents-read OR fleet-setup].'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-agents-read OR fleet-setup.'
       operationId: post-fleet-agent-policies-bulk-get
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -17658,7 +17658,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}:
     get:
-      description: 'Get an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-agent-policies-read OR fleet-agents-read OR fleet-setup].'
+      description: 'Get an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read OR fleet-agents-read OR fleet-setup.'
       operationId: get-fleet-agent-policies-agentpolicyid
       parameters:
         - in: path
@@ -18316,7 +18316,7 @@ paths:
       tags:
         - Elastic Agent policies
     put:
-      description: 'Update an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all].'
+      description: 'Update an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all.'
       operationId: put-fleet-agent-policies-agentpolicyid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -19188,7 +19188,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/copy:
     post:
-      description: 'Copy an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all].'
+      description: 'Copy an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all.'
       operationId: post-fleet-agent-policies-agentpolicyid-copy
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -19868,7 +19868,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/download:
     get:
-      description: 'Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-setup].'
+      description: 'Download an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.'
       operationId: get-fleet-agent-policies-agentpolicyid-download
       parameters:
         - in: path
@@ -19934,7 +19934,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/full:
     get:
-      description: 'Get a full agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read].'
+      description: 'Get a full agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read.'
       operationId: get-fleet-agent-policies-agentpolicyid-full
       parameters:
         - in: path
@@ -20284,7 +20284,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/agent_policies/{agentPolicyId}/outputs:
     get:
-      description: 'Get a list of outputs associated with agent policy by policy id.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-settings-read].'
+      description: 'Get a list of outputs associated with agent policy by policy id.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-settings-read.'
       operationId: get-fleet-agent-policies-agentpolicyid-outputs
       parameters:
         - in: path
@@ -20380,7 +20380,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/agent_policies/delete:
     post:
-      description: 'Delete an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all].'
+      description: 'Delete an agent policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all.'
       operationId: post-fleet-agent-policies-delete
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -20440,7 +20440,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/agent_policies/outputs:
     post:
-      description: 'Get a list of outputs associated with agent policies.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-settings-read].'
+      description: 'Get a list of outputs associated with agent policies.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-settings-read.'
       operationId: post-fleet-agent-policies-outputs
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -20645,7 +20645,7 @@ paths:
         - Elastic Agent status
   /api/fleet/agent_status/data:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: get-fleet-agent-status-data
       parameters:
         - in: query
@@ -20720,7 +20720,7 @@ paths:
         - Elastic Agents
   /api/fleet/agents:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: get-fleet-agents
       parameters:
         - in: query
@@ -21103,7 +21103,7 @@ paths:
       tags:
         - Elastic Agents
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: post-fleet-agents
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -21161,7 +21161,7 @@ paths:
         - Elastic Agents
   /api/fleet/agents/{agentId}:
     delete:
-      description: 'Delete an agent by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: 'Delete an agent by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: delete-fleet-agents-agentid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -21210,7 +21210,7 @@ paths:
       tags:
         - Elastic Agents
     get:
-      description: 'Get an agent by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: 'Get an agent by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: get-fleet-agents-agentid
       parameters:
         - in: path
@@ -21535,7 +21535,7 @@ paths:
       tags:
         - Elastic Agents
     put:
-      description: 'Update an agent by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: 'Update an agent by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: put-fleet-agents-agentid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -21876,7 +21876,7 @@ paths:
         - Elastic Agents
   /api/fleet/agents/{agentId}/actions:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-agents-agentid-actions
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22012,7 +22012,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/reassign:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-agents-agentid-reassign
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22067,7 +22067,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/request_diagnostics:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: post-fleet-agents-agentid-request-diagnostics
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22129,7 +22129,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/unenroll:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-agents-agentid-unenroll
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22162,7 +22162,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/upgrade:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-agents-agentid-upgrade
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22223,7 +22223,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/{agentId}/uploads:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: get-fleet-agents-agentid-uploads
       parameters:
         - in: path
@@ -22296,7 +22296,7 @@ paths:
         - Elastic Agents
   /api/fleet/agents/action_status:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: get-fleet-agents-action-status
       parameters:
         - in: query
@@ -22454,7 +22454,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/actions/{actionId}/cancel:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-agents-actions-actionid-cancel
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22540,7 +22540,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/available_versions:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: get-fleet-agents-available-versions
       parameters: []
       responses:
@@ -22578,7 +22578,7 @@ paths:
         - Elastic Agents
   /api/fleet/agents/bulk_reassign:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-agents-bulk-reassign
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22644,7 +22644,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/bulk_request_diagnostics:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: post-fleet-agents-bulk-request-diagnostics
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22710,7 +22710,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/bulk_unenroll:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-agents-bulk-unenroll
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22781,7 +22781,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/bulk_update_agent_tags:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-agents-bulk-update-agent-tags
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22852,7 +22852,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/bulk_upgrade:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-agents-bulk-upgrade
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22929,7 +22929,7 @@ paths:
         - Elastic Agent actions
   /api/fleet/agents/files/{fileId}:
     delete:
-      description: 'Delete a file uploaded by an agent.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: 'Delete a file uploaded by an agent.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: delete-fleet-agents-files-fileid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -22980,7 +22980,7 @@ paths:
         - Elastic Agents
   /api/fleet/agents/files/{fileId}/{fileName}:
     get:
-      description: 'Get a file uploaded by an agent.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: 'Get a file uploaded by an agent.<br/><br/>[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: get-fleet-agents-files-fileid-filename
       parameters:
         - in: path
@@ -23020,7 +23020,7 @@ paths:
         - Elastic Agents
   /api/fleet/agents/setup:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup.'
       operationId: get-fleet-agents-setup
       parameters: []
       responses:
@@ -23080,7 +23080,7 @@ paths:
       tags:
         - Elastic Agents
     post:
-      description: '[Required authorization] Route required privileges: ANY of [fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup.'
       operationId: post-fleet-agents-setup
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -23138,7 +23138,7 @@ paths:
         - Elastic Agents
   /api/fleet/agents/tags:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read.'
       operationId: get-fleet-agents-tags
       parameters:
         - in: query
@@ -23233,7 +23233,7 @@ paths:
         - Fleet internals
   /api/fleet/data_streams:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all, fleet-agent-policies-all, fleet-settings-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all AND fleet-agent-policies-all AND fleet-settings-all.'
       operationId: get-fleet-data-streams
       parameters: []
       responses:
@@ -23330,7 +23330,7 @@ paths:
         - Data streams
   /api/fleet/enrollment_api_keys:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [fleet-agents-all OR fleet-setup].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all OR fleet-setup.'
       operationId: get-fleet-enrollment-api-keys
       parameters:
         - in: query
@@ -23453,7 +23453,7 @@ paths:
       tags:
         - Fleet enrollment API keys
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-enrollment-api-keys
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -23543,7 +23543,7 @@ paths:
         - Fleet enrollment API keys
   /api/fleet/enrollment_api_keys/{keyId}:
     delete:
-      description: 'Revoke an enrollment API key by ID by marking it as inactive.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: 'Revoke an enrollment API key by ID by marking it as inactive.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: delete-fleet-enrollment-api-keys-keyid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -23592,7 +23592,7 @@ paths:
       tags:
         - Fleet enrollment API keys
     get:
-      description: 'Get an enrollment API key by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-agents-all OR fleet-setup].'
+      description: 'Get an enrollment API key by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all OR fleet-setup.'
       operationId: get-fleet-enrollment-api-keys-keyid
       parameters:
         - in: path
@@ -23660,7 +23660,7 @@ paths:
         - Fleet enrollment API keys
   /api/fleet/epm/bulk_assets:
     post:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: post-fleet-epm-bulk-assets
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -23751,7 +23751,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/categories:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: get-fleet-epm-categories
       parameters:
         - in: query
@@ -23815,7 +23815,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/custom_integrations:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].'
+      description: '[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.'
       operationId: post-fleet-epm-custom-integrations
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -23952,7 +23952,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/data_streams:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: get-fleet-epm-data-streams
       parameters:
         - in: query
@@ -24027,7 +24027,7 @@ paths:
         - Data streams
   /api/fleet/epm/packages:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: get-fleet-epm-packages
       parameters:
         - in: query
@@ -24426,7 +24426,7 @@ paths:
       tags:
         - Elastic Package Manager (EPM)
     post:
-      description: '[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].'
+      description: '[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.'
       operationId: post-fleet-epm-packages
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -24548,7 +24548,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/_bulk:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].'
+      description: '[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.'
       operationId: post-fleet-epm-packages-bulk
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -24725,7 +24725,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/{pkgVersion}:
     delete:
-      description: '[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].'
+      description: '[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.'
       operationId: delete-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -25312,7 +25312,7 @@ paths:
       tags:
         - Elastic Package Manager (EPM)
     post:
-      description: '[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].'
+      description: '[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.'
       operationId: post-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -25456,7 +25456,7 @@ paths:
       tags:
         - Elastic Package Manager (EPM)
     put:
-      description: '[Required authorization] Route required privileges: ALL of [integrations-all, fleet-agent-policies-all].'
+      description: '[Required authorization] Route required privileges: integrations-all AND fleet-agent-policies-all.'
       operationId: put-fleet-epm-packages-pkgname-pkgversion
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -25925,7 +25925,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/{pkgVersion}/{filePath}:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: get-fleet-epm-packages-pkgname-pkgversion-filepath
       parameters:
         - in: path
@@ -26053,7 +26053,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/{pkgName}/stats:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: get-fleet-epm-packages-pkgname-stats
       parameters:
         - in: path
@@ -26100,7 +26100,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/installed:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: get-fleet-epm-packages-installed
       parameters:
         - in: query
@@ -26246,7 +26246,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/packages/limited:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: get-fleet-epm-packages-limited
       parameters: []
       responses:
@@ -26284,7 +26284,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: get-fleet-epm-templates-pkgname-pkgversion-inputs
       parameters:
         - in: path
@@ -26384,7 +26384,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/epm/verification_key_id:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [integrations-read OR fleet-setup OR fleet-all].'
+      description: '[Required authorization] Route required privileges: integrations-read OR fleet-setup OR fleet-all.'
       operationId: get-fleet-epm-verification-key-id
       parameters: []
       responses:
@@ -26421,7 +26421,7 @@ paths:
         - Elastic Package Manager (EPM)
   /api/fleet/fleet_server_hosts:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [fleet-agents-all OR fleet-settings-read].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all OR fleet-settings-read.'
       operationId: get-fleet-fleet-server-hosts
       parameters: []
       responses:
@@ -26493,7 +26493,7 @@ paths:
       tags:
         - Fleet Server hosts
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: '[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: post-fleet-fleet-server-hosts
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -26592,7 +26592,7 @@ paths:
         - Fleet Server hosts
   /api/fleet/fleet_server_hosts/{itemId}:
     delete:
-      description: 'Delete a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: 'Delete a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: delete-fleet-fleet-server-hosts-itemid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -26639,7 +26639,7 @@ paths:
       tags:
         - Fleet Server hosts
     get:
-      description: 'Get a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-read].'
+      description: 'Get a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-read.'
       operationId: get-fleet-fleet-server-hosts-itemid
       parameters:
         - in: path
@@ -26705,7 +26705,7 @@ paths:
       tags:
         - Fleet Server hosts
     put:
-      description: 'Update a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: 'Update a Fleet Server host by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: put-fleet-fleet-server-hosts-itemid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -26802,7 +26802,7 @@ paths:
         - Fleet Server hosts
   /api/fleet/health_check:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: '[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: post-fleet-health-check
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -26876,7 +26876,7 @@ paths:
         - Fleet internals
   /api/fleet/kubernetes:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-setup].'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.'
       operationId: get-fleet-kubernetes
       parameters:
         - in: query
@@ -26927,7 +26927,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/kubernetes/download:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, fleet-setup].'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read AND fleet-setup.'
       operationId: get-fleet-kubernetes-download
       parameters:
         - in: query
@@ -26988,7 +26988,7 @@ paths:
         - Elastic Agent policies
   /api/fleet/logstash_api_keys:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: '[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: post-fleet-logstash-api-keys
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -27031,7 +27031,7 @@ paths:
         - Fleet outputs
   /api/fleet/message_signing_service/rotate_key_pair:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all, fleet-agent-policies-all, fleet-settings-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all AND fleet-agent-policies-all AND fleet-settings-all.'
       operationId: post-fleet-message-signing-service-rotate-key-pair
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -27096,7 +27096,7 @@ paths:
         - Message Signing Service
   /api/fleet/outputs:
     get:
-      description: '[Required authorization] Route required privileges: ANY of [fleet-settings-read OR fleet-agent-policies-read].'
+      description: '[Required authorization] Route required privileges: fleet-settings-read OR fleet-agent-policies-read.'
       operationId: get-fleet-outputs
       parameters: []
       responses:
@@ -27821,7 +27821,7 @@ paths:
       tags:
         - Fleet outputs
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: '[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: post-fleet-outputs
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -29227,7 +29227,7 @@ paths:
         - Fleet outputs
   /api/fleet/outputs/{outputId}:
     delete:
-      description: 'Delete output by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: 'Delete output by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: delete-fleet-outputs-outputid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -29290,7 +29290,7 @@ paths:
       tags:
         - Fleet outputs
     get:
-      description: 'Get output by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-settings-read OR fleet-agent-policies-read].'
+      description: 'Get output by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-read OR fleet-agent-policies-read.'
       operationId: get-fleet-outputs-outputid
       parameters:
         - in: path
@@ -30009,7 +30009,7 @@ paths:
       tags:
         - Fleet outputs
     put:
-      description: 'Update output by ID.<br/><br/>[Required authorization] Route required privileges: ANY of [fleet-settings-all OR fleet-agent-policies-all].'
+      description: 'Update output by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all OR fleet-agent-policies-all.'
       operationId: put-fleet-outputs-outputid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -31399,7 +31399,7 @@ paths:
         - Fleet outputs
   /api/fleet/outputs/{outputId}/health:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-read].'
+      description: '[Required authorization] Route required privileges: fleet-settings-read.'
       operationId: get-fleet-outputs-outputid-health
       parameters:
         - in: path
@@ -33207,7 +33207,7 @@ paths:
         - Fleet package policies
   /api/fleet/package_policies/{packagePolicyId}:
     delete:
-      description: 'Delete a package policy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all, integrations-all].'
+      description: 'Delete a package policy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all AND integrations-all.'
       operationId: delete-fleet-package-policies-packagepolicyid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -34532,7 +34532,7 @@ paths:
         - Fleet package policies
   /api/fleet/package_policies/delete:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all, integrations-all].'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-all AND integrations-all.'
       operationId: post-fleet-package-policies-delete
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -34661,7 +34661,7 @@ paths:
         - Fleet package policies
   /api/fleet/package_policies/upgrade:
     post:
-      description: 'Upgrade a package policy to a newer package version.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agent-policies-all, integrations-all].'
+      description: 'Upgrade a package policy to a newer package version.<br/><br/>[Required authorization] Route required privileges: fleet-agent-policies-all AND integrations-all.'
       operationId: post-fleet-package-policies-upgrade
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -34734,7 +34734,7 @@ paths:
         - Fleet package policies
   /api/fleet/package_policies/upgrade/dryrun:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agent-policies-read, integrations-read].'
+      description: '[Required authorization] Route required privileges: fleet-agent-policies-read AND integrations-read.'
       operationId: post-fleet-package-policies-upgrade-dryrun
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -35527,7 +35527,7 @@ paths:
         - Fleet package policies
   /api/fleet/proxies:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-read].'
+      description: '[Required authorization] Route required privileges: fleet-settings-read.'
       operationId: get-fleet-proxies
       parameters: []
       responses:
@@ -35605,7 +35605,7 @@ paths:
       tags:
         - Fleet proxies
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: '[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: post-fleet-proxies
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -35716,7 +35716,7 @@ paths:
         - Fleet proxies
   /api/fleet/proxies/{itemId}:
     delete:
-      description: 'Delete a proxy by ID<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: 'Delete a proxy by ID<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: delete-fleet-proxies-itemid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -35763,7 +35763,7 @@ paths:
       tags:
         - Fleet proxies
     get:
-      description: 'Get a proxy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-read].'
+      description: 'Get a proxy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-read.'
       operationId: get-fleet-proxies-itemid
       parameters:
         - in: path
@@ -35835,7 +35835,7 @@ paths:
       tags:
         - Fleet proxies
     put:
-      description: 'Update a proxy by ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: 'Update a proxy by ID.<br/><br/>[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: put-fleet-proxies-itemid
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -35948,7 +35948,7 @@ paths:
         - Fleet proxies
   /api/fleet/service_tokens:
     post:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: '[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: post-fleet-service-tokens
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -36005,7 +36005,7 @@ paths:
         - Fleet service tokens
   /api/fleet/settings:
     get:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-read].'
+      description: '[Required authorization] Route required privileges: fleet-settings-read.'
       operationId: get-fleet-settings
       parameters: []
       responses:
@@ -36093,7 +36093,7 @@ paths:
       tags:
         - Fleet internals
     put:
-      description: '[Required authorization] Route required privileges: ALL of [fleet-settings-all].'
+      description: '[Required authorization] Route required privileges: fleet-settings-all.'
       operationId: put-fleet-settings
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -36220,7 +36220,7 @@ paths:
         - Fleet internals
   /api/fleet/setup:
     post:
-      description: '[Required authorization] Route required privileges: ANY of [fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup].'
+      description: '[Required authorization] Route required privileges: fleet-agents-read OR fleet-agent-policies-read OR fleet-settings-read OR fleet-setup.'
       operationId: post-fleet-setup
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -36290,7 +36290,7 @@ paths:
         - Fleet internals
   /api/fleet/uninstall_tokens:
     get:
-      description: 'List the metadata for the latest uninstall tokens per agent policy.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: 'List the metadata for the latest uninstall tokens per agent policy.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: get-fleet-uninstall-tokens
       parameters:
         - description: Partial match filtering for policy IDs
@@ -36382,7 +36382,7 @@ paths:
         - Fleet uninstall tokens
   /api/fleet/uninstall_tokens/{uninstallTokenId}:
     get:
-      description: 'Get one decrypted uninstall token by its ID.<br/><br/>[Required authorization] Route required privileges: ALL of [fleet-agents-all].'
+      description: 'Get one decrypted uninstall token by its ID.<br/><br/>[Required authorization] Route required privileges: fleet-agents-all.'
       operationId: get-fleet-uninstall-tokens-uninstalltokenid
       parameters:
         - in: path
@@ -41772,7 +41772,7 @@ paths:
       x-state: Technical Preview
   /api/spaces/_copy_saved_objects:
     post:
-      description: 'It also allows you to automatically copy related objects, so when you copy a dashboard, this can automatically copy over the associated visualizations, data views, and saved Discover sessions, as required. You can request to overwrite any objects that already exist in the target space if they share an identifier or you can use the resolve copy saved objects conflicts API to do this on a per-object basis.<br/><br/>[Required authorization] Route required privileges: ALL of [copySavedObjectsToSpaces].'
+      description: 'It also allows you to automatically copy related objects, so when you copy a dashboard, this can automatically copy over the associated visualizations, data views, and saved Discover sessions, as required. You can request to overwrite any objects that already exist in the target space if they share an identifier or you can use the resolve copy saved objects conflicts API to do this on a per-object basis.<br/><br/>[Required authorization] Route required privileges: copySavedObjectsToSpaces.'
       operationId: post-spaces-copy-saved-objects
       parameters:
         - description: A required header to protect against CSRF attacks
@@ -41935,7 +41935,7 @@ paths:
         - spaces
   /api/spaces/_resolve_copy_saved_objects_errors:
     post:
-      description: 'Overwrite saved objects that are returned as errors from the copy saved objects to space API.<br/><br/>[Required authorization] Route required privileges: ALL of [copySavedObjectsToSpaces].'
+      description: 'Overwrite saved objects that are returned as errors from the copy saved objects to space API.<br/><br/>[Required authorization] Route required privileges: copySavedObjectsToSpaces.'
       operationId: post-spaces-resolve-copy-saved-objects-errors
       parameters:
         - description: A required header to protect against CSRF attacks

--- a/src/core/packages/http/router-server-internal/tsconfig.json
+++ b/src/core/packages/http/router-server-internal/tsconfig.json
@@ -21,7 +21,8 @@
     "@kbn/core-http-common",
     "@kbn/logging-mocks",
     "@kbn/config-mocks",
-    "@kbn/config"
+    "@kbn/config",
+    "@kbn/core-security-server"
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/http/server/index.ts
+++ b/src/core/packages/http/server/index.ts
@@ -119,6 +119,8 @@ export type {
   AuthcEnabled,
   Privilege,
   PrivilegeSet,
+  AllRequiredCondition,
+  AnyRequiredCondition,
   RouteSecurity,
   RouteSecurityGetter,
   InternalRouteSecurity,

--- a/src/core/packages/http/server/src/router/index.ts
+++ b/src/core/packages/http/server/src/router/index.ts
@@ -63,6 +63,8 @@ export type {
   AuthcDisabled,
   AuthcEnabled,
   RouteSecurity,
+  AllRequiredCondition,
+  AnyRequiredCondition,
   Privilege,
   PrivilegeSet,
   RouteDeprecationInfo,

--- a/src/core/packages/http/server/src/router/route.ts
+++ b/src/core/packages/http/server/src/router/route.ts
@@ -200,6 +200,9 @@ interface DeprecateApiDeprecationType {
   type: 'deprecate';
 }
 
+export type AllRequiredCondition = Array<Privilege | { anyOf: Privilege[] }>;
+export type AnyRequiredCondition = Array<Privilege | { allOf: Privilege[] }>;
+
 /**
  * A set of privileges that can be used to define complex authorization requirements.
  *
@@ -207,14 +210,14 @@ interface DeprecateApiDeprecationType {
  * - `allRequired`: An array of privileges where all listed privileges must be satisfied to meet the authorization requirement.
  */
 export interface PrivilegeSet {
-  anyRequired?: Privilege[];
-  allRequired?: Privilege[];
+  anyRequired?: AnyRequiredCondition;
+  allRequired?: AllRequiredCondition;
 }
 
 /**
  * An array representing a combination of simple privileges or complex privilege sets.
  */
-type Privileges = Array<Privilege | PrivilegeSet>;
+export type Privileges = Array<Privilege | PrivilegeSet>;
 
 /**
  * Describes the authorization requirements when authorization is enabled.

--- a/src/core/packages/security/server/index.ts
+++ b/src/core/packages/security/server/index.ts
@@ -50,3 +50,4 @@ export type {
 export type { KibanaPrivilegesType, ElasticsearchPrivilegesType } from './src/roles';
 export { isCreateRestAPIKeyParams } from './src/authentication/api_keys';
 export type { CoreFipsService } from './src/fips';
+export { unwindNestedSecurityPrivileges } from './src/authz';

--- a/src/core/packages/security/server/src/authz.ts
+++ b/src/core/packages/security/server/src/authz.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export const unwindNestedSecurityPrivileges = <
+  T extends Array<string | { allOf?: string[]; anyOf?: string[] }>
+>(
+  privileges: T
+): string[] =>
+  privileges.reduce((acc: string[], privilege) => {
+    if (typeof privilege === 'object') {
+      if (privilege.allOf?.length) {
+        acc.push(...privilege.allOf);
+      }
+
+      if (privilege?.anyOf?.length) {
+        acc.push(...privilege.anyOf);
+      }
+    } else if (typeof privilege === 'string') {
+      acc.push(privilege);
+    }
+
+    return acc;
+  }, []);

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -615,4 +615,6 @@ export type {
   RouteSecurityGetter,
   Privilege,
   PrivilegeSet,
+  AllRequiredCondition,
+  AnyRequiredCondition,
 } from '@kbn/core-http-server';

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
@@ -126,6 +126,7 @@ Object {
     "/bar": Object {
       "get": Object {
         "deprecated": true,
+        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "get-bar",
         "parameters": Array [],
         "requestBody": Object {
@@ -490,6 +491,7 @@ Object {
     "/no-xsrf/{id}/{path}": Object {
       "post": Object {
         "deprecated": true,
+        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "post-no-xsrf-id-path",
         "parameters": Array [],
         "requestBody": Object {
@@ -702,6 +704,7 @@ Object {
     },
     "/test": Object {
       "get": Object {
+        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "get-test",
         "parameters": Array [],
         "requestBody": Object {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/__snapshots__/generate_oas.test.ts.snap
@@ -126,7 +126,6 @@ Object {
     "/bar": Object {
       "get": Object {
         "deprecated": true,
-        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "get-bar",
         "parameters": Array [],
         "requestBody": Object {
@@ -491,7 +490,6 @@ Object {
     "/no-xsrf/{id}/{path}": Object {
       "post": Object {
         "deprecated": true,
-        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "post-no-xsrf-id-path",
         "parameters": Array [],
         "requestBody": Object {
@@ -704,7 +702,6 @@ Object {
     },
     "/test": Object {
       "get": Object {
-        "description": "[Required authorization] Route required privileges: foo.",
         "operationId": "get-test",
         "parameters": Array [],
         "requestBody": Object {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/extract_authz_description.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/extract_authz_description.test.ts
@@ -33,9 +33,7 @@ describe('extractAuthzDescription', () => {
       },
     };
     const description = extractAuthzDescription(routeSecurity);
-    expect(description).toBe(
-      '[Required authorization] Route required privileges: ALL of [manage_spaces].'
-    );
+    expect(description).toBe('[Required authorization] Route required privileges: manage_spaces.');
   });
 
   it('should return route authz description for privilege groups', () => {
@@ -46,9 +44,7 @@ describe('extractAuthzDescription', () => {
         },
       };
       const description = extractAuthzDescription(routeSecurity);
-      expect(description).toBe(
-        '[Required authorization] Route required privileges: ALL of [console].'
-      );
+      expect(description).toBe('[Required authorization] Route required privileges: console.');
     }
     {
       const routeSecurity: RouteSecurity = {
@@ -62,7 +58,7 @@ describe('extractAuthzDescription', () => {
       };
       const description = extractAuthzDescription(routeSecurity);
       expect(description).toBe(
-        '[Required authorization] Route required privileges: ANY of [manage_spaces OR taskmanager].'
+        '[Required authorization] Route required privileges: manage_spaces OR taskmanager.'
       );
     }
     {
@@ -78,7 +74,25 @@ describe('extractAuthzDescription', () => {
       };
       const description = extractAuthzDescription(routeSecurity);
       expect(description).toBe(
-        '[Required authorization] Route required privileges: ALL of [console, filesManagement] AND ANY of [manage_spaces OR taskmanager].'
+        '[Required authorization] Route required privileges: (console AND filesManagement) AND (manage_spaces OR taskmanager).'
+      );
+    }
+    {
+      const routeSecurity: RouteSecurity = {
+        authz: {
+          requiredPrivileges: [
+            {
+              anyRequired: [
+                { allOf: ['manage_spaces', 'taskmanager'] },
+                { allOf: ['console', 'filesManagement'] },
+              ],
+            },
+          ],
+        },
+      };
+      const description = extractAuthzDescription(routeSecurity);
+      expect(description).toBe(
+        '[Required authorization] Route required privileges: (manage_spaces AND taskmanager) OR (console AND filesManagement).'
       );
     }
   });

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
@@ -36,6 +36,7 @@ export const sharedOas = {
         deprecated: true,
         'x-discontinued': 'route discontinued version or date',
         operationId: 'get-bar',
+        description: '[Required authorization] Route required privileges: foo.',
         parameters: [],
         requestBody: {
           content: {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.fixture.ts
@@ -36,7 +36,6 @@ export const sharedOas = {
         deprecated: true,
         'x-discontinued': 'route discontinued version or date',
         operationId: 'get-bar',
-        description: '[Required authorization] Route required privileges: foo.',
         parameters: [],
         requestBody: {
           content: {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/process_router.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/process_router.test.ts
@@ -118,7 +118,7 @@ describe('processRouter', () => {
               'manage_spaces',
               {
                 allRequired: ['taskmanager'],
-                anyRequired: ['console'],
+                anyRequired: ['console', 'devtools'],
               },
             ],
           },
@@ -139,7 +139,7 @@ describe('processRouter', () => {
               'manage_spaces',
               {
                 allRequired: ['taskmanager'],
-                anyRequired: ['console'],
+                anyRequired: ['console', 'devtools'],
               },
             ],
           },
@@ -172,11 +172,11 @@ describe('processRouter', () => {
     expect(result.paths['/qux']?.post).toBeDefined();
 
     expect(result.paths['/qux']?.post?.description).toEqual(
-      '[Required authorization] Route required privileges: ALL of [manage_spaces, taskmanager] AND ANY of [console].'
+      '[Required authorization] Route required privileges: (manage_spaces AND taskmanager) AND (console OR devtools).'
     );
 
     expect(result.paths['/quux']?.post?.description).toEqual(
-      'This a test route description.<br/><br/>[Required authorization] Route required privileges: ALL of [manage_spaces, taskmanager] AND ANY of [console].'
+      'This a test route description.<br/><br/>[Required authorization] Route required privileges: (manage_spaces AND taskmanager) AND (console OR devtools).'
     );
   });
 });

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/process_versioned_router.test.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/process_versioned_router.test.ts
@@ -156,7 +156,7 @@ describe('processVersionedRouter', () => {
     expect(results.paths['/foo']!.get).toBeDefined();
 
     expect(results.paths['/foo']!.get!.description).toBe(
-      'This is a test route description.<br/><br/>[Required authorization] Route required privileges: ALL of [manage_spaces].'
+      'This is a test route description.<br/><br/>[Required authorization] Route required privileges: manage_spaces.'
     );
   });
 });

--- a/x-pack/platform/plugins/shared/security/server/authorization/api_authorization.test.ts
+++ b/x-pack/platform/plugins/shared/security/server/authorization/api_authorization.test.ts
@@ -546,6 +546,255 @@ describe('initAPIAuthorization', () => {
       }
     );
 
+    testSecurityConfig(
+      `protected route returns "authzResult" if user has permissions with complex anyRequired config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                anyRequired: [
+                  { allOf: ['privilege1', 'privilege2'] },
+                  { allOf: ['privilege3', 'privilege4'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: true },
+              { privilege: 'api:privilege4', authorized: true },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: ['privilege1', 'privilege2', 'privilege3', 'privilege4'],
+        asserts: {
+          authzResult: {
+            privilege1: true,
+            privilege2: false,
+            privilege3: true,
+            privilege4: true,
+          },
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns "authzResult" if user has permissions  requested with complex allRequired config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                allRequired: [
+                  { anyOf: ['privilege1', 'privilege2'] },
+                  { anyOf: ['privilege3', 'privilege4'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: true },
+              { privilege: 'api:privilege4', authorized: false },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: ['privilege1', 'privilege2', 'privilege3', 'privilege4'],
+        asserts: {
+          authzResult: {
+            privilege1: true,
+            privilege2: false,
+            privilege3: true,
+            privilege4: false,
+          },
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns forbidden if user doesn't have required privileges requested with complex allRequired config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                allRequired: [
+                  { anyOf: ['privilege1', 'privilege2'] },
+                  { anyOf: ['privilege3', 'privilege4'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: false },
+              { privilege: 'api:privilege4', authorized: false },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: ['privilege1', 'privilege2', 'privilege3', 'privilege4'],
+        asserts: {
+          forbidden: true,
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns "authzResult" if user has permissions requested with complex config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                // (privilege1 OR privilege2) AND (privilege3 OR privilege4)
+                // AND ((privilege5 AND privilege6) OR (privilege7 AND privilege8))
+                allRequired: [
+                  { anyOf: ['privilege1', 'privilege2'] },
+                  { anyOf: ['privilege3', 'privilege4'] },
+                ],
+                anyRequired: [
+                  { allOf: ['privilege5', 'privilege6'] },
+                  { allOf: ['privilege7', 'privilege8'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: false },
+              { privilege: 'api:privilege4', authorized: true },
+              { privilege: 'api:privilege5', authorized: false },
+              { privilege: 'api:privilege6', authorized: false },
+              { privilege: 'api:privilege7', authorized: true },
+              { privilege: 'api:privilege8', authorized: true },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: [
+          'privilege1',
+          'privilege2',
+          'privilege3',
+          'privilege4',
+          'privilege5',
+          'privilege6',
+          'privilege7',
+          'privilege8',
+        ],
+        asserts: {
+          authzResult: {
+            privilege1: true,
+            privilege2: false,
+            privilege3: false,
+            privilege4: true,
+            privilege5: false,
+            privilege6: false,
+            privilege7: true,
+            privilege8: true,
+          },
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns forbidden if user doesn't have required privileges with complex config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                // (privilege1 OR privilege2) AND (privilege3 OR privilege4)
+                // AND ((privilege5 AND privilege6) OR (privilege7 AND privilege8))
+                allRequired: [
+                  { anyOf: ['privilege1', 'privilege2'] },
+                  { anyOf: ['privilege3', 'privilege4'] },
+                ],
+                anyRequired: [
+                  { allOf: ['privilege5', 'privilege6'] },
+                  { allOf: ['privilege7', 'privilege8'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: false },
+              { privilege: 'api:privilege4', authorized: true },
+              { privilege: 'api:privilege5', authorized: false },
+              { privilege: 'api:privilege6', authorized: false },
+              { privilege: 'api:privilege7', authorized: true },
+              { privilege: 'api:privilege8', authorized: false },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: [
+          'privilege1',
+          'privilege2',
+          'privilege3',
+          'privilege4',
+          'privilege5',
+          'privilege6',
+          'privilege7',
+          'privilege8',
+        ],
+        asserts: {
+          forbidden: true,
+        },
+      }
+    );
+
+    testSecurityConfig(
+      `protected route returns forbidden if user doesn't have required privileges requested with complex anyRequired config`,
+      {
+        security: {
+          authz: {
+            requiredPrivileges: [
+              {
+                anyRequired: [
+                  { allOf: ['privilege1', 'privilege2'] },
+                  { allOf: ['privilege3', 'privilege4'] },
+                ],
+              },
+            ],
+          },
+        },
+        kibanaPrivilegesResponse: {
+          privileges: {
+            kibana: [
+              { privilege: 'api:privilege1', authorized: true },
+              { privilege: 'api:privilege2', authorized: false },
+              { privilege: 'api:privilege3', authorized: false },
+              { privilege: 'api:privilege4', authorized: true },
+            ],
+          },
+        },
+        kibanaPrivilegesRequestActions: ['privilege1', 'privilege2', 'privilege3', 'privilege4'],
+        asserts: {
+          forbidden: true,
+        },
+      }
+    );
+
     testSecurityConfig(`route returns next if route has authz disabled`, {
       security: {
         authz: {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/product_features_service/product_features_service.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/product_features_service/product_features_service.ts
@@ -290,12 +290,24 @@ export class ProductFeaturesService {
         const disabled = authz.requiredPrivileges.some((privilegeEntry) => {
           if (typeof privilegeEntry === 'object') {
             if (privilegeEntry.allRequired) {
-              if (privilegeEntry.allRequired.some(isApiPrivilegeSecurityAndDisabled)) {
+              if (
+                privilegeEntry.allRequired.some((entry) =>
+                  typeof entry === 'string'
+                    ? isApiPrivilegeSecurityAndDisabled(entry)
+                    : entry.anyOf.every(isApiPrivilegeSecurityAndDisabled)
+                )
+              ) {
                 return true;
               }
             }
             if (privilegeEntry.anyRequired) {
-              if (privilegeEntry.anyRequired.every(isApiPrivilegeSecurityAndDisabled)) {
+              if (
+                privilegeEntry.anyRequired.every((entry) =>
+                  typeof entry === 'string'
+                    ? isApiPrivilegeSecurityAndDisabled(entry)
+                    : entry.allOf.some(isApiPrivilegeSecurityAndDisabled)
+                )
+              ) {
                 return true;
               }
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Authz] Added allOf and anyOf nested conditions (#215516)](https://github.com/elastic/kibana/pull/215516)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Shostak","email":"165678770+elena-shostak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-03T12:28:17Z","message":"[Authz] Added allOf and anyOf nested conditions (#215516)\n\n## Summary\n\nCurrently, our `requiredPrivileges` structure supports `allRequired` and\n`anyRequired` for defining authorization logic. However, there is [a\nneed to\nsupport](https://github.com/elastic/kibana/pull/205335#issuecomment-2569275302)\nmore complex scenarios as `(privilege1 AND privilege2) OR (privilege3\nAND privilege4)`\n\nTo achieve `anyRequired` has been extended to allow defining multiple\nAND conditions evaluated with OR logic:\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       anyRequired: [\n          { allOf: ['privilege1', 'privilege2'] }, \n          { allOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n`allRequired` now also supports scenarios `(privilege1 OR privilege2)\nAND (privilege3 OR privilege4)`\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       allRequired: [\n          { anyOf: ['privilege1', 'privilege2'] }, \n          { anyOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n> [!IMPORTANT]\n> We expect to have unique privileges in `anyOf` or `allOf` conditions,\nassuming that most complex conditions can be simplified by boolean\nalgebra laws (OR/AND distributive etc).\n\n\n### Checklist\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n__Closes: https://github.com/elastic/kibana/issues/210977__\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ed058086e27c2b6f5015647b446304608d6b14a9","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","enhancement","release_note:skip","Feature:Security/Authorization","backport:prev-minor","backport:version","v9.1.0","v8.19.0"],"title":"[Authz] Added allOf and anyOf nested conditions","number":215516,"url":"https://github.com/elastic/kibana/pull/215516","mergeCommit":{"message":"[Authz] Added allOf and anyOf nested conditions (#215516)\n\n## Summary\n\nCurrently, our `requiredPrivileges` structure supports `allRequired` and\n`anyRequired` for defining authorization logic. However, there is [a\nneed to\nsupport](https://github.com/elastic/kibana/pull/205335#issuecomment-2569275302)\nmore complex scenarios as `(privilege1 AND privilege2) OR (privilege3\nAND privilege4)`\n\nTo achieve `anyRequired` has been extended to allow defining multiple\nAND conditions evaluated with OR logic:\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       anyRequired: [\n          { allOf: ['privilege1', 'privilege2'] }, \n          { allOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n`allRequired` now also supports scenarios `(privilege1 OR privilege2)\nAND (privilege3 OR privilege4)`\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       allRequired: [\n          { anyOf: ['privilege1', 'privilege2'] }, \n          { anyOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n> [!IMPORTANT]\n> We expect to have unique privileges in `anyOf` or `allOf` conditions,\nassuming that most complex conditions can be simplified by boolean\nalgebra laws (OR/AND distributive etc).\n\n\n### Checklist\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n__Closes: https://github.com/elastic/kibana/issues/210977__\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ed058086e27c2b6f5015647b446304608d6b14a9"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215516","number":215516,"mergeCommit":{"message":"[Authz] Added allOf and anyOf nested conditions (#215516)\n\n## Summary\n\nCurrently, our `requiredPrivileges` structure supports `allRequired` and\n`anyRequired` for defining authorization logic. However, there is [a\nneed to\nsupport](https://github.com/elastic/kibana/pull/205335#issuecomment-2569275302)\nmore complex scenarios as `(privilege1 AND privilege2) OR (privilege3\nAND privilege4)`\n\nTo achieve `anyRequired` has been extended to allow defining multiple\nAND conditions evaluated with OR logic:\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       anyRequired: [\n          { allOf: ['privilege1', 'privilege2'] }, \n          { allOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n`allRequired` now also supports scenarios `(privilege1 OR privilege2)\nAND (privilege3 OR privilege4)`\n```ts\nsecurity: {\n  authz: {\n    requiredPrivileges: [{\n       allRequired: [\n          { anyOf: ['privilege1', 'privilege2'] }, \n          { anyOf: ['privilege3', 'privilege4'] }\n        ] \n      }\n    ]\n  }\n}\n```\n\n> [!IMPORTANT]\n> We expect to have unique privileges in `anyOf` or `allOf` conditions,\nassuming that most complex conditions can be simplified by boolean\nalgebra laws (OR/AND distributive etc).\n\n\n### Checklist\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n__Closes: https://github.com/elastic/kibana/issues/210977__\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"ed058086e27c2b6f5015647b446304608d6b14a9"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217050","number":217050,"state":"OPEN"}]}] BACKPORT-->