### PR TITLE
[8.x] [Security solution] [Ai Assistant] Allow user to disabled content references by using the content_references_disabled query arg (#215818)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -37577,6 +37577,14 @@ paths:
     post:
       description: Create a model response for the given chat conversation.
       operationId: ChatComplete
+      parameters:
+        - description: If true, the response will not include content references.
+          in: query
+          name: content_references_disabled
+          required: false
+          schema:
+            default: false
+            type: boolean
       requestBody:
         content:
           application/json; Elastic-Api-Version=2023-10-31:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -19765,6 +19765,14 @@ paths:
     post:
       description: Create a model response for the given chat conversation.
       operationId: ChatComplete
+      parameters:
+        - description: If true, the response will not include content references.
+          in: query
+          name: content_references_disabled
+          required: false
+          schema:
+            default: false
+            type: boolean
       requestBody:
         content:
           application/json:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -158,6 +158,14 @@ paths:
     post:
       description: Create a model response for the given chat conversation.
       operationId: ChatComplete
+      parameters:
+        - description: If true, the response will not include content references.
+          in: query
+          name: content_references_disabled
+          required: false
+          schema:
+            default: false
+            type: boolean
       requestBody:
         content:
           application/json:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/ess/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -159,7 +159,7 @@ paths:
       description: Create a model response for the given chat conversation.
       operationId: ChatComplete
       parameters:
-        - description: If true, the response will not include content references.
+        - description: 'If true, the response will not include content references.'
           in: query
           name: content_references_disabled
           required: false

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -158,6 +158,14 @@ paths:
     post:
       description: Create a model response for the given chat conversation.
       operationId: ChatComplete
+      parameters:
+        - description: If true, the response will not include content references.
+          in: query
+          name: content_references_disabled
+          required: false
+          schema:
+            default: false
+            type: boolean
       requestBody:
         content:
           application/json:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/docs/openapi/serverless/elastic_assistant_api_2023_10_31.bundled.schema.yaml
@@ -159,7 +159,7 @@ paths:
       description: Create a model response for the given chat conversation.
       operationId: ChatComplete
       parameters:
-        - description: If true, the response will not include content references.
+        - description: 'If true, the response will not include content references.'
           in: query
           name: content_references_disabled
           required: false

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/content_references_store.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/content_references_store.test.ts
@@ -7,15 +7,11 @@
 
 import { newContentReferencesStore } from './content_references_store';
 import { securityAlertsPageReference } from '../references';
-import { ContentReferencesStore } from '../types';
 
 describe('newContentReferencesStore', () => {
-  let contentReferencesStore: ContentReferencesStore;
-  beforeEach(() => {
-    contentReferencesStore = newContentReferencesStore();
-  });
-
   it('adds multiple content reference', async () => {
+    const contentReferencesStore = newContentReferencesStore();
+
     const alertsPageReference1 = contentReferencesStore.add((p) =>
       securityAlertsPageReference(p.id)
     );
@@ -31,18 +27,35 @@ describe('newContentReferencesStore', () => {
     const keys = Object.keys(store);
 
     expect(keys.length).toEqual(3);
-    expect(store[alertsPageReference1.id]).toEqual(alertsPageReference1);
-    expect(store[alertsPageReference2.id]).toEqual(alertsPageReference2);
-    expect(store[alertsPageReference3.id]).toEqual(alertsPageReference3);
+    expect(store[alertsPageReference1!.id]).toEqual(alertsPageReference1);
+    expect(store[alertsPageReference2!.id]).toEqual(alertsPageReference2);
+    expect(store[alertsPageReference3!.id]).toEqual(alertsPageReference3);
+  });
+
+  it('disabled content reference store', async () => {
+    const contentReferencesStore = newContentReferencesStore({
+      disabled: true,
+    });
+    const alertsPageReference1 = contentReferencesStore.add((p) =>
+      securityAlertsPageReference(p.id)
+    );
+
+    const store = contentReferencesStore.getStore();
+
+    const keys = Object.keys(store);
+
+    expect(keys.length).toEqual(0);
+    expect(alertsPageReference1).toBeUndefined();
   });
 
   it('referenceIds are unique', async () => {
+    const contentReferencesStore = newContentReferencesStore();
     const numberOfReferencesToCreate = 50;
 
     const referenceIds = new Set(
       [...new Array(numberOfReferencesToCreate)]
         .map(() => contentReferencesStore.add((p) => securityAlertsPageReference(p.id)))
-        .map((alertsPageReference) => alertsPageReference.id)
+        .map((alertsPageReference) => alertsPageReference!.id)
     );
 
     const store = contentReferencesStore.getStore();

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/content_references_store.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/content_references_store.ts
@@ -11,13 +11,22 @@ import { ContentReferencesStore } from '../types';
 const CONTENT_REFERENCE_ID_ALPHABET =
   'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
+interface Options {
+  disabled?: boolean;
+}
+
 /**
  * Creates a new ContentReferencesStore used for storing references (also known as citations)
  */
-export const newContentReferencesStore: () => ContentReferencesStore = () => {
+export const newContentReferencesStore: (options?: Options) => ContentReferencesStore = (
+  options?: Options
+) => {
   const store = new Map<string, ContentReference>();
 
   const add: ContentReferencesStore['add'] = (creator) => {
+    if (options?.disabled) {
+      return undefined;
+    }
     const entry = creator({ id: generateUnsecureId() });
     store.set(entry.id, entry);
     return entry;

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/prune_content_references.test.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/content_references_store/prune_content_references.test.ts
@@ -32,7 +32,7 @@ describe('pruneContentReferences', () => {
 
     const prunedContentReferences = pruneContentReferences(content, contentReferencesStore);
 
-    const keys = Object.keys(prunedContentReferences!);
-    expect(keys.sort()).toEqual([alertsPageReference1.id, alertsPageReference2.id].sort());
+    const keys = Object.keys(prunedContentReferences);
+    expect(keys.sort()).toEqual([alertsPageReference1!.id, alertsPageReference2!.id].sort());
   });
 });

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/types.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/content_references/types.ts
@@ -19,7 +19,9 @@ export interface ContentReferencesStore {
    * @param generator.params.id An ID that is guaranteed to not exist in the store. Intended to be used as the Id of the ContentReference but not required.
    * @returns the new ContentReference
    */
-  add: <T extends ContentReference>(generator: (params: { id: ContentReferenceId }) => T) => T;
+  add: <T extends ContentReference>(
+    generator: (params: { id: ContentReferenceId }) => T
+  ) => T | undefined;
 
   /**
    * Used to read the content reference store.

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/actions_connector/post_actions_connector_execute_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/actions_connector/post_actions_connector_execute_route.gen.ts
@@ -15,9 +15,19 @@
  */
 
 import { z } from '@kbn/zod';
+import { BooleanFromString } from '@kbn/zod-helpers';
 
 import { NonEmptyString, ScreenContext } from '../common_attributes.gen';
 import { Replacements } from '../conversations/common_attributes.gen';
+
+export type ExecuteConnectorRequestQuery = z.infer<typeof ExecuteConnectorRequestQuery>;
+export const ExecuteConnectorRequestQuery = z.object({
+  /**
+   * If true, the response will not include content references.
+   */
+  content_references_disabled: BooleanFromString.optional().default(false),
+});
+export type ExecuteConnectorRequestQueryInput = z.input<typeof ExecuteConnectorRequestQuery>;
 
 export type ExecuteConnectorRequestParams = z.infer<typeof ExecuteConnectorRequestParams>;
 export const ExecuteConnectorRequestParams = z.object({

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/actions_connector/post_actions_connector_execute_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/actions_connector/post_actions_connector_execute_route.schema.yaml
@@ -19,6 +19,13 @@ paths:
           description: The connector's `id` value.
           schema:
             type: string
+        - name: content_references_disabled
+          in: query
+          required: false
+          description: If true, the response will not include content references.
+          schema:
+            type: boolean
+            default: false
       requestBody:
         required: true
         content:

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/chat/post_chat_complete_route.gen.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/chat/post_chat_complete_route.gen.ts
@@ -15,6 +15,7 @@
  */
 
 import { z } from '@kbn/zod';
+import { BooleanFromString } from '@kbn/zod-helpers';
 
 import { NonEmptyString } from '../common_attributes.gen';
 
@@ -65,6 +66,15 @@ export const ChatCompleteProps = z.object({
   persist: z.boolean(),
   messages: z.array(ChatMessage),
 });
+
+export type ChatCompleteRequestQuery = z.infer<typeof ChatCompleteRequestQuery>;
+export const ChatCompleteRequestQuery = z.object({
+  /**
+   * If true, the response will not include content references.
+   */
+  content_references_disabled: BooleanFromString.optional().default(false),
+});
+export type ChatCompleteRequestQueryInput = z.input<typeof ChatCompleteRequestQuery>;
 
 export type ChatCompleteRequestBody = z.infer<typeof ChatCompleteRequestBody>;
 export const ChatCompleteRequestBody = ChatCompleteProps;

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/chat/post_chat_complete_route.schema.yaml
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/impl/schemas/chat/post_chat_complete_route.schema.yaml
@@ -12,6 +12,14 @@ paths:
       summary: Create a model response
       tags:
         - Chat Complete API
+      parameters:
+        - name: content_references_disabled
+          in: query
+          required: false
+          description: If true, the response will not include content references.
+          schema:
+            type: boolean
+            default: false
       requestBody:
         required: true
         content:

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/chat/chat_complete_route.test.ts
@@ -137,6 +137,7 @@ const mockRequest = {
   events: {
     aborted$: NEVER,
   },
+  query: {},
 };
 
 const mockResponse = {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/helpers.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/helpers.ts
@@ -124,7 +124,7 @@ export function getAssistantToolParams({
   langSmithProject?: string;
   langSmithApiKey?: string;
   logger: Logger;
-  contentReferencesStore: ContentReferencesStore | undefined;
+  contentReferencesStore: ContentReferencesStore;
   latestReplacements: Replacements;
   onNewReplacements: (newReplacements: Replacements) => void;
   request: KibanaRequest<unknown, unknown, DefendInsightsPostRequestBody>;
@@ -136,7 +136,7 @@ export function getAssistantToolParams({
   langChainTimeout: number;
   llm: ActionsClientLlm;
   logger: Logger;
-  contentReferencesStore: ContentReferencesStore | undefined;
+  contentReferencesStore: ContentReferencesStore;
   replacements: Replacements;
   onNewReplacements: (newReplacements: Replacements) => void;
   request: KibanaRequest<unknown, unknown, DefendInsightsPostRequestBody>;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
@@ -16,6 +16,7 @@ import {
   DefendInsightsPostResponse,
   API_VERSIONS,
   Replacements,
+  newContentReferencesStore,
 } from '@kbn/elastic-assistant-common';
 import { transformError } from '@kbn/securitysolution-es-utils';
 import { IRouter, Logger } from '@kbn/core/server';
@@ -144,6 +145,8 @@ export const postDefendInsightsRoute = (router: IRouter<ElasticAssistantRequestH
             latestReplacements = { ...latestReplacements, ...newReplacements };
           };
 
+          const contentReferencesStore = newContentReferencesStore()
+
           const assistantToolParams = getAssistantToolParams({
             endpointIds,
             insightType,
@@ -152,7 +155,7 @@ export const postDefendInsightsRoute = (router: IRouter<ElasticAssistantRequestH
             apiConfig,
             esClient,
             latestReplacements,
-            contentReferencesStore: undefined,
+            contentReferencesStore,
             connectorTimeout: CONNECTOR_TIMEOUT,
             langChainTimeout: LANG_CHAIN_TIMEOUT,
             langSmithProject,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/defend_insights/post_defend_insights.ts
@@ -145,7 +145,7 @@ export const postDefendInsightsRoute = (router: IRouter<ElasticAssistantRequestH
             latestReplacements = { ...latestReplacements, ...newReplacements };
           };
 
-          const contentReferencesStore = newContentReferencesStore()
+          const contentReferencesStore = newContentReferencesStore();
 
           const assistantToolParams = getAssistantToolParams({
             endpointIds,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.test.ts
@@ -117,6 +117,7 @@ const mockRequest = {
   events: {
     aborted$: NEVER,
   },
+  query: {},
 };
 
 const mockResponse = {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
@@ -17,6 +17,7 @@ import {
   Message,
   Replacements,
   pruneContentReferences,
+  ExecuteConnectorRequestQuery,
 } from '@kbn/elastic-assistant-common';
 import { buildRouteValidationWithZod } from '@kbn/elastic-assistant-common/impl/schemas/common';
 import { INVOKE_ASSISTANT_ERROR_EVENT } from '../lib/telemetry/event_based_telemetry';
@@ -55,6 +56,7 @@ export const postActionsConnectorExecuteRoute = (
             params: schema.object({
               connectorId: schema.string(),
             }),
+            query: buildRouteValidationWithZod(ExecuteConnectorRequestQuery),
           },
         },
       },
@@ -114,7 +116,9 @@ export const postActionsConnectorExecuteRoute = (
             await assistantContext.getAIAssistantConversationsDataClient();
           const promptsDataClient = await assistantContext.getAIAssistantPromptsDataClient();
 
-          const contentReferencesStore = newContentReferencesStore();
+          const contentReferencesStore = newContentReferencesStore({
+            disabled: request.query.content_references_disabled,
+          });
 
           onLlmResponse = async (
             content: string,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/types.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/types.ts
@@ -239,8 +239,8 @@ export interface AssistantToolParams {
   inference?: InferenceServerStart;
   isEnabledKnowledgeBase: boolean;
   connectorId?: string;
+  contentReferencesStore: ContentReferencesStore;
   description?: string;
-  contentReferencesStore: ContentReferencesStore | undefined;
   esClient: ElasticsearchClient;
   kbDataClient?: AIAssistantKnowledgeBaseDataClient;
   langChainTimeout?: number;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.ts
@@ -39,7 +39,7 @@ export const ALERT_COUNTS_TOOL: AssistantTool = {
       async () => {
         const query = getAlertsCountQuery(alertsIndexPattern);
         const result = await esClient.search<SearchResponse>(query);
-        const alertsCountReference = contentReferencesStore?.add((p) =>
+        const alertsCountReference = contentReferencesStore.add((p) =>
           securityAlertsPageReference(p.id)
         );
 

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/knowledge_base/knowledge_base_retrieval_tool.ts
@@ -67,9 +67,9 @@ export const KNOWLEDGE_BASE_RETRIEVAL_TOOL: AssistantTool = {
   },
 };
 
-function enrichDocument(contentReferencesStore: ContentReferencesStore | undefined) {
+function enrichDocument(contentReferencesStore: ContentReferencesStore) {
   return (document: Document<Record<string, string>>) => {
-    if (document.id == null || contentReferencesStore == null) {
+    if (document.id == null) {
       return document;
     }
     const documentId = document.id;

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.ts
@@ -93,7 +93,7 @@ export const OPEN_AND_ACKNOWLEDGED_ALERTS_TOOL: AssistantTool = {
 
             const hitId = hit._id;
             const reference = hitId
-              ? contentReferencesStore?.add((p) => securityAlertReference(p.id, hitId))
+              ? contentReferencesStore.add((p) => securityAlertReference(p.id, hitId))
               : undefined;
             const citation = reference && `\nCitation,${contentReferenceBlock(reference)}`;
 

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/product_docs/product_documentation_tool.ts
@@ -94,11 +94,8 @@ type EnrichedDocument = RetrieveDocumentationResultDoc & {
   citation?: string;
 };
 
-const enrichDocument = (contentReferencesStore: ContentReferencesStore | undefined) => {
+const enrichDocument = (contentReferencesStore: ContentReferencesStore) => {
   return (document: RetrieveDocumentationResultDoc): EnrichedDocument => {
-    if (contentReferencesStore == null) {
-      return document;
-    }
     const reference = contentReferencesStore.add((p) =>
       productDocumentationReference(p.id, document.title, document.url)
     );

--- a/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/security_labs/security_labs_tool.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/assistant/tools/security_labs/security_labs_tool.ts
@@ -42,7 +42,7 @@ export const SECURITY_LABS_KNOWLEDGE_BASE_TOOL: AssistantTool = {
           query: input.question,
         });
 
-        const reference = contentReferencesStore?.add((p) =>
+        const reference = contentReferencesStore.add((p) =>
           knowledgeBaseReference(p.id, 'Elastic Security Labs content', 'securityLabsId')
         );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Security solution] [Ai Assistant] Allow user to disabled content references by using the content_references_disabled query arg (#215818)](https://github.com/elastic/kibana/pull/215818)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kenneth Kreindler","email":"42113355+KDKHD@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-03T15:10:22Z","message":"[Security solution] [Ai Assistant] Allow user to disabled content references by using the content_references_disabled query arg (#215818)\n\n## Summary\n\nSome users using the security AI assistant through the API may want to\ndisable content references (aka citations) programmatically. This PR\nallows users to disable content references using the\n`content_references_disabled` query arg in the following routes:\n- POST\n/internal/elastic_assistant/actions/connector/gpt4oAzure/_execute?content_references_disabled=true\n- POST\n/api/security_ai_assistant/chat/complete?content_references_disabled=true\n\n\n## How to test:\nBellow are 2 example curl requests (with\ncontent_references_disabled=true). When executed, you will notice that\nthe response stream does not contain the string `{reference(...)}`\nanywhere. If you remove the query arg, the reference will be visible.\n\n####\n/internal/elastic_assistant/actions/connector/gpt4oAzure/_execute?content_references_disabled=true\n```curl\ncurl --location 'http://localhost:5601/internal/elastic_assistant/actions/connector/gpt4oAzure/_execute?content_references_disabled=true' \\\n--header 'Accept: */*' \\\n--header 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \\\n--header 'Connection: keep-alive' \\\n--header 'Content-Type: application/json' \\\n--header 'Origin: http://localhost:5601' \\\n--header 'Referer: http://localhost:5601/app/security/dashboards?sourcerer=(default:(id:security-solution-default,selectedPatterns:!()))&timeline=(activeTab:query,graphEventId:%27%27,isOpen:!f)' \\\n--header 'Sec-Fetch-Dest: empty' \\\n--header 'Sec-Fetch-Mode: cors' \\\n--header 'Sec-Fetch-Site: same-origin' \\\n--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36' \\\n--header 'elastic-api-version: 1' \\\n--header 'kbn-build-number: 9007199254740991' \\\n--header 'kbn-version: 9.1.0' \\\n--header 'sec-ch-ua: \"Chromium\";v=\"134\", \"Not:A-Brand\";v=\"24\", \"Google Chrome\";v=\"134\"' \\\n--header 'sec-ch-ua-mobile: ?0' \\\n--header 'sec-ch-ua-platform: \"macOS\"' \\\n--header 'x-elastic-internal-origin: Kibana' \\\n--header 'x-kbn-context: %7B%22type%22%3A%22application%22%2C%22name%22%3A%22securitySolutionUI%22%2C%22url%22%3A%22%2Fapp%2Fsecurity%2Fdashboards%22%2C%22page%22%3A%22list%22%7D' \\\n--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \\\n--data '{\n    \"subAction\": \"invokeStream\",\n    \"actionTypeId\": \".gen-ai\",\n    \"replacements\": {},\n    \"message\": \"What is elastic security? Include citations\",\n    \"screenContext\": {\n        \"timeZone\": \"Asia/Calcutta\"\n    },\n    \"alertsIndexPattern\": \".alerts-security.alerts-default\",\n    \"size\": 100\n}'\n```\n\n####\n/api/security_ai_assistant/chat/complete?content_references_disabled=true\n\n```curl\ncurl --location 'http://localhost:5601/api/security_ai_assistant/chat/complete?content_references_disabled=true' \\\n--header 'Content-Type: application/json' \\\n--header 'Accept: application/octet-stream' \\\n--header 'kbn-xsrf: 123' \\\n--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \\\n--data '{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"what is semantic text in esql. Include references to the product documentation\"\n    }\n  ],\n  \"persist\": false,\n  \"connectorId\": \"gpt4oAzure\",\n  \"isStream\": false\n}'\n```\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4c3274d3a26348fd61a02e6f68351bfcf0420af6","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Security Generative AI","backport:version","v9.1.0","v8.19.0"],"title":"[Security solution] [Ai Assistant] Allow user to disabled content references by using the content_references_disabled query arg","number":215818,"url":"https://github.com/elastic/kibana/pull/215818","mergeCommit":{"message":"[Security solution] [Ai Assistant] Allow user to disabled content references by using the content_references_disabled query arg (#215818)\n\n## Summary\n\nSome users using the security AI assistant through the API may want to\ndisable content references (aka citations) programmatically. This PR\nallows users to disable content references using the\n`content_references_disabled` query arg in the following routes:\n- POST\n/internal/elastic_assistant/actions/connector/gpt4oAzure/_execute?content_references_disabled=true\n- POST\n/api/security_ai_assistant/chat/complete?content_references_disabled=true\n\n\n## How to test:\nBellow are 2 example curl requests (with\ncontent_references_disabled=true). When executed, you will notice that\nthe response stream does not contain the string `{reference(...)}`\nanywhere. If you remove the query arg, the reference will be visible.\n\n####\n/internal/elastic_assistant/actions/connector/gpt4oAzure/_execute?content_references_disabled=true\n```curl\ncurl --location 'http://localhost:5601/internal/elastic_assistant/actions/connector/gpt4oAzure/_execute?content_references_disabled=true' \\\n--header 'Accept: */*' \\\n--header 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \\\n--header 'Connection: keep-alive' \\\n--header 'Content-Type: application/json' \\\n--header 'Origin: http://localhost:5601' \\\n--header 'Referer: http://localhost:5601/app/security/dashboards?sourcerer=(default:(id:security-solution-default,selectedPatterns:!()))&timeline=(activeTab:query,graphEventId:%27%27,isOpen:!f)' \\\n--header 'Sec-Fetch-Dest: empty' \\\n--header 'Sec-Fetch-Mode: cors' \\\n--header 'Sec-Fetch-Site: same-origin' \\\n--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36' \\\n--header 'elastic-api-version: 1' \\\n--header 'kbn-build-number: 9007199254740991' \\\n--header 'kbn-version: 9.1.0' \\\n--header 'sec-ch-ua: \"Chromium\";v=\"134\", \"Not:A-Brand\";v=\"24\", \"Google Chrome\";v=\"134\"' \\\n--header 'sec-ch-ua-mobile: ?0' \\\n--header 'sec-ch-ua-platform: \"macOS\"' \\\n--header 'x-elastic-internal-origin: Kibana' \\\n--header 'x-kbn-context: %7B%22type%22%3A%22application%22%2C%22name%22%3A%22securitySolutionUI%22%2C%22url%22%3A%22%2Fapp%2Fsecurity%2Fdashboards%22%2C%22page%22%3A%22list%22%7D' \\\n--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \\\n--data '{\n    \"subAction\": \"invokeStream\",\n    \"actionTypeId\": \".gen-ai\",\n    \"replacements\": {},\n    \"message\": \"What is elastic security? Include citations\",\n    \"screenContext\": {\n        \"timeZone\": \"Asia/Calcutta\"\n    },\n    \"alertsIndexPattern\": \".alerts-security.alerts-default\",\n    \"size\": 100\n}'\n```\n\n####\n/api/security_ai_assistant/chat/complete?content_references_disabled=true\n\n```curl\ncurl --location 'http://localhost:5601/api/security_ai_assistant/chat/complete?content_references_disabled=true' \\\n--header 'Content-Type: application/json' \\\n--header 'Accept: application/octet-stream' \\\n--header 'kbn-xsrf: 123' \\\n--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \\\n--data '{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"what is semantic text in esql. Include references to the product documentation\"\n    }\n  ],\n  \"persist\": false,\n  \"connectorId\": \"gpt4oAzure\",\n  \"isStream\": false\n}'\n```\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4c3274d3a26348fd61a02e6f68351bfcf0420af6"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215818","number":215818,"mergeCommit":{"message":"[Security solution] [Ai Assistant] Allow user to disabled content references by using the content_references_disabled query arg (#215818)\n\n## Summary\n\nSome users using the security AI assistant through the API may want to\ndisable content references (aka citations) programmatically. This PR\nallows users to disable content references using the\n`content_references_disabled` query arg in the following routes:\n- POST\n/internal/elastic_assistant/actions/connector/gpt4oAzure/_execute?content_references_disabled=true\n- POST\n/api/security_ai_assistant/chat/complete?content_references_disabled=true\n\n\n## How to test:\nBellow are 2 example curl requests (with\ncontent_references_disabled=true). When executed, you will notice that\nthe response stream does not contain the string `{reference(...)}`\nanywhere. If you remove the query arg, the reference will be visible.\n\n####\n/internal/elastic_assistant/actions/connector/gpt4oAzure/_execute?content_references_disabled=true\n```curl\ncurl --location 'http://localhost:5601/internal/elastic_assistant/actions/connector/gpt4oAzure/_execute?content_references_disabled=true' \\\n--header 'Accept: */*' \\\n--header 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \\\n--header 'Connection: keep-alive' \\\n--header 'Content-Type: application/json' \\\n--header 'Origin: http://localhost:5601' \\\n--header 'Referer: http://localhost:5601/app/security/dashboards?sourcerer=(default:(id:security-solution-default,selectedPatterns:!()))&timeline=(activeTab:query,graphEventId:%27%27,isOpen:!f)' \\\n--header 'Sec-Fetch-Dest: empty' \\\n--header 'Sec-Fetch-Mode: cors' \\\n--header 'Sec-Fetch-Site: same-origin' \\\n--header 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36' \\\n--header 'elastic-api-version: 1' \\\n--header 'kbn-build-number: 9007199254740991' \\\n--header 'kbn-version: 9.1.0' \\\n--header 'sec-ch-ua: \"Chromium\";v=\"134\", \"Not:A-Brand\";v=\"24\", \"Google Chrome\";v=\"134\"' \\\n--header 'sec-ch-ua-mobile: ?0' \\\n--header 'sec-ch-ua-platform: \"macOS\"' \\\n--header 'x-elastic-internal-origin: Kibana' \\\n--header 'x-kbn-context: %7B%22type%22%3A%22application%22%2C%22name%22%3A%22securitySolutionUI%22%2C%22url%22%3A%22%2Fapp%2Fsecurity%2Fdashboards%22%2C%22page%22%3A%22list%22%7D' \\\n--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \\\n--data '{\n    \"subAction\": \"invokeStream\",\n    \"actionTypeId\": \".gen-ai\",\n    \"replacements\": {},\n    \"message\": \"What is elastic security? Include citations\",\n    \"screenContext\": {\n        \"timeZone\": \"Asia/Calcutta\"\n    },\n    \"alertsIndexPattern\": \".alerts-security.alerts-default\",\n    \"size\": 100\n}'\n```\n\n####\n/api/security_ai_assistant/chat/complete?content_references_disabled=true\n\n```curl\ncurl --location 'http://localhost:5601/api/security_ai_assistant/chat/complete?content_references_disabled=true' \\\n--header 'Content-Type: application/json' \\\n--header 'Accept: application/octet-stream' \\\n--header 'kbn-xsrf: 123' \\\n--header 'Authorization: Basic ZWxhc3RpYzpjaGFuZ2VtZQ==' \\\n--data '{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"what is semantic text in esql. Include references to the product documentation\"\n    }\n  ],\n  \"persist\": false,\n  \"connectorId\": \"gpt4oAzure\",\n  \"isStream\": false\n}'\n```\n\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"4c3274d3a26348fd61a02e6f68351bfcf0420af6"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->