### PR TITLE
[Security Solution] Remove hardcoded ids of preconfigured connectors from Security Solution Cypress tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/common.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/common.ts
@@ -25,9 +25,6 @@ export const API_HEADERS = Object.freeze({
   [ELASTIC_HTTP_VERSION_HEADER]: [INITIAL_REST_VERSION],
 });
 
-export const INTERNAL_CLOUD_CONNECTORS = ['Elastic-Cloud-SMTP'];
-export const INTERNAL_INFERENCE_CONNECTORS = ['Elastic-Managed-LLM'];
-
 export const rootRequest = <T = unknown>({
   headers: optionHeaders = {},
   role = 'admin',
@@ -99,27 +96,36 @@ export const getConnectors = () =>
   });
 
 export const deleteConnectors = () => {
+  cy.log('Deleting connectors...');
+
   cy.currentSpace().then((spaceId) => {
     getConnectors().then(($response) => {
-      if ($response.body.length > 0) {
-        const ids = $response.body.map((connector) => {
-          return connector.id;
-        });
-        ids.forEach((id) => {
-          if (
-            !INTERNAL_CLOUD_CONNECTORS.includes(id) &&
-            !INTERNAL_INFERENCE_CONNECTORS.includes(id)
-          ) {
-            rootRequest({
-              method: 'DELETE',
-              url: spaceId
-                ? getSpaceUrl(spaceId, `api/actions/connector/${id}`)
-                : `api/actions/connector/${id}`,
-            });
-          }
-        });
-      }
+      const connectors = $response.body;
+      const connectorNames = connectors.map((c) => c.name);
+
+      cy.log(`Found ${connectors.length} connectors`, connectorNames);
+
+      connectors.forEach((connector) => {
+        deleteConnector(spaceId, connector);
+      });
     });
+  });
+};
+
+const deleteConnector = (spaceId: string, connector: AllConnectorsResponse) => {
+  if (connector.is_preconfigured) {
+    // NOTE: Preconfigured connectors can't be deleted.
+    // https://www.elastic.co/guide/en/kibana/current/pre-configured-connectors.html
+    cy.log(`Skipping connector "${connector.name}" as it's preconfigured`);
+    return;
+  }
+
+  cy.log(`Deleting connector "${connector.name}"`);
+  rootRequest({
+    method: 'DELETE',
+    url: spaceId
+      ? getSpaceUrl(spaceId, `api/actions/connector/${connector.id}`)
+      : `api/actions/connector/${connector.id}`,
   });
 };
 


### PR DESCRIPTION
## Summary

[Preconfigured connectors](https://www.elastic.co/guide/en/kibana/current/pre-configured-connectors.html) are those that are specified via the `kibana.yml` config, and thus they can't be deleted. In tests, we've hardcoded their ids to skip deleting them when we need to clean up the tests' state.

Sometimes, the id of a preconfigured connector gets changed by somebody, which breaks tests of multiple teams in MKI pipelines, such as the periodic pipeline or the release quality gates. The problem is that it doesn't happen on CI where Kibana doesn't have any preconfigured connectors, so this feedback loop is too long. When tests in an MKI pipeline break, it's not immediately clear what happened and who should fix it. Eventually it gets fixed by someone [like this](https://github.com/elastic/kibana/pull/217570/files).

Instead of hardcoding the ids, we should dynamically determine if a connector is preconfigured and if it should be deleted by a test or not. This is possible to do as each connector has the corresponding `is_preconfigured` property.

<img width="1073" alt="Screenshot 2025-04-10 at 14 16 15" src="https://github.com/user-attachments/assets/e330cd5f-c9f0-43da-b4b4-f2a0a2fd10a5" />

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.18","8.x","9.0"]} ONMERGE-->