### PR TITLE
Update chart label when there are no docs

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/components/stream_chart_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_detail_overview/components/stream_chart_panel.tsx
@@ -141,7 +141,7 @@ export function StreamChartPanel({ definition }: StreamChartPanelProps) {
   };
 
   const docCount = docCountFetch?.value?.details.count;
-  const formattedDocCount = docCount ? formatNumber(docCount, 'decimal0') : '-';
+  const formattedDocCount = docCount ? formatNumber(docCount, 'decimal0') : '0';
 
   return (
     <EuiPanel hasShadow={false} hasBorder>


### PR DESCRIPTION
Update chart label when there are no docs

Closes https://github.com/elastic/streams-program/issues/250

### Before
<img width="967" alt="image" src="https://github.com/user-attachments/assets/2e26b631-4a8a-46a2-80d1-c29f77fec969" />


### After
<img width="943" alt="image" src="https://github.com/user-attachments/assets/5e2cd7a2-4624-4c3a-9968-4121198fd3df" />


<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->