### PR TITLE
[Fleet] add overlay to add/edit integration page

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/single_page_layout/index.tsx
@@ -20,6 +20,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLink,
+  EuiOverlayMask,
   EuiSpacer,
   EuiSteps,
 } from '@elastic/eui';
@@ -619,6 +620,11 @@ export const CreatePackagePolicySinglePage: CreatePackagePolicyParams = ({
               </>
             )}
             <StepsWithLessPadding steps={steps} />
+            {formState === 'LOADING' ? (
+              <EuiOverlayMask headerZindexLocation="below">
+                <Loading />
+              </EuiOverlayMask>
+            ) : null}
             <EuiSpacer size="xl" />
             <EuiSpacer size="xl" />
             <CustomEuiBottomBar data-test-subj="integrationsBottomBar">

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/edit_package_policy_page/index.tsx
@@ -16,6 +16,7 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiErrorBoundary,
+  EuiOverlayMask,
 } from '@elastic/eui';
 
 import { useSetIsReadOnly } from '../../../../integrations/hooks/use_read_only_context';
@@ -571,6 +572,11 @@ export const EditPackagePolicyForm = memo<{
             ) : (
               replaceConfigurePackage || configurePackage
             )}
+            {formState === 'LOADING' ? (
+              <EuiOverlayMask headerZindexLocation="below">
+                <Loading />
+              </EuiOverlayMask>
+            ) : null}
             {/* Extra space to accomodate the EuiBottomBar height */}
             <EuiSpacer size="xxl" />
             <EuiSpacer size="xxl" />


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/214266

Prevent edits when Add integration / Edit integration form is being submitted by adding an overlay.


https://github.com/user-attachments/assets/2bf20e1f-2990-445a-ae76-1cfa75e7c1e1


https://github.com/user-attachments/assets/1f03021f-e990-4b5d-a6e7-3ffabccb9618


https://github.com/user-attachments/assets/6a84e80a-d3a5-49c9-a808-cc5ff8e9248d



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->