### PR TITLE
[SharedUX][A11y] Fix Share modal export icon focusable

### DIFF
--- a/src/platform/plugins/shared/share/public/components/tabs/export/export_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/export/export_content.tsx
@@ -18,14 +18,13 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
-  EuiIcon,
   EuiRadioGroup,
   EuiSpacer,
   EuiSwitch,
   EuiSwitchEvent,
   EuiText,
-  EuiToolTip,
   type EuiRadioGroupOption,
+  EuiIconTip,
 } from '@elastic/eui';
 import { SupportedExportTypes, ShareMenuItemV2 } from '../../../types';
 import { type IShareContext } from '../../context';
@@ -113,16 +112,14 @@ const ExportContentUi = ({
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiToolTip
+            <EuiIconTip
               content={
                 <FormattedMessage
                   id="share.screenCapturePanelContent.optimizeForPrintingHelpText"
                   defaultMessage="Uses multiple pages, showing at most 2 visualizations per page "
                 />
               }
-            >
-              <EuiIcon type="questionInCircle" />
-            </EuiToolTip>
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       );
@@ -152,7 +149,7 @@ const ExportContentUi = ({
             </EuiCopy>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiToolTip
+            <EuiIconTip
               content={
                 <EuiText size="s">
                   <FormattedMessage
@@ -161,9 +158,7 @@ const ExportContentUi = ({
                   />
                 </EuiText>
               }
-            >
-              <EuiIcon type="questionInCircle" />
-            </EuiToolTip>
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       );

--- a/src/platform/plugins/shared/share/public/components/tabs/export/export_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/export/export_content.tsx
@@ -18,11 +18,13 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
+  EuiIcon,
   EuiRadioGroup,
   EuiSpacer,
   EuiSwitch,
   EuiSwitchEvent,
   EuiText,
+  EuiToolTip,
   type EuiRadioGroupOption,
   EuiIconTip,
 } from '@elastic/eui';
@@ -112,14 +114,16 @@ const ExportContentUi = ({
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiIconTip
+            <EuiToolTip
               content={
                 <FormattedMessage
                   id="share.screenCapturePanelContent.optimizeForPrintingHelpText"
                   defaultMessage="Uses multiple pages, showing at most 2 visualizations per page "
                 />
               }
-            />
+            >
+              <EuiIcon type="questionInCircle" />
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
       );

--- a/src/platform/plugins/shared/share/public/components/tabs/export/export_content.tsx
+++ b/src/platform/plugins/shared/share/public/components/tabs/export/export_content.tsx
@@ -18,15 +18,13 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
-  EuiIcon,
   EuiRadioGroup,
   EuiSpacer,
   EuiSwitch,
   EuiSwitchEvent,
   EuiText,
-  EuiToolTip,
-  type EuiRadioGroupOption,
   EuiIconTip,
+  type EuiRadioGroupOption,
 } from '@elastic/eui';
 import { SupportedExportTypes, ShareMenuItemV2 } from '../../../types';
 import { type IShareContext } from '../../context';
@@ -114,16 +112,14 @@ const ExportContentUi = ({
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiToolTip
+            <EuiIconTip
               content={
                 <FormattedMessage
                   id="share.screenCapturePanelContent.optimizeForPrintingHelpText"
                   defaultMessage="Uses multiple pages, showing at most 2 visualizations per page "
                 />
               }
-            >
-              <EuiIcon type="questionInCircle" />
-            </EuiToolTip>
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       );


### PR DESCRIPTION
## Summary

This PR fixes [[Platform:Dashboards:DashboardViewMode] Tooltips on export tab on share panel are not announced because of lack of focus on](https://github.com/elastic/kibana/issues/214447) and fixes [[a11y] In the sharing menu the POST url info cannot be accessed with the keyboar](https://github.com/elastic/kibana/issues/215991d) issues.

Before:

https://github.com/user-attachments/assets/9c8c532d-1628-4f57-a2f0-2fe1d09e5cb6

After: 

https://github.com/user-attachments/assets/d7716469-ad73-4241-934d-f9f4d23a1279



<!--ONMERGE {"backportTargets":["8.16","8.17","8.18","8.x"]} ONMERGE-->