### PR TITLE
[ftr] split oblt DA configs to speedup CI

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -30,4 +30,7 @@ enabled:
   - x-pack/test_serverless/functional/test_suites/observability/config.telemetry.ts
   # serverless config files that run deployment-agnostic tests
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts
+  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts
+  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts
+  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Serverless Observability - Deployment-agnostic APM API integration tests', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../../apis/observability/ai_assistant'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerlessTestConfig } from '../../default_configs/serverless.config.base';
+
+export default createServerlessTestConfig({
+  serverlessProject: 'oblt',
+  testFiles: [require.resolve('./oblt.ai_assistant.index.ts')],
+  junit: {
+    reportName: 'Serverless Observability - Deployment-agnostic API Integration Tests',
+  },
+});

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.index.ts
@@ -10,7 +10,8 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
   describe('Serverless Observability - Deployment-agnostic API integration tests', function () {
     this.tags(['esGate']);
 
-    // load new oblt (except APM) and platform deployment-agnostic test here
+    // load new oblt and platform deployment-agnostic test here
+    // Note: if your tests runtime is over 5 minutes, create a new index and config file
     loadTestFile(require.resolve('../../apis/console'));
     loadTestFile(require.resolve('../../apis/core'));
     loadTestFile(require.resolve('../../apis/management'));
@@ -20,9 +21,6 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('../../apis/painless_lab'));
     loadTestFile(require.resolve('../../apis/saved_objects_management'));
     loadTestFile(require.resolve('../../apis/observability/slo'));
-    loadTestFile(require.resolve('../../apis/observability/synthetics'));
-    loadTestFile(require.resolve('../../apis/observability/ai_assistant'));
-    loadTestFile(require.resolve('../../apis/observability/streams'));
     loadTestFile(require.resolve('../../apis/observability/onboarding'));
     loadTestFile(require.resolve('../../apis/observability/incident_management'));
   });

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Serverless Observability - Deployment-agnostic APM API integration tests', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../../apis/observability/streams'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerlessTestConfig } from '../../default_configs/serverless.config.base';
+
+export default createServerlessTestConfig({
+  serverlessProject: 'oblt',
+  testFiles: [require.resolve('./oblt.streams.index.ts')],
+  junit: {
+    reportName: 'Serverless Observability - Deployment-agnostic API Integration Tests',
+  },
+});

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Serverless Observability - Deployment-agnostic APM API integration tests', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../../apis/observability/synthetics'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerlessTestConfig } from '../../default_configs/serverless.config.base';
+
+export default createServerlessTestConfig({
+  serverlessProject: 'oblt',
+  testFiles: [require.resolve('./oblt.synthetics.index.ts')],
+  junit: {
+    reportName: 'Serverless Observability - Deployment-agnostic API Integration Tests',
+  },
+});


### PR DESCRIPTION
## Summary

Splitting the following config:

- x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts **~61 min**

by moving `ai_assistant`, `synthetics` and `streams` tests in its own configs

  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts ~11m 30s
  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts ~21m 30s
  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts ~21m 43s

original config with less tests:
 - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts ~17 min



<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->