### PR TITLE
[ci] increase inspector limit to allow for recent updates

### DIFF
--- a/packages/kbn-optimizer/limits.yml
+++ b/packages/kbn-optimizer/limits.yml
@@ -85,7 +85,7 @@ pageLoadAssetSize:
   infra: 184320
   ingestPipelines: 58003
   inputControlVis: 172675
-  inspector: 17740
+  inspector: 17900
   interactiveSetup: 80000
   inventory: 27430
   kibanaOverview: 56279


### PR DESCRIPTION
## Summary
It seems there's been some sort of unintended bundle limit branch through 2 minor changes (greenlit separately on PRs) - and this one broke the camel's back: https://github.com/elastic/kibana/pull/212163