### PR TITLE
[Fleet] Added instructions for installing elastic agent complete

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/page_steps/install_agent/install_agent_managed.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/page_steps/install_agent/install_agent_managed.tsx
@@ -10,7 +10,11 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiText, EuiLink, EuiSteps, EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
 
 import { Error } from '../../../../../../../components';
-import { useStartServices, useAgentVersion } from '../../../../../../../../../hooks';
+import {
+  useStartServices,
+  useAgentVersion,
+  useShowCompleteAgentInstructions,
+} from '../../../../../../../../../hooks';
 
 import { CreatePackagePolicyBottomBar, NotObscuredByBottomBar } from '../..';
 import {
@@ -50,6 +54,9 @@ export const InstallElasticAgentManagedPageStep: React.FC<InstallAgentPageProps>
   const [commandCopied, setCommandCopied] = useState(false);
   const [applyCommandCopied, setApplyCommandCopied] = useState(false);
 
+  const { onChangeShowCompleteAgentInstructions, showCompleteAgentInstructions } =
+    useShowCompleteAgentInstructions();
+
   if (!enrollmentAPIKey) {
     return (
       <Error
@@ -75,6 +82,7 @@ export const InstallElasticAgentManagedPageStep: React.FC<InstallAgentPageProps>
     fleetServerHost,
     agentVersion: agentVersion || '',
     showInstallServers,
+    showCompleteAgentInstructions,
   });
 
   const steps = [
@@ -89,6 +97,8 @@ export const InstallElasticAgentManagedPageStep: React.FC<InstallAgentPageProps>
       fleetServerHost,
       onCopy: () => setCommandCopied(true),
       rootIntegrations: getRootIntegrations(agentPolicy?.package_policies ?? []),
+      onChangeShowCompleteAgentInstructions,
+      showCompleteAgentInstructions,
     }),
   ];
 

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/page_steps/install_agent/install_agent_standalone.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/page_steps/install_agent/install_agent_standalone.tsx
@@ -17,7 +17,10 @@ import {
 } from '../..';
 
 import { Error as FleetError } from '../../../../../../../components';
