### PR TITLE
[8.17] [Synthetics] Fix save lens visualization on monitors overview (#216695)

### DIFF
--- a/x-pack/plugins/observability_solution/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
+++ b/x-pack/plugins/observability_solution/exploratory_view/public/components/shared/exploratory_view/embeddable/embeddable.tsx
@@ -220,7 +220,7 @@ export default function Embeddable(props: ExploratoryEmbeddableComponentProps) {
       />
       {isSaveOpen && attributesJSON && (
         <LensSaveModalComponent
-          initialInput={attributesJSON as unknown as LensEmbeddableInput}
+          initialInput={{ attributes: attributesJSON } as LensEmbeddableInput}
           onClose={() => setIsSaveOpen(false)}
           // if we want to do anything after the viz is saved
           // right now there is no action, so an empty function

--- a/x-pack/plugins/observability_solution/synthetics/e2e/synthetics/journeys/index.ts
+++ b/x-pack/plugins/observability_solution/synthetics/e2e/synthetics/journeys/index.ts
@@ -25,3 +25,4 @@ export * from './monitor_details_page/monitor_summary.journey';
 export * from './test_run_details.journey';
 export * from './step_details.journey';
 export * from './project_monitor_read_only.journey';
+export * from './overview_save_lens_visualization.journey';

--- a/x-pack/plugins/observability_solution/synthetics/e2e/synthetics/journeys/overview_save_lens_visualization.journey.ts
+++ b/x-pack/plugins/observability_solution/synthetics/e2e/synthetics/journeys/overview_save_lens_visualization.journey.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { before, expect, journey, step, after } from '@elastic/synthetics';
+import { syntheticsAppPageProvider } from '../page_objects/synthetics_app';
+import { SyntheticsServices } from './services/synthetics_services';
+
+journey('OverviewSaveLensVisualization', async ({ page, params }) => {
+  const syntheticsApp = syntheticsAppPageProvider({ page, kibanaUrl: params.kibanaUrl, params });
+  const syntheticsService = new SyntheticsServices(params);
+
+  before(async () => {
+    await syntheticsService.cleaUp();
+  });
+
+  after(async () => {
+    await syntheticsService.cleaUp();
+  });
+
+  step('Go to Monitors overview page', async () => {
+    await syntheticsApp.navigateToOverview(true, 15);
+  });
+
+  step('Create test monitor', async () => {
+    await syntheticsService.addTestMonitor('Test Overview Save Lens Visualization Monitor', {
+      type: 'http',
+      urls: 'https://www.google.com',
+      locations: ['us_central'],
+    });
+    await page.getByTestId('syntheticsRefreshButtonButton').click();
+  });
+
+  step('Open the save lens visualization', async () => {
+    await page
+      .getByTestId('overviewErrorsSparklines')
+      .getByTestId('embeddablePanelHoverActions-')
+      .hover();
+
+    await page
+      .getByTestId('overviewErrorsSparklines')
+      .getByTestId('embeddablePanelToggleMenuIcon')
+      .click();
+    await page.getByTestId('embeddablePanelAction-expViewSave').click();
+  });
+
+  step('The attributes are correctly passed to the save lens visualization modal', async () => {
+    expect(await page.getByTestId('savedObjectTitle').inputValue()).toBe(
+      'Prefilled from exploratory view app'
+    );
+  });
+});

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_errors/overview_errors_sparklines.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_errors/overview_errors_sparklines.tsx
@@ -30,6 +30,7 @@ export const OverviewErrorsSparklines = ({ from, to }: Props) => {
   return (
     <ExploratoryViewEmbeddable
       id="overviewErrorsSparklines"
+      dataTestSubj="overviewErrorsSparklines"
       reportType="kpi-over-time"
       axisTitlesVisibility={{ x: false, yRight: false, yLeft: false }}
       legendIsVisible={false}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Synthetics] Fix save lens visualization on monitors overview (#216695)](https://github.com/elastic/kibana/pull/216695)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-04-07T13:47:53Z","message":"[Synthetics] Fix save lens visualization on monitors overview (#216695)\n\nThis PR closes #212490 by fixing the save lens visualization.\n\n\n\nhttps://github.com/user-attachments/assets/34949692-6b72-41f5-aa61-6c743ea5c5a3","sha":"07994d2706808d7ddf1bf2ca3cdf8a29ac033839","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","v8.18.1","v9.0.1","v8.17.5"],"title":"[Synthetics] Fix save lens visualization on monitors overview","number":216695,"url":"https://github.com/elastic/kibana/pull/216695","mergeCommit":{"message":"[Synthetics] Fix save lens visualization on monitors overview (#216695)\n\nThis PR closes #212490 by fixing the save lens visualization.\n\n\n\nhttps://github.com/user-attachments/assets/34949692-6b72-41f5-aa61-6c743ea5c5a3","sha":"07994d2706808d7ddf1bf2ca3cdf8a29ac033839"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0","8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216695","number":216695,"mergeCommit":{"message":"[Synthetics] Fix save lens visualization on monitors overview (#216695)\n\nThis PR closes #212490 by fixing the save lens visualization.\n\n\n\nhttps://github.com/user-attachments/assets/34949692-6b72-41f5-aa61-6c743ea5c5a3","sha":"07994d2706808d7ddf1bf2ca3cdf8a29ac033839"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217329","number":217329,"state":"OPEN"},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->