### PR TITLE
[Streams] Data ingestion tooltip

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ingestion_rate.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ingestion_rate.tsx
@@ -17,8 +17,9 @@ import {
   EuiLoadingChart,
   EuiPanel,
   EuiSpacer,
-  EuiText,
   useEuiTheme,
+  EuiIconTip,
+  EuiText,
 } from '@elastic/eui';
 import {
   AreaSeries,
@@ -60,11 +61,22 @@ export function IngestionRate({
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem grow={3}>
             <EuiText>
-              <h5>
+                <h5>
                 {i18n.translate('xpack.streams.streamDetailLifecycle.ingestionRatePanel', {
                   defaultMessage: 'Ingestion rate',
                 })}
-              </h5>
+                <EuiIconTip
+                  content={i18n.translate(
+                  'xpack.streams.streamDetailLifecycle.ingestionRatePanelTooltip',
+                  {
+                    defaultMessage:
+                    'Approximate average. Interval adjusts dynamically based on the time range. Calculated using the average document size in the stream, multiplied with the number of documents in the time bucket.',
+                  }
+                  )}
+                  position="right"
+                />
+                </h5>
+              
             </EuiText>
           </EuiFlexItem>
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ingestion_rate.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ingestion_rate.tsx
@@ -60,24 +60,25 @@ export function IngestionRate({
       <EuiPanel hasShadow={false} hasBorder={false} paddingSize="s">
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem grow={3}>
-            <EuiText>
+            <EuiFlexGroup gutterSize="xs" alignItems="center">
+              <EuiText>
                 <h5>
-                {i18n.translate('xpack.streams.streamDetailLifecycle.ingestionRatePanel', {
-                  defaultMessage: 'Ingestion rate',
-                })}
-                <EuiIconTip
-                  content={i18n.translate(
+                  {i18n.translate('xpack.streams.streamDetailLifecycle.ingestionRatePanel', {
+                    defaultMessage: 'Ingestion rate',
+                  })}
+                </h5>
+              </EuiText>
+              <EuiIconTip
+                content={i18n.translate(
                   'xpack.streams.streamDetailLifecycle.ingestionRatePanelTooltip',
                   {
                     defaultMessage:
-                    'Approximate average. Interval adjusts dynamically based on the time range. Calculated using the average document size in the stream, multiplied with the number of documents in the time bucket.',
+                      'Approximate average. Interval adjusts dynamically based on the time range. Calculated using the average document size in the stream, multiplied with the number of documents in the time bucket.',
                   }
-                  )}
-                  position="right"
-                />
-                </h5>
-              
-            </EuiText>
+                )}
+                position="right"
+              />
+            </EuiFlexGroup>
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/metadata.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/metadata.tsx
@@ -175,7 +175,7 @@ export function RetentionMetadata({
         })}
         tip={i18n.translate('xpack.streams.streamDetailLifecycle.ingestionRateDetails', {
           defaultMessage:
-            'Estimated average (stream total size divided by the number of days since creation).',
+            'Approximate average (stream total size divided by the number of days since creation).',
         })}
         value={
           statsError ? (

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/components/stream_stats_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/components/stream_stats_panel.tsx
@@ -144,7 +144,7 @@ export function StreamStatsPanel({ definition }: StreamStatsPanelProps) {
                       'xpack.streams.streamDetailLifecycle.ingestionRateDetails',
                       {
                         defaultMessage:
-                          'Estimated average (stream total size divided by the number of days since creation).',
+                          'Approximate average (stream total size divided by the number of days since creation).',
                       }
                     )}
                     position="right"


### PR DESCRIPTION
Adds a tooltip to the histogram, and adjusts the wording of the other ingestion tooltips slightly

Before:
![CleanShot 2025-04-08 at 10 26 28@2x](https://github.com/user-attachments/assets/49d9c242-9a3f-42a4-a787-c3a1f3da6b51)
After:
![CleanShot 2025-04-08 at 10 22 33@2x](https://github.com/user-attachments/assets/a816be12-0d06-4184-9803-8b161932dc95)


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->