### PR TITLE
[8.x] feat(slo): group by slo id (#210469)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/find_group.ts
+++ b/x-pack/platform/packages/shared/kbn-slo-schema/src/rest_specs/routes/find_group.ts
@@ -14,6 +14,7 @@ const groupBySchema = t.union([
   t.literal('slo.indicator.type'),
   t.literal('slo.instanceId'),
   t.literal('_index'),
+  t.literal('slo.id'),
 ]);
 
 const findSLOGroupsParamsSchema = t.partial({

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/common/quick_filters.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/common/quick_filters.tsx
@@ -59,6 +59,9 @@ export function QuickFilters({
           align-items: flex-start;
           min-height: initial;
         }
+        .controlPanel {
+          height: initial;
+        }
         .controlGroup {
           min-height: initial;
         }

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/grouped_slos/hooks/use_group_name.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/grouped_slos/hooks/use_group_name.ts
@@ -18,6 +18,7 @@ export function useGroupName(groupBy: GroupByField, group: string, summary?: Gro
     case 'ungrouped':
     case 'slo.tags':
     case 'status':
+    case 'slo.id':
       return groupName;
     case 'slo.instanceId':
       if (groupName === ALL_VALUE || !summary?.worst?.slo?.groupings) {

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list_group_by.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_list_group_by.tsx
@@ -81,6 +81,16 @@ export function SloGroupBy({ onStateChange, state, loading }: Props) {
       },
     },
     {
+      label: i18n.translate('xpack.slo.list.groupBy.sloId', {
+        defaultMessage: 'SLO definition id',
+      }),
+      checked: groupBy === 'slo.id',
+      value: 'slo.id',
+      onClick: () => {
+        handleChangeGroupBy('slo.id');
+      },
+    },
+    {
       label: i18n.translate('xpack.slo.list.groupBy.sloInstanceId', {
         defaultMessage: 'SLO instance id',
       }),

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slos/types.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slos/types.ts
@@ -12,7 +12,8 @@ export type GroupByField =
   | 'status'
   | 'slo.indicator.type'
   | 'slo.instanceId'
-  | '_index';
+  | '_index'
+  | 'slo.id';
 export type SortDirection = 'asc' | 'desc';
 export type SortField =
   | 'sli_value'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [feat(slo): group by slo id (#210469)](https://github.com/elastic/kibana/pull/210469)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kevin Delemme","email":"kevin.delemme@elastic.co"},"sourceCommit":{"committedDate":"2025-02-11T12:55:41Z","message":"feat(slo): group by slo id (#210469)","sha":"9545d6b1270785ffecc2b6bcb1434a21d2b2c053","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"feat(slo): group by slo id","number":210469,"url":"https://github.com/elastic/kibana/pull/210469","mergeCommit":{"message":"feat(slo): group by slo id (#210469)","sha":"9545d6b1270785ffecc2b6bcb1434a21d2b2c053"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210469","number":210469,"mergeCommit":{"message":"feat(slo): group by slo id (#210469)","sha":"9545d6b1270785ffecc2b6bcb1434a21d2b2c053"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->