### PR TITLE
[Dashboards] Export source (serializable state) of a dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,6 +239,7 @@
     "@kbn/content-management-content-editor": "link:src/platform/packages/shared/content-management/content_editor",
     "@kbn/content-management-content-insights-public": "link:src/platform/packages/shared/content-management/content_insights/content_insights_public",
     "@kbn/content-management-content-insights-server": "link:src/platform/packages/shared/content-management/content_insights/content_insights_server",
+    "@kbn/content-management-content-source": "link:src/platform/packages/shared/content-management/content_source",
     "@kbn/content-management-examples-plugin": "link:examples/content_management_examples",
     "@kbn/content-management-favorites-common": "link:src/platform/packages/shared/content-management/favorites/favorites_common",
     "@kbn/content-management-favorites-public": "link:src/platform/packages/shared/content-management/favorites/favorites_public",

--- a/src/platform/packages/shared/content-management/content_source/README.md
+++ b/src/platform/packages/shared/content-management/content_source/README.md
@@ -1,0 +1,3 @@
+# @kbn/content-management-content-source
+
+A component that opens a flyout containing the source of a content item (such as a dashboard).

--- a/src/platform/packages/shared/content-management/content_source/index.ts
+++ b/src/platform/packages/shared/content-management/content_source/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { ContentSourceKibanaProvider, useOpenContentSource } from './src';
+export type { ContentSourceFlyoutProps } from './src';

--- a/src/platform/packages/shared/content-management/content_source/jest.config.js
+++ b/src/platform/packages/shared/content-management/content_source/jest.config.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+module.exports = {
+  preset: '@kbn/test/jest_node',
+  rootDir: '../../../../../..',
+  roots: ['<rootDir>/src/platform/packages/shared/content-management/content_source'],
+};

--- a/src/platform/packages/shared/content-management/content_source/kibana.jsonc
+++ b/src/platform/packages/shared/content-management/content_source/kibana.jsonc
@@ -1,0 +1,7 @@
+{
+  "type": "shared-common",
+  "id": "@kbn/content-management-content-source",
+  "owner": "@elastic/kibana-presentation",
+  "group": "platform",
+  "visibility": "shared"
+}

--- a/src/platform/packages/shared/content-management/content_source/package.json
+++ b/src/platform/packages/shared/content-management/content_source/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kbn/content-management-content-source",
+  "private": true,
+  "version": "1.0.0",
+  "license": "Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0"
+}

