### PR TITLE
[Security Solution] User Settings Service to persist user specific configurations/preferences/settings.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@ examples/unified_doc_viewer @elastic/kibana-core
 examples/unified_field_list_examples @elastic/kibana-data-discovery
 examples/unified_tabs_examples @elastic/kibana-data-discovery
 examples/user_profile_examples @elastic/kibana-security
+examples/user_settings @elastic/security-threat-hunting-investigations
 examples/v8_profiler_examples @elastic/response-ops
 packages/kbn-babel-preset @elastic/kibana-operations
 packages/kbn-bazel-runner @elastic/kibana-operations
@@ -298,6 +299,7 @@ src/core/packages/user-profile/common @elastic/kibana-core
 src/core/packages/user-profile/server @elastic/kibana-core
 src/core/packages/user-profile/server-internal @elastic/kibana-core
 src/core/packages/user-profile/server-mocks @elastic/kibana-core
+src/core/packages/user-settings/browser @elastic/security-threat-hunting-investigations
 src/core/packages/user-settings/server @elastic/kibana-security
 src/core/packages/user-settings/server-internal @elastic/kibana-security
 src/core/packages/user-settings/server-mocks @elastic/kibana-security

--- a/examples/user_settings/kibana.jsonc
+++ b/examples/user_settings/kibana.jsonc
@@ -1,0 +1,15 @@
+{
+  "type": "plugin",
+  "id": "@kbn/user-settings-example-plugin",
+  "owner": "@elastic/security-threat-hunting-investigations",
+  "description": "Demonstrates the usage of user settings.",
+  "plugin": {
+    "id": "userSettingsExample",
+    "server": false,
+    "browser": true,
+    "requiredPlugins": [
+      "spaces",
+      "developerExamples"
+    ]
+  }
+}

--- a/examples/user_settings/public/app.tsx
+++ b/examples/user_settings/public/app.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { I18nProvider } from '@kbn/i18n-react';
+import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
+import type { AppMountParameters, CoreStart } from '@kbn/core/public';
+import { AppServices } from './types';
+import { UserSettingsExample } from './user_settings_example_app';
+
+export const renderApp = (core: CoreStart, deps: AppServices, { element }: AppMountParameters) => {
+  ReactDOM.render(
+    <I18nProvider>
+      <KibanaThemeProvider {...core}>
+        <UserSettingsExample services={deps} />
+      </KibanaThemeProvider>
+    </I18nProvider>,
+    element
+  );
+
+  return () => {
+    ReactDOM.unmountComponentAtNode(element);
+  };
+};

--- a/examples/user_settings/public/constants.ts
+++ b/examples/user_settings/public/constants.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { UserSettingsMeta } from '@kbn/core-user-settings-browser';
+
+export const DEFAULT_TABLE_CONFIGURATION = {
+  autoFit: false,
+  rowHeight: 20,
+  rowDensity: 'default',
+};
+
+export const SPACE_AGNOSTIC_SETTING_DEFAULT_VALUE = {
+  checkbox_2: true,
+} as const;
+
+export const tableConfigurationSetting: UserSettingsMeta = {
+  name: 'tableConfiguration',
+  isSpaceAware: true,
+  defaultValue: DEFAULT_TABLE_CONFIGURATION,
+  requiredPageReload: false,
+};
+
+export const spaceAgnosticSetting: UserSettingsMeta = {
+  name: 'spaceAgnosticSetting',
+  isSpaceAware: false,
+  defaultValue: SPACE_AGNOSTIC_SETTING_DEFAULT_VALUE,
+  requiredPageReload: false,
+};

--- a/examples/user_settings/public/hooks/use_user_settings.ts
+++ b/examples/user_settings/public/hooks/use_user_settings.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useEffect } from 'react';
+import { UserSettingsService } from '@kbn/core-user-settings-browser';
+import { Subscription } from 'rxjs';
+
+export const useUserSetting = <T>(userSetting: UserSettingsService, key: string) => {
+  const [value, setValue] = React.useState(userSetting.get<T>(key));
+
+  const valueSub = React.useRef<Subscription | null>(null);
+
+  useEffect(() => {
+    valueSub.current = userSetting.get$<T>(key).subscribe((newValue) => {
+      setValue(newValue);
+    });
+
+    return () => {
+      valueSub.current?.unsubscribe();
+    };
+  });
+
+  const updateUserSetting = useCallback(
+    (newValue: T) => {
+      userSetting.set(key, newValue);
+    },
+    [userSetting, key]
+  );
+
+  return [value, updateUserSetting] as const;
+};

--- a/examples/user_settings/public/index.ts
+++ b/examples/user_settings/public/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { UserSettingsExamplePlugin } from './plugin';
+
+export function plugin() {
+  return new UserSettingsExamplePlugin();
+}

--- a/examples/user_settings/public/layout.tsx
+++ b/examples/user_settings/public/layout.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { FC, PropsWithChildren } from 'react';
+import { EuiPageHeader, EuiPageSection } from '@elastic/eui';
+
+interface LayoutProps {
+  extendedBorder?: boolean;
+  restrictWidth?: boolean;
+  centeredContent?: boolean;
+}
+
+export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
+  extendedBorder = true,
+  restrictWidth = true,
+  centeredContent = false,
+  children,
+}) => {
+  const width = restrictWidth ? '75%' : false;
+  const bottomBorder = extendedBorder ? 'extended' : true;
+  return (
+    <>
+      <EuiPageHeader
+        paddingSize="l"
+        restrictWidth={width}
+        bottomBorder={bottomBorder}
+        pageTitle="User Settings Demo"
+        description="This is demo to demonstrate the use of user settings. It show an example each of a space aware and a space agnostic user setting."
+      />
+      <EuiPageSection
+        restrictWidth={width}
+        alignment={centeredContent ? 'center' : 'top'}
+        color={extendedBorder ? 'plain' : 'transparent'}
+        grow={centeredContent ? true : false}
+      >
+        {children}
+      </EuiPageSection>
+    </>
+  );
+};

