### PR TITLE
[Dashboards] Replace contentClient with getContentClient on DashboardStart server api

### DIFF
--- a/src/platform/plugins/shared/dashboard/server/plugin.test.ts
+++ b/src/platform/plugins/shared/dashboard/server/plugin.test.ts
@@ -51,7 +51,9 @@ describe('DashboardPlugin', () => {
       });
       expect(scheduleDashboardTelemetry).toHaveBeenCalledTimes(1);
       expect(await mockTaskManager.runSoon).toHaveBeenCalledTimes(1);
-      expect(response).toEqual({});
+      expect(response).toEqual({
+        getContentClient: expect.any(Function),
+      });
     });
   });
 });

--- a/src/platform/plugins/shared/dashboard/server/plugin.ts
+++ b/src/platform/plugins/shared/dashboard/server/plugin.ts
@@ -144,7 +144,7 @@ export class DashboardPlugin
     }
 
     return {
-      contentClient: this.contentClient,
+      getContentClient: () => this.contentClient,
     };
   }
 

--- a/src/platform/plugins/shared/dashboard/server/types.ts
+++ b/src/platform/plugins/shared/dashboard/server/types.ts
@@ -13,40 +13,40 @@ import { ContentManagementServerSetup } from '@kbn/content-management-plugin/ser
 export interface DashboardPluginSetup {}
 export interface DashboardPluginStart {
   /**
-   * Use contentClient.getForRequest to get a scoped client to perform CRUD and search operations for dashboards using the methods available in the {@link DashboardStorage} class.
+   * Use getContentClient().getForRequest to get a scoped client to perform CRUD and search operations for dashboards using the methods available in the {@link DashboardStorage} class.
    *
    * @example
    * Get a dashboard client for the current request
    * ```ts
    * // dashboardClient is scoped to the current user
    * // specifying the version is recommended to return a consistent result
-   * const dashboardClient = plugins.dashboard.contentClient.getForRequest({ requestHandlerContext, request, version: 3 });
-   *
-   * const { search, create, update, delete: deleteDashboard } = dashboardClient;
+   * const dashboardClient = plugins.dashboard.getContentClient().getForRequest({ requestHandlerContext, request, version: 3 });
    * ```
    *
    * @example
    * Search using {@link DashboardStorage#search}
    * ```ts
-   * const dashboardList = await search({ text: 'my dashboard' }, { spaces: ['default'] } });
+   * const dashboardList = await dashboardClient.search({ text: 'my dashboard' }, { spaces: ['default'] } });
    * ```
    * @example
    * Create a new dashboard using {@link DashboardCreateIn}
    * ```ts
-   * const newDashboard = await create({ attributes: { title: 'My Dashboard' } });
+   * const newDashboard = await dashboardClient.create({ attributes: { title: 'My Dashboard' } });
    * ```
    *
    * @example
    * Update an existing dashboard using {@link DashboardUpdateIn}
    * ```ts
-   * const updatedDashboard = await update({ id: 'dashboard-id', attributes: { title: 'My Updated Dashboard' } });
+   * const updatedDashboard = await dashboardClient.update({ id: 'dashboard-id', attributes: { title: 'My Updated Dashboard' } });
    * ```
    *
    * @example
    * Delete an existing dashboard using {@link DashboardDeleteIn}
    * ```ts
-   * deleteDashboard({ id: 'dashboard-id' });
+   * dashboardClient.delete({ id: 'dashboard-id' });
    * ```
    */
-  contentClient?: ReturnType<ContentManagementServerSetup['register']>['contentClient'];
+  getContentClient: () =>
+    | ReturnType<ContentManagementServerSetup['register']>['contentClient']
+    | undefined;
 }

--- a/x-pack/solutions/observability/plugins/observability/server/routes/alerts/route.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/routes/alerts/route.ts
@@ -32,8 +32,8 @@ const alertsDynamicDashboardSuggestions = createObservabilityServerRoute({
     const { dependencies, params, request, response, context, logger } = services;
     const { alertId } = params.query;
     const { ruleRegistry, dashboard } = dependencies;
-    const { contentClient } = dashboard;
-    const dashboardClient = contentClient!.getForRequest<
+    const { getContentClient } = dashboard;
+    const dashboardClient = getContentClient()!.getForRequest<
       SavedObjectsFindResult<DashboardAttributes>
     >({
       requestHandlerContext: context,


### PR DESCRIPTION
## Summary

Changes the DashboardStart server api to provide a getContentClient function.

In https://github.com/elastic/kibana/pull/214788, we set the `contentClient` returned from the content management register method after start lifecycle of all plugins. This means the `contentClient` returned from the `DashboardStart` contract was undefined. This PR changes the start contract to provide a getContentClient function instead. 

Only one consumer was using the contentClient from DashboardStart and this PR also updates that consumer.




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->