### PR TITLE
[A11y][APM] Add missing `aria-label` for some services buttons

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_groups/service_groups_list/sort.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_groups/service_groups_list/sort.tsx
@@ -36,6 +36,9 @@ export function Sort({ type, onChange }: Props) {
   return (
     <EuiSelect
       data-test-subj="apmSortSelect"
+      aria-label={i18n.translate('xpack.apm.serviceGroups.list.sort.ariaLabel', {
+        defaultMessage: 'Sort service groups by',
+      })}
       options={options}
       value={type}
       onChange={(e) => onChange(e.target.value as ServiceGroupsSortType)}

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/key_value_filter_list/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/key_value_filter_list/index.tsx
@@ -20,6 +20,7 @@ import { i18n } from '@kbn/i18n';
 import React, { Fragment } from 'react';
 import styled from '@emotion/styled';
 import { isEmpty } from 'lodash';
+import { css } from '@emotion/react';
 
 interface KeyValue {
   key: string;
@@ -79,23 +80,41 @@ export function KeyValueFilterList({
             <Fragment key={key}>
               <EuiDescriptionListTitle
                 className="descriptionList__title"
-                style={{ height: '40px' }}
+                css={css`
+                  height: 40px;
+                `}
               >
-                <EuiText size="s" style={{ fontWeight: 'bold' }}>
+                <EuiText
+                  size="s"
+                  css={css`
+                    font-weight: bold;
+                  `}
+                >
                   {key}
                 </EuiText>
               </EuiDescriptionListTitle>
               <EuiDescriptionListDescription
                 className="descriptionList__description"
-                style={{ height: '40px' }}
+                css={css`
+                  height: 40px;
+                `}
               >
                 <EuiFlexGroup alignItems="baseline" responsive={false} gutterSize="none">
-                  <EuiFlexItem style={{ minWidth: '32px' }} grow={false}>
+                  <EuiFlexItem
+                    css={css`
+                      min-width: 32px;
+                    `}
+                    grow={false}
+                  >
                     {isFilterable && (
                       <EuiButtonEmpty
                         onClick={() => {
                           onClickFilter({ key, value });
                         }}
+                        aria-label={i18n.translate(
+                          'xpack.apm.keyValueFilterList.actionFilterLabel',
+                          { defaultMessage: 'Filter by value' }
+                        )}
                         data-test-subj={`filter_by_${key}`}
                       >
                         <EuiToolTip


### PR DESCRIPTION
## Summary

Fixes #212264

This PR adds a couple of `aria-label` attributes to buttons that do not have a screen-reader announcement under the Services and Services Groups pages.




<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->