### PR TITLE
[8.17] [index mgmt] Fix preview of index templates which are used by data streams (#217604)

### DIFF
--- a/x-pack/plugins/index_management/server/routes/api/templates/register_simulate_route.ts
+++ b/x-pack/plugins/index_management/server/routes/api/templates/register_simulate_route.ts
@@ -34,9 +34,6 @@ export function registerSimulateRoute({ router, lib: { handleEsError } }: RouteD
       const params: estypes.IndicesSimulateTemplateRequest = templateName
         ? {
             name: templateName,
-            body: {
-              index_patterns,
-            },
           }
         : {
             body: {

--- a/x-pack/test/api_integration/apis/management/index_management/templates.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/templates.ts
@@ -15,6 +15,7 @@ import { getRandomString } from './lib/random';
 
 export default function ({ getService }: FtrProviderContext) {
   const log = getService('log');
+  const es = getService('es');
   const { catTemplate, getTemplatePayload, getSerializedTemplate } = templatesHelpers(getService);
   const {
     getAllTemplates,

--- a/x-pack/test/api_integration/apis/management/index_management/templates.ts
+++ b/x-pack/test/api_integration/apis/management/index_management/templates.ts
@@ -472,6 +472,23 @@ export default function ({ getService }: FtrProviderContext) {
         // cleanup
         await deleteTemplates([{ name: templateName }]);
       });
+
+      it('should simulate an index template by name with a related data stream', async () => {
+        const dataStreamName = `test-foo`;
+        const templateName = `template-${getRandomString()}`;
+        const payload = getTemplatePayload(templateName);
+
+        await createTemplate({ ...payload, dataStream: {} }).expect(200);
+
+        // Matches index template
+        await es.indices.createDataStream({ name: dataStreamName });
+
+        await simulateTemplateByName(templateName).expect(200);
+
+        // cleanup
+        await deleteTemplates([{ name: templateName }]);
+        await es.indices.deleteDataStream({ name: dataStreamName });
+      });
     });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[index mgmt] Fix preview of index templates which are used by data streams (#217604)](https://github.com/elastic/kibana/pull/217604)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Matthew Kime","email":"matt@mattki.me"},"sourceCommit":{"committedDate":"2025-04-09T17:29:12Z","message":"[index mgmt] Fix preview of index templates which are used by data streams (#217604)\n\n## Summary\n\nFixes error message when attempting to preview an index template which\nis used by a data stream.\n\nWhen previewing a saved index template, a index template name and index\npattern were provided. If the index pattern didn't match data streams\nthat relied on the index template (and they never did) an error would be\nshown. As it turns out, supplying the index pattern was entirely\nunnecessary. This PR simply removes the index pattern from the api call\nand adds a test to make sure that preview functionality works when index\ntemplates match data streams.\n\nFollow up to https://github.com/elastic/kibana/pull/195174\n\nCloses https://github.com/elastic/kibana/issues/212781","sha":"b542a760cf5c87900c87b3f5424749eec52366c6","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Feature:Index Management","Team:Kibana Management","backport:prev-major","v8.18.0","v9.1.0","v8.19.0"],"title":"[index mgmt] Fix preview of index templates which are used by data streams","number":217604,"url":"https://github.com/elastic/kibana/pull/217604","mergeCommit":{"message":"[index mgmt] Fix preview of index templates which are used by data streams (#217604)\n\n## Summary\n\nFixes error message when attempting to preview an index template which\nis used by a data stream.\n\nWhen previewing a saved index template, a index template name and index\npattern were provided. If the index pattern didn't match data streams\nthat relied on the index template (and they never did) an error would be\nshown. As it turns out, supplying the index pattern was entirely\nunnecessary. This PR simply removes the index pattern from the api call\nand adds a test to make sure that preview functionality works when index\ntemplates match data streams.\n\nFollow up to https://github.com/elastic/kibana/pull/195174\n\nCloses https://github.com/elastic/kibana/issues/212781","sha":"b542a760cf5c87900c87b3f5424749eec52366c6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217737","number":217737,"state":"MERGED","mergeCommit":{"sha":"b652d91bd4dcace9f127c0e475ced46ef91388c6","message":"[8.18] [index mgmt] Fix preview of index templates which are used by data streams (#217604) (#217737)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[index mgmt] Fix preview of index templates which are used by data\nstreams (#217604)](https://github.com/elastic/kibana/pull/217604)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Matthew Kime <matt@mattki.me>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217604","number":217604,"mergeCommit":{"message":"[index mgmt] Fix preview of index templates which are used by data streams (#217604)\n\n## Summary\n\nFixes error message when attempting to preview an index template which\nis used by a data stream.\n\nWhen previewing a saved index template, a index template name and index\npattern were provided. If the index pattern didn't match data streams\nthat relied on the index template (and they never did) an error would be\nshown. As it turns out, supplying the index pattern was entirely\nunnecessary. This PR simply removes the index pattern from the api call\nand adds a test to make sure that preview functionality works when index\ntemplates match data streams.\n\nFollow up to https://github.com/elastic/kibana/pull/195174\n\nCloses https://github.com/elastic/kibana/issues/212781","sha":"b542a760cf5c87900c87b3f5424749eec52366c6"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217738","number":217738,"state":"MERGED","mergeCommit":{"sha":"28cc7e2d2484d35f5691fad2edcfc44998e41b9a","message":"[8.x] [index mgmt] Fix preview of index templates which are used by data streams (#217604) (#217738)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[index mgmt] Fix preview of index templates which are used by data\nstreams (#217604)](https://github.com/elastic/kibana/pull/217604)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Matthew Kime <matt@mattki.me>"}}]}] BACKPORT-->