### PR TITLE
[Dataset Quality] Add 'source' and 'target' fields to 'Dataset Quality Navigated' event

### DIFF
--- a/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_dataset_telemetry.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/hooks/use_dataset_telemetry.ts
@@ -11,7 +11,12 @@ import { getDateISORange } from '@kbn/timerange';
 import { useDatasetQualityContext } from '../components/dataset_quality/context';
 import { useDatasetQualityFilters } from './use_dataset_quality_filters';
 import { DataStreamStat } from '../../common/data_streams_stats';
-import { DatasetEbtProps, DatasetNavigatedEbtProps } from '../services/telemetry';
+import {
+  DatasetEbtProps,
+  DatasetNavigatedEbtProps,
+  NavigationSource,
+  NavigationTarget,
+} from '../services/telemetry';
 
 export function useDatasetTelemetry() {
   const { service, telemetryClient } = useDatasetQualityContext();
@@ -115,5 +120,7 @@ function getDatasetEbtProps(
     ...datasetEbtProps,
     sort,
     filters: ebtFilters,
+    target: NavigationTarget.Discover,
+    source: NavigationSource.Table,
   };
 }

--- a/x-pack/platform/plugins/shared/dataset_quality/public/services/telemetry/telemetry_events.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/services/telemetry/telemetry_events.ts
@@ -195,6 +195,19 @@ const datasetNavigatedEventType: DatasetQualityTelemetryEvent = {
     ...datasetCommonSchema,
     sort: sortSchema,
     filters: filtersSchema,
+    target: {
+      type: 'keyword',
+      _meta: {
+        description: 'Action that user took to navigate away from the dataset quality page',
+      },
+    },
+    source: {
+      type: 'keyword',
+      _meta: {
+        description:
+          'Section of dataset quality page the action is originated from e.g. header, summary, chart or table etc.',
+      },
+    },
   },
 };
 

--- a/x-pack/platform/plugins/shared/dataset_quality/public/services/telemetry/telemetry_service.test.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/services/telemetry/telemetry_service.test.ts
@@ -96,6 +96,8 @@ describe('TelemetryService', () => {
       ...defaultEbtProps,
       sort: defaultSort,
       filters: defaultFilters,
+      target: NavigationTarget.Discover,
+      source: NavigationSource.Table,
     };
 
     telemetry.trackDatasetNavigated(exampleEventData);

--- a/x-pack/platform/plugins/shared/dataset_quality/public/services/telemetry/types.ts
+++ b/x-pack/platform/plugins/shared/dataset_quality/public/services/telemetry/types.ts
@@ -84,6 +84,8 @@ export interface DatasetNavigatedEbtProps extends DatasetEbtProps {
     namespaces: DatasetEbtFilter;
     qualities: DatasetEbtFilter;
   };
+  target: NavigationTarget;
+  source: NavigationSource;
 }
 
 export interface DatasetDetailsEbtProps extends DatasetEbtProps {


### PR DESCRIPTION
When reporting telemetry for the `Dataset Quality Navigated` event from the Data Set Quality page, the `source` and `target` fields were missing.  This change adds those two props to the event.

![Screenshot 2025-04-08 at 19 13 50](https://github.com/user-attachments/assets/4c51c5f8-7529-4abc-82c3-a9a69042a779)


<!--ONMERGE {"backportTargets":["8.18","8.x"]} ONMERGE-->