### PR TITLE
[9.0] [Fleet] Update deb and rpm install commands (#218068)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.test.ts
@@ -76,14 +76,13 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--x86_64.rpm
-        sudo rpm -vi elastic-agent--x86_64.rpm
+        sudo ELASTIC_AGENT_FLAVOR=servers rpm -vi elastic-agent--x86_64.rpm
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll \\\\
           --fleet-server-es=http://elasticsearch:9200 \\\\
           --fleet-server-service-token=service-token-1 \\\\
-          --fleet-server-port=8220 \\\\
-          --install-servers"
+          --fleet-server-port=8220"
       `);
     });
 
@@ -96,14 +95,13 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--amd64.deb
-        sudo dpkg -i elastic-agent--amd64.deb
+        sudo ELASTIC_AGENT_FLAVOR=servers dpkg -i elastic-agent--amd64.deb
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll \\\\
           --fleet-server-es=http://elasticsearch:9200 \\\\
           --fleet-server-service-token=service-token-1 \\\\
-          --fleet-server-port=8220 \\\\
-          --install-servers"
+          --fleet-server-port=8220"
       `);
     });
 
@@ -204,15 +202,14 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--x86_64.rpm
-        sudo rpm -vi elastic-agent--x86_64.rpm
+        sudo ELASTIC_AGENT_FLAVOR=servers rpm -vi elastic-agent--x86_64.rpm
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll \\\\
           --fleet-server-es=http://elasticsearch:9200 \\\\
           --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1 \\\\
-          --fleet-server-port=8220 \\\\
-          --install-servers"
+          --fleet-server-port=8220"
       `);
     });
 
@@ -226,15 +223,14 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--amd64.deb
-        sudo dpkg -i elastic-agent--amd64.deb
+        sudo ELASTIC_AGENT_FLAVOR=servers dpkg -i elastic-agent--amd64.deb
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll \\\\
           --fleet-server-es=http://elasticsearch:9200 \\\\
           --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1 \\\\
-          --fleet-server-port=8220 \\\\
-          --install-servers"
+          --fleet-server-port=8220"
       `);
     });
   });
@@ -363,7 +359,7 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--x86_64.rpm
-        sudo rpm -vi elastic-agent--x86_64.rpm
+        sudo ELASTIC_AGENT_FLAVOR=servers rpm -vi elastic-agent--x86_64.rpm
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll --url=http://fleetserver:8220 \\\\
@@ -374,8 +370,7 @@ describe('getInstallCommandForPlatform', () => {
           --fleet-server-es-ca=<PATH_TO_ES_CERT> \\\\
           --fleet-server-cert=<PATH_TO_FLEET_SERVER_CERT> \\\\
           --fleet-server-cert-key=<PATH_TO_FLEET_SERVER_CERT_KEY> \\\\
-          --fleet-server-port=8220 \\\\
-          --install-servers"
+          --fleet-server-port=8220"
       `);
     });
 
@@ -391,7 +386,7 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent--amd64.deb
-        sudo dpkg -i elastic-agent--amd64.deb
+        sudo ELASTIC_AGENT_FLAVOR=servers dpkg -i elastic-agent--amd64.deb
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll --url=http://fleetserver:8220 \\\\
@@ -402,8 +397,7 @@ describe('getInstallCommandForPlatform', () => {
           --fleet-server-es-ca=<PATH_TO_ES_CERT> \\\\
           --fleet-server-cert=<PATH_TO_FLEET_SERVER_CERT> \\\\
           --fleet-server-cert-key=<PATH_TO_FLEET_SERVER_CERT_KEY> \\\\
-          --fleet-server-port=8220 \\\\
-          --install-servers"
+          --fleet-server-port=8220"
       `);
     });
   });
@@ -566,7 +560,7 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://download-src/8.12.0-test/beats/elastic-agent/elastic-agent--x86_64.rpm --proxy http://download-src-proxy:2222
-        sudo rpm -vi elastic-agent--x86_64.rpm
+        sudo ELASTIC_AGENT_FLAVOR=servers rpm -vi elastic-agent--x86_64.rpm
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll \\\\
@@ -574,7 +568,6 @@ describe('getInstallCommandForPlatform', () => {
           --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1 \\\\
           --fleet-server-port=8220 \\\\
-          --install-servers \\\\
           --proxy-url=http://es-proxy:1111"
       `);
     });
@@ -609,7 +602,7 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://download-src/8.12.0-test/beats/elastic-agent/elastic-agent--amd64.deb --proxy http://download-src-proxy:2222
-        sudo dpkg -i elastic-agent--amd64.deb
+        sudo ELASTIC_AGENT_FLAVOR=servers dpkg -i elastic-agent--amd64.deb
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll \\\\
@@ -617,7 +610,6 @@ describe('getInstallCommandForPlatform', () => {
           --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1 \\\\
           --fleet-server-port=8220 \\\\
-          --install-servers \\\\
           --proxy-url=http://es-proxy:1111"
       `);
     });
