### PR TITLE
SKA: Make src/test plugins part of platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1918,7 +1918,7 @@ src/platform/plugins/shared/discover/public/context_awareness/profile_providers/
 /x-pack/test/functional_gen_ai/inference @elastic/appex-ai-infra
 
 # AppEx Platform Services Security
-//x-pack/test_serverless/api_integration/test_suites/common/security_response_headers.ts  @elastic/kibana-security
+/x-pack/test_serverless/api_integration/test_suites/common/security_response_headers.ts  @elastic/kibana-security
 /x-pack/test/api_integration/apis/es  @elastic/kibana-security
 /x-pack/test/api_integration/apis/features  @elastic/kibana-security
 
@@ -2760,9 +2760,13 @@ docs/settings-gen                             @elastic/platform-docs
 /x-pack/plugins/**/kibana.jsonc @elastic/kibana-core
 /x-pack/platform/plugins/shared/**/kibana.jsonc @elastic/kibana-core
 /x-pack/platform/plugins/private/**/kibana.jsonc @elastic/kibana-core
-/x-pack//solutions/observability/plugins/**/kibana.jsonc @elastic/kibana-core
-/x-pack//solutions/search/plugins/**/kibana.jsonc @elastic/kibana-core
-/x-pack//solutions/security/plugins/**/kibana.jsonc @elastic/kibana-core
+/x-pack/solutions/observability/plugins/**/kibana.jsonc @elastic/kibana-core
+/x-pack/solutions/search/plugins/**/kibana.jsonc @elastic/kibana-core
+/x-pack/solutions/security/plugins/**/kibana.jsonc @elastic/kibana-core
+
+# Plugin manifests for test plugins
+/src/platform/test/**/kibana.jsonc @elastic/appex-qa @elastic/kibana-core
+/x-pack/test/**/kibana.jsonc @elastic/appex-qa @elastic/kibana-core
 
 # Temporary Encrypted Saved Objects (ESO) guarding
 # This additional code-ownership is meant to be a temporary precaution to notify the Kibana platform security team

--- a/src/platform/test/analytics/plugins/analytics_ftr_helpers/kibana.jsonc
+++ b/src/platform/test/analytics/plugins/analytics_ftr_helpers/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/analytics-ftr-helpers-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "analyticsFtrHelpers",
     "server": true,

--- a/src/platform/test/analytics/plugins/analytics_plugin_a/kibana.jsonc
+++ b/src/platform/test/analytics/plugins/analytics_plugin_a/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/analytics-plugin-a-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "analyticsPluginA",
     "server": true,

--- a/src/platform/test/common/plugins/newsfeed/kibana.jsonc
+++ b/src/platform/test/common/plugins/newsfeed/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/newsfeed-test-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "newsfeedTestPlugin",
     "server": true,

--- a/src/platform/test/common/plugins/otel_metrics/kibana.jsonc
+++ b/src/platform/test/common/plugins/otel_metrics/kibana.jsonc
@@ -3,6 +3,8 @@
   "id": "@kbn/open-telemetry-instrumented-plugin",
   "owner": "@elastic/obs-ux-infra_services-team",
   "group": "platform",
