### PR TITLE
[Security Solution] transfer ownership of the detections grouped alerts table from explore to investigations team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2377,7 +2377,6 @@ x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout  @elastic/
 /x-pack/solutions/security/plugins/security_solution/public/common/components/alert_count_by_status @elastic/security-threat-hunting-explore
 /x-pack/solutions/security/plugins/security_solution/public/common/components/guided_onboarding_tour @elastic/security-threat-hunting-explore
 /x-pack/solutions/security/plugins/security_solution/public/common/components/charts @elastic/security-threat-hunting-explore
-/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings @elastic/security-threat-hunting-explore
 /x-pack/solutions/security/plugins/security_solution/public/common/components/header_page @elastic/security-threat-hunting-explore
 /x-pack/solutions/security/plugins/security_solution/public/common/components/header_section @elastic/security-threat-hunting-explore
 /x-pack/solutions/security/plugins/security_solution/public/common/components/inspect @elastic/security-threat-hunting-explore


### PR DESCRIPTION
## Summary

Small PR to transfer ownership of the `GroupedAlertsTable` code within the `detections/components/alerts_table` from the @elastic/security-threat-hunting-explore team to the @elastic/security-threat-hunting-investigations team.

While the code was originally primarily written a developer on the Explore team, that person has moved to a different team since then. The Investigations team has more knowledge about how the grouped table works, and is also primary user for it.