### PR TITLE
[8.x] [Dashboards] Provide a method for fetching dashboards on the Dashboard server plugin contract (#209678)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
@@ -217,6 +217,7 @@ export const useDashboardListingTable = ({
           options: {
             // include only tags references in the response to save bandwidth
             includeReferences: ['tag'],
+            fields: ['title', 'description', 'timeRestore'],
           },
         })
         .then(({ total, hits }) => {

--- a/src/platform/plugins/shared/dashboard/server/api/register_routes.ts
+++ b/src/platform/plugins/shared/dashboard/server/api/register_routes.ts
@@ -255,7 +255,15 @@ export function registerAPIRoutes({
       let result;
       try {
         // TODO add filtering
-        ({ result } = await client.search({ cursor: page.toString(), limit }));
+        ({ result } = await client.search(
+          {
+            cursor: page.toString(),
+            limit,
+          },
+          {
+            fields: ['title', 'description', 'timeRestore'],
+          }
+        ));
       } catch (e) {
         if (e.isBoom && e.output.statusCode === 403) {
           return res.forbidden();

--- a/src/platform/plugins/shared/dashboard/server/content_management/dashboard_storage.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/dashboard_storage.ts
@@ -40,11 +40,12 @@ const searchArgsToSOFindOptions = (
   return {
     type: DASHBOARD_SAVED_OBJECT_TYPE,
     searchFields: options?.onlyTitle ? ['title'] : ['title^3', 'description'],
-    fields: options?.fields ?? ['title', 'description', 'timeRestore'],
+    fields: options?.fields,
     search: query.text,
     perPage: query.limit,
     page: query.cursor ? +query.cursor : undefined,
     defaultSearchOperator: 'AND',
+    namespaces: options?.spaces,
     ...tagsToFindOptions(query.tags),
   };
 };

--- a/src/platform/plugins/shared/dashboard/server/content_management/v3/cm_services.ts
+++ b/src/platform/plugins/shared/dashboard/server/content_management/v3/cm_services.ts
@@ -456,6 +456,14 @@ export const dashboardSearchOptionsSchema = schema.maybe(
       kuery: schema.maybe(schema.string()),
       cursor: schema.maybe(schema.number()),
       limit: schema.maybe(schema.number()),
+      spaces: schema.maybe(
+        schema.arrayOf(schema.string(), {
+          meta: {
+            description:
+              'An array of spaces to search or "*" to search all spaces. Defaults to the current space if not specified.',
+          },
+        })
+      ),
     },
     { unknowns: 'forbid' }
   )

--- a/src/platform/plugins/shared/dashboard/server/plugin.ts
+++ b/src/platform/plugins/shared/dashboard/server/plugin.ts
@@ -47,6 +47,7 @@ interface StartDeps {
 export class DashboardPlugin
   implements Plugin<DashboardPluginSetup, DashboardPluginStart, SetupDeps, StartDeps>
 {
+  private contentClient?: ReturnType<ContentManagementServerSetup['register']>['contentClient'];
   private readonly logger: Logger;
 
   constructor(private initializerContext: PluginInitializerContext) {
@@ -64,7 +65,7 @@ export class DashboardPlugin
       })
     );
 
-    plugins.contentManagement.register({
+    const { contentClient } = plugins.contentManagement.register({
       id: CONTENT_ID,
       storage: new DashboardStorage({
         throwOnResultValidationError: this.initializerContext.env.mode.dev,
@@ -74,6 +75,7 @@ export class DashboardPlugin
         latest: LATEST_VERSION,
       },
     });
+    this.contentClient = contentClient;
 
     plugins.contentManagement.favorites.registerFavoriteType('dashboard');
 
@@ -136,7 +138,9 @@ export class DashboardPlugin
         });
     }
 
-    return {};
+    return {
+      contentClient: this.contentClient,
+    };
   }
 
   public stop() {}

--- a/src/platform/plugins/shared/dashboard/server/types.ts
+++ b/src/platform/plugins/shared/dashboard/server/types.ts
@@ -7,7 +7,46 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { ContentManagementServerSetup } from '@kbn/content-management-plugin/server';
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DashboardPluginSetup {}
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface DashboardPluginStart {}
+export interface DashboardPluginStart {
+  /**
+   * Use contentClient.getForRequest to get a scoped client to perform CRUD and search operations for dashboards using the methods available in the {@link DashboardStorage} class.
+   *
+   * @example
+   * Get a dashboard client for the current request
+   * ```ts
+   * // dashboardClient is scoped to the current user
+   * // specifying the version is recommended to return a consistent result
+   * const dashboardClient = plugins.dashboard.contentClient.getForRequest({ requestHandlerContext, request, version: 3 });
+   *
+   * const { search, create, update, delete: deleteDashboard } = dashboardClient;
+   * ```
+   *
+   * @example
+   * Search using {@link DashboardStorage#search}
+   * ```ts
+   * const dashboardList = await search({ text: 'my dashboard' }, { spaces: ['default'] } });
+   * ```
+   * @example
+   * Create a new dashboard using {@link DashboardCreateIn}
+   * ```ts
+   * const newDashboard = await create({ attributes: { title: 'My Dashboard' } });
+   * ```
+   *
+   * @example
+   * Update an existing dashboard using {@link DashboardUpdateIn}
+   * ```ts
+   * const updatedDashboard = await update({ id: 'dashboard-id', attributes: { title: 'My Updated Dashboard' } });
+   * ```
+   *
+   * @example
+   * Delete an existing dashboard using {@link DashboardDeleteIn}
+   * ```ts
+   * deleteDashboard({ id: 'dashboard-id' });
+   * ```
+   */
+  contentClient?: ReturnType<ContentManagementServerSetup['register']>['contentClient'];
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Dashboards] Provide a method for fetching dashboards on the Dashboard server plugin contract (#209678)](https://github.com/elastic/kibana/pull/209678)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Peihl","email":"nick.peihl@elastic.co"},"sourceCommit":{"committedDate":"2025-02-28T15:05:04Z","message":"[Dashboards] Provide a method for fetching dashboards on the Dashboard server plugin contract (#209678)\n\nFixes #209695\n\n## Summary\n\nAdds a method from content management for exposing a server-side\nDashboard CRUD client.\n\nConsumers who want to search, retrieve, or modify Dashboards from a\nserver plugin find themselves using the Saved Object client. This means\nthey need to handle JSON parse/stringify and reference handling\nthemselves. We could expose a CRUD functionality from content management\non the Dashboard server plugin contract to avoid re-creating all of this\nboilerplate handling.\n\nCommit c53f47d72aa10013291048ffb25bd4c22b958f40 shows a crude\ndemonstration of how a plugin can use the methods available on the\nDashboard server plugin with a request to retrieve a list of dashboards.\nYou can test this in the Dev Tools:\n\n```\nGET kbn:/api/search_dashboards?spaces=*\n```\n\nThis will use the Search method from content management to return a list\nof dashboards across all spaces.\n\nTo allow the Search method to return all fields in the Dashboard, I\nneeded to remove the default fields. I updated all current uses of the\nsearch method to specify the necessary fields. See\nhttps://github.com/elastic/kibana/pull/209678/commits/618e025210d8fa4185ca358de88bdea959c82209.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"08c4338a25e5371e723b692b7734d61de44dc78d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","Team:Presentation","release_note:plugin_api_changes","loe:medium","impact:medium","backport:version","v9.1.0","v8.19.0"],"title":"[Dashboards] Provide a method for fetching dashboards on the Dashboard server plugin contract","number":209678,"url":"https://github.com/elastic/kibana/pull/209678","mergeCommit":{"message":"[Dashboards] Provide a method for fetching dashboards on the Dashboard server plugin contract (#209678)\n\nFixes #209695\n\n## Summary\n\nAdds a method from content management for exposing a server-side\nDashboard CRUD client.\n\nConsumers who want to search, retrieve, or modify Dashboards from a\nserver plugin find themselves using the Saved Object client. This means\nthey need to handle JSON parse/stringify and reference handling\nthemselves. We could expose a CRUD functionality from content management\non the Dashboard server plugin contract to avoid re-creating all of this\nboilerplate handling.\n\nCommit c53f47d72aa10013291048ffb25bd4c22b958f40 shows a crude\ndemonstration of how a plugin can use the methods available on the\nDashboard server plugin with a request to retrieve a list of dashboards.\nYou can test this in the Dev Tools:\n\n```\nGET kbn:/api/search_dashboards?spaces=*\n```\n\nThis will use the Search method from content management to return a list\nof dashboards across all spaces.\n\nTo allow the Search method to return all fields in the Dashboard, I\nneeded to remove the default fields. I updated all current uses of the\nsearch method to specify the necessary fields. See\nhttps://github.com/elastic/kibana/pull/209678/commits/618e025210d8fa4185ca358de88bdea959c82209.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"08c4338a25e5371e723b692b7734d61de44dc78d"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/209678","number":209678,"mergeCommit":{"message":"[Dashboards] Provide a method for fetching dashboards on the Dashboard server plugin contract (#209678)\n\nFixes #209695\n\n## Summary\n\nAdds a method from content management for exposing a server-side\nDashboard CRUD client.\n\nConsumers who want to search, retrieve, or modify Dashboards from a\nserver plugin find themselves using the Saved Object client. This means\nthey need to handle JSON parse/stringify and reference handling\nthemselves. We could expose a CRUD functionality from content management\non the Dashboard server plugin contract to avoid re-creating all of this\nboilerplate handling.\n\nCommit c53f47d72aa10013291048ffb25bd4c22b958f40 shows a crude\ndemonstration of how a plugin can use the methods available on the\nDashboard server plugin with a request to retrieve a list of dashboards.\nYou can test this in the Dev Tools:\n\n```\nGET kbn:/api/search_dashboards?spaces=*\n```\n\nThis will use the Search method from content management to return a list\nof dashboards across all spaces.\n\nTo allow the Search method to return all fields in the Dashboard, I\nneeded to remove the default fields. I updated all current uses of the\nsearch method to specify the necessary fields. See\nhttps://github.com/elastic/kibana/pull/209678/commits/618e025210d8fa4185ca358de88bdea959c82209.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"08c4338a25e5371e723b692b7734d61de44dc78d"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->