### PR TITLE
[Cloud Security] add limit of 100 values when grouping by multi value fields

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
@@ -94,7 +94,7 @@ describe('group selector', () => {
     it('groupByField script should contain logic which gets all values of groupByField', () => {
       const scriptResponse = {
         source:
-          "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
+          "if (doc[params['selectedGroup']].size()==0 || doc[params['selectedGroup']].size() > 100 ) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
         params: {
           selectedGroup: 'resource.name',
           uniqueValue: 'whatAGreatAndUniqueValue',
@@ -113,7 +113,7 @@ describe('group selector', () => {
 
       const scriptResponse = {
         source:
-          "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) } else { for (def id : doc[params['selectedGroup']]) { emit(id) }}",
+          "if (doc[params['selectedGroup']].size()==0 || doc[params['selectedGroup']].size() > 100 ) { emit(params['uniqueValue']) } else { int i = 0; for (def id : doc[params['selectedGroup']]) { if (i++ >= 100) break; emit(id)}}",
         params: {
           selectedGroup: groupByField,
           uniqueValue: 'whatAGreatAndUniqueValue',

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
@@ -94,7 +94,7 @@ describe('group selector', () => {
     it('groupByField script should contain logic which gets all values of groupByField', () => {
       const scriptResponse = {
         source:
-          "if (doc[params['selectedGroup']].size()==0 || doc[params['selectedGroup']].size() > 100 ) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
+          "def groupValues = doc[params['selectedGroup']]; int count = groupValues.size(); if (count == 0 || count > 100 ) { emit(params['uniqueValue']); } else { emit(groupValues.join(params['uniqueValue']))}",
         params: {
           selectedGroup: 'resource.name',
           uniqueValue: 'whatAGreatAndUniqueValue',
@@ -113,7 +113,7 @@ describe('group selector', () => {
 
       const scriptResponse = {
         source:
-          "if (doc[params['selectedGroup']].size()==0 || doc[params['selectedGroup']].size() > 100 ) { emit(params['uniqueValue']) } else { int i = 0; for (def id : doc[params['selectedGroup']]) { if (i++ >= 100) break; emit(id)}}",
+          "def groupValues = doc[params['selectedGroup']]; int count = groupValues.size(); if (count == 0 || count > 100 ) { emit(params['uniqueValue']); } else { for (int i = 0; i < count && i < 100; i++) { emit(groupValues[i]); } }",
         params: {
           selectedGroup: groupByField,
           uniqueValue: 'whatAGreatAndUniqueValue',

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
@@ -17,6 +17,9 @@ export const DEFAULT_GROUP_BY_FIELD_SIZE = 10;
 // https://github.com/elastic/kibana/issues/151913
 export const MAX_QUERY_SIZE = 10000;
 
+// there is known limitation for max size of runtime field which is used in the runtime_mappings script
+export const MAX_RUNTIME_FIELD_SIZE = 100;
+
 /**
  * Composes grouping query and aggregations
  * @param additionalFilters Global filtering applicable to the grouping component.
@@ -64,7 +67,8 @@ export const getGroupingQuery = ({
         script: {
           source:
             // when size()==0, emits a uniqueValue as the value to represent this group
-            "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) }" +
+            `if (doc[params['selectedGroup']].size()==0 || doc[params['selectedGroup']].size() > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']) }` +
+            // `if (doc[params['selectedGroup']].size()==0 ) { emit(params['uniqueValue']) }` +
             /*
              * condition to decide between joining values or flattening based on shouldFlattenMultiValueField and groupByField parameters
              * if shouldFlattenMultiValueField is true, and the selectedGroup field is an array, then emit each value in the array
@@ -78,7 +82,7 @@ export const getGroupingQuery = ({
              * We will format into a proper array in parseGroupingQuery
              */
             (shouldFlattenMultiValueField
-              ? " else { for (def id : doc[params['selectedGroup']]) { emit(id) }}"
+              ? ` else { int i = 0; for (def id : doc['vulnerability.id']) { if (i++ >= ${MAX_RUNTIME_FIELD_SIZE}) break; emit(id)}}`
               : " else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}"),
           params: {
             selectedGroup: groupByField,

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
@@ -66,9 +66,8 @@ export const getGroupingQuery = ({
         type: 'keyword',
         script: {
           source:
-            // when size()==0, emits a uniqueValue as the value to represent this group
+            // when size()==0 or size() > MAX_RUNTIME_FIELD_SIZE, emits a uniqueValue as the value to represent this group
             `if (doc[params['selectedGroup']].size()==0 || doc[params['selectedGroup']].size() > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']) }` +
-            // `if (doc[params['selectedGroup']].size()==0 ) { emit(params['uniqueValue']) }` +
             /*
              * condition to decide between joining values or flattening based on shouldFlattenMultiValueField and groupByField parameters
              * if shouldFlattenMultiValueField is true, and the selectedGroup field is an array, then emit each value in the array
@@ -82,7 +81,7 @@ export const getGroupingQuery = ({
              * We will format into a proper array in parseGroupingQuery
              */
             (shouldFlattenMultiValueField
-              ? ` else { int i = 0; for (def id : doc['vulnerability.id']) { if (i++ >= ${MAX_RUNTIME_FIELD_SIZE}) break; emit(id)}}`
+              ? ` else { int i = 0; for (def id : doc[params['selectedGroup']]) { if (i++ >= ${MAX_RUNTIME_FIELD_SIZE}) break; emit(id)}}`
               : " else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}"),
           params: {
             selectedGroup: groupByField,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
@@ -97,7 +97,7 @@ export const getQuery = (
       type: 'keyword',
       script: {
         source:
-          "if (doc[params['selectedGroup']].size()==0 || doc[params['selectedGroup']].size() > 100 ) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
+          "def groupValues = doc[params['selectedGroup']]; int count = groupValues.size(); if (count == 0 || count > 100 ) { emit(params['uniqueValue']); } else { emit(groupValues.join(params['uniqueValue']))}",
         params: {
           selectedGroup,
           uniqueValue,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
@@ -97,7 +97,7 @@ export const getQuery = (
       type: 'keyword',
       script: {
         source:
-          "if (doc[params['selectedGroup']].size()==0) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
+          "if (doc[params['selectedGroup']].size()==0 || doc[params['selectedGroup']].size() > 100 ) { emit(params['uniqueValue']) } else { emit(doc[params['selectedGroup']].join(params['uniqueValue']))}",
         params: {
           selectedGroup,
           uniqueValue,


### PR DESCRIPTION
## Summary

The following PR fixes and issue in the kbn-grouping package which causes painless script throwing an error when trying to group by fields which include more than 100 values. The fix adds a limit of 100 values so every document that has field.size() > 100 counted as a none-group.
Changes only affect multi value fields which are passed as multiValueFieldsToFlatten param the query grouping builder function.

## The error
`"caused_by": {
            "type": "illegal_argument_exception",
            "reason": "Runtime field [groupByField] is emitting [101] values while the maximum number of values allowed is [100]"
          }`



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

This PR should mitigate the possible errors thrown by grouping queries which are executed when using the grouping functionality by limit the amount of values the script it executed on.

### Future improvements 

A pre computed fields for certain fields should be considered to be added as part of ingest pipelines which may allow us to avoid using painless script which have take a significant amount of the total query execution.

![image](https://github.com/user-attachments/assets/f7b2f352-c7b8-4105-b3c5-b769bcc85443)

![image](https://github.com/user-attachments/assets/2326ec4e-6e6e-4783-bf2e-d2d1a887b9b9)



