### PR TITLE
[9.0] [HCM] High contrast mode style adjustments (#216964)

### DIFF
--- a/src/platform/packages/shared/kbn-search-api-panels/components/overview_panel.tsx
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/overview_panel.tsx
@@ -45,7 +45,7 @@ export const OverviewPanel: FC<PropsWithChildren<OverviewPanelProps>> = ({
       <EuiFlexGroup alignItems="flexStart" gutterSize="xl">
         {leftPanelContent && <EuiFlexItem grow={6}>{leftPanelContent}</EuiFlexItem>}
         <EuiFlexItem grow={4}>
-          <EuiPanel paddingSize="none" color="subdued" {...overviewPanelProps}>
+          <EuiPanel paddingSize="none" color="transparent" {...overviewPanelProps}>
             <EuiTitle size="s">
               <h2>{title}</h2>
             </EuiTitle>

--- a/src/platform/packages/shared/kbn-search-api-panels/components/select_client.scss
+++ b/src/platform/packages/shared/kbn-search-api-panels/components/select_client.scss
@@ -1,6 +1,6 @@
-.serverlessSearchSelectClientPanelSelectedBorder {
+.serverlessSearchSelectClientPanelSelectedBorder::before {
   border: 1px solid $euiColorPrimary;
 }
-.serverlessSearchSelectClientPanelBorder {
+.serverlessSearchSelectClientPanelBorder::before {
   border: 1px solid $euiColorLightShade;
 }

--- a/src/platform/plugins/shared/unified_histogram/public/chart/toolbar_selector.tsx
+++ b/src/platform/plugins/shared/unified_histogram/public/chart/toolbar_selector.tsx
@@ -175,7 +175,12 @@ export const ToolbarSelector: React.FC<ToolbarSelectorProps> = ({
         {(list, search) => (
           <>
             {search && (
-              <EuiPanel paddingSize="s" hasShadow={false} css={{ paddingBottom: 0 }}>
+              <EuiPanel
+                color="transparent"
+                paddingSize="s"
+                hasShadow={false}
+                css={{ paddingBottom: 0 }}
+              >
                 {search}
               </EuiPanel>
             )}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/sections/empty/empty_sections.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/overview/components/sections/empty/empty_sections.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlexGrid, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGrid, EuiFlexItem, EuiSpacer, useEuiTheme } from '@elastic/eui';
 import React, { useContext } from 'react';
 import { ThemeContext } from 'styled-components';
 import { i18n } from '@kbn/i18n';
@@ -25,6 +25,7 @@ export function EmptySections() {
     ?.useUrl({ category: 'metrics' });
   const theme = useContext(ThemeContext);
   const { hasDataMap } = useHasData();
+  const { euiTheme } = useEuiTheme();
 
   const appEmptySections = getEmptySections({ http, onboardingMetricsHref }).filter(({ id }) => {
     const app = hasDataMap[id];
@@ -49,6 +50,7 @@ export function EmptySections() {
               key={app.id}
               style={{
                 border: `${theme.eui.euiBorderEditable}`,
+                borderColor: euiTheme.border.color,
                 borderRadius: `${theme.eui.euiBorderRadius}`,
               }}
             >

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/semantic_search/components/semantic_search_guide/semantic_search_guide.scss
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/semantic_search/components/semantic_search_guide/semantic_search_guide.scss
@@ -1,6 +1,6 @@
-.chooseEmbeddingModelSelectedBorder {
+.chooseEmbeddingModelSelectedBorder::before {
   border: 1px solid $euiColorPrimary;
 }
-.chooseEmbeddingModelBorder {
+.chooseEmbeddingModelBorder::before {
   border: 1px solid $euiColorLightShade;
 }

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/getting_started/getting_started.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/shared/getting_started/getting_started.tsx
@@ -75,7 +75,7 @@ export const GettingStarted: React.FC<GettingStartedProps> = ({
           kibanaRunApiInConsole: docLinks.consoleGuide,
         }}
         isPanelLeft={isPanelLeft}
-        overviewPanelProps={{ color: 'plain', hasShadow: false }}
+        overviewPanelProps={{ hasShadow: false }}
         application={services.application}
         sharePlugin={services.share}
         consolePlugin={services.console}
@@ -101,7 +101,7 @@ export const GettingStarted: React.FC<GettingStartedProps> = ({
         application={services.application}
         sharePlugin={services.share}
         isPanelLeft={isPanelLeft}
-        overviewPanelProps={{ color: 'plain', hasShadow: false }}
+        overviewPanelProps={{ hasShadow: false }}
       />
 
       <OverviewPanel
@@ -129,14 +129,14 @@ export const GettingStarted: React.FC<GettingStartedProps> = ({
             defaultMessage: 'Generate an API key',
           }
         )}
-        overviewPanelProps={{ color: 'plain', hasShadow: false }}
+        overviewPanelProps={{ hasShadow: false }}
       />
 
       <CloudDetailsPanel
         cloudId={codeArgs.cloudId}
         elasticsearchUrl={codeArgs.url}
         isPanelLeft={isPanelLeft}
-        overviewPanelProps={{ color: 'plain', hasShadow: false }}
+        overviewPanelProps={{ hasShadow: false }}
       />
 
       <OverviewPanel
@@ -173,7 +173,7 @@ export const GettingStarted: React.FC<GettingStartedProps> = ({
             defaultMessage: 'Configure your client',
           }
         )}
-        overviewPanelProps={{ color: 'plain', hasShadow: false }}
+        overviewPanelProps={{ hasShadow: false }}
       />
 
       <OverviewPanel
@@ -211,7 +211,7 @@ export const GettingStarted: React.FC<GettingStartedProps> = ({
             defaultMessage: 'Test your connection',
           }
         )}
-        overviewPanelProps={{ color: 'plain', hasShadow: false }}
+        overviewPanelProps={{ hasShadow: false }}
       />
       <OverviewPanel
         description={i18n.translate(
@@ -244,7 +244,7 @@ export const GettingStarted: React.FC<GettingStartedProps> = ({
         title={i18n.translate('xpack.enterpriseSearch.overview.gettingStarted.ingestData.title', {
           defaultMessage: 'Ingest Data',
         })}
-        overviewPanelProps={{ color: 'plain', hasShadow: false }}
+        overviewPanelProps={{ hasShadow: false }}
       />
 
       <OverviewPanel
@@ -279,7 +279,7 @@ export const GettingStarted: React.FC<GettingStartedProps> = ({
         title={i18n.translate('xpack.enterpriseSearch.overview.gettingStarted.searchQuery.title', {
           defaultMessage: 'Build your first search query',
         })}
-        overviewPanelProps={{ color: 'plain', hasShadow: false }}
+        overviewPanelProps={{ hasShadow: false }}
       />
       {showPipelinesPanel && (
         <OverviewPanel
@@ -326,7 +326,7 @@ export const GettingStarted: React.FC<GettingStartedProps> = ({
           }
           leftPanelContent={<GettingStartedPipelinePanel />}
           links={[]}
-          overviewPanelProps={{ color: 'plain', hasShadow: false }}
+          overviewPanelProps={{ hasShadow: false }}
           title={i18n.translate('xpack.enterpriseSearch.pipeline.title', {
             defaultMessage: 'Transform and enrich your data',
           })}

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/card_content_panel.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/common/card_content_panel.tsx
@@ -16,8 +16,20 @@ export const OnboardingCardContentPanel = React.memo<PropsWithChildren<EuiPanelP
     const nestedClassName = classnames(NESTED_PANEL_CLASS_NAME, className);
 
     return (
-      <EuiPanel paddingSize="m" hasShadow={false} hasBorder={false} className={panelClassName}>
-        <EuiPanel hasShadow={false} paddingSize="l" {...panelProps} className={nestedClassName}>
+      <EuiPanel
+        color="transparent"
+        paddingSize="m"
+        hasShadow={false}
+        hasBorder={false}
+        className={panelClassName}
+      >
+        <EuiPanel
+          color="transparent"
+          hasShadow={false}
+          paddingSize="l"
+          {...panelProps}
+          className={nestedClassName}
+        >
           {children}
         </EuiPanel>
       </EuiPanel>

--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/siem_migrations/start_migration/missing_ai_connector_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/components/onboarding_body/cards/siem_migrations/start_migration/missing_ai_connector_callout.tsx
@@ -16,7 +16,7 @@ interface MissingAIConnectorCalloutProps {
 
 export const MissingAIConnectorCallout = React.memo<MissingAIConnectorCalloutProps>(
   ({ onExpandAiConnectorsCard }) => (
-    <EuiPanel hasShadow={false} paddingSize="none">
+    <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
       <CardCallOut
         color="warning"
         text={i18n.START_MIGRATION_CARD_CONNECTOR_MISSING_TEXT}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[HCM] High contrast mode style adjustments (#216964)](https://github.com/elastic/kibana/pull/216964)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lene Gadewoll","email":"lene.gadewoll@elastic.co"},"sourceCommit":{"committedDate":"2025-04-08T08:39:07Z","message":"[HCM] High contrast mode style adjustments (#216964)\n\n## Summary\n\nThis PR adds a couple of style fixes to ensure improved visual output in\nhigh contrast mode.\n\nThe updates focus on borders, mainly removing duplicate borders due to\nnested `EuiPanel` usages and ensuring custom borders are correctly\napplied and receive a high contrast color.\n\n### Changes\n\n| Solution | Before | After |\n|--------|-----|-----|\n| discover | ![Screenshot 2025-04-03 at 09 48\n20](https://github.com/user-attachments/assets/068c5dc7-be38-482a-9b60-74ec15ec0c69)\n| ![Screenshot 2025-04-03 at 09 50\n45](https://github.com/user-attachments/assets/3e06c775-6c4f-481f-9186-334803ee0f3b)\n|\n| dashboard | ![Screenshot 2025-04-03 at 09 32\n56](https://github.com/user-attachments/assets/ca4cda9d-5607-4aff-9485-b9e5a864322f)\n| ![Screenshot 2025-04-03 at 09 31\n44](https://github.com/user-attachments/assets/0324d367-f86e-440b-950a-a4debd77962c)\n|\n| dashboard | ![Screenshot 2025-04-03 at 09 33\n07](https://github.com/user-attachments/assets/3aac0640-1d34-4f03-8d47-32253d6f7092)\n| ![Screenshot 2025-04-03 at 09 33\n37](https://github.com/user-attachments/assets/9679e008-9aac-441c-ae0c-5d713eb83a61)\n|\n| elasticsearch | ![Screenshot 2025-04-03 at 09 40\n26](https://github.com/user-attachments/assets/ced77757-086a-4dc6-ab9d-4befcd543177)\n| ![Screenshot 2025-04-03 at 09 41\n36](https://github.com/user-attachments/assets/39f51db1-fb0b-4231-9d58-cd3100e1f7f8)\n|\n| observability | ![Screenshot 2025-04-03 at 09 47\n40](https://github.com/user-attachments/assets/568c9c60-63ea-4ffa-9155-26bd160600c5)\n| ![Screenshot 2025-04-03 at 09 47\n55](https://github.com/user-attachments/assets/be036721-fccc-4514-b7b0-67340087b020)\n|\n| security | ![Screenshot 2025-04-03 at 09 31\n01](https://github.com/user-attachments/assets/01b24035-54bc-4471-a5b8-df3446fbc230)\n| ![Screenshot 2025-04-03 at 09 30\n46](https://github.com/user-attachments/assets/fbb3ac03-50fe-4ecc-aaeb-e0dfecabc566)\n|\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0f4361d05d532654fb287941f76027e5a4a3c8b0","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","EUI","v9.0.0","backport:prev-minor","ci:cloud-deploy","Team:obs-ux-management","v9.1.0"],"title":"[HCM] High contrast mode style adjustments","number":216964,"url":"https://github.com/elastic/kibana/pull/216964","mergeCommit":{"message":"[HCM] High contrast mode style adjustments (#216964)\n\n## Summary\n\nThis PR adds a couple of style fixes to ensure improved visual output in\nhigh contrast mode.\n\nThe updates focus on borders, mainly removing duplicate borders due to\nnested `EuiPanel` usages and ensuring custom borders are correctly\napplied and receive a high contrast color.\n\n### Changes\n\n| Solution | Before | After |\n|--------|-----|-----|\n| discover | ![Screenshot 2025-04-03 at 09 48\n20](https://github.com/user-attachments/assets/068c5dc7-be38-482a-9b60-74ec15ec0c69)\n| ![Screenshot 2025-04-03 at 09 50\n45](https://github.com/user-attachments/assets/3e06c775-6c4f-481f-9186-334803ee0f3b)\n|\n| dashboard | ![Screenshot 2025-04-03 at 09 32\n56](https://github.com/user-attachments/assets/ca4cda9d-5607-4aff-9485-b9e5a864322f)\n| ![Screenshot 2025-04-03 at 09 31\n44](https://github.com/user-attachments/assets/0324d367-f86e-440b-950a-a4debd77962c)\n|\n| dashboard | ![Screenshot 2025-04-03 at 09 33\n07](https://github.com/user-attachments/assets/3aac0640-1d34-4f03-8d47-32253d6f7092)\n| ![Screenshot 2025-04-03 at 09 33\n37](https://github.com/user-attachments/assets/9679e008-9aac-441c-ae0c-5d713eb83a61)\n|\n| elasticsearch | ![Screenshot 2025-04-03 at 09 40\n26](https://github.com/user-attachments/assets/ced77757-086a-4dc6-ab9d-4befcd543177)\n| ![Screenshot 2025-04-03 at 09 41\n36](https://github.com/user-attachments/assets/39f51db1-fb0b-4231-9d58-cd3100e1f7f8)\n|\n| observability | ![Screenshot 2025-04-03 at 09 47\n40](https://github.com/user-attachments/assets/568c9c60-63ea-4ffa-9155-26bd160600c5)\n| ![Screenshot 2025-04-03 at 09 47\n55](https://github.com/user-attachments/assets/be036721-fccc-4514-b7b0-67340087b020)\n|\n| security | ![Screenshot 2025-04-03 at 09 31\n01](https://github.com/user-attachments/assets/01b24035-54bc-4471-a5b8-df3446fbc230)\n| ![Screenshot 2025-04-03 at 09 30\n46](https://github.com/user-attachments/assets/fbb3ac03-50fe-4ecc-aaeb-e0dfecabc566)\n|\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0f4361d05d532654fb287941f76027e5a4a3c8b0"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216964","number":216964,"mergeCommit":{"message":"[HCM] High contrast mode style adjustments (#216964)\n\n## Summary\n\nThis PR adds a couple of style fixes to ensure improved visual output in\nhigh contrast mode.\n\nThe updates focus on borders, mainly removing duplicate borders due to\nnested `EuiPanel` usages and ensuring custom borders are correctly\napplied and receive a high contrast color.\n\n### Changes\n\n| Solution | Before | After |\n|--------|-----|-----|\n| discover | ![Screenshot 2025-04-03 at 09 48\n20](https://github.com/user-attachments/assets/068c5dc7-be38-482a-9b60-74ec15ec0c69)\n| ![Screenshot 2025-04-03 at 09 50\n45](https://github.com/user-attachments/assets/3e06c775-6c4f-481f-9186-334803ee0f3b)\n|\n| dashboard | ![Screenshot 2025-04-03 at 09 32\n56](https://github.com/user-attachments/assets/ca4cda9d-5607-4aff-9485-b9e5a864322f)\n| ![Screenshot 2025-04-03 at 09 31\n44](https://github.com/user-attachments/assets/0324d367-f86e-440b-950a-a4debd77962c)\n|\n| dashboard | ![Screenshot 2025-04-03 at 09 33\n07](https://github.com/user-attachments/assets/3aac0640-1d34-4f03-8d47-32253d6f7092)\n| ![Screenshot 2025-04-03 at 09 33\n37](https://github.com/user-attachments/assets/9679e008-9aac-441c-ae0c-5d713eb83a61)\n|\n| elasticsearch | ![Screenshot 2025-04-03 at 09 40\n26](https://github.com/user-attachments/assets/ced77757-086a-4dc6-ab9d-4befcd543177)\n| ![Screenshot 2025-04-03 at 09 41\n36](https://github.com/user-attachments/assets/39f51db1-fb0b-4231-9d58-cd3100e1f7f8)\n|\n| observability | ![Screenshot 2025-04-03 at 09 47\n40](https://github.com/user-attachments/assets/568c9c60-63ea-4ffa-9155-26bd160600c5)\n| ![Screenshot 2025-04-03 at 09 47\n55](https://github.com/user-attachments/assets/be036721-fccc-4514-b7b0-67340087b020)\n|\n| security | ![Screenshot 2025-04-03 at 09 31\n01](https://github.com/user-attachments/assets/01b24035-54bc-4471-a5b8-df3446fbc230)\n| ![Screenshot 2025-04-03 at 09 30\n46](https://github.com/user-attachments/assets/fbb3ac03-50fe-4ecc-aaeb-e0dfecabc566)\n|\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"0f4361d05d532654fb287941f76027e5a4a3c8b0"}},{"url":"https://github.com/elastic/kibana/pull/217455","number":217455,"branch":"8.x","state":"OPEN"}]}] BACKPORT-->