### PR TITLE
[Fleet] Reuse shared integration policies when duplicating agent policies

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agent_policy.ts
@@ -849,32 +849,48 @@ class AgentPolicyService {
       options
     );
 
-    // Copy all package policies and append (copy n) to their names
     if (baseAgentPolicy.package_policies) {
-      const newPackagePolicies = await pMap(
-        baseAgentPolicy.package_policies as PackagePolicy[],
-        async (packagePolicy: PackagePolicy) => {
-          const { id: packagePolicyId, version, ...newPackagePolicy } = packagePolicy;
+      // Copy non-shared package policies and append (copy n) to their names.
+      const basePackagePolicies = baseAgentPolicy.package_policies.filter(
+        (packagePolicy) => packagePolicy.policy_ids.length < 2
+      );
+      if (basePackagePolicies.length > 0) {
+        const newPackagePolicies = await pMap(
+          basePackagePolicies,
+          async (packagePolicy: PackagePolicy) => {
+            const { id: packagePolicyId, version, ...newPackagePolicy } = packagePolicy;
 
-          const updatedPackagePolicy = {
+            const updatedPackagePolicy = {
+              ...newPackagePolicy,
+              name: await incrementPackagePolicyCopyName(soClient, packagePolicy.name),
+            };
+            return updatedPackagePolicy;
+          }
+        );
+        await packagePolicyService.bulkCreate(
+          soClient,
+          esClient,
+          newPackagePolicies.map((newPackagePolicy) => ({
             ...newPackagePolicy,
-            name: await incrementPackagePolicyCopyName(soClient, packagePolicy.name),
-          };
-          return updatedPackagePolicy;
-        }
+            policy_ids: [newAgentPolicy.id],
+          })),
+          {
+            ...options,
+            bumpRevision: false,
+          }
+        );
+      }
+      // Link shared package policies to new agent policy.
+      const sharedBasePackagePolicies = baseAgentPolicy.package_policies.filter(
+        (packagePolicy) => packagePolicy.policy_ids.length > 1
       );
-      await packagePolicyService.bulkCreate(
-        soClient,
-        esClient,
-        newPackagePolicies.map((newPackagePolicy) => ({
-          ...newPackagePolicy,
-          policy_ids: [newAgentPolicy.id],
-        })),
-        {
-          ...options,
-          bumpRevision: false,
-        }
-      );
+      if (sharedBasePackagePolicies.length > 0) {
+        const updatedSharedPackagePolicies = sharedBasePackagePolicies.map((packagePolicy) => ({
+          ...packagePolicy,
+          policy_ids: [...packagePolicy.policy_ids, newAgentPolicy.id],
+        }));
+        await packagePolicyService.bulkUpdate(soClient, esClient, updatedSharedPackagePolicies);
+      }
     }
 
     // Tamper protection is dependent on endpoint package policy


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/215335

Currently, when an agent policy is duplicated, shared integration policies are also duplicated. This PR adds logic where the duplicated agent policy also shares these integration policies.

### Testing

* Run ES with an [Entreprise license](https://www.elastic.co/subscriptions) to avail of reusable integration policies.
* Create an agent policy with a shared integration policy and a non-shared integration policy.
* Duplicate the agent policy: the duplicated policy should only duplicate the non-shared integration policy and the shared integration policy should be reused.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Incorrect package policies in duplicated agent policies.





<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->