### PR TITLE
[Ai4dSoc] Hide Siem Migrations on `search_ai_lake` tier

### DIFF
--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -11,6 +11,7 @@ xpack.features.overrides:
   securitySolutionNotes.hidden: true
   siem.description: null
   siemV2.description: null
+  securitySolutionSiemMigrations.hidden: true
 
 ## Agentless deployment by default
 xpack.fleet.agentless.isDefault: true

--- a/x-pack/test/security_solution_cypress/cypress/e2e/ai4dsoc/privileges/security_privileges.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/ai4dsoc/privileges/security_privileges.cy.ts
@@ -12,6 +12,7 @@ import {
   MACHINE_LEARNING_FEATURE,
   NOTES_FEATURE,
   SECURITY_FEATURE,
+  SIEM_MIGRATIONS_FEATURE,
   TIMELINE_FEATURE,
 } from '../../../screens/custom_roles/assign_to_space_flyout';
 import { login } from '../../../tasks/login';
@@ -39,6 +40,12 @@ describe('Custom role creation', { tags: '@serverless' }, () => {
       // should not have Timeline/Notes sub-privileges
       cy.get(TIMELINE_FEATURE).should('not.exist');
       cy.get(NOTES_FEATURE).should('not.exist');
+    });
+
+    it('should not show `Siem Migration` feature', () => {
+      selectAllSpaces();
+      // should not have Siem Migration sub-privileges
+      cy.get(SIEM_MIGRATIONS_FEATURE).should('not.exist');
     });
 
     it('should show `Cases`, `Machine Learning`, `Elastic AI Assistant` and `Attack discovery` features', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/ai4dsoc/privileges/security_privileges.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/ai4dsoc/privileges/security_privileges.cy.ts
@@ -12,6 +12,7 @@ import {
   MACHINE_LEARNING_FEATURE,
   NOTES_FEATURE,
   SECURITY_FEATURE,
+  SECURITY_FEATURE_DESCRIPTION,
   SIEM_MIGRATIONS_FEATURE,
   TIMELINE_FEATURE,
 } from '../../../screens/custom_roles/assign_to_space_flyout';
@@ -31,6 +32,7 @@ describe('Custom role creation', { tags: '@serverless' }, () => {
       selectAllSpaces();
       // should not have Security sub-privileges
       cy.get(SECURITY_FEATURE).should('exist');
+      cy.get(SECURITY_FEATURE_DESCRIPTION).should('not.exist');
       cy.get(SECURITY_FEATURE).click();
       cy.get(`${SECURITY_FEATURE} button.euiAccordion__arrow`).should('not.exist');
     });

--- a/x-pack/test/security_solution_cypress/cypress/screens/custom_roles/assign_to_space_flyout.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/custom_roles/assign_to_space_flyout.ts
@@ -12,6 +12,7 @@ export const SECURITY_CATEGORY = '[data-test-subj="featureCategory_securitySolut
 
 // Sub-privileges
 export const SECURITY_FEATURE = '[data-test-subj="featureCategory_securitySolution_siemV2"]';
+export const SECURITY_FEATURE_DESCRIPTION = '[aria-describedby="Security description text"]';
 
 export const CASES_FEATURE =
   '[data-test-subj="featureCategory_securitySolution_securitySolutionCasesV3"]';

--- a/x-pack/test/security_solution_cypress/cypress/screens/custom_roles/assign_to_space_flyout.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/custom_roles/assign_to_space_flyout.ts
@@ -24,3 +24,5 @@ export const TIMELINE_FEATURE =
   '[data-test-subj="featureCategory_securitySolution_securitySolutionTimeline"]';
 export const NOTES_FEATURE =
   '[data-test-subj="featureCategory_securitySolution_securitySolutionNotes"]';
+export const SIEM_MIGRATIONS_FEATURE =
+  '[data-test-subj="featureCategory_securitySolution_securitySolutionSiemMigrations"]';

--- a/x-pack/test/security_solution_cypress/cypress/tasks/select_all_spaces.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/select_all_spaces.ts
@@ -19,6 +19,6 @@ export const selectAllSpaces = (): void => {
   cy.get(SPACE_SELECTOR_COMBO_BOX).type('* All Spaces');
   cy.get(SPACE_SELECTOR_COMBO_BOX).type('{enter}');
 
-  // expand security privileges
+  // expand security category
   cy.get(SECURITY_CATEGORY).click();
 };


### PR DESCRIPTION
> [!CAUTION]
> Merge after https://github.com/elastic/kibana/pull/217210


## Summary

Hides SIEM Migrations feature for `ai4soc/search_ai_lake` tier.

![Screenshot 2025-04-11 at 15 44 16](https://github.com/user-attachments/assets/fa1415e4-ffcd-4d9e-9072-6cf19b00f93e)

## How to Test

1. While on the Kibana root directory, run ES/Kibana on serverless mode with:

```bash
yarn es serverless --kill --projectType security --kibanaUrl=http://0.0.0.0:5601
```
and on a new window
```bash
yarn serverless-security --no-base-path
```

Enable the AI for SOC tier, by adding the following to your `serverless.security.dev.yaml` file:

```json5
xpack.securitySolutionServerless.productTypes:
  [
    { product_line: 'ai_soc', product_tier: 'search_ai_lake' },
  ]
```

2. Once Kibana is up and running login in with the `admin` role using the role dropdown.
3. Navigate to `app/management/roles/edit`
4. Click on `Assign to space` button and assign a space to that role on the `Assign role to spaces` flyout.
6. Expand the `Security` category and verify that `SIEM Migrations` is not visible in the list.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->