### PR TITLE
[8.x] [Response Ops][Reporting] Add health API to inform whether conditions are sufficient for scheduled reports (#216857)

### DIFF
--- a/src/platform/packages/private/kbn-reporting/common/routes.ts
+++ b/src/platform/packages/private/kbn-reporting/common/routes.ts
@@ -25,6 +25,7 @@ export const INTERNAL_ROUTES = {
     DOWNLOAD_PREFIX: prefixInternalPath + '/jobs/download', // docId is added to the final path
   },
   DOWNLOAD_CSV: prefixInternalPath + '/generate/immediate/csv_searchsource', // DEPRECATED
+  HEALTH: prefixInternalPath + '/_health',
   GENERATE_PREFIX: prefixInternalPath + '/generate', // exportTypeId is added to the final path
 };
 

--- a/src/platform/packages/private/kbn-reporting/common/types.ts
+++ b/src/platform/packages/private/kbn-reporting/common/types.ts
@@ -109,6 +109,11 @@ export interface ReportingServerInfo {
   uuid: string;
 }
 
+export interface ReportingHealthInfo {
+  isSufficientlySecure: boolean;
+  hasPermanentEncryptionKey: boolean;
+}
+
 export type IlmPolicyMigrationStatus = 'policy-not-found' | 'indices-not-managed-by-policy' | 'ok';
 
 export interface IlmPolicyStatusResponse {

--- a/x-pack/platform/plugins/private/reporting/kibana.jsonc
+++ b/x-pack/platform/plugins/private/reporting/kibana.jsonc
@@ -18,6 +18,7 @@
     "requiredPlugins": [
       "data",
       "discover",
+      "encryptedSavedObjects",
       "fieldFormats",
       "home",
       "management",

--- a/x-pack/platform/plugins/private/reporting/server/core.ts
+++ b/x-pack/platform/plugins/private/reporting/server/core.ts
@@ -28,7 +28,7 @@ import type { DiscoverServerPluginStart } from '@kbn/discover-plugin/server';
 import type { FeaturesPluginSetup } from '@kbn/features-plugin/server';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/server';
 import type { LicensingPluginStart } from '@kbn/licensing-plugin/server';
-import type { ReportingServerInfo } from '@kbn/reporting-common/types';
+import type { ReportingHealthInfo, ReportingServerInfo } from '@kbn/reporting-common/types';
 import {
   CsvSearchSourceExportType,
   CsvSearchSourceImmediateExportType,
@@ -50,6 +50,7 @@ import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 
 import { checkLicense } from '@kbn/reporting-server/check_license';
 import { ExportTypesRegistry } from '@kbn/reporting-server/export_types_registry';
+import { EncryptedSavedObjectsPluginSetup } from '@kbn/encrypted-saved-objects-plugin/server';
 import type { ReportingSetup } from '.';
 import { createConfig } from './config';
 import { reportingEventLoggerFactory } from './lib/event_logger/logger';
@@ -60,15 +61,16 @@ import { EventTracker } from './usage';
 
 export interface ReportingInternalSetup {
   basePath: Pick<IBasePath, 'set'>;
-  router: ReportingPluginRouter;
+  docLinks: DocLinksServiceSetup;
+  encryptedSavedObjects: EncryptedSavedObjectsPluginSetup;
   features: FeaturesPluginSetup;
+  logger: Logger;
+  router: ReportingPluginRouter;
   security?: SecurityPluginSetup;
   spaces?: SpacesPluginSetup;
-  usageCounter?: UsageCounter;
-  taskManager: TaskManagerSetupContract;
-  logger: Logger;
   status: StatusServiceSetup;
-  docLinks: DocLinksServiceSetup;
+  taskManager: TaskManagerSetupContract;
+  usageCounter?: UsageCounter;
 }
 
 export interface ReportingInternalStart {
@@ -254,6 +256,32 @@ export class ReportingCore {
     };
   }
 
+  public async getHealthInfo(): Promise<ReportingHealthInfo> {
+    const { encryptedSavedObjects } = this.getPluginSetupDeps();
+    const { securityService } = await this.getPluginStartDeps();
+    const isSecurityEnabled = await this.isSecurityEnabled();
+
+    let isSufficientlySecure: boolean;
+    const apiKeysAreEnabled = (await securityService.authc.apiKeys.areAPIKeysEnabled()) ?? false;
+
+    if (isSecurityEnabled === null) {
+      isSufficientlySecure = false;
+    } else {
+      // if esSecurityIsEnabled = true, then areApiKeysEnabled must be true to be considered secure
+      // if esSecurityIsEnabled = false, then it does not matter what areApiKeysEnabled is
+      if (!isSecurityEnabled) {
+        isSufficientlySecure = false;
+      } else {
+        isSufficientlySecure = apiKeysAreEnabled;
+      }
+    }
+
+    return {
+      isSufficientlySecure,
+      hasPermanentEncryptionKey: encryptedSavedObjects.canEncrypt,
+    };
+  }
+
   /*
    * Gives synchronous access to the config
    */
@@ -320,6 +348,22 @@ export class ReportingCore {
 
     return await Rx.firstValueFrom(
       license$.pipe(map((license) => checkLicense(registry, license)))
+    );
+  }
+
+  public async isSecurityEnabled() {
+    const { license$ } = (await this.getPluginStartDeps()).licensing;
+    return await Rx.firstValueFrom(
+      license$.pipe(
+        map((license) => {
+          if (!license || !license?.isAvailable) {
+            return null;
+          }
+
+          const { isEnabled } = license.getFeature('security');
+          return isEnabled;
+        })
+      )
     );
   }
 

--- a/x-pack/platform/plugins/private/reporting/server/routes/index.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/index.ts
@@ -10,6 +10,7 @@ import { ReportingCore } from '..';
 import { registerDeprecationsRoutes } from './internal/deprecations/deprecations';
 import { registerDiagnosticRoutes } from './internal/diagnostic';
 import { registerGenerateCsvFromSavedObjectImmediate } from './internal/generate/csv_searchsource_immediate';
+import { registerHealthRoute } from './internal/health';
 import { registerGenerationRoutesInternal } from './internal/generate/generate_from_jobparams';
 import { registerJobInfoRoutesInternal } from './internal/management/jobs';
 import { registerGenerationRoutesPublic } from './public/generate_from_jobparams';
@@ -17,6 +18,7 @@ import { registerJobInfoRoutesPublic } from './public/jobs';
 
 export function registerRoutes(reporting: ReportingCore, logger: Logger) {
   registerDeprecationsRoutes(reporting, logger);
+  registerHealthRoute(reporting, logger);
   registerDiagnosticRoutes(reporting, logger);
   registerGenerationRoutesInternal(reporting, logger);
   registerJobInfoRoutesInternal(reporting);

--- a/x-pack/platform/plugins/private/reporting/server/routes/internal/health/health.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/internal/health/health.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/core/server';
+import { INTERNAL_ROUTES } from '@kbn/reporting-common';
+import type { ReportingCore } from '../../..';
+import { authorizedUserPreRouting } from '../../common';
+
+const path = INTERNAL_ROUTES.HEALTH;
+export const registerHealthRoute = (reporting: ReportingCore, logger: Logger) => {
+  const { router } = reporting.getPluginSetupDeps();
+
+  router.get(
+    {
+      path,
+      security: {
+        authz: {
+          enabled: false,
+          reason: 'This route is opted out from authorization',
+        },
+      },
+      validate: false,
+      options: { access: 'internal' },
+    },
+    authorizedUserPreRouting(reporting, async (_user, _context, req, res) => {
+      try {
+        const healthInfo = await reporting.getHealthInfo();
+        return res.ok({
+          body: {
+            has_permanent_encryption_key: healthInfo.hasPermanentEncryptionKey,
+            is_sufficiently_secure: healthInfo.isSufficientlySecure,
+          },
+        });
+      } catch (err) {
+        logger.error(err);
+        return res.custom({ statusCode: 500 });
+      }
+    })
+  );
+};

--- a/x-pack/platform/plugins/private/reporting/server/routes/internal/health/index.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/internal/health/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { registerHealthRoute } from './health';

--- a/x-pack/platform/plugins/private/reporting/server/test_helpers/create_mock_reportingplugin.ts
+++ b/x-pack/platform/plugins/private/reporting/server/test_helpers/create_mock_reportingplugin.ts
@@ -19,6 +19,7 @@ import {
 } from '@kbn/core/server/mocks';
 import { dataPluginMock } from '@kbn/data-plugin/server/mocks';
 import { discoverPluginMock } from '@kbn/discover-plugin/server/mocks';
+import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
 import { featuresPluginMock } from '@kbn/features-plugin/server/mocks';
 import { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
@@ -38,6 +39,7 @@ export const createMockPluginSetup = (
   setupMock: Partial<Record<keyof ReportingInternalSetup, any>>
 ): ReportingInternalSetup => {
   return {
+    encryptedSavedObjects: encryptedSavedObjectsMock.createSetup(),
     features: featuresPluginMock.createSetup(),
     basePath: { set: jest.fn() },
     router: { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() },

--- a/x-pack/platform/plugins/private/reporting/server/types.ts
+++ b/x-pack/platform/plugins/private/reporting/server/types.ts
@@ -31,6 +31,7 @@ import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 
 import { ExportTypesRegistry } from '@kbn/reporting-server/export_types_registry';
 import type { AuthenticatedUser } from '@kbn/core-security-common';
+import { EncryptedSavedObjectsPluginSetup } from '@kbn/encrypted-saved-objects-plugin/server';
 
 /**
  * Plugin Setup Contract
@@ -52,6 +53,7 @@ export type ReportingUser = { username: AuthenticatedUser['username'] } | false;
 export type ScrollConfig = ReportingConfigType['csv']['scroll'];
 
 export interface ReportingSetupDeps {
+  encryptedSavedObjects: EncryptedSavedObjectsPluginSetup;
   features: FeaturesPluginSetup;
   screenshotMode: ScreenshotModePluginSetup;
   taskManager: TaskManagerSetupContract;

--- a/x-pack/platform/plugins/private/reporting/tsconfig.json
+++ b/x-pack/platform/plugins/private/reporting/tsconfig.json
@@ -14,6 +14,7 @@
     "@kbn/screenshot-mode-plugin",
     "@kbn/share-plugin",
     "@kbn/ui-actions-plugin",
+    "@kbn/encrypted-saved-objects-plugin",
     "@kbn/usage-collection-plugin",
     "@kbn/field-formats-plugin",
     "@kbn/features-plugin",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Response Ops][Reporting] Add health API to inform whether conditions are sufficient for scheduled reports (#216857)](https://github.com/elastic/kibana/pull/216857)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-04-07T20:46:02Z","message":"[Response Ops][Reporting] Add health API to inform whether conditions are sufficient for scheduled reports (#216857)\n\nResolves https://github.com/elastic/kibana/issues/216319\n\n## Summary\n\nAdds an internal reporting health API to return whether conditions are\nsufficient to support scheduled reports. For scheduled reporting, we\nneed for security and API keys to be enabled in Elasticsearch and for a\npermanent encryption key to be set for the encrypted saved objects\nplugin.\n\n```\nGET kbn:/internal/reporting/_health\n\nResponse \n{\n  \"has_permanent_encryption_key\": true,\n  \"is_sufficiently_secure\": true\n}\n```\n\nThe issue also mentions returning whether a preconfigured email service\nis configured, but that will be done as part of the main scheduled\nreporting task.\n\n## To Verify\n\n1. Run kibana and ES with no special flags, both flags should be `true`\n2. Run ES with `-E xpack.security.enabled=false`.\n`is_sufficiently_secure` should be set to `false`\n3. Run ES With `-E xpack.security.authc.api_key.enabled=false`.\n`is_sufficient_secure` should be set to `false`\n\nNote that in dev mode, an encryption key is auto-set if not defined in\nthe Kibana yml so `has_permanent_encryption_key` will always return\n`true` in dev mode.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3d54923123b37ff0c1d7e51067ac30a20965461b","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Feature:Reporting:Framework","backport:version","v9.1.0","v8.19.0"],"title":"[Response Ops][Reporting] Add health API to inform whether conditions are sufficient for scheduled reports","number":216857,"url":"https://github.com/elastic/kibana/pull/216857","mergeCommit":{"message":"[Response Ops][Reporting] Add health API to inform whether conditions are sufficient for scheduled reports (#216857)\n\nResolves https://github.com/elastic/kibana/issues/216319\n\n## Summary\n\nAdds an internal reporting health API to return whether conditions are\nsufficient to support scheduled reports. For scheduled reporting, we\nneed for security and API keys to be enabled in Elasticsearch and for a\npermanent encryption key to be set for the encrypted saved objects\nplugin.\n\n```\nGET kbn:/internal/reporting/_health\n\nResponse \n{\n  \"has_permanent_encryption_key\": true,\n  \"is_sufficiently_secure\": true\n}\n```\n\nThe issue also mentions returning whether a preconfigured email service\nis configured, but that will be done as part of the main scheduled\nreporting task.\n\n## To Verify\n\n1. Run kibana and ES with no special flags, both flags should be `true`\n2. Run ES with `-E xpack.security.enabled=false`.\n`is_sufficiently_secure` should be set to `false`\n3. Run ES With `-E xpack.security.authc.api_key.enabled=false`.\n`is_sufficient_secure` should be set to `false`\n\nNote that in dev mode, an encryption key is auto-set if not defined in\nthe Kibana yml so `has_permanent_encryption_key` will always return\n`true` in dev mode.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3d54923123b37ff0c1d7e51067ac30a20965461b"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216857","number":216857,"mergeCommit":{"message":"[Response Ops][Reporting] Add health API to inform whether conditions are sufficient for scheduled reports (#216857)\n\nResolves https://github.com/elastic/kibana/issues/216319\n\n## Summary\n\nAdds an internal reporting health API to return whether conditions are\nsufficient to support scheduled reports. For scheduled reporting, we\nneed for security and API keys to be enabled in Elasticsearch and for a\npermanent encryption key to be set for the encrypted saved objects\nplugin.\n\n```\nGET kbn:/internal/reporting/_health\n\nResponse \n{\n  \"has_permanent_encryption_key\": true,\n  \"is_sufficiently_secure\": true\n}\n```\n\nThe issue also mentions returning whether a preconfigured email service\nis configured, but that will be done as part of the main scheduled\nreporting task.\n\n## To Verify\n\n1. Run kibana and ES with no special flags, both flags should be `true`\n2. Run ES with `-E xpack.security.enabled=false`.\n`is_sufficiently_secure` should be set to `false`\n3. Run ES With `-E xpack.security.authc.api_key.enabled=false`.\n`is_sufficient_secure` should be set to `false`\n\nNote that in dev mode, an encryption key is auto-set if not defined in\nthe Kibana yml so `has_permanent_encryption_key` will always return\n`true` in dev mode.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"3d54923123b37ff0c1d7e51067ac30a20965461b"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->