### PR TITLE
[8.x] [Dashboard] Remove mSearch from content management (#210709)

### DIFF
--- a/examples/content_management_examples/public/examples/msearch/msearch_table.tsx
+++ b/examples/content_management_examples/public/examples/msearch/msearch_table.tsx
@@ -35,7 +35,6 @@ export const MSearchTable = () => {
       },
       contentTypes: [
         { contentTypeId: 'map' },
-        { contentTypeId: 'dashboard' },
         { contentTypeId: 'visualization' },
         { contentTypeId: 'lens' },
         { contentTypeId: 'search' },

--- a/src/platform/plugins/shared/dashboard/server/content_management/dashboard_storage.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/dashboard_storage.ts
@@ -9,10 +9,7 @@
 
 import Boom from '@hapi/boom';
 import { tagsToFindOptions } from '@kbn/content-management-utils';
-import {
-  SavedObjectsFindOptions,
-  SavedObjectsFindResult,
-} from '@kbn/core-saved-objects-api-server';
+import { SavedObjectsFindOptions } from '@kbn/core-saved-objects-api-server';
 import type { Logger } from '@kbn/logging';
 
 import { CreateResult, DeleteResult, SearchQuery } from '@kbn/content-management-plugin/common';
@@ -68,56 +65,10 @@ export class DashboardStorage {
   }) {
     this.logger = logger;
     this.throwOnResultValidationError = throwOnResultValidationError ?? false;
-    this.mSearch = {
-      savedObjectType: DASHBOARD_SAVED_OBJECT_TYPE,
-      additionalSearchFields: [],
-      toItemResult: (ctx: StorageContext, savedObject: SavedObjectsFindResult): DashboardItem => {
-        const transforms = ctx.utils.getTransforms(cmServicesDefinition);
-
-        const { item, error: itemError } = savedObjectToItem(
-          savedObject as SavedObjectsFindResult<DashboardSavedObjectAttributes>,
-          false
-        );
-        if (itemError) {
-          throw Boom.badRequest(`Invalid response. ${itemError.message}`);
-        }
-
-        const validationError = transforms.mSearch.out.result.validate(item);
-        if (validationError) {
-          if (this.throwOnResultValidationError) {
-            throw Boom.badRequest(`Invalid response. ${validationError.message}`);
-          } else {
-            this.logger.warn(`Invalid response. ${validationError.message}`);
-          }
-        }
-
-        // Validate DB response and DOWN transform to the request version
-        const { value, error: resultError } = transforms.mSearch.out.result.down<
-          DashboardItem,
-          DashboardItem
-        >(
-          item,
-          undefined, // do not override version
-          { validate: false } // validation is done above
-        );
-
-        if (resultError) {
-          throw Boom.badRequest(`Invalid response. ${resultError.message}`);
-        }
-
-        return value;
-      },
-    };
   }
 
   private logger: Logger;
   private throwOnResultValidationError: boolean;
-
-  mSearch: {
-    savedObjectType: string;
-    toItemResult: (ctx: StorageContext, savedObject: SavedObjectsFindResult) => DashboardItem;
-    additionalSearchFields?: string[];
-  };
 
   async get(ctx: StorageContext, id: string): Promise<DashboardGetOut> {
     const transforms = ctx.utils.getTransforms(cmServicesDefinition);

--- a/src/platform/plugins/shared/presentation_util/public/components/dashboard_picker/dashboard_picker.tsx
+++ b/src/platform/plugins/shared/presentation_util/public/components/dashboard_picker/dashboard_picker.tsx
@@ -23,6 +23,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { ToolbarButton } from '@kbn/shared-ux-button-toolbar';
 import { SavedObjectCommon } from '@kbn/saved-objects-finder-plugin/common';
+import type { SearchIn, SearchResult } from '@kbn/content-management-plugin/common';
 
 import { contentManagementService } from '../../services/kibana_services';
 
@@ -73,8 +74,11 @@ export function DashboardPicker({ isDisabled, onChange, idsToOmit }: DashboardPi
     (async () => {
       setIsLoading(true);
 
-      const response = await contentManagementService.client.mSearch<DashboardHit>({
-        contentTypes: [{ contentTypeId: 'dashboard' }],
+      const response = await contentManagementService.client.search<
+        SearchIn<'dashboard'>,
+        SearchResult<DashboardHit>
+      >({
+        contentTypeId: 'dashboard',
         query: {
           text: debouncedQuery ? `${debouncedQuery}*` : undefined,
           limit: 30,

--- a/src/platform/test/examples/content_management/msearch.ts
+++ b/src/platform/test/examples/content_management/msearch.ts
@@ -43,7 +43,6 @@ export default function ({ getService, getPageObjects }: PluginFunctionalProvide
         `kibana_sample_data_flights`,
         `[Flights] Airport Connections (Hover Over Airport)`,
         `[Flights] Departures Count Map`,
-        `[Flights] Global Flight Dashboard`,
         `[Flights] Origin Time Delayed`,
         `[Flights] Flight Log`,
       ];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Dashboard] Remove mSearch from content management (#210709)](https://github.com/elastic/kibana/pull/210709)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Peihl","email":"nick.peihl@elastic.co"},"sourceCommit":{"committedDate":"2025-03-03T16:31:09Z","message":"[Dashboard] Remove mSearch from content management (#210709)\n\n## Summary\n\nRemoves the mSearch method from Dashboard content management.\n\nThe `mSearch` content management method was designed to be a temporary\nimplementation of search that allowed searching multiple saved object\ntypes ([see more\n[internal]](https://docs.google.com/document/d/1ssYmqSEUPrsuCR4iz8DohkEWekoYrm2yL4QR_fVxXLg/edit?tab=t.0#heading=h.6sj4n6bjcgp5)).\nHowever, the mSearch implementation in the Dashboard Storage class lacks\nextensibility as it requires a synchronous `toItemResult` function. As\nwe start migrating reference handling to the server, we will likely need\ntransforms that return Promises (ex. `savedObjectToItem`), such as\n[retrieving tag saved objects from the SavedObjectTagging\nclient](https://github.com/elastic/kibana/issues/210619).\n\nThe Dashboard `mSearch` method was only used by the dashboard_picker and\nthis PR replaces its usage with the `search` method.\n\n### Identify risks\n\nThere is a slight risk in serverless environments where a browser may\nhave already loaded the dashboard_picker module but lags behind the\nserver. In this case, the dashboard picker may fail to retrieve a list\nof dashboards due to it calling the now non-existent `mSearch` method\nprovided by the server. In this case, the user simply needs to refresh\ntheir browser to retrieve the latest UI modules.","sha":"2a7e38b0fc3c33921f5a29f427bc3a6de8809c67","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","release_note:skip","backport:version","v9.1.0","v8.19.0"],"title":"[Dashboard] Remove mSearch from content management","number":210709,"url":"https://github.com/elastic/kibana/pull/210709","mergeCommit":{"message":"[Dashboard] Remove mSearch from content management (#210709)\n\n## Summary\n\nRemoves the mSearch method from Dashboard content management.\n\nThe `mSearch` content management method was designed to be a temporary\nimplementation of search that allowed searching multiple saved object\ntypes ([see more\n[internal]](https://docs.google.com/document/d/1ssYmqSEUPrsuCR4iz8DohkEWekoYrm2yL4QR_fVxXLg/edit?tab=t.0#heading=h.6sj4n6bjcgp5)).\nHowever, the mSearch implementation in the Dashboard Storage class lacks\nextensibility as it requires a synchronous `toItemResult` function. As\nwe start migrating reference handling to the server, we will likely need\ntransforms that return Promises (ex. `savedObjectToItem`), such as\n[retrieving tag saved objects from the SavedObjectTagging\nclient](https://github.com/elastic/kibana/issues/210619).\n\nThe Dashboard `mSearch` method was only used by the dashboard_picker and\nthis PR replaces its usage with the `search` method.\n\n### Identify risks\n\nThere is a slight risk in serverless environments where a browser may\nhave already loaded the dashboard_picker module but lags behind the\nserver. In this case, the dashboard picker may fail to retrieve a list\nof dashboards due to it calling the now non-existent `mSearch` method\nprovided by the server. In this case, the user simply needs to refresh\ntheir browser to retrieve the latest UI modules.","sha":"2a7e38b0fc3c33921f5a29f427bc3a6de8809c67"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210709","number":210709,"mergeCommit":{"message":"[Dashboard] Remove mSearch from content management (#210709)\n\n## Summary\n\nRemoves the mSearch method from Dashboard content management.\n\nThe `mSearch` content management method was designed to be a temporary\nimplementation of search that allowed searching multiple saved object\ntypes ([see more\n[internal]](https://docs.google.com/document/d/1ssYmqSEUPrsuCR4iz8DohkEWekoYrm2yL4QR_fVxXLg/edit?tab=t.0#heading=h.6sj4n6bjcgp5)).\nHowever, the mSearch implementation in the Dashboard Storage class lacks\nextensibility as it requires a synchronous `toItemResult` function. As\nwe start migrating reference handling to the server, we will likely need\ntransforms that return Promises (ex. `savedObjectToItem`), such as\n[retrieving tag saved objects from the SavedObjectTagging\nclient](https://github.com/elastic/kibana/issues/210619).\n\nThe Dashboard `mSearch` method was only used by the dashboard_picker and\nthis PR replaces its usage with the `search` method.\n\n### Identify risks\n\nThere is a slight risk in serverless environments where a browser may\nhave already loaded the dashboard_picker module but lags behind the\nserver. In this case, the dashboard picker may fail to retrieve a list\nof dashboards due to it calling the now non-existent `mSearch` method\nprovided by the server. In this case, the user simply needs to refresh\ntheir browser to retrieve the latest UI modules.","sha":"2a7e38b0fc3c33921f5a29f427bc3a6de8809c67"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->