### PR TITLE
[ML] Change Point Detection: Fixes 'Use full data' button issue which could cause page to crash

### DIFF
--- a/x-pack/platform/packages/private/ml/field_stats_flyout/field_stats_flyout_provider.tsx
+++ b/x-pack/platform/packages/private/ml/field_stats_flyout/field_stats_flyout_provider.tsx
@@ -129,7 +129,7 @@ export const FieldStatsFlyoutProvider: FC<FieldStatsFlyoutProviderProps> = (prop
 
       const cachedResult = manager.get(cacheKey);
       if (cachedResult) {
-        return cachedResult;
+        setPopulatedFields(cachedResult);
       } else {
         fetchPopulatedFields();
       }

--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
@@ -536,7 +536,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
         </EuiFlexItem>
 
         <EuiFlexItem>
-          <FieldsControls fieldConfig={fieldConfig} onChange={onChange} data-test-subj="blablabla">
+          <FieldsControls fieldConfig={fieldConfig} onChange={onChange}>
             <EuiFlexItem {...(progress === null && { css: { display: 'none' } })} grow={true}>
               <EuiProgress
                 label={


### PR DESCRIPTION
Fixes an issue on pages which have a 'Use full data' button, such as the Change Point Detection page inside ML AIOps Labs and the Transforms wizard, where an error where with caching inside the `FieldStatsFlyoutProvider` could cause  the page to break.

Steps to reproduce:
1. Go to Change Point Detection in ML.
2. Click "Use full data".
3. Change the date in the time picker to a range different from the full data time range (e.g., last 15 minutes) and apply.
4. Click "Use full data" again.

It occurs only in `React` > 18
Backporting to 8.19, as it is possible that React 18 will be enabled in 8.19 as well.

<img width="1481" alt="image" src="https://github.com/user-attachments/assets/926c1f2f-4b83-44bb-ba99-a45b2428697a" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->