### PR TITLE
[UA] Wait filter button to exists

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/es_deprecations.helpers.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/es_deprecations.helpers.ts
@@ -8,6 +8,7 @@ import { act } from 'react-dom/test-utils';
 
 import { registerTestBed, TestBed, AsyncTestBedConfig } from '@kbn/test-jest-helpers';
 import { HttpSetup } from '@kbn/core/public';
+import { waitFor } from '@testing-library/dom';
 import { EsDeprecations } from '../../../public/application/components';
 import { WithAppDependencies } from '../helpers';
 
@@ -95,19 +96,11 @@ const createActions = (testBed: TestBed) => {
     clickFilterByTitle: async (title: string) => {
       // We need to read the document "body" as the filter dropdown (an EuiSelectable)
       // is added in a portalled popover and not inside the component DOM tree.
-      let filterButton: HTMLButtonElement | null = null;
-
-      // Wait for the filterButton to be available
-      await act(async () => {
-        while (!filterButton) {
-          filterButton = document.body.querySelector(`.euiSelectableListItem[title=${title}]`);
-          await new Promise((resolve) => setTimeout(resolve, 50));
-        }
-      });
-
-      expect(filterButton).not.toBeNull();
-
-      await act(async () => {
+      await waitFor(() => {
+        const filterButton: HTMLButtonElement | null = document.body.querySelector(
+          `.euiSelectableListItem[title=${title}]`
+        );
+        expect(filterButton).not.toBeNull();
         filterButton!.click();
       });
 

--- a/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/es_deprecations.helpers.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/__jest__/client_integration/es_deprecations/es_deprecations.helpers.ts
@@ -95,9 +95,15 @@ const createActions = (testBed: TestBed) => {
     clickFilterByTitle: async (title: string) => {
       // We need to read the document "body" as the filter dropdown (an EuiSelectable)
       // is added in a portalled popover and not inside the component DOM tree.
-      const filterButton: HTMLButtonElement | null = document.body.querySelector(
-        `.euiSelectableListItem[title=${title}]`
-      );
+      let filterButton: HTMLButtonElement | null = null;
+
+      // Wait for the filterButton to be available
+      await act(async () => {
+        while (!filterButton) {
+          filterButton = document.body.querySelector(`.euiSelectableListItem[title=${title}]`);
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+      });
 
       expect(filterButton).not.toBeNull();
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/214423

## Summary
Fix flaky test by waiting for the filterButton to be available. Probably caused by https://github.com/elastic/kibana/pull/211581