--- a/examples/user_settings/public/plugin.ts
+++ b/examples/user_settings/public/plugin.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { AppMountParameters, CoreSetup, CoreStart, Plugin } from '@kbn/core/public';
+import { UserSettingsService } from '@kbn/core-user-settings-browser';
+import { AppSetupDeps, AppStartDeps, AppServices } from './types';
+import { spaceAgnosticSetting, tableConfigurationSetting } from './constants';
+
+const PLUGIN_ID = 'userSettingsExample';
+const PLUGIN_NAME = 'User Settings Example';
+
+export class UserSettingsExamplePlugin implements Plugin<{}, {}, AppSetupDeps, AppStartDeps> {
+  public setup(core: CoreSetup, { developerExamples }: AppSetupDeps) {
+    // Register an application into the side navigation menu
+    core.application.register({
+      id: PLUGIN_ID,
+      title: PLUGIN_NAME,
+      mount: async (params: AppMountParameters) => {
+        // Load application bundle
+        const { renderApp } = await import('./app');
+        // Get start services as specified in kibana.json
+        const [coreStart, depsStart] = await core.getStartServices();
+        // Register the user Settings for this particular plugin
+
+        const userSettingsService = await this.getUserSettingsService(
+          coreStart,
+          depsStart as AppStartDeps
+        );
+        await userSettingsService.registerSettings([
+          // Register the table configuration setting
+          tableConfigurationSetting,
+          spaceAgnosticSetting,
+        ]);
+
+        const appServices: AppServices = {
+          ...(depsStart as AppStartDeps),
+          userSettings: userSettingsService,
+        };
+
+        // Render the application
+        return renderApp(coreStart, appServices, params);
+      },
+    });
+
+    developerExamples.register({
+      appId: PLUGIN_ID,
+      title: PLUGIN_NAME,
+      description: `Examples of user settings functionality.`,
+    });
+
+    return {};
+  }
+
+  private async getUserSettingsService(core: CoreStart, depsStart: AppStartDeps) {
+    const space = await depsStart.spaces.getActiveSpace();
+    return new UserSettingsService(core.userProfile, space.id, PLUGIN_ID);
+  }
+
+  public start(_core: CoreStart) {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/examples/user_settings/public/space_agnostic_setting.tsx
+++ b/examples/user_settings/public/space_agnostic_setting.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { FC } from 'react';
+import { EuiCheckboxGroup, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiTitle } from '@elastic/eui';
+import { AppServices } from './types';
+import { useUserSetting } from './hooks/use_user_settings';
+
+interface SpaceAgnosticSettingProps {
+  services: AppServices;
+}
+
+const checkboxes = [
+  {
+    id: 'checkbox_1',
+    label: 'Option one',
+    'data-test-sub': 'dts_test',
+  },
+  {
+    id: 'checkbox_2',
+    label: 'Option two ( checked by default )',
+    className: 'classNameTest',
+  },
+  {
+    id: 'checkbox_3',
+    label: 'Option three',
+  },
+];
+
+export const SpaceAgnosticSetting: FC<SpaceAgnosticSettingProps> = ({ services }) => {
+  const [settingValue, setSettingValue] = useUserSetting<Record<string, boolean>>(
+    services.userSettings,
+    'spaceAgnosticSetting'
+  );
+
+  const onSelectionChange = (id: string) => {
+    const newValue = {
+      ...settingValue,
+      [id]: !(settingValue[id] ?? false),
+    };
+    setSettingValue(newValue);
+  };
+
+  return (
+    <EuiPanel hasBorder paddingSize="m">
+      <EuiFlexGroup gutterSize="s" direction="row">
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="s" direction="column">
+            <EuiFlexItem>
+              <EuiTitle>
+                <h2> {'Space Agnostic Setting Example'} </h2>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <p>
+                {
+                  'This is a NOT space aware setting. This means that any changes to this setting will be visible across all spaces'
+                }
+              </p>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <p>
+                {
+                  'You can now try to change and these login in a different browser or incognito mode to see that the settings are persisted across sessions and spaces.'
+                }
+              </p>
+            </EuiFlexItem>
+            <EuiFlexItem />
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCheckboxGroup
+            options={checkboxes}
+            idToSelectedMap={settingValue}
+            onChange={onSelectionChange}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/examples/user_settings/public/table_config_setting.tsx
+++ b/examples/user_settings/public/table_config_setting.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  EuiSwitchEvent,
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonGroup,
+  EuiSwitch,
+  EuiRange,
+  EuiTitle,
+  EuiFormRow,
+  EuiListGroupItem,
+  EuiListGroup,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
+import React, { FC } from 'react';
+import { _SingleRangeChangeEvent } from '@elastic/eui/src/components/form/range/types';
+import { tableConfigurationSetting } from './constants';
+import { useUserSetting } from './hooks/use_user_settings';
+import { AppServices } from './types';
+
+interface TableConfiguration {
+  autoFit: boolean;
+  rowHeight: number;
+  rowDensity: string;
+}
+
+const toggleButtons = [
+  {
+    id: `compact`,
+    label: `Compact`,
+  },
+  {
+    id: `default`,
+    label: 'Default',
+  },
+  {
+    id: 'comfortable',
+    label: 'Comfortable',
+  },
+];
+
+interface TableConfigSettingProps {
+  services: AppServices;
+}
+
+export const TableConfigSetting: FC<TableConfigSettingProps> = ({ services }) => {
+  const [tableConfigration, setTableConfiguration] = useUserSetting<TableConfiguration>(
+    services.userSettings,
+    tableConfigurationSetting.name
+  );
+
+  const onSwitchChange = (ev: EuiSwitchEvent) => {
+    setTableConfiguration({
+      ...tableConfigration,
+      autoFit: ev.target.checked,
+    });
+  };
+
+  const onRowDensityChange = (id: string) => {
+    setTableConfiguration({
+      ...tableConfigration,
+      rowDensity: id,
+    });
+  };
+
+  const onRowHeightChange = (e: _SingleRangeChangeEvent) => {
+    setTableConfiguration({
+      ...tableConfigration,
+      rowHeight: parseInt(e.currentTarget.value, 10),
+    });
+  };
+
+  const inputRangeSliderId = useGeneratedHtmlId({ prefix: 'inputRangeSlider' });
+
+  return (
+    <EuiPanel hasBorder paddingSize="l">
+      <EuiFlexGroup gutterSize="m" direction="row">
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="s" direction="column">
+            <EuiFlexItem>
+              <EuiTitle>
+                <h2> {'Table Configuration'} </h2>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <p>
+                {
+                  'This is a space aware setting. Below will be the default values if you has not changed it already.'
+                }
+              </p>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <p>
+                {
+                  'You can now try to change and these login in a different browser or incognito mode to see that the settings are persisted across sessions.'
+                }
+              </p>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiListGroup>
+                <EuiListGroupItem
+                  label={
+                    <span>
+                      Row Height: <b>20</b>
+                    </span>
+                  }
+                />
+                <EuiListGroupItem
+                  label={
+                    <span>
+                      Row Density: <b>Default</b>
+                    </span>
+                  }
+                />
+                <EuiListGroupItem
+                  label={
+                    <span>
+                      Autofit content: <b>False</b>
+                    </span>
+                  }
+                />
+              </EuiListGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFormRow>
+            <EuiSwitch
+              checked={tableConfigration.autoFit}
+              onChange={onSwitchChange}
+              label={'Autofit content'}
+              showLabel
+            />
+          </EuiFormRow>
+          <EuiFormRow>
+            <>
+              <EuiTitle size="xxs">
+                <h3>Row Density</h3>
+              </EuiTitle>
+              <EuiButtonGroup
+                legend="Default single select button group"
+                isFullWidth={true}
+                isDisabled={false}
+                options={toggleButtons}
+                idSelected={tableConfigration.rowDensity}
+                onChange={onRowDensityChange}
+              />
+            </>
+          </EuiFormRow>
+          <EuiFormRow>
+            <>
+              <EuiTitle size="xxs">
+                <h3>Row Height</h3>
+              </EuiTitle>
+              <EuiRange
+                id={inputRangeSliderId}
+                min={0}
+                max={100}
+                value={tableConfigration.rowHeight}
+                onChange={onRowHeightChange}
+                showInput
+                aria-label="An example of EuiRange"
+              />
+            </>
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/examples/user_settings/public/types.ts
+++ b/examples/user_settings/public/types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import { UserSettingsService } from '@kbn/core-user-settings-browser';
+import type { SpacesPluginStart, SpacesPluginSetup } from '@kbn/spaces-plugin/public';
+import { DeveloperExamplesSetup } from '@kbn/developer-examples-plugin/public';
+
+export interface AppSetupDeps {
+  developerExamples: DeveloperExamplesSetup;
+  spaces: SpacesPluginSetup;
+}
+
+export interface AppStartDeps {
+  spaces: SpacesPluginStart;
+}
+
+export interface AppServices extends AppStartDeps {
+  userSettings: UserSettingsService;
+}

--- a/examples/user_settings/public/user_settings_example_app.tsx
+++ b/examples/user_settings/public/user_settings_example_app.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { FC } from 'react';
+import { EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
+import { AppServices } from './types';
+import { Layout } from './layout';
+import { TableConfigSetting } from './table_config_setting';
+import { SpaceAgnosticSetting } from './space_agnostic_setting';
+
+interface UserSettingsExampleProps {
+  services: AppServices;
+}
+
+export const UserSettingsExample: FC<UserSettingsExampleProps> = ({ services }) => {
+  return (
+    <Layout>
+      <EuiFlexGroup direction="column" gutterSize="l">
+        <EuiFlexItem>
+          <TableConfigSetting services={services} />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <SpaceAgnosticSetting services={services} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </Layout>
+  );
+};

--- a/examples/user_settings/tsconfig.json
+++ b/examples/user_settings/tsconfig.json
@@ -16,21 +16,9 @@
   "kbn_references": [
     "@kbn/core",
     "@kbn/core-user-settings-browser",
-    "@kbn/data-plugin",
-    "@kbn/data-views-plugin",
-    "@kbn/navigation-plugin",
     "@kbn/developer-examples-plugin",
-    "@kbn/unified-search-plugin",
     "@kbn/i18n-react",
-    "@kbn/i18n",
-    "@kbn/core-lifecycle-browser",
-    "@kbn/charts-plugin",
-    "@kbn/field-formats-plugin",
-    "@kbn/data-view-field-editor-plugin",
-    "@kbn/unified-field-list",
-    "@kbn/ui-actions-plugin",
     "@kbn/react-kibana-context-theme",
-    "@kbn/unified-tabs",
-    "@kbn/core-application-browser"
+    "@kbn/spaces-plugin"
   ]
 }

--- a/examples/user_settings/tsconfig.json
+++ b/examples/user_settings/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types"
+  },
+  "include": [
+    "index.ts",
+    "common/**/*.ts",
+    "public/**/*.ts",
+    "public/**/*.tsx",
+    "../../typings/**/*",
+  ],
+  "exclude": [
+    "target/**/*",
+  ],
+  "kbn_references": [
+    "@kbn/core",
+    "@kbn/core-user-settings-browser",
+    "@kbn/data-plugin",
+    "@kbn/data-views-plugin",
+    "@kbn/navigation-plugin",
+    "@kbn/developer-examples-plugin",
+    "@kbn/unified-search-plugin",
+    "@kbn/i18n-react",
+    "@kbn/i18n",
+    "@kbn/core-lifecycle-browser",
+    "@kbn/charts-plugin",
+    "@kbn/field-formats-plugin",
+    "@kbn/data-view-field-editor-plugin",
+    "@kbn/unified-field-list",
+    "@kbn/ui-actions-plugin",
+    "@kbn/react-kibana-context-theme",
+    "@kbn/unified-tabs",
+    "@kbn/core-application-browser"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -419,6 +419,7 @@
     "@kbn/core-user-profile-server": "link:src/core/packages/user-profile/server",
     "@kbn/core-user-profile-server-internal": "link:src/core/packages/user-profile/server-internal",
     "@kbn/core-user-profile-server-mocks": "link:src/core/packages/user-profile/server-mocks",
+    "@kbn/core-user-settings-browser": "link:src/core/packages/user-settings/browser",
     "@kbn/core-user-settings-server": "link:src/core/packages/user-settings/server",
     "@kbn/core-user-settings-server-internal": "link:src/core/packages/user-settings/server-internal",
     "@kbn/core-user-settings-server-mocks": "link:src/core/packages/user-settings/server-mocks",

--- a/package.json
+++ b/package.json
@@ -1018,6 +1018,7 @@
     "@kbn/user-profile-components": "link:src/platform/packages/shared/kbn-user-profile-components",
     "@kbn/user-profile-examples-plugin": "link:examples/user_profile_examples",
     "@kbn/user-profiles-consumer-plugin": "link:x-pack/test/security_api_integration/plugins/user_profiles_consumer",
+    "@kbn/user-settings-example-plugin": "link:examples/user_settings",
     "@kbn/utility-types": "link:src/platform/packages/shared/kbn-utility-types",
     "@kbn/utility-types-jest": "link:src/platform/packages/shared/kbn-utility-types-jest",
     "@kbn/utils": "link:src/platform/packages/shared/kbn-utils",

--- a/src/core/packages/user-settings/browser/index.ts
+++ b/src/core/packages/user-settings/browser/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export type { UserSettingsMeta, IUserSettingsService } from './src/types';
+
+export { UserSettingsService } from './src/user_settings_service';

--- a/src/core/packages/user-settings/browser/jest.config.js
+++ b/src/core/packages/user-settings/browser/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../../../../..',
+  roots: ['<rootDir>/src/core/packages/user-settings/browser'],
+};

--- a/src/core/packages/user-settings/browser/kibana.jsonc
+++ b/src/core/packages/user-settings/browser/kibana.jsonc
@@ -1,0 +1,9 @@
+{
+  "type": "shared-browser",
+  "id": "@kbn/core-user-settings-browser",
+  "owner": [
+    "@elastic/security-threat-hunting-investigations"
+  ],
+  "group": "platform",
+  "visibility": "shared"
+}

--- a/src/core/packages/user-settings/browser/package.json
+++ b/src/core/packages/user-settings/browser/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/core-user-settings-browser",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0"
+}

--- a/src/core/packages/user-settings/browser/src/types.ts
+++ b/src/core/packages/user-settings/browser/src/types.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Observable } from 'rxjs';
+
+export interface UserSettingsMeta {
+  name: string;
+  defaultValue: any;
+  isSpaceAware?: boolean;
+  requiredPageReload: boolean;
+}
+
+export interface IUserSettingsService {
+  registerSettings: (settings: UserSettingsMeta[]) => Promise<void>;
+
+  /**
+   *
+   * Gets the value of settings synchronously from the memory.
+   *
+   * @param key The key of the setting to get
+   *
+   * @returns The value of the setting, or undefined if it is not set
+   * @throws Error if the setting is not registered
+   *
+   */
+  get: <T = any>(key: string) => Promise<T>;
+
+  /**
+   *
+   * Returns an observable that emits the value of the setting on every change.
+   *
+   * @param key The key of the setting to get
+   *
+   */
+  get$: <T = any>(key: string, defaultOverride?: T) => Observable<T | Promise<T>>;
+
+  /**
+   * Optimistically and synchronously updates the cache and notify the observers with new value.
+   * In background, sends the update request to the server and succeeds silently.
+   * If the request fails, reverts the changes in the cache and notifies the observers with old value.
+   *
+   * @returns true if the value was set successfully, false if there was an issue
+   * @throws Error if the setting is not registered
+   *
+   */
+  set: (key: string, value: any) => boolean;
+
+  /**
+   *
+   * Removes the setting from the cache and notifies the observers with undefined value.
+   *
+   */
+  remove: (key: string) => Promise<void>;
+
+  /**
+   * Returns true if the key is a "known" or registered setting, meaning it is either registered
+   * by any plugin or was previously added as a custom setting via the `set()` method.
+   *
+   */
+  isRegistered: (key: string) => boolean;
+
+  /**
+   * Returns an Observable that notifies subscribers of each update to the uiSettings,
+   * including the key, newValue, and oldValue of the setting that changed.
+   */
+  getUpdate$: <T = any>() => Observable<{
+    key: string;
+    newValue: T;
+    oldValue: T;
+  }>;
+
+  /**
+   * Returns an Observable that notifies subscribers of each error while trying to update
+   * the settings, containing the actual Error class.
+   */
+  getUpdateErrors$: () => Observable<Error>;
+}

--- a/src/core/packages/user-settings/browser/src/types.ts
+++ b/src/core/packages/user-settings/browser/src/types.ts
@@ -77,7 +77,8 @@ export interface IUserSettingsService {
 
   /**
    * Returns an Observable that notifies subscribers of each error while trying to update
-   * the settings, containing the actual Error class.
+   * the settings in a key value format. The key is the setting name and the value is the error.
+   *
    */
-  getUpdateErrors$: () => Observable<Error>;
+  getUpdateErrors$: () => Observable<Record<string, Error>>;
 }

--- a/src/core/packages/user-settings/browser/src/user_settings_service.test.ts
+++ b/src/core/packages/user-settings/browser/src/user_settings_service.test.ts
@@ -1,0 +1,415 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { UserProfileService } from '@kbn/core-user-profile-browser';
+import { UserSettingsService } from './user_settings_service';
+import { UserSettingsMeta } from './types';
+
+const mockedUserProfile = {
+  getCurrent: jest.fn(),
+  partialUpdate: jest.fn(() => Promise.resolve()),
+};
+
+const normalUserSetting: UserSettingsMeta = {
+  name: 'setting1',
+  isSpaceAware: false,
+  defaultValue: 'default_setting1',
+  requiredPageReload: false,
+};
+
+const spaceAwareUserSetting: UserSettingsMeta = {
+  name: 'setting2',
+  isSpaceAware: true,
+  defaultValue: 'default_setting2',
+  requiredPageReload: false,
+};
+
+describe('UserSettingsService', () => {
+  let userSettingsService: UserSettingsService;
+  const spaceId = 'spaceId';
+  const appId = 'appId';
+
+  beforeEach(() => {
+    userSettingsService = new UserSettingsService(
+      mockedUserProfile as unknown as UserProfileService,
+      spaceId,
+      appId
+    );
+
+    mockedUserProfile.getCurrent.mockReturnValue({
+      data: {
+        userSettings: {},
+      },
+    });
+
+    mockedUserProfile.partialUpdate.mockReturnValue(Promise.resolve());
+
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should create an instance of UserSettingsService', () => {
+    expect(userSettingsService).toBeInstanceOf(UserSettingsService);
+  });
+
+  describe('register Setting', () => {
+    it('should register a setting correctly', async () => {
+      await userSettingsService.registerSettings([normalUserSetting, spaceAwareUserSetting]);
+      expect(userSettingsService.isRegistered(normalUserSetting.name)).toBe(true);
+      expect(userSettingsService.isRegistered(spaceAwareUserSetting.name)).toBe(true);
+    });
+
+    it('should call get latest user settings on registeration', async () => {
+      await userSettingsService.registerSettings([normalUserSetting, spaceAwareUserSetting]);
+      expect(mockedUserProfile.getCurrent).toHaveBeenCalledWith({
+        dataPath: `userSettings.${appId}`,
+      });
+    });
+
+    describe('Errors', () => {
+      it('should throw an error if trying to register the same key twice', async () => {
+        await userSettingsService.registerSettings([normalUserSetting, spaceAwareUserSetting]);
+
+        await userSettingsService.registerSettings([normalUserSetting]).catch((e) => {
+          expect(e.message).toBe(`Setting ${normalUserSetting.name} is already registered`);
+        });
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('should return the default value if the setting is not set', async () => {
+      await userSettingsService.registerSettings([normalUserSetting]);
+      const key = normalUserSetting.name;
+      expect(userSettingsService.get(key)).toBe(normalUserSetting.defaultValue);
+    });
+
+    it('should return the value if the setting is set for non-space aware setting', async () => {
+      const key = normalUserSetting.name;
+      const value = 'custom_value';
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([[key, value]]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([normalUserSetting]);
+      expect(userSettingsService.get(key)).toBe(value);
+    });
+
+    it('should return value if the setting is set for space aware setting', async () => {
+      const key = `${spaceAwareUserSetting.name}`;
+      const value = 'custom_value';
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([[`${key}:${spaceId}`, value]]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([spaceAwareUserSetting]);
+      expect(userSettingsService.get(key)).toBe(value);
+    });
+
+    describe('Errors', () => {
+      it('should throw an error if trying to get a setting that is not registered', async () => {
+        await userSettingsService.registerSettings([normalUserSetting, spaceAwareUserSetting]);
+        const key = 'unknown_setting';
+        expect(() => userSettingsService.get(key)).toThrow(`Setting ${key} is not registered.`);
+      });
+    });
+  });
+
+  describe('get$', () => {
+    it('should get the updated value when user subscribes to the getter', async () => {
+      const key = normalUserSetting.name;
+      const value = 'custom_value';
+      const value2 = 'custom_value2';
+      const value3 = 'custom_value3';
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([[key, value]]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([normalUserSetting]);
+
+      const mockFn = jest.fn();
+      const valueObserver = userSettingsService.get$(key).subscribe((newValue) => mockFn(newValue));
+
+      expect(mockFn).toHaveBeenNthCalledWith(1, value);
+
+      userSettingsService.set(key, value2);
+      expect(mockFn).toHaveBeenNthCalledWith(2, value2);
+
+      userSettingsService.set(key, value3);
+      expect(mockFn).toHaveBeenNthCalledWith(3, value3);
+
+      valueObserver.unsubscribe();
+    });
+
+    describe('Errors', () => {
+      it('should throw an error if trying to get a setting that is not registered', async () => {
+        await userSettingsService.registerSettings([normalUserSetting, spaceAwareUserSetting]);
+        const key = 'unknown_setting';
+        expect(() => userSettingsService.get$(key)).toThrow(`Setting ${key} is not registered.`);
+      });
+    });
+  });
+
+  describe('set', () => {
+    it('should set the value synchroously for a setting and fire update request later', async () => {
+      const key = normalUserSetting.name;
+      const value = 'custom_value';
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([normalUserSetting]);
+      userSettingsService.set(key, value);
+      expect(mockedUserProfile.partialUpdate).not.toHaveBeenCalled();
+      expect(userSettingsService.get(key)).toBe(value);
+      jest.advanceTimersByTime(1500);
+      expect(mockedUserProfile.partialUpdate).toHaveBeenCalledWith({
+        userSettings: {
+          [appId]: JSON.stringify([[key, value]]),
+        },
+      });
+    });
+
+    it('should debounce the update request if set is called multiple times', async () => {
+      const key = normalUserSetting.name;
+      const value1 = 'custom_value1';
+      const value2 = 'custom_value2';
+      const value3 = 'custom_value3';
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([normalUserSetting]);
+      userSettingsService.set(key, value1);
+      userSettingsService.set(key, value2);
+      userSettingsService.set(key, value3);
+      expect(mockedUserProfile.partialUpdate).not.toHaveBeenCalled();
+      expect(userSettingsService.get(key)).toBe(value3);
+      jest.advanceTimersByTime(1500);
+      expect(mockedUserProfile.partialUpdate).toHaveBeenNthCalledWith(1, {
+        userSettings: {
+          [appId]: JSON.stringify([[key, value3]]),
+        },
+      });
+    });
+
+    describe('Errors', () => {
+      it('should throw an error if trying to set a value for an unregistered setting', async () => {
+        await userSettingsService.registerSettings([normalUserSetting]);
+        const key = 'unknown_setting';
+        expect(() => userSettingsService.set(key, 'value')).toThrow(
+          `Setting ${key} is not registered.`
+        );
+      });
+    });
+  });
+
+  describe('update$', () => {
+    it('should return the updated value when user subscribes to the update$', async () => {
+      const key = normalUserSetting.name;
+      const value = 'custom_value';
+      const value2 = 'custom_value2';
+      const value3 = 'custom_value3';
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([[key, value]]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([normalUserSetting]);
+
+      const mockFn = jest.fn();
+      const updatesObserver = userSettingsService
+        .getUpdate$()
+        .subscribe((newValue) => mockFn(newValue));
+
+      userSettingsService.set(key, value2);
+      expect(mockFn).toHaveBeenNthCalledWith(1, {
+        key,
+        newValue: value2,
+        oldValue: value,
+      });
+
+      userSettingsService.set(key, value3);
+      expect(mockFn).toHaveBeenNthCalledWith(2, {
+        key,
+        newValue: value3,
+        oldValue: value2,
+      });
+
+      updatesObserver.unsubscribe();
+    });
+
+    it('should not public the update if the value is the same as the old value', async () => {
+      const key = normalUserSetting.name;
+      const value = 'custom_value';
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([[key, value]]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([normalUserSetting]);
+
+      const mockFn = jest.fn();
+      const updatesObserver = userSettingsService
+        .getUpdate$()
+        .subscribe((newValue) => mockFn(newValue));
+
+      userSettingsService.set(key, value);
+      jest.runAllTimers();
+
+      expect(mockedUserProfile.partialUpdate).not.toHaveBeenCalled();
+      expect(mockFn).toHaveBeenCalledTimes(0);
+
+      updatesObserver.unsubscribe();
+    });
+  });
+
+  describe('updateError$', () => {
+    const key = normalUserSetting.name;
+    const value = 'custom_value';
+    const customValue = 'custom_value2';
+    const errorMessage = 'error_message';
+    beforeEach(async () => {
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([[key, value]]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([normalUserSetting]);
+    });
+    it('should return the error when user subscribes to the updateError$', (done) => {
+      mockedUserProfile.partialUpdate.mockRejectedValue(new Error(errorMessage));
+      userSettingsService.getUpdateErrors$().subscribe((err) => {
+        expect(err.message).toBe(errorMessage);
+        done();
+      });
+
+      userSettingsService.set(key, customValue);
+      jest.runAllTimers();
+    });
+
+    it('should revert the changes in cache if there is an error while updating user profile', (done) => {
+      mockedUserProfile.partialUpdate.mockRejectedValue(new Error(errorMessage));
+      const mockFn = jest.fn();
+      userSettingsService.getUpdate$().subscribe(mockFn);
+      userSettingsService.getUpdateErrors$().subscribe((err) => {
+        expect(userSettingsService.get(key)).toBe(value);
+        expect(mockFn).toHaveBeenCalledTimes(2);
+        expect(mockFn).toHaveBeenNthCalledWith(1, {
+          key,
+          newValue: customValue,
+          oldValue: value,
+        });
+
+        expect(mockFn).toHaveBeenNthCalledWith(2, {
+          key,
+          newValue: value,
+          oldValue: customValue,
+        });
+
+        done();
+      });
+
+      userSettingsService.set(key, customValue);
+      expect(mockedUserProfile.partialUpdate).not.toHaveBeenCalled();
+      expect(userSettingsService.get(key)).toBe(customValue);
+
+      jest.runAllTimers();
+      expect(mockedUserProfile.partialUpdate).toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove the non-space aware setting and call the update request', async () => {
+      const key = normalUserSetting.name;
+      const customValue = 'custom_value';
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([[key, customValue]]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([normalUserSetting]);
+      // should return the custom value stored in user profile
+      expect(userSettingsService.get(key)).toBe(customValue);
+
+      await userSettingsService.remove(key);
+
+      // should return the default value after removing
+      expect(userSettingsService.get(key)).toBe(normalUserSetting.defaultValue);
+
+      expect(mockedUserProfile.partialUpdate).toHaveBeenCalledWith({
+        userSettings: {
+          [appId]: JSON.stringify([]),
+        },
+      });
+    });
+
+    it('should remove the space aware setting and call the update request', async () => {
+      const key = `${spaceAwareUserSetting.name}`;
+      const customValue = 'custom_value';
+      mockedUserProfile.getCurrent.mockReturnValue({
+        data: {
+          userSettings: {
+            [appId]: JSON.stringify([[`${key}:${spaceId}`, customValue]]),
+          },
+        },
+      });
+      await userSettingsService.registerSettings([spaceAwareUserSetting]);
+      // should return the custom value stored in user profile
+      expect(userSettingsService.get(key)).toBe(customValue);
+
+      await userSettingsService.remove(key);
+
+      // should return the default value after removing
+      expect(userSettingsService.get(key)).toBe(spaceAwareUserSetting.defaultValue);
+
+      expect(mockedUserProfile.partialUpdate).toHaveBeenCalledWith({
+        userSettings: {
+          [appId]: JSON.stringify([]),
+        },
+      });
+    });
+
+    describe('Errors', () => {
+      it('should throw an error if trying to remove an unregistered setting', async () => {
+        await userSettingsService.registerSettings([normalUserSetting]);
+        const key = 'unknown_setting';
+        await userSettingsService.remove(key).catch((e) => {
+          expect(e.message).toBe(`Setting ${key} is not registered.`);
+        });
+      });
+    });
+  });
+});

--- a/src/core/packages/user-settings/browser/src/user_settings_service.test.ts
+++ b/src/core/packages/user-settings/browser/src/user_settings_service.test.ts
@@ -310,7 +310,8 @@ describe('UserSettingsService', () => {
     it('should return the error when user subscribes to the updateError$', (done) => {
       mockedUserProfile.partialUpdate.mockRejectedValue(new Error(errorMessage));
       userSettingsService.getUpdateErrors$().subscribe((err) => {
-        expect(err.message).toBe(errorMessage);
+        expect(key in err).toBe(true);
+        expect(err[key].message).toBe(errorMessage);
         done();
       });
 
@@ -323,6 +324,9 @@ describe('UserSettingsService', () => {
       const mockFn = jest.fn();
       userSettingsService.getUpdate$().subscribe(mockFn);
       userSettingsService.getUpdateErrors$().subscribe((err) => {
+        expect(key in err).toBe(true);
+        expect(err[key].message).toBe(errorMessage);
+
         expect(userSettingsService.get(key)).toBe(value);
         expect(mockFn).toHaveBeenCalledTimes(2);
         expect(mockFn).toHaveBeenNthCalledWith(1, {

--- a/src/core/packages/user-settings/browser/src/user_settings_service.ts
+++ b/src/core/packages/user-settings/browser/src/user_settings_service.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { UserProfileService } from '@kbn/core-user-profile-browser';
+import { Observable, Subject, concat, defer, filter, map, of } from 'rxjs';
+import { DebouncedFunc, debounce, isEqual } from 'lodash';
+import { UserProfileData } from '@kbn/core-user-profile-common';
+import { IUserSettingsService, UserSettingsMeta } from './types';
+
+export class UserSettingsService implements IUserSettingsService {
+  protected cache: Map<string, any>;
+  protected meta: Map<string, UserSettingsMeta>;
+  private update$ = new Subject<{ key: string; newValue: any; oldValue: any }>();
+  private updateErrors$ = new Subject<Error>();
+  protected userSettingUpdater: DebouncedFunc<
+    <D extends UserProfileData>(data: D) => Promise<void>
+  >;
+
+  private settingDelimiter = ':';
+
+  constructor(
+    private userProfile: UserProfileService,
+    private spaceId: string,
+    private appId: string
+  ) {
+    this.cache = new Map();
+    this.meta = new Map<string, UserSettingsMeta>();
+    this.userSettingUpdater = debounce<<D extends UserProfileData>(data: D) => Promise<void>>(
+      this.userProfile.partialUpdate,
+      1000
+    );
+  }
+
+  private getFullSettingName(key: string) {
+    const isSpaceAware = this.meta.get(key)?.isSpaceAware;
+
+    return isSpaceAware
+      ? [key, this.spaceId].join(this.settingDelimiter)
+      : [this.appId, key].join(this.settingDelimiter);
+  }
+
+  public isRegistered(key: string) {
+    return this.meta.has(key);
+  }
+
+  private assertRegistered(key: string) {
+    if (!this.isRegistered(key)) {
+      throw new Error(`Setting ${key} is not registered.`);
+    }
+  }
+
+  private serializeCache() {
+    return JSON.stringify(Array.from(this.cache.entries()));
+  }
+
+  private deserializeCache(serializedCache: string) {
+    console.log(`Deserializing cache: ${serializedCache}`);
+    return new Map<string, any>(JSON.parse(serializedCache));
+  }
+
+  async remove(key: string): Promise<void> {
+    this.assertRegistered(key);
+    this.cache.delete(this.getFullSettingName(key));
+  }
+
+  /**
+   *
+   * Registers settings with required meta data.
+   * Populate the cache with the stored values or default values in case there are no stored values.
+   *
+   * */
+  async registerSettings(settings: UserSettingsMeta[]) {
+    const defaultsCache: Map<string, any> = new Map();
+
+    settings.forEach((setting) => {
+      this.meta.set(setting.name, setting);
+      defaultsCache.set(this.getFullSettingName(setting.name), setting.defaultValue);
+    });
+
+    const savedSettingsWrapped = await this.userProfile.getCurrent<{
+      userSettings: {
+        [key: string]: string;
+      };
+    }>({
+      dataPath: `userSettings.${this.appId}`,
+    });
+
+    const savedSettings = this.deserializeCache(
+      savedSettingsWrapped.data?.userSettings?.[this.appId] ?? '[]'
+    );
+
+    console.log({ savedSettings });
+
+    this.cache = new Map([...defaultsCache, ...this.cache, ...savedSettings]);
+    console.log({ newCache: this.cache });
+  }
+
+  get<T>(key: string): T {
+    this.assertRegistered(key);
+    return (this.cache.get(this.getFullSettingName(key)) ?? this.meta.get(key)?.defaultValue) as T;
+  }
+
+  get$<T>(key: string): Observable<T> {
+    this.assertRegistered(key);
+    const fullSettingName = this.getFullSettingName(key);
+    return concat(
+      defer(() => of(this.get<T>(fullSettingName))),
+      this.update$.pipe(
+        filter(({ key: updatedKey }) => updatedKey === key),
+        map(() => this.get<T>(fullSettingName))
+      )
+    );
+  }
+
+  set(key: string, newValue: any): boolean {
+    this.assertRegistered(key);
+    return this.update(key, newValue);
+  }
+
+  private update(key: string, newValue: any): boolean {
+    this.assertRegistered(key);
+    const fullSettingName = this.getFullSettingName(key);
+    const valueBeforeUpdate = this.cache.get(fullSettingName);
+    if (isEqual(valueBeforeUpdate, newValue)) {
+      return true;
+    }
+
+    this.updateCache(key, newValue);
+
+    const updatedCacheSerialized = this.serializeCache();
+    this.userSettingUpdater({
+      userSettings: {
+        [this.appId]: updatedCacheSerialized,
+      },
+    }).catch((error) => {
+      // revert Changes
+      this.cache.set(fullSettingName, valueBeforeUpdate);
+      this.update$.next({ key, oldValue: valueBeforeUpdate, newValue });
+      this.updateErrors$.next(error);
+    });
+
+    return true;
+  }
+
+  private updateCache(key: string, newValue: any) {
+    const fullSettingName = this.getFullSettingName(key);
+    const oldValue = this.cache.get(fullSettingName);
+    this.cache.set(fullSettingName, newValue);
+    this.update$.next({ key, newValue, oldValue });
+  }
+
+  getUpdate$<T>(): Observable<{ key: string; newValue: T; oldValue: T }> {
+    return this.update$.asObservable();
+  }
+
+  getUpdateErrors$(): Observable<Error> {
+    return this.updateErrors$.asObservable();
+  }
+}

--- a/src/core/packages/user-settings/browser/src/user_settings_service.ts
+++ b/src/core/packages/user-settings/browser/src/user_settings_service.ts
@@ -111,12 +111,11 @@ export class UserSettingsService implements IUserSettingsService {
 
   get$<T>(key: string): Observable<T> {
     this.assertRegistered(key);
-    const fullSettingName = this.getFullSettingName(key);
     return concat(
-      defer(() => of(this.get<T>(fullSettingName))),
+      defer(() => of(this.get<T>(key))),
       this.update$.pipe(
         filter(({ key: updatedKey }) => updatedKey === key),
-        map(() => this.get<T>(fullSettingName))
+        map(() => this.get<T>(key))
       )
     );
   }

--- a/src/core/packages/user-settings/browser/src/utils.ts
+++ b/src/core/packages/user-settings/browser/src/utils.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { debounce } from 'lodash';
+
+export const debounceAsync = <F extends (...args: any[]) => Promise<any>>(
+  fn: F,
+  intervalMs: number
+) => {
+  const debounced = debounce((resolve, reject, ...args) => {
+    fn(...args)
+      .then(resolve)
+      .catch(reject);
+  }, intervalMs);
+
+  return (...args: Parameters<F>): ReturnType<F> => {
+    return new Promise((resolve, reject) => {
+      debounced(resolve, reject, ...args);
+    }) as ReturnType<F>;
+  };
+};

--- a/src/core/packages/user-settings/browser/tsconfig.json
+++ b/src/core/packages/user-settings/browser/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "jest",
+      "node",
+      "react"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": []
+}

--- a/src/core/packages/user-settings/browser/tsconfig.json
+++ b/src/core/packages/user-settings/browser/tsconfig.json
@@ -15,5 +15,8 @@
   "exclude": [
     "target/**/*"
   ],
-  "kbn_references": []
+  "kbn_references": [
+    "@kbn/core-user-profile-browser",
+    "@kbn/core-user-profile-common",
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2090,6 +2090,8 @@
       "@kbn/user-profile-examples-plugin/*": ["examples/user_profile_examples/*"],
       "@kbn/user-profiles-consumer-plugin": ["x-pack/test/security_api_integration/plugins/user_profiles_consumer"],
       "@kbn/user-profiles-consumer-plugin/*": ["x-pack/test/security_api_integration/plugins/user_profiles_consumer/*"],
+      "@kbn/user-settings-example-plugin": ["examples/user_settings"],
+      "@kbn/user-settings-example-plugin/*": ["examples/user_settings/*"],
       "@kbn/utility-types": ["src/platform/packages/shared/kbn-utility-types"],
       "@kbn/utility-types/*": ["src/platform/packages/shared/kbn-utility-types/*"],
       "@kbn/utility-types-jest": ["src/platform/packages/shared/kbn-utility-types-jest"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -680,6 +680,8 @@
       "@kbn/core-user-profile-server-internal/*": ["src/core/packages/user-profile/server-internal/*"],
       "@kbn/core-user-profile-server-mocks": ["src/core/packages/user-profile/server-mocks"],
       "@kbn/core-user-profile-server-mocks/*": ["src/core/packages/user-profile/server-mocks/*"],
+      "@kbn/core-user-settings-browser": ["src/core/packages/user-settings/browser"],
+      "@kbn/core-user-settings-browser/*": ["src/core/packages/user-settings/browser/*"],
       "@kbn/core-user-settings-server": ["src/core/packages/user-settings/server"],
       "@kbn/core-user-settings-server/*": ["src/core/packages/user-settings/server/*"],
       "@kbn/core-user-settings-server-internal": ["src/core/packages/user-settings/server-internal"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5046,6 +5046,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/core-user-settings-browser@link:src/core/packages/user-settings/browser":
+  version "0.0.0"
+  uid ""
+
 "@kbn/core-user-settings-server-internal@link:src/core/packages/user-settings/server-internal":
   version "0.0.0"
   uid ""

--- a/yarn.lock
+++ b/yarn.lock
@@ -7870,6 +7870,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/user-settings-example-plugin@link:examples/user_settings":
+  version "0.0.0"
+  uid ""
+
 "@kbn/utility-types-jest@link:src/platform/packages/shared/kbn-utility-types-jest":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
## Summary

This PR introduces User Settings Service. Below we go through the demo, motivation and design of this service.

## Demo


https://github.com/user-attachments/assets/ab8b55e5-a29f-4b8e-a3d1-cf25eb063de6



## Assumptions

The user Settings currently makes following assumptions.

1. User setting **_values_** are never user facing unlike `UI Settings`. There will always be a UI for the user to interact with the setting and in background, setting can be of any format.
2. User setting value can be of any type which is serializable, we never validate those values and clients of the service are responsible for the same.
3. One of the most common use case this service is trying to address is `drop-in` replacement of Response ops's [Storage](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/response-ops/alerts-table/utils/storage.ts#L15) Class with synchronous `get` and `set` methods, so that any places apps are using `localstorage`, they can immediately start using `UserSettingsService`.


## Motivation

Today, security solution stores a lot of user's configurations/settings in local storage. These settings help user to customize Security views to their liking. Below are some examples of the same:

- Columns in the alerts table that user wants to view.
- Sort order of those columns
- Filters on the alert page that user want to keep.

While this strategy has served us well over past years, there are some pitfalls.

1. These settings are not available across browsers. So in case user decides to change the browser, they have to start all over again to change the security view to their liking.
4. Some customers have a policy to clear the browser's `localstorage` at regular intervals. This leads in the loss of user defined configurations and they have to rinse and repeat same steps again.
5. Clearing `localstorage` is a common way to try to see if the error goes away, this also results in loss of configs that user have done.

Because of above reasons we needed a way to persist these settings on user's profile so that these are available at all times for the user to play with.

## Design

Below is a quick sequence diagram to show how the `UserSettingsService` works and details about the different components.


```mermaid
sequenceDiagram

actor User

User->>+App: Logs in and boots an app (eg. Security Solution)

App->>+UserSettingService: Initiates for that App and Space

UserSettingService->>-App: Returns the instance

App->>+UserSettingService: Registers all the settings

UserSettingService-->>+UserProfile: Gets settings from User's Profile for that APP

UserProfile-->>-UserSettingService: Returns latest settings

UserSettingService->>UserSettingService: Desializes the setting and populated cache

UserSettingService->>-App: Settings Registered

App->>-User: App boot complete and page loads

User->>+App: Loads a component that needs setting A

App->>+UserSettingService: Get the setting from Cache

UserSettingService->>-App: Returns the setting from cache

App->>-User: Component is loaded with a saved setting

User->>+App: Make changes to the setting

App->>+UserSettingService: Updating setting with new value

UserSettingService->>-App:Update Setting in cache and Returns

App->>-User: Setting Saved

UserSettingService->>+UserSettingService: Serialize the setting before persisting

UserSettingService-->>+UserProfile: Persist Latest Cache
```

### Cache

Cache is like a local state manager from the perspective of the App using it. It is always synchronous once the a setting has been registered. At no point will the App wait for the setting to saved to User Profile.

Cache will asynchronously update the `UserProfile` in debounced manner. Current `debounce` timeout is 1000ms. In case user makes lots of quick changes to the cache, only latest change will applied to the `UserProfile`.

It is also assumed that during the life cycle of an App, cache will always be the representation of the latest state. We will only refresh cache when the app intiates as shown in above Sequence Diagram and then keep it always updated.
#### Point of Conflict

Let's say if the user has 2 tabs ( Tab A & B ) open simultaneously and they are making changes to a same setting, then changes done `last` (let's say `Tab A` ) will be persisted and can overwrite the changes done in `Tab B`.

I think we are OKAY with this trade-off because of 2 reasons.

1. With this we are making it a drop-in replacement of Storage Class. Wherever users are using `localstorage`, User settings may be used easily.
2. This is very edge case and can be implemented as the `UserSettingService` evolves and need arises.


### Initiation

`UserSettingsService` is initiated when the app boots up. It has only one dependency i.e. `userProfile` service which is provided by `CoreStart` today. `UserSettingsService` also needs below arguments for initiation

1. APP_ID
	- `UserSettingsService` is instantiated once for a single APP and maintains the namespace of that app in UserProfile. It has helps in fetching all the latest settings from `UserProfile` for that App on boot-up.
2. SpaceId
	- `SpaceId` helps in getting the correct setting if it is a space aware setting. This is applied during instantiation since space is not changed once the App has completely booted up. 


### Registration

**Registration** is an important step in the lifecycle of `UserSettingsService`. To register a setting below pieced of metadata is needed.

- name: This is unique identifier for a setting. We can also call it `id`.
- isSpaceAware: Is the setting space aware or not.
- defaultValue: This is used if there is not setting with same `name/id` existing in the `UserProfile`.

Registration ensures :
- We populate the cache with latest setting so that `cache` can act as a local state manager.
- It ensures `opt-in` for the users of `UserSettingService` for each setting. With this user accepts the assumptions about the setting that `UserSettingsService` makes such as `persisting` of data in User Profile.
- With this we also have a default value to always use before user `gets` the setting for the first time.


### Serialize / Deserialize

#### Limitation of Elasticsearch w.r.t User Profile.

Once an `json` type value has been stored in ES in user profiles, any updates to those values will always be deeply merged in the existing value. These no way to remove a `key`. Only possibility is to set it as `null`. See below example,

Let's say we set a user setting called `testing` in user profile with below command in Dev tools:

```bash
POST /_security/profile/{uid}/_data

{
	"data": {
		"kibana": {
			"userSettings": {
				"testing": {
					"foo": "value1",
					"bar": "value2"
				}
			}
		}
	}
}
```

Once the update is done, you can check the current value of setting using below command:

```bash
GET /_security/profile/{uid}?data=kibana.userSettings.testing

## output looks like below
{
	"data": {
		"kibana": {
			"userSettings": {
				"testing": {
					"bar": "value2",
					"foo": "value1"
				}
			}
		}
	}
}
```


Now we would like to remove `bar` key from the `testing` setting and for that we run below command.
```bash
POST /_security/profile/u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0/_data

{
	"data": {
		"kibana": {
			"userSettings": {
				"testing": {
					"foo": "value1"
				}
			}
		}
	}
}
```

This does not work, now if you check the latest value of `testing` setting again using `GET` command mentioned above. It will not be changed. This is why settings are stored in serialized manner so that we can control which settings should be stored and with what value.

#### Usage

`UserSettingsService` serializes/deserializes whole cache for that `APP` into a string to store it. For example, this is how a sample setting will look like :

<details>
	<summary>Sample settings of 2 apps ( `userSettingsExample` and `securitySolution`)</summary>

<code>

```json
{
	"data": {
		"kibana": {
			"userSettings": {
				"securitySolution": """[["detection-engine-alert-table-alerts-page-gridView:space-2",{"columns":[{"initialWidth":200,"schema":"datetime","columnHeaderType":"not-filtered","id":"@timestamp"},{"id":"event.category","schema":"string"},{"id":"event.action","schema":"string"},{"initialWidth":180,"schema":"string","id":"_id"},{"initialWidth":180,"schema":"string","displayAsText":"Rule","linkField":"kibana.alert.rule.uuid","columnHeaderType":"not-filtered","id":"kibana.alert.rule.name"},{"initialWidth":190,"schema":"string","displayAsText":"Assignees","columnHeaderType":"not-filtered","id":"kibana.alert.workflow_assignee_ids"},{"initialWidth":105,"schema":"string","displayAsText":"Severity","columnHeaderType":"not-filtered","id":"kibana.alert.severity"},{"initialWidth":100,"schema":"numeric","displayAsText":"Risk Score","columnHeaderType":"not-filtered","id":"kibana.alert.risk_score"},{"initialWidth":450,"schema":"string","displayAsText":"Reason","columnHeaderType":"not-filtered","id":"kibana.alert.reason"},{"initialWidth":180,"schema":"string","columnHeaderType":"not-filtered","id":"host.name"},{"initialWidth":180,"schema":"string","columnHeaderType":"not-filtered","id":"user.name"},{"initialWidth":180,"schema":"string","columnHeaderType":"not-filtered","id":"process.name"},{"initialWidth":180,"schema":"string","columnHeaderType":"not-filtered","id":"file.name"},{"initialWidth":180,"schema":"ip","columnHeaderType":"not-filtered","id":"source.ip"},{"initialWidth":180,"schema":"ip","columnHeaderType":"not-filtered","id":"destination.ip"}],"sort":[{"@timestamp":{"order":"desc"}}],"visibleColumns":["@timestamp","event.category","event.action","_id","kibana.alert.rule.name","kibana.alert.workflow_assignee_ids","kibana.alert.severity","kibana.alert.risk_score","kibana.alert.reason","host.name","user.name","process.name","file.name","source.ip","destination.ip"]}],["alertFilterControls:space-2",{"initialChildControlState":{"0":{"type":"optionsListControl","order":0,"hideExclude":true,"hideSort":true,"placeholder":"","width":"small","grow":true,"dataViewId":"security_solution_alerts_dv","title":"Status","fieldName":"kibana.alert.workflow_status","selectedOptions":["open"],"hideActionBar":true,"persist":true,"hideExists":true,"existsSelected":false,"exclude":false},"1":{"type":"optionsListControl","order":1,"hideExclude":true,"hideSort":true,"placeholder":"","width":"small","grow":true,"dataViewId":"security_solution_alerts_dv","fieldName":"event.category","title":"Event Category","selectedOptions":[],"existsSelected":false,"exclude":false}},"labelPosition":"oneLine","chainingSystem":"HIERARCHICAL","autoApplySelections":true,"ignoreParentSettings":{"ignoreValidations":true},"editorConfig":{"hideWidthSettings":true,"hideDataViewSelector":true,"hideAdditionalSettings":true}}]]""",
				
				"userSettingsExample": """[["tableConfiguration:default",{"autoFit":true,"rowHeight":50,"rowDensity":"comfortable"}],["spaceAgnosticSetting",{"checkbox_2":false,"checkbox_3":true,"checkbox_1":true}]]""",
			}
		}
	}
}
```
</code>
</details>

>[!Note]
>Feel Free to suggest if there are any better methods to do it.

