### PR TITLE
feat(authc): implement PoC for opt-in "minimal" authentication and session cache

### DIFF
--- a/src/core/packages/http/router-server-internal/src/security_route_config_validator.ts
+++ b/src/core/packages/http/router-server-internal/src/security_route_config_validator.ts
@@ -148,12 +148,25 @@ const authzSchema = schema.object({
 });
 
 const authcSchema = schema.object({
-  enabled: schema.oneOf([schema.literal(true), schema.literal('optional'), schema.literal(false)]),
+  enabled: schema.oneOf([
+    schema.literal(true),
+    schema.literal('optional'),
+    schema.literal('minimal'),
+    schema.literal(false),
+  ]),
   reason: schema.conditional(
     schema.siblingRef('enabled'),
     schema.literal(false),
     schema.string(),
     schema.never()
+  ),
+  sessionCache: schema.maybe(
+    schema.conditional(
+      schema.siblingRef('enabled'),
+      schema.literal(false),
+      schema.never(),
+      schema.duration()
+    )
   ),
 });
 

--- a/src/core/packages/http/server-internal/src/http_server.ts
+++ b/src/core/packages/http/server-internal/src/http_server.ts
@@ -379,11 +379,12 @@ export class HttpServer {
   }
 
   private getAuthOption(
-    authRequired: RouteConfigOptions<any>['authRequired'] = true
+    authRequired: RouteConfigOptions<any>['authRequired'] | 'minimal' = true
   ): undefined | false | { mode: 'required' | 'try' } {
     if (this.authRegistered === false) return undefined;
 
-    if (authRequired === true) {
+    // Minimal authentication still should go through the authentication handler.
+    if (authRequired === true || authRequired === 'minimal') {
       return { mode: 'required' };
     }
     if (authRequired === 'optional') {

--- a/src/core/packages/http/server/src/router/route.ts
+++ b/src/core/packages/http/server/src/router/route.ts
@@ -9,6 +9,7 @@
 
 import type { OpenAPIV3 } from 'openapi-types';
 import type { DeepPartial } from '@kbn/utility-types';
+import type { Duration } from 'moment';
 import type { RouteValidator } from './route_validator';
 
 /**
@@ -244,10 +245,12 @@ export interface AuthzDisabled {
 /**
  * Describes the authentication status when authentication is enabled.
  *
- * - `enabled`: A boolean or string indicating the authentication status. Can be `true` (authentication required) or `'optional'` (authentication is optional).
+ * - `enabled`: A boolean or string indicating the authentication status. Can be `true` (authentication required) or
+ *   `'optional'` (authentication is optional), or `'minimal'` (only existence of credentials is checked).
  */
 export interface AuthcEnabled {
-  enabled: true | 'optional';
+  enabled: true | 'optional' | 'minimal';
+  sessionCache?: Duration;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/authenticator.ts
@@ -738,6 +738,14 @@ export class Authenticator {
       );
     }
 
+    // Don't update session if request is "minimally" authenticated.
+    if (request.route.options.security?.authc?.enabled === 'minimal') {
+      this.logger.debug(
+        'Session should not be changed for requests that require minimal authentication, skipping session update.'
+      );
+      return null;
+    }
+
     if (!existingSessionValue && !authenticationResult.shouldUpdateState()) {
       return null;
     }

--- a/x-pack/platform/plugins/shared/security/server/authentication/providers/base.ts
+++ b/x-pack/platform/plugins/shared/security/server/authentication/providers/base.ts
@@ -122,7 +122,36 @@ export abstract class BaseAuthenticationProvider {
    * @param request Request instance.
    * @param [authHeaders] Optional `Headers` dictionary to send with the request.
    */
-  protected async getUser(request: KibanaRequest, authHeaders: Headers = {}) {
+  protected async getUser(
+    request: KibanaRequest,
+    authHeaders: Headers = {}
+  ): Promise<AuthenticatedUser> {
+    // For "minimal" authentication, we don't need to call the `_authenticate` endpoint and can just
+    // return a static user object. The caveat here is that we don't validate credentials, but it
+    // will be done by the Elasticsearch itself anyway.
+    if (request.route.options.security?.authc?.enabled === 'minimal') {
+      this.logger.debug(`Performing "minimal" authentication for request ${request.url.pathname}.`);
+
+      // TODO: If we keep some properties with stub values, we should wrap this object with `Proxy`
+      // to throw an error if someone tries to access such a property. Some of the properties we can
+      // derive from the session, but not all unless we decide to store more information in the session.
+      return deepFreeze({
+        enabled: true,
+        authentication_provider: { type: this.type, name: this.options.name },
+
+        // These properties can be retrieved from the session, but we don't have it here yet.
+        username: 'unknown',
+        elastic_cloud_user: this.options.isElasticCloudDeployment() && this.type === 'saml',
+
+        // These properties are required currently, but we're considering to remove them in the
+        // future to make the `AuthenticatedUser` interface.
+        authentication_realm: { type: this.type, name: this.options.name },
+        lookup_realm: { type: this.type, name: this.options.name },
+        authentication_type: 'unknown',
+        roles: [],
+      });
+    }
+
     return this.authenticationInfoToAuthenticatedUser(
       // @ts-expect-error Metadata is defined as Record<string, any>
       await this.options.client

--- a/x-pack/platform/plugins/shared/security/server/routes/authentication/common.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/authentication/common.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import moment from 'moment/moment';
+
 import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { parseNextURL } from '@kbn/std';
@@ -96,6 +98,38 @@ export function defineCommonRoutes({
     createLicensedRouteHandler(async (context, request, response) => {
       const { security: coreSecurity } = await context.core;
       return response.ok({ body: coreSecurity.authc.getCurrentUser()! });
+    })
+  );
+
+  router.get(
+    {
+      path: '/api/security/performant_me',
+      security: {
+        authz: {
+          enabled: false,
+          reason: `This route delegates authorization to Core's security service; there must be an authenticated user for this route to return information`,
+        },
+        authc: {
+          enabled: 'minimal',
+          sessionCache: moment.duration(5, 's'),
+        },
+      },
+      validate: false,
+      options: {
+        access: 'public',
+        excludeFromOAS: true,
+      },
+    },
+    createLicensedRouteHandler(async (context, request, response) => {
+      const { security: coreSecurity, elasticsearch } = await context.core;
+      return response.ok({
+        body: {
+          principal: coreSecurity.authc.getCurrentUser()!,
+          hasManage: await elasticsearch.client.asCurrentUser.security.hasPrivileges({
+            cluster: ['manage'],
+          }),
+        },
+      });
     })
   );
 

--- a/x-pack/platform/plugins/shared/security/server/session_management/session.ts
+++ b/x-pack/platform/plugins/shared/security/server/session_management/session.ts
@@ -142,8 +142,15 @@ export class Session {
    */
   private readonly randomBytes = promisify(randomBytes);
 
+  /**
+   * Sessions cache (DECRYPTED) for the requests that explicitly opt-in to use it.
+   * @private
+   */
+  private readonly sessionCache: Map<string, Readonly<SessionValue>>;
+
   constructor(private readonly options: Readonly<SessionOptions>) {
     this.crypto = nodeCrypto({ encryptionKey: this.options.config.encryptionKey });
+    this.sessionCache = new Map();
   }
 
   /**
@@ -178,6 +185,23 @@ export class Session {
       sessionLogger.debug('Session has expired and will be invalidated.');
       await this.invalidate(request, { match: 'current' });
       return { error: new SessionExpiredError(), value: null };
+    }
+
+    // We use cache for the requests that explicitly opt-in to use it.
+    const sessionCacheTimeout =
+      request.route.options.security?.authc?.enabled !== false
+        ? request.route.options.security?.authc?.sessionCache?.asMilliseconds()
+        : undefined;
+    if (sessionCacheTimeout) {
+      const cachedSessionValue = this.sessionCache.get(sessionCookieValue.sid);
+      if (cachedSessionValue) {
+        sessionLogger.debug(`The session value is retrieved from cache.`);
+        return { error: null, value: cachedSessionValue };
+      }
+
+      sessionLogger.debug(
+        `The session value is not found in cache, and will be fetched from Elasticsearch.`
+      );
     }
 
     const sessionIndexValue = await this.options.sessionIndex.get(sessionCookieValue.sid);
@@ -222,14 +246,30 @@ export class Session {
       return { error: new SessionConcurrencyLimitError(), value: null };
     }
 
-    return {
-      error: null,
-      value: {
-        ...Session.sessionIndexValueToSessionValue(sessionIndexValue, decryptedContent),
-        // Unlike session index, session cookie contains the most up-to-date idle timeout expiration.
-        idleTimeoutExpiration: sessionCookieValue.idleTimeoutExpiration,
-      },
+    const sessionValue = {
+      ...Session.sessionIndexValueToSessionValue(sessionIndexValue, decryptedContent),
+      // Unlike session index, session cookie contains the most up-to-date idle timeout expiration.
+      idleTimeoutExpiration: sessionCookieValue.idleTimeoutExpiration,
     };
+
+    if (sessionCacheTimeout) {
+      sessionLogger.debug(
+        `The session value is requested to be cached for ${sessionCacheTimeout} ms.`
+      );
+      this.sessionCache.set(sessionValue.sid, sessionValue);
+
+      // TODO: It should be a single periodic task that clears expired sessions from the cache.
+      // The session should be removed from the cache after the timeout, even if it's being actively
+      // used, to ensure we don't use a potentially stale session value for a long period of time.
+      setTimeout(() => {
+        sessionLogger.debug(
+          `The session value cache expired after ${sessionCacheTimeout} ms and will be removed.`
+        );
+        this.sessionCache.delete(sessionValue.sid);
+      }, sessionCacheTimeout);
+    }
+
+    return { error: null, value: sessionValue };
   }
 
   /**
@@ -463,9 +503,11 @@ export class Session {
       sessionLogger.debug('Invalidating current session.');
       await this.options.sessionCookie.clear(request);
       invalidateIndexValueFilter = { match: 'sid' as 'sid', sid: sessionCookieValue.sid };
+      this.sessionCache.delete(sessionCookieValue.sid);
     } else if (filter.match === 'all') {
       sessionLogger.debug('Invalidating all sessions.');
       invalidateIndexValueFilter = filter;
+      this.sessionCache.clear();
     } else {
       sessionLogger.debug(
         () =>
@@ -482,6 +524,8 @@ export class Session {
             },
           }
         : filter;
+      // TODO: We should keep more info in the cache to be able to handle custom invalidate
+      // session queries as well.
     }
 
     const invalidatedCount = await this.options.sessionIndex.invalidate(invalidateIndexValueFilter);


### PR DESCRIPTION
## Summary

In this PoC, I'm adding two more properties to the security request configuration:
```ts
router.get(
  {
    path: '/api/security/performant_me',
    security: {
      authc: {
        enabled: 'minimal', <-- Enable "minimal" authentication
        sessionCache: moment.duration(5, 's') <-- Enable session cache,
      },
      ...
    },
    ...
  },
  () => { ... }
);
```

The "minimal" authentication mode is almost the same as the default/required authentication mode, but Kibana doesn't make an `_authenticate` call to Elasticsearch to validate credentials and retrieve user information. Instead, user information is constructed from available session values, and credential validation is delegated to Elasticsearch. This mode should be carefully considered and only used for Kibana routes that are essentially shallow wrappers around Elasticsearch APIs - where user information isn't needed and avoiding the performance penalty of an unnecessary `_authenticate` call is beneficial.

Additionally, a route can opt into an in-memory session cache to avoid round-trips to Elasticsearch for retrieving and decrypting the session document on every request. The use case is similar to that of "minimal" authentication and can help further reduce unnecessary overhead, especially when many requests are made simultaneously. Ideally, the cache time shouldn't exceed a few seconds to prevent stale cache issues.

## How to test

This PoC defines a test `GET '/api/security/performant_me'` endpoint that you can navigate to directly in the browser, access with Kibana Dev Tools, or call using `curl`. The endpoint returns "static" user info and also makes a call to `_has_privileges` endpoint to demonstrate that authentication headers are properly set.

I suggest enabling security debug logs to see what's happening under the hood:

```yaml
logging:
  loggers:
    - name: plugins.security
      level: debug
```
---
```
[2025-04-03T18:18:27.631+02:00][DEBUG][plugins.security.session.QBSdEA2yc=] The session value is not found in cache, and will be fetched from Elasticsearch.
[2025-04-03T18:18:27.642+02:00][DEBUG][plugins.security.session.QBSdEA2yc=] The session value is requested to be cached for 5000 ms.                                                         [2025-04-03T18:18:27.642+02:00][DEBUG][plugins.security.basic.basic] Trying to authenticate user request to /api/security/performant_me.
[2025-04-03T18:18:27.642+02:00][DEBUG][plugins.security.basic.basic] Trying to authenticate via state.
[2025-04-03T18:18:27.642+02:00][DEBUG][plugins.security.basic.basic] Performing "minimal" authentication for request /api/security/performant_me.
[2025-04-03T18:18:27.643+02:00][DEBUG][plugins.security.basic.basic] Request has been authenticated via state.
[2025-04-03T18:18:27.643+02:00][DEBUG][plugins.security.authenticator] Session should not be changed for requests that require minimal authentication, skipping session update.
[2025-04-03T18:18:27.776+02:00][DEBUG][plugins.security.session.QBSdEA2yc=] The session value is retrieved from cache.
[2025-04-03T18:18:27.776+02:00][DEBUG][plugins.security.basic.basic] Trying to authenticate user request to /api/security/performant_me.
[2025-04-03T18:18:27.776+02:00][DEBUG][plugins.security.basic.basic] Trying to authenticate via state.
[2025-04-03T18:18:27.776+02:00][DEBUG][plugins.security.basic.basic] Performing "minimal" authentication for request /api/security/performant_me.
[2025-04-03T18:18:27.777+02:00][DEBUG][plugins.security.basic.basic] Request has been authenticated via state.
...
[2025-04-03T18:18:32.643+02:00][DEBUG][plugins.security.session.QBSdEA2yc=] The session value cache expired after 5000 ms and will be removed.
```