--- a/src/platform/packages/shared/content-management/content_source/src/components/content_flyout.tsx
+++ b/src/platform/packages/shared/content-management/content_source/src/components/content_flyout.tsx
@@ -38,11 +38,13 @@ const flyoutBodyCss = css`
 export interface ContentSourceFlyoutProps {
   onClose: () => void;
   getContent: () => Promise<object>;
+  contentName: string;
 }
 
 export const ContentSourceFlyout: React.FC<ContentSourceFlyoutProps> = ({
   onClose,
   getContent,
+  contentName,
 }) => {
   const [{ content, loading, error }, setContent] = useState<{
     loading: boolean;
@@ -86,7 +88,10 @@ export const ContentSourceFlyout: React.FC<ContentSourceFlyoutProps> = ({
           <h2>
             <FormattedMessage
               id="contentManagement.contentSource.flyoutTitle"
-              defaultMessage="Export dashboard"
+              defaultMessage="Export {contentName} JSON source"
+              values={{
+                contentName,
+              }}
             />
           </h2>
         </EuiTitle>
@@ -111,7 +116,13 @@ export const ContentSourceFlyout: React.FC<ContentSourceFlyoutProps> = ({
                 icon={<EuiLoadingSpinner size="l" />}
               />
             ) : (
-              <EuiCodeBlock language="json" isCopyable overflowHeight="100%" isVirtualized>
+              <EuiCodeBlock
+                language="json"
+                lineNumbers
+                isCopyable
+                overflowHeight="100%"
+                isVirtualized
+              >
                 {JSON.stringify(content, null, 2)}
               </EuiCodeBlock>
             )}
@@ -144,7 +155,7 @@ export const ContentSourceFlyout: React.FC<ContentSourceFlyoutProps> = ({
             >
               <FormattedMessage
                 id="contentManagement.contentSource.flyoutDownloadButton"
-                defaultMessage="Download"
+                defaultMessage="Download file"
               />
             </EuiButton>
           </EuiFlexItem>

--- a/src/platform/packages/shared/content-management/content_source/src/components/content_flyout.tsx
+++ b/src/platform/packages/shared/content-management/content_source/src/components/content_flyout.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { css } from '@emotion/react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiCodeBlock,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiLoadingSpinner,
+  EuiTitle,
+} from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+// @ts-expect-error untyped library
+import { saveAs } from '@elastic/filesaver';
+
+const flyoutBodyCss = css`
+  height: 100%;
+  .euiFlyoutBody__overflowContent {
+    height: 100%;
+    padding: 0;
+  }
+`;
+
+export interface ContentSourceFlyoutProps {
+  onClose: () => void;
+  getContent: () => Promise<object>;
+}
+
+export const ContentSourceFlyout: React.FC<ContentSourceFlyoutProps> = ({
+  onClose,
+  getContent,
+}) => {
+  const [{ content, loading, error }, setContent] = useState<{
+    loading: boolean;
+    content: Awaited<object> | null;
+    error: unknown | null;
+  }>({ loading: true, content: null, error: null });
+
+  const onDownload = useCallback(() => {
+    const blob = new Blob([JSON.stringify(content, null, 2)], {
+      type: 'application/json',
+    });
+    saveAs(blob, 'export.json');
+  }, [content]);
+
+  useEffect(() => {
+    const loadContent = () => {
+      getContent()
+        .then((_content) =>
+          setContent((prevState) => ({
+            ...prevState,
+            loading: false,
+            content: _content,
+          }))
+        )
+        .catch((err) =>
+          setContent((prevState) => ({
+            ...prevState,
+            loading: false,
+            error: err,
+          }))
+        );
+    };
+
+    loadContent();
+  }, [getContent]);
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle data-test-subj="flyoutTitle">
+          <h2>
+            <FormattedMessage
+              id="contentManagement.contentSource.flyoutTitle"
+              defaultMessage="Export dashboard"
+            />
+          </h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody css={flyoutBodyCss}>
+        {error ? (
+          <EuiCallOut
+            title={
+              <FormattedMessage
+                id="contentManagement.contentSource.flyoutError"
+                defaultMessage="An error occurred"
+              />
+            }
+            color="danger"
+            iconType="alert"
+          />
+        ) : (
+          <>
+            {loading ? (
+              <EuiEmptyPrompt
+                data-test-subj="contentManagement.contentSource.loadingIndicator"
+                icon={<EuiLoadingSpinner size="l" />}
+              />
+            ) : (
+              <EuiCodeBlock language="json" isCopyable overflowHeight="100%" isVirtualized>
+                {JSON.stringify(content, null, 2)}
+              </EuiCodeBlock>
+            )}
+          </>
+        )}
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              iconType="cross"
+              flush="left"
+              onClick={onClose}
+              data-test-subj="closeFlyoutButton"
+            >
+              <FormattedMessage
+                id="contentManagement.contentSource.flyoutCloseButton"
+                defaultMessage="Close"
+              />
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              iconType="download"
+              color="primary"
+              fill
+              onClick={onDownload}
+              data-test-subj="downloadButton"
+              disabled={loading}
+            >
+              <FormattedMessage
+                id="contentManagement.contentSource.flyoutDownloadButton"
+                defaultMessage="Download"
+              />
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </>
+  );
+};

--- a/src/platform/packages/shared/content-management/content_source/src/components/content_flyout_container.tsx
+++ b/src/platform/packages/shared/content-management/content_source/src/components/content_flyout_container.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import type { FC } from 'react';
+
+import { ContentSourceFlyout } from './content_flyout';
+import type { ContentSourceFlyoutProps } from './content_flyout';
+
+export type ContentSourceFlyoutContainerProps = ContentSourceFlyoutProps;
+
+export const ContentSourceFlyoutContainer: FC<ContentSourceFlyoutContainerProps> = (props) => {
+  return <ContentSourceFlyout {...props} />;
+};

--- a/src/platform/packages/shared/content-management/content_source/src/components/content_source_loader.tsx
+++ b/src/platform/packages/shared/content-management/content_source/src/components/content_source_loader.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { EuiFlyoutBody, EuiFlyoutFooter, EuiFlyoutHeader } from '@elastic/eui';
+import type { ContentSourceFlyoutContainerProps } from './content_flyout_container';
+
+const ContentSourceFlyoutContentContainer = React.lazy(() =>
+  import('./content_flyout_container').then(
+    ({ ContentSourceFlyoutContainer: _ContentSourceFlyoutContentContainer }) => ({
+      default: _ContentSourceFlyoutContentContainer,
+    })
+  )
+);
+
+export const ContentSourceLoader: React.FC<ContentSourceFlyoutContainerProps> = (props) => {
+  return (
+    <React.Suspense
+      fallback={
+        <>
+          <EuiFlyoutHeader />
+          <EuiFlyoutBody />
+          <EuiFlyoutFooter />
+        </>
+      }
+    >
+      <ContentSourceFlyoutContentContainer {...props} />
+    </React.Suspense>
+  );
+};

--- a/src/platform/packages/shared/content-management/content_source/src/components/index.ts
+++ b/src/platform/packages/shared/content-management/content_source/src/components/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { ContentSourceLoader } from './content_source_loader';
+export type { ContentSourceFlyoutProps } from './content_flyout';

--- a/src/platform/packages/shared/content-management/content_source/src/index.ts
+++ b/src/platform/packages/shared/content-management/content_source/src/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { ContentSourceKibanaProvider } from './services';
+export { useOpenContentSource } from './open_content_source';
+export type { ContentSourceFlyoutProps } from './components';

--- a/src/platform/packages/shared/content-management/content_source/src/open_content_source.tsx
+++ b/src/platform/packages/shared/content-management/content_source/src/open_content_source.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React, { useCallback, useRef } from 'react';
+import type { OverlayRef } from '@kbn/core-mount-utils-browser';
+
+import type { ContentSourceFlyoutProps } from './components';
+
+import { ContentSourceLoader } from './components';
+import { useServices } from './services';
+
+export function useOpenContentSource() {
+  const services = useServices();
+  const { openFlyout } = services;
+  const flyout = useRef<OverlayRef | null>(null);
+
+  return useCallback(
+    (args: ContentSourceFlyoutProps) => {
+      const closeFlyout = () => {
+        flyout.current?.close();
+      };
+
+      flyout.current = openFlyout(<ContentSourceLoader {...args} onClose={closeFlyout} />, {
+        maxWidth: 600,
+        size: 'm',
+        ownFocus: true,
+        hideCloseButton: true,
+      });
+
+      return closeFlyout;
+    },
+    [openFlyout]
+  );
+}

--- a/src/platform/packages/shared/content-management/content_source/src/services.tsx
+++ b/src/platform/packages/shared/content-management/content_source/src/services.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { FC, PropsWithChildren, ReactNode } from 'react';
+import React, { useCallback, useContext } from 'react';
+
+import type { AnalyticsServiceStart } from '@kbn/core-analytics-browser';
+import type { I18nStart } from '@kbn/core-i18n-browser';
+import type { MountPoint, OverlayRef } from '@kbn/core-mount-utils-browser';
+import type { OverlayFlyoutOpenOptions } from '@kbn/core-overlays-browser';
+import type { ThemeServiceStart } from '@kbn/core-theme-browser';
+import type { UserProfileService } from '@kbn/core-user-profile-browser';
+import { toMountPoint } from '@kbn/react-kibana-mount';
+
+type NotifyFn = (title: JSX.Element, text?: string) => void;
+
+export interface Theme {
+  readonly darkMode: boolean;
+}
+
+/**
+ * Abstract external services for this component.
+ */
+export interface Services {
+  openFlyout(node: ReactNode, options?: OverlayFlyoutOpenOptions): OverlayRef;
+  notifyError: NotifyFn;
+}
+
+const ContentSourceContext = React.createContext<Services | null>(null);
+
+/**
+ * Abstract external service Provider.
+ */
+export const ContentSourceProvider: FC<PropsWithChildren<Services>> = ({
+  children,
+  ...services
+}) => {
+  return <ContentSourceContext.Provider value={services}>{children}</ContentSourceContext.Provider>;
+};
+
+/**
+ * Specific services for mounting React
+ */
+interface ContentSourceStartServices {
+  analytics: Pick<AnalyticsServiceStart, 'reportEvent'>;
+  i18n: I18nStart;
+  theme: Pick<ThemeServiceStart, 'theme$'>;
+  userProfile: UserProfileService;
+}
+
+/**
+ * Kibana-specific service types.
+ */
+export interface ContentSourceKibanaDependencies {
+  /** CoreStart contract */
+  core: ContentSourceStartServices & {
+    overlays: {
+      openFlyout(mount: MountPoint, options?: OverlayFlyoutOpenOptions): OverlayRef;
+    };
+    notifications: {
+      toasts: {
+        addDanger: (notifyArgs: { title: MountPoint; text?: string }) => void;
+      };
+    };
+  };
+}
+
+/**
+ * Kibana-specific Provider that maps to known dependency types.
+ */
+export const ContentSourceKibanaProvider: FC<
+  PropsWithChildren<ContentSourceKibanaDependencies>
+> = ({ children, ...services }) => {
+  const { core } = services;
+  const { overlays, notifications, ...startServices } = core;
+  const { openFlyout: coreOpenFlyout } = overlays;
+
+  const openFlyout = useCallback(
+    (node: ReactNode, options: OverlayFlyoutOpenOptions) => {
+      return coreOpenFlyout(toMountPoint(node, startServices), options);
+    },
+    [coreOpenFlyout, startServices]
+  );
+
+  return (
+    <ContentSourceProvider
+      openFlyout={openFlyout}
+      notifyError={(title, text) => {
+        notifications.toasts.addDanger({ title: toMountPoint(title, startServices), text });
+      }}
+    >
+      {children}
+    </ContentSourceProvider>
+  );
+};
+
+/**
+ * React hook for accessing pre-wired services.
+ */
+export function useServices() {
+  const context = useContext(ContentSourceContext);
+
+  if (!context) {
+    throw new Error(
+      'ContentSourceContext is missing. Ensure your component or React root is wrapped with <ContentSourceProvider /> or <ContentSourceKibanaProvider />.'
+    );
+  }
+
+  return context;
+}

--- a/src/platform/packages/shared/content-management/content_source/tsconfig.json
+++ b/src/platform/packages/shared/content-management/content_source/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "target/types",
+    "types": [
+      "jest",
+      "node"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+  ],
+  "exclude": [
+    "target/**/*"
+  ],
+  "kbn_references": []
+}

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -15,6 +15,7 @@ import useMountedState from 'react-use/lib/useMountedState';
 import { useOpenContentSource } from '@kbn/content-management-content-source';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
 import { UI_SETTINGS } from '../../../common';
+import { CONTENT_ID } from '../../../common/content_management';
 import { useDashboardApi } from '../../dashboard_api/use_dashboard_api';
 import { openSettingsFlyout } from '../../dashboard_renderer/settings/open_settings_flyout';
 import { confirmDiscardUnsavedChanges } from '../../dashboard_listing/confirm_overlays';
@@ -76,6 +77,7 @@ export const useDashboardMenuItems = ({
     const close = openContentSource({
       getContent: async () => dashboardApi.getSerializedState(),
       onClose: () => close(),
+      contentName: CONTENT_ID,
     });
   }, [dashboardApi, openContentSource]);
 

--- a/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/dashboard_top_nav_with_context.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_top_nav/dashboard_top_nav_with_context.tsx
@@ -8,10 +8,12 @@
  */
 
 import React from 'react';
+import { ContentSourceKibanaProvider } from '@kbn/content-management-content-source';
 import {
   InternalDashboardTopNav,
   InternalDashboardTopNavProps,
 } from './internal_dashboard_top_nav';
+import { coreServices } from '../services/kibana_services';
 import { DashboardContext } from '../dashboard_api/use_dashboard_api';
 import { DashboardApi } from '../dashboard_api/types';
 export interface DashboardTopNavProps extends InternalDashboardTopNavProps {
@@ -20,7 +22,9 @@ export interface DashboardTopNavProps extends InternalDashboardTopNavProps {
 
 export const DashboardTopNavWithContext = (props: DashboardTopNavProps) => (
   <DashboardContext.Provider value={props.dashboardApi}>
-    <InternalDashboardTopNav {...props} />
+    <ContentSourceKibanaProvider core={coreServices}>
+      <InternalDashboardTopNav {...props} />
+    </ContentSourceKibanaProvider>
   </DashboardContext.Provider>
 );
 

--- a/src/platform/plugins/shared/dashboard/tsconfig.json
+++ b/src/platform/plugins/shared/dashboard/tsconfig.json
@@ -55,6 +55,7 @@
     "@kbn/content-management-table-list-view-table",
     "@kbn/shared-ux-prompt-not-found",
     "@kbn/content-management-content-editor",
+    "@kbn/content-management-content-source",
     "@kbn/serverless",
     "@kbn/no-data-page-plugin",
     "@kbn/react-kibana-mount",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -208,6 +208,8 @@
       "@kbn/content-management-content-insights-public/*": ["src/platform/packages/shared/content-management/content_insights/content_insights_public/*"],
       "@kbn/content-management-content-insights-server": ["src/platform/packages/shared/content-management/content_insights/content_insights_server"],
       "@kbn/content-management-content-insights-server/*": ["src/platform/packages/shared/content-management/content_insights/content_insights_server/*"],
+      "@kbn/content-management-content-source": ["src/platform/packages/shared/content-management/content_source"],
+      "@kbn/content-management-content-source/*": ["src/platform/packages/shared/content-management/content_source/*"],
       "@kbn/content-management-examples-plugin": ["examples/content_management_examples"],
       "@kbn/content-management-examples-plugin/*": ["examples/content_management_examples/*"],
       "@kbn/content-management-favorites-common": ["src/platform/packages/shared/content-management/favorites/favorites_common"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4094,6 +4094,10 @@
   version "0.0.0"
   uid ""
 
+"@kbn/content-management-content-source@link:src/platform/packages/shared/content-management/content_source":
+  version "0.0.0"
+  uid ""
+
 "@kbn/content-management-examples-plugin@link:examples/content_management_examples":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
Fixes #192913 
WIP 
Blocked by https://github.com/elastic/kibana/pull/217109

## Summary

Adds a flyout that can export the serializable state (JSON source) of a dashboard. 

![localhost_5701_app_dashboards](https://github.com/user-attachments/assets/e416823f-4db1-4812-9bb2-5f2c8348706a)

Since the flyout uses the `dashboardApi.getSerializedState` method, it is not necessary to save a dashboard before exporting the source. The state can be copied and pasted into the request body of the Dashboard HTTP API, e.g. 
```
POST kbn:/api/dashboards/dashboard
{
  "attributes": ...,
  "references": ...
}
```

TODO 
 - Wire into the upcoming [export menu](https://github.com/elastic/kibana/pull/217109)
 - Remove the current changes to the dashboard top nav as this is just a demo

This PR also adds a re-useable `@kbn/content-management-content-source` package that other plugins may use to show their content source.

