### PR TITLE
[ES|QL] Allows editing values

### DIFF
--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/index.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/index.tsx
@@ -129,7 +129,8 @@ export function ESQLControlsFlyout({
 
   useEffect(() => {
     const variableNameWithoutQuestionmark = variableName.replace(/^\?+/, '');
-    const variableExists = checkVariableExistence(esqlVariables, variableName);
+    const variableExists =
+      checkVariableExistence(esqlVariables, variableName) && !isControlInEditMode;
     setFormIsInvalid(
       !variableNameWithoutQuestionmark ||
         variableExists ||
@@ -137,6 +138,7 @@ export function ESQLControlsFlyout({
         !controlState?.availableOptions.length
     );
   }, [
+    isControlInEditMode,
     areValuesValid,
     controlState?.availableOptions.length,
     esqlVariables,


### PR DESCRIPTION
## Summary

My refactor caused a bug, in editing the button wasn't active. This PR is fixing it

<img width="1649" alt="image" src="https://github.com/user-attachments/assets/4da7eace-8b44-49a6-b3a5-9908ce16b63b" />








<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->