### PR TITLE
[ES|QL] Mutes the forward compatibility tests

### DIFF
--- a/src/platform/test/functional/apps/dashboard/esql_controls/field_control.ts
+++ b/src/platform/test/functional/apps/dashboard/esql_controls/field_control.ts
@@ -28,6 +28,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const elasticChart = getService('elasticChart');
 
   describe('dashboard - add a field type ES|QL control', function () {
+    // this mutes the forward-compatibility test with Elasticsearch, 8.19 kibana and 9.0 ES.
+    // There are not expected to work together.
+    this.onlyEsVersion('8.19 || >=9.1');
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await kibanaServer.importExport.load(


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/216398

### Checklist

This test fails because it tests ES 9.0 with kibana 8.19 but this is not compatible for field controls (ES changed the backend implementation in 8.19 and 9.1)




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->