### PR TITLE
[Lens] Fix generation of on-click filters for generated ESQL Lens

### DIFF
--- a/src/platform/packages/shared/kbn-es-query/src/filters/build_filters/range_filter.ts
+++ b/src/platform/packages/shared/kbn-es-query/src/filters/build_filters/range_filter.ts
@@ -189,12 +189,13 @@ export const buildRangeFilter = (
 
 export const buildSimpleNumberRangeFilter = (
   fieldName: string,
+  fieldType: 'number' | 'date',
   params: RangeFilterParams,
   value: string,
   dataViewId: string
 ) => {
   return buildRangeFilter(
-    { name: fieldName, type: 'number' },
+    { name: fieldName, type: fieldType },
     params,
     { id: dataViewId, title: dataViewId },
     value

--- a/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.test.ts
+++ b/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.test.ts
@@ -121,7 +121,9 @@ describe('createFiltersFromClickEvent', () => {
             meta: {
               type: 'number',
               sourceParams: {
+                indexPattern: 'logs*',
                 sourceField: 'bytes',
+                operationType: 'sum',
               },
             },
           },
@@ -148,24 +150,54 @@ describe('createFiltersFromClickEvent', () => {
       expect(filter).toEqual([]);
     });
 
-    test('handles an event when operation type is a date histogram', async () => {
-      (table.columns[0].meta.sourceParams as any).operationType = 'date_histogram';
+    test('ignores event when sourceField.indexPattern is missing', async () => {
+      (table.columns[0].meta.sourceParams as any).indexPattern = null;
       const filter = await createFilterESQL(table, 0, 0);
 
-      expect(filter).toMatchInlineSnapshot(`Array []`);
+      expect(filter).toEqual([]);
+    });
+
+    test('handles an event when operation type is a date histogram', async () => {
+      (table.columns[0].meta.sourceParams as any).operationType = 'date_histogram';
+      (table.columns[0].meta.sourceParams as any).sourceField = '@timestamp';
+      (table.columns[0].meta.sourceParams as any).interval = 1000;
+      (table.columns[0].meta as any).type = 'date';
+      table.rows[0]['1-1'] = 1696118400000;
+
+      const filter = await createFilterESQL(table, 0, 0);
+
+      expect(filter).toEqual([
+        {
+          meta: { field: '@timestamp', formattedValue: 1696118400000, index: 'logs*', params: {} },
+          query: {
+            range: {
+              '@timestamp': {
+                format: 'strict_date_optional_time',
+                gte: 1696118400000,
+                lt: 1696118401000,
+              },
+            },
+          },
+        },
+      ]);
     });
 
     test('handles an event when operation type is histogram', async () => {
       (table.columns[0].meta.sourceParams as any).operationType = 'histogram';
       const filter = await createFilterESQL(table, 0, 0);
 
-      expect(filter).toMatchInlineSnapshot(`Array []`);
+      expect(filter).toEqual([
+        {
+          meta: { field: 'bytes', formattedValue: '2048', index: 'logs*', params: {} },
+          query: { range: { bytes: { gte: 2048, lt: 20480 } } },
+        },
+      ]);
     });
 
     test('handles an event when operation type is not date histogram', async () => {
       const filter = await createFilterESQL(table, 0, 0);
 
-      expect(filter).toMatchInlineSnapshot(`Array []`);
+      expect(filter.length).toBe(1);
     });
   });
 

--- a/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.ts
+++ b/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.ts
@@ -162,10 +162,11 @@ export const createFilterESQL = async (
     filters.push(
       buildSimpleNumberRangeFilter(
         sourceField,
+        operationType === 'date_histogram' ? 'date': 'number',
         {
           gte: value,
-          lt: value + (interval || 0),
-          ...(operationType === 'date_hisotgram' ? { format: 'strict_date_optional_time' } : {}),
+          lt: value + (interval ?? 0),
+          ...(operationType === 'date_histogram' ? { format: 'strict_date_optional_time' } : {}),
         },
         value,
         indexPattern
@@ -185,25 +186,22 @@ export const createFiltersFromValueClickAction = async ({
 }: ValueClickDataContext) => {
   const filters: Filter[] = [];
 
-  await Promise.all(
-    data
-      .filter((point) => point)
-      .map(async (val) => {
-        const { table, column, row } = val;
-        const filter =
-          table.meta?.type === 'es_ql'
-            ? await createFilterESQL(table, column, row)
-            : (await createFilter(table, column, row)) || [];
-        if (filter) {
-          filter.forEach((f) => {
-            if (negate) {
-              f = toggleFilterNegated(f);
-            }
-            filters.push(f);
-          });
-        }
-      })
-  );
+  for(const value of data) {
+    if(!value) {
+      continue;
+    }
+    const { table, column, row } = value;
+    const filter =
+      table.meta?.type === 'es_ql'
+        ? await createFilterESQL(table, column, row)
+        : (await createFilter(table, column, row)) ?? [];
+    filter.forEach((f) => {
+      if (negate) {
+        f = toggleFilterNegated(f);
+      }
+      filters.push(f);
+    });
+  }
 
   return _.uniqWith(mapAndFlattenFilters(filters), (a, b) =>
     compareFilters(a, b, COMPARE_ALL_OPTIONS)

--- a/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.ts
+++ b/src/platform/plugins/shared/data/public/actions/filters/create_filters_from_value_click.ts
@@ -162,7 +162,7 @@ export const createFilterESQL = async (
     filters.push(
       buildSimpleNumberRangeFilter(
         sourceField,
-        operationType === 'date_histogram' ? 'date': 'number',
+        operationType === 'date_histogram' ? 'date' : 'number',
         {
           gte: value,
           lt: value + (interval ?? 0),
@@ -186,8 +186,8 @@ export const createFiltersFromValueClickAction = async ({
 }: ValueClickDataContext) => {
   const filters: Filter[] = [];
 
-  for(const value of data) {
-    if(!value) {
+  for (const value of data) {
+    if (!value) {
       continue;
     }
     const { table, column, row } = value;


### PR DESCRIPTION
## Summary

The PR fixes the following issues related to the on-click creatation of filters from a generated ESQL Lens

- a typo in the code
- fix the test to actually checks if the event is actually generated or not
- cleanup a useless Promise.all call





<!--ONMERGE {"backportTargets":["8.x","9.0"]} ONMERGE-->