### PR TITLE
[9.0] [DOCS] Use new responseOps URLs in doc link service and APIs (#217601)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -49,7 +49,7 @@ tags:
       Alerting enables you to define rules, which detect complex conditions within your data. When a condition is met, the rule tracks it as an alert and runs the actions that are defined in the rule.  Actions typically involve the use of connectors to interact with Kibana services or third party integrations.
     externalDocs:
       description: Alerting documentation
-      url: https://www.elastic.co/docs/current/serverless/rules
+      url: https://www.elastic.co/docs/explore-analyze/alerts-cases/alerts
     x-displayName: Alerting
   - description: |
       Adjust APM agent configuration without need to redeploy your application.
@@ -71,7 +71,7 @@ tags:
       Connectors provide a central place to store connection information for services and integrations with Elastic or third party systems. Alerting rules can use connectors to run actions when rule conditions are met.
     externalDocs:
       description: Connector documentation
-      url: https://www.elastic.co/docs/current/serverless/action-connectors
+      url: https://www.elastic.co/docs/reference/kibana/connectors-kibana
     x-displayName: Connectors
   - name: Dashboards
   - name: Data streams
@@ -224,7 +224,7 @@ tags:
       Get information about the system status, resource usage, and installed plugins.
   - externalDocs:
       description: Task manager
-      url: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
+      url: https://www.elastic.co/docs/deploy-manage/distributed-architecture/kibana-tasks-management
     name: task manager
     x-displayName: Task manager
 paths:

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -43,6 +43,11 @@ info:
     label: Feedback
     url: https://github.com/elastic/docs-content/issues/new?assignees=&labels=feedback%2Ccommunity&projects=&template=api-feedback.yaml&title=%5BFeedback%5D%3A+
 servers:
+  - url: http://localhost:5622
+  - url: https://{kibana_url}
+    variables:
+      kibana_url:
+        default: localhost:5601
   - url: https://{kibana_url}
     variables:
       kibana_url:
@@ -56,7 +61,7 @@ tags:
       Alerting enables you to define rules, which detect complex conditions within your data. When a condition is met, the rule tracks it as an alert and runs the actions that are defined in the rule. Actions typically involve the use of connectors to interact with Kibana services or third party integrations.
     externalDocs:
       description: Alerting documentation
-      url: https://www.elastic.co/guide/en/kibana/master/alerting-getting-started.html
+      url: https://www.elastic.co/docs/explore-analyze/alerts-cases/alerts
     x-displayName: Alerting
   - description: |
       Adjust APM agent configuration without need to redeploy your application.
@@ -78,14 +83,14 @@ tags:
     name: cases
     externalDocs:
       description: Cases documentation
-      url: https://www.elastic.co/guide/en/kibana/master/cases.html
+      url: https://www.elastic.co/docs/explore-analyze/alerts-cases/cases
     x-displayName: Cases
   - name: connectors
     description: |
       Connectors provide a central place to store connection information for services and integrations with Elastic or third party systems. Alerting rules can use connectors to run actions when rule conditions are met.
     externalDocs:
       description: Connector documentation
-      url: https://www.elastic.co/guide/en/kibana/current/action-types.html
+      url: https://www.elastic.co/docs/reference/kibana/connectors-kibana
     x-displayName: Connectors
   - name: Dashboards
   - name: Data streams
@@ -259,7 +264,7 @@ tags:
     x-displayName: System
   - externalDocs:
       description: Task manager
-      url: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
+      url: https://www.elastic.co/docs/deploy-manage/distributed-architecture/kibana-tasks-management
     name: task manager
     x-displayName: Task manager
   - description: The assistant helps you prepare for the next major version of Elasticsearch.

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -43,11 +43,6 @@ info:
     label: Feedback
     url: https://github.com/elastic/docs-content/issues/new?assignees=&labels=feedback%2Ccommunity&projects=&template=api-feedback.yaml&title=%5BFeedback%5D%3A+
 servers:
-  - url: http://localhost:5622
-  - url: https://{kibana_url}
-    variables:
-      kibana_url:
-        default: localhost:5601
   - url: https://{kibana_url}
     variables:
       kibana_url:

--- a/oas_docs/overlays/kibana.overlays.shared.yaml
+++ b/oas_docs/overlays/kibana.overlays.shared.yaml
@@ -4,6 +4,39 @@ info:
   title: Overlays that are applicable to both serverless and non-serverless documentas
   version: 0.0.1
 actions:
+# Add some tag descriptions and displayNames
+  - target: '$.tags[?(@.name=="alerting")]'
+    description: Change tag description and displayName
+    update:
+      description: >
+        Alerting enables you to define rules, which detect complex conditions within your data.
+        When a condition is met, the rule tracks it as an alert and runs the actions that are defined in the rule.
+        Actions typically involve the use of connectors to interact with Kibana services or third party integrations.
+      externalDocs:
+        description: Alerting documentation
+        url: https://www.elastic.co/docs/explore-analyze/alerts-cases/alerts
+      x-displayName: "Alerting"
+  - target: '$.tags[?(@.name=="cases")]'
+    description: Change tag description and displayName
+    update:
+      description: >
+        Cases are used to open and track issues.
+        You can add assignees and tags to your cases, set their severity and status, and add alerts, comments, and visualizations.
+        You can also send cases to external incident management systems by configuring connectors.
+      externalDocs:
+        description: Cases documentation
+        url: https://www.elastic.co/docs/explore-analyze/alerts-cases/cases
+      x-displayName: "Cases"
+  - target: '$.tags[?(@.name=="connectors")]'
+    description: Change tag description and displayName
+    update:
+      description: >
+        Connectors provide a central place to store connection information for services and integrations with Elastic or third party systems.
+        Alerting rules can use connectors to run actions when rule conditions are met.
+      externalDocs:
+        description: Connector documentation
+        url: https://www.elastic.co/docs/reference/kibana/connectors-kibana
+      x-displayName: "Connectors"
 # Add some spaces API examples
   - target: "$.paths['/api/spaces/space']['post']"
     description: "Add example to create space API"

--- a/oas_docs/overlays/kibana.overlays.yaml
+++ b/oas_docs/overlays/kibana.overlays.yaml
@@ -36,38 +36,12 @@ actions:
 
             To learn more, check out [Spaces](https://www.elastic.co/guide/en/kibana/master/xpack-spaces.html).
 # Add some tag descriptions and displayNames
-  - target: '$.tags[?(@.name=="alerting")]'
+  - target: '$.tags[?(@.name=="streams")]'
     description: Change tag description and displayName
     update:
       description: >
-        Alerting enables you to define rules, which detect complex conditions within your data.
-        When a condition is met, the rule tracks it as an alert and runs the actions that are defined in the rule.
-        Actions typically involve the use of connectors to interact with Kibana services or third party integrations.
-      externalDocs:
-        description: Alerting documentation
-        url: https://www.elastic.co/guide/en/kibana/master/alerting-getting-started.html
-      x-displayName: "Alerting"
-  - target: '$.tags[?(@.name=="cases")]'
-    description: Change tag description and displayName
-    update:
-      description: >
-        Cases are used to open and track issues.
-        You can add assignees and tags to your cases, set their severity and status, and add alerts, comments, and visualizations.
-        You can also send cases to external incident management systems by configuring connectors.
-      externalDocs:
-        description: Cases documentation
-        url: https://www.elastic.co/guide/en/kibana/master/cases.html
-      x-displayName: "Cases"
-  - target: '$.tags[?(@.name=="connectors")]'
-    description: Change tag description and displayName
-    update:
-      description: >
-        Connectors provide a central place to store connection information for services and integrations with Elastic or third party systems.
-        Alerting rules can use connectors to run actions when rule conditions are met.
-      externalDocs:
-        description: Connector documentation
-        url: https://www.elastic.co/guide/en/kibana/current/action-types.html
-      x-displayName: "Connectors"
+        Streams is a new and experimental way to manage your data in Kibana (currently experimental - expect changes).
+      x-displayName: "Streams"
   - target: '$.tags[?(@.name=="data views")]'
     description: Change displayName
     update:

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -24,6 +24,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
   const ELASTIC_WEBSITE_URL = meta.elasticWebsiteUrl;
   const ELASTIC_GITHUB = meta.elasticGithubUrl;
   const SEARCH_LABS_URL = meta.searchLabsUrl;
+  const ELASTIC_DOCS = meta.docsWebsiteUrl;
 
   const ELASTICSEARCH_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/reference/${DOC_LINK_VERSION}/`;
   const KIBANA_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/`;
@@ -41,11 +42,11 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
   const isServerless = buildFlavor === 'serverless';
 
   return deepFreeze({
-    settings: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/settings.html`,
+    settings: `${ELASTIC_DOCS}reference/kibana/configuration-reference`,
     elasticStackGetStarted: isServerless
-      ? `${SERVERLESS_DOCS}intro.html`
-      : `${ELASTIC_WEBSITE_URL}guide/en/index.html`,
-    apiReference: `${ELASTIC_WEBSITE_URL}guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/api-reference.html`,
+      ? `${ELASTIC_DOCS}deploy-manage/deploy/elastic-cloud/serverless`
+      : `${ELASTIC_DOCS}get-started`,
+    apiReference: `${ELASTIC_DOCS}apis`,
     upgrade: {
       upgradingStackOnPrem: `${ELASTIC_WEBSITE_URL}guide/en/elastic-stack/current/upgrading-elastic-stack-on-prem.html`,
       upgradingStackOnCloud: `${ELASTIC_WEBSITE_URL}guide/en/elastic-stack/current/upgrade-elastic-stack-for-elastic-cloud.html`,
@@ -600,49 +601,34 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       aiAssistant: `${OBSERVABILITY_DOCS}obs-ai-assistant.html`,
     },
     alerting: {
-      guide: isServerless
-        ? `${SERVERLESS_DOCS}rules.html`
-        : `${KIBANA_DOCS}create-and-manage-rules.html`,
-      actionTypes: isServerless
-        ? `${SERVERLESS_DOCS}action-connectors.html`
-        : `${KIBANA_DOCS}action-types.html`,
-      apmRulesErrorCount: isServerless
-        ? `${SERVERLESS_DOCS}observability-create-error-count-threshold-alert-rule.html`
-        : `${KIBANA_DOCS}apm-alerts.html`,
-      apmRulesTransactionDuration: isServerless
-        ? `${SERVERLESS_DOCS}observability-create-latency-threshold-alert-rule.html`
-        : `${KIBANA_DOCS}apm-alerts.html`,
-      apmRulesTransactionError: isServerless
-        ? `${SERVERLESS_DOCS}observability-create-failed-transaction-rate-threshold-alert-rule.html`
-        : `${KIBANA_DOCS}apm-alerts.html`,
-      apmRulesAnomaly: isServerless
-        ? `${SERVERLESS_DOCS}observability-create-anomaly-alert-rule.html`
-        : `${KIBANA_DOCS}apm-alerts.html`,
-      emailAction: `${KIBANA_DOCS}email-action-type.html`,
-      emailActionConfig: `${KIBANA_DOCS}email-action-type.html`,
-      emailExchangeClientSecretConfig: `${KIBANA_DOCS}email-action-type.html#exchange-client-secret`,
-      emailExchangeClientIdConfig: `${KIBANA_DOCS}email-action-type.html#exchange-client-tenant-id`,
-      generalSettings: `${KIBANA_DOCS}alert-action-settings-kb.html#general-alert-action-settings`,
-      indexAction: `${KIBANA_DOCS}index-action-type.html`,
-      esQuery: `${KIBANA_DOCS}rule-type-es-query.html`,
-      indexThreshold: `${KIBANA_DOCS}rule-type-index-threshold.html`,
-      maintenanceWindows: isServerless
-        ? `${SERVERLESS_DOCS}maintenance-windows.html`
-        : `${KIBANA_DOCS}maintenance-windows.html`,
-      pagerDutyAction: `${KIBANA_DOCS}pagerduty-action-type.html`,
-      preconfiguredConnectors: `${KIBANA_DOCS}pre-configured-connectors.html`,
-      preconfiguredAlertHistoryConnector: `${KIBANA_DOCS}pre-configured-connectors.html#preconfigured-connector-alert-history`,
-      serviceNowAction: `${KIBANA_DOCS}servicenow-action-type.html#configuring-servicenow`,
-      serviceNowSIRAction: `${KIBANA_DOCS}servicenow-sir-action-type.html`,
-      setupPrerequisites: `${KIBANA_DOCS}alerting-setup.html#alerting-prerequisites`,
-      slackAction: `${KIBANA_DOCS}slack-action-type.html#configuring-slack-webhook`,
-      slackApiAction: `${KIBANA_DOCS}slack-action-type.html#configuring-slack-web-api`,
-      teamsAction: `${KIBANA_DOCS}teams-action-type.html#configuring-teams`,
-      connectors: `${KIBANA_DOCS}action-types.html`,
-      legacyRuleApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-201550`,
+      guide: `${ELASTIC_DOCS}explore-analyze/alerts-cases/alerts/create-manage-rules`,
+      actionTypes: `${ELASTIC_DOCS}reference/kibana/connectors-kibana`,
+      apmRulesErrorCount: `${ELASTIC_DOCS}solutions/observability/incident-management/create-an-error-count-threshold-rule`,
+      apmRulesTransactionDuration: `${ELASTIC_DOCS}solutions/observability/incident-management/create-latency-threshold-rule`,
+      apmRulesTransactionError: `${ELASTIC_DOCS}solutions/observability/incident-management/create-failed-transaction-rate-threshold-rule`,
+      apmRulesAnomaly: `${ELASTIC_DOCS}solutions/observability/incident-management/create-an-apm-anomaly-rule`,
+      emailAction: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/email-action-type`,
+      emailActionConfig: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/email-action-type`,
+      emailExchangeClientSecretConfig: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/email-action-type#exchange-client-secret`,
+      emailExchangeClientIdConfig: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/email-action-type#exchange-client-tenant-id`,
+      generalSettings: `${ELASTIC_DOCS}reference/kibana/configuration-reference/alerting-settings#general-alert-action-settings`,
+      indexAction: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/index-action-type`,
+      esQuery: `${ELASTIC_DOCS}explore-analyze/alerts-cases/alerts/rule-type-es-query`,
+      indexThreshold: `${ELASTIC_DOCS}explore-analyze/alerts-cases/alerts/rule-type-index-threshold`,
+      maintenanceWindows: `${ELASTIC_DOCS}explore-analyze/alerts-cases/alerts/maintenance-windows`,
+      pagerDutyAction: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/pagerduty-action-type`,
+      preconfiguredConnectors: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/pre-configured-connectors`,
+      preconfiguredAlertHistoryConnector: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/pre-configured-connectors#preconfigured-connector-alert-history`,
+      serviceNowAction: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/servicenow-action-type#configuring-servicenow`,
+      serviceNowSIRAction: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/servicenow-sir-action-type`,
+      setupPrerequisites: `${ELASTIC_DOCS}explore-analyze/alerts-cases/alerts/alerting-setup#alerting-prerequisites`,
+      slackAction: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/slack-action-type#configuring-slack-webhook`,
+      slackApiAction: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/slack-action-type#configuring-slack-web-api`,
+      teamsAction: `${ELASTIC_DOCS}reference/kibana/connectors-kibana/teams-action-type#configuring-teams`,
+      connectors: `${ELASTIC_DOCS}reference/kibana/connectors-kibana`,
     },
     taskManager: {
-      healthMonitoring: `${KIBANA_DOCS}task-manager-health-monitoring.html`,
+      healthMonitoring: `${ELASTIC_DOCS}deploy-manage/monitor/kibana-task-manager-health-monitoring`,
     },
     maps: {
       connectToEms: `${KIBANA_DOCS}maps-connect-to-ems.html`,
@@ -668,10 +654,9 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       troubleshootKibana: `${KIBANA_DOCS}monitor-troubleshooting.html`,
     },
     reporting: {
-      cloudMinimumRequirements: `${KIBANA_DOCS}reporting-getting-started.html#reporting-on-cloud-resource-requirements`,
-      grantUserAccess: `${KIBANA_DOCS}secure-reporting.html#grant-user-access`,
-      browserSystemDependencies: `${KIBANA_DOCS}secure-reporting.html#install-reporting-packages`,
-      browserSandboxDependencies: `${KIBANA_DOCS}reporting-troubleshooting-pdf.html#reporting-troubleshooting-sandbox-dependency`,
+      cloudMinimumRequirements: `${ELASTIC_DOCS}explore-analyze/report-and-share#_embed_outside_of_kib`,
+      browserSystemDependencies: `${ELASTIC_DOCS}deploy-manage/kibana-reporting-configuration#install-reporting-packages`,
+      browserSandboxDependencies: `${ELASTIC_DOCS}explore-analyze/report-and-share/reporting-troubleshooting-pdf#reporting-troubleshooting-sandbox-dependency`,
     },
     security: {
       apiKeyServiceSettings: `${ELASTICSEARCH_DOCS}security-settings.html#api-key-service-settings`,
@@ -972,9 +957,6 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
     },
     inferenceManagement: {
       inferenceAPIDocumentation: `${ELASTIC_WEBSITE_URL}docs/api/doc/elasticsearch/operation/operation-inference-put`,
-    },
-    cases: {
-      legacyApiDeprecations: `${KIBANA_DOCS}breaking-changes-summary.html#breaking-201004`,
     },
     synonyms: {
       synonymsAPIDocumentation: `${ELASTIC_WEBSITE_URL}guide/en/elasticsearch/reference/current/synonyms-apis.html`,

--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_meta.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_meta.ts
@@ -23,7 +23,7 @@ export const getDocLinksMeta = ({
     ecs_version: 'current',
     elasticWebsiteUrl: 'https://www.elastic.co/',
     elasticGithubUrl: 'https://github.com/elastic/',
-    docsWebsiteUrl: 'https://docs.elastic.co/',
+    docsWebsiteUrl: 'https://www.elastic.co/docs/',
     searchLabsUrl: 'https://search-labs.elastic.co/',
   };
 };

--- a/src/platform/packages/shared/kbn-doc-links/src/types.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/types.ts
@@ -430,7 +430,6 @@ export interface DocLinks {
     slackApiAction: string;
     teamsAction: string;
     connectors: string;
-    legacyRuleApiDeprecations: string;
   }>;
   readonly taskManager: Readonly<{
     healthMonitoring: string;
@@ -445,7 +444,6 @@ export interface DocLinks {
   readonly monitoring: Record<string, string>;
   readonly reporting: Readonly<{
     cloudMinimumRequirements: string;
-    grantUserAccess: string;
     browserSystemDependencies: string;
     browserSandboxDependencies: string;
   }>;
@@ -635,9 +633,6 @@ export interface DocLinks {
   };
   readonly inferenceManagement: {
     readonly inferenceAPIDocumentation: string;
-  };
-  readonly cases: {
-    readonly legacyApiDeprecations: string;
   };
   readonly synonyms: {
     readonly synonymsAPIDocumentation: string;

--- a/x-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/maybe_add_cloud_links.test.ts
+++ b/x-pack/platform/plugins/private/cloud_integrations/cloud_links/public/maybe_add_cloud_links/maybe_add_cloud_links.test.ts
@@ -84,7 +84,7 @@ describe('maybeAddCloudLinks', () => {
       Array [
         Array [
           Object {
-            "href": "https://www.elastic.co/guide/en/index.html",
+            "href": "https://www.elastic.co/docs/get-started",
             "title": "Documentation",
           },
           Object {
@@ -158,7 +158,7 @@ describe('maybeAddCloudLinks', () => {
       Array [
         Array [
           Object {
-            "href": "https://www.elastic.co/guide/en/index.html",
+            "href": "https://www.elastic.co/docs/get-started",
             "title": "Documentation",
           },
           Object {

--- a/x-pack/platform/plugins/shared/task_manager/README.md
+++ b/x-pack/platform/plugins/shared/task_manager/README.md
@@ -2,9 +2,10 @@
 
 The task manager is a generic system for running background tasks.
 
-Documentation: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
+[Documentation](https://www.elastic.co/docs/deploy-manage/distributed-architecture/kibana-tasks-management)
 
 It supports:
+
 - Single-run and recurring tasks
 - Scheduling tasks to run after a specified datetime
 - Basic retry logic

--- a/x-pack/platform/plugins/shared/task_manager/docs/openapi/bundled.yaml
+++ b/x-pack/platform/plugins/shared/task_manager/docs/openapi/bundled.yaml
@@ -12,7 +12,7 @@ tags:
   - name: task manager
     x-displayName: Task manager
     externalDocs:
-      url: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
+      url: https://www.elastic.co/docs/deploy-manage/distributed-architecture/kibana-tasks-management
       description: Task manager
 paths:
   /api/task_manager/_health:

--- a/x-pack/platform/plugins/shared/task_manager/docs/openapi/bundled_serverless.yaml
+++ b/x-pack/platform/plugins/shared/task_manager/docs/openapi/bundled_serverless.yaml
@@ -12,7 +12,7 @@ tags:
   - name: task manager
     x-displayName: Task manager
     externalDocs:
-      url: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
+      url: https://www.elastic.co/docs/deploy-manage/distributed-architecture/kibana-tasks-management
       description: Task manager
 paths:
   /api/task_manager/_health:

--- a/x-pack/platform/plugins/shared/task_manager/docs/openapi/entrypoint.yaml
+++ b/x-pack/platform/plugins/shared/task_manager/docs/openapi/entrypoint.yaml
@@ -10,8 +10,7 @@ tags:
   - name: task manager
     x-displayName: Task manager
     externalDocs:
-      url: >-
-        https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
+      url: https://www.elastic.co/docs/deploy-manage/distributed-architecture/kibana-tasks-management
       description: Task manager
 servers:
   - url: /

--- a/x-pack/platform/plugins/shared/task_manager/docs/openapi/entrypoint_serverless.yaml
+++ b/x-pack/platform/plugins/shared/task_manager/docs/openapi/entrypoint_serverless.yaml
@@ -10,8 +10,7 @@ tags:
   - name: task manager
     x-displayName: Task manager
     externalDocs:
-      url: >-
-        https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
+      url: https://www.elastic.co/docs/deploy-manage/distributed-architecture/kibana-tasks-management
       description: Task manager
 servers:
   - url: /

--- a/x-pack/platform/plugins/shared/task_manager/docs/openapi/health_apis.yaml
+++ b/x-pack/platform/plugins/shared/task_manager/docs/openapi/health_apis.yaml
@@ -11,7 +11,7 @@ tags:
     # description:
     x-displayName: Task manager
     externalDocs:
-      url: https://www.elastic.co/guide/en/kibana/current/task-manager-production-considerations.html
+      url: https://www.elastic.co/docs/deploy-manage/distributed-architecture/kibana-tasks-management
       description: Task manager
 servers:
   - url: /

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/health_check.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/application/components/health_check.test.tsx
@@ -121,10 +121,8 @@ describe('health check', () => {
     expect(action.textContent).toMatchInlineSnapshot(
       `"Learn more.(external, opens in a new tab or window)"`
     );
-
-    expect(action.getAttribute('href')).toMatchInlineSnapshot(
-      `"https://www.elastic.co/guide/en/elasticsearch/reference/mocked-test-branch/security-settings.html#api-key-service-settings"`
-    );
+    expect(action.getAttribute('href')).toMatch(/^https:\/\/www\.elastic\.co\//);
+    expect(action.getAttribute('href')).toContain('security-settings');
   });
 
   test('renders warning if encryption key is ephemeral', async () => {
@@ -160,9 +158,8 @@ describe('health check', () => {
     expect(action!.textContent).toMatchInlineSnapshot(
       `"Learn more.(external, opens in a new tab or window)"`
     );
-    expect(action!.getAttribute('href')).toMatchInlineSnapshot(
-      `"https://www.elastic.co/guide/en/kibana/mocked-test-branch/alert-action-settings-kb.html#general-alert-action-settings"`
-    );
+    expect(action!.getAttribute('href')).toMatch(/^https:\/\/www\.elastic\.co\//);
+    expect(action!.getAttribute('href')).toContain('alerting-settings');
   });
 
   test('renders warning if encryption key is ephemeral and keys are disabled', async () => {
@@ -200,9 +197,8 @@ describe('health check', () => {
     expect(action!.textContent).toMatchInlineSnapshot(
       `"Learn more.(external, opens in a new tab or window)"`
     );
-    expect(action!.getAttribute('href')).toMatchInlineSnapshot(
-      `"https://www.elastic.co/guide/en/kibana/mocked-test-branch/alerting-setup.html#alerting-prerequisites"`
-    );
+    expect(action!.getAttribute('href')).toMatch(/^https:\/\/www\.elastic\.co\//);
+    expect(action!.getAttribute('href')).toContain('alerting-setup');
   });
 
   it('renders children and no warnings if error thrown getting alerting health', async () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[DOCS] Use new responseOps URLs in doc link service and APIs (#217601)](https://github.com/elastic/kibana/pull/217601)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2025-04-11T00:18:12Z","message":"[DOCS] Use new responseOps URLs in doc link service and APIs (#217601)","sha":"3908dc8b299aefc33f46bb332cbbbeac3552fb4a","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Feature:Task Manager","Team:ResponseOps","docs","Feature:Cases","Feature:Reporting:CSV","backport:version","v9.1.0","v9.0.1"],"title":"[DOCS] Use new responseOps URLs in doc link service and APIs","number":217601,"url":"https://github.com/elastic/kibana/pull/217601","mergeCommit":{"message":"[DOCS] Use new responseOps URLs in doc link service and APIs (#217601)","sha":"3908dc8b299aefc33f46bb332cbbbeac3552fb4a"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217601","number":217601,"mergeCommit":{"message":"[DOCS] Use new responseOps URLs in doc link service and APIs (#217601)","sha":"3908dc8b299aefc33f46bb332cbbbeac3552fb4a"}},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->