### PR TITLE
[8.17] [Dashboard] Fix controls being overwritten on navigation

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -752,6 +752,7 @@ export class DashboardContainer
     newSavedObjectId?: string,
     newCreationOptions?: Partial<DashboardCreationOptions>
   ) => {
+    this.restoredRuntimeState = undefined; // restored runtime state will be set in `initializeDashboard`, if necessary
     this.integrationSubscriptions.unsubscribe();
     this.integrationSubscriptions = new Subscription();
     this.stopSyncingWithUnifiedSearch?.();


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/208330

## Summary

Consider how we set `restoredRuntimeState` for controls in `initializeDashboard`:

https://github.com/elastic/kibana/blob/ce91dea75c2bf8940f7767736656ed8a89f24470/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts#L439-L445

Now, consider the following scenario:

1. We have two dashboards - dashboard B has unsaved changes to its control group, and dashboard A does not
2. We start in dashboard B and, since it has unsaved control changes, `restoredRuntimeState[PANELS_CONTROL_GROUP_KEY]` (in `DashboardContainer`) is populated with these changes
3. We navigate to Dashboard A via the `navigateToDashboard` method, which calls `initializeDashboard`
4. In `initializeDashboard`, `overrideInput` does **not** have control group state for dashboard A (since it does not have unsaved control changes) - so, we skip calling `setRuntimeStateForChild` for dashboard A
5. This means that `DashboardContainer` still has `restoredRuntimeState[PANELS_CONTROL_GROUP_KEY]` equal to the changes from dashboard B, which results in Dashboard A's control group getting overwritten with `restoredRuntimeState[PANELS_CONTROL_GROUP_KEY]` :fire:

If we clear `restoredRuntimeState` in `navigateToDashboard`, this is no longer an issue - we will now start from a blank slate on navigation, which is the desired behaviour.


**Before**

https://github.com/user-attachments/assets/d04fa41f-2603-4b64-963d-b59c6be6fa14

**After**

https://github.com/user-attachments/assets/ce42c204-4ed0-4c44-8c15-c2f49a60131b
