### PR TITLE
[ResponseOps][Cases]Fix table layout in the add to existing case modal

### DIFF
--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -313,7 +313,7 @@ describe('useCasesColumns ', () => {
           Object {
             "align": "right",
             "render": [Function],
-            "width": "70px",
+            "width": "120px",
           },
         ],
         "isLoadingColumns": false,
@@ -364,7 +364,7 @@ describe('useCasesColumns ', () => {
           Object {
             "align": "right",
             "render": [Function],
-            "width": "70px",
+            "width": "120px",
           },
         ],
         "isLoadingColumns": false,
@@ -415,7 +415,7 @@ describe('useCasesColumns ', () => {
           Object {
             "align": "right",
             "render": [Function],
-            "width": "70px",
+            "width": "120px",
           },
         ],
         "isLoadingColumns": false,

--- a/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/all_cases/use_cases_columns.tsx
@@ -325,7 +325,7 @@ export const useCasesColumns = ({
           }
           return getEmptyCellValue();
         },
-        width: '70px',
+        width: '120px',
       },
     }),
     [assignCaseAction, casesColumnsConfig, connectors, isSelectorView, userProfiles]


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/216582
## Summary

- increased column width to fit the `select` button

https://github.com/user-attachments/assets/64199991-c765-40e4-8d17-38cb6dfd16f6


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->