### PR TITLE
[kbn-grid-layout] [Dashboard] Fix memoization of `onLayoutChange` callback

### DIFF
--- a/src/platform/packages/private/kbn-grid-layout/grid/grid_layout.tsx
+++ b/src/platform/packages/private/kbn-grid-layout/grid/grid_layout.tsx
@@ -90,6 +90,13 @@ export const GridLayout = ({
         }
       });
 
+    return () => {
+      onLayoutChangeSubscription.unsubscribe();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onLayoutChange]);
+
+  useEffect(() => {
     /**
      * This subscription ensures that rows get re-rendered when their orders change
      */
@@ -131,7 +138,6 @@ export const GridLayout = ({
     });
 
     return () => {
-      onLayoutChangeSubscription.unsubscribe();
       rowOrderSubscription.unsubscribe();
       gridLayoutClassSubscription.unsubscribe();
     };


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/217117

## Summary

In the dashboard grid component, we memoize the `onLayoutChange` callback with `viewMode` as a dependency:

https://github.com/elastic/kibana/blob/64142047fba15f52b28304b09fb78c3aa2d23b3a/src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid.tsx#L80-L105

However, on the `kbn-grid-layout` side, the subscription responsible for calling `onLayoutChange` was set up in a `useEffect` that did **not** have the `onLayoutChange` prop as a dependency - so even though the prop was changing, the subscription continued to use the original value. 

That means that if the dashboard starts in view mode, then the `kbn-grid-layout` layout change subscription will always be calling the version of `onLayoutChange` where it returns early; and likewise when you start the dashboard in edit mode. By adding `onLayoutChange` as a dependency to the `useEffect` that sets up the subscriptions, this no longer happens.

### Before


https://github.com/user-attachments/assets/5df796f5-929d-4522-b438-64cc49292ed6

### After


https://github.com/user-attachments/assets/286dd459-b429-40fb-8cb7-661b3f870214



### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->