### PR TITLE
[ES|QL] Fixes the broken tooltip suggestions descriptions

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/helpers.ts
@@ -356,5 +356,9 @@ export const getEditorOverwrites = (theme: UseEuiTheme<{}>) => {
     .monaco-list .monaco-scrollable-element .monaco-list-row.focused {
       border-radius: ${theme.euiTheme.border.radius.medium};
     }
+    // fixes the bug with the broken suggestion details https://github.com/elastic/kibana/issues/217998
+    .suggest-details > .monaco-scrollable-element > .body > .header > .type {
+      white-space: normal !important;
+    }
   `;
 };


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/217998

Fixes the descriptions problem in some markdown texts in the editor (the markdown is correct)

![image (93)](https://github.com/user-attachments/assets/0b2c9d75-1933-4345-8a2d-aae9a2c778c9)




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->