### PR TITLE
[Console] Fix a11y overlay test

### DIFF
--- a/src/platform/test/functional/apps/console/_settings.ts
+++ b/src/platform/test/functional/apps/console/_settings.ts
@@ -27,8 +27,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('displays the a11y overlay', async () => {
       await PageObjects.console.pressEscape();
-      const isOverlayVisible = await PageObjects.console.isA11yOverlayVisible();
-      expect(isOverlayVisible).to.be(true);
+
+      await retry.try(async () => {
+        const isOverlayVisible = await PageObjects.console.isA11yOverlayVisible();
+        expect(isOverlayVisible).to.be(true);
+      });
     });
 
     it('disables the a11y overlay via settings', async () => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/217057

## Summary

This PR fixes the flaky test for the a11y overlay by adding a `retry` and allowing more time for the overlay element to be detected.

Flaky test runner build: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/8176



<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->