### PR TITLE
[Synthetics] Improve un-runnable script errors.

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/browser/browser_test_results.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/browser/browser_test_results.tsx
@@ -186,7 +186,8 @@ export const FAILED_TO_RUN = i18n.translate('xpack.synthetics.monitorManagement.
 });
 
 export const ERROR_RUNNING_TEST = i18n.translate('xpack.synthetics.testRun.testErrorLabel', {
-  defaultMessage: 'Error running test',
+  defaultMessage:
+    'This synthetics script could not be run as written. Debug this locally by running elastic-synthetics with the --dry-run flag.',
 });
 
 const LOADING_STEPS = i18n.translate('xpack.synthetics.monitorManagement.loadingSteps', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/browser/browser_test_results.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/test_now_mode/browser/browser_test_results.tsx
@@ -187,7 +187,7 @@ export const FAILED_TO_RUN = i18n.translate('xpack.synthetics.monitorManagement.
 
 export const ERROR_RUNNING_TEST = i18n.translate('xpack.synthetics.testRun.testErrorLabel', {
   defaultMessage:
-    'This synthetics script could not be run as written. Debug this locally by running elastic-synthetics with the --dry-run flag.',
+    'This Elastic Synthetics script could not be run as written. Debug this locally by running elastic-synthetics with the --dry-run flag.',
 });
 
 const LOADING_STEPS = i18n.translate('xpack.synthetics.monitorManagement.loadingSteps', {


### PR DESCRIPTION
## Summary

This copy-only improves the error message in situations where a script cannot be executed and the `elastic-synthetics` runner immediately exits with an error code of `1`, typically for syntax issues or a missing `async` etc.

This improved message directs the user to try debugging locally where determining the root cause should be more obvious.
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
~- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
~- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
~- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.~
~- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed~
~- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)~

### Identify risks

Low risk, copy-only change


