### PR TITLE
[9.0] Added DisabledAuthz utility (#216633)

### DIFF
--- a/src/core/packages/security/server/index.ts
+++ b/src/core/packages/security/server/index.ts
@@ -50,5 +50,5 @@ export type {
 export type { KibanaPrivilegesType, ElasticsearchPrivilegesType } from './src/roles';
 export { isCreateRestAPIKeyParams } from './src/authentication/api_keys';
 export type { CoreFipsService } from './src/fips';
+export { AuthzDisabled, AuthzOptOutReason, unwindNestedSecurityPrivileges } from './src/authz';
 export { ApiPrivileges, ApiOperation } from './src/api_privileges';
-export { unwindNestedSecurityPrivileges } from './src/authz';

--- a/src/core/packages/security/server/src/authz.ts
+++ b/src/core/packages/security/server/src/authz.ts
@@ -7,6 +7,29 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+export enum AuthzOptOutReason {
+  DelegateToESClient = 'Route delegates authorization to the scoped ES client',
+  DelegateToSOClient = 'Route delegates authorization to the scoped SO client',
+  ServeStaticFiles = 'Route serves static files that do not require authorization',
+}
+
+export class AuthzDisabled {
+  public static fromReason(reason: AuthzOptOutReason | string): { enabled: false; reason: string } {
+    return {
+      enabled: false,
+      reason,
+    };
+  }
+
+  static readonly delegateToESClient = AuthzDisabled.fromReason(
+    AuthzOptOutReason.DelegateToESClient
+  );
+  static readonly delegateToSOClient = AuthzDisabled.fromReason(
+    AuthzOptOutReason.DelegateToSOClient
+  );
+  static readonly serveStaticFiles = AuthzDisabled.fromReason(AuthzOptOutReason.ServeStaticFiles);
+}
+
 export const unwindNestedSecurityPrivileges = <
   T extends Array<string | { allOf?: string[]; anyOf?: string[] }>
 >(

--- a/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/delete.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/delete.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { AuthzDisabled } from '@kbn/core-security-server';
 
 import type { RouteDefinitionParams } from '../..';
 import { API_VERSIONS } from '../../../../common/constants';
@@ -21,16 +22,13 @@ export function defineDeleteRolesRoutes({ router }: RouteDefinitionParams) {
       options: {
         tags: ['oas-tag:roles'],
       },
+      security: {
+        authz: AuthzDisabled.delegateToESClient,
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.roles.public.v1,
-        security: {
-          authz: {
-            enabled: false,
-            reason: `This route delegates authorization to Core's scoped ES cluster client`,
-          },
-        },
         validate: {
           request: {
             params: schema.object({ name: schema.string({ minLength: 1 }) }),

--- a/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/get.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/get.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { AuthzDisabled } from '@kbn/core-security-server';
 
 import type { RouteDefinitionParams } from '../..';
 import { API_VERSIONS } from '../../../../common/constants';
@@ -28,16 +29,13 @@ export function defineGetRolesRoutes({
       options: {
         tags: ['oas-tag:roles'],
       },
+      security: {
+        authz: AuthzDisabled.delegateToESClient,
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.roles.public.v1,
-        security: {
-          authz: {
-            enabled: false,
-            reason: `This route delegates authorization to Core's scoped ES cluster client`,
-          },
-        },
         validate: {
           request: {
             params: schema.object({

--- a/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/get_all.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/get_all.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { AuthzDisabled } from '@kbn/core-security-server';
 
 import type { RouteDefinitionParams } from '../..';
 import { API_VERSIONS } from '../../../../common/constants';
@@ -29,16 +30,13 @@ export function defineGetAllRolesRoutes({
       options: {
         tags: ['oas-tag:roles'],
       },
+      security: {
+        authz: AuthzDisabled.delegateToESClient,
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.roles.public.v1,
-        security: {
-          authz: {
-            enabled: false,
-            reason: `This route delegates authorization to Core's scoped ES cluster client`,
-          },
-        },
         validate: {
           request: {
             query: schema.maybe(

--- a/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/post.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/post.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { AuthzDisabled } from '@kbn/core-security-server';
+
 import { roleGrantsSubFeaturePrivileges } from './lib';
 import {
   getBulkCreateOrUpdatePayloadSchema,
@@ -48,16 +50,13 @@ export function defineBulkCreateOrUpdateRolesRoutes({
       options: {
         tags: ['oas-tag:roles'],
       },
+      security: {
+        authz: AuthzDisabled.delegateToESClient,
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.roles.public.v1,
-        security: {
-          authz: {
-            enabled: false,
-            reason: `This route delegates authorization to Core's scoped ES cluster client`,
-          },
-        },
         validate: {
           request: {
             body: getBulkCreateOrUpdatePayloadSchema(() => {

--- a/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/put.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/put.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { AuthzDisabled } from '@kbn/core-security-server';
 
 import { roleGrantsSubFeaturePrivileges } from './lib';
 import { getPutPayloadSchema, transformPutPayloadToElasticsearchRole } from './model';
@@ -31,16 +32,13 @@ export function definePutRolesRoutes({
       options: {
         tags: ['oas-tag:roles'],
       },
+      security: {
+        authz: AuthzDisabled.delegateToESClient,
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.roles.public.v1,
-        security: {
-          authz: {
-            enabled: false,
-            reason: `This route delegates authorization to Core's scoped ES cluster client`,
-          },
-        },
         validate: {
           request: {
             params: schema.object({

--- a/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/query.ts
+++ b/x-pack/platform/plugins/shared/security/server/routes/authorization/roles/query.ts
@@ -6,6 +6,7 @@
  */
 
 import { schema } from '@kbn/config-schema';
+import { AuthzDisabled } from '@kbn/core-security-server';
 import type { QueryRolesResult } from '@kbn/security-plugin-types-common';
 
 import type { RouteDefinitionParams } from '../..';
@@ -33,16 +34,13 @@ export function defineQueryRolesRoutes({
       options: {
         tags: ['oas-tags:roles'],
       },
+      security: {
+        authz: AuthzDisabled.delegateToESClient,
+      },
     })
     .addVersion(
       {
         version: API_VERSIONS.roles.public.v1,
-        security: {
-          authz: {
-            enabled: false,
-            reason: `This route delegates authorization to Core's scoped ES cluster client`,
-          },
-        },
         validate: {
           request: {
             body: schema.object({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Added DisabledAuthz utility (#216633)](https://github.com/elastic/kibana/pull/216633)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Shostak","email":"165678770+elena-shostak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-08T10:59:28Z","message":"Added DisabledAuthz utility (#216633)\n\n## Summary\n\nAdded `DisabledAuthz` utility class, this will address the current\nrepetition of the reason string `'This route delegates authorization to\nthe ES/SO client` and other common scenarios.\n\n__Closes: https://github.com/elastic/kibana/issues/216632__\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>","sha":"18ca869d926d91b126b754bbbc1234a524949e14","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","enhancement","release_note:skip","backport missing","backport:version","v9.1.0","v8.19.0"],"title":"Added DisabledAuthz utility","number":216633,"url":"https://github.com/elastic/kibana/pull/216633","mergeCommit":{"message":"Added DisabledAuthz utility (#216633)\n\n## Summary\n\nAdded `DisabledAuthz` utility class, this will address the current\nrepetition of the reason string `'This route delegates authorization to\nthe ES/SO client` and other common scenarios.\n\n__Closes: https://github.com/elastic/kibana/issues/216632__\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>","sha":"18ca869d926d91b126b754bbbc1234a524949e14"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216633","number":216633,"mergeCommit":{"message":"Added DisabledAuthz utility (#216633)\n\n## Summary\n\nAdded `DisabledAuthz` utility class, this will address the current\nrepetition of the reason string `'This route delegates authorization to\nthe ES/SO client` and other common scenarios.\n\n__Closes: https://github.com/elastic/kibana/issues/216632__\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Jeramy Soucy <jeramy.soucy@elastic.co>","sha":"18ca869d926d91b126b754bbbc1234a524949e14"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->