### PR TITLE
[CodeQL] Set CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES for all branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,15 +46,11 @@ jobs:
         echo "CHECKOUT_REF=$(git symbolic-ref HEAD)" >> "$GITHUB_ENV"
         echo "CHECKOUT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
-    - name: Set experimental environment variable for 8.x branch
-      if: env.CHECKOUT_REF == 'refs/heads/8.x'
-      run: echo "CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES=true" >> "$GITHUB_ENV"
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
       env:
         NODE_OPTIONS: "--max-old-space-size=8192"
-        CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES: ${{ env.CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES }}
+        CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES: true
         # CodeQL divides the memory between ts and jvm, though most of the memory is used by the ts.
         # We double the memory, so ts can use it in full capacity.
         # Refer to https://github.com/github/codeql/blob/59a77a873c894bca7274a7ed7c7c6d937547e9b3/javascript/resources/tools/autobuild.sh#L7-L13


### PR DESCRIPTION
## Summary

Set `CODEQL_EXTRACTOR_JAVASCRIPT_OPTION_SKIP_TYPES` for all branches by default.


