### PR TITLE
[8.x] [SLO] update default feature flag value for slo management (#216919)

### DIFF
--- a/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -379,7 +379,6 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.apm.featureFlags.ruleFormV2Enabled (boolean?)',
         'xpack.observability.unsafe.ruleFormV2.enabled (boolean?)',
         'xpack.slo.experimental.ruleFormV2.enabled (boolean?)',
-        'xpack.slo.experimental.management.enabled (boolean?)',
         /**/
       ];
       // We don't assert that actualExposedConfigKeys and expectedExposedConfigKeys are equal, because test failure messages with large

--- a/x-pack/solutions/observability/plugins/slo/common/config.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/config.ts
@@ -16,9 +16,6 @@ export const configSchema = schema.object({
       ruleFormV2: schema.object({
         enabled: schema.boolean({ defaultValue: false }),
       }),
-      management: schema.object({
-        enabled: schema.boolean({ defaultValue: false }),
-      }),
     })
   ),
 });

--- a/x-pack/solutions/observability/plugins/slo/public/application.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/application.tsx
@@ -140,9 +140,9 @@ export const renderApp = ({
 };
 
 function App() {
-  const { isServerless, experimentalFeatures } = usePluginContext();
+  const { isServerless } = usePluginContext();
 
-  const routes = getRoutes(isServerless, experimentalFeatures);
+  const routes = getRoutes(isServerless);
 
   return (
     <Routes enableExecutionContextTracking={true}>

--- a/x-pack/solutions/observability/plugins/slo/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/plugin.ts
@@ -44,7 +44,6 @@ export class SLOPlugin
 {
   private readonly appUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
   private experimentalFeatures: ExperimentalFeatures = {
-    management: { enabled: false },
     ruleFormV2: { enabled: false },
   };
 

--- a/x-pack/solutions/observability/plugins/slo/public/routes/routes.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/routes/routes.tsx
@@ -22,12 +22,10 @@ import {
 } from '../../common/locators/paths';
 import { SlosOutdatedDefinitions } from '../pages/slo_outdated_definitions';
 import { SloSettingsPage } from '../pages/slo_settings/slo_settings';
-import { ExperimentalFeatures } from '../../common/config';
 import { SloManagementPage } from '../pages/slo_management/slo_management_page';
 
 export const getRoutes = (
-  isServerless?: boolean,
-  experimentalFeatures?: ExperimentalFeatures
+  isServerless?: boolean
 ): {
   [key: string]: {
     handler: () => React.ReactElement;
@@ -82,17 +80,13 @@ export const getRoutes = (
           },
         }
       : {}),
-    ...(!!experimentalFeatures?.management.enabled
-      ? {
-          [SLOS_MANAGEMENT_PATH]: {
-            handler: () => {
-              return <SloManagementPage />;
-            },
-            params: {},
-            exact: true,
-          },
-        }
-      : {}),
+    [SLOS_MANAGEMENT_PATH]: {
+      handler: () => {
+        return <SloManagementPage />;
+      },
+      params: {},
+      exact: true,
+    },
     [SLO_DETAIL_PATH]: {
       handler: () => {
         return <SloDetailsPage />;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[SLO] update default feature flag value for slo management (#216919)](https://github.com/elastic/kibana/pull/216919)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2025-04-07T13:07:35Z","message":"[SLO] update default feature flag value for slo management (#216919)\n\n## Summary\n\nupdate default feature flag value for slo management, persist flag state\nto callout","sha":"8999324ed563fa1c081d6270a873fdaefbea7732","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-ux-management","v9.1.0"],"title":"[SLO] update default feature flag value for slo management","number":216919,"url":"https://github.com/elastic/kibana/pull/216919","mergeCommit":{"message":"[SLO] update default feature flag value for slo management (#216919)\n\n## Summary\n\nupdate default feature flag value for slo management, persist flag state\nto callout","sha":"8999324ed563fa1c081d6270a873fdaefbea7732"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216919","number":216919,"mergeCommit":{"message":"[SLO] update default feature flag value for slo management (#216919)\n\n## Summary\n\nupdate default feature flag value for slo management, persist flag state\nto callout","sha":"8999324ed563fa1c081d6270a873fdaefbea7732"}}]}] BACKPORT-->