### PR TITLE
[Streams] Fix invalid mapping parameter

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/field_definition.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/field_definition.ts
@@ -8,8 +8,8 @@
 import { omit } from 'lodash';
 import { FieldDefinitionConfig, InheritedFieldDefinition, WiredStreamDefinition } from '../models';
 
-// Parameters that we consider first class and provide a curated experience for
-const FIRST_CLASS_PARAMETERS = ['type', 'format'];
+// Parameters that we consider first class and provide a curated experience for, or are added as metadata.
+const FIRST_CLASS_PARAMETERS = ['type', 'format', 'from'];
 
 // Advanced parameters that we provide a generic experience (JSON blob) for
 export const getAdvancedParameters = (fieldName: string, fieldConfig: FieldDefinitionConfig) => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/217935 (in the quickest way possible for now).

## Possible followups

- We could potentially move these advanced parameters to a sub object. However, the idea was that `FieldDefinitionConfig` utilises a union of `MappingProperty` (from ES) so that this wasn't needed 🤔

- The types can definitely be improved (`getAdvancedParameters` takes in `fieldConfig: FieldDefinitionConfig` and this missed the possibility of `InheritedFieldDefinitionConfig`, for example). We could also make the stripping schema driven.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->