### PR TITLE
[Config stack compilation] Read inline security tier

### DIFF
--- a/src/cli/serve/compile_config_stack.js
+++ b/src/cli/serve/compile_config_stack.js
@@ -25,10 +25,16 @@ const VALID_SERVERLESS_PROJECT_MODE = ['es', 'oblt', 'security', 'chat'];
 
 /**
  * Collects paths to configurations to be included in the final configuration stack.
- * @param {{configOverrides?: string[], devConfig?: boolean, dev?: boolean, serverless?: string | true}} options Options impacting the outgoing config list
+ * @param {{configOverrides?: string[], devConfig?: boolean, dev?: boolean, serverless?: string | true, securityProductTier?: ServerlessSecurityTier}} options Options impacting the outgoing config list
  * @returns List of paths to configurations to be merged, from left to right.
  */
-export function compileConfigStack({ configOverrides, devConfig, dev, serverless }) {
+export function compileConfigStack({
+  configOverrides,
+  devConfig,
+  dev,
+  serverless,
+  securityProductTier,
+}) {
   const cliConfigs = configOverrides || [];
   const envConfigs = getEnvConfigs();
   const defaultConfig = getConfigPath();
@@ -56,7 +62,7 @@ export function compileConfigStack({ configOverrides, devConfig, dev, serverless
   // Security specific configs
   if (serverlessMode === 'security') {
     // Security specific tier configs
-    const serverlessSecurityTier = getSecurityTierFromCfg(configs);
+    const serverlessSecurityTier = securityProductTier || getSecurityTierFromCfg(configs);
     if (serverlessSecurityTier) {
       configs.push(resolveConfig(`serverless.${serverlessMode}.${serverlessSecurityTier}.yml`));
       if (dev && devConfig !== false) {

--- a/src/cli/serve/compile_config_stack.test.js
+++ b/src/cli/serve/compile_config_stack.test.js
@@ -79,7 +79,6 @@ describe('compileConfigStack', () => {
     async (productTier) => {
       getConfigFromFiles.mockImplementationOnce(() => {
         return {
-          serverless: 'es',
           xpack: {
             securitySolutionServerless: {
               enabled: true,
@@ -111,10 +110,31 @@ describe('compileConfigStack', () => {
     }
   );
 
+  it.each(['search_ai_lake', 'essentials', 'complete'])(
+    'adds all `security` %s tier config to the stack (when coming from CLI options)',
+    async (productTier) => {
+      const configList = compileConfigStack({
+        serverless: 'security',
+        dev: true,
+        securityProductTier: productTier,
+      }).map(toFileNames);
+
+      expect(configList).toEqual([
+        'serverless.yml',
+        'serverless.security.yml',
+        'kibana.yml',
+        'kibana.dev.yml',
+        'serverless.dev.yml',
+        'serverless.security.dev.yml',
+        `serverless.security.${productTier}.yml`,
+        `serverless.security.${productTier}.dev.yml`,
+      ]);
+    }
+  );
+
   it('adds no additional `security` tier config to the stack when no product tier', async () => {
     getConfigFromFiles.mockImplementationOnce(() => {
       return {
-        serverless: 'es',
         xpack: {
           securitySolutionServerless: {
             enabled: true,

--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -282,6 +282,10 @@ export default function (program) {
       devConfig: opts.devConfig,
       dev: opts.dev,
       serverless: opts.serverless || unknownOptions.serverless,
+      securityProductTier: _.get(
+        unknownOptions,
+        'xpack.securitySolutionServerless.productTypes[0].product_tier'
+      ),
     });
 
     const configsEvaluated = getConfigFromFiles(configs);


### PR DESCRIPTION
## Summary

I noticed that FTRs providing product tier's configuration didn't load the configuration coming from the `serverless.security.{productTier}.yml` files, which is a code smell since we're not testing the real end product.

This PR makes sure to read the CLI options when deciding if a Security product tier is selected.

Noticed while working on https://github.com/elastic/kibana/issues/215919

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



