### PR TITLE
[UA] Tests should run only for 8

### DIFF
--- a/x-pack/test/accessibility/apps/group3/upgrade_assistant.ts
+++ b/x-pack/test/accessibility/apps/group3/upgrade_assistant.ts
@@ -12,7 +12,7 @@
 
 import { FtrProviderContext } from '../../ftr_provider_context';
 
-export default function ({ getService, getPageObjects }: FtrProviderContext) {
+export default function upgradeAssistantPage({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['upgradeAssistant', 'common']);
   const a11y = getService('a11y');
   const testSubjects = getService('testSubjects');

--- a/x-pack/test/accessibility/apps/group3/upgrade_assistant.ts
+++ b/x-pack/test/accessibility/apps/group3/upgrade_assistant.ts
@@ -20,7 +20,7 @@ export default function upgradeAssistantPage({ getService, getPageObjects }: Ftr
   const es = getService('es');
   const log = getService('log');
 
-  describe('Upgrade Assistant Accessibility', () => {
+  describe('Upgrade Assistant Accessibility', function () {
     // Only run this test in 8 as the deprecation we are testing is only available in 8
     this.onlyEsVersion('8');
 

--- a/x-pack/test/accessibility/apps/group3/upgrade_assistant.ts
+++ b/x-pack/test/accessibility/apps/group3/upgrade_assistant.ts
@@ -21,6 +21,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const log = getService('log');
 
   describe('Upgrade Assistant Accessibility', () => {
+    // Only run this test in 8 as the deprecation we are testing is only available in 8
+    this.onlyEsVersion('8');
+
     before(async () => {
       await PageObjects.upgradeAssistant.navigateToPage();
 

--- a/x-pack/test/functional/apps/upgrade_assistant/es_deprecation_logs_page.ts
+++ b/x-pack/test/functional/apps/upgrade_assistant/es_deprecation_logs_page.ts
@@ -17,6 +17,8 @@ export default function upgradeAssistantESDeprecationLogsPageFunctionalTests({
   const es = getService('es');
 
   describe('ES deprecation logs flyout', function () {
+    // Only run this test in 8 as the deprecation we are testing is only available in 8
+    this.onlyEsVersion('8');
     this.tags(['skipFirefox', 'upgradeAssistant']);
 
     before(async () => {

--- a/x-pack/test/functional/apps/upgrade_assistant/overview_page.ts
+++ b/x-pack/test/functional/apps/upgrade_assistant/overview_page.ts
@@ -16,6 +16,8 @@ export default function upgradeAssistantOverviewPageFunctionalTests({
   const testSubjects = getService('testSubjects');
 
   describe('Overview Page', function () {
+    // Only run this test in 8 as the deprecation we are testing is only available in 8
+    this.onlyEsVersion('8');
     this.tags(['skipFirefox', 'upgradeAssistant']);
 
     before(async () => {


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/216576
Fixes: https://github.com/elastic/kibana/issues/217131
Fixes: https://github.com/elastic/kibana/issues/216947

## Summary

ES test suites should only run against es8 as certain generated deprecations dont exist on es9 and it breaks the es9-compat pipeline.
