### PR TITLE
[9.0] [ftr] split oblt DA configs to speedup CI (#217452)

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -32,3 +32,7 @@ disabled:
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts
+
+# Serverless tests only run on main
+defaultQueue: 'n2-4-spot'
+enabled:

--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -28,8 +28,7 @@ disabled:
   - x-pack/test_serverless/functional/test_suites/observability/config.telemetry.ts
   # serverless config files that run deployment-agnostic tests
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts
+  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.apm.serverless.config.ts
-
-# Serverless tests only run on main
-defaultQueue: 'n2-4-spot'
-enabled:
+  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts
+  - x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Serverless Observability - Deployment-agnostic APM API integration tests', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../../apis/observability/ai_assistant'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerlessTestConfig } from '../../default_configs/serverless.config.base';
+
+export default createServerlessTestConfig({
+  serverlessProject: 'oblt',
+  testFiles: [require.resolve('./oblt.ai_assistant.index.ts')],
+  junit: {
+    reportName: 'Serverless Observability - Deployment-agnostic API Integration Tests',
+  },
+});

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.index.ts
@@ -10,7 +10,8 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
   describe('Serverless Observability - Deployment-agnostic API integration tests', function () {
     this.tags(['esGate']);
 
-    // load new oblt (except APM) and platform deployment-agnostic test here
+    // load new oblt and platform deployment-agnostic test here
+    // Note: if your tests runtime is over 5 minutes, create a new index and config file
     loadTestFile(require.resolve('../../apis/console'));
     loadTestFile(require.resolve('../../apis/core'));
     loadTestFile(require.resolve('../../apis/management'));
@@ -20,8 +21,5 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('../../apis/painless_lab'));
     loadTestFile(require.resolve('../../apis/saved_objects_management'));
     loadTestFile(require.resolve('../../apis/observability/slo'));
-    loadTestFile(require.resolve('../../apis/observability/synthetics'));
-    loadTestFile(require.resolve('../../apis/observability/ai_assistant'));
-    loadTestFile(require.resolve('../../apis/observability/streams'));
   });
 }

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Serverless Observability - Deployment-agnostic APM API integration tests', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../../apis/observability/streams'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerlessTestConfig } from '../../default_configs/serverless.config.base';
+
+export default createServerlessTestConfig({
+  serverlessProject: 'oblt',
+  testFiles: [require.resolve('./oblt.streams.index.ts')],
+  junit: {
+    reportName: 'Serverless Observability - Deployment-agnostic API Integration Tests',
+  },
+});

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Serverless Observability - Deployment-agnostic APM API integration tests', function () {
+    this.tags(['esGate']);
+
+    loadTestFile(require.resolve('../../apis/observability/synthetics'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createServerlessTestConfig } from '../../default_configs/serverless.config.base';
+
+export default createServerlessTestConfig({
+  serverlessProject: 'oblt',
+  testFiles: [require.resolve('./oblt.synthetics.index.ts')],
+  junit: {
+    reportName: 'Serverless Observability - Deployment-agnostic API Integration Tests',
+  },
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[ftr] split oblt DA configs to speedup CI (#217452)](https://github.com/elastic/kibana/pull/217452)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-04-08T13:14:58Z","message":"[ftr] split oblt DA configs to speedup CI (#217452)\n\n## Summary\n\nSplitting the following config:\n\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts\n**~61 min**\n\nby moving `ai_assistant`, `synthetics` and `streams` tests in its own\nconfigs\n\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts\n~11m 30s\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts\n~21m 30s\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts\n~21m 43s\n\noriginal config with less tests:\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts\n~17 min","sha":"aa9be6a62148ae83e0ae5ffd4b2aef89d977329c","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","FTR","backport:version","v9.1.0","v8.19.0","v9.0.1"],"title":"[ftr] split oblt DA configs to speedup CI","number":217452,"url":"https://github.com/elastic/kibana/pull/217452","mergeCommit":{"message":"[ftr] split oblt DA configs to speedup CI (#217452)\n\n## Summary\n\nSplitting the following config:\n\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts\n**~61 min**\n\nby moving `ai_assistant`, `synthetics` and `streams` tests in its own\nconfigs\n\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts\n~11m 30s\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts\n~21m 30s\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts\n~21m 43s\n\noriginal config with less tests:\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts\n~17 min","sha":"aa9be6a62148ae83e0ae5ffd4b2aef89d977329c"}},"sourceBranch":"main","suggestedTargetBranches":["8.x","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217452","number":217452,"mergeCommit":{"message":"[ftr] split oblt DA configs to speedup CI (#217452)\n\n## Summary\n\nSplitting the following config:\n\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts\n**~61 min**\n\nby moving `ai_assistant`, `synthetics` and `streams` tests in its own\nconfigs\n\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.ai_assistant.serverless.config.ts\n~11m 30s\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.synthetics.serverless.config.ts\n~21m 30s\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.streams.serverless.config.ts\n~21m 43s\n\noriginal config with less tests:\n-\nx-pack/test/api_integration/deployment_agnostic/configs/serverless/oblt.serverless.config.ts\n~17 min","sha":"aa9be6a62148ae83e0ae5ffd4b2aef89d977329c"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->