### PR TITLE
[DOCS] Fix path to images in connector docs

### DIFF
--- a/docs/reference/connectors-kibana/bedrock-action-type.md
+++ b/docs/reference/connectors-kibana/bedrock-action-type.md
@@ -14,7 +14,7 @@ The {{bedrock}} connector uses [axios](https://github.com/axios/axios) to send a
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.  For example:
 
-:::{image} ../images/bedrock-connector.png
+:::{image} /reference/images/bedrock-connector.png
 :alt: {{bedrock}} connector
 :class: screenshot
 :::
@@ -44,7 +44,7 @@ Secret
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/bedrock-params.png
+:::{image} /reference/images/bedrock-params.png
 :alt: {{bedrock}} params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/cases-action-type.md
+++ b/docs/reference/connectors-kibana/cases-action-type.md
@@ -16,7 +16,7 @@ To use this connector you must have `All` {{kib}} privileges for the **Cases** f
 
 You cannot manage this connector in **{{stack-manage-app}} > {{connectors-ui}}** or by using APIs. You also cannot create a Cases [preconfigured connector](/reference/connectors-kibana/pre-configured-connectors.md). It is available only when you’re creating a rule in {{kib}}. For example:
 
-:::{image} ../images/cases-action.png
+:::{image} /reference/images/cases-action.png
 :alt: Add a cases action while creating a rule in {{kib}} {{rules-ui}}
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/cases-webhook-action-type.md
+++ b/docs/reference/connectors-kibana/cases-webhook-action-type.md
@@ -14,28 +14,28 @@ The {{webhook-cm}} connector uses [axios](https://github.com/axios/axios) to sen
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. In the first step, you must provide a name for the connector and its authentication details. For example:
 
-:::{image} ../images/cases-webhook-connector.png
+:::{image} /reference/images/cases-webhook-connector.png
 :alt: Set authentication details in the {{webhook-cm}} connector
 :class: screenshot
 :::
 
 In the second step, you must provide the information necessary to create cases in the external system. For example:
 
-:::{image} ../images/cases-webhook-connector-create-case.png
+:::{image} /reference/images/cases-webhook-connector-create-case.png
 :alt: Add case creation details in the {{webhook-cm}} connector
 :class: screenshot
 :::
 
 In the third step, you must provide information related to retrieving case details from the external system. For example:
 
-:::{image} ../images/cases-webhook-connector-get-case.png
+:::{image} /reference/images/cases-webhook-connector-get-case.png
 :alt: Add case retrieval details in the {{webhook-cm}} connector
 :class: screenshot
 :::
 
 In the fourth step, you must provide information necessary to update cases in the external system. You can also optionally provide information to add comments to cases. For example:
 
-:::{image} ../images/cases-webhook-connector-comments.png
+:::{image} /reference/images/cases-webhook-connector-comments.png
 :alt: Add case update and comment details in the {{webhook-cm}} connector
 :class: screenshot
 :::
@@ -168,7 +168,7 @@ Update case URL
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/cases-webhook-test.png
+:::{image} /reference/images/cases-webhook-test.png
 :alt: {{webhook-cm}} params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/crowdstrike-action-type.md
+++ b/docs/reference/connectors-kibana/crowdstrike-action-type.md
@@ -21,7 +21,7 @@ To use this connector, you must have authority to run {{endpoint-sec}} connector
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**. For example:
 
-:::{image} ../images/crowdstrike-connector.png
+:::{image} /reference/images/crowdstrike-connector.png
 :alt: CrowdStrike connector
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/d3security-action-type.md
+++ b/docs/reference/connectors-kibana/d3security-action-type.md
@@ -16,7 +16,7 @@ To create this connector, you must first configure a webhook key in your D3 SOAR
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.  For example:
 
-:::{image} ../images/d3security-connector.png
+:::{image} /reference/images/d3security-connector.png
 :alt: D3 Security connector
 :class: screenshot
 :::
@@ -40,7 +40,7 @@ Token
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/d3security-params-test.png
+:::{image} /reference/images/d3security-params-test.png
 :alt: D3 Security params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/email-action-type.md
+++ b/docs/reference/connectors-kibana/email-action-type.md
@@ -21,7 +21,7 @@ The email connector uses the SMTP protocol to send mail messages. Email message 
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/email-connector.png
+:::{image} /reference/images/email-connector.png
 :alt: Email connector
 :class: screenshot
 :::
@@ -72,7 +72,7 @@ Password
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/email-params-test.png
+:::{image} /reference/images/email-params-test.png
 :alt: Email params test
 :class: screenshot
 :::
@@ -158,35 +158,35 @@ The email connector uses Microsoft Graph REST API v1.0, in particular the [sendM
 
 Before you create an email connector for Microsoft Exchange, you must create and register the client integration application on the [Azure portal](https://go.microsoft.com/fwlink/?linkid=2083908):
 
-:::{image} ../images/exchange-register-app.png
+:::{image} /reference/images/exchange-register-app.png
 :alt: Register client application for MS Exchange
 :class: screenshot
 :::
 
 Next, open **Manage > API permissions**, and then define the permissions for the registered application to send emails. Refer to the [documentation](https://docs.microsoft.com/en-us/graph/api/user-sendmail?view=graph-rest-1.0&tabs=http#permissions) for the Microsoft Graph API.
 
-:::{image} ../images/exchange-api-permissions.png
+:::{image} /reference/images/exchange-api-permissions.png
 :alt: MS Exchange API permissions
 :class: screenshot
 :::
 
 Add the "Mail.Send" permission for Microsoft Graph. The permission appears in the list with the status "Not granted for <your Azure active directory>":
 
-:::{image} ../images/exchange-not-granted.png
+:::{image} /reference/images/exchange-not-granted.png
 :alt: MS Exchange "Mail.Send" not granted
 :class: screenshot
 :::
 
 Click **Grant admin consent for <your Azure active directory>**.
 
-:::{image} ../images/exchange-grant-confirm.png
+:::{image} /reference/images/exchange-grant-confirm.png
 :alt: MS Exchange grant confirmation
 :class: screenshot
 :::
 
 Confirm that the status for the "Mail.Send" permission is now granted.
 
-:::{image} ../images/exchange-granted.png
+:::{image} /reference/images/exchange-granted.png
 :alt: MS Exchange grant confirmation
 :class: screenshot
 :::
@@ -196,7 +196,7 @@ Confirm that the status for the "Mail.Send" permission is now granted.
 
 To configure the Microsoft Exchange Client secret, open **Manage > Certificates & secrets**:
 
-:::{image} ../images/exchange-secrets.png
+:::{image} /reference/images/exchange-secrets.png
 :alt: MS Exchange secrets configuration
 :class: screenshot
 :::
@@ -208,7 +208,7 @@ Add a new client secret, then copy the value and put it to the proper field in t
 
 To find the Microsoft Exchange client and tenant IDs, open the **Overview** page:
 
-:::{image} ../images/exchange-client-tenant.png
+:::{image} /reference/images/exchange-client-tenant.png
 :alt: MS Exchange Client ID and Tenant ID configuration
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/gemini-action-type.md
+++ b/docs/reference/connectors-kibana/gemini-action-type.md
@@ -14,7 +14,7 @@ The {{gemini}} connector uses [axios](https://github.com/axios/axios) to send a 
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.  For example:
 
-:::{image} ../images/gemini-connector.png
+:::{image} /reference/images/gemini-connector.png
 :alt: {{gemini}} connector
 :class: screenshot
 :::
@@ -47,7 +47,7 @@ Credentials JSON
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/gemini-params.png
+:::{image} /reference/images/gemini-params.png
 :alt: {{gemini}} params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/index-action-type.md
+++ b/docs/reference/connectors-kibana/index-action-type.md
@@ -14,7 +14,7 @@ An index connector indexes a document into {{es}}.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/index-connector.png
+:::{image} /reference/images/index-connector.png
 :alt: Index connector
 :class: screenshot
 :::
@@ -29,7 +29,7 @@ Index connectors must have a name and an {{es}} index. You can optionally choose
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/index-params-test.png
+:::{image} /reference/images/index-params-test.png
 :alt: Index params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/jira-action-type.md
+++ b/docs/reference/connectors-kibana/jira-action-type.md
@@ -19,7 +19,7 @@ Jira Cloud and Jira Data Center are supported. Jira on-premise deployments are n
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/jira-connector.png
+:::{image} /reference/images/jira-connector.png
 :alt: Jira connector
 :class: screenshot
 :::
@@ -49,7 +49,7 @@ API token
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/jira-params-test.png
+:::{image} /reference/images/jira-params-test.png
 :alt: Jira params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/obs-ai-assistant-action-type.md
+++ b/docs/reference/connectors-kibana/obs-ai-assistant-action-type.md
@@ -21,7 +21,7 @@ To learn how to interact with the assistant through this connector, refer to the
 
 To use this connector, you must have been granted access to use the Observability AI Assistant feature. You cannot manage this connector in **{{stack-manage-app}} > {{connectors-ui}}** or by using APIs. You also cannot create an Observability AI Assistant [preconfigured connector](/reference/connectors-kibana/pre-configured-connectors.md). It is available only when you’re creating a rule in {{kib}}. For example:
 
-:::{image} ../images/obs-ai-assistant-action.png
+:::{image} /reference/images/obs-ai-assistant-action.png
 :alt: Add an Observability AI Assistant action while creating a rule in the Observability UI
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/openai-action-type.md
+++ b/docs/reference/connectors-kibana/openai-action-type.md
@@ -14,7 +14,7 @@ The OpenAI connector uses [axios](https://github.com/axios/axios) to send a POST
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.  For example:
 
-:::{image} ../images/gen-ai-connector.png
+:::{image} /reference/images/gen-ai-connector.png
 :alt: OpenAI connector
 :class: screenshot
 :::
@@ -52,7 +52,7 @@ API key
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/gen-ai-params-test.png
+:::{image} /reference/images/gen-ai-params-test.png
 :alt: OpenAI params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/opsgenie-action-type.md
+++ b/docs/reference/connectors-kibana/opsgenie-action-type.md
@@ -16,7 +16,7 @@ To create this connector, you must have a valid {{opsgenie}} URL and API key. Fo
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/opsgenie-connector.png
+:::{image} /reference/images/opsgenie-connector.png
 :alt: Opsgenie connector
 :class: screenshot
 :::
@@ -53,7 +53,7 @@ After you create a connector, use the **Test** tab to test its actions:
 
 When you create a rule that uses an {{opsgenie}} connector, its actions (with the exception of recovery actions) create {{opsgenie}} alerts. You can test this type of action when you create or edit your connector:
 
-:::{image} ../images/opsgenie-create-alert-test.png
+:::{image} /reference/images/opsgenie-create-alert-test.png
 :alt: {{opsgenie}} create alert action test
 :class: screenshot
 :::
@@ -146,7 +146,7 @@ Example JSON editor contents
 
 When you create a rule that uses an {{opsgenie}} connector, its recovery actions close {{opsgenie}} alerts. You can test this type of action when you create or edit your connector:
 
-:::{image} ../images/opsgenie-close-alert-test.png
+:::{image} /reference/images/opsgenie-close-alert-test.png
 :alt: {{opsgenie}} close alert action test
 :class: screenshot
 :::
@@ -177,25 +177,25 @@ After obtaining an Opsgenie instance, configure the API integration. For details
 
 If you’re using a free trial, go to the `Teams` dashboard and select the appropriate team.
 
-:::{image} ../images/opsgenie-teams.png
+:::{image} /reference/images/opsgenie-teams.png
 :alt: Opsgenie teams dashboard
 :::
 
 Select the `Integrations` menu item, then select `Add integration`.
 
-:::{image} ../images/opsgenie-integrations.png
+:::{image} /reference/images/opsgenie-integrations.png
 :alt: Opsgenie teams integrations
 :::
 
 Search for `API` and select the `API` integration.
 
-:::{image} ../images/opsgenie-add-api-integration.png
+:::{image} /reference/images/opsgenie-add-api-integration.png
 :alt: Opsgenie API integration
 :::
 
 Configure the integration and ensure you record the `API Key`. This key will be used to populate the `API Key` field when creating the Kibana Opsgenie connector. Click `Save Integration` after you finish configuring the integration.
 
-:::{image} ../images/opsgenie-save-integration.png
+:::{image} /reference/images/opsgenie-save-integration.png
 :alt: Opsgenie save integration
 :::
 

--- a/docs/reference/connectors-kibana/pagerduty-action-type.md
+++ b/docs/reference/connectors-kibana/pagerduty-action-type.md
@@ -16,7 +16,7 @@ To create this connector, you must have a valid PagerDuty integration key. For c
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/pagerduty-connector.png
+:::{image} /reference/images/pagerduty-connector.png
 :alt: PagerDuty connector
 :class: screenshot
 :::
@@ -51,7 +51,7 @@ When you create a rule that uses a PagerDuty connector, you can use any of these
 
 When you test the acknowlege action, you must provide the de-duplication key for a PagerDuty alert:
 
-:::{image} ../images/pagerduty-acknowledge-test.png
+:::{image} /reference/images/pagerduty-acknowledge-test.png
 :alt: PagerDuty params test
 :class: screenshot
 :::
@@ -61,7 +61,7 @@ When you test the acknowlege action, you must provide the de-duplication key for
 
 Likewise when you test the resolve action, you must provide the de-duplication key:
 
-:::{image} ../images/pagerduty-resolve-test.png
+:::{image} /reference/images/pagerduty-resolve-test.png
 :alt: PagerDuty params test
 :class: screenshot
 :::
@@ -71,7 +71,7 @@ Likewise when you test the resolve action, you must provide the de-duplication k
 
 When you test the trigger action, you must provide a summary for the PagerDuty alert:
 
-:::{image} ../images/pagerduty-trigger-test.png
+:::{image} /reference/images/pagerduty-trigger-test.png
 :alt: PagerDuty params test
 :class: screenshot
 :::
@@ -144,7 +144,7 @@ To set up PagerDuty:
 
     You will be redirected to the **Integrations** tab for your service. An Integration Key is generated on this screen.
 
-    :::{image} ../images/pagerduty-integration.png
+    :::{image} /reference/images/pagerduty-integration.png
     :alt: PagerDuty Integrations tab
     :class: screenshot
     :::

--- a/docs/reference/connectors-kibana/pre-configured-connectors.md
+++ b/docs/reference/connectors-kibana/pre-configured-connectors.md
@@ -66,7 +66,7 @@ Sensitive properties, such as passwords, can also be stored in the [{{kib}} keys
 
 go to the **{{connectors-ui}}** page using the navigation menu or the [global search field](docs-content://get-started/the-stack.md#kibana-navigation-search). Preconfigured connectors appear regardless of which space you are in. They are tagged as “preconfigured”, and you cannot delete them.
 
-:::{image} ../images/preconfigured-connectors-managing.png
+:::{image} /reference/images/preconfigured-connectors-managing.png
 :alt: Connectors managing tab with pre-configured
 :class: screenshot
 :::
@@ -93,7 +93,7 @@ This functionality is in technical preview and may be changed or removed in a fu
 
 When you subsequently create rules, you can use the `Alert history Elasticsearch index (preconfigured)` connector.
 
-:::{image} ../images/pre-configured-alert-history-connector.png
+:::{image} /reference/images/pre-configured-alert-history-connector.png
 :alt: Creating a rule action that uses the pre-configured alert history connector
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/resilient-action-type.md
+++ b/docs/reference/connectors-kibana/resilient-action-type.md
@@ -14,7 +14,7 @@ The {{ibm-r}} connector uses the [RESILIENT REST v2](https://developer.ibm.com/s
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/resilient-connector.png
+:::{image} /reference/images/resilient-connector.png
 :alt: {{ibm-r}} connector
 :class: screenshot
 :::
@@ -41,7 +41,7 @@ URL
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/resilient-params-test.png
+:::{image} /reference/images/resilient-params-test.png
 :alt: IBM Resilient connector test options
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/sentinelone-action-type.md
+++ b/docs/reference/connectors-kibana/sentinelone-action-type.md
@@ -21,7 +21,7 @@ To use this connector, you must have authority to run {{endpoint-sec}} connector
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**. For example:
 
-:::{image} ../images/sentinelone-connector.png
+:::{image} /reference/images/sentinelone-connector.png
 :alt: SentinelOne connector
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/server-log-action-type.md
+++ b/docs/reference/connectors-kibana/server-log-action-type.md
@@ -14,7 +14,7 @@ A server log connector writes an entry to the {{kib}} server log.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/serverlog-connector.png
+:::{image} /reference/images/serverlog-connector.png
 :alt: Server log connector
 :class: screenshot
 :::
@@ -29,7 +29,7 @@ Server log connectors do not have any configuration properties other than a name
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/serverlog-params-test.png
+:::{image} /reference/images/serverlog-params-test.png
 :alt: Server log connector test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/servicenow-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-action-type.md
@@ -14,12 +14,12 @@ The {{sn-itsm}} connector uses the [import set API](https://developer.servicenow
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You must choose whether to use OAuth for authentication.
 
-:::{image} ../images/servicenow-connector-basic.png
+:::{image} /reference/images/servicenow-connector-basic.png
 :alt: ServiceNow connector using basic auth
 :class: screenshot
 :::
 
-:::{image} ../images/servicenow-connector-oauth.png
+:::{image} /reference/images/servicenow-connector-oauth.png
 :alt: ServiceNow connector using OAuth
 :class: screenshot
 :::
@@ -64,7 +64,7 @@ Username
 
 When you create or edit a connector, use the **Test** tab to test its actions:
 
-:::{image} ../images/servicenow-params-test.png
+:::{image} /reference/images/servicenow-params-test.png
 :alt: ServiceNow params test
 :class: screenshot
 :::
@@ -245,7 +245,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the certificate.
     * **PEM Certificate**: Copy the generated public key into this text field.
 
-    :::{image} ../images/servicenow-new-certificate.png
+    :::{image} /reference/images/servicenow-new-certificate.png
     :alt: Shows new certificate form in ServiceNow
     :class: screenshot
     :::
@@ -260,7 +260,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 1. In your {{sn}} instance, go to **Application Registry** and select **New**.
 2. Select **Create an OAuth JWT API endpoint for external clients** from the list of options.
 
-    :::{image} ../images/servicenow-jwt-endpoint.png
+    :::{image} /reference/images/servicenow-jwt-endpoint.png
     :alt: Shows application type selection
     :class: screenshot
     :::
@@ -270,7 +270,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the application.
     * **User field**: Select the field to use as the user identifier.
 
-    :::{image} ../images/servicenow-new-application.png
+    :::{image} /reference/images/servicenow-new-application.png
     :alt: Shows new application form in ServiceNow
     :class: screenshot
     :::
@@ -287,7 +287,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the JWT Verifier Map.
     * **Sys certificate**: Click the search icon and select the name of the certificate created in the previous step.
 
-    :::{image} ../images/servicenow-new-jwt-verifier-map.png
+    :::{image} /reference/images/servicenow-new-jwt-verifier-map.png
     :alt: Shows new JWT Verifier Map form in ServiceNow
     :class: screenshot
     :::
@@ -295,7 +295,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 8. Click **Submit** to create the verifier map.
 9. Note the **Client ID**, **Client Secret** and **JWT Key ID**. You will need these values to create your {{sn}} connector.
 
-    :::{image} ../images/servicenow-oauth-values.png
+    :::{image} /reference/images/servicenow-oauth-values.png
     :alt: Shows where to find OAuth values in ServiceNow
     :class: screenshot
     :::
@@ -306,7 +306,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 
 {{sn-itsm}} connectors created in {{stack}} version 7.15.0 or earlier are marked as deprecated after you upgrade to version 7.16.0 or later. Deprecated connectors have a yellow icon after their name and display a warning message when selected.
 
-:::{image} ../images/servicenow-sir-update-connector.png
+:::{image} /reference/images/servicenow-sir-update-connector.png
 :alt: Shows deprecated ServiceNow connectors
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/servicenow-itom-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-itom-action-type.md
@@ -14,12 +14,12 @@ The {{sn-itom}} connector uses the [event API](https://docs.servicenow.com/bundl
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You must choose whether to use OAuth for authentication.
 
-:::{image} ../images/servicenow-itom-connector-basic.png
+:::{image} /reference/images/servicenow-itom-connector-basic.png
 :alt: {{sn-itom}} connector using basic auth
 :class: screenshot
 :::
 
-:::{image} ../images/servicenow-itom-connector-oauth.png
+:::{image} /reference/images/servicenow-itom-connector-oauth.png
 :alt: {{sn-itom}} connector using OAuth
 :class: screenshot
 :::
@@ -64,7 +64,7 @@ Username
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/servicenow-itom-params-test.png
+:::{image} /reference/images/servicenow-itom-params-test.png
 :alt: {{sn-itom}} params test
 :class: screenshot
 :::
@@ -172,7 +172,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the certificate.
     * **PEM Certificate**: Copy the generated public key into this text field.
 
-    :::{image} ../images/servicenow-new-certificate.png
+    :::{image} /reference/images/servicenow-new-certificate.png
     :alt: Shows new certificate form in ServiceNow
     :class: screenshot
     :::
@@ -187,7 +187,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 1. In your {{sn}} instance, go to **Application Registry** and select **New**.
 2. Select **Create an OAuth JWT API endpoint for external clients** from the list of options.
 
-    :::{image} ../images/servicenow-jwt-endpoint.png
+    :::{image} /reference/images/servicenow-jwt-endpoint.png
     :alt: Shows application type selection
     :class: screenshot
     :::
@@ -197,7 +197,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the application.
     * **User field**: Select the field to use as the user identifier.
 
-    :::{image} ../images/servicenow-new-application.png
+    :::{image} /reference/images/servicenow-new-application.png
     :alt: Shows new application form in ServiceNow
     :class: screenshot
     :::
@@ -214,7 +214,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the JWT Verifier Map.
     * **Sys certificate**: Click the search icon and select the name of the certificate created in the previous step.
 
-    :::{image} ../images/servicenow-new-jwt-verifier-map.png
+    :::{image} /reference/images/servicenow-new-jwt-verifier-map.png
     :alt: Shows new JWT Verifier Map form in ServiceNow
     :class: screenshot
     :::
@@ -222,7 +222,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 8. Click **Submit** to create the verifier map.
 9. Note the **Client ID**, **Client Secret** and **JWT Key ID**. You will need these values to create your {{sn}} connector.
 
-    :::{image} ../images/servicenow-oauth-values.png
+    :::{image} /reference/images/servicenow-oauth-values.png
     :alt: Shows where to find OAuth values in ServiceNow
     :class: screenshot
     :::

--- a/docs/reference/connectors-kibana/servicenow-sir-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-sir-action-type.md
@@ -14,12 +14,12 @@ The {{sn-sir}} connector uses the [import set API](https://developer.servicenow.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You must choose whether to use OAuth for authentication.
 
-:::{image} ../images/servicenow-sir-connector-basic.png
+:::{image} /reference/images/servicenow-sir-connector-basic.png
 :alt: {{sn-sir}} connector using basic auth
 :class: screenshot
 :::
 
-:::{image} ../images/servicenow-sir-connector-oauth.png
+:::{image} /reference/images/servicenow-sir-connector-oauth.png
 :alt: {{sn-sir}} connector using OAuth
 :class: screenshot
 :::
@@ -64,7 +64,7 @@ Username
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/servicenow-sir-params-test.png
+:::{image} /reference/images/servicenow-sir-params-test.png
 :alt: {{sn-sir}} params test
 :class: screenshot
 :::
@@ -241,7 +241,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the certificate.
     * **PEM Certificate**: Copy the generated public key into this text field.
 
-    :::{image} ../images/servicenow-new-certificate.png
+    :::{image} /reference/images/servicenow-new-certificate.png
     :alt: Shows new certificate form in ServiceNow
     :class: screenshot
     :::
@@ -256,7 +256,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 1. In your {{sn}} instance, go to **Application Registry** and select **New**.
 2. Select **Create an OAuth JWT API endpoint for external clients** from the list of options.
 
-    :::{image} ../images/servicenow-jwt-endpoint.png
+    :::{image} /reference/images/servicenow-jwt-endpoint.png
     :alt: Shows application type selection
     :class: screenshot
     :::
@@ -266,7 +266,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the application.
     * **User field**: Select the field to use as the user identifier.
 
-    :::{image} ../images/servicenow-new-application.png
+    :::{image} /reference/images/servicenow-new-application.png
     :alt: Shows new application form in ServiceNow
     :class: screenshot
     :::
@@ -283,7 +283,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the JWT Verifier Map.
     * **Sys certificate**: Click the search icon and select the name of the certificate created in the previous step.
 
-    :::{image} ../images/servicenow-new-jwt-verifier-map.png
+    :::{image} /reference/images/servicenow-new-jwt-verifier-map.png
     :alt: Shows new JWT Verifier Map form in ServiceNow
     :class: screenshot
     :::
@@ -291,7 +291,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 8. Click **Submit** to create the verifier map.
 9. Note the **Client ID**, **Client Secret** and **JWT Key ID**. You will need these values to create your {{sn}} connector.
 
-    :::{image} ../images/servicenow-oauth-values.png
+    :::{image} /reference/images/servicenow-oauth-values.png
     :alt: Shows where to find OAuth values in ServiceNow
     :class: screenshot
     :::
@@ -302,7 +302,7 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 
 {{sn-sir}} connectors created in {{stack}} version 7.15.0 or earlier are marked as deprecated after you upgrade to version 7.16.0 or later. Deprecated connectors have a yellow icon after their name and display a warning message when selected.
 
-:::{image} ../images/servicenow-sir-update-connector.png
+:::{image} /reference/images/servicenow-sir-update-connector.png
 :alt: Shows deprecated ServiceNow connectors
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/slack-action-type.md
+++ b/docs/reference/connectors-kibana/slack-action-type.md
@@ -9,19 +9,18 @@ mapped_pages:
 
 The Slack connector uses incoming webhooks or an API method to send Slack messages.
 
-
 ## Create connectors in {{kib}} [define-slack-ui]
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You can choose to use a webhook URL that’s specific to a single channel. For example:
 
-:::{image} ../images/slack-webhook-connector.png
+:::{image} /reference/images/slack-webhook-connector.png
 :alt: Slack connector
 :class: screenshot
 :::
 
 Alternatively, you can create a connector that supports multiple channels. For example:
 
-:::{image} ../images/slack-api-connector.png
+:::{image} /reference/images/slack-api-connector.png
 :alt: Slack API connector
 :class: screenshot
 :::
@@ -35,14 +34,14 @@ For Slack setup details, go to [Configure a Slack account](#configuring-slack).
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For the webhook type of connector, its message text cannot contain Markdown, images, or other advanced formatting:
 
-:::{image} ../images/slack-webhook-params.png
+:::{image} /reference/images/slack-webhook-params.png
 :alt: Slack webhook connector test
 :class: screenshot
 :::
 
 For the web API type of connector, you must choose one of the channel IDs. You can then test either plain text or block kit messages:
 
-:::{image} ../images/slack-api-connector-test.png
+:::{image} /reference/images/slack-api-connector-test.png
 :alt: Slack web API connector test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/swimlane-action-type.md
+++ b/docs/reference/connectors-kibana/swimlane-action-type.md
@@ -14,7 +14,7 @@ The Swimlane connector uses the [Swimlane REST API](https://swimlane.com/knowled
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/swimlane-connector.png
+:::{image} /reference/images/swimlane-connector.png
 :alt: Swimlane connector
 :class: screenshot
 :::
@@ -41,7 +41,7 @@ API token
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/swimlane-params-test.png
+:::{image} /reference/images/swimlane-params-test.png
 :alt: Swimlane params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/teams-action-type.md
+++ b/docs/reference/connectors-kibana/teams-action-type.md
@@ -14,7 +14,7 @@ The Microsoft Teams connector uses a webhook to send notifications.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/teams-connector.png
+:::{image} /reference/images/teams-connector.png
 :alt: Teams connector
 :class: screenshot
 :::
@@ -35,7 +35,7 @@ Webhook URL
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/teams-params-test.png
+:::{image} /reference/images/teams-params-test.png
 :alt: Teams params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/thehive-action-type.md
+++ b/docs/reference/connectors-kibana/thehive-action-type.md
@@ -11,16 +11,13 @@ mapped_pages:
 
 ::::{note}
 If you use this connector with [cases](docs-content://explore-analyze/alerts-cases/cases.md), the status values differ in {{kib}} and {{hive}}. The status values are not synchronized when you update a case.
-
 ::::
-
-
 
 ## Create connectors in {{kib}} [define-thehive-ui]
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/thehive-connector.png
+:::{image} /reference/images/thehive-connector.png
 :alt: {{hive}} connector
 :class: screenshot
 :::
@@ -47,12 +44,12 @@ API key
 
 You can test connectors for creating a case or an alert with the [run connector API](https://www.elastic.co/docs/api/doc/kibana/v8/group/endpoint-connectors) or as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/thehive-params-case-test.png
+:::{image} /reference/images/thehive-params-case-test.png
 :alt: {{hive}} case params test
 :class: screenshot
 :::
 
-:::{image} ../images/thehive-params-alert-test.png
+:::{image} /reference/images/thehive-params-alert-test.png
 :alt: {{hive}} alert params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/tines-action-type.md
+++ b/docs/reference/connectors-kibana/tines-action-type.md
@@ -14,7 +14,7 @@ The Tines connector uses Tines’s [Webhook actions](https://www.tines.com/docs/
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/tines-connector.png
+:::{image} /reference/images/tines-connector.png
 :alt: Tines connector
 :class: screenshot
 :::
@@ -38,7 +38,7 @@ API Token
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/tines-params-test.png
+:::{image} /reference/images/tines-params-test.png
 :alt: Tines params test
 :class: screenshot
 :::
@@ -52,7 +52,7 @@ It is possible that requests to the Tines API to get the stories and webhooks fo
 
 When the webhook URL is defined, the connector will use it directly when an action runs, and the story and webhook selectors will be disabled and ignored. To re-enable the story and webhook selectors, remove the webhook URL value.
 
-:::{image} ../images/tines-webhook-url-fallback.png
+:::{image} /reference/images/tines-webhook-url-fallback.png
 :alt: Tines Webhook URL fallback
 :class: screenshot
 :::
@@ -62,7 +62,7 @@ When the webhook URL is defined, the connector will use it directly when an acti
 
 In order to simplify the integration with Elastic, Tines offers a set of pre-defined Elastic stories in the Story library. They can be found by searching for "Elastic" in the [Tines Story library](https://www.tines.com/story-library?s=elastic):
 
-:::{image} ../images/tines_elastic_stories.png
+:::{image} /reference/images/tines_elastic_stories.png
 :alt: Tines Elastic stories
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/torq-action-type.md
+++ b/docs/reference/connectors-kibana/torq-action-type.md
@@ -14,7 +14,7 @@ The Torq connector uses a Torq webhook to trigger workflows with Kibana actions.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/torq-configured-connector.png
+:::{image} /reference/images/torq-configured-connector.png
 :alt: configured Torq connector
 :class: screenshot
 :::
@@ -38,7 +38,7 @@ Torq authentication header secret
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/torq-connector-test.png
+:::{image} /reference/images/torq-connector-test.png
 :alt: Torq connector test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/webhook-action-type.md
+++ b/docs/reference/connectors-kibana/webhook-action-type.md
@@ -14,7 +14,7 @@ The Webhook connector uses [axios](https://github.com/axios/axios) to send a POS
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} ../images/webhook-connector.png
+:::{image} /reference/images/webhook-connector.png
 :alt: Webhook connector
 :class: screenshot
 :::
@@ -58,7 +58,7 @@ Certificate authority
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/webhook-params-test.png
+:::{image} /reference/images/webhook-params-test.png
 :alt: Webhook params test
 :class: screenshot
 :::

--- a/docs/reference/connectors-kibana/xmatters-action-type.md
+++ b/docs/reference/connectors-kibana/xmatters-action-type.md
@@ -14,12 +14,12 @@ The xMatters connector uses the [xMatters Workflow for Elastic](https://help.xma
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You must choose between basic and URL authentication for the requests.
 
-:::{image} ../images/xmatters-connector-basic.png
+:::{image} /reference/images/xmatters-connector-basic.png
 :alt: xMatters connector with basic authentication
 :class: screenshot
 :::
 
-:::{image} ../images/xmatters-connector-url.png
+:::{image} /reference/images/xmatters-connector-url.png
 :alt: xMatters connector with url authentication
 :class: screenshot
 :::
@@ -49,7 +49,7 @@ Password
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} ../images/xmatters-params-test.png
+:::{image} /reference/images/xmatters-params-test.png
 :alt: xMatters params test
 :class: screenshot
 :::


### PR DESCRIPTION
## Summary

This PR fixes broken images in the Kibana connector documentation.
Though they worked in local builds, the image path must be relative to the `toc.yml` file or an absolute path to work in a full build.


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->