### PR TITLE
[ES|QL] Enable suggestions for `CHANGE_POINT` command

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -590,7 +590,6 @@ export const commandDefinitions: Array<CommandDefinition<any>> = [
     suggest: suggestForJoin,
   },
   {
-    hidden: true,
     name: 'change_point',
     preview: true,
     description: i18n.translate(


### PR DESCRIPTION
## Summary

With the `CHANGE_POINT` command moved to tech preview (PR https://github.com/elastic/elasticsearch/pull/126407), we can enable suggestions in the editor.



<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->