### PR TITLE
[CI] Also download FIPS artifacts before validating

### DIFF
--- a/.buildkite/scripts/steps/artifacts/publish.sh
+++ b/.buildkite/scripts/steps/artifacts/publish.sh
@@ -35,6 +35,10 @@ download "kibana-cloud-$FULL_VERSION-docker-build-context.tar.gz"
 download "kibana-ironbank-$FULL_VERSION-docker-build-context.tar.gz"
 download "kibana-wolfi-$FULL_VERSION-docker-build-context.tar.gz"
 
+download "kibana-cloud-fips-$FULL_VERSION-docker-build-context.tar.gz"
+download "kibana-cloud-fips-$FULL_VERSION-docker-image-aarch64.tar.gz"
+download "kibana-cloud-fips-$FULL_VERSION-docker-image.tar.gz"
+
 download "kibana-$FULL_VERSION-linux-aarch64.tar.gz"
 download "kibana-$FULL_VERSION-linux-x86_64.tar.gz"
 


### PR DESCRIPTION
## Summary
Attempts to fix: https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/5949#01962428-99a7-4481-8b8b-95685d1d4d79

The step was trying to validate cloud fips artifacts (after: https://github.com/elastic/infra/pull/42268) but these were never downloaded in that step.




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->