-import { useKibanaVersion } from '../../../../../../../../../hooks';
+import {
+  useKibanaVersion,
+  useShowCompleteAgentInstructions,
+} from '../../../../../../../../../hooks';
 import {
   InstallStandaloneAgentStep,
   ConfigureStandaloneAgentStep,
@@ -38,6 +41,9 @@ export const InstallElasticAgentStandalonePageStep: React.FC<InstallAgentPagePro
   const { yaml, onCreateApiKey, isCreatingApiKey, apiKey, downloadYaml } =
     useFetchFullPolicy(agentPolicy);
 
+  const { onChangeShowCompleteAgentInstructions, showCompleteAgentInstructions } =
+    useShowCompleteAgentInstructions();
+
   if (!agentPolicy) {
     return (
       <FleetError
@@ -52,7 +58,10 @@ export const InstallElasticAgentStandalonePageStep: React.FC<InstallAgentPagePro
     );
   }
 
-  const installManagedCommands = StandaloneInstructions({ agentVersion: kibanaVersion });
+  const installManagedCommands = StandaloneInstructions({
+    agentVersion: kibanaVersion,
+    showCompleteAgentInstructions,
+  });
 
   const steps = [
     ConfigureStandaloneAgentStep({
@@ -71,6 +80,8 @@ export const InstallElasticAgentStandalonePageStep: React.FC<InstallAgentPagePro
       fullCopyButton: true,
       onCopy: () => setCommandCopied(true),
       rootIntegrations: getRootIntegrations(agentPolicy?.package_policies ?? []),
+      onChangeShowCompleteAgentInstructions,
+      showCompleteAgentInstructions,
     }),
   ];
 

--- a/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/compute_steps.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/compute_steps.tsx
@@ -17,7 +17,12 @@ import { getGcpIntegrationDetailsFromAgentPolicy } from '../../cloud_security_po
 
 import { StandaloneInstructions, ManualInstructions } from '../../enrollment_instructions';
 
-import { useGetOneEnrollmentAPIKey, useStartServices, useAgentVersion } from '../../../hooks';
+import {
+  useGetOneEnrollmentAPIKey,
+  useStartServices,
+  useAgentVersion,
+  useShowCompleteAgentInstructions,
+} from '../../../hooks';
 import { useFetchFullPolicy } from '../hooks';
 
 import type { InstructionProps } from '../types';
@@ -61,6 +66,9 @@ export const StandaloneSteps: React.FunctionComponent<InstructionProps> = ({
     isK8s
   );
 
+  const { showCompleteAgentInstructions, onChangeShowCompleteAgentInstructions } =
+    useShowCompleteAgentInstructions();
+
   const agentVersion = useAgentVersion();
 
   const instructionsSteps = useMemo(() => {
@@ -68,6 +76,7 @@ export const StandaloneSteps: React.FunctionComponent<InstructionProps> = ({
       agentVersion: agentVersion || '',
       downloadSource,
       downloadSourceProxy,
+      showCompleteAgentInstructions,
     });
 
     const steps: EuiContainedStepProps[] = !agentPolicy
@@ -107,6 +116,8 @@ export const StandaloneSteps: React.FunctionComponent<InstructionProps> = ({
         isK8s,
         cloudSecurityIntegration,
         rootIntegrations: getRootIntegrations(selectedPolicy?.package_policies ?? []),
+        showCompleteAgentInstructions,
+        onChangeShowCompleteAgentInstructions,
       })
     );
 
@@ -132,6 +143,8 @@ export const StandaloneSteps: React.FunctionComponent<InstructionProps> = ({
     cloudSecurityIntegration,
     mode,
     setMode,
+    showCompleteAgentInstructions,
+    onChangeShowCompleteAgentInstructions,
   ]);
 
   if (!agentVersion) {
@@ -173,6 +186,8 @@ export const ManagedSteps: React.FunctionComponent<InstructionProps> = ({
   const { enrolledAgentIds } = usePollingAgentCount(selectedPolicy?.id || '');
 
   const agentVersion = useAgentVersion();
+  const { showCompleteAgentInstructions, onChangeShowCompleteAgentInstructions } =
+    useShowCompleteAgentInstructions();
 
   const { gcpProjectId, gcpOrganizationId, gcpAccountType } =
     getGcpIntegrationDetailsFromAgentPolicy(selectedPolicy);
@@ -190,6 +205,7 @@ export const ManagedSteps: React.FunctionComponent<InstructionProps> = ({
     gcpOrganizationId,
     gcpAccountType,
     showInstallServers,
+    showCompleteAgentInstructions,
   });
 
   const instructionsSteps = useMemo(() => {
@@ -259,6 +275,8 @@ export const ManagedSteps: React.FunctionComponent<InstructionProps> = ({
           fleetServerHost,
           enrollToken,
           rootIntegrations: getRootIntegrations(selectedPolicy?.package_policies ?? []),
+          showCompleteAgentInstructions,
+          onChangeShowCompleteAgentInstructions,
         })
       );
     }
@@ -310,6 +328,8 @@ export const ManagedSteps: React.FunctionComponent<InstructionProps> = ({
     agentDataConfirmed,
     installedPackagePolicy,
     gcpProjectId,
+    showCompleteAgentInstructions,
+    onChangeShowCompleteAgentInstructions,
   ]);
 
   if (!agentVersion) {

--- a/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/install_managed_agent_step.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/install_managed_agent_step.tsx
@@ -11,6 +11,8 @@ import { i18n } from '@kbn/i18n';
 
 import type { EuiContainedStepProps } from '@elastic/eui/src/components/steps/steps';
 
+import type { EuiSwitchProps } from '@elastic/eui';
+
 import type { GetOneEnrollmentAPIKeyResponse } from '../../../../common/types/rest_spec/enrollment_api_key';
 
 import { InstallSection } from '../../enrollment_instructions/install_section';
@@ -30,6 +32,8 @@ export const InstallManagedAgentStep = ({
   fullCopyButton,
   onCopy,
   rootIntegrations,
+  showCompleteAgentInstructions,
+  onChangeShowCompleteAgentInstructions,
 }: {
   selectedApiKeyId?: string;
   apiKeyData?: GetOneEnrollmentAPIKeyResponse | null;
@@ -42,6 +46,8 @@ export const InstallManagedAgentStep = ({
   fullCopyButton?: boolean;
   onCopy?: () => void;
   rootIntegrations?: Array<{ name: string; title: string }>;
+  showCompleteAgentInstructions: boolean;
+  onChangeShowCompleteAgentInstructions: EuiSwitchProps['onChange'];
 }): EuiContainedStepProps => {
   const nonCompleteStatus = selectedApiKeyId ? undefined : 'disabled';
   const status = isComplete ? 'complete' : nonCompleteStatus;
@@ -61,6 +67,8 @@ export const InstallManagedAgentStep = ({
           fullCopyButton={fullCopyButton}
           fleetServerHost={fleetServerHost}
           rootIntegrations={rootIntegrations}
+          showCompleteAgentInstructions={showCompleteAgentInstructions}
+          onChangeShowCompleteAgentInstructions={onChangeShowCompleteAgentInstructions}
         />
       ) : (
         <React.Fragment />

--- a/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/install_standalone_agent_step.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/agent_enrollment_flyout/steps/install_standalone_agent_step.tsx
@@ -10,6 +10,8 @@ import { i18n } from '@kbn/i18n';
 
 import type { EuiContainedStepProps } from '@elastic/eui/src/components/steps/steps';
 
+import type { EuiSwitchProps } from '@elastic/eui';
+
 import type { CommandsByPlatform } from '../../../applications/fleet/components/fleet_server_instructions/utils/install_command_utils';
 
 import { InstallSection } from '../../enrollment_instructions/install_section';
@@ -24,6 +26,8 @@ export const InstallStandaloneAgentStep = ({
   fullCopyButton,
   onCopy,
   rootIntegrations,
+  showCompleteAgentInstructions,
+  onChangeShowCompleteAgentInstructions,
 }: {
   installCommand: CommandsByPlatform;
   isK8s?: K8sMode;
@@ -32,6 +36,8 @@ export const InstallStandaloneAgentStep = ({
   fullCopyButton?: boolean;
   onCopy?: () => void;
   rootIntegrations?: Array<{ name: string; title: string }>;
+  showCompleteAgentInstructions: boolean;
+  onChangeShowCompleteAgentInstructions: EuiSwitchProps['onChange'];
 }): EuiContainedStepProps => {
   return {
     title: i18n.translate('xpack.fleet.agentEnrollment.stepEnrollAndRunAgentTitle', {
@@ -46,6 +52,8 @@ export const InstallStandaloneAgentStep = ({
         fullCopyButton={fullCopyButton}
         isManaged={false}
         rootIntegrations={rootIntegrations}
+        showCompleteAgentInstructions={showCompleteAgentInstructions}
+        onChangeShowCompleteAgentInstructions={onChangeShowCompleteAgentInstructions}
       />
     ),
     status: isComplete ? 'complete' : undefined,

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/install_section.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/install_section.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 
 import type { EuiSwitchProps } from '@elastic/eui';
-import { EuiSpacer, EuiSwitch } from '@elastic/eui';
+import { EuiIcon, EuiSpacer, EuiSwitch, EuiToolTip } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
@@ -60,6 +60,9 @@ export const InstallSection: React.FunctionComponent<Props> = ({
         onChange={onChangeShowCompleteAgentInstructions}
         compressed
       />
+      <EuiToolTip position="top" content={addElasticAgentCompleteTooltipContent}>
+        <EuiIcon tabIndex={0} type="questionInCircle" />
+      </EuiToolTip>
       <EuiSpacer size="m" />
       <PlatformSelector
         fullCopyButton={fullCopyButton}
@@ -77,8 +80,15 @@ export const InstallSection: React.FunctionComponent<Props> = ({
 };
 
 const addElasticAgentCompleteLabel = i18n.translate(
-  'xpack.fleet.enrollmentInstructions.completeAgent',
+  'xpack.fleet.enrollmentInstructions.completeAgent.label',
   {
-    defaultMessage: 'Add elastic agent complete which is required for synthetics browser test',
+    defaultMessage: 'Use the elastic-agent-complete docker image',
+  }
+);
+
+const addElasticAgentCompleteTooltipContent = i18n.translate(
+  'xpack.fleet.enrollmentInstructions.completeAgent.tooltip',
+  {
+    defaultMessage: 'Required to run Synthetics browser tests',
   }
 );

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/install_section.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/install_section.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 
 import type { EuiSwitchProps } from '@elastic/eui';
-import { EuiIcon, EuiSpacer, EuiSwitch, EuiToolTip } from '@elastic/eui';
+import { EuiFlexGroup, EuiIcon, EuiSpacer, EuiSwitch, EuiToolTip } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 
@@ -54,15 +54,17 @@ export const InstallSection: React.FunctionComponent<Props> = ({
       <InstallationMessage isK8s={isK8s} isManaged={isManaged} />
       <RootPrivilegesCallout rootIntegrations={rootIntegrations} />
       <UnprivilegedInfo />
-      <EuiSwitch
-        label={addElasticAgentCompleteLabel}
-        checked={showCompleteAgentInstructions}
-        onChange={onChangeShowCompleteAgentInstructions}
-        compressed
-      />
-      <EuiToolTip position="top" content={addElasticAgentCompleteTooltipContent}>
-        <EuiIcon tabIndex={0} type="questionInCircle" />
-      </EuiToolTip>
+      <EuiFlexGroup gutterSize="xs">
+        <EuiSwitch
+          label={addElasticAgentCompleteLabel}
+          checked={showCompleteAgentInstructions}
+          onChange={onChangeShowCompleteAgentInstructions}
+          compressed
+        />
+        <EuiToolTip position="top" content={addElasticAgentCompleteTooltipContent}>
+          <EuiIcon tabIndex={0} type="iInCircle" />
+        </EuiToolTip>
+      </EuiFlexGroup>
       <EuiSpacer size="m" />
       <PlatformSelector
         fullCopyButton={fullCopyButton}

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/install_section.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/install_section.tsx
@@ -7,6 +7,11 @@
 
 import React from 'react';
 
+import type { EuiSwitchProps } from '@elastic/eui';
+import { EuiSpacer, EuiSwitch } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+
 import type { CommandsByPlatform } from '../../applications/fleet/components/fleet_server_instructions/utils';
 
 import { InstallationMessage } from '../agent_enrollment_flyout/installation_message';
@@ -27,6 +32,8 @@ interface Props {
   isManaged?: boolean;
   onCopy?: () => void;
   rootIntegrations?: Array<{ name: string; title: string }>;
+  showCompleteAgentInstructions: boolean;
+  onChangeShowCompleteAgentInstructions: EuiSwitchProps['onChange'];
 }
 
 export const InstallSection: React.FunctionComponent<Props> = ({
@@ -39,12 +46,21 @@ export const InstallSection: React.FunctionComponent<Props> = ({
   isManaged = true,
   onCopy,
   rootIntegrations,
+  showCompleteAgentInstructions,
+  onChangeShowCompleteAgentInstructions,
 }) => {
   return (
     <>
       <InstallationMessage isK8s={isK8s} isManaged={isManaged} />
       <RootPrivilegesCallout rootIntegrations={rootIntegrations} />
       <UnprivilegedInfo />
+      <EuiSwitch
+        label={addElasticAgentCompleteLabel}
+        checked={showCompleteAgentInstructions}
+        onChange={onChangeShowCompleteAgentInstructions}
+        compressed
+      />
+      <EuiSpacer size="m" />
       <PlatformSelector
         fullCopyButton={fullCopyButton}
         onCopy={onCopy}
@@ -59,3 +75,10 @@ export const InstallSection: React.FunctionComponent<Props> = ({
     </>
   );
 };
+
+const addElasticAgentCompleteLabel = i18n.translate(
+  'xpack.fleet.enrollmentInstructions.completeAgent',
+  {
+    defaultMessage: 'Add elastic agent complete which is required for synthetics browser test',
+  }
+);

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.tsx
@@ -83,6 +83,7 @@ export const ManualInstructions = ({
   gcpOrganizationId = '<ORGANIZATION_ID>',
   gcpAccountType,
   showInstallServers,
+  showCompleteAgentInstructions = false,
 }: {
   apiKey: string;
   fleetServerHost: string;
@@ -94,6 +95,7 @@ export const ManualInstructions = ({
   gcpOrganizationId?: string;
   gcpAccountType?: string;
   showInstallServers?: boolean;
+  showCompleteAgentInstructions?: boolean;
 }) => {
   const getEnrollArgsByPlatForm = (platform: EXTENDED_PLATFORM_TYPE) => {
     return getFleetServerHostsEnrollArgs({
@@ -104,65 +106,69 @@ export const ManualInstructions = ({
       showInstallServers,
     });
   };
+
+  const elasticAgentName = showCompleteAgentInstructions
+    ? 'elastic-agent-complete'
+    : 'elastic-agent';
+
   const downloadBaseUrl = getDownloadBaseUrl(downloadSource);
 
-  const k8sCommand = 'kubectl apply -f elastic-agent-managed-kubernetes.yml';
+  const k8sCommand = `kubectl apply -f ${elasticAgentName}-managed-kubernetes.yml`;
 
   const { windows: windowsDownloadSourceProxyArgs, curl: curlDownloadSourceProxyArgs } =
     getDownloadSourceProxyArgs(downloadSourceProxy);
-
   const debOrRpmWithInstallServers = showInstallServers ? `ELASTIC_AGENT_FLAVOR=servers ` : '';
 
-  const linuxAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-linux-arm64.tar.gz ${curlDownloadSourceProxyArgs}
-  tar xzvf elastic-agent-${agentVersion}-linux-arm64.tar.gz
-  cd elastic-agent-${agentVersion}-linux-arm64
+  const linuxAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-linux-arm64.tar.gz ${curlDownloadSourceProxyArgs}
+  tar xzvf ${elasticAgentName}-${agentVersion}-linux-arm64.tar.gz
+  cd ${elasticAgentName}-${agentVersion}-linux-arm64
   sudo ./elastic-agent install ${getEnrollArgsByPlatForm('linux_aarch64')}`;
 
-  const linuxX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-linux-x86_64.tar.gz ${curlDownloadSourceProxyArgs}
-tar xzvf elastic-agent-${agentVersion}-linux-x86_64.tar.gz
-cd elastic-agent-${agentVersion}-linux-x86_64
+  const linuxX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-linux-x86_64.tar.gz ${curlDownloadSourceProxyArgs}
+tar xzvf ${elasticAgentName}-${agentVersion}-linux-x86_64.tar.gz
+cd ${elasticAgentName}-${agentVersion}-linux-x86_64
 sudo ./elastic-agent install ${getEnrollArgsByPlatForm('linux_x86_64')}`;
 
-  const macAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-darwin-aarch64.tar.gz ${curlDownloadSourceProxyArgs}
-tar xzvf elastic-agent-${agentVersion}-darwin-aarch64.tar.gz
-cd elastic-agent-${agentVersion}-darwin-aarch64
+  const macAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-darwin-aarch64.tar.gz ${curlDownloadSourceProxyArgs}
+tar xzvf ${elasticAgentName}-${agentVersion}-darwin-aarch64.tar.gz
+cd ${elasticAgentName}-${agentVersion}-darwin-aarch64
 sudo ./elastic-agent install ${getEnrollArgsByPlatForm('mac_aarch64')}`;
 
-  const macX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-darwin-x86_64.tar.gz ${curlDownloadSourceProxyArgs}
-tar xzvf elastic-agent-${agentVersion}-darwin-x86_64.tar.gz
-cd elastic-agent-${agentVersion}-darwin-x86_64
+  const macX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-darwin-x86_64.tar.gz ${curlDownloadSourceProxyArgs}
+tar xzvf ${elasticAgentName}-${agentVersion}-darwin-x86_64.tar.gz
+cd ${elasticAgentName}-${agentVersion}-darwin-x86_64
 sudo ./elastic-agent install ${getEnrollArgsByPlatForm('mac_x86_64')}`;
 
   const windowsCommand = `$ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-windows-x86_64.zip -OutFile elastic-agent-${agentVersion}-windows-x86_64.zip ${windowsDownloadSourceProxyArgs}
-Expand-Archive .\\elastic-agent-${agentVersion}-windows-x86_64.zip -DestinationPath .
-cd elastic-agent-${agentVersion}-windows-x86_64
+Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-windows-x86_64.zip -OutFile ${elasticAgentName}-${agentVersion}-windows-x86_64.zip ${windowsDownloadSourceProxyArgs}
+Expand-Archive .\\${elasticAgentName}-${agentVersion}-windows-x86_64.zip -DestinationPath .
+cd ${elasticAgentName}-${agentVersion}-windows-x86_64
 .\\elastic-agent.exe install ${getEnrollArgsByPlatForm('windows')}`;
 
   const windowsMSICommand = `$ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-windows-x86_64.msi -OutFile elastic-agent-${agentVersion}-windows-x86_64.msi ${windowsDownloadSourceProxyArgs}
+Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-windows-x86_64.msi -OutFile ${elasticAgentName}-${agentVersion}-windows-x86_64.msi ${windowsDownloadSourceProxyArgs}
 .\\elastic-agent.msi --% INSTALLARGS="${getEnrollArgsByPlatForm('windows_msi')}"`;
 
-  const linuxDebAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-arm64.deb ${curlDownloadSourceProxyArgs}
-sudo ${debOrRpmWithInstallServers}dpkg -i elastic-agent-${agentVersion}-arm64.deb
+  const linuxDebAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-arm64.deb ${curlDownloadSourceProxyArgs}
+sudo ${debOrRpmWithInstallServers}dpkg -i ${elasticAgentName}-${agentVersion}-arm64.deb
 sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm(
     'deb_aarch64'
   )} \n`;
 
-  const linuxDebX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-amd64.deb ${curlDownloadSourceProxyArgs}
-sudo ${debOrRpmWithInstallServers}dpkg -i elastic-agent-${agentVersion}-amd64.deb
+  const linuxDebX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-amd64.deb ${curlDownloadSourceProxyArgs}
+sudo ${debOrRpmWithInstallServers}dpkg -i ${elasticAgentName}-${agentVersion}-amd64.deb
 sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm(
     'deb_x86_64'
   )} \n`;
 
-  const linuxRpmAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-aarch64.rpm ${curlDownloadSourceProxyArgs}
-sudo ${debOrRpmWithInstallServers}rpm -vi elastic-agent-${agentVersion}-aarch64.rpm
+  const linuxRpmAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-aarch64.rpm ${curlDownloadSourceProxyArgs}
+sudo ${debOrRpmWithInstallServers}rpm -vi ${elasticAgentName}-${agentVersion}-aarch64.rpm
 sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm(
     'rpm_aarch64'
   )} \n`;
 
-  const linuxRpmX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-x86_64.rpm ${curlDownloadSourceProxyArgs}
-sudo ${debOrRpmWithInstallServers}rpm -vi elastic-agent-${agentVersion}-x86_64.rpm
+  const linuxRpmX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-x86_64.rpm ${curlDownloadSourceProxyArgs}
+sudo ${debOrRpmWithInstallServers}rpm -vi ${elasticAgentName}-${agentVersion}-x86_64.rpm
 sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm(
     'rpm_x86_64'
   )} \n`;

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/standalone/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/standalone/index.tsx
@@ -13,58 +13,64 @@ export const StandaloneInstructions = ({
   agentVersion,
   downloadSource,
   downloadSourceProxy,
+  showCompleteAgentInstructions,
 }: {
   agentVersion: string;
   downloadSource?: DownloadSource;
   downloadSourceProxy?: FleetProxy;
+  showCompleteAgentInstructions: boolean;
 }): CommandsByPlatform => {
+  const elasticAgentName = showCompleteAgentInstructions
+    ? 'elastic-agent-complete'
+    : 'elastic-agent';
+
   const downloadBaseUrl = getDownloadBaseUrl(downloadSource);
   const { windows: windowsDownloadSourceProxyArgs, curl: curlDownloadSourceProxyArgs } =
     getDownloadSourceProxyArgs(downloadSourceProxy);
 
-  const linuxDebAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-arm64.deb ${curlDownloadSourceProxyArgs}
-sudo dpkg -i elastic-agent-${agentVersion}-arm64.deb \nsudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent`;
+  const linuxDebAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-arm64.deb ${curlDownloadSourceProxyArgs}
+sudo dpkg -i ${elasticAgentName}-${agentVersion}-arm64.deb \nsudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent`;
 
-  const linuxDebX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-amd64.deb ${curlDownloadSourceProxyArgs}
-sudo dpkg -i elastic-agent-${agentVersion}-amd64.deb \nsudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent`;
+  const linuxDebX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-amd64.deb ${curlDownloadSourceProxyArgs}
+sudo dpkg -i ${elasticAgentName}-${agentVersion}-amd64.deb \nsudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent`;
 
-  const linuxRpmAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-aarch64.rpm ${curlDownloadSourceProxyArgs}
-sudo rpm -vi elastic-agent-${agentVersion}-aarch64.rpm \nsudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent`;
+  const linuxRpmAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-aarch64.rpm ${curlDownloadSourceProxyArgs}
+sudo rpm -vi ${elasticAgentName}-${agentVersion}-aarch64.rpm \nsudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent`;
 
-  const linuxRpmX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-x86_64.rpm ${curlDownloadSourceProxyArgs}
-sudo rpm -vi elastic-agent-${agentVersion}-x86_64.rpm \nsudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent`;
+  const linuxRpmX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-x86_64.rpm ${curlDownloadSourceProxyArgs}
+sudo rpm -vi ${elasticAgentName}-${agentVersion}-x86_64.rpm \nsudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent`;
 
-  const linuxAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-linux-arm64.tar.gz ${curlDownloadSourceProxyArgs}
-tar xzvf elastic-agent-${agentVersion}-linux-arm64.tar.gz
-cd elastic-agent-${agentVersion}-linux-arm64
+  const linuxAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-linux-arm64.tar.gz ${curlDownloadSourceProxyArgs}
+tar xzvf ${elasticAgentName}-${agentVersion}-linux-arm64.tar.gz
+cd ${elasticAgentName}-${agentVersion}-linux-arm64
 sudo ./elastic-agent install`;
 
-  const linuxX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-linux-x86_64.tar.gz ${curlDownloadSourceProxyArgs}
-tar xzvf elastic-agent-${agentVersion}-linux-x86_64.tar.gz
-cd elastic-agent-${agentVersion}-linux-x86_64
+  const linuxX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-linux-x86_64.tar.gz ${curlDownloadSourceProxyArgs}
+tar xzvf ${elasticAgentName}-${agentVersion}-linux-x86_64.tar.gz
+cd ${elasticAgentName}-${agentVersion}-linux-x86_64
 sudo ./elastic-agent install`;
 
-  const macAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-darwin-aarch64.tar.gz ${curlDownloadSourceProxyArgs}
-tar xzvf elastic-agent-${agentVersion}-darwin-aarch64.tar.gz
-cd elastic-agent-${agentVersion}-darwin-aarch64
+  const macAarch64Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-darwin-aarch64.tar.gz ${curlDownloadSourceProxyArgs}
+tar xzvf ${elasticAgentName}-${agentVersion}-darwin-aarch64.tar.gz
+cd ${elasticAgentName}-${agentVersion}-darwin-aarch64
 sudo ./elastic-agent install`;
 
-  const macX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-darwin-x86_64.tar.gz ${curlDownloadSourceProxyArgs}
-tar xzvf elastic-agent-${agentVersion}-darwin-x86_64.tar.gz
-cd elastic-agent-${agentVersion}-darwin-x86_64
+  const macX8664Command = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-darwin-x86_64.tar.gz ${curlDownloadSourceProxyArgs}
+tar xzvf ${elasticAgentName}-${agentVersion}-darwin-x86_64.tar.gz
+cd ${elasticAgentName}-${agentVersion}-darwin-x86_64
 sudo ./elastic-agent install`;
 
   const windowsCommand = `$ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-windows-x86_64.zip -OutFile elastic-agent-${agentVersion}-windows-x86_64.zip ${windowsDownloadSourceProxyArgs}
-Expand-Archive .\elastic-agent-${agentVersion}-windows-x86_64.zip -DestinationPath .
-cd elastic-agent-${agentVersion}-windows-x86_64
+Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-windows-x86_64.zip -OutFile ${elasticAgentName}-${agentVersion}-windows-x86_64.zip ${windowsDownloadSourceProxyArgs}
+Expand-Archive .\${elasticAgentName}-${agentVersion}-windows-x86_64.zip -DestinationPath .
+cd ${elasticAgentName}-${agentVersion}-windows-x86_64
 .\\elastic-agent.exe install`;
 
   const windowsMSICommand = `$ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-windows-x86_64.msi -OutFile elastic-agent-${agentVersion}-windows-x86_64.msi ${windowsDownloadSourceProxyArgs}
+Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/${elasticAgentName}-${agentVersion}-windows-x86_64.msi -OutFile ${elasticAgentName}-${agentVersion}-windows-x86_64.msi ${windowsDownloadSourceProxyArgs}
 .\\elastic-agent.msi install`;
 
-  const k8sCommand = 'kubectl apply -f elastic-agent-standalone-kubernetes.yml';
+  const k8sCommand = `kubectl apply -f ${elasticAgentName}-standalone-kubernetes.yml`;
 
   return {
     linux_aarch64: linuxAarch64Command,

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/index.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/index.ts
@@ -35,3 +35,4 @@ export * from './use_locator';
 export * from './use_agent_version';
 export * from './use_fleet_server_agents';
 export * from './use_multiple_agent_policies';
+export * from './use_show_complete_agent_instructions';

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_show_complete_agent_instructions.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_show_complete_agent_instructions.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState } from 'react';
+
+export const useShowCompleteAgentInstructions = () => {
+  const [showCompleteAgentInstructions, setShowCompleteAgentInstructions] = useState(false);
+  const onChangeShowCompleteAgentInstructions = (e: {
+    target: { checked: React.SetStateAction<boolean> };
+  }) => {
+    setShowCompleteAgentInstructions(e.target.checked);
+  };
+
+  return { showCompleteAgentInstructions, onChangeShowCompleteAgentInstructions };
+};


### PR DESCRIPTION
This PR closes #197089 by adding instructions to download the elastic agent complete.


https://github.com/user-attachments/assets/04f0eed9-3ce4-443b-876e-e4a251ae1004



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->