### PR TITLE
[Fleet] Add support for new `siem` security subcategory

### DIFF
--- a/src/platform/plugins/shared/custom_integrations/common/index.ts
+++ b/src/platform/plugins/shared/custom_integrations/common/index.ts
@@ -69,6 +69,7 @@ export const INTEGRATION_CATEGORY_DISPLAY: {
   sdk_search: { title: 'SDK', parent_id: 'search' },
   search: { title: 'Elasticsearch', parent_id: undefined },
   security: { title: 'Security', parent_id: undefined },
+  siem: { title: 'SIEM', parent_id: 'security' },
   stream_processing: { title: 'Stream Processing', parent_id: 'observability' },
   support: { title: 'Support', parent_id: undefined },
   threat_intel: { title: 'Threat Intelligence', parent_id: 'security' },

--- a/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/package_spec.ts
@@ -104,6 +104,7 @@ export type PackageSpecCategory =
   | 'proxy_security'
   | 'sdk_search'
   | 'security'
+  | 'siem'
   | 'stream_processing'
   | 'support'
   | 'threat_intel'


### PR DESCRIPTION
## Summary

Adding the new sub-category for security: `siem`

<img width="1807" alt="Screenshot 2025-04-10 at 11 36 49 AM" src="https://github.com/user-attachments/assets/30cbdacb-4bd8-4523-ae79-2f49f5c59856" />

---
Relates
- https://github.com/elastic/security-team/issues/12103
- https://github.com/elastic/package-registry/pull/1284




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->