+  "visibility": "private",
+  "group": "platform",
   "visibility": "shared",
   "plugin": {
     "id": "openTelemetryInstrumentedPlugin",

--- a/src/platform/test/health_gateway/plugins/status/kibana.jsonc
+++ b/src/platform/test/health_gateway/plugins/status/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/kbn-health-gateway-status-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "kbnHealthGatewayStatus",
     "server": true,

--- a/src/platform/test/interactive_setup_api_integration/plugins/test_endpoints/kibana.jsonc
+++ b/src/platform/test/interactive_setup_api_integration/plugins/test_endpoints/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/interactive-setup-test-endpoints-plugin",
   "owner": "@elastic/kibana-security",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "interactiveSetupTestEndpoints",
     "type": "preboot",

--- a/src/platform/test/interpreter_functional/plugins/kbn_tp_run_pipeline/kibana.jsonc
+++ b/src/platform/test/interpreter_functional/plugins/kbn_tp_run_pipeline/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/kbn-tp-run-pipeline-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "kbnTpRunPipeline",
     "server": true,

--- a/src/platform/test/node_roles_functional/plugins/core_plugin_initializer_context/kibana.jsonc
+++ b/src/platform/test/node_roles_functional/plugins/core_plugin_initializer_context/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-initializer-context-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginInitializerContext",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/app_link_test/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/app_link_test/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/app-link-test-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "appLinkTest",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/core_app_status/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_app_status/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-app-status-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "coreAppStatus",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/core_dynamic_resolving_a/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_dynamic_resolving_a/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-dynamic-resolving-a",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "coreDynamicResolvingA",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/core_dynamic_resolving_b/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_dynamic_resolving_b/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-dynamic-resolving-b",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "coreDynamicResolvingB",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/core_history_block/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_history_block/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-history-block-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "coreHistoryBlock",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/core_http/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_http/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-http-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "coreHttp",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_a/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_a/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-a-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginA",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_appleave/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_appleave/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-appleave-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginAppleave",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_b/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_b/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-b-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginB",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_chromeless/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_chromeless/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-chromeless-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginChromeless",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_deep_links/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_deep_links/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-deep-links-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginDeepLinks",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_deprecations/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_deprecations/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-deprecations-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginDeprecations",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_execution_context/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_execution_context/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-execution-context-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginExecutionContext",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_helpmenu/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_helpmenu/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-helpmenu-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginHelpmenu",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_route_timeouts/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_route_timeouts/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-route-timeouts-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginRouteTimeouts",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/core_plugin_static_assets/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_plugin_static_assets/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-plugin-static-assets-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "corePluginStaticAssets",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/core_provider_plugin/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/core_provider_plugin/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/core-provider-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "coreProviderPlugin",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/data_search/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/data_search/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/data-search-plugin",
   "owner": "@elastic/kibana-data-discovery",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "dataSearchPlugin",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/elasticsearch_client_plugin/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/elasticsearch_client_plugin/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/elasticsearch-client-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "elasticsearchClientPlugin",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/eui_provider_dev_warning/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/eui_provider_dev_warning/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/eui-provider-dev-warning",
   "owner": "@elastic/appex-sharedux",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "euiProviderDevWarning",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/hardening/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/hardening/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/hardening-plugin",
   "owner": "@elastic/kibana-security",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "hardeningPlugin",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/index_patterns/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/index_patterns/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/index-patterns-test-plugin",
   "owner": "@elastic/kibana-data-discovery",
+  "group": "platform",
+  "visibility": "private",
   "description": "Index pattern test plugin",
   "plugin": {
     "id": "indexPatternsTestPlugin",

--- a/src/platform/test/plugin_functional/plugins/kbn_sample_panel_action/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/kbn_sample_panel_action/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/kbn-sample-panel-action-plugin",
   "owner": "@elastic/appex-sharedux",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "kbnSamplePanelAction",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/kbn_top_nav/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/kbn_top_nav/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/kbn-top-nav-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "kbnTopNav",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/kbn_tp_custom_visualizations/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/kbn_tp_custom_visualizations/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/kbn-tp-custom-visualizations-plugin",
   "owner": "@elastic/kibana-visualizations",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "kbnTpCustomVisualizations",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/management_test_plugin/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/management_test_plugin/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/management-test-plugin",
   "owner": "@elastic/kibana-management",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "managementTestPlugin",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/rendering_plugin/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/rendering_plugin/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/rendering-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "renderingPlugin",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/saved_object_export_transforms/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/saved_object_export_transforms/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/saved-object-export-transforms-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "savedObjectExportTransforms",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/saved_object_import_warnings/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/saved_object_import_warnings/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/saved-object-import-warnings-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "savedObjectImportWarnings",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/saved_objects_hidden_from_http_apis_type/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/saved_objects_hidden_from_http_apis_type/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/saved-objects-hidden-from-http-apis-type-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "savedObjectsHiddenFromHttpApisType",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/saved_objects_hidden_type/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/saved_objects_hidden_type/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/saved-objects-hidden-type-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "savedObjectsHiddenType",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/session_notifications/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/session_notifications/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/session-notifications-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "sessionNotifications",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/telemetry/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/telemetry/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/telemetry-test-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "telemetryTestPlugin",
     "server": false,

--- a/src/platform/test/plugin_functional/plugins/ui_settings_plugin/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/ui_settings_plugin/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/ui-settings-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "uiSettingsPlugin",
     "server": true,

--- a/src/platform/test/plugin_functional/plugins/usage_collection/kibana.jsonc
+++ b/src/platform/test/plugin_functional/plugins/usage_collection/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/usage-collection-test-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "usageCollectionTestPlugin",
     "server": true,

--- a/src/platform/test/server_integration/plugins/status_plugin_a/kibana.jsonc
+++ b/src/platform/test/server_integration/plugins/status_plugin_a/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/status-plugin-a-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "statusPluginA",
     "server": true,

--- a/src/platform/test/server_integration/plugins/status_plugin_b/kibana.jsonc
+++ b/src/platform/test/server_integration/plugins/status_plugin_b/kibana.jsonc
@@ -2,6 +2,8 @@
   "type": "plugin",
   "id": "@kbn/status-plugin-b-plugin",
   "owner": "@elastic/kibana-core",
+  "group": "platform",
+  "visibility": "private",
   "plugin": {
     "id": "statusPluginB",
     "server": true,


### PR DESCRIPTION
## Summary

This is needed by https://github.com/elastic/kibana/pull/216088, in order to enable these plugins on CI for FTR tests.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->