### PR TITLE
[8.x] [Onboarding] Hide card labels in search results (#213417)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/onboarding_flow_form/onboarding_flow_form.tsx
@@ -333,7 +333,7 @@ export const OnboardingFlowForm: FunctionComponent = () => {
             </strong>
           </EuiTitle>
           <EuiSpacer size="m" />
-          <PackageList list={featuredCardsForCategory} />
+          <PackageList list={featuredCardsForCategory} showCardLabels={true} />
         </div>
       </div>
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/package_list/package_list.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/package_list/package_list.tsx
@@ -17,9 +17,10 @@ export const LazyPackageList = lazy(async () => ({
 interface Props {
   list: IntegrationCardItem[];
   searchTerm?: string;
+  showCardLabels?: boolean;
 }
 
-export function PackageList({ list, searchTerm = '' }: Props) {
+export function PackageList({ list, searchTerm = '', showCardLabels }: Props) {
   return (
     /**
      * Suspense wrapper is required by PackageListGrid, but
@@ -40,7 +41,7 @@ export function PackageList({ list, searchTerm = '' }: Props) {
         categories={[]}
         setUrlandReplaceHistory={() => {}}
         setUrlandPushHistory={() => {}}
-        showCardLabels={true}
+        showCardLabels={showCardLabels}
       />
     </Suspense>
   );

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/package_list_search_form/package_list_search_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/package_list_search_form/package_list_search_form.tsx
@@ -77,7 +77,9 @@ const PackageListGridWrapper = ({
         }}
         query={searchQuery}
       />
-      {searchQuery !== '' && <PackageList list={list} searchTerm={searchQuery} />}
+      {searchQuery !== '' && (
+        <PackageList list={list} searchTerm={searchQuery} showCardLabels={false} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Onboarding] Hide card labels in search results (#213417)](https://github.com/elastic/kibana/pull/213417)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mykola Harmash","email":"mykola.harmash@gmail.com"},"sourceCommit":{"committedDate":"2025-03-07T14:40:39Z","message":"[Onboarding] Hide card labels in search results (#213417)\n\nCloses https://github.com/elastic/kibana/issues/200917\n\nLooking at the code in Fleet search results screen, cards would also\nhave the `Unverified` badges. ([this\ncheck](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx#L101)\nwould return `true` because this specific page doesn't provides\n`packageVerificationKeyId` to the `isPackageUnverified()` function, this\nonly happens on the individual integration details page. Fleet search\njust [hides the\nbadges](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx#L188)\nfor cards in search results.\n\nThis change aligns Onboarding search results with Fleet search results\nand hides the card labels which fixes the issue with `Unverified` badge\nappearing for installed integrations.\n\n| Before | After |\n| --- | --- |\n|\n![388110694-bd6abaf4-15ac-4d56-b556-fddb11c85ba7](https://github.com/user-attachments/assets/751a6572-192c-45f6-bfa8-82433b73398d)\n| ![CleanShot 2025-03-07 at 14 35\n53@2x](https://github.com/user-attachments/assets/d1588d7d-eec8-4207-a1e6-9a53272bbddf)\n|","sha":"33f71ae678e833b4c91325e40f47d819e1edb08d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","ci:project-deploy-observability","Feature: Observability Onboarding","v9.1.0"],"title":"[Onboarding] Hide card labels in search results","number":213417,"url":"https://github.com/elastic/kibana/pull/213417","mergeCommit":{"message":"[Onboarding] Hide card labels in search results (#213417)\n\nCloses https://github.com/elastic/kibana/issues/200917\n\nLooking at the code in Fleet search results screen, cards would also\nhave the `Unverified` badges. ([this\ncheck](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx#L101)\nwould return `true` because this specific page doesn't provides\n`packageVerificationKeyId` to the `isPackageUnverified()` function, this\nonly happens on the individual integration details page. Fleet search\njust [hides the\nbadges](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx#L188)\nfor cards in search results.\n\nThis change aligns Onboarding search results with Fleet search results\nand hides the card labels which fixes the issue with `Unverified` badge\nappearing for installed integrations.\n\n| Before | After |\n| --- | --- |\n|\n![388110694-bd6abaf4-15ac-4d56-b556-fddb11c85ba7](https://github.com/user-attachments/assets/751a6572-192c-45f6-bfa8-82433b73398d)\n| ![CleanShot 2025-03-07 at 14 35\n53@2x](https://github.com/user-attachments/assets/d1588d7d-eec8-4207-a1e6-9a53272bbddf)\n|","sha":"33f71ae678e833b4c91325e40f47d819e1edb08d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213417","number":213417,"mergeCommit":{"message":"[Onboarding] Hide card labels in search results (#213417)\n\nCloses https://github.com/elastic/kibana/issues/200917\n\nLooking at the code in Fleet search results screen, cards would also\nhave the `Unverified` badges. ([this\ncheck](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/card_utils.tsx#L101)\nwould return `true` because this specific page doesn't provides\n`packageVerificationKeyId` to the `isPackageUnverified()` function, this\nonly happens on the individual integration details page. Fleet search\njust [hides the\nbadges](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/fleet/public/applications/integrations/sections/epm/screens/home/available_packages.tsx#L188)\nfor cards in search results.\n\nThis change aligns Onboarding search results with Fleet search results\nand hides the card labels which fixes the issue with `Unverified` badge\nappearing for installed integrations.\n\n| Before | After |\n| --- | --- |\n|\n![388110694-bd6abaf4-15ac-4d56-b556-fddb11c85ba7](https://github.com/user-attachments/assets/751a6572-192c-45f6-bfa8-82433b73398d)\n| ![CleanShot 2025-03-07 at 14 35\n53@2x](https://github.com/user-attachments/assets/d1588d7d-eec8-4207-a1e6-9a53272bbddf)\n|","sha":"33f71ae678e833b4c91325e40f47d819e1edb08d"}},{"url":"https://github.com/elastic/kibana/pull/213579","number":213579,"branch":"9.0","state":"MERGED","mergeCommit":{"sha":"ff5042eb811c5eb1eb6bccc797feec06f52e1e32","message":"[9.0] [Onboarding] Hide card labels in search results (#213417) (#213579)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Onboarding] Hide card labels in search results\n(#213417)](https://github.com/elastic/kibana/pull/213417)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Mykola Harmash <mykola.harmash@gmail.com>"}},{"url":"https://github.com/elastic/kibana/pull/216666","number":216666,"branch":"8.18","state":"MERGED","mergeCommit":{"sha":"ca96f071c305f6b66f15bc8cb0ce17e49cf94b9e","message":"[8.18] [Onboarding] Hide card labels in search results (#213417) (#216666)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Onboarding] Hide card labels in search results\n(#213417)](https://github.com/elastic/kibana/pull/213417)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: Mykola Harmash <mykola.harmash@gmail.com>"}},{"url":"https://github.com/elastic/kibana/pull/216689","number":216689,"branch":"8.17","state":"OPEN"}]}] BACKPORT-->