### PR TITLE
[8.18] [Performance] Refactor TTFMP query `from`, `to` fields (#213911)

### DIFF
--- a/dev_docs/tutorials/performance/adding_custom_performance_metrics.mdx
+++ b/dev_docs/tutorials/performance/adding_custom_performance_metrics.mdx
@@ -330,8 +330,9 @@ This will be indexed as:
     "duration": 736,                                                    // Event duration as specified when reporting it
     "meta": {
       "target": '/home',
-      "query_range_secs": 900
-      "query_offset_secs": 0 // now
+      "query_range_secs": 900, // 15 minutes
+      "query_from_offset_secs": -900 // From 15 minutes ago
+      "query_to_offset_secs": 0 // To now
     },
     "context": {                                                        // Context holds information identifying the deployment, version, application and page that generated the event
       "version": "8.16.0-SNAPSHOT",

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/measure_interaction/index.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/measure_interaction/index.ts
@@ -12,28 +12,32 @@ import {
   getOffsetFromNowInSeconds,
   getTimeDifferenceInSeconds,
 } from '@kbn/timerange';
-import { perfomanceMarkers } from '../../performance_markers';
 import { EventData } from '../performance_context';
+import { perfomanceMarkers } from '../../performance_markers';
+import { DescriptionWithPrefix } from '../types';
 
 interface PerformanceMeta {
-  queryRangeSecs: number;
-  queryOffsetSecs: number;
+  queryRangeSecs?: number;
+  queryFromOffsetSecs?: number;
+  queryToOffsetSecs?: number;
+  isInitialLoad?: boolean;
+  description?: DescriptionWithPrefix;
 }
 
-export function measureInteraction() {
+export function measureInteraction(pathname: string) {
   performance.mark(perfomanceMarkers.startPageChange);
-  const trackedRoutes: string[] = [];
+
   return {
     /**
      * Marks the end of the page ready state and measures the performance between the start of the page change and the end of the page ready state.
      * @param pathname - The pathname of the page.
      * @param customMetrics - Custom metrics to be included in the performance measure.
      */
-    pageReady(pathname: string, eventData?: EventData) {
-      let performanceMeta: PerformanceMeta | undefined;
+    pageReady(eventData?: EventData) {
+      const performanceMeta: PerformanceMeta = {};
       performance.mark(perfomanceMarkers.endPageReady);
 
-      if (eventData?.meta) {
+      if (eventData?.meta?.rangeFrom && eventData?.meta?.rangeTo) {
         const { rangeFrom, rangeTo } = eventData.meta;
 
         // Convert the date range  to epoch timestamps (in milliseconds)
@@ -42,26 +46,59 @@ export function measureInteraction() {
           to: rangeTo,
         });
 
-        performanceMeta = {
-          queryRangeSecs: getTimeDifferenceInSeconds(dateRangesInEpoch),
-          queryOffsetSecs:
-            rangeTo === 'now' ? 0 : getOffsetFromNowInSeconds(dateRangesInEpoch.endDate),
-        };
+        performanceMeta.queryRangeSecs = getTimeDifferenceInSeconds(dateRangesInEpoch);
+        performanceMeta.queryFromOffsetSecs =
+          rangeFrom === 'now' ? 0 : getOffsetFromNowInSeconds(dateRangesInEpoch.startDate);
+        performanceMeta.queryToOffsetSecs =
+          rangeTo === 'now' ? 0 : getOffsetFromNowInSeconds(dateRangesInEpoch.endDate);
       }
 
-      if (!trackedRoutes.includes(pathname)) {
-        performance.measure(pathname, {
+      if (eventData?.meta?.description) {
+        performanceMeta.description = eventData.meta.description;
+      }
+
+      if (
+        performance.getEntriesByName(perfomanceMarkers.startPageChange).length > 0 &&
+        performance.getEntriesByName(perfomanceMarkers.endPageReady).length > 0
+      ) {
+        performance.measure(`[ttfmp:initial] - ${pathname}`, {
           detail: {
             eventName: 'kibana:plugin_render_time',
             type: 'kibana:performance',
             customMetrics: eventData?.customMetrics,
-            meta: performanceMeta,
+            meta: { ...performanceMeta, isInitialLoad: true },
           },
           start: perfomanceMarkers.startPageChange,
           end: perfomanceMarkers.endPageReady,
         });
-        trackedRoutes.push(pathname);
+
+        // Clean up the marks once the measure is done
+        performance.clearMarks(perfomanceMarkers.startPageChange);
+        performance.clearMarks(perfomanceMarkers.endPageReady);
       }
+
+      if (
+        performance.getEntriesByName(perfomanceMarkers.startPageRefresh).length > 0 &&
+        performance.getEntriesByName(perfomanceMarkers.endPageReady).length > 0
+      ) {
+        performance.measure(`[ttfmp:refresh] - ${pathname}`, {
+          detail: {
+            eventName: 'kibana:plugin_render_time',
+            type: 'kibana:performance',
+            customMetrics: eventData?.customMetrics,
+            meta: { ...performanceMeta, isInitialLoad: false },
+          },
+          start: perfomanceMarkers.startPageRefresh,
+          end: perfomanceMarkers.endPageReady,
+        });
+
+        // // Clean up the marks once the measure is done
+        performance.clearMarks(perfomanceMarkers.startPageRefresh);
+        performance.clearMarks(perfomanceMarkers.endPageReady);
+      }
+    },
+    pageRefreshStart() {
+      performance.mark(perfomanceMarkers.startPageRefresh);
     },
   };
 }

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/performance_context.tsx
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/performance_context.tsx
@@ -13,13 +13,15 @@ import { useLocation } from 'react-router-dom';
 import { PerformanceApi, PerformanceContext } from './use_performance_context';
 import { PerformanceMetricEvent } from '../../performance_metric_events';
 import { measureInteraction } from './measure_interaction';
-
+import { DescriptionWithPrefix } from './types';
 export type CustomMetrics = Omit<PerformanceMetricEvent, 'eventName' | 'meta' | 'duration'>;
 
 export interface Meta {
-  rangeFrom: string;
-  rangeTo: string;
+  rangeFrom?: string;
+  rangeTo?: string;
+  description?: DescriptionWithPrefix;
 }
+
 export interface EventData {
   customMetrics?: CustomMetrics;
   meta?: Meta;
@@ -28,7 +30,8 @@ export interface EventData {
 export function PerformanceContextProvider({ children }: { children: React.ReactElement }) {
   const [isRendered, setIsRendered] = useState(false);
   const location = useLocation();
-  const interaction = measureInteraction();
+
+  const interaction = useMemo(() => measureInteraction(location.pathname), [location.pathname]);
 
   React.useEffect(() => {
     afterFrame(() => {
@@ -44,11 +47,14 @@ export function PerformanceContextProvider({ children }: { children: React.React
     () => ({
       onPageReady(eventData) {
         if (isRendered) {
-          interaction.pageReady(location.pathname, eventData);
+          interaction.pageReady(eventData);
         }
       },
+      onPageRefreshStart() {
+        interaction.pageRefreshStart();
+      },
     }),
-    [isRendered, location.pathname, interaction]
+    [isRendered, interaction]
   );
 
   return <PerformanceContext.Provider value={api}>{children}</PerformanceContext.Provider>;

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/types.ts
@@ -7,9 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-// Time To First Meaningful Paint (ttfmp)
-export const perfomanceMarkers = {
-  startPageChange: 'start::pageChange',
-  endPageReady: 'end::pageReady',
-  startPageRefresh: 'start::pageRefresh',
-};
+type ApmPageId = 'services' | 'traces' | 'dependencies';
+type InfraPageId = 'hosts';
+type OnboardingPageId = 'onboarding';
+
+export type Key = `${ApmPageId}` | `${InfraPageId}` | `${OnboardingPageId}`;
+
+export type DescriptionWithPrefix = `[ttfmp_${Key}] ${string}`;

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/use_performance_context.tsx
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_metrics/context/use_performance_context.tsx
@@ -15,6 +15,19 @@ export interface PerformanceApi {
    * @param eventData - Data to send with the performance measure, conforming the structure of a {@link EventData}.
    */
   onPageReady(eventData?: EventData): void;
+  /**
+   * Marks the start of a page refresh event for performance tracking.
+   * This method adds a performance marker start::pageRefresh to indicate when a page refresh begins.
+   *
+   * Usage:
+   * ```ts
+   * onPageRefreshStart();
+   * ```
+   *
+   * The marker set by this function can later be used in performance measurements
+   * along with an end marker end::pageReady to determine the total refresh duration.
+   */
+  onPageRefreshStart(): void;
 }
 
 export const PerformanceContext = createContext<PerformanceApi | undefined>(undefined);

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_overview/service_overview.test.tsx
@@ -11,6 +11,13 @@ import React from 'react';
 import * as stories from './service_overview.stories';
 import * as useAdHocApmDataView from '../../../hooks/use_adhoc_apm_data_view';
 
+// Mock the usePerformanceContext hook
+jest.mock('@kbn/ebt-tools', () => ({
+  usePerformanceContext: () => ({
+    onPageReady: jest.fn(),
+  }),
+}));
+
 const { Example } = composeStories(stories);
 
 describe('ServiceOverview', () => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/search_bar/search_bar.test.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/search_bar/search_bar.test.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import { getByTestId, fireEvent, getByText, act } from '@testing-library/react';
+import { getByTestId, fireEvent, getByText, act, waitFor } from '@testing-library/react';
 import type { MemoryHistory } from 'history';
+import { PerformanceContextProvider } from '@kbn/ebt-tools';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { createKibanaReactContext } from '@kbn/kibana-react-plugin/public';
@@ -79,7 +80,9 @@ function setup({
         <UrlParamsProvider>
           <ApmTimeRangeMetadataContextProvider>
             <ApmServiceContextProvider>
-              <SearchBar showTransactionTypeSelector />
+              <PerformanceContextProvider>
+                <SearchBar showTransactionTypeSelector />
+              </PerformanceContextProvider>
             </ApmServiceContextProvider>
           </ApmTimeRangeMetadataContextProvider>
         </UrlParamsProvider>
@@ -96,7 +99,7 @@ describe('when transactionType is selected and multiple transaction types are gi
     jest.spyOn(history, 'replace');
   });
 
-  it('renders a radio group with transaction types', () => {
+  it('renders a radio group with transaction types', async () => {
     const { container } = setup({
       history,
       serviceTransactionTypes: ['firstType', 'secondType'],
@@ -108,14 +111,16 @@ describe('when transactionType is selected and multiple transaction types are gi
     });
 
     // transaction type selector
-    const dropdown = getByTestId(container, 'headerFilterTransactionType');
+    await waitFor(() => {
+      const dropdown = getByTestId(container, 'headerFilterTransactionType');
 
-    // both options should be listed
-    expect(getByText(dropdown, 'firstType')).toBeInTheDocument();
-    expect(getByText(dropdown, 'secondType')).toBeInTheDocument();
+      // both options should be listed
+      expect(getByText(dropdown, 'firstType')).toBeInTheDocument();
+      expect(getByText(dropdown, 'secondType')).toBeInTheDocument();
 
-    // second option should be selected
-    expect(dropdown).toHaveValue('secondType');
+      // second option should be selected
+      expect(dropdown).toHaveValue('secondType');
+    });
   });
 
   it('should update the URL when a transaction type is selected', async () => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/unified_search_bar/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/unified_search_bar/index.tsx
@@ -13,6 +13,7 @@ import {
   toElasticsearchQuery,
 } from '@kbn/es-query';
 import { useHistory, useLocation } from 'react-router-dom';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import deepEqual from 'fast-deep-equal';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import qs from 'query-string';
@@ -141,6 +142,7 @@ export function UnifiedSearchBar({
 
   const { kuery, serviceName, environment, groupId, refreshPausedFromUrl, refreshIntervalFromUrl } =
     useSearchBarParams(value);
+  const { onPageRefreshStart } = usePerformanceContext();
   const timePickerTimeDefaults = core.uiSettings.get<TimePickerTimeDefaults>(
     UI_SETTINGS.TIMEPICKER_TIME_DEFAULTS
   );
@@ -204,6 +206,7 @@ export function UnifiedSearchBar({
   const onRefresh = () => {
     clearCache();
     incrementTimeRangeId();
+    onPageRefreshStart();
   };
 
   const onRefreshChange = ({ isPaused, refreshInterval }: Partial<OnRefreshChangeProps>) => {

--- a/x-pack/solutions/observability/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
@@ -216,6 +216,9 @@ export function MockApmPluginContextWrapper({
     createCallApmApi(contextValue.core);
   }
 
+  performance.mark = jest.fn();
+  performance.clearMeasures = jest.fn();
+
   const contextHistory = useHistory();
 
   const usedHistory = useMemo(() => {

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback } from 'react';
 import type { TimeRange } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { useEuiTheme, EuiHorizontalRule, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useKibanaContextForPlugin } from '../../../../../hooks/use_kibana';
@@ -24,6 +25,7 @@ export const UnifiedSearchBar = () => {
   const { metricsView } = useMetricsDataViewContext();
   const { searchCriteria, onLimitChange, onPanelFiltersChange, onSubmit } =
     useUnifiedSearchContext();
+  const { onPageRefreshStart } = usePerformanceContext();
 
   const { SearchBar } = unifiedSearch.ui;
 
@@ -32,9 +34,10 @@ export const UnifiedSearchBar = () => {
       // This makes sure `onSubmit` is only called when the submit button is clicked
       if (isUpdate === false) {
         onSubmit(payload);
+        onPageRefreshStart();
       }
     },
-    [onSubmit]
+    [onSubmit, onPageRefreshStart]
   );
 
   return (

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metric_explorer_state.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/metrics_explorer/hooks/use_metric_explorer_state.ts
@@ -7,6 +7,7 @@
 
 import DateMath from '@kbn/datemath';
 import { useCallback, useEffect } from 'react';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import type {
   MetricsExplorerChartOptions,
   MetricsExplorerOptions,
@@ -35,6 +36,7 @@ export const useMetricsExplorerState = ({ enabled }: { enabled: boolean } = { en
     timestamps,
     setTimestamps,
   } = useMetricsExplorerOptionsContainerContext();
+  const { onPageRefreshStart } = usePerformanceContext();
 
   const refreshTimestamps = useCallback(() => {
     const fromTimestamp = DateMath.parse(timeRange.from)!.valueOf();
@@ -45,7 +47,8 @@ export const useMetricsExplorerState = ({ enabled }: { enabled: boolean } = { en
       fromTimestamp,
       toTimestamp,
     });
-  }, [setTimestamps, timeRange]);
+    onPageRefreshStart();
+  }, [setTimestamps, timeRange, onPageRefreshStart]);
 
   const { data, error, fetchNextPage, isLoading } = useMetricsExplorerData({
     options,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Performance] Refactor TTFMP query `from`, `to` fields (#213911)](https://github.com/elastic/kibana/pull/213911)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Abdul Wahab Zahid","email":"awahab07@yahoo.com"},"sourceCommit":{"committedDate":"2025-03-20T10:40:24Z","message":"[Performance] Refactor TTFMP query `from`, `to` fields (#213911)\n\nCurrently Kibana forwards `query_range_secs` and `query_offset_secs` to\nmark the selected time range when reporting TTFMP event. This format\ncaused some challenges to identify `from`, `to` date offsets in\nvisualizations.\n\nTo simplify, the PR renames and sends the three fields explicitly:\n- `query_from_offset_secs` offset to `0` (now), with -ve for past and\n+ve for future dates\n- `query_to_offset_secs` offset to `0` (now), with -ve for past and +ve\nfor future dates\n- `query_range_secs`                      same as previously sent\n\n_This approach is followed after a discussion, and based on the\n[gist](https://gist.github.com/andrewvc/1f04a57a336d768e4ec5ff2eff06ba54)\nexcerpt:_\n\n```\nEarliest date -> QueryFrom\nNewest date -> QueryTo\nDuration -> QueryRange\n```\n\n### Indexing\nThese fields then should be mapped in the EBT indexer to ingest in the\ntop level of the document, eventually removing the need to create\nruntime fields in data views for visualizations.\n\nAlso, runtime fields in data views should be updated to reflect this\nchange. For backward compatibility, the runtime fields can cater both\nthe old and new field names conditionally.\n\n### Testing\n- Ensure that the TTFMP events are correctly reporting the date ranges.\n\n### Example\n\n![image](https://github.com/user-attachments/assets/529507fc-66f7-440a-8bbb-b34176e8d093)","sha":"e6e78ac6d83fe9c4a83785c717fb1b7f3fedbf0e","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.1.0","v8.19.0"],"title":"[Performance] Refactor TTFMP query `from`, `to` fields","number":213911,"url":"https://github.com/elastic/kibana/pull/213911","mergeCommit":{"message":"[Performance] Refactor TTFMP query `from`, `to` fields (#213911)\n\nCurrently Kibana forwards `query_range_secs` and `query_offset_secs` to\nmark the selected time range when reporting TTFMP event. This format\ncaused some challenges to identify `from`, `to` date offsets in\nvisualizations.\n\nTo simplify, the PR renames and sends the three fields explicitly:\n- `query_from_offset_secs` offset to `0` (now), with -ve for past and\n+ve for future dates\n- `query_to_offset_secs` offset to `0` (now), with -ve for past and +ve\nfor future dates\n- `query_range_secs`                      same as previously sent\n\n_This approach is followed after a discussion, and based on the\n[gist](https://gist.github.com/andrewvc/1f04a57a336d768e4ec5ff2eff06ba54)\nexcerpt:_\n\n```\nEarliest date -> QueryFrom\nNewest date -> QueryTo\nDuration -> QueryRange\n```\n\n### Indexing\nThese fields then should be mapped in the EBT indexer to ingest in the\ntop level of the document, eventually removing the need to create\nruntime fields in data views for visualizations.\n\nAlso, runtime fields in data views should be updated to reflect this\nchange. For backward compatibility, the runtime fields can cater both\nthe old and new field names conditionally.\n\n### Testing\n- Ensure that the TTFMP events are correctly reporting the date ranges.\n\n### Example\n\n![image](https://github.com/user-attachments/assets/529507fc-66f7-440a-8bbb-b34176e8d093)","sha":"e6e78ac6d83fe9c4a83785c717fb1b7f3fedbf0e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213911","number":213911,"mergeCommit":{"message":"[Performance] Refactor TTFMP query `from`, `to` fields (#213911)\n\nCurrently Kibana forwards `query_range_secs` and `query_offset_secs` to\nmark the selected time range when reporting TTFMP event. This format\ncaused some challenges to identify `from`, `to` date offsets in\nvisualizations.\n\nTo simplify, the PR renames and sends the three fields explicitly:\n- `query_from_offset_secs` offset to `0` (now), with -ve for past and\n+ve for future dates\n- `query_to_offset_secs` offset to `0` (now), with -ve for past and +ve\nfor future dates\n- `query_range_secs`                      same as previously sent\n\n_This approach is followed after a discussion, and based on the\n[gist](https://gist.github.com/andrewvc/1f04a57a336d768e4ec5ff2eff06ba54)\nexcerpt:_\n\n```\nEarliest date -> QueryFrom\nNewest date -> QueryTo\nDuration -> QueryRange\n```\n\n### Indexing\nThese fields then should be mapped in the EBT indexer to ingest in the\ntop level of the document, eventually removing the need to create\nruntime fields in data views for visualizations.\n\nAlso, runtime fields in data views should be updated to reflect this\nchange. For backward compatibility, the runtime fields can cater both\nthe old and new field names conditionally.\n\n### Testing\n- Ensure that the TTFMP events are correctly reporting the date ranges.\n\n### Example\n\n![image](https://github.com/user-attachments/assets/529507fc-66f7-440a-8bbb-b34176e8d093)","sha":"e6e78ac6d83fe9c4a83785c717fb1b7f3fedbf0e"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217090","number":217090,"state":"OPEN"},{"url":"https://github.com/elastic/kibana/pull/217089","number":217089,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->