### PR TITLE
🌊 Streams: Fix dashboards error toast on first visit of classic streams

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -619,6 +619,7 @@ export class StreamsClient {
     if (!isElasticsearch404(dataStream) && isElasticsearch404(streamDefinition)) {
       // stream definition does not exist, but data stream does - create an empty stream definition
       await this.updateStoredStream(this.getDataStreamAsIngestStream(dataStream));
+      return;
     }
     // if both do not exist, the stream does not exist, so this should be a 404
     throw streamDefinition;

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/assets/dashboard.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/assets/dashboard.ts
@@ -244,6 +244,27 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       });
     });
 
+    describe('on class stream that has not been touched yet', () => {
+      before(async () => {
+        await esClient.indices.createDataStream({
+          name: 'logs-testlogs-default',
+        });
+      });
+      after(async () => {
+        await esClient.indices.deleteDataStream({
+          name: 'logs-testlogs-default',
+        });
+      });
+      it('does not list any dashboards but returns 200', async () => {
+        const response = await apiClient.fetch('GET /api/streams/{name}/dashboards 2023-10-31', {
+          params: { path: { name: 'logs-testlogs-default' } },
+        });
+
+        expect(response.status).to.eql(200);
+        expect(response.body.dashboards.length).to.eql(0);
+      });
+    });
+
     describe('suggestions', () => {
       before(async () => {
         await loadDashboards();


### PR DESCRIPTION
When navigating to the details page of a classic stream for the first time, it would show an error toast from the `/dashboards` endpoint. This happened because there was a bug in `ensureStream` - it would throw if the data stream has been found but there wouldn't be a streams definition.

This PR fixes the bug and adds an integration test for it.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->