### PR TITLE
[Unzyme] `src/core/packages/application`

### DIFF
--- a/src/core/packages/application/browser-internal/integration_tests/router.test.tsx
+++ b/src/core/packages/application/browser-internal/integration_tests/router.test.tsx
@@ -15,7 +15,7 @@ import { analyticsServiceMock } from '@kbn/core-analytics-browser-mocks';
 import { themeServiceMock } from '@kbn/core-theme-browser-mocks';
 import { AppStatus } from '@kbn/core-application-browser';
 
-import { AppRouter, AppNotFound } from '../src/ui';
+import { AppRouter } from '../src/ui';
 import { MockedMounterMap, MockedMounterTuple } from '../src/test_helpers/test_types';
 import { createRenderer, createAppMounter, getUnmounter } from './utils';
 
@@ -119,24 +119,16 @@ describe('AppRouter', () => {
     let dom = await navigate('/app/app1');
 
     expect(app1.mounter.mount).toHaveBeenCalled();
-    expect(dom?.html()).toMatchInlineSnapshot(`
-      "<span class=\\"euiLoadingElastic css-1qir6ap-EuiLoadingElastic\\" role=\\"progressbar\\" aria-label=\\"Loading application\\"><span data-euiicon-type=\\"logoElastic\\"></span></span><div class=\\"kbnAppWrapper\\" aria-busy=\\"false\\"><div>
-      basename: /app/app1
-      html: <span>App 1</span>
-      </div></div>"
-    `);
+    expect(dom?.queryByText('basename: /app/app1')).toBeDefined();
+    expect(dom?.queryByText('App 1')).toBeDefined();
 
     const app1Unmount = await getUnmounter(app1);
     dom = await navigate('/app/app2');
 
     expect(app1Unmount).toHaveBeenCalled();
     expect(app2.mounter.mount).toHaveBeenCalled();
-    expect(dom?.html()).toMatchInlineSnapshot(`
-      "<span class=\\"euiLoadingElastic css-1qir6ap-EuiLoadingElastic\\" role=\\"progressbar\\" aria-label=\\"Loading application\\"><span data-euiicon-type=\\"logoElastic\\"></span></span><div class=\\"kbnAppWrapper\\" aria-busy=\\"false\\"><div>
-      basename: /app/app2
-      html: <div>App 2</div>
-      </div></div>"
-    `);
+    expect(dom?.queryByText('basename: /app/app2')).toBeDefined();
+    expect(dom?.queryByText('App 2')).toBeDefined();
   });
 
   it('can navigate between standard application and one with custom appRoute', async () => {
@@ -145,36 +137,24 @@ describe('AppRouter', () => {
     let dom = await navigate('/app/app1');
 
     expect(standardApp.mounter.mount).toHaveBeenCalled();
-    expect(dom?.html()).toMatchInlineSnapshot(`
-      "<span class=\\"euiLoadingElastic css-1qir6ap-EuiLoadingElastic\\" role=\\"progressbar\\" aria-label=\\"Loading application\\"><span data-euiicon-type=\\"logoElastic\\"></span></span><div class=\\"kbnAppWrapper\\" aria-busy=\\"false\\"><div>
-      basename: /app/app1
-      html: <span>App 1</span>
-      </div></div>"
-    `);
+    expect(dom?.queryByText('basename: /app/app1')).toBeDefined();
+    expect(dom?.queryByText('App 1')).toBeDefined();
 
     const standardAppUnmount = await getUnmounter(standardApp);
     dom = await navigate('/chromeless-a/path');
 
     expect(standardAppUnmount).toHaveBeenCalled();
     expect(chromelessApp.mounter.mount).toHaveBeenCalled();
-    expect(dom?.html()).toMatchInlineSnapshot(`
-      "<span class=\\"euiLoadingElastic css-1qir6ap-EuiLoadingElastic\\" role=\\"progressbar\\" aria-label=\\"Loading application\\"><span data-euiicon-type=\\"logoElastic\\"></span></span><div class=\\"kbnAppWrapper\\" aria-busy=\\"false\\"><div>
-      basename: /chromeless-a/path
-      html: <div>Chromeless A</div>
-      </div></div>"
-    `);
+    expect(dom?.queryByText('basename: /chromeless-a/path')).toBeDefined();
+    expect(dom?.queryByText('Chromeless A')).toBeDefined();
 
     const chromelessAppUnmount = await getUnmounter(standardApp);
     dom = await navigate('/app/app1');
 
     expect(chromelessAppUnmount).toHaveBeenCalled();
     expect(standardApp.mounter.mount).toHaveBeenCalledTimes(2);
-    expect(dom?.html()).toMatchInlineSnapshot(`
-      "<span class=\\"euiLoadingElastic css-1qir6ap-EuiLoadingElastic\\" role=\\"progressbar\\" aria-label=\\"Loading application\\"><span data-euiicon-type=\\"logoElastic\\"></span></span><div class=\\"kbnAppWrapper\\" aria-busy=\\"false\\"><div>
-      basename: /app/app1
-      html: <span>App 1</span>
-      </div></div>"
-    `);
+    expect(dom?.queryByText('basename: /app/app1')).toBeDefined();
+    expect(dom?.queryByText('App 1')).toBeDefined();
   });
 
   it('can navigate between two applications with custom appRoutes', async () => {
@@ -183,36 +163,24 @@ describe('AppRouter', () => {
     let dom = await navigate('/chromeless-a/path');
 
     expect(chromelessAppA.mounter.mount).toHaveBeenCalled();
-    expect(dom?.html()).toMatchInlineSnapshot(`
-      "<span class=\\"euiLoadingElastic css-1qir6ap-EuiLoadingElastic\\" role=\\"progressbar\\" aria-label=\\"Loading application\\"><span data-euiicon-type=\\"logoElastic\\"></span></span><div class=\\"kbnAppWrapper\\" aria-busy=\\"false\\"><div>
-      basename: /chromeless-a/path
-      html: <div>Chromeless A</div>
-      </div></div>"
-    `);
+    expect(dom?.queryByText('basename: /chromeless-a/path')).toBeDefined();
+    expect(dom?.queryByText('Chromeless A')).toBeDefined();
 
     const chromelessAppAUnmount = await getUnmounter(chromelessAppA);
     dom = await navigate('/chromeless-b/path');
 
     expect(chromelessAppAUnmount).toHaveBeenCalled();
     expect(chromelessAppB.mounter.mount).toHaveBeenCalled();
-    expect(dom?.html()).toMatchInlineSnapshot(`
-      "<span class=\\"euiLoadingElastic css-1qir6ap-EuiLoadingElastic\\" role=\\"progressbar\\" aria-label=\\"Loading application\\"><span data-euiicon-type=\\"logoElastic\\"></span></span><div class=\\"kbnAppWrapper\\" aria-busy=\\"false\\"><div>
-      basename: /chromeless-b/path
-      html: <div>Chromeless B</div>
-      </div></div>"
-    `);
+    expect(dom?.queryByText('basename: /chromeless-b/path')).toBeDefined();
+    expect(dom?.queryByText('Chromeless B')).toBeDefined();
 
     const chromelessAppBUnmount = await getUnmounter(chromelessAppB);
     dom = await navigate('/chromeless-a/path');
 
     expect(chromelessAppBUnmount).toHaveBeenCalled();
     expect(chromelessAppA.mounter.mount).toHaveBeenCalledTimes(2);
-    expect(dom?.html()).toMatchInlineSnapshot(`
-      "<span class=\\"euiLoadingElastic css-1qir6ap-EuiLoadingElastic\\" role=\\"progressbar\\" aria-label=\\"Loading application\\"><span data-euiicon-type=\\"logoElastic\\"></span></span><div class=\\"kbnAppWrapper\\" aria-busy=\\"false\\"><div>
-      basename: /chromeless-a/path
-      html: <div>Chromeless A</div>
-      </div></div>"
-    `);
+    expect(dom?.queryByText('basename: /chromeless-a/path')).toBeDefined();
+    expect(dom?.queryByText('Chromeless A')).toBeDefined();
   });
 
   it('should not mount when partial route path matches', async () => {
@@ -396,12 +364,12 @@ describe('AppRouter', () => {
   it('displays error page if no app is found', async () => {
     const dom = await navigate('/app/unknown');
 
-    expect(dom?.exists(AppNotFound)).toBe(true);
+    expect(dom?.queryByTestId('appNotFoundPageContent')).toBeDefined();
   });
 
   it('displays error page if app is inaccessible', async () => {
     const dom = await navigate('/app/disabledApp');
 
-    expect(dom?.exists(AppNotFound)).toBe(true);
+    expect(dom?.queryByTestId('appNotFoundPageContent')).toBeDefined();
   });
 });

--- a/src/core/packages/application/browser-internal/integration_tests/utils.tsx
+++ b/src/core/packages/application/browser-internal/integration_tests/utils.tsx
@@ -8,26 +8,23 @@
  */
 
 import React, { ReactElement } from 'react';
-import { act } from 'react-dom/test-utils';
-import { mount } from 'enzyme';
+import { render, act } from '@testing-library/react';
 import { I18nProvider } from '@kbn/i18n-react';
 import type { AppMountParameters } from '@kbn/core-application-browser';
 
 import { MockedMounterTuple, Mountable } from '../src/test_helpers/test_types';
 
-type Dom = ReturnType<typeof mount> | null;
+type Dom = ReturnType<typeof render> | null;
 type Renderer = () => Dom | Promise<Dom>;
 
 export const createRenderer = (element: ReactElement | null): Renderer => {
-  const dom: Dom = element && mount(<I18nProvider>{element}</I18nProvider>);
+  const dom: Dom = element && render(<I18nProvider>{element}</I18nProvider>);
 
   return () =>
     new Promise(async (resolve, reject) => {
       try {
         if (dom) {
-          await act(async () => {
-            dom.update();
-          });
+          await act(async () => {}); // just acts, nothing else.
         }
 
         setImmediate(() => resolve(dom)); // flushes any pending promises


### PR DESCRIPTION
## Summary

Related to #217387

Migrates from `enzyme` tests to the RTL. I took advantage to move away from snapshots since every CSS lib upgrade will trigger new snapshots.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->