### PR TITLE
[8.18] [ObsUX][A11y] Add aria-label to group by count (#217302)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/group_name.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/group_name.tsx
@@ -9,6 +9,7 @@ import { EuiButtonEmpty, EuiScreenReaderOnly, EuiToolTip } from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
+import type { InventoryItemType } from '@kbn/metrics-data-access-plugin/common';
 import type {
   InfraWaffleMapGroup,
   InfraWaffleMapOptions,
@@ -19,9 +20,10 @@ interface Props {
   group: InfraWaffleMapGroup;
   isChild?: boolean;
   options: InfraWaffleMapOptions;
+  nodeType: InventoryItemType;
 }
 
-export const GroupName: React.FC<Props> = ({ onDrilldown, group, isChild, options }) => {
+export const GroupName: React.FC<Props> = ({ onDrilldown, group, isChild, options, nodeType }) => {
   const [a11yAnnouncement, setA11yAnnouncement] = useState('');
 
   const handleClick = useCallback(
@@ -69,11 +71,14 @@ export const GroupName: React.FC<Props> = ({ onDrilldown, group, isChild, option
           <Name>
             <EuiToolTip position="top" content={group.name}>
               <EuiButtonEmpty
-                aria-label={i18n.translate('xpack.infra.inventory.groupBySelectorButtonLabel', {
-                  defaultMessage: 'Group by {group}',
-                  values: { group: group.name },
-                })}
-                style={buttonStyle}
+                aria-label={i18n.translate(
+                  'xpack.infra.inventory.groupBySelectorButton.ariaLabel',
+                  {
+                    defaultMessage: 'Group by {group}',
+                    values: { group: group.name },
+                  }
+                )}
+                css={buttonStyle}
                 onClick={handleClick}
                 data-test-subj="groupNameButton"
               >
@@ -81,7 +86,14 @@ export const GroupName: React.FC<Props> = ({ onDrilldown, group, isChild, option
               </EuiButtonEmpty>
             </EuiToolTip>
           </Name>
-          <Count>{group.count}</Count>
+          <Count
+            aria-label={i18n.translate('xpack.infra.inventory.groupByCount.ariaLabel', {
+              defaultMessage: '{count} {nodeType} in this group',
+              values: { nodeType, count: group.count },
+            })}
+          >
+            {group.count}
+          </Count>
         </Inner>
       </GroupNameContainer>
     </>

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/group_of_groups.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/group_of_groups.tsx
@@ -31,7 +31,12 @@ interface Props {
 export const GroupOfGroups: React.FC<Props> = (props) => {
   return (
     <GroupOfGroupsContainer>
-      <GroupName group={props.group} onDrilldown={props.onDrilldown} options={props.options} />
+      <GroupName
+        group={props.group}
+        onDrilldown={props.onDrilldown}
+        options={props.options}
+        nodeType={props.nodeType}
+      />
       <Groups>
         {props.group.groups.map((group) => (
           <GroupOfNodes

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/group_of_nodes.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/waffle/group_of_nodes.tsx
@@ -60,7 +60,13 @@ export const GroupOfNodes = React.memo<Props>(
 
     return (
       <GroupOfNodesContainer style={{ width }}>
-        <GroupName group={group} onDrilldown={onDrilldown} isChild={isChild} options={options} />
+        <GroupName
+          group={group}
+          onDrilldown={onDrilldown}
+          isChild={isChild}
+          options={options}
+          nodeType={nodeType}
+        />
         <Nodes>
           {group.width ? (
             group.nodes.map((node) => (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ObsUX][A11y] Add aria-label to group by count (#217302)](https://github.com/elastic/kibana/pull/217302)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miriam","email":"31922082+MiriamAparicio@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-07T13:42:12Z","message":"[ObsUX][A11y] Add aria-label to group by count (#217302)\n\nCloses https://github.com/elastic/kibana/issues/194974\n\n### What was done\n\n- for the `All` button a description and spell out was done in\nhttps://github.com/elastic/kibana/pull/216592\n- added aria-label to count number so it spells out the number of type\nof node\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 26 32\"\nsrc=\"https://github.com/user-attachments/assets/7b0e814f-7713-4a6c-9b6c-2a45bb9b28c5\"\n/>\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 26 15\"\nsrc=\"https://github.com/user-attachments/assets/33ca56d4-09e6-4b5a-be36-7771b1467272\"\n/>\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 25 51\"\nsrc=\"https://github.com/user-attachments/assets/2c8bcf14-6308-4c22-a76a-b8313f2f580e\"\n/>\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 24 47\"\nsrc=\"https://github.com/user-attachments/assets/10497f74-77ba-48a9-ac2d-d3cbdcbeb609\"\n/>","sha":"340c86e5d4b1d48589c62fb5b1fc3a1acc9a5572","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:obs-ux-infra_services","backport:version","v8.18.0","v9.1.0","v8.19.0"],"title":"[ObsUX][A11y] Add aria-label to group by count","number":217302,"url":"https://github.com/elastic/kibana/pull/217302","mergeCommit":{"message":"[ObsUX][A11y] Add aria-label to group by count (#217302)\n\nCloses https://github.com/elastic/kibana/issues/194974\n\n### What was done\n\n- for the `All` button a description and spell out was done in\nhttps://github.com/elastic/kibana/pull/216592\n- added aria-label to count number so it spells out the number of type\nof node\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 26 32\"\nsrc=\"https://github.com/user-attachments/assets/7b0e814f-7713-4a6c-9b6c-2a45bb9b28c5\"\n/>\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 26 15\"\nsrc=\"https://github.com/user-attachments/assets/33ca56d4-09e6-4b5a-be36-7771b1467272\"\n/>\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 25 51\"\nsrc=\"https://github.com/user-attachments/assets/2c8bcf14-6308-4c22-a76a-b8313f2f580e\"\n/>\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 24 47\"\nsrc=\"https://github.com/user-attachments/assets/10497f74-77ba-48a9-ac2d-d3cbdcbeb609\"\n/>","sha":"340c86e5d4b1d48589c62fb5b1fc3a1acc9a5572"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217328","number":217328,"state":"MERGED","mergeCommit":{"sha":"7fb23f119491bb83b61773c4621c1f380ac3f90f","message":"[9.0] [ObsUX][A11y] Add aria-label to group by count (#217302) (#217328)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[ObsUX][A11y] Add aria-label to group by count\n(#217302)](https://github.com/elastic/kibana/pull/217302)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Miriam <31922082+MiriamAparicio@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217302","number":217302,"mergeCommit":{"message":"[ObsUX][A11y] Add aria-label to group by count (#217302)\n\nCloses https://github.com/elastic/kibana/issues/194974\n\n### What was done\n\n- for the `All` button a description and spell out was done in\nhttps://github.com/elastic/kibana/pull/216592\n- added aria-label to count number so it spells out the number of type\nof node\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 26 32\"\nsrc=\"https://github.com/user-attachments/assets/7b0e814f-7713-4a6c-9b6c-2a45bb9b28c5\"\n/>\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 26 15\"\nsrc=\"https://github.com/user-attachments/assets/33ca56d4-09e6-4b5a-be36-7771b1467272\"\n/>\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 25 51\"\nsrc=\"https://github.com/user-attachments/assets/2c8bcf14-6308-4c22-a76a-b8313f2f580e\"\n/>\n<img width=\"460\" alt=\"Screenshot 2025-04-07 at 11 24 47\"\nsrc=\"https://github.com/user-attachments/assets/10497f74-77ba-48a9-ac2d-d3cbdcbeb609\"\n/>","sha":"340c86e5d4b1d48589c62fb5b1fc3a1acc9a5572"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->