### PR TITLE
[9.0] [Build] Remove Beats download for Cloud FIPS

### DIFF
--- a/src/dev/build/tasks/download_cloud_dependencies.ts
+++ b/src/dev/build/tasks/download_cloud_dependencies.ts
@@ -84,11 +84,6 @@ export const DownloadCloudDependencies: Task = {
       await downloadBeat('filebeat', buildId);
     }
 
-    if (config.buildOptions.createDockerCloudFIPS) {
-      await downloadBeat('metricbeat', buildId, 'fips');
-      await downloadBeat('filebeat', buildId, 'fips');
-    }
-
     await writeManifest(manifestUrl, manifestJSON);
   },
 };


### PR DESCRIPTION
## Summary

If a Cloud image is being built and `--skip-docker-cloud-fips` is not passed, the Beats FIPS artifacts will be attempted to download. This will always fail because the `9.0` artifacts do not exist, thus causing the entire build to fail.

Original PR #213163
Backport PR #216203