### PR TITLE
[ES|QL] Allows to retrieve empty columns

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -73,12 +73,17 @@ export const getGridAttrs = async (
     search: data.search.search,
     signal: abortController?.signal,
     filter,
-    dropNullColumns: false,
+    dropNullColumns: true,
     timeRange: data.query.timefilter.timefilter.getAbsoluteTime(),
     variables: esqlVariables,
   });
 
-  const columns = formatESQLColumns(results.response.columns);
+  let queryColumns = results.response.columns;
+  if (queryColumns.length === 0 && results.response.all_columns) {
+    queryColumns = results.response.all_columns;
+  }
+
+  const columns = formatESQLColumns(queryColumns);
 
   return {
     rows: results.response.values,

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -79,6 +79,8 @@ export const getGridAttrs = async (
   });
 
   let queryColumns = results.response.columns;
+  // if the query columns are empty, we need to use the all_columns
+  // which has all columns regardless if they have data or not
   if (queryColumns.length === 0 && results.response.all_columns) {
     queryColumns = results.response.all_columns;
   }

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -73,7 +73,7 @@ export const getGridAttrs = async (
     search: data.search.search,
     signal: abortController?.signal,
     filter,
-    dropNullColumns: true,
+    dropNullColumns: false,
     timeRange: data.query.timefilter.timefilter.getAbsoluteTime(),
     variables: esqlVariables,
   });

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -79,7 +79,7 @@ export const getGridAttrs = async (
   });
 
   let queryColumns = results.response.columns;
-  // if the query columns are empty, we need to use the all_columns
+  // if the query columns are empty, we need to use the all_columns property
   // which has all columns regardless if they have data or not
   if (queryColumns.length === 0 && results.response.all_columns) {
     queryColumns = results.response.all_columns;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/200039

Here we are asking ES to do a grouping between empty columns and non-empty. The `dropNullColumns: true` in the request does the trick.

In case of true the response comes as:

```
// only columns with data
columns: [...]
// all columns
all_columns: [...]
```

When the query is empty the columns array comes empty but the all_columns has all the columns information. The PR just takes the empty columns scenario under consideration in order to serve the `all_columns` instead. In that case the text based datasource has the info it needs to serve a valid visualization state.


<img width="990" alt="image" src="https://github.com/user-attachments/assets/7d0b2c58-eda2-4807-9203-36f7da48a6ff" />


<img width="814" alt="image" src="https://github.com/user-attachments/assets/8b0ef3bf-14d5-4438-b8fd-a13d346da420" />


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios






<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->