### PR TITLE
[8.18] [Oblt Onboarding][Auto Detect] Filter out httpjson inputs and fix accidental config backup file (#216978)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/assets/auto_detect.sh
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/assets/auto_detect.sh
@@ -310,9 +310,14 @@ apply_elastic_agent_config() {
     # Remove existing config file including `inputs.d` directory
     rm -rf "$elastic_agent_config_path" "$(dirname "$elastic_agent_config_path")/inputs.d" &&
     # Extract new config files from downloaded archive
-    tar --extract --file "$elastic_agent_tmp_config_path" --directory "$(dirname "$elastic_agent_config_path")" &&
+    tar --extract --file "$elastic_agent_tmp_config_path" --directory "$(dirname "$elastic_agent_config_path")"
     # Replace placeholder with the Ingest API key
-    sed -i='' "s/\${API_KEY}/$decoded_ingest_api_key/" "$elastic_agent_config_path"
+    if [ "${OS}" == "Linux" ]; then
+      sed -i "s/\${API_KEY}/$decoded_ingest_api_key/" "$elastic_agent_config_path"
+    else
+      # macOS requires an empty string for the backup extension
+      sed -i '' "s/\${API_KEY}/$decoded_ingest_api_key/" "$elastic_agent_config_path"
+    fi
   if [ "$?" -eq 0 ]; then
     printf "\e[32;1m✓\e[0m %s\n" "Config files written to:"
     while IFS= read -r file; do

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
@@ -12,7 +12,7 @@ import {
   FleetUnauthorizedError,
   type PackageClient,
 } from '@kbn/fleet-plugin/server';
-import { load, dump } from 'js-yaml';
+import { safeLoad, safeDump } from 'js-yaml';
 import { PackageDataStreamTypes, Output } from '@kbn/fleet-plugin/common/types';
 import { transformOutputToFullPolicyOutput } from '@kbn/fleet-plugin/server/services/output_client';
 import { OBSERVABILITY_ONBOARDING_TELEMETRY_EVENT } from '../../../common/telemetry_events';
@@ -482,7 +482,7 @@ async function ensureInstalledIntegrations(
         pkgName,
         pkgVersion: '1.0.0', // Custom integrations are always installed as version `1.0.0`
         title: pkgName,
-        config: dump({
+        config: safeDump({
           inputs: [
             {
               id: `filestream-${pkgName}`,
@@ -529,13 +529,13 @@ async function ensureInstalledIntegrations(
 }
 
 function filterUnsupportedInputs(policyYML: string): string {
-  const policy = load(policyYML);
+  const policy = safeLoad(policyYML);
 
   if (!policy) {
     return policyYML;
   }
 
-  return dump({
+  return safeDump({
     ...policy,
     inputs: (policy.inputs || []).filter((input: any) => {
       return input.type !== 'httpjson';
@@ -623,7 +623,7 @@ function generateAgentConfigTar(output: Output, installedIntegrations: Installed
       path: 'elastic-agent.yml',
       mode: 0o644,
       mtime: now,
-      data: dump({
+      data: safeDump({
         outputs: {
           default: transformOutputToFullPolicyOutput(output, undefined, true),
         },

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
@@ -12,7 +12,7 @@ import {
   FleetUnauthorizedError,
   type PackageClient,
 } from '@kbn/fleet-plugin/server';
-import { safeDump } from 'js-yaml';
+import { load, dump } from 'js-yaml';
 import { PackageDataStreamTypes, Output } from '@kbn/fleet-plugin/common/types';
 import { transformOutputToFullPolicyOutput } from '@kbn/fleet-plugin/server/services/output_client';
 import { OBSERVABILITY_ONBOARDING_TELEMETRY_EVENT } from '../../../common/telemetry_events';
@@ -454,7 +454,10 @@ async function ensureInstalledIntegrations(
       if (installSource === 'registry') {
         const installation = await packageClient.ensureInstalledPackage({ pkgName });
         const pkg = installation.package;
-        const config = await packageClient.getAgentPolicyConfigYAML(pkg.name, pkg.version);
+        const config = filterUnsupportedInputs(
+          await packageClient.getAgentPolicyConfigYAML(pkg.name, pkg.version)
+        );
+
         const { packageInfo } = await packageClient.getPackage(pkg.name, pkg.version);
 
         return {
@@ -479,7 +482,7 @@ async function ensureInstalledIntegrations(
         pkgName,
         pkgVersion: '1.0.0', // Custom integrations are always installed as version `1.0.0`
         title: pkgName,
-        config: safeDump({
+        config: dump({
           inputs: [
             {
               id: `filestream-${pkgName}`,
@@ -523,6 +526,21 @@ async function ensureInstalledIntegrations(
       }
     })
   );
+}
+
+function filterUnsupportedInputs(policyYML: string): string {
+  const policy = load(policyYML);
+
+  if (!policy) {
+    return policyYML;
+  }
+
+  return dump({
+    ...policy,
+    inputs: (policy.inputs || []).filter((input: any) => {
+      return input.type !== 'httpjson';
+    }),
+  });
 }
 
 /**
@@ -605,7 +623,7 @@ function generateAgentConfigTar(output: Output, installedIntegrations: Installed
       path: 'elastic-agent.yml',
       mode: 0o644,
       mtime: now,
-      data: safeDump({
+      data: dump({
         outputs: {
           default: transformOutputToFullPolicyOutput(output, undefined, true),
         },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Oblt Onboarding][Auto Detect] Filter out httpjson inputs and fix accidental config backup file (#216978)](https://github.com/elastic/kibana/pull/216978)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mykola Harmash","email":"mykola.harmash@gmail.com"},"sourceCommit":{"committedDate":"2025-04-07T13:57:33Z","message":"[Oblt Onboarding][Auto Detect] Filter out httpjson inputs and fix accidental config backup file (#216978)\n\nCloses https://github.com/elastic/kibana/issues/199744\n\n* Adds a separate `sed` commands for Linux and macOS when replacing API\nkey within the Agent config. GNU and BSD versions of `sed` treat `-i`\n(in-place editing) argument differently, GNU version allows `-i` without\na value while BSD version requires a backup file extension even when\nit's empty 🫠\n* Adds filtering of unsupported input types inside the integration\npolicies. For now it only filters out `httpjson`.\n\n## How to test\n1. Go through the auto-detect flow\n2. Make sure there is no `'elastic-agent.yml='` file in the Agent\ndirectory, or any other weird artifacts\n3. Inspect individual integration config files, make sure they don't\nhave `httpjson` inputs\n\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>","sha":"ec72d4a880cc7c396fc0376bb33bdb2821bc6db5","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","ci:project-deploy-observability","Feature: Observability Onboarding","backport:version","v9.1.0","v8.18.1","v9.0.1"],"title":"[Oblt Onboarding][Auto Detect] Filter out httpjson inputs and fix accidental config backup file","number":216978,"url":"https://github.com/elastic/kibana/pull/216978","mergeCommit":{"message":"[Oblt Onboarding][Auto Detect] Filter out httpjson inputs and fix accidental config backup file (#216978)\n\nCloses https://github.com/elastic/kibana/issues/199744\n\n* Adds a separate `sed` commands for Linux and macOS when replacing API\nkey within the Agent config. GNU and BSD versions of `sed` treat `-i`\n(in-place editing) argument differently, GNU version allows `-i` without\na value while BSD version requires a backup file extension even when\nit's empty 🫠\n* Adds filtering of unsupported input types inside the integration\npolicies. For now it only filters out `httpjson`.\n\n## How to test\n1. Go through the auto-detect flow\n2. Make sure there is no `'elastic-agent.yml='` file in the Agent\ndirectory, or any other weird artifacts\n3. Inspect individual integration config files, make sure they don't\nhave `httpjson` inputs\n\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>","sha":"ec72d4a880cc7c396fc0376bb33bdb2821bc6db5"}},"sourceBranch":"main","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217334","number":217334,"state":"MERGED","mergeCommit":{"sha":"5ea5a88198dc9bf1a5d235764596ab3914b328e1","message":"[9.0] [Oblt Onboarding][Auto Detect] Filter out httpjson inputs and fix accidental config backup file (#216978) (#217334)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Oblt Onboarding][Auto Detect] Filter out httpjson inputs and fix\naccidental config backup file\n(#216978)](https://github.com/elastic/kibana/pull/216978)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Mykola Harmash <mykola.harmash@gmail.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216978","number":216978,"mergeCommit":{"message":"[Oblt Onboarding][Auto Detect] Filter out httpjson inputs and fix accidental config backup file (#216978)\n\nCloses https://github.com/elastic/kibana/issues/199744\n\n* Adds a separate `sed` commands for Linux and macOS when replacing API\nkey within the Agent config. GNU and BSD versions of `sed` treat `-i`\n(in-place editing) argument differently, GNU version allows `-i` without\na value while BSD version requires a backup file extension even when\nit's empty 🫠\n* Adds filtering of unsupported input types inside the integration\npolicies. For now it only filters out `httpjson`.\n\n## How to test\n1. Go through the auto-detect flow\n2. Make sure there is no `'elastic-agent.yml='` file in the Agent\ndirectory, or any other weird artifacts\n3. Inspect individual integration config files, make sure they don't\nhave `httpjson` inputs\n\nCo-authored-by: Joe Reuter <johannes.reuter@elastic.co>","sha":"ec72d4a880cc7c396fc0376bb33bdb2821bc6db5"}},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->