### PR TITLE
🌊 Streams: Do not order component templates

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/component_template_panel.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_management/component_template_panel.tsx
@@ -95,13 +95,6 @@ export function ComponentTemplatePanel({
     [onFlyoutOpen]
   );
 
-  const sorting = {
-    sort: {
-      field: 'name',
-      direction: 'asc' as const,
-    },
-  };
-
   return (
     <EuiPanel hasShadow={false} hasBorder>
       <EuiFlexGroup direction="column" gutterSize="m">
@@ -114,7 +107,6 @@ export function ComponentTemplatePanel({
           <EuiInMemoryTable
             items={componentTemplates}
             columns={columns}
-            sorting={sorting}
             tableLayout={'auto'}
             // align text with heading
             className={css`


### PR DESCRIPTION
By feedback from @LucaWintergerst we shouldn't sort the component templates in the "advanced" tab since their order matters when applied.

This PR removes the sorting that's set on the table.

<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->