@@ -819,7 +811,7 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://download-src/8.12.0-test/beats/elastic-agent/elastic-agent--x86_64.rpm --proxy http://download-src-proxy:2222 --proxy-header \\"Accept-Language=en-US,en;q=0.5\\" --proxy-header \\"second-header=second-value\\"
-        sudo rpm -vi elastic-agent--x86_64.rpm
+        sudo ELASTIC_AGENT_FLAVOR=servers rpm -vi elastic-agent--x86_64.rpm
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll \\\\
@@ -827,7 +819,6 @@ describe('getInstallCommandForPlatform', () => {
           --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1 \\\\
           --fleet-server-port=8220 \\\\
-          --install-servers \\\\
           --proxy-url=http://es-proxy:1111 \\\\
           --proxy-header=\\"X-Forwarded-For=forwarded-value\\" \\\\
           --proxy-header=\\"test-header=test-value\\""
@@ -872,7 +863,7 @@ describe('getInstallCommandForPlatform', () => {
 
       expect(res).toMatchInlineSnapshot(`
         "curl -L -O https://download-src/8.12.0-test/beats/elastic-agent/elastic-agent--amd64.deb --proxy http://download-src-proxy:2222 --proxy-header \\"Accept-Language=en-US,en;q=0.5\\" --proxy-header \\"second-header=second-value\\"
-        sudo dpkg -i elastic-agent--amd64.deb
+        sudo ELASTIC_AGENT_FLAVOR=servers dpkg -i elastic-agent--amd64.deb
         sudo systemctl enable elastic-agent
         sudo systemctl start elastic-agent
         sudo elastic-agent enroll \\\\
@@ -880,7 +871,6 @@ describe('getInstallCommandForPlatform', () => {
           --fleet-server-service-token=service-token-1 \\\\
           --fleet-server-policy=policy-1 \\\\
           --fleet-server-port=8220 \\\\
-          --install-servers \\\\
           --proxy-url=http://es-proxy:1111 \\\\
           --proxy-header=\\"X-Forwarded-For=forwarded-value\\" \\\\
           --proxy-header=\\"test-header=test-value\\""

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.ts
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/components/fleet_server_instructions/utils/install_command_utils.ts
@@ -11,6 +11,7 @@ import {
   getDownloadSourceProxyArgs,
 } from '../../../../../components/enrollment_instructions/manual';
 import type { PLATFORM_TYPE } from '../../../hooks';
+import { PLATFORM_WITH_INSTALL_SERVERS } from '../../../hooks';
 
 export type CommandsByPlatform = {
   [key in PLATFORM_TYPE]: string;
@@ -59,13 +60,13 @@ function getArtifact(
     deb: {
       downloadCommand: [
         `curl -L -O ${ARTIFACT_BASE_URL}/elastic-agent-${kibanaVersion}-amd64.deb${appendCurlDownloadSourceProxyArgs}`,
-        `sudo dpkg -i elastic-agent-${kibanaVersion}-amd64.deb`,
+        `sudo ELASTIC_AGENT_FLAVOR=servers dpkg -i elastic-agent-${kibanaVersion}-amd64.deb`,
       ].join(`\n`),
     },
     rpm: {
       downloadCommand: [
         `curl -L -O ${ARTIFACT_BASE_URL}/elastic-agent-${kibanaVersion}-x86_64.rpm${appendCurlDownloadSourceProxyArgs}`,
-        `sudo rpm -vi elastic-agent-${kibanaVersion}-x86_64.rpm`,
+        `sudo ELASTIC_AGENT_FLAVOR=servers rpm -vi elastic-agent-${kibanaVersion}-x86_64.rpm`,
       ].join(`\n`),
     },
     kubernetes: {
@@ -132,7 +133,9 @@ export function getInstallCommandForPlatform({
 
   commandArguments.push(['fleet-server-port', '8220']);
 
-  commandArguments.push(['install-servers']);
+  if (PLATFORM_WITH_INSTALL_SERVERS.includes(platform)) {
+    commandArguments.push(['install-servers']);
+  }
 
   const enrollmentProxyArgs = [];
   if (esOutputProxy) {

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.test.tsx
@@ -1,0 +1,308 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ManualInstructions } from '.';
+
+describe('ManualInstructions', () => {
+  describe('With basic parameters', () => {
+    const result = ManualInstructions({
+      apiKey: 'APIKEY',
+      fleetServerHost: 'https://testhost',
+      agentVersion: '9.0.0',
+    });
+
+    it('should return instructions for linux', async () => {
+      expect(result.linux.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-linux-x86_64.tar.gz ',
+        'tar xzvf elastic-agent-9.0.0-linux-x86_64.tar.gz',
+        'cd elastic-agent-9.0.0-linux-x86_64',
+        'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY',
+      ]);
+    });
+
+    it('should return instructions for deb', async () => {
+      expect(result.deb.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-amd64.deb ',
+        'sudo dpkg -i elastic-agent-9.0.0-amd64.deb',
+        'sudo systemctl enable elastic-agent ',
+        'sudo systemctl start elastic-agent ',
+        'sudo elastic-agent enroll --url=https://testhost --enrollment-token=APIKEY ',
+        '',
+      ]);
+    });
+
+    it('should return instructions for rpm', async () => {
+      expect(result.rpm.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-x86_64.rpm ',
+        'sudo rpm -vi elastic-agent-9.0.0-x86_64.rpm',
+        'sudo systemctl enable elastic-agent ',
+        'sudo systemctl start elastic-agent ',
+        'sudo elastic-agent enroll --url=https://testhost --enrollment-token=APIKEY ',
+        '',
+      ]);
+    });
+
+    it('should return instructions for mac', async () => {
+      expect(result.mac.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-darwin-aarch64.tar.gz ',
+        'tar xzvf elastic-agent-9.0.0-darwin-aarch64.tar.gz',
+        'cd elastic-agent-9.0.0-darwin-aarch64',
+        'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY',
+      ]);
+    });
+
+    it('should return instructions for kubernetes', async () => {
+      expect(result.kubernetes.split('\n')).toEqual([
+        'kubectl apply -f elastic-agent-managed-kubernetes.yml',
+      ]);
+    });
+  });
+
+  describe('With showInstallServers', () => {
+    const result = ManualInstructions({
+      apiKey: 'APIKEY',
+      fleetServerHost: 'https://testhost',
+      agentVersion: '9.0.0',
+      showInstallServers: true,
+    });
+
+
+    it('should return instructions for linux', async () => {
+      expect(result.linux.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-linux-x86_64.tar.gz ',
+        'tar xzvf elastic-agent-9.0.0-linux-x86_64.tar.gz',
+        'cd elastic-agent-9.0.0-linux-x86_64',
+        'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY --install-servers',
+      ]);
+    });
+
+    it('should return instructions for deb', async () => {
+      expect(result.deb.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-amd64.deb ',
+        'sudo ELASTIC_AGENT_FLAVOR=servers dpkg -i elastic-agent-9.0.0-amd64.deb',
+        'sudo systemctl enable elastic-agent ',
+        'sudo systemctl start elastic-agent ',
+        'sudo elastic-agent enroll --url=https://testhost --enrollment-token=APIKEY ',
+        '',
+      ]);
+    });
+
+    it('should return instructions for rpm', async () => {
+      expect(result.rpm.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-x86_64.rpm ',
+        'sudo ELASTIC_AGENT_FLAVOR=servers rpm -vi elastic-agent-9.0.0-x86_64.rpm',
+        'sudo systemctl enable elastic-agent ',
+        'sudo systemctl start elastic-agent ',
+        'sudo elastic-agent enroll --url=https://testhost --enrollment-token=APIKEY ',
+        '',
+      ]);
+    });
+
+    it('should return instructions for mac', async () => {
+      expect(result.mac.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-darwin-aarch64.tar.gz ',
+        'tar xzvf elastic-agent-9.0.0-darwin-aarch64.tar.gz',
+        'cd elastic-agent-9.0.0-darwin-aarch64',
+        'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY --install-servers',
+      ]);
+    });
+
+    it('should return instructions for kubernetes', async () => {
+      expect(result.kubernetes.split('\n')).toEqual([
+        'kubectl apply -f elastic-agent-managed-kubernetes.yml',
+      ]);
+    });
+
+    it('should return instructions for googleCloudShell', async () => {
+      expect(result.googleCloudShell.split('\n')).toEqual([
+        'gcloud config set project <PROJECT_ID> &&  FLEET_URL=https://testhost ENROLLMENT_TOKEN=APIKEY STACK_VERSION=9.0.0 ./deploy.sh',
+      ]);
+    });
+  });
+
+  describe('With fleetProxy', () => {
+    const result = ManualInstructions({
+      apiKey: 'APIKEY',
+      fleetServerHost: 'https://testhost',
+      agentVersion: '9.0.0',
+      fleetProxy: {
+        id: 'id1',
+        name: 'test-proxy',
+        url: 'http://test-proxy',
+        is_preconfigured: false,
+        proxy_headers: { test1: 'header' },
+      },
+    });
+
+    it('should return instructions for linux', async () => {
+      expect(result.linux.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-linux-x86_64.tar.gz ',
+        'tar xzvf elastic-agent-9.0.0-linux-x86_64.tar.gz',
+        'cd elastic-agent-9.0.0-linux-x86_64',
+        'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY --proxy-url=http://test-proxy --proxy-header "test1=header"',
+      ]);
+    });
+
+    it('should return instructions for deb', async () => {
+      expect(result.deb.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-amd64.deb ',
+        'sudo dpkg -i elastic-agent-9.0.0-amd64.deb',
+        'sudo systemctl enable elastic-agent ',
+        'sudo systemctl start elastic-agent ',
+        'sudo elastic-agent enroll --url=https://testhost --enrollment-token=APIKEY --proxy-url=http://test-proxy --proxy-header "test1=header" ',
+        '',
+      ]);
+    });
+
+    it('should return instructions for rpm', async () => {
+      expect(result.rpm.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-x86_64.rpm ',
+        'sudo rpm -vi elastic-agent-9.0.0-x86_64.rpm',
+        'sudo systemctl enable elastic-agent ',
+        'sudo systemctl start elastic-agent ',
+        'sudo elastic-agent enroll --url=https://testhost --enrollment-token=APIKEY --proxy-url=http://test-proxy --proxy-header "test1=header" ',
+        '',
+      ]);
+    });
+
+    it('should return instructions for mac', async () => {
+      expect(result.mac.split('\n')).toEqual([
+        'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-darwin-aarch64.tar.gz ',
+        'tar xzvf elastic-agent-9.0.0-darwin-aarch64.tar.gz',
+        'cd elastic-agent-9.0.0-darwin-aarch64',
+        'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY --proxy-url=http://test-proxy --proxy-header "test1=header"',
+      ]);
+    });
+
+    it('should return instructions for kubernetes', async () => {
+      expect(result.kubernetes.split('\n')).toEqual([
+        'kubectl apply -f elastic-agent-managed-kubernetes.yml',
+      ]);
+    });
+
+    it('should return instructions for googleCloudShell', async () => {
+      expect(result.googleCloudShell.split('\n')).toEqual([
+        'gcloud config set project <PROJECT_ID> &&  FLEET_URL=https://testhost ENROLLMENT_TOKEN=APIKEY --proxy-url=http://test-proxy --proxy-header "test1=header" STACK_VERSION=9.0.0 ./deploy.sh',
+      ]);
+    });
+  });
+
+  describe('With downloadSource and downloadSourceProxy', () => {
+    const result = ManualInstructions({
+      apiKey: 'APIKEY',
+      fleetServerHost: 'https://testhost',
+      agentVersion: '9.0.0',
+      downloadSource: {
+        name: 'ds',
+        host: 'http://localregistry.co',
+        proxy_id: 'ds_id',
+      } as any,
+      downloadSourceProxy: {
+        id: 'ds_id',
+        name: 'ds-proxy',
+        url: 'http://ds-proxy',
+      } as any,
+    });
+
+    it('should return instructions for linux', async () => {
+      expect(result.linux.split('\n')).toEqual([
+        'curl -L -O http://localregistry.co/beats/elastic-agent/elastic-agent-9.0.0-linux-x86_64.tar.gz --proxy http://ds-proxy',
+        'tar xzvf elastic-agent-9.0.0-linux-x86_64.tar.gz',
+        'cd elastic-agent-9.0.0-linux-x86_64',
+        'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY',
+      ]);
+    });
+
+    it('should return instructions for deb', async () => {
+      expect(result.deb.split('\n')).toEqual([
+        'curl -L -O http://localregistry.co/beats/elastic-agent/elastic-agent-9.0.0-amd64.deb --proxy http://ds-proxy',
+        'sudo dpkg -i elastic-agent-9.0.0-amd64.deb',
+        'sudo systemctl enable elastic-agent ',
+        'sudo systemctl start elastic-agent ',
+        'sudo elastic-agent enroll --url=https://testhost --enrollment-token=APIKEY ',
+        '',
+      ]);
+    });
+
+    it('should return instructions for rpm', async () => {
+      expect(result.rpm.split('\n')).toEqual([
+        'curl -L -O http://localregistry.co/beats/elastic-agent/elastic-agent-9.0.0-x86_64.rpm --proxy http://ds-proxy',
+        'sudo rpm -vi elastic-agent-9.0.0-x86_64.rpm',
+        'sudo systemctl enable elastic-agent ',
+        'sudo systemctl start elastic-agent ',
+        'sudo elastic-agent enroll --url=https://testhost --enrollment-token=APIKEY ',
+        '',
+      ]);
+    });
+
+    it('should return instructions for mac', async () => {
+      expect(result.mac.split('\n')).toEqual([
+        'curl -L -O http://localregistry.co/beats/elastic-agent/elastic-agent-9.0.0-darwin-aarch64.tar.gz --proxy http://ds-proxy',
+        'tar xzvf elastic-agent-9.0.0-darwin-aarch64.tar.gz',
+        'cd elastic-agent-9.0.0-darwin-aarch64',
+        'sudo ./elastic-agent install --url=https://testhost --enrollment-token=APIKEY',
+      ]);
+    });
+
+    it('should return instructions for kubernetes', async () => {
+      expect(result.kubernetes.split('\n')).toEqual([
+        'kubectl apply -f elastic-agent-managed-kubernetes.yml',
+      ]);
+    });
+  });
+
+  describe('For googleCloudShell', () => {
+    it('should return instructions with basic commands', async () => {
+      const result = ManualInstructions({
+        apiKey: 'APIKEY',
+        fleetServerHost: 'https://testhost',
+        agentVersion: '9.0.0',
+      });
+      expect(result.googleCloudShell).toEqual(
+        'gcloud config set project <PROJECT_ID> &&  FLEET_URL=https://testhost ENROLLMENT_TOKEN=APIKEY STACK_VERSION=9.0.0 ./deploy.sh'
+      );
+    });
+
+    it('should return correct project_id', async () => {
+      const result = ManualInstructions({
+        apiKey: 'APIKEY',
+        fleetServerHost: 'https://testhost',
+        agentVersion: '9.0.0',
+        gcpProjectId: 'gcpID',
+      });
+      expect(result.googleCloudShell).toEqual(
+        'gcloud config set project gcpID &&  FLEET_URL=https://testhost ENROLLMENT_TOKEN=APIKEY STACK_VERSION=9.0.0 ./deploy.sh'
+      );
+    });
+
+    it('should return gcpProjectId when gcpAccountType = organization-account', async () => {
+      const result = ManualInstructions({
+        apiKey: 'APIKEY',
+        fleetServerHost: 'https://testhost',
+        agentVersion: '9.0.0',
+        gcpAccountType: 'organization-account',
+        gcpOrganizationId: 'test-org',
+      });
+      expect(result.googleCloudShell).toEqual(
+        'gcloud config set project <PROJECT_ID> && ORG_ID=test-org FLEET_URL=https://testhost ENROLLMENT_TOKEN=APIKEY STACK_VERSION=9.0.0 ./deploy.sh'
+      );
+    });
+
+    it('should not return gcpProjectId when gcpAccountType != organization-account', async () => {
+      const result = ManualInstructions({
+        apiKey: 'APIKEY',
+        fleetServerHost: 'https://testhost',
+        agentVersion: '9.0.0',
+        gcpAccountType: '',
+        gcpOrganizationId: 'test-org',
+      });
+      expect(result.googleCloudShell).toEqual(
+        'gcloud config set project <PROJECT_ID> &&  FLEET_URL=https://testhost ENROLLMENT_TOKEN=APIKEY STACK_VERSION=9.0.0 ./deploy.sh'
+      );
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.test.tsx
@@ -70,7 +70,6 @@ describe('ManualInstructions', () => {
       showInstallServers: true,
     });
 
-
     it('should return instructions for linux', async () => {
       expect(result.linux.split('\n')).toEqual([
         'curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-linux-x86_64.tar.gz ',

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.tsx
@@ -131,12 +131,15 @@ cd elastic-agent-${agentVersion}-windows-x86_64
 
   const linuxDebCommand = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-amd64.deb ${curlDownloadSourceProxyArgs}
 sudo ${debOrRpmWithInstallServers}dpkg -i elastic-agent-${agentVersion}-amd64.deb
-sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm('deb')} \n`;
+sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm(
+    'deb'
+  )} \n`;
 
   const linuxRpmCommand = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-x86_64.rpm ${curlDownloadSourceProxyArgs}
 sudo ${debOrRpmWithInstallServers}rpm -vi elastic-agent-${agentVersion}-x86_64.rpm
-sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm('rpm') } \n`;
-
+sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm(
+    'rpm'
+  )} \n`;
 
   // google shell commands
   const googleShellEnrollArgs = getEnrollArgsByPlatForm('google_shell');

--- a/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/components/enrollment_instructions/manual/index.tsx
@@ -6,14 +6,22 @@
  */
 
 import { DEFAULT_DOWNLOAD_SOURCE_URI } from '../../../../common/constants';
+import { PLATFORM_WITH_INSTALL_SERVERS, type EXTENDED_PLATFORM_TYPE } from '../../../hooks';
 import type { DownloadSource, FleetProxy } from '../../../types';
 
-function getfleetServerHostsEnrollArgs(
-  apiKey: string,
-  fleetServerHost: string,
-  fleetProxy?: FleetProxy,
-  showInstallServers: boolean = false
-) {
+function getFleetServerHostsEnrollArgs({
+  apiKey,
+  fleetServerHost,
+  fleetProxy,
+  showInstallServers,
+  platform,
+}: {
+  apiKey: string;
+  fleetServerHost: string;
+  fleetProxy?: FleetProxy;
+  showInstallServers?: boolean;
+  platform: EXTENDED_PLATFORM_TYPE;
+}) {
   const proxyHeadersArgs = fleetProxy?.proxy_headers
     ? Object.entries(fleetProxy.proxy_headers).reduce((acc, [proxyKey, proyVal]) => {
         acc += ` --proxy-header "${proxyKey}=${proyVal}"`;
@@ -22,7 +30,10 @@ function getfleetServerHostsEnrollArgs(
       }, '')
     : '';
   const proxyArgs = fleetProxy ? ` --proxy-url=${fleetProxy.url}${proxyHeadersArgs}` : '';
-  const showInstallServersArgs = showInstallServers ? ' --install-servers' : '';
+  const showInstallServersArgs =
+    showInstallServers && PLATFORM_WITH_INSTALL_SERVERS.includes(platform)
+      ? ' --install-servers'
+      : '';
   return `--url=${
     fleetServerHost || `FLEET_SERVER_HOST`
   } --enrollment-token=${apiKey}${proxyArgs}${showInstallServersArgs}`;
@@ -84,49 +95,61 @@ export const ManualInstructions = ({
   gcpAccountType?: string;
   showInstallServers?: boolean;
 }) => {
-  const enrollArgs = getfleetServerHostsEnrollArgs(
-    apiKey,
-    fleetServerHost,
-    fleetProxy,
-    showInstallServers
-  );
+  const getEnrollArgsByPlatForm = (platform: EXTENDED_PLATFORM_TYPE) => {
+    return getFleetServerHostsEnrollArgs({
+      apiKey,
+      fleetServerHost,
+      platform,
+      fleetProxy,
+      showInstallServers,
+    });
+  };
   const downloadBaseUrl = getDownloadBaseUrl(downloadSource);
-
-  const fleetServerUrl = enrollArgs?.split('--url=')?.pop()?.split('--enrollment')[0];
-  const enrollmentToken = enrollArgs?.split('--enrollment-token=')[1];
 
   const k8sCommand = 'kubectl apply -f elastic-agent-managed-kubernetes.yml';
 
   const { windows: windowsDownloadSourceProxyArgs, curl: curlDownloadSourceProxyArgs } =
     getDownloadSourceProxyArgs(downloadSourceProxy);
 
+  const debOrRpmWithInstallServers = showInstallServers ? `ELASTIC_AGENT_FLAVOR=servers ` : '';
+
   const linuxCommand = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-linux-x86_64.tar.gz ${curlDownloadSourceProxyArgs}
 tar xzvf elastic-agent-${agentVersion}-linux-x86_64.tar.gz
 cd elastic-agent-${agentVersion}-linux-x86_64
-sudo ./elastic-agent install ${enrollArgs}`;
+sudo ./elastic-agent install ${getEnrollArgsByPlatForm('linux')}`;
 
   const macCommand = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-darwin-aarch64.tar.gz ${curlDownloadSourceProxyArgs}
 tar xzvf elastic-agent-${agentVersion}-darwin-aarch64.tar.gz
 cd elastic-agent-${agentVersion}-darwin-aarch64
-sudo ./elastic-agent install ${enrollArgs}`;
+sudo ./elastic-agent install ${getEnrollArgsByPlatForm('mac')}`;
 
   const windowsCommand = `$ProgressPreference = 'SilentlyContinue'
 Invoke-WebRequest -Uri ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-windows-x86_64.zip -OutFile elastic-agent-${agentVersion}-windows-x86_64.zip ${windowsDownloadSourceProxyArgs}
 Expand-Archive .\\elastic-agent-${agentVersion}-windows-x86_64.zip -DestinationPath .
 cd elastic-agent-${agentVersion}-windows-x86_64
-.\\elastic-agent.exe install ${enrollArgs}`;
+.\\elastic-agent.exe install ${getEnrollArgsByPlatForm('windows')}`;
 
   const linuxDebCommand = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-amd64.deb ${curlDownloadSourceProxyArgs}
-sudo dpkg -i elastic-agent-${agentVersion}-amd64.deb
-sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${enrollArgs} \n`;
+sudo ${debOrRpmWithInstallServers}dpkg -i elastic-agent-${agentVersion}-amd64.deb
+sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm('deb')} \n`;
 
   const linuxRpmCommand = `curl -L -O ${downloadBaseUrl}/beats/elastic-agent/elastic-agent-${agentVersion}-x86_64.rpm ${curlDownloadSourceProxyArgs}
-sudo rpm -vi elastic-agent-${agentVersion}-x86_64.rpm
-sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${enrollArgs} \n`;
+sudo ${debOrRpmWithInstallServers}rpm -vi elastic-agent-${agentVersion}-x86_64.rpm
+sudo systemctl enable elastic-agent \nsudo systemctl start elastic-agent \nsudo elastic-agent enroll ${getEnrollArgsByPlatForm('rpm') } \n`;
+
+
+  // google shell commands
+  const googleShellEnrollArgs = getEnrollArgsByPlatForm('google_shell');
+
+  const googleShellFleetServerUrl = googleShellEnrollArgs
+    ?.split('--url=')
+    ?.pop()
+    ?.split('--enrollment')[0];
+  const googleShellEnrollmentToken = googleShellEnrollArgs?.split('--enrollment-token=')[1];
 
   const googleCloudShellCommand = `gcloud config set project ${gcpProjectId} && ${
     gcpAccountType === 'organization-account' ? `ORG_ID=${gcpOrganizationId}` : ``
-  } FLEET_URL=${fleetServerUrl?.trim()} ENROLLMENT_TOKEN=${enrollmentToken} STACK_VERSION=${agentVersion} ./deploy.sh`;
+  } FLEET_URL=${googleShellFleetServerUrl?.trim()} ENROLLMENT_TOKEN=${googleShellEnrollmentToken} STACK_VERSION=${agentVersion} ./deploy.sh`;
 
   return {
     linux: linuxCommand,

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_platform.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_platform.tsx
@@ -9,7 +9,8 @@ import { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 
 export type PLATFORM_TYPE = 'linux' | 'mac' | 'windows' | 'rpm' | 'deb' | 'kubernetes';
-export type EXTENDED_PLATFORM_TYPE = 'linux' | 'mac' | 'windows' | 'rpm' | 'deb' | 'kubernetes' | 'google_shell' | 'cloud_formation;
+export type EXTENDED_PLATFORM_TYPE = 'linux' | 'mac' | 'windows' | 'rpm' | 'deb' | 'kubernetes' | 'google_shell' | 'cloud_formation';
+
 export const PLATFORM_WITH_INSTALL_SERVERS = [
   'linux',
   'mac',

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_platform.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_platform.tsx
@@ -9,13 +9,17 @@ import { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 
 export type PLATFORM_TYPE = 'linux' | 'mac' | 'windows' | 'rpm' | 'deb' | 'kubernetes';
-export type EXTENDED_PLATFORM_TYPE = 'linux' | 'mac' | 'windows' | 'rpm' | 'deb' | 'kubernetes' | 'google_shell' | 'cloud_formation';
+export type EXTENDED_PLATFORM_TYPE =
+  | 'linux'
+  | 'mac'
+  | 'windows'
+  | 'rpm'
+  | 'deb'
+  | 'kubernetes'
+  | 'google_shell'
+  | 'cloud_formation';
 
-export const PLATFORM_WITH_INSTALL_SERVERS = [
-  'linux',
-  'mac',
-  'windows',
-];
+export const PLATFORM_WITH_INSTALL_SERVERS = ['linux', 'mac', 'windows'];
 
 export const REDUCED_PLATFORM_OPTIONS: Array<{
   label: string;

--- a/x-pack/platform/plugins/shared/fleet/public/hooks/use_platform.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/hooks/use_platform.tsx
@@ -9,6 +9,12 @@ import { useState } from 'react';
 import { i18n } from '@kbn/i18n';
 
 export type PLATFORM_TYPE = 'linux' | 'mac' | 'windows' | 'rpm' | 'deb' | 'kubernetes';
+export type EXTENDED_PLATFORM_TYPE = 'linux' | 'mac' | 'windows' | 'rpm' | 'deb' | 'kubernetes' | 'google_shell' | 'cloud_formation;
+export const PLATFORM_WITH_INSTALL_SERVERS = [
+  'linux',
+  'mac',
+  'windows',
+];
 
 export const REDUCED_PLATFORM_OPTIONS: Array<{
   label: string;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Fleet] Update deb and rpm install commands (#218068)](https://github.com/elastic/kibana/pull/218068)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Cristina Amico","email":"criamico@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-15T10:14:40Z","message":"[Fleet] Update deb and rpm install commands (#218068)\n\nFixes https://github.com/elastic/kibana/issues/212609\n\n## Summary\n\nThe `--install-servers` flag present in the enroll commands for fleet\nservers and elastic agents doesn't work in case of `deb` and `rpm`\ninstallers. It should be used `ELASTIC_AGENT_FLAVOR` instead (see [this\ncomment](https://github.com/elastic/kibana/issues/212609#issuecomment-2752335880)\nexplaining it).\n\nI fixed the command in those cases and also added some unit tests (that\nweren't present in some cases).\n\n### Testing \n- try to enroll a fleet server or elastic agent\n- check that `rpm` and `deb` commands don't have `--install-servers` in\nthe enroll commands but\n\n```\nsudo ELASTIC_AGENT_FLAVOR=servers dpkg -i $path_to_deb\n```\n\n### screenshots\n<img width=\"780\" alt=\"Screenshot 2025-04-14 at 16 40 39\" src=\"http\n<img width=\"743\" alt=\"Screenshot 2025-04-14 at 16 40 30\"\nsrc=\"https://github.com/user-attachments/assets/0bb405a7-7682-44ed-959e-b81832fd84af\"\n/>\n\ns://github.com/user-attachments/assets/f693f830-7e7f-43bd-a0ac-f378352cda93\"\n/>\n\n\n### Checklist\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"7ffe810fc4d4189c285bdb2c08e8736f8ae27354","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","release_note:skip","Team:Fleet","v9.0.0","backport:prev-minor","v9.1.0"],"title":"[Fleet] Update deb and rpm install commands","number":218068,"url":"https://github.com/elastic/kibana/pull/218068","mergeCommit":{"message":"[Fleet] Update deb and rpm install commands (#218068)\n\nFixes https://github.com/elastic/kibana/issues/212609\n\n## Summary\n\nThe `--install-servers` flag present in the enroll commands for fleet\nservers and elastic agents doesn't work in case of `deb` and `rpm`\ninstallers. It should be used `ELASTIC_AGENT_FLAVOR` instead (see [this\ncomment](https://github.com/elastic/kibana/issues/212609#issuecomment-2752335880)\nexplaining it).\n\nI fixed the command in those cases and also added some unit tests (that\nweren't present in some cases).\n\n### Testing \n- try to enroll a fleet server or elastic agent\n- check that `rpm` and `deb` commands don't have `--install-servers` in\nthe enroll commands but\n\n```\nsudo ELASTIC_AGENT_FLAVOR=servers dpkg -i $path_to_deb\n```\n\n### screenshots\n<img width=\"780\" alt=\"Screenshot 2025-04-14 at 16 40 39\" src=\"http\n<img width=\"743\" alt=\"Screenshot 2025-04-14 at 16 40 30\"\nsrc=\"https://github.com/user-attachments/assets/0bb405a7-7682-44ed-959e-b81832fd84af\"\n/>\n\ns://github.com/user-attachments/assets/f693f830-7e7f-43bd-a0ac-f378352cda93\"\n/>\n\n\n### Checklist\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"7ffe810fc4d4189c285bdb2c08e8736f8ae27354"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218068","number":218068,"mergeCommit":{"message":"[Fleet] Update deb and rpm install commands (#218068)\n\nFixes https://github.com/elastic/kibana/issues/212609\n\n## Summary\n\nThe `--install-servers` flag present in the enroll commands for fleet\nservers and elastic agents doesn't work in case of `deb` and `rpm`\ninstallers. It should be used `ELASTIC_AGENT_FLAVOR` instead (see [this\ncomment](https://github.com/elastic/kibana/issues/212609#issuecomment-2752335880)\nexplaining it).\n\nI fixed the command in those cases and also added some unit tests (that\nweren't present in some cases).\n\n### Testing \n- try to enroll a fleet server or elastic agent\n- check that `rpm` and `deb` commands don't have `--install-servers` in\nthe enroll commands but\n\n```\nsudo ELASTIC_AGENT_FLAVOR=servers dpkg -i $path_to_deb\n```\n\n### screenshots\n<img width=\"780\" alt=\"Screenshot 2025-04-14 at 16 40 39\" src=\"http\n<img width=\"743\" alt=\"Screenshot 2025-04-14 at 16 40 30\"\nsrc=\"https://github.com/user-attachments/assets/0bb405a7-7682-44ed-959e-b81832fd84af\"\n/>\n\ns://github.com/user-attachments/assets/f693f830-7e7f-43bd-a0ac-f378352cda93\"\n/>\n\n\n### Checklist\n\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"7ffe810fc4d4189c285bdb2c08e8736f8ae27354"}}]}] BACKPORT-->