### PR TITLE
[8.16] [Dashboard] Fix controls being overwritten on navigation (#217596)

### DIFF
--- a/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/dashboard_container.tsx
@@ -756,6 +756,7 @@ export class DashboardContainer
     newSavedObjectId?: string,
     newCreationOptions?: Partial<DashboardCreationOptions>
   ) => {
+    this.restoredRuntimeState = undefined; // restored runtime state will be set in `initializeDashboard`, if necessary
     this.integrationSubscriptions.unsubscribe();
     this.integrationSubscriptions = new Subscription();
     this.stopSyncingWithUnifiedSearch?.();


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.17` to `8.16`:
 - [[8.17] [Dashboard] Fix controls being overwritten on navigation (#217596)](https://github.com/elastic/kibana/pull/217596)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Mudge","email":"Heenawter@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-09T14:46:56Z","message":"[8.17] [Dashboard] Fix controls being overwritten on navigation (#217596)\n\nCloses https://github.com/elastic/kibana/issues/208330\n\n## Summary\n\nConsider how we set `restoredRuntimeState` for controls in\n`initializeDashboard`:\n\n\nhttps://github.com/elastic/kibana/blob/ce91dea75c2bf8940f7767736656ed8a89f24470/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts#L439-L445\n\nNow, consider the following scenario:\n\n1. We have two dashboards - dashboard B has unsaved changes to its\ncontrol group, and dashboard A does not\n2. We start in dashboard B and, since it has unsaved control changes,\n`restoredRuntimeState[PANELS_CONTROL_GROUP_KEY]` (in\n`DashboardContainer`) is populated with these changes\n3. We navigate to Dashboard A via the `navigateToDashboard` method,\nwhich calls `initializeDashboard`\n4. In `initializeDashboard`, `overrideInput` does **not** have control\ngroup state for dashboard A (since it does not have unsaved control\nchanges) - so, we skip calling `setRuntimeStateForChild` for dashboard A\n5. This means that `DashboardContainer` still has\n`restoredRuntimeState[PANELS_CONTROL_GROUP_KEY]` equal to the changes\nfrom dashboard B, which results in Dashboard A's control group getting\noverwritten with `restoredRuntimeState[PANELS_CONTROL_GROUP_KEY]` :fire:\n\nIf we clear `restoredRuntimeState` in `navigateToDashboard`, this is no\nlonger an issue - we will now start from a blank slate on navigation,\nwhich is the desired behaviour.\n\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/d04fa41f-2603-4b64-963d-b59c6be6fa14\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/ce42c204-4ed0-4c44-8c15-c2f49a60131b","sha":"1b0d1f7623ae3403e69092138ea8905314ddd819","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","release_note:fix","Team:Presentation","loe:small","impact:medium","backport:version","v8.16.7"],"title":"[8.17] [Dashboard] Fix controls being overwritten on navigation","number":217596,"url":"https://github.com/elastic/kibana/pull/217596","mergeCommit":{"message":"[8.17] [Dashboard] Fix controls being overwritten on navigation (#217596)\n\nCloses https://github.com/elastic/kibana/issues/208330\n\n## Summary\n\nConsider how we set `restoredRuntimeState` for controls in\n`initializeDashboard`:\n\n\nhttps://github.com/elastic/kibana/blob/ce91dea75c2bf8940f7767736656ed8a89f24470/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.ts#L439-L445\n\nNow, consider the following scenario:\n\n1. We have two dashboards - dashboard B has unsaved changes to its\ncontrol group, and dashboard A does not\n2. We start in dashboard B and, since it has unsaved control changes,\n`restoredRuntimeState[PANELS_CONTROL_GROUP_KEY]` (in\n`DashboardContainer`) is populated with these changes\n3. We navigate to Dashboard A via the `navigateToDashboard` method,\nwhich calls `initializeDashboard`\n4. In `initializeDashboard`, `overrideInput` does **not** have control\ngroup state for dashboard A (since it does not have unsaved control\nchanges) - so, we skip calling `setRuntimeStateForChild` for dashboard A\n5. This means that `DashboardContainer` still has\n`restoredRuntimeState[PANELS_CONTROL_GROUP_KEY]` equal to the changes\nfrom dashboard B, which results in Dashboard A's control group getting\noverwritten with `restoredRuntimeState[PANELS_CONTROL_GROUP_KEY]` :fire:\n\nIf we clear `restoredRuntimeState` in `navigateToDashboard`, this is no\nlonger an issue - we will now start from a blank slate on navigation,\nwhich is the desired behaviour.\n\n\n**Before**\n\n\nhttps://github.com/user-attachments/assets/d04fa41f-2603-4b64-963d-b59c6be6fa14\n\n**After**\n\n\nhttps://github.com/user-attachments/assets/ce42c204-4ed0-4c44-8c15-c2f49a60131b","sha":"1b0d1f7623ae3403e69092138ea8905314ddd819"}},"sourceBranch":"8.17","suggestedTargetBranches":["8.16"],"targetPullRequestStates":[{"branch":"8.16","label":"v8.16.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->