### PR TITLE
chore(slo): optimize resources management

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/constants.ts
@@ -85,6 +85,9 @@ export const getSLOPipelineId = (sloId: string, sloRevision: number) =>
 export const getSLOSummaryPipelineId = (sloId: string, sloRevision: number) =>
   `.slo-observability.summary.pipeline-${sloId}-${sloRevision}`;
 
+export const getWildcardPipelineId = (sloId: string, sloRevision: number) =>
+  `.slo-observability.*.pipeline-${sloId}-${sloRevision}`;
+
 export const SYNTHETICS_INDEX_PATTERN = 'synthetics-*';
 export const SYNTHETICS_DEFAULT_GROUPINGS = ['monitor.name', 'observer.geo.name', 'monitor.id'];
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/__snapshots__/delete_slo.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/slo/server/services/__snapshots__/delete_slo.test.ts.snap
@@ -36,7 +36,7 @@ exports[`DeleteSLO happy path removes all resources associatde to the slo 3`] = 
 [MockFunction] {
   "calls": Array [
     Array [
-      "slo-summary-irrelevant-1",
+      "slo-irrelevant-1",
     ],
   ],
   "results": Array [
@@ -52,13 +52,20 @@ exports[`DeleteSLO happy path removes all resources associatde to the slo 4`] = 
 [MockFunction] {
   "calls": Array [
     Array [
-      "slo-irrelevant-1",
+      Object {
+        "id": ".slo-observability.*.pipeline-irrelevant-1",
+      },
+      Object {
+        "ignore": Array [
+          404,
+        ],
+      },
     ],
   ],
   "results": Array [
     Object {
       "type": "return",
-      "value": undefined,
+      "value": Promise {},
     },
   ],
 }
@@ -68,65 +75,16 @@ exports[`DeleteSLO happy path removes all resources associatde to the slo 5`] = 
 [MockFunction] {
   "calls": Array [
     Array [
-      "slo-irrelevant-1",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
-exports[`DeleteSLO happy path removes all resources associatde to the slo 6`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      Object {
-        "id": ".slo-observability.sli.pipeline-irrelevant-1",
-      },
-      Object {
-        "ignore": Array [
-          404,
-        ],
-      },
-    ],
-    Array [
-      Object {
-        "id": ".slo-observability.summary.pipeline-irrelevant-1",
-      },
-      Object {
-        "ignore": Array [
-          404,
-        ],
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": Promise {},
-    },
-    Object {
-      "type": "return",
-      "value": Promise {},
-    },
-  ],
-}
-`;
-
-exports[`DeleteSLO happy path removes all resources associatde to the slo 7`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
       Object {
         "conflicts": "proceed",
         "index": ".slo-observability.sli-v3*",
         "query": Object {
-          "match": Object {
-            "slo.id": "irrelevant",
+          "bool": Object {
+            "filter": Object {
+              "term": Object {
+                "slo.id": "irrelevant",
+              },
+            },
           },
         },
         "slices": "auto",
@@ -138,8 +96,12 @@ exports[`DeleteSLO happy path removes all resources associatde to the slo 7`] = 
         "conflicts": "proceed",
         "index": ".slo-observability.summary-v3*",
         "query": Object {
-          "match": Object {
-            "slo.id": "irrelevant",
+          "bool": Object {
+            "filter": Object {
+              "term": Object {
+                "slo.id": "irrelevant",
+              },
+            },
           },
         },
         "refresh": true,
@@ -161,7 +123,7 @@ exports[`DeleteSLO happy path removes all resources associatde to the slo 7`] = 
 }
 `;
 
-exports[`DeleteSLO happy path removes all resources associatde to the slo 8`] = `
+exports[`DeleteSLO happy path removes all resources associatde to the slo 6`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -179,7 +141,7 @@ exports[`DeleteSLO happy path removes all resources associatde to the slo 8`] = 
 }
 `;
 
-exports[`DeleteSLO happy path removes all resources associatde to the slo 9`] = `
+exports[`DeleteSLO happy path removes all resources associatde to the slo 7`] = `
 [MockFunction] {
   "calls": Array [
     Array [

--- a/x-pack/solutions/observability/plugins/slo/server/services/__snapshots__/reset_slo.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/slo/server/services/__snapshots__/reset_slo.test.ts.snap
@@ -20,7 +20,7 @@ exports[`ResetSLO happy path resets all associated resources 2`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "slo-summary-irrelevant-1",
+      "slo-irrelevant-1",
     ],
   ],
   "results": Array [
@@ -33,38 +33,6 @@ exports[`ResetSLO happy path resets all associated resources 2`] = `
 `;
 
 exports[`ResetSLO happy path resets all associated resources 3`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "slo-irrelevant-1",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
-exports[`ResetSLO happy path resets all associated resources 4`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "slo-irrelevant-1",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
-exports[`ResetSLO happy path resets all associated resources 5`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -119,7 +87,7 @@ exports[`ResetSLO happy path resets all associated resources 5`] = `
 }
 `;
 
-exports[`ResetSLO happy path resets all associated resources 6`] = `
+exports[`ResetSLO happy path resets all associated resources 4`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -184,7 +152,7 @@ exports[`ResetSLO happy path resets all associated resources 6`] = `
 }
 `;
 
-exports[`ResetSLO happy path resets all associated resources 7`] = `
+exports[`ResetSLO happy path resets all associated resources 5`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -200,7 +168,7 @@ exports[`ResetSLO happy path resets all associated resources 7`] = `
 }
 `;
 
-exports[`ResetSLO happy path resets all associated resources 8`] = `
+exports[`ResetSLO happy path resets all associated resources 6`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -568,7 +536,7 @@ exports[`ResetSLO happy path resets all associated resources 8`] = `
 }
 `;
 
-exports[`ResetSLO happy path resets all associated resources 9`] = `
+exports[`ResetSLO happy path resets all associated resources 7`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -633,7 +601,7 @@ exports[`ResetSLO happy path resets all associated resources 9`] = `
 }
 `;
 
-exports[`ResetSLO happy path resets all associated resources 10`] = `
+exports[`ResetSLO happy path resets all associated resources 8`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -649,7 +617,7 @@ exports[`ResetSLO happy path resets all associated resources 10`] = `
 }
 `;
 
-exports[`ResetSLO happy path resets all associated resources 11`] = `
+exports[`ResetSLO happy path resets all associated resources 9`] = `
 [MockFunction] {
   "calls": Array [
     Array [

--- a/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.test.ts
@@ -56,9 +56,7 @@ describe('DeleteSLO', () => {
       await deleteSLO.execute(slo.id);
 
       expect(mockRepository.findById).toMatchSnapshot();
-      expect(mockSummaryTransformManager.stop).toMatchSnapshot();
       expect(mockSummaryTransformManager.uninstall).toMatchSnapshot();
-      expect(mockTransformManager.stop).toMatchSnapshot();
       expect(mockTransformManager.uninstall).toMatchSnapshot();
       expect(mockScopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline).toMatchSnapshot();
       expect(mockEsClient.deleteByQuery).toMatchSnapshot();

--- a/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/delete_slo.ts
@@ -8,17 +8,16 @@
 import { RulesClientApi } from '@kbn/alerting-plugin/server/types';
 import { ElasticsearchClient, IScopedClusterClient } from '@kbn/core/server';
 import {
-  getSLOPipelineId,
-  getSLOSummaryPipelineId,
-  getSLOSummaryTransformId,
-  getSLOTransformId,
   SLI_DESTINATION_INDEX_PATTERN,
   SUMMARY_DESTINATION_INDEX_PATTERN,
+  getSLOSummaryTransformId,
+  getSLOTransformId,
+  getWildcardPipelineId,
 } from '../../common/constants';
+import { SLODefinition } from '../domain/models';
 import { retryTransientEsErrors } from '../utils/retry';
 import { SLORepository } from './slo_repository';
 import { TransformManager } from './transform_manager';
-import { SLODefinition } from '../domain/models';
 
 export class DeleteSLO {
   constructor(
@@ -35,20 +34,12 @@ export class DeleteSLO {
 
     await Promise.all([this.deleteSummaryTransform(slo), this.deleteRollupTransform(slo)]);
 
-    await Promise.all([
-      retryTransientEsErrors(() =>
-        this.scopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline(
-          { id: getSLOPipelineId(slo.id, slo.revision) },
-          { ignore: [404] }
-        )
-      ),
-      retryTransientEsErrors(() =>
-        this.scopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline(
-          { id: getSLOSummaryPipelineId(slo.id, slo.revision) },
-          { ignore: [404] }
-        )
-      ),
-    ]);
+    await retryTransientEsErrors(() =>
+      this.scopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline(
+        { id: getWildcardPipelineId(slo.id, slo.revision) },
+        { ignore: [404] }
+      )
+    );
 
     await Promise.all([
       this.deleteRollupData(slo.id),
@@ -60,13 +51,11 @@ export class DeleteSLO {
 
   private async deleteRollupTransform(slo: SLODefinition) {
     const rollupTransformId = getSLOTransformId(slo.id, slo.revision);
-    await this.transformManager.stop(rollupTransformId);
     await this.transformManager.uninstall(rollupTransformId);
   }
 
   private async deleteSummaryTransform(slo: SLODefinition) {
     const summaryTransformId = getSLOSummaryTransformId(slo.id, slo.revision);
-    await this.summaryTransformManager.stop(summaryTransformId);
     await this.summaryTransformManager.uninstall(summaryTransformId);
   }
 
@@ -77,8 +66,12 @@ export class DeleteSLO {
       conflicts: 'proceed',
       slices: 'auto',
       query: {
-        match: {
-          'slo.id': sloId,
+        bool: {
+          filter: {
+            term: {
+              'slo.id': sloId,
+            },
+          },
         },
       },
     });
@@ -92,8 +85,12 @@ export class DeleteSLO {
       conflicts: 'proceed',
       slices: 'auto',
       query: {
-        match: {
-          'slo.id': sloId,
+        bool: {
+          filter: {
+            term: {
+              'slo.id': sloId,
+            },
+          },
         },
       },
     });

--- a/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.test.ts
@@ -75,10 +75,7 @@ describe('ResetSLO', () => {
       await resetSLO.execute(slo.id);
 
       // delete existing resources and data
-      expect(mockSummaryTransformManager.stop).toMatchSnapshot();
       expect(mockSummaryTransformManager.uninstall).toMatchSnapshot();
-
-      expect(mockTransformManager.stop).toMatchSnapshot();
       expect(mockTransformManager.uninstall).toMatchSnapshot();
 
       expect(mockEsClient.deleteByQuery).toMatchSnapshot();

--- a/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
@@ -12,10 +12,9 @@ import {
   SLO_MODEL_VERSION,
   SUMMARY_DESTINATION_INDEX_PATTERN,
   SUMMARY_TEMP_INDEX_NAME,
-  getSLOPipelineId,
-  getSLOSummaryPipelineId,
   getSLOSummaryTransformId,
   getSLOTransformId,
+  getWildcardPipelineId,
 } from '../../common/constants';
 import { getSLIPipelineTemplate } from '../assets/ingest_templates/sli_pipeline_template';
 import { getSummaryPipelineTemplate } from '../assets/ingest_templates/summary_pipeline_template';
@@ -43,11 +42,9 @@ export class ResetSLO {
     await assertExpectedIndicatorSourceIndexPrivileges(slo, this.esClient);
 
     const summaryTransformId = getSLOSummaryTransformId(slo.id, slo.revision);
-    await this.summaryTransformManager.stop(summaryTransformId);
     await this.summaryTransformManager.uninstall(summaryTransformId);
 
     const rollupTransformId = getSLOTransformId(slo.id, slo.revision);
-    await this.transformManager.stop(rollupTransformId);
     await this.transformManager.uninstall(rollupTransformId);
 
     await Promise.all([this.deleteRollupData(slo.id), this.deleteSummaryData(slo.id)]);
@@ -90,17 +87,10 @@ export class ResetSLO {
         `Cannot reset the SLO [id: ${slo.id}, revision: ${slo.revision}]. Rolling back. ${err}`
       );
 
-      await this.summaryTransformManager.stop(summaryTransformId);
       await this.summaryTransformManager.uninstall(summaryTransformId);
-      await this.transformManager.stop(rollupTransformId);
       await this.transformManager.uninstall(rollupTransformId);
       await this.scopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline(
-        { id: getSLOSummaryPipelineId(slo.id, slo.revision) },
-        { ignore: [404] }
-      );
-
-      await this.scopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline(
-        { id: getSLOPipelineId(slo.id, slo.revision) },
+        { id: getWildcardPipelineId(slo.id, slo.revision) },
         { ignore: [404] }
       );
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
@@ -107,7 +107,12 @@ export class DefaultTransformManager implements TransformManager {
       await retryTransientEsErrors(
         () =>
           this.scopedClusterClient.asSecondaryAuthUser.transform.stopTransform(
-            { transform_id: transformId, wait_for_completion: true, force: true },
+            {
+              transform_id: transformId,
+              wait_for_completion: true,
+              force: true,
+              allow_no_match: true,
+            },
             { ignore: [404] }
           ),
         { logger: this.logger }

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.test.ts
@@ -485,11 +485,9 @@ describe('UpdateSLO', () => {
 
   function expectDeletionOfOriginalSLOResources(originalSlo: SLODefinition) {
     const transformId = getSLOTransformId(originalSlo.id, originalSlo.revision);
-    expect(mockTransformManager.stop).toHaveBeenCalledWith(transformId);
     expect(mockTransformManager.uninstall).toHaveBeenCalledWith(transformId);
 
     const summaryTransformId = getSLOSummaryTransformId(originalSlo.id, originalSlo.revision);
-    expect(mockSummaryTransformManager.stop).toHaveBeenCalledWith(summaryTransformId);
     expect(mockSummaryTransformManager.uninstall).toHaveBeenCalledWith(summaryTransformId);
 
     expect(mockScopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline).toHaveBeenCalled();

--- a/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/update_slo.ts
@@ -18,6 +18,7 @@ import {
   getSLOSummaryPipelineId,
   getSLOSummaryTransformId,
   getSLOTransformId,
+  getWildcardPipelineId,
 } from '../../common/constants';
 import { getSLIPipelineTemplate } from '../assets/ingest_templates/sli_pipeline_template';
 import { getSummaryPipelineTemplate } from '../assets/ingest_templates/summary_pipeline_template';
@@ -208,23 +209,16 @@ export class UpdateSLO {
   private async deleteOriginalSLO(originalSlo: SLODefinition) {
     try {
       const originalRollupTransformId = getSLOTransformId(originalSlo.id, originalSlo.revision);
-      await this.transformManager.stop(originalRollupTransformId);
       await this.transformManager.uninstall(originalRollupTransformId);
 
       const originalSummaryTransformId = getSLOSummaryTransformId(
         originalSlo.id,
         originalSlo.revision
       );
-      await this.summaryTransformManager.stop(originalSummaryTransformId);
       await this.summaryTransformManager.uninstall(originalSummaryTransformId);
 
       await this.scopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline(
-        { id: getSLOSummaryPipelineId(originalSlo.id, originalSlo.revision) },
-        { ignore: [404] }
-      );
-
-      await this.scopedClusterClient.asSecondaryAuthUser.ingest.deletePipeline(
-        { id: getSLOPipelineId(originalSlo.id, originalSlo.revision) },
+        { id: getWildcardPipelineId(originalSlo.id, originalSlo.revision) },
         { ignore: [404] }
       );
     } catch (err) {


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/209925

Looking at the delete SLO service, i've noticed some unecessary calls that we can safely remove:
- uninstalling a transform will force stop it, meaning it does not need to be stopped before.
- deletePipeline can take a wildcard in its id, so we can delete both the summary and sli pipeline in one call.