### PR TITLE
🌊 Streams: Add experimental badge to nav entry

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/navigation_tree.ts
@@ -77,6 +77,14 @@ function createNavTree({ streamsAvailable }: { streamsAvailable?: boolean }) {
             ? [
                 {
                   link: 'streams' as const,
+                  withBadge: true,
+                  badgeOptions: {
+                    icon: 'beaker',
+                    tooltip: i18n.translate('xpack.observability.obltNav.streamsBadgeTooltip', {
+                      defaultMessage:
+                        'This functionality is experimental and not supported. It may change or be removed at any time.',
+                    }),
+                  },
                 },
               ]
             : []),

--- a/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
+++ b/x-pack/solutions/observability/plugins/serverless_observability/public/navigation_tree.ts
@@ -78,6 +78,17 @@ export const createNavigationTree = ({
             ? [
                 {
                   link: 'streams' as const,
+                  withBadge: true,
+                  badgeOptions: {
+                    icon: 'beaker',
+                    tooltip: i18n.translate(
+                      'xpack.serverlessObservability.nav.streamsBadgeTooltip',
+                      {
+                        defaultMessage:
+                          'This functionality is experimental and not supported. It may change or be removed at any time.',
+                      }
+                    ),
+                  },
                 },
               ]
             : []),


### PR DESCRIPTION
This PR adds the experimental badge to the nav entry for streams (if enabled)

<img width="343" alt="Screenshot 2025-04-10 at 12 47 22" src="https://github.com/user-attachments/assets/765e0dd2-6ebd-4516-b024-ec207fcea43f" />

We also render a tech preview badge in the classic observability sub nav:
<img width="224" alt="Screenshot 2025-04-10 at 12 52 04" src="https://github.com/user-attachments/assets/c51210c0-056e-4ead-97ee-891e3fb6851f" />

Important to note: we don't render a badge in the classic main nav since it's not supported there:
<img width="257" alt="Screenshot 2025-04-10 at 12 52 29" src="https://github.com/user-attachments/assets/5a1fb3c8-88dd-49c9-bade-82965f367e46" />



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->