### PR TITLE
[8.x] chore(slo): delete by queries (#217108)

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/__snapshots__/delete_slo.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/slo/server/services/__snapshots__/delete_slo.test.ts.snap
@@ -122,17 +122,20 @@ exports[`DeleteSLO happy path removes all resources associatde to the slo 7`] = 
   "calls": Array [
     Array [
       Object {
+        "conflicts": "proceed",
         "index": ".slo-observability.sli-v3*",
         "query": Object {
           "match": Object {
             "slo.id": "irrelevant",
           },
         },
+        "slices": "auto",
         "wait_for_completion": false,
       },
     ],
     Array [
       Object {
+        "conflicts": "proceed",
         "index": ".slo-observability.summary-v3*",
         "query": Object {
           "match": Object {
@@ -140,6 +143,8 @@ exports[`DeleteSLO happy path removes all resources associatde to the slo 7`] = 
           },
         },
         "refresh": true,
+        "slices": "auto",
+        "wait_for_completion": false,
       },
     ],
   ],

--- a/x-pack/solutions/observability/plugins/slo/server/services/__snapshots__/reset_slo.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/slo/server/services/__snapshots__/reset_slo.test.ts.snap
@@ -69,6 +69,7 @@ exports[`ResetSLO happy path resets all associated resources 5`] = `
   "calls": Array [
     Array [
       Object {
+        "conflicts": "proceed",
         "index": ".slo-observability.sli-v3*",
         "query": Object {
           "bool": Object {
@@ -82,10 +83,12 @@ exports[`ResetSLO happy path resets all associated resources 5`] = `
           },
         },
         "refresh": true,
+        "slices": "auto",
       },
     ],
     Array [
       Object {
+        "conflicts": "proceed",
         "index": ".slo-observability.summary-v3*",
         "query": Object {
           "bool": Object {
@@ -99,6 +102,7 @@ exports[`ResetSLO happy path resets all associated resources 5`] = `
           },
         },
         "refresh": true,
+        "slices": "auto",
       },
     ],
   ],

--- a/x-pack/solutions/observability/plugins/slo/server/services/delete_slo_instances.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/delete_slo_instances.test.ts
@@ -43,6 +43,7 @@ describe('DeleteSLOInstances', () => {
     expect(mockEsClient.deleteByQuery).toHaveBeenCalledTimes(2);
     expect(mockEsClient.deleteByQuery.mock.calls[0][0]).toMatchInlineSnapshot(`
       Object {
+        "conflicts": "proceed",
         "index": ".slo-observability.sli-v3*",
         "query": Object {
           "bool": Object {
@@ -98,11 +99,13 @@ describe('DeleteSLOInstances', () => {
             ],
           },
         },
+        "slices": "auto",
         "wait_for_completion": false,
       }
     `);
     expect(mockEsClient.deleteByQuery.mock.calls[1][0]).toMatchInlineSnapshot(`
       Object {
+        "conflicts": "proceed",
         "index": ".slo-observability.summary-v3*",
         "query": Object {
           "bool": Object {
@@ -159,6 +162,8 @@ describe('DeleteSLOInstances', () => {
           },
         },
         "refresh": true,
+        "slices": "auto",
+        "wait_for_completion": false,
       }
     `);
   });

--- a/x-pack/solutions/observability/plugins/slo/server/services/delete_slo_instances.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/delete_slo_instances.ts
@@ -24,8 +24,7 @@ export class DeleteSLOInstances {
       throw new IllegalArgumentError("Cannot delete an SLO instance '*'");
     }
 
-    await this.deleteRollupData(params.list);
-    await this.deleteSummaryData(params.list);
+    await Promise.all([this.deleteRollupData(params.list), this.deleteSummaryData(params.list)]);
   }
 
   // Delete rollup data when excluding rollup data is not explicitly requested
@@ -33,6 +32,8 @@ export class DeleteSLOInstances {
     await this.esClient.deleteByQuery({
       index: SLI_DESTINATION_INDEX_PATTERN,
       wait_for_completion: false,
+      conflicts: 'proceed',
+      slices: 'auto',
       query: {
         bool: {
           should: list
@@ -54,6 +55,9 @@ export class DeleteSLOInstances {
     await this.esClient.deleteByQuery({
       index: SUMMARY_DESTINATION_INDEX_PATTERN,
       refresh: true,
+      wait_for_completion: false,
+      conflicts: 'proceed',
+      slices: 'auto',
       query: {
         bool: {
           should: list.map((item) => ({

--- a/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/reset_slo.ts
@@ -126,6 +126,8 @@ export class ResetSLO {
     await this.esClient.deleteByQuery({
       index: SLI_DESTINATION_INDEX_PATTERN,
       refresh: true,
+      conflicts: 'proceed',
+      slices: 'auto',
       query: {
         bool: {
           filter: [{ term: { 'slo.id': sloId } }],
@@ -144,6 +146,8 @@ export class ResetSLO {
     await this.esClient.deleteByQuery({
       index: SUMMARY_DESTINATION_INDEX_PATTERN,
       refresh: true,
+      conflicts: 'proceed',
+      slices: 'auto',
       query: {
         bool: {
           filter: [{ term: { 'slo.id': sloId } }],

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client/__snapshots__/summary_search_client.test.ts.snap
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client/__snapshots__/summary_search_client.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Summary Search Client returns the summary documents without duplicate temporary summary documents 1`] = `
 Array [
   Object {
+    "conflicts": "proceed",
     "index": ".slo-observability.summary-v3*",
     "query": Object {
       "bool": Object {
@@ -25,6 +26,7 @@ Array [
         ],
       },
     },
+    "slices": "auto",
     "wait_for_completion": false,
   },
 ]

--- a/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client/summary_search_client.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/summary_search_client/summary_search_client.ts
@@ -172,6 +172,8 @@ export class DefaultSummarySearchClient implements SummarySearchClient {
     await this.esClient.deleteByQuery({
       index: SUMMARY_DESTINATION_INDEX_PATTERN,
       wait_for_completion: false,
+      conflicts: 'proceed',
+      slices: 'auto',
       query: {
         bool: {
           filter: [{ terms: { 'slo.id': summarySloIds } }, { term: { isTempDoc: true } }],

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/orphan_summary_cleanup_task.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/orphan_summary_cleanup_task.test.ts
@@ -69,6 +69,8 @@ describe('SloSummaryCleanupTask', () => {
           ],
         },
       },
+      conflicts: 'proceed',
+      slices: 'auto',
       wait_for_completion: false,
     });
   });
@@ -99,6 +101,8 @@ describe('SloSummaryCleanupTask', () => {
     expect(task.fetchSloSummariesIds).toHaveBeenCalledTimes(1);
     expect(esClient.deleteByQuery).toHaveBeenCalledTimes(1);
     expect(esClient.deleteByQuery).toHaveBeenNthCalledWith(1, {
+      conflicts: 'proceed',
+      slices: 'auto',
       wait_for_completion: false,
       index: SUMMARY_DESTINATION_INDEX_PATTERN,
       query: {
@@ -159,6 +163,9 @@ describe('SloSummaryCleanupTask', () => {
 
     expect(esClient.deleteByQuery).toHaveBeenNthCalledWith(1, {
       index: SUMMARY_DESTINATION_INDEX_PATTERN,
+      conflicts: 'proceed',
+      slices: 'auto',
+      wait_for_completion: false,
       query: {
         bool: {
           should: getDeleteQueryFilter([
@@ -169,12 +176,13 @@ describe('SloSummaryCleanupTask', () => {
           ]),
         },
       },
-      wait_for_completion: false,
     });
 
     expect(esClient.deleteByQuery).toHaveBeenLastCalledWith({
-      wait_for_completion: false,
       index: SUMMARY_DESTINATION_INDEX_PATTERN,
+      wait_for_completion: false,
+      conflicts: 'proceed',
+      slices: 'auto',
       query: {
         bool: {
           should: getDeleteQueryFilter([
@@ -231,6 +239,8 @@ describe('SloSummaryCleanupTask', () => {
     expect(task.fetchSloSummariesIds).toHaveBeenCalledTimes(2);
     expect(esClient.deleteByQuery).toHaveBeenCalledTimes(2);
     expect(esClient.deleteByQuery).toHaveBeenNthCalledWith(1, {
+      conflicts: 'proceed',
+      slices: 'auto',
       wait_for_completion: false,
       index: SUMMARY_DESTINATION_INDEX_PATTERN,
       query: {
@@ -245,6 +255,8 @@ describe('SloSummaryCleanupTask', () => {
       },
     });
     expect(esClient.deleteByQuery).toHaveBeenLastCalledWith({
+      conflicts: 'proceed',
+      slices: 'auto',
       wait_for_completion: false,
       index: SUMMARY_DESTINATION_INDEX_PATTERN,
       query: {
@@ -299,6 +311,8 @@ describe('SloSummaryCleanupTask', () => {
     expect(esClient.deleteByQuery).toHaveBeenCalledTimes(2);
 
     expect(esClient.deleteByQuery).toHaveBeenNthCalledWith(1, {
+      conflicts: 'proceed',
+      slices: 'auto',
       wait_for_completion: false,
       index: SUMMARY_DESTINATION_INDEX_PATTERN,
       query: {

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/orphan_summary_cleanup_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/orphan_summary_cleanup_task.ts
@@ -105,8 +105,10 @@ export class SloOrphanSummaryCleanupTask {
           );
 
           await this.esClient.deleteByQuery({
-            wait_for_completion: false,
             index: SUMMARY_DESTINATION_INDEX_PATTERN,
+            wait_for_completion: false,
+            conflicts: 'proceed',
+            slices: 'auto',
             query: {
               bool: {
                 should: getDeleteQueryFilter(sloSummaryIdsToDelete.sort()),

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
@@ -151,7 +151,7 @@ export class DefaultTransformManager implements TransformManager {
     }
   }
 
-  async scheduleNowTransform(transformId: TransformId) {
+  private async scheduleNowTransform(transformId: TransformId) {
     this.scopedClusterClient.asSecondaryAuthUser.transform
       .scheduleNowTransform({ transform_id: transformId })
       .then(() => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [chore(slo): delete by queries (#217108)](https://github.com/elastic/kibana/pull/217108)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kevin Delemme","email":"kevin.delemme@elastic.co"},"sourceCommit":{"committedDate":"2025-04-03T22:36:35Z","message":"chore(slo): delete by queries (#217108)\n\n## Summary\n\nAdd safer parameters when deleting by queries, and make all delete by\nqueries async (wait = false).\nIn some cases, I've parallelized the calls","sha":"3a63089dc75c03cb3c867c4ad09bd271593d807b","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-ux-management","v9.1.0"],"title":"chore(slo): delete by queries","number":217108,"url":"https://github.com/elastic/kibana/pull/217108","mergeCommit":{"message":"chore(slo): delete by queries (#217108)\n\n## Summary\n\nAdd safer parameters when deleting by queries, and make all delete by\nqueries async (wait = false).\nIn some cases, I've parallelized the calls","sha":"3a63089dc75c03cb3c867c4ad09bd271593d807b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217108","number":217108,"mergeCommit":{"message":"chore(slo): delete by queries (#217108)\n\n## Summary\n\nAdd safer parameters when deleting by queries, and make all delete by\nqueries async (wait = false).\nIn some cases, I've parallelized the calls","sha":"3a63089dc75c03cb3c867c4ad09bd271593d807b"}}]}] BACKPORT-->