### PR TITLE
Upgrade EUI to v101.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@elastic/ecs": "^8.11.5",
     "@elastic/elasticsearch": "9.0.0-alpha.4",
     "@elastic/ems-client": "8.6.3",
-    "@elastic/eui": "101.2.0",
+    "@elastic/eui": "101.3.0",
     "@elastic/eui-theme-borealis": "0.1.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "^1.2.3",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -88,7 +88,7 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.6.3': ['Elastic License 2.0'],
-  '@elastic/eui@101.2.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
+  '@elastic/eui@101.3.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   '@elastic/eui-theme-borealis@0.1.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
   'buffers@0.1.1': ['MIT'], // license in importing module https://www.npmjs.com/package/binary

--- a/src/platform/packages/shared/shared-ux/page/kibana_template/impl/src/__snapshots__/page_template.test.tsx.snap
+++ b/src/platform/packages/shared/shared-ux/page/kibana_template/impl/src/__snapshots__/page_template.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`KibanaPageTemplate render basic template 1`] = `
             </div>
           </div>
           <div
-            class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+            class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
           >
             <div
               class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"

--- a/src/platform/plugins/shared/saved_objects_management/public/management_section/object_view/components/__snapshots__/header.test.tsx.snap
+++ b/src/platform/plugins/shared/saved_objects_management/public/management_section/object_view/components/__snapshots__/header.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Intro component renders correctly 1`] = `
         </h1>
       </div>
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/src/list_header/__snapshots__/list_header.test.tsx.snap
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/src/list_header/__snapshots__/list_header.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`ExceptionListHeader should render edit modal 1`] = `
             </div>
           </div>
           <div
-            class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+            class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
           >
             <div
               class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -366,7 +366,7 @@ exports[`ExceptionListHeader should render the List Header with name, default de
             </div>
           </div>
           <div
-            class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+            class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
           >
             <div
               class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -558,7 +558,7 @@ exports[`ExceptionListHeader should render the List Header with name, default de
             </div>
           </div>
           <div
-            class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+            class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
           >
             <div
               class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -751,7 +751,7 @@ exports[`ExceptionListHeader should render the List Header with name, default de
             </div>
           </div>
           <div
-            class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+            class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
           >
             <div
               class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,10 +2181,10 @@
     chroma-js "^2.4.2"
     lodash "^4.17.21"
 
-"@elastic/eui@101.2.0":
-  version "101.2.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-101.2.0.tgz#d3cd36f37ef0246c1b54303c007c6b9bfafb1c5a"
-  integrity sha512-wRcTECIMLYC04NqV8Wl+89YNCaC8wm3qycUtnkiiIBvJMrSLvbIPJeNIQyEuippA6bgExIsUVLCFHv7fgSkDgg==
+"@elastic/eui@101.3.0":
+  version "101.3.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-101.3.0.tgz#17bb2d0ead708f46a0518c97972f742555694417"
+  integrity sha512-59WT6+qTo43qYw7o9phZpD5OhZNicZ3oYRZcYMp6ro+M59asZAbTzaDZMouh+KghnVqKNevCiOIDpu7gMIJoAA==
   dependencies:
     "@elastic/eui-theme-common" "0.1.0"
     "@elastic/prismjs-esql" "^1.0.0"


### PR DESCRIPTION
`101.2.0` ⏩ `101.3.0`

[Questions? Please see our Kibana upgrade FAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)

## Package updates

### `@elastic/eui`

#### [`v101.3.0`](https://github.com/elastic/eui/releases/v101.3.0)

- Updated 78 existing and added two new glyphs (`code` and `checkCircle`) for `EuiIcon` ([#8530](https://github.com/elastic/eui/pull/8530))
- Changed `gutterSize` to `m` between right side items on `EuiPageHeader` ([#8529](https://github.com/elastic/eui/pull/8529))

**Bug fixes**

- Fixed a visual bug on disabled `EuiButton` in high contrast mode where wrong text colors were applied ([#8550](https://github.com/elastic/eui/pull/8550))

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->