### PR TITLE
[Fleet] Handle permissions errors when querying datastreams

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/routes/data_streams/handlers.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/routes/data_streams/handlers.ts
@@ -10,6 +10,7 @@ import type { RequestHandler } from '@kbn/core/server';
 import pMap from 'p-map';
 import type { IndicesDataStreamsStatsDataStreamsStatsItem } from '@elastic/elasticsearch/lib/api/types';
 import { ByteSizeValue } from '@kbn/config-schema';
+import { errors } from '@elastic/elasticsearch';
 
 import type { DataStream } from '../../types';
 import { KibanaSavedObjectType } from '../../../common/types';
@@ -19,6 +20,7 @@ import type { MeteringStats } from '../../services/data_streams';
 import { dataStreamService } from '../../services/data_streams';
 import { MAX_CONCURRENT_DATASTREAM_OPERATIONS } from '../../constants';
 import { appContextService } from '../../services';
+import { FleetUnauthorizedError } from '../../errors';
 
 import { getDataStreamsQueryMetadata } from './get_data_streams_query_metadata';
 
@@ -47,162 +49,166 @@ interface ESDataStreamInfo {
 }
 
 export const getListHandler: RequestHandler = async (context, request, response) => {
-  // Query datastreams as the current user as the Kibana internal user may not have all the required permission
-  const { savedObjects, elasticsearch } = await context.core;
-  const esClient = elasticsearch.client.asCurrentUser;
+  try {
+    // Query datastreams as the current user as the Kibana internal user may not have all the required permission
+    const { savedObjects, elasticsearch } = await context.core;
+    const esClient = elasticsearch.client.asCurrentUser;
 
-  const body: GetDataStreamsResponse = {
-    data_streams: [],
-  };
-
-  const useMeteringApi = appContextService.getConfig()?.internal?.useMeteringApi;
-
-  // Get matching data streams, their stats, and package SOs
-  const [
-    dataStreamsInfo,
-    dataStreamStatsOrUndefined,
-    dataStreamMeteringStatsorUndefined,
-    packageSavedObjects,
-  ] = await Promise.all([
-    dataStreamService.getAllFleetDataStreams(esClient),
-    useMeteringApi
-      ? undefined
-      : dataStreamService.getAllFleetDataStreamsStats(elasticsearch.client.asSecondaryAuthUser),
-    useMeteringApi
-      ? dataStreamService.getAllFleetMeteringStats(elasticsearch.client.asSecondaryAuthUser)
-      : undefined,
-    getPackageSavedObjects(savedObjects.client),
-  ]);
-
-  // managed_by property 'ingest-manager' added to allow for legacy data streams to be displayed
-  // See https://github.com/elastic/elastic-agent/issues/654
-
-  const filteredDataStreamsInfo = dataStreamsInfo.filter(
-    (ds) => ds?._meta?.managed_by === MANAGED_BY || ds?._meta?.managed_by === LEGACY_MANAGED_BY
-  );
-
-  const dataStreamsInfoByName = keyBy<ESDataStreamInfo>(filteredDataStreamsInfo, 'name');
-
-  let dataStreamsStatsByName: Dictionary<IndicesDataStreamsStatsDataStreamsStatsItem> = {};
-  if (dataStreamStatsOrUndefined) {
-    const filteredDataStreamsStats = dataStreamStatsOrUndefined.filter(
-      (dss) => !!dataStreamsInfoByName[dss.data_stream]
-    );
-    dataStreamsStatsByName = keyBy(filteredDataStreamsStats, 'data_stream');
-  }
-  let dataStreamsMeteringStatsByName: Dictionary<MeteringStats> = {};
-  if (dataStreamMeteringStatsorUndefined) {
-    dataStreamsMeteringStatsByName = keyBy(dataStreamMeteringStatsorUndefined, 'name');
-  }
-
-  // Combine data stream info
-  const dataStreams = merge(
-    dataStreamsInfoByName,
-    dataStreamsStatsByName,
-    dataStreamsMeteringStatsByName
-  );
-  const dataStreamNames = keys(dataStreams);
-
-  // Map package SOs
-  const packageSavedObjectsByName = keyBy(packageSavedObjects.saved_objects, 'id');
-  const packageMetadata: any = {};
-
-  // Get dashboard information for all packages
-  const dashboardIdsByPackageName = packageSavedObjects.saved_objects.reduce<
-    Record<string, string[]>
-  >((allDashboards, pkgSavedObject) => {
-    const dashboards: string[] = [];
-    (pkgSavedObject.attributes?.installed_kibana || []).forEach((o) => {
-      if (o.type === KibanaSavedObjectType.dashboard) {
-        dashboards.push(o.id);
-      }
-    });
-    allDashboards[pkgSavedObject.id] = dashboards;
-    return allDashboards;
-  }, {});
-  const allDashboardSavedObjectsResponse = await savedObjects.client.bulkGet<{
-    title?: string;
-  }>(
-    Object.values(dashboardIdsByPackageName).flatMap((dashboardIds) =>
-      dashboardIds.map((id) => ({
-        id,
-        type: KibanaSavedObjectType.dashboard,
-        fields: ['title'],
-      }))
-    )
-  );
-  // Ignore dashboards not found
-  const allDashboardSavedObjects = allDashboardSavedObjectsResponse.saved_objects.filter((so) => {
-    if (so.error) {
-      if (so.error.statusCode === 404) {
-        return false;
-      }
-      throw so.error;
-    }
-    return true;
-  });
-
-  const allDashboardSavedObjectsById = keyBy(
-    allDashboardSavedObjects,
-    (dashboardSavedObject) => dashboardSavedObject.id
-  );
-
-  // Query additional information for each data stream
-  const queryDataStreamInfo = async (dataStreamName: string) => {
-    const dataStream = dataStreams[dataStreamName];
-
-    const dataStreamResponse: DataStream = {
-      index: dataStreamName,
-      dataset: '',
-      namespace: '',
-      type: '',
-      package: dataStream._meta?.package?.name || '',
-      package_version: '',
-      last_activity_ms: dataStream.maximum_timestamp, // overridden below if maxIngestedTimestamp agg returns a result
-      size_in_bytes: dataStream.store_size_bytes || dataStream.size_in_bytes,
-      // `store_size` should be available from ES due to ?human=true flag
-      // but fallback to bytes just in case
-      size_in_bytes_formatted:
-        dataStream.store_size ||
-        new ByteSizeValue(dataStream.store_size_bytes || dataStream.size_in_bytes || 0).toString(),
-      dashboards: [],
-      serviceDetails: null,
+    const body: GetDataStreamsResponse = {
+      data_streams: [],
     };
 
-    const { maxIngested, namespace, dataset, type, serviceNames, environments } =
-      await getDataStreamsQueryMetadata({ dataStreamName: dataStream.name, esClient });
+    const useMeteringApi = appContextService.getConfig()?.internal?.useMeteringApi;
 
-    // some integrations e.g custom logs don't have event.ingested
-    if (maxIngested) {
-      dataStreamResponse.last_activity_ms = maxIngested;
+    // Get matching data streams, their stats, and package SOs
+    const [
+      dataStreamsInfo,
+      dataStreamStatsOrUndefined,
+      dataStreamMeteringStatsorUndefined,
+      packageSavedObjects,
+    ] = await Promise.all([
+      dataStreamService.getAllFleetDataStreams(esClient),
+      useMeteringApi
+        ? undefined
+        : dataStreamService.getAllFleetDataStreamsStats(elasticsearch.client.asSecondaryAuthUser),
+      useMeteringApi
+        ? dataStreamService.getAllFleetMeteringStats(elasticsearch.client.asSecondaryAuthUser)
+        : undefined,
+      getPackageSavedObjects(savedObjects.client),
+    ]);
+
+    // managed_by property 'ingest-manager' added to allow for legacy data streams to be displayed
+    // See https://github.com/elastic/elastic-agent/issues/654
+
+    const filteredDataStreamsInfo = dataStreamsInfo.filter(
+      (ds) => ds?._meta?.managed_by === MANAGED_BY || ds?._meta?.managed_by === LEGACY_MANAGED_BY
+    );
+
+    const dataStreamsInfoByName = keyBy<ESDataStreamInfo>(filteredDataStreamsInfo, 'name');
+
+    let dataStreamsStatsByName: Dictionary<IndicesDataStreamsStatsDataStreamsStatsItem> = {};
+    if (dataStreamStatsOrUndefined) {
+      const filteredDataStreamsStats = dataStreamStatsOrUndefined.filter(
+        (dss) => !!dataStreamsInfoByName[dss.data_stream]
+      );
+      dataStreamsStatsByName = keyBy(filteredDataStreamsStats, 'data_stream');
+    }
+    let dataStreamsMeteringStatsByName: Dictionary<MeteringStats> = {};
+    if (dataStreamMeteringStatsorUndefined) {
+      dataStreamsMeteringStatsByName = keyBy(dataStreamMeteringStatsorUndefined, 'name');
     }
 
-    if (serviceNames?.length === 1) {
-      const serviceDetails = {
-        serviceName: serviceNames[0],
-        environment: environments?.length === 1 ? environments[0] : 'ENVIRONMENT_ALL',
+    // Combine data stream info
+    const dataStreams = merge(
+      dataStreamsInfoByName,
+      dataStreamsStatsByName,
+      dataStreamsMeteringStatsByName
+    );
+    const dataStreamNames = keys(dataStreams);
+
+    // Map package SOs
+    const packageSavedObjectsByName = keyBy(packageSavedObjects.saved_objects, 'id');
+    const packageMetadata: any = {};
+
+    // Get dashboard information for all packages
+    const dashboardIdsByPackageName = packageSavedObjects.saved_objects.reduce<
+      Record<string, string[]>
+    >((allDashboards, pkgSavedObject) => {
+      const dashboards: string[] = [];
+      (pkgSavedObject.attributes?.installed_kibana || []).forEach((o) => {
+        if (o.type === KibanaSavedObjectType.dashboard) {
+          dashboards.push(o.id);
+        }
+      });
+      allDashboards[pkgSavedObject.id] = dashboards;
+      return allDashboards;
+    }, {});
+    const allDashboardSavedObjectsResponse = await savedObjects.client.bulkGet<{
+      title?: string;
+    }>(
+      Object.values(dashboardIdsByPackageName).flatMap((dashboardIds) =>
+        dashboardIds.map((id) => ({
+          id,
+          type: KibanaSavedObjectType.dashboard,
+          fields: ['title'],
+        }))
+      )
+    );
+    // Ignore dashboards not found
+    const allDashboardSavedObjects = allDashboardSavedObjectsResponse.saved_objects.filter((so) => {
+      if (so.error) {
+        if (so.error.statusCode === 404) {
+          return false;
+        }
+        throw so.error;
+      }
+      return true;
+    });
+
+    const allDashboardSavedObjectsById = keyBy(
+      allDashboardSavedObjects,
+      (dashboardSavedObject) => dashboardSavedObject.id
+    );
+
+    // Query additional information for each data stream
+    const queryDataStreamInfo = async (dataStreamName: string) => {
+      const dataStream = dataStreams[dataStreamName];
+
+      const dataStreamResponse: DataStream = {
+        index: dataStreamName,
+        dataset: '',
+        namespace: '',
+        type: '',
+        package: dataStream._meta?.package?.name || '',
+        package_version: '',
+        last_activity_ms: dataStream.maximum_timestamp, // overridden below if maxIngestedTimestamp agg returns a result
+        size_in_bytes: dataStream.store_size_bytes || dataStream.size_in_bytes,
+        // `store_size` should be available from ES due to ?human=true flag
+        // but fallback to bytes just in case
+        size_in_bytes_formatted:
+          dataStream.store_size ||
+          new ByteSizeValue(
+            dataStream.store_size_bytes || dataStream.size_in_bytes || 0
+          ).toString(),
+        dashboards: [],
+        serviceDetails: null,
       };
-      dataStreamResponse.serviceDetails = serviceDetails;
-    }
 
-    dataStreamResponse.dataset = dataset;
-    dataStreamResponse.namespace = namespace;
-    dataStreamResponse.type = type;
+      const { maxIngested, namespace, dataset, type, serviceNames, environments } =
+        await getDataStreamsQueryMetadata({ dataStreamName: dataStream.name, esClient });
 
-    // Find package saved object
-    const pkgName = dataStreamResponse.package;
-    const pkgSavedObject = pkgName ? packageSavedObjectsByName[pkgName] : null;
+      // some integrations e.g custom logs don't have event.ingested
+      if (maxIngested) {
+        dataStreamResponse.last_activity_ms = maxIngested;
+      }
 
-    if (pkgSavedObject) {
-      // if
-      // - the data stream is associated with a package
-      // - and the package has been installed through EPM
-      // - and we didn't pick the metadata in an earlier iteration of this map()
-      if (!packageMetadata[pkgName]) {
-        // then pick the dashboards from the package saved object
-        const packageDashboardIds = dashboardIdsByPackageName[pkgName] || [];
-        const packageDashboards = packageDashboardIds.reduce<Array<{ id: string; title: string }>>(
-          (dashboards, dashboardId) => {
+      if (serviceNames?.length === 1) {
+        const serviceDetails = {
+          serviceName: serviceNames[0],
+          environment: environments?.length === 1 ? environments[0] : 'ENVIRONMENT_ALL',
+        };
+        dataStreamResponse.serviceDetails = serviceDetails;
+      }
+
+      dataStreamResponse.dataset = dataset;
+      dataStreamResponse.namespace = namespace;
+      dataStreamResponse.type = type;
+
+      // Find package saved object
+      const pkgName = dataStreamResponse.package;
+      const pkgSavedObject = pkgName ? packageSavedObjectsByName[pkgName] : null;
+
+      if (pkgSavedObject) {
+        // if
+        // - the data stream is associated with a package
+        // - and the package has been installed through EPM
+        // - and we didn't pick the metadata in an earlier iteration of this map()
+        if (!packageMetadata[pkgName]) {
+          // then pick the dashboards from the package saved object
+          const packageDashboardIds = dashboardIdsByPackageName[pkgName] || [];
+          const packageDashboards = packageDashboardIds.reduce<
+            Array<{ id: string; title: string }>
+          >((dashboards, dashboardId) => {
             const dashboard = allDashboardSavedObjectsById[dashboardId];
             if (dashboard) {
               dashboards.push({
@@ -211,36 +217,43 @@ export const getListHandler: RequestHandler = async (context, request, response)
               });
             }
             return dashboards;
-          },
-          []
-        );
+          }, []);
 
-        packageMetadata[pkgName] = {
-          version: pkgSavedObject.attributes?.version || '',
-          dashboards: packageDashboards,
-        };
+          packageMetadata[pkgName] = {
+            version: pkgSavedObject.attributes?.version || '',
+            dashboards: packageDashboards,
+          };
+        }
+
+        // Set values from package information
+        dataStreamResponse.package = pkgName;
+        dataStreamResponse.package_version = packageMetadata[pkgName].version;
+        dataStreamResponse.dashboards = packageMetadata[pkgName].dashboards;
       }
 
-      // Set values from package information
-      dataStreamResponse.package = pkgName;
-      dataStreamResponse.package_version = packageMetadata[pkgName].version;
-      dataStreamResponse.dashboards = packageMetadata[pkgName].dashboards;
+      return dataStreamResponse;
+    };
+
+    // Return final data streams objects sorted by last activity, descending
+    // After filtering out data streams that are missing dataset/namespace/type/package fields
+    body.data_streams = (
+      await pMap(dataStreamNames, (dataStreamName) => queryDataStreamInfo(dataStreamName), {
+        concurrency: MAX_CONCURRENT_DATASTREAM_OPERATIONS,
+      })
+    )
+      .filter(({ dataset, namespace, type }) => dataset && namespace && type)
+      .sort((a, b) => b.last_activity_ms - a.last_activity_ms);
+
+    return response.ok({
+      body,
+    });
+  } catch (err) {
+    const isResponseError = err instanceof errors.ResponseError;
+    if (isResponseError && err?.body?.error?.type === 'security_exception') {
+      throw new FleetUnauthorizedError(
+        `Not enough permissions to query datastreams: ${err.message}`
+      );
     }
-
-    return dataStreamResponse;
-  };
-
-  // Return final data streams objects sorted by last activity, descending
-  // After filtering out data streams that are missing dataset/namespace/type/package fields
-  body.data_streams = (
-    await pMap(dataStreamNames, (dataStreamName) => queryDataStreamInfo(dataStreamName), {
-      concurrency: MAX_CONCURRENT_DATASTREAM_OPERATIONS,
-    })
-  )
-    .filter(({ dataset, namespace, type }) => dataset && namespace && type)
-    .sort((a, b) => b.last_activity_ms - a.last_activity_ms);
-
-  return response.ok({
-    body,
-  });
+    throw err;
+  }
 };


### PR DESCRIPTION
## Summary

The datastream endpoint on Fleet rely on user permission to ES to query datastreams, these calls will fail if user do not have enought permissions as expected, so instead of returning a 500 we should return a 403 error.

That PR does that.