### PR TITLE
[9.0] [Solution Side Nav] Misc UI fixes (#216109)

### DIFF
--- a/src/platform/packages/shared/shared-ux/chrome/navigation/__jest__/panel.test.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/__jest__/panel.test.tsx
@@ -500,5 +500,120 @@ describe('Panel', () => {
       expect(queryByTestId(/panelNavItem-id-item1/)).toBeVisible();
       expect(queryByTestId(/panelNavItem-id-item3/)).toBeVisible();
     });
+
+    test('allows panel to contain a mix of ungrouped items and grouped items', () => {
+      const navTree: NavigationTreeDefinitionUI = {
+        id: 'es',
+        body: [
+          {
+            id: 'root',
+            title: 'Root',
+            path: 'root',
+            isCollapsible: false,
+            children: [
+              {
+                id: 'group1',
+                title: 'Group 1',
+                path: 'root.group1',
+                href: '/app/item1',
+                renderAs: 'panelOpener',
+                children: [
+                  {
+                    id: 'item0',
+                    title: 'Item 0',
+                    href: '/app/item0',
+                    path: 'root.group1.foo.item0',
+                  },
+                  {
+                    id: 'foo',
+                    title: 'Group 1',
+                    path: 'root.group1.foo',
+                    children: [
+                      {
+                        id: 'item1',
+                        href: '/app/item1',
+                        path: 'root.group1.foo.item1',
+                        title: 'Item 1',
+                      },
+                      {
+                        id: 'item2',
+                        href: '/app/item2',
+                        path: 'root.group1.foo.item2',
+                        title: 'Item 2',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const { queryByTestId } = renderNavigation({
+        navTreeDef: of(navTree),
+      });
+
+      queryByTestId(/panelOpener-root.group1/)?.click(); // open the panel
+
+      expect(queryByTestId(/panelGroupId-foo/)).toBeVisible(); // no crash
+    });
+
+    test('allows panel items to use custom rendering', () => {
+      const componentSpy = jest.fn();
+
+      const Custom: React.FC = () => {
+        componentSpy();
+        return <>Hello</>;
+      };
+
+      const navTree: NavigationTreeDefinitionUI = {
+        id: 'es',
+        body: [
+          {
+            id: 'root',
+            title: 'Root',
+            path: 'root',
+            isCollapsible: false,
+            children: [
+              {
+                id: 'group1',
+                title: 'Group 1',
+                path: 'root.group1',
+                href: '/app/item1',
+                renderAs: 'panelOpener',
+                children: [
+                  {
+                    id: 'foo',
+                    title: 'Group 1',
+                    path: 'root.group1.foo',
+                    children: [
+                      {
+                        id: 'item1',
+                        title: 'Item 1',
+                        path: 'root.group1.foo.item1',
+                        renderItem: () => {
+                          return <Custom />;
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const { queryByTestId } = renderNavigation({
+        navTreeDef: of(navTree),
+      });
+
+      expect(componentSpy).not.toHaveBeenCalled();
+
+      queryByTestId(/panelOpener-root.group1/)?.click(); // open the panel
+
+      expect(componentSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/navigation_item_open_panel.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/navigation_item_open_panel.tsx
@@ -81,7 +81,7 @@ export const NavigationItemOpenPanel: FC<Props> = ({ item, navigateToUrl, active
   const isIconVisible = isNotMobile && !isSideNavCollapsed && !!children && children.length > 0;
   const hasLandingPage = Boolean(href);
   const isExpanded = selectedNode?.path === path;
-  const isActive = hasLandingPage ? isActiveFromUrl(item.path, activeNodes) : isExpanded;
+  const isActive = isActiveFromUrl(item.path, activeNodes) || isExpanded;
 
   const itemClassNames = classNames(
     'sideNavItem',

--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/panel/default_content.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/panel/default_content.tsx
@@ -14,10 +14,6 @@ import React, { Fragment, type FC } from 'react';
 import { PanelGroup } from './panel_group';
 import { PanelNavItem } from './panel_nav_item';
 
-function isGroupNode({ children }: Pick<ChromeProjectNavigationNode, 'children'>) {
-  return children !== undefined;
-}
-
 function isItemNode({ children }: Pick<ChromeProjectNavigationNode, 'children'>) {
   return children === undefined;
 }
@@ -35,12 +31,12 @@ function isItemNode({ children }: Pick<ChromeProjectNavigationNode, 'children'>)
 function serializeChildren(node: PanelSelectedNode): ChromeProjectNavigationNode[] | undefined {
   if (!node.children) return undefined;
 
-  const allChildrenAreItems = node.children.every((_node) => {
+  const someChildrenAreItems = node.children.some((_node) => {
     if (isItemNode(_node)) return true;
     return _node.renderAs === 'item';
   });
 
-  if (allChildrenAreItems) {
+  if (someChildrenAreItems) {
     // Automatically wrap all the children into top level "root" group.
     return [
       {
@@ -50,17 +46,6 @@ function serializeChildren(node: PanelSelectedNode): ChromeProjectNavigationNode
         children: [...node.children],
       },
     ];
-  }
-
-  const allChildrenAreGroups = node.children.every((_node) => {
-    if (_node.renderAs === 'item') return false;
-    return isGroupNode(_node);
-  });
-
-  if (!allChildrenAreGroups) {
-    throw new Error(
-      `[Chrome navigation] Error in node [${node.id}]. Children must either all be "groups" or all "items" but not a mix of both.`
-    );
   }
 
   return node.children;

--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/panel/panel_group.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/panel/panel_group.tsx
@@ -113,6 +113,7 @@ export const PanelGroup: FC<Props> = ({ navNode, isFirstInList, hasHorizontalRul
           className={classNames.accordion}
           buttonClassName={accordionButtonClassName}
           data-test-subj={groupTestSubj}
+          initialIsOpen={navNode.defaultIsCollapsed === false}
           buttonProps={{
             'data-test-subj': `panelAccordionBtnId-${navNode.id}`,
           }}

--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/panel/panel_nav_item.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/components/panel/panel_nav_item.tsx
@@ -25,7 +25,7 @@ interface Props {
 export const PanelNavItem: FC<Props> = ({ item, parentIsAccordion }) => {
   const { navigateToUrl } = useServices();
   const { close: closePanel } = usePanel();
-  const { id, icon, deepLink, openInNewTab } = item;
+  const { id, icon, deepLink, openInNewTab, renderItem } = item;
   const href = deepLink?.url ?? item.href;
   const { euiTheme } = useEuiTheme();
 
@@ -40,7 +40,9 @@ export const PanelNavItem: FC<Props> = ({ item, parentIsAccordion }) => {
     [closePanel, href, navigateToUrl]
   );
 
-  return (
+  return renderItem ? (
+    renderItem()
+  ) : (
     <EuiListGroupItem
       key={id}
       label={parentIsAccordion ? <SubItemTitle item={item} /> : item.title}

--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/navigation.stories.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/navigation.stories.tsx
@@ -7,27 +7,31 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta } from '@storybook/react';
 import React, { EventHandler, FC, MouseEvent, useState, useEffect } from 'react';
 import { of } from 'rxjs';
 
 import {
   EuiButton,
+  EuiCallOut,
   EuiCollapsibleNavBeta,
   EuiCollapsibleNavBetaProps,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiHeader,
   EuiHeaderSection,
   EuiPageTemplate,
-  EuiText,
+  EuiSpacer,
 } from '@elastic/eui';
 
-import type { NavigationTreeDefinitionUI } from '@kbn/core-chrome-browser';
+import type {
+  ChromeProjectNavigationNode,
+  NavigationTreeDefinitionUI,
+} from '@kbn/core-chrome-browser';
 import { NavigationStorybookMock } from '../../mocks';
-import mdx from '../../README.mdx';
 import type { NavigationServices } from '../types';
 import { NavigationProvider } from '../services';
 import { Navigation } from './navigation';
-import { ContentProvider } from './components/panel';
 
 const storybookMock = new NavigationStorybookMock();
 
@@ -90,1086 +94,482 @@ const NavigationWrapper: FC<Props & Omit<Partial<EuiCollapsibleNavBetaProps>, 'c
   );
 };
 
-const groupExamplesNavigationTree: NavigationTreeDefinitionUI = {
+const generalLayoutNavTree: NavigationTreeDefinitionUI = {
   id: 'es',
   body: [
     // My custom project
     {
-      id: 'example_projet',
-      title: 'Example project',
-      icon: 'logoObservability',
-      defaultIsCollapsed: false,
-      path: 'example_projet',
+      id: 'example_project',
+      path: '',
+      title: 'Solution name',
+      isCollapsible: false,
+      icon: 'logoElastic',
       children: [
         {
-          id: 'blockGroup',
-          path: 'example_projet.blockGroup',
-          title: 'Block group',
-          children: [
-            {
-              id: 'item1',
-              title: 'Item 1',
-              href: '/app/kibana',
-              path: 'group1.item1',
-            },
-            {
-              id: 'item2',
-              title: 'Item 2',
-              href: '/app/kibana',
-              path: 'group1.item2',
-            },
-            {
-              id: 'item3',
-
-              title: 'Item 3',
-              href: '/app/kibana',
-              path: 'group1.item3',
-            },
-          ],
-        },
-        {
-          id: 'accordionGroup',
-          path: 'example_projet.accordionGroup',
-          title: 'Accordion group',
-          renderAs: 'accordion',
-          children: [
-            {
-              id: 'item1',
-              title: 'Item 1',
-              href: '/app/kibana',
-              path: 'group1.item1',
-            },
-            {
-              id: 'item2',
-              title: 'Item 2',
-              href: '/app/kibana',
-              path: 'group1.item1',
-            },
-            {
-              id: 'item3',
-              title: 'Item 3',
-              href: '/app/kibana',
-              path: 'group1.item1',
-            },
-          ],
-        },
-        {
-          id: 'groupWithouTitle',
-          path: 'example_projet.groupWithouTitle',
-          title: '',
-          children: [
-            {
-              id: 'item1',
-              title: 'Block group',
-              href: '/app/kibana',
-              path: 'group1.item1',
-            },
-            {
-              id: 'item2',
-              title: 'without',
-              href: '/app/kibana',
-              path: 'group1.item1',
-            },
-            {
-              id: 'item3',
-              title: 'title',
-              href: '/app/kibana',
-              path: 'group1.item1',
-            },
-          ],
-        },
-        {
-          id: 'panelGroup',
+          id: 'item01',
+          path: '',
+          title: 'Item 01',
           href: '/app/kibana',
-          title: 'Panel group',
-          path: 'example_projet.panelGroup',
-          renderAs: 'panelOpener',
+          icon: 'iInCircle',
+        },
+        {
+          id: 'item02',
+          path: '',
+          title: 'Item 02',
+          href: '/app/kibana',
+          icon: 'iInCircle',
+        },
+        {
+          id: 'root-section1',
+          path: '',
+          title: 'Section one',
           children: [
             {
-              id: 'group1',
-              title: 'Group 1',
-              path: 'panelGroup.group1',
+              id: 'item03',
+              path: '',
+              title: 'Item 03',
+              icon: 'iInCircle',
+              renderAs: 'panelOpener',
               children: [
                 {
-                  id: 'logs',
-                  href: '/app/kibana',
-                  path: 'group1.item1',
-                  title: 'Logs',
+                  id: 'sub0',
+                  path: '',
+                  title: 'This text is not shown',
+                  renderItem: () => (
+                    <>
+                      <p>This panel contains a mix of ungrouped items and grouped items</p>
+                      <EuiSpacer />
+                    </>
+                  ),
                 },
                 {
-                  id: 'signals',
-                  title: 'Signals',
+                  id: 'sub1',
+                  path: '',
+                  title: 'Item 11',
                   href: '/app/kibana',
-                  path: 'group1.item1',
+                  icon: 'iInCircle',
                 },
                 {
-                  id: 'signals-2',
-                  title: 'Signals - should NOT appear',
+                  id: 'sub2',
+                  path: '',
+                  title: 'Item 12',
                   href: '/app/kibana',
-                  path: 'group1.item1',
-                  sideNavStatus: 'hidden', // Should not appear
+                  icon: 'iInCircle',
                 },
                 {
-                  id: 'tracing',
-                  title: 'Tracing',
+                  id: 'sub3',
+                  path: '',
+                  title: 'Item 13',
                   href: '/app/kibana',
-                  path: 'group1.item1',
-                },
-              ],
-            },
-            {
-              id: 'group2',
-              title: 'Group 2',
-              path: 'panelGroup.group2',
-              children: [
-                {
-                  id: 'item1',
-                  path: 'panelGroup.group2.item1',
-                  href: '/app/kibana',
-                  title: 'Some link title',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
-
-export const GroupsExamples = {
-  render: (args: NavigationServices) => {
-    const services = storybookMock.getServices({
-      ...args,
-      recentlyAccessed$: of([
-        { label: 'This is an example', link: '/app/example/39859', id: '39850' },
-        { label: 'Another example', link: '/app/example/5235', id: '5235' },
-      ]),
-    });
-
-    return (
-      <NavigationWrapper>
-        {({ isCollapsed }) => (
-          <NavigationProvider {...services} isSideNavCollapsed={isCollapsed}>
-            <Navigation navigationTree$={of(groupExamplesNavigationTree)} />
-          </NavigationProvider>
-        )}
-      </NavigationWrapper>
-    );
-  },
-};
-
-const navigationTree: NavigationTreeDefinitionUI = {
-  id: 'es',
-  body: [
-    // My custom project
-    {
-      type: 'recentlyAccessed',
-      defaultIsCollapsed: true,
-      // Override the default recently accessed items with our own
-      recentlyAccessed$: of([
-        {
-          label: 'My own recent item',
-          id: '1234',
-          link: '/app/example/39859',
-        },
-        {
-          label: 'I also own this',
-          id: '4567',
-          link: '/app/example/39859',
-        },
-      ]),
-    },
-    {
-      id: 'example_projet',
-      title: 'Example project',
-      icon: 'logoObservability',
-      defaultIsCollapsed: false,
-      path: 'example_projet',
-      children: [
-        {
-          id: 'item1',
-          href: '/app/kibana',
-          path: 'example_projet.item1',
-          title: 'Get started',
-        },
-        {
-          title: 'Group 1',
-          id: 'group1',
-          path: 'example_projet.group1',
-          children: [
-            {
-              id: 'item1',
-              title: 'Item 1',
-              href: '/app/kibana',
-              path: 'example_projet.group1.item1',
-            },
-            {
-              id: 'item2',
-              title: 'Item 2',
-              href: '/app/kibana',
-              path: 'example_projet.group1.item1',
-            },
-            {
-              id: 'item3',
-              title: 'Item 3',
-              href: '/app/kibana',
-              path: 'example_projet.group1.item1',
-            },
-          ],
-        },
-        {
-          id: 'item2',
-          title: 'Alerts',
-          href: '/app/kibana',
-          path: 'example_projet.item2',
-        },
-        {
-          id: 'item2-2',
-          title: 'Item should NOT appear!!',
-          sideNavStatus: 'hidden', // Should not appear
-          href: '/app/kibana',
-          path: 'example_projet.item2-2',
-        },
-        {
-          id: 'item3',
-          title: 'Some other node',
-          href: '/app/kibana',
-          path: 'example_projet.item3',
-        },
-        {
-          id: 'group:settingsAsNavItem',
-          title: 'Settings as nav Item',
-          href: '/app/kibana',
-          path: 'example_projet.group:settingsAsNavItem',
-          renderAs: 'item', // Render just like any other item, even if it has children
-          children: [
-            {
-              id: 'logs',
-              title: 'Logs',
-              href: '/app/kibana',
-              path: 'example_projet.group:settingsAsNavItem.logs',
-            },
-            {
-              id: 'signals',
-              title: 'Signals',
-              href: '/app/kibana',
-              path: 'example_projet.group:settingsAsNavItem.signals',
-            },
-            {
-              id: 'signalsHidden',
-              title: 'Signals - should NOT appear',
-              sideNavStatus: 'hidden', // Should not appear
-              href: '/app/kibana',
-              path: 'example_projet.group:settingsAsNavItem.signalsHidden',
-            },
-            {
-              id: 'tracing',
-              title: 'Tracing',
-              href: '/app/kibana',
-              path: 'example_projet.group:settingsAsNavItem.tracing',
-            },
-          ],
-        },
-        {
-          id: 'group:settingsAsPanelOpener',
-          title: 'Settings panel opener',
-          path: 'example_projet.group:settingsAsPanelOpener',
-          renderAs: 'panelOpener',
-          children: [
-            {
-              id: 'group1',
-              title: 'Group 1',
-              path: 'example_projet.group:settingsAsPanelOpener.group1',
-              children: [
-                {
-                  id: 'logs',
-                  title: 'Logs',
-                  href: '/app/kibana',
-                  path: 'example_projet.group:settingsAsPanelOpener.group1.logs',
+                  icon: 'iInCircle',
                 },
                 {
-                  id: 'signals',
-                  title: 'Signals',
-                  href: '/app/kibana',
-                  path: 'example_projet.group:settingsAsPanelOpener.group1.signals',
-                },
-                {
-                  id: 'signals-2',
-                  title: 'Signals - should NOT appear',
-                  sideNavStatus: 'hidden', // Should not appear
-                  href: '/app/kibana',
-                  path: 'example_projet.group:settingsAsPanelOpener.group1.signals',
-                },
-                {
-                  id: 'tracing',
-                  title: 'Tracing',
-                  href: '/app/kibana',
-                  path: 'example_projet.group:settingsAsPanelOpener.group1.tracing',
-                },
-              ],
-            },
-            {
-              id: 'group2',
-              title: 'Group 2',
-              path: 'example_projet.group:settingsAsPanelOpener.group2',
-              children: [
-                {
-                  id: 'nestedGroup',
-                  title: 'Nested group',
-                  renderAs: 'item',
-                  path: 'example_projet.group:settingsAsPanelOpener.group2.nestedGroup',
-                  href: '/app/kibana',
+                  id: 'child-section1',
+                  path: '',
+                  title: 'Section one',
                   children: [
                     {
-                      id: 'item1',
-                      path: 'example_projet.group:settingsAsPanelOpener.group2.nestedGroup.item1',
-                      title: 'Hidden - should NOT appear',
+                      id: 'sub1',
+                      path: '',
+                      title: 'Item 14',
+                      href: '/app/kibana',
+                      icon: 'iInCircle',
+                      withBadge: true,
+                    },
+                    {
+                      id: 'sub2',
+                      path: '',
+                      title: 'Item 15',
+                      href: '/app/kibana',
+                      icon: 'iInCircle',
+                    },
+                    {
+                      id: 'sub3',
+                      path: '',
+                      title: 'Item 16',
+                      href: '/app/kibana',
+                      icon: 'iInCircle',
+                    },
+                  ],
+                },
+                {
+                  id: 'child-section2',
+                  path: '',
+                  title: 'Section two',
+                  children: [
+                    {
+                      id: 'sub1',
+                      path: '',
+                      title: 'Item 17',
+                      href: '/app/kibana',
+                      icon: 'iInCircle',
+                    },
+                    {
+                      id: 'sub2',
+                      path: '',
+                      title: 'Just if we want to bring back those icons at some point',
+                      href: '/app/kibana',
+                      icon: 'dashboardApp',
+                    },
+                    {
+                      id: 'sub3',
+                      path: '',
+                      title: 'Item 18',
+                      href: '/app/kibana',
+                      icon: 'iInCircle',
+                    },
+                  ],
+                },
+                {
+                  id: 'child-section3',
+                  path: '',
+                  title: 'Item 19',
+                  icon: 'iInCircle',
+                  renderAs: 'accordion',
+                  children: [
+                    {
+                      id: 'sub1',
+                      path: '',
+                      title: 'Item-Beta',
+                      href: '/app/kibana',
+                      withBadge: true,
+                    },
+                    {
+                      id: 'sub2',
+                      path: '',
+                      title: 'Item-Labs',
+                      href: '/app/kibana',
+                      withBadge: true,
+                      badgeOptions: {
+                        icon: 'bell',
+                        tooltip: 'This is a tooltip',
+                      },
+                    },
+                  ],
+                },
+                {
+                  id: 'child-section4',
+                  title: 'Parent item, opened',
+                  path: '',
+                  icon: 'iInCircle',
+                  renderAs: 'accordion',
+                  defaultIsCollapsed: false,
+                  children: [
+                    {
+                      id: 'sub1',
+                      path: '',
+                      title: 'Item 20',
+                      href: '/app/kibana',
+                    },
+                    {
+                      id: 'sub2',
+                      path: '',
+                      title: 'Item 21',
+                      href: '/app/kibana',
+                    },
+                    {
+                      id: 'sub3',
+                      path: '',
+                      title: 'Item 22',
+                      href: '/app/kibana',
                     },
                   ],
                 },
               ],
             },
             {
-              id: 'group3',
-              title: '',
-              path: 'example_projet.group:settingsAsPanelOpener.group3',
+              id: 'item04',
+              path: '',
+              title: 'Item 04',
+              href: '/app/kibana',
+              icon: 'iInCircle',
+            },
+            {
+              id: 'item05',
+              title: 'Item 05, with custom',
+              path: '',
+              icon: 'iInCircle',
+              renderAs: 'panelOpener',
               children: [
                 {
-                  id: 'nestedGroup',
-                  title: 'Just an item in a group',
-                  path: 'example_projet.group:settingsAsPanelOpener.group3.nestedGroup',
+                  id: 'sub1',
+                  path: '',
+                  title: 'Item 23',
                   href: '/app/kibana',
+                  icon: 'iInCircle',
+                },
+                {
+                  id: 'spacer1',
+                  path: '',
+                  title: 'This text is not shown.',
+                  renderItem: () => {
+                    return <EuiSpacer />;
+                  },
+                },
+                {
+                  id: 'callout1',
+                  path: '',
+                  title: 'This text is not shown.',
+                  renderItem: () => {
+                    return (
+                      <EuiCallOut title="Check it out" iconType="cluster">
+                        <EuiFlexGroup justifyContent="spaceAround" direction="column">
+                          <EuiFlexItem>
+                            <p>Choose an integration to start</p>
+                            <EuiButton>Browse integrations</EuiButton>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </EuiCallOut>
+                    );
+                  },
                 },
               ],
             },
           ],
         },
         {
-          id: 'group:settingsIsHidden',
-          title: 'Settings - should NOT appear', // sideNavStatus is 'hidden'
-          sideNavStatus: 'hidden',
-          path: 'example_projet.group:settingsIsHidden',
+          id: 'root-section2',
+          title: 'Section two',
+          path: '',
           children: [
             {
-              id: 'logs',
-              title: 'Logs',
+              id: 'item06',
+              icon: 'iInCircle',
+              title: 'Item 06',
+              path: '',
+              renderAs: 'panelOpener',
+              children: [
+                {
+                  id: 'sub1',
+                  path: '',
+                  title: 'Item 24',
+                  href: '/app/kibana',
+                  icon: 'iInCircle',
+                },
+              ],
+            },
+            {
+              id: 'item07',
+              path: '',
+              title: 'Item 07',
               href: '/app/kibana',
-              path: 'example_projet.group:settingsIsHidden.logs',
+              icon: 'iInCircle',
+            },
+            {
+              id: 'item08',
+              path: '',
+              title: 'Item 08',
+              href: '/app/kibana',
+              icon: 'iInCircle',
             },
           ],
         },
         {
-          id: 'group:settingsWithChildrenHidden',
-          title: 'Settings - should NOT appear', // All children are hidden
-          path: 'example_projet.group:settingsWithChildrenHidden',
-          children: [
-            {
-              id: 'logs',
-              title: 'Logs',
-              sideNavStatus: 'hidden',
-              href: '/app/kibana',
-              path: 'example_projet.group:settingsWithChildrenHidden.logs',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      id: 'linkAtRootLevel',
-      title: 'Custom link at root level',
-      href: '/app/kibana',
-      path: 'linkAtRootLevel',
-    },
-    {
-      id: 'groupRenderAsItem',
-      title: 'Test group render as Item',
-      renderAs: 'item',
-      href: '/app/kibana',
-      path: 'groupRenderAsItem',
-      children: [
-        {
-          id: 'item1',
-          title: 'Item 1',
+          id: 'root-section3',
+          title: 'Standalone item with long name',
+          path: '',
           href: '/app/kibana',
-          path: 'groupRenderAsItem.item1',
+          icon: 'iInCircle',
+        },
+        {
+          id: 'root-section4',
+          title: 'Standalone group item with long name',
+          path: '',
+          icon: 'iInCircle',
+          renderAs: 'panelOpener',
+          children: [
+            {
+              id: 'item25',
+              path: '',
+              title: 'Item 25',
+              href: '/app/kibana',
+              icon: 'iInCircle',
+            },
+            {
+              id: 'item26',
+              path: '',
+              title: 'Item 26',
+              href: '/app/kibana',
+              icon: 'iInCircle',
+            },
+            {
+              id: 'item27',
+              path: '',
+              title: 'Item 27',
+              href: '/app/kibana',
+              icon: 'iInCircle',
+            },
+          ],
+        },
+        {
+          id: 'item09',
+          title: 'Item 09',
+          path: '',
+          renderAs: 'accordion',
+          icon: 'iInCircle',
+          children: [
+            {
+              id: 'item-beta',
+              path: '',
+              title: 'Item-Beta',
+              href: '/app/kibana',
+              withBadge: true,
+            },
+            {
+              id: 'item-labs',
+              path: '',
+              title: 'Item-Labs',
+              href: '/app/kibana',
+              withBadge: true,
+            },
+            {
+              id: 'item27',
+              path: '',
+              title: 'Item 27 - name plus badge & icon',
+              renderAs: 'panelOpener',
+              children: [
+                {
+                  id: 'sub1',
+                  path: '',
+                  title: 'Item 28',
+                  href: '/app/kibana',
+                  icon: 'iInCircle',
+                },
+              ],
+            },
+          ],
         },
       ],
-    },
-    {
-      id: 'linkAtRootLevelWithIcon',
-      icon: 'logoElastic',
-      title: 'Link at root level + icon',
-      href: '/app/kibana',
-      path: 'linkAtRootLevelWithIcon',
     },
   ],
   footer: [
     {
-      type: 'recentlyAccessed',
-      defaultIsCollapsed: true,
-      // Override the default recently accessed items with our own
-      recentlyAccessed$: of([
-        {
-          label: 'My own recent item',
-          id: '1234',
-          link: '/app/example/39859',
-        },
-        {
-          label: 'I also own this',
-          id: '4567',
-          link: '/app/example/39859',
-        },
-      ]),
-    },
-  ],
-};
-
-export const ComplexObjectDefinition: StoryObj<NavigationServices> = {
-  render: (args) => {
-    const services = storybookMock.getServices({
-      ...args,
-      recentlyAccessed$: of([
-        { label: 'This is an example', link: '/app/example/39859', id: '39850' },
-        { label: 'Another example', link: '/app/example/5235', id: '5235' },
-      ]),
-    });
-
-    return (
-      <NavigationWrapper>
-        {({ isCollapsed }) => (
-          <NavigationProvider {...services} isSideNavCollapsed={isCollapsed}>
-            <Navigation navigationTree$={of(navigationTree)} />
-          </NavigationProvider>
-        )}
-      </NavigationWrapper>
-    );
-  },
-};
-
-const panelContentProvider: ContentProvider = (id: string) => {
-  if (id === 'example_projet.group:openpanel1') {
-    return; // Use default title & content
-  }
-
-  if (id === 'example_projet.group:openpanel2') {
-    // Custom content
-    return {
-      content: ({ closePanel }) => {
-        return (
-          <div>
-            <EuiText>This is a custom component to render in the panel.</EuiText>
-            <EuiButton onClick={() => closePanel()}>Close panel</EuiButton>
-          </div>
-        );
-      },
-    };
-  }
-
-  if (id === 'example_projet.group:openpanel3') {
-    return {
-      title: <div style={{ backgroundColor: 'yellow', fontWeight: 600 }}>Custom title</div>,
-    };
-  }
-};
-
-const navigationTreeWithPanels: NavigationTreeDefinitionUI = {
-  id: 'es',
-  body: [
-    // My custom project
-    {
-      id: 'example_projet',
-      title: 'Example project',
-      icon: 'logoObservability',
-      defaultIsCollapsed: false,
-      isCollapsible: false,
-      path: 'example_projet',
+      id: 'footer-section5',
+      title: 'Parent item, closed',
+      path: '',
+      renderAs: 'accordion',
+      icon: 'iInCircle',
       children: [
         {
-          id: 'item1',
+          id: 'item29',
+          path: '',
+          title: 'Item 29',
           href: '/app/kibana',
-          path: 'example_projet.item1',
-          title: 'Get started',
+          icon: 'iInCircle',
         },
         {
-          id: 'item2',
+          id: 'item30',
+          path: '',
+          title: 'Item 30',
           href: '/app/kibana',
-          path: 'example_projet.item2',
-          title: 'Alerts',
+          icon: 'iInCircle',
         },
         {
-          // Panel with default content
-          // Groups with title
-          id: 'group:openpanel1',
-          title: 'Open panel (1)',
-          renderAs: 'panelOpener',
+          id: 'item31',
+          path: '',
+          title: 'Item 31',
           href: '/app/kibana',
-          path: 'example_projet.group:openpanel1',
-          children: [
-            {
-              id: 'group1',
-              title: 'Group 1',
-              path: 'example_projet.group:openpanel1.group1',
-              children: [
-                {
-                  id: 'item1',
-                  href: '/app/kibana',
-                  path: 'example_projet.group:openpanel1.group1.item1',
-                  title: 'Logs',
-                  icon: 'logoObservability',
-                },
-                {
-                  id: 'item2',
-                  href: '/app/kibana',
-                  path: 'example_projet.group:openpanel1.group1.item2',
-                  title: 'Signals xxxxxx',
-                  openInNewTab: true,
-                },
-                {
-                  id: 'item3',
-                  href: '/app/kibana',
-                  path: 'example_projet.group:openpanel1.group1.item3',
-                  title: 'Tracing',
-                  withBadge: true, // Default to "Beta" badge
-                },
-              ],
-            },
-            {
-              id: 'group2',
-              path: 'example_projet.group:openpanel1.group2',
-              title: 'Group 2',
-              children: [
-                {
-                  id: 'group2:settings.logs',
-                  href: '/app/kibana',
-                  path: 'example_projet.group:openpanel1.group2.group2:settings.logs',
-                  title: 'Logs',
-                },
-                {
-                  id: 'group2:settings.signals',
-                  href: '/app/kibana',
-                  path: 'example_projet.group:openpanel1.group2.group2:settings.signals',
-                  title: 'Signals',
-                },
-                {
-                  id: 'group2:settings.tracing',
-                  href: '/app/kibana',
-                  path: 'example_projet.group:openpanel1.group2.group2:settings.tracing',
-                  title: 'Tracing',
-                },
-              ],
-            },
-          ],
+          icon: 'iInCircle',
         },
         {
-          // Panel with default content
-          // Groups with **not** title
-          id: 'group.openpanel2',
-          title: 'Open panel (2)',
-          renderAs: 'panelOpener',
-          path: 'example_projet.group.openpanel2',
+          id: 'sub-accordion',
+          icon: 'iInCircle',
+          title: 'Sub-Accordion',
+          path: '',
+          renderAs: 'accordion',
           children: [
             {
-              id: 'group1',
-              path: 'example_projet.group.openpanel2.group1',
-              title: '',
-              appendHorizontalRule: true, // Add a separator after the group
-              children: [
-                {
-                  id: 'logs',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel2.group1.logs',
-                  title: 'Logs',
-                },
-                {
-                  id: 'signals',
-                  title: 'Signals',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel2.group1.signals',
-                },
-                {
-                  id: 'tracing',
-                  title: 'Tracing',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel2.group1.tracing',
-                  withBadge: true, // Default to "Beta" badge
-                },
-              ],
-            },
-            {
-              id: 'group2',
-              path: 'example_projet.group.openpanel2.group2',
-              title: '',
-              children: [
-                {
-                  id: 'logs',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel2.group2.logs',
-                  title: 'Logs',
-                },
-                {
-                  id: 'signals',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel2.group2.signals',
-                  title: 'Signals',
-                },
-                {
-                  id: 'tracing',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel2.group2.tracing',
-                  title: 'Tracing',
-                },
-              ],
-            },
-          ],
-        },
-        {
-          // Panel with default content
-          // Accordion to wrap groups
-          id: 'group.openpanel3',
-          title: 'Open panel (3)',
-          renderAs: 'panelOpener',
-          path: 'example_projet.group.openpanel3',
-          children: [
-            {
-              id: 'group1',
-              title: '',
-              path: 'example_projet.group.openpanel3.group1',
-              appendHorizontalRule: true,
-              children: [
-                {
-                  id: 'logs',
-                  title: 'Logs',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel3.group1.logs',
-                },
-                {
-                  id: 'signals',
-                  title: 'Signals',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel3.group1.signals',
-                },
-                {
-                  id: 'tracing',
-                  title: 'Tracing',
-                  withBadge: true, // Default to "Beta" badge
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel3.group1.tracing',
-                },
-              ],
-            },
-            // Groups with accordion
-            {
-              id: 'group2',
-              title: 'MANAGEMENT',
-              renderAs: 'accordion',
-              path: 'example_projet.group.openpanel3.group2',
-              children: [
-                {
-                  id: 'group2-A',
-                  title: 'Group 1',
-                  path: 'example_projet.group.openpanel3.group2.group2-A',
-                  children: [
-                    {
-                      id: 'logs',
-                      title: 'Logs',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel3.group2.group2-A.logs',
-                    },
-                    {
-                      id: 'signals',
-                      title: 'Signals',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel3.group2.group2-A.signals',
-                    },
-                    {
-                      id: 'tracing',
-                      title: 'Tracing',
-                      withBadge: true, // Default to "Beta" badge
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel3.group2.group2-A.tracing',
-                    },
-                  ],
-                },
-                {
-                  id: 'group2-B',
-                  title: 'Group 2 (marked as collapsible)',
-                  renderAs: 'accordion',
-                  path: 'example_projet.group.openpanel3.group2.group2-B',
-                  children: [
-                    {
-                      id: 'logs',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel3.group2.group2-B.logs',
-                      title: 'Logs',
-                    },
-                    {
-                      id: 'signals',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel3.group2.group2-B.signals',
-                      title: 'Signals',
-                    },
-                    {
-                      id: 'tracing',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel3.group2.group2-B.tracing',
-                      title: 'Tracing',
-                    },
-                  ],
-                },
-                {
-                  id: 'group2-C',
-                  title: 'Group 3',
-                  path: 'example_projet.group.openpanel3.group2.group2-C',
-                  children: [
-                    {
-                      id: 'logs',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel3.group2.group2-C.logs',
-                      title: 'Logs',
-                    },
-                    {
-                      id: 'signals',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel3.group2.group2-C.signals',
-                      title: 'Signals',
-                    },
-                    {
-                      id: 'tracing',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel3.group2.group2-C.tracing',
-                      title: 'Tracing',
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          // Panel with nav group title that acts like nav items
-          id: 'group.openpanel4',
-          title: 'Open panel (4) - sideNavStatus',
-          renderAs: 'panelOpener',
-          path: 'example_projet.group.openpanel4',
-          children: [
-            {
-              id: 'root',
-              path: 'example_projet.group.openpanel4.root',
-              title: '',
-              children: [
-                {
-                  id: 'groupAsItem1',
-                  title: 'Group renders as "item" (1)',
-                  renderAs: 'item',
-                  path: 'example_projet.group.openpanel4.root.groupAsItem1',
-                  children: [
-                    {
-                      id: 'logs',
-                      title: 'Logs',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.root.groupAsItem1.logs',
-                    },
-                    {
-                      id: 'signals',
-                      title: 'Signals',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.root.groupAsItem1.signals',
-                    },
-                  ],
-                },
-                {
-                  id: 'logs',
-                  title: 'Item 2',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel4.root.logs',
-                },
-                {
-                  id: 'logs2',
-                  title: 'Item should NOT appear!', // Should not appear
-                  sideNavStatus: 'hidden',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel4.root.logs2',
-                },
-                {
-                  title: 'Group should NOT appear!',
-                  id: 'logs3',
-                  sideNavStatus: 'hidden', // This group should not appear
-                  path: 'example_projet.group.openpanel4.root.logs3',
-                  children: [
-                    {
-                      id: 'logs',
-                      title: 'Logs',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.root.logs3.logs',
-                    },
-                    {
-                      id: 'signals',
-                      title: 'Signals',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.root.logs3.signals',
-                    },
-                  ],
-                },
-                {
-                  title: 'Group renders as "item" (2)',
-                  id: 'group2.renderAsItem',
-                  renderAs: 'item',
-                  path: 'example_projet.group.openpanel4.root.group2.renderAsItem',
-                  children: [
-                    {
-                      id: 'logs',
-                      title: 'Logs',
-                      sideNavStatus: 'hidden',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.root.group2.renderAsItem.logs',
-                    },
-                    {
-                      id: 'signals',
-                      title: 'Signals',
-                      sideNavStatus: 'hidden',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.root.group2.renderAsItem.signals',
-                    },
-                    {
-                      id: 'tracing',
-                      title: 'Tracing',
-                      sideNavStatus: 'hidden',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.root.group2.renderAsItem.tracing',
-                    },
-                  ],
-                },
-              ],
-            },
-            // Groups with accordion
-            {
-              id: 'group2',
-              title: 'MANAGEMENT',
-              renderAs: 'accordion',
-              path: 'example_projet.group.openpanel4.group2',
-              children: [
-                {
-                  id: 'group2-A',
-                  title: 'Group 1',
-                  path: 'example_projet.group.openpanel4.group2.group2-A',
-                  children: [
-                    {
-                      id: 'logs',
-                      title: 'Logs',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.group2.group2-A.logs',
-                    },
-                    {
-                      id: 'signals',
-                      title: 'Signals',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.group2.group2-A.signals',
-                    },
-                    {
-                      id: 'tracing',
-                      title: 'Tracing',
-                      withBadge: true, // Default to "Beta" badge
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.group2.group2-A.tracing',
-                    },
-                  ],
-                },
-                {
-                  id: 'root-groupB',
-                  path: 'example_projet.group.openpanel4.group2.root-groupB',
-                  title: '',
-                  children: [
-                    {
-                      id: 'group2-B',
-                      title: 'Group renders as "item" (3)',
-                      renderAs: 'item', // This group renders as a normal item
-                      path: 'example_projet.group.openpanel4.group2.root-groupB.group2-B',
-                      children: [
-                        {
-                          id: 'logs',
-                          title: 'Logs',
-                          href: '/app/kibana',
-                          path: 'example_projet.group.openpanel4.group2.root-groupB.group2-B.logs',
-                        },
-                        {
-                          id: 'signals',
-                          title: 'Signals',
-                          href: '/app/kibana',
-                          path: 'example_projet.group.openpanel4.group2.root-groupB.group2-B.signals',
-                        },
-                        {
-                          id: 'tracing',
-                          title: 'Tracing',
-                          href: '/app/kibana',
-                          path: 'example_projet.group.openpanel4.group2.root-groupB.group2-B.tracing',
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  id: 'group2-C',
-                  title: 'Group 3',
-                  path: 'example_projet.group.openpanel4.group2.group2-C',
-                  children: [
-                    {
-                      id: 'logs',
-                      title: 'Logs',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.group2.group2-C.logs',
-                    },
-                    {
-                      id: 'groupAsItem',
-                      title: 'Yet another group as item',
-                      renderAs: 'item',
-                      path: 'example_projet.group.openpanel4.group2.group2-C.groupAsItem',
-                      children: [
-                        {
-                          id: 'logs',
-                          title: 'Logs',
-                          href: '/app/kibana',
-                          path: 'example_projet.group.openpanel4.group2.group2-C.groupAsItem.logs',
-                        },
-                        {
-                          id: 'signals',
-                          title: 'Signals',
-                          href: '/app/kibana',
-                          path: 'example_projet.group.openpanel4.group2.group2-C.groupAsItem.signals',
-                        },
-                      ],
-                    },
-                    {
-                      id: 'signals',
-                      title: 'Signals',
-                      href: '/app/kibana',
-                      path: 'example_projet.group.openpanel4.group2.group2-C.signals',
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        {
-          // Panel where all children are hidden. The "open panel" icon should NOT
-          // appear next to the node title
-          id: 'group.openpanel5',
-          title: 'Open panel (5) - all children hidden',
-          renderAs: 'panelOpener',
-          path: 'example_projet.group.openpanel5',
-          children: [
-            {
-              id: 'test1',
-              title: 'Test 1',
-              sideNavStatus: 'hidden',
-              href: '/app/kibana',
-              path: 'example_projet.group.openpanel5.test1',
-            },
-            {
-              id: 'test2',
-              title: 'Some group',
+              id: 'sub1',
               path: '',
-              children: [
-                {
-                  id: 'item1',
-                  title: 'My first group item',
-                  sideNavStatus: 'hidden',
-                  href: '/app/kibana',
-                  path: 'example_projet.group.openpanel5.test2.item1',
-                },
-              ],
+              title: 'Item 32',
+              href: '/app/kibana',
+              icon: 'iInCircle',
             },
           ],
         },
+      ],
+    },
+    { id: 'item10', path: '', title: 'Item 10', icon: 'iInCircle', href: '/app/kibana' },
+    {
+      id: 'footer-section6',
+      title: 'Parent item, opened',
+      path: '',
+      renderAs: 'accordion',
+      icon: 'iInCircle',
+      defaultIsCollapsed: false,
+      children: [
         {
-          id: 'group.openpanel6',
-          title: 'Open panel (custom content)',
-          renderAs: 'panelOpener',
-          path: 'example_projet.group.openpanel6',
-          children: [
-            {
-              id: 'logs',
-              title: 'Logs',
-              href: '/app/kibana',
-              path: 'example_projet.group.openpanel6.logs',
-            },
-            {
-              id: 'signals',
-              title: 'Signals',
-              href: '/app/kibana',
-              path: 'example_projet.group.openpanel6.signals',
-            },
-            {
-              id: 'tracing',
-              title: 'Tracing',
-              href: '/app/kibana',
-              path: 'example_projet.group.openpanel6.tracing',
-            },
-          ],
+          id: 'item33',
+          path: '',
+          title: 'Item 33',
+          href: '/app/kibana',
+          icon: 'iInCircle',
         },
         {
-          id: 'group.openpanel7',
-          title: 'Open panel (custom title)',
-          renderAs: 'panelOpener',
-          path: 'example_projet.group.openpanel7',
-          children: [
-            {
-              id: 'logs',
-              title: 'Those links',
-              href: '/app/kibana',
-              path: 'example_projet.group.openpanel7.logs',
-            },
-            {
-              id: 'signals',
-              title: 'are automatically',
-              href: '/app/kibana',
-              path: 'example_projet.group.openpanel7.signals',
-            },
-            {
-              id: 'tracing',
-              title: 'generated',
-              href: '/app/kibana',
-              path: 'example_projet.group.openpanel7.tracing',
-            },
-          ],
+          id: 'item34',
+          path: '',
+          title: 'Item 34',
+          href: '/app/kibana',
+          icon: 'iInCircle',
+        },
+        {
+          id: 'item35',
+          path: '',
+          title: 'Item 35',
+          href: '/app/kibana',
+          icon: 'iInCircle',
+          openInNewTab: true, // FIXME: show "popout" icon aligned to the right
         },
       ],
     },
   ],
 };
 
-export const ObjectDefinitionWithPanel: StoryObj<NavigationServices> = {
-  render: (args) => {
-    const services = storybookMock.getServices({
-      ...args,
-      recentlyAccessed$: of([
-        { label: 'This is an example', link: '/app/example/39859', id: '39850' },
-        { label: 'Another example', link: '/app/example/5235', id: '5235' },
-      ]),
-    });
+/**
+ * The "path" fields are statically defined as empty strings.
+ * In Kibana, these will be dynamically defined based on where the item is within the tree.
+ * This helper function dynamically defines each path.
+ */
+function correctPaths(sourceTree: ChromeProjectNavigationNode[], contextId = '') {
+  const result: ChromeProjectNavigationNode[] = [];
+  for (const key in sourceTree) {
+    if (Object.prototype.hasOwnProperty.call(sourceTree, key)) {
+      const current = sourceTree[key];
+      const currentId = contextId ? `${contextId}.${current.id}` : current.id;
+      current.path = currentId;
+      if (current.children) {
+        current.children = correctPaths(current.children, currentId);
+      }
+      result[key] = current;
+    }
+  }
+  return result;
+}
 
-    return (
-      <NavigationWrapper>
-        {({ isCollapsed }) => (
-          <NavigationProvider {...services} isSideNavCollapsed={isCollapsed}>
-            <Navigation
-              navigationTree$={of(navigationTreeWithPanels)}
-              panelContentProvider={panelContentProvider}
-            />
-          </NavigationProvider>
-        )}
-      </NavigationWrapper>
-    );
-  },
+generalLayoutNavTree.body = correctPaths(
+  generalLayoutNavTree.body as ChromeProjectNavigationNode[]
+);
+generalLayoutNavTree.footer = correctPaths(
+  generalLayoutNavTree.footer as ChromeProjectNavigationNode[]
+);
+
+export const GeneralLayoutStructure = (args: NavigationServices) => {
+  const services = storybookMock.getServices(args);
+
+  return (
+    <NavigationWrapper>
+      {({ isCollapsed }) => (
+        <NavigationProvider {...services} isSideNavCollapsed={isCollapsed}>
+          <Navigation navigationTree$={of(generalLayoutNavTree)} />
+        </NavigationProvider>
+      )}
+    </NavigationWrapper>
+  );
 };
 
 export default {
   title: 'Chrome/Navigation',
   description: 'Navigation container to render items for cross-app linking',
-  parameters: {
-    docs: {
-      page: mdx,
-    },
-  },
-} as Meta;
+  parameters: {},
+  component: GeneralLayoutStructure,
+} as Meta<typeof GeneralLayoutStructure>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Solution Side Nav] Misc UI fixes (#216109)](https://github.com/elastic/kibana/pull/216109)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-03-28T16:12:12Z","message":"[Solution Side Nav] Misc UI fixes (#216109)\n\nPart of https://github.com/elastic/kibana-team/issues/1439\nPulled from https://github.com/elastic/kibana/pull/210893\nhttps://github.com/elastic/kibana/pull/215969\n\n## Summary\n\n1. Allow item in the secondary panel to use the `renderItem` field\n2. Fix handling of `defaultIsCollapsed` for items in the secondary panel\n3. Allow secondary panel to contain a mix of ungrouped items as well as\nsub-groups of items\n\n\n![alksdjnfgklsdfhglskdhkds](https://github.com/user-attachments/assets/11d316d6-6c9a-4743-897f-93c40efa9013)\n\n4. Fix the flagging of the \"active\" parent in the main nav panel, based\non the current URL\n\n\n![jhgkdfgkjfhkhn](https://github.com/user-attachments/assets/b5f6efe3-e8f5-494b-bc12-abbd51acc12a)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"05a8703d48b551f51248319a045cdf9786584df1","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","v9.0.0","Team:SharedUX","backport:version","v9.1.0","v8.19.0"],"title":"[Solution Side Nav] Misc UI fixes","number":216109,"url":"https://github.com/elastic/kibana/pull/216109","mergeCommit":{"message":"[Solution Side Nav] Misc UI fixes (#216109)\n\nPart of https://github.com/elastic/kibana-team/issues/1439\nPulled from https://github.com/elastic/kibana/pull/210893\nhttps://github.com/elastic/kibana/pull/215969\n\n## Summary\n\n1. Allow item in the secondary panel to use the `renderItem` field\n2. Fix handling of `defaultIsCollapsed` for items in the secondary panel\n3. Allow secondary panel to contain a mix of ungrouped items as well as\nsub-groups of items\n\n\n![alksdjnfgklsdfhglskdhkds](https://github.com/user-attachments/assets/11d316d6-6c9a-4743-897f-93c40efa9013)\n\n4. Fix the flagging of the \"active\" parent in the main nav panel, based\non the current URL\n\n\n![jhgkdfgkjfhkhn](https://github.com/user-attachments/assets/b5f6efe3-e8f5-494b-bc12-abbd51acc12a)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"05a8703d48b551f51248319a045cdf9786584df1"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216109","number":216109,"mergeCommit":{"message":"[Solution Side Nav] Misc UI fixes (#216109)\n\nPart of https://github.com/elastic/kibana-team/issues/1439\nPulled from https://github.com/elastic/kibana/pull/210893\nhttps://github.com/elastic/kibana/pull/215969\n\n## Summary\n\n1. Allow item in the secondary panel to use the `renderItem` field\n2. Fix handling of `defaultIsCollapsed` for items in the secondary panel\n3. Allow secondary panel to contain a mix of ungrouped items as well as\nsub-groups of items\n\n\n![alksdjnfgklsdfhglskdhkds](https://github.com/user-attachments/assets/11d316d6-6c9a-4743-897f-93c40efa9013)\n\n4. Fix the flagging of the \"active\" parent in the main nav panel, based\non the current URL\n\n\n![jhgkdfgkjfhkhn](https://github.com/user-attachments/assets/b5f6efe3-e8f5-494b-bc12-abbd51acc12a)\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"05a8703d48b551f51248319a045cdf9786584df1"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->