### PR TITLE
[8.17] [Lens] Fix getIndexPatternsObjects for index-pattern only and minor cleanups (#215325)

### DIFF
--- a/src/plugins/share/common/url_service/locators/README.md
+++ b/src/plugins/share/common/url_service/locators/README.md
@@ -8,7 +8,7 @@ so the developer of the app/page has a way to change their url structure without
 breaking users of this system. If users were to generate the URLs on their own, 
 using string concatenation, those links may break often.
 
-Owners: __Kibana App Services team__.
+Owners: __@elastic/appex-sharedux__.
 
 
 ## Producer Usage

--- a/x-pack/plugins/lens/common/locator/locator.ts
+++ b/x-pack/plugins/lens/common/locator/locator.ts
@@ -162,12 +162,12 @@ function getStateFromParams(params: LensAppLocatorParams): MainHistoryLocationSt
     return {};
   }
   const outputState: LensShareableState = {
-    activeDatasourceId: params.activeDatasourceId!,
-    visualization: params.visualization!,
+    activeDatasourceId: params.activeDatasourceId,
+    visualization: params.visualization,
     datasourceStates: Object.fromEntries(
-      Object.entries(params.datasourceStates!).map(([id, { state }]) => [id, state])
+      Object.entries(params.datasourceStates).map(([id, { state }]) => [id, state])
     ) as Record<string, { state: unknown }> & SerializableRecord,
-    references: params.references!,
+    references: params.references,
   };
   if (params.dataViewSpecs) {
     outputState.dataViewSpecs = params.dataViewSpecs;

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -1542,12 +1542,12 @@ export class Embeddable
     }
 
     const { indexPatterns } = await getIndexPatternsObjects(
-      this.savedVis?.references.map(({ id }) => id) || [],
+      this.savedVis?.references.filter(({ type }) => type === 'index-pattern').map(({ id }) => id) ?? [],
       this.deps.dataViews
     );
     (
       await Promise.all(
-        Object.values(this.savedVis?.state.adHocDataViews || {}).map((spec) =>
+        Object.values(this.savedVis?.state.adHocDataViews ?? {}).map((spec) =>
           this.deps.dataViews.create(spec)
         )
       )

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -1542,7 +1542,9 @@ export class Embeddable
     }
 
     const { indexPatterns } = await getIndexPatternsObjects(
-      this.savedVis?.references.filter(({ type }) => type === 'index-pattern').map(({ id }) => id) ?? [],
+      this.savedVis?.references
+        .filter(({ type }) => type === 'index-pattern')
+        .map(({ id }) => id) ?? [],
       this.deps.dataViews
     );
     (

--- a/x-pack/plugins/lens/public/persistence/saved_object_store.ts
+++ b/x-pack/plugins/lens/public/persistence/saved_object_store.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { Filter, Query } from '@kbn/es-query';
-import { SavedObjectReference } from '@kbn/core/public';
+import type { Filter, Query } from '@kbn/es-query';
+import type { SavedObjectReference } from '@kbn/core/server';
 import type { DataViewSpec } from '@kbn/data-views-plugin/public';
 import type { ContentManagementPublicStart } from '@kbn/content-management-plugin/public';
 import type { SearchQuery } from '@kbn/content-management-plugin/common';

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -118,25 +118,25 @@ export const getPreloadedState = ({
   const state: LensAppState = {
     ...initialState,
     isLoading: true,
+    query,
     // Do not use app-specific filters from previous app,
     // only if Lens was opened with the intention to visualize a field (e.g. coming from Discover)
-    query: query as Query,
     filters: !initialContext
       ? data.query.filterManager.getGlobalFilters()
       : 'searchFilters' in initialContext && initialContext.searchFilters
       ? initialContext.searchFilters
       : data.query.filterManager.getFilters(),
-    searchSessionId: data.search.session.getSessionId() || '',
+    searchSessionId: data.search.session.getSessionId() ?? '',
     resolvedDateRange: getResolvedDateRange(data.query.timefilter.timefilter),
     isLinkedToOriginatingApp: Boolean(
-      embeddableEditorIncomingState?.originatingApp ||
-        (initialContext && 'isEmbeddable' in initialContext && initialContext?.isEmbeddable)
+      embeddableEditorIncomingState?.originatingApp ??
+        (initialContext && 'isEmbeddable' in initialContext && initialContext.isEmbeddable)
     ),
     activeDatasourceId: initialDatasourceId,
     datasourceStates,
     visualization: {
       state: null,
-      activeId: Object.keys(visualizationMap)[0] || null,
+      activeId: Object.keys(visualizationMap)[0] ?? null,
     },
   };
   return state;

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -118,7 +118,7 @@ export const getPreloadedState = ({
   const state: LensAppState = {
     ...initialState,
     isLoading: true,
-    query,
+    query: query as Query,
     // Do not use app-specific filters from previous app,
     // only if Lens was opened with the intention to visualize a field (e.g. coming from Discover)
     filters: !initialContext

--- a/x-pack/plugins/lens/public/utils.ts
+++ b/x-pack/plugins/lens/public/utils.ts
@@ -116,7 +116,7 @@ export function getActiveVisualizationIdFromDoc(doc?: Document) {
   return doc.visualizationType || null;
 }
 
-export function getInitialDatasourceId(datasourceMap: DatasourceMap, doc?: LensDocument) {
+export function getInitialDatasourceId(datasourceMap: DatasourceMap, doc?: Document) {
   return (doc && getActiveDatasourceIdFromDoc(doc)) || Object.keys(datasourceMap)[0] || null;
 }
 

--- a/x-pack/plugins/lens/public/utils.ts
+++ b/x-pack/plugins/lens/public/utils.ts
@@ -48,7 +48,7 @@ export function getVisualizeGeoFieldMessage(fieldType: string) {
   });
 }
 
-export const isLensRange = (range: unknown = {}): range is RangeTypeLens => {
+export function isLensRange(range: unknown = {}): range is RangeTypeLens {
   if (!range || typeof range !== 'object') return false;
   const { from, to, label } = range as RangeTypeLens;
 
@@ -57,23 +57,23 @@ export const isLensRange = (range: unknown = {}): range is RangeTypeLens => {
     (typeof from === 'number' || from === null) &&
     (typeof to === 'number' || to === null)
   );
-};
+}
 
-export const getResolvedDateRange = function (timefilter: TimefilterContract) {
+export function getResolvedDateRange(timefilter: TimefilterContract) {
   const { from, to } = timefilter.getTime();
   return { fromDate: from, toDate: to };
-};
+}
 
-export const getAbsoluteDateRange = function (timefilter: TimefilterContract) {
+export function getAbsoluteDateRange(timefilter: TimefilterContract) {
   const { from, to } = timefilter.getTime();
   const { min, max } = timefilter.calculateBounds({
     from,
     to,
   });
   return { fromDate: min?.toISOString() || from, toDate: max?.toISOString() || to };
-};
+}
 
-export const convertToAbsoluteDateRange = function (dateRange: DateRange, now: Date) {
+export function convertToAbsoluteDateRange(dateRange: DateRange, now: Date) {
   const absRange = getAbsoluteTimeRange(
     {
       from: dateRange.fromDate as string,
@@ -86,7 +86,7 @@ export const convertToAbsoluteDateRange = function (dateRange: DateRange, now: D
     fromDate: absRange.from,
     toDate: absRange.to,
   };
-};
+}
 
 export function containsDynamicMath(dateMathString: string) {
   return dateMathString.includes('now');
@@ -116,9 +116,9 @@ export function getActiveVisualizationIdFromDoc(doc?: Document) {
   return doc.visualizationType || null;
 }
 
-export const getInitialDatasourceId = (datasourceMap: DatasourceMap, doc?: Document) => {
+export function getInitialDatasourceId(datasourceMap: DatasourceMap, doc?: LensDocument) {
   return (doc && getActiveDatasourceIdFromDoc(doc)) || Object.keys(datasourceMap)[0] || null;
-};
+}
 
 export function getInitialDataViewsObject(
   indexPatterns: IndexPatternMap,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Lens] Fix getIndexPatternsObjects for index-pattern only and minor cleanups (#215325)](https://github.com/elastic/kibana/pull/215325)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2025-04-08T16:31:56Z","message":"[Lens] Fix getIndexPatternsObjects for index-pattern only and minor cleanups (#215325)\n\n## Summary\n\nThis PR fixes the https://github.com/elastic/kibana/issues/215323 issue\nand also provide small cleanup on the code near the edited file, not\ndirectly correlated but I was already there and the changes are pretty\nminimal.\n\nCleanups:\n\n- the `SavedObjectReference` is deprecated and needs to be imported from\n`core/server` instead\n- Looking at the locator I've noticed a couple of non-null assertion\nthat wasn't necessary\n- the locator readme was referencing the old `kibana app services` team\n- cleaned up the `x-pack/platform/plugins/shared/lens/public/utils.ts`\nto align all the method to use the same form (or all functions or all\narrow function, there was a pretty interesting mix there)\n- replaced usages of exclusive OR with a more appropriate nullish\ncoalescing operator","sha":"971edc124a9334ea79d8308864234d93c3e10f8c","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport:version","v9.1.0","v8.19.0","v8.18.1","v9.0.1","v8.17.5"],"title":"[Lens] Fix getIndexPatternsObjects for index-pattern only and minor cleanups","number":215325,"url":"https://github.com/elastic/kibana/pull/215325","mergeCommit":{"message":"[Lens] Fix getIndexPatternsObjects for index-pattern only and minor cleanups (#215325)\n\n## Summary\n\nThis PR fixes the https://github.com/elastic/kibana/issues/215323 issue\nand also provide small cleanup on the code near the edited file, not\ndirectly correlated but I was already there and the changes are pretty\nminimal.\n\nCleanups:\n\n- the `SavedObjectReference` is deprecated and needs to be imported from\n`core/server` instead\n- Looking at the locator I've noticed a couple of non-null assertion\nthat wasn't necessary\n- the locator readme was referencing the old `kibana app services` team\n- cleaned up the `x-pack/platform/plugins/shared/lens/public/utils.ts`\nto align all the method to use the same form (or all functions or all\narrow function, there was a pretty interesting mix there)\n- replaced usages of exclusive OR with a more appropriate nullish\ncoalescing operator","sha":"971edc124a9334ea79d8308864234d93c3e10f8c"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215325","number":215325,"mergeCommit":{"message":"[Lens] Fix getIndexPatternsObjects for index-pattern only and minor cleanups (#215325)\n\n## Summary\n\nThis PR fixes the https://github.com/elastic/kibana/issues/215323 issue\nand also provide small cleanup on the code near the edited file, not\ndirectly correlated but I was already there and the changes are pretty\nminimal.\n\nCleanups:\n\n- the `SavedObjectReference` is deprecated and needs to be imported from\n`core/server` instead\n- Looking at the locator I've noticed a couple of non-null assertion\nthat wasn't necessary\n- the locator readme was referencing the old `kibana app services` team\n- cleaned up the `x-pack/platform/plugins/shared/lens/public/utils.ts`\nto align all the method to use the same form (or all functions or all\narrow function, there was a pretty interesting mix there)\n- replaced usages of exclusive OR with a more appropriate nullish\ncoalescing operator","sha":"971edc124a9334ea79d8308864234d93c3e10f8c"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217565","number":217565,"state":"OPEN"},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217564","number":217564,"state":"OPEN"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217566","number":217566,"state":"OPEN"},{"branch":"8.17","label":"v8.17.5","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->