### PR TITLE
[8.18] [build] Use docker hub to download ubi (#217322)

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/run.ts
+++ b/src/dev/build/tasks/os_packages/docker_generator/run.ts
@@ -42,7 +42,7 @@ export async function runDockerGenerator(
 ) {
   let baseImageName = '';
   if (flags.baseImage === 'ubuntu') baseImageName = 'ubuntu:20.04';
-  if (flags.baseImage === 'ubi') baseImageName = 'docker.elastic.co/ubi9/ubi-minimal:latest';
+  if (flags.baseImage === 'ubi') baseImageName = 'redhat/ubi9-minimal:latest';
   /**
    * Renovate config contains a regex manager to automatically updates this Chainguard reference
    *


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[build] Use docker hub to download ubi (#217322)](https://github.com/elastic/kibana/pull/217322)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jon","email":"jon@elastic.co"},"sourceCommit":{"committedDate":"2025-04-07T17:06:38Z","message":"[build] Use docker hub to download ubi (#217322)\n\nMoves away from our mirror for all images based on UBI.\n\nBased on feedback in\nhttps://github.com/docker-library/official-images/pull/18692.","sha":"87b3816a4c4a22bc6abacdebbf6184c2d4e47c38","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","v9.0.0","backport:all-open","v9.1.0"],"title":"[build] Use docker hub to download ubi","number":217322,"url":"https://github.com/elastic/kibana/pull/217322","mergeCommit":{"message":"[build] Use docker hub to download ubi (#217322)\n\nMoves away from our mirror for all images based on UBI.\n\nBased on feedback in\nhttps://github.com/docker-library/official-images/pull/18692.","sha":"87b3816a4c4a22bc6abacdebbf6184c2d4e47c38"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/217375","number":217375,"state":"MERGED","mergeCommit":{"sha":"b2f0e71be6cad6c343786a9ed87422fc0aa03a80","message":"[9.0] [build] Use docker hub to download ubi (#217322) (#217375)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[build] Use docker hub to download ubi\n(#217322)](https://github.com/elastic/kibana/pull/217322)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Jon <jon@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217322","number":217322,"mergeCommit":{"message":"[build] Use docker hub to download ubi (#217322)\n\nMoves away from our mirror for all images based on UBI.\n\nBased on feedback in\nhttps://github.com/docker-library/official-images/pull/18692.","sha":"87b3816a4c4a22bc6abacdebbf6184c2d4e47c38"}}]}] BACKPORT-->