### PR TITLE
[8.x] [FTR] unify custom role name with Scout (#217882)

### DIFF
--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/saml_auth/get_auth_provider.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/saml_auth/get_auth_provider.ts
@@ -12,6 +12,8 @@ import { ServerlessAuthProvider } from './serverless/auth_provider';
 import { StatefulAuthProvider } from './stateful/auth_provider';
 
 export interface AuthProvider {
+  isServerless(): boolean;
+  getProjectType(): string | undefined;
   getSupportedRoleDescriptors(): Map<string, any>;
   getDefaultRole(): string;
   isCustomRoleEnabled(): boolean;

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/saml_auth/serverless/auth_provider.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/saml_auth/serverless/auth_provider.ts
@@ -60,6 +60,14 @@ export class ServerlessAuthProvider implements AuthProvider {
     this.rolesDefinitionPath = resolve(SERVERLESS_ROLES_ROOT_PATH, this.projectType, 'roles.yml');
   }
 
+  isServerless(): boolean {
+    return true;
+  }
+
+  getProjectType() {
+    return this.projectType;
+  }
+
   getSupportedRoleDescriptors() {
     const roleDescriptors = new Map<string, any>(
       Object.entries(
@@ -83,8 +91,9 @@ export class ServerlessAuthProvider implements AuthProvider {
     );
   }
 
+  // For compatibility with the Scout test framework we use the same name for the custom role
   getCustomRole() {
-    return 'customRole';
+    return 'custom_role_worker_1';
   }
 
   getRolesDefinitionPath(): string {

--- a/src/platform/packages/shared/kbn-ftr-common-functional-services/services/saml_auth/stateful/auth_provider.ts
+++ b/src/platform/packages/shared/kbn-ftr-common-functional-services/services/saml_auth/stateful/auth_provider.ts
@@ -19,6 +19,14 @@ import {
 export class StatefulAuthProvider implements AuthProvider {
   private readonly rolesDefinitionPath = resolve(REPO_ROOT, STATEFUL_ROLES_ROOT_PATH, 'roles.yml');
 
+  isServerless() {
+    return false;
+  }
+
+  getProjectType() {
+    return undefined;
+  }
+
   getSupportedRoleDescriptors() {
     const roleDescriptors = new Map<string, any>(
       Object.entries(
@@ -39,8 +47,9 @@ export class StatefulAuthProvider implements AuthProvider {
     return true;
   }
 
+  // For compatibility with the Scout test framework we use the same name for the custom role
   getCustomRole() {
-    return 'customRole';
+    return 'custom_role_worker_1';
   }
 
   getRolesDefinitionPath() {

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/core_fixtures.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/core_fixtures.ts
@@ -131,9 +131,18 @@ export const coreWorkerFixtures = base.extend<
    */
   samlAuth: [
     ({ log, config, esClient, kbnClient }, use, workerInfo) => {
-      let customRoleHash = '';
-      const customRoleName = `custom_role_worker_${workerInfo.parallelIndex}`;
+      /**
+       * When running tests against Cloud, ensure the `.ftr/role_users.json` file is populated with the required roles
+       * and credentials. Each worker uses a unique custom role named `custom_role_worker_<index>`.
+       * If running tests in parallel, make sure the file contains enough entries to accommodate all workers.
+       * The file should be structured as follows:
+       * {
+       *   "custom_role_worker_1": { "username": ..., "password": ... },
+       *   "custom_role_worker_2": { "username": ..., "password": ... },
+       */
+      const customRoleName = `custom_role_worker_${workerInfo.parallelIndex + 1}`;
       const session = createSamlSessionManager(config, log, customRoleName);
+      let customRoleHash = '';
 
       const isCustomRoleSet = (roleHash: string) => roleHash === customRoleHash;
 

--- a/x-pack/test/security_solution_api_integration/config/services/security_solution_serverless_utils.ts
+++ b/x-pack/test/security_solution_api_integration/config/services/security_solution_serverless_utils.ts
@@ -86,7 +86,7 @@ export function SecuritySolutionServerlessUtils({
         throw new Error(`Could not find a role definition for ${userRoleName}`);
       }
       await svlUserManager.setCustomRole(roleDefinition.privileges);
-      const roleAuthc = await svlUserManager.createM2mApiKeyWithRoleScope('customRole');
+      const roleAuthc = await svlUserManager.createM2mApiKeyWithCustomRoleScope();
       const superTest = supertest
         .agent(kbnUrl)
         .set(svlCommonApi.getInternalRequestHeader())

--- a/x-pack/test_serverless/README.md
+++ b/x-pack/test_serverless/README.md
@@ -209,9 +209,23 @@ defining and authenticating with custom roles in both UI functional tests and AP
 
 To test role management within the Observability project, you can execute the tests using the existing [config.feature_flags.ts](x-pack/test_serverless/functional/test_suites/observability/config.feature_flags.ts), where this functionality is explicitly enabled. Though the config is not run on MKI, it provides the ability to test custom roles in Kibana CI before the functionality is enabled in MKI. When roles management is enabled on MKI, these tests can be migrated to the regular FTR config and will be run on MKI.
 
-For compatibility with MKI, the role name `customRole` is reserved for use in tests. The test user is automatically assigned to this role, but before logging in via the browser, generating a cookie header, or creating an API key in each test suite, the role’s privileges must be updated.
+When running tests locally against MKI, ensure that the `.ftr/role_users.json` file includes the reserved role name `custom_role_worker_1` along with its credentials. This role name has been updated for compatibility with Scout, which supports parallel test execution and allows multiple credential pairs to be passed.
 
-Note: We are still working on a solution to run these tests against MKI. In the meantime, please tag the suite with `skipMKI`.
+```json
+{
+  "viewer": {
+    "email": ...,
+    "password": ..."
+  },
+  ...
+  "custom_role_worker_1": {
+    "email": ...,
+    "password": ...
+  }
+}
+```
+
+When using QAF to create a project with a custom native role, ensure that the role name `custom_role_worker_1` is configured as a Kibana role. While the test user is automatically assigned to the custom role, you must update the role's privileges before performing actions such as logging in via the browser, generating a cookie header, or creating an API key within each test suite.
 
 FTR UI test example:
 ```
@@ -254,7 +268,7 @@ await samlAuth.setCustomRole({
 });
 
 // Then, generate an API key with the newly defined privileges
-const roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('customRole');
+const roleAuthc = await samlAuth.createM2mApiKeyWithCustomRoleScope();
 
 // Remember to invalidate the API key after use and delete the custom role
 await samlAuth.invalidateM2mApiKeyWithRoleScope(roleAuthc);

--- a/x-pack/test_serverless/api_integration/test_suites/common/data_usage/tests/data_streams_privileges.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/data_usage/tests/data_streams_privileges.ts
@@ -53,7 +53,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
         ],
       });
-      roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('customRole');
+      roleAuthc = await samlAuth.createM2mApiKeyWithCustomRoleScope();
       const res = await supertestWithoutAuth
         .get(DATA_USAGE_DATA_STREAMS_API_ROUTE)
         .query({ includeZeroStorage: true })
@@ -83,7 +83,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
         ],
       });
-      roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('customRole');
+      roleAuthc = await samlAuth.createM2mApiKeyWithCustomRoleScope();
       const res = await supertestWithoutAuth
         .get(DATA_USAGE_DATA_STREAMS_API_ROUTE)
         .query({ includeZeroStorage: true })
@@ -115,7 +115,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
         ],
       });
-      roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('customRole');
+      roleAuthc = await samlAuth.createM2mApiKeyWithCustomRoleScope();
       const res = await supertestWithoutAuth
         .get(DATA_USAGE_DATA_STREAMS_API_ROUTE)
         .query({ includeZeroStorage: true })
@@ -140,7 +140,7 @@ export default function ({ getService }: FtrProviderContext) {
           },
         ],
       });
-      roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('customRole');
+      roleAuthc = await samlAuth.createM2mApiKeyWithCustomRoleScope();
       const res = await supertestWithoutAuth
         .get(DATA_USAGE_DATA_STREAMS_API_ROUTE)
         .query({ includeZeroStorage: true })

--- a/x-pack/test_serverless/functional/page_objects/svl_common_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_common_page.ts
@@ -68,6 +68,7 @@ export function SvlCommonPageProvider({ getService, getPageObjects }: FtrProvide
      * Login to Kibana using SAML authentication with provided project-specfic role
      */
     async loginWithRole(role: string) {
+      svlUserManager.checkRoleIsSupported(role);
       log.debug(`Fetch the cookie for '${role}' role`);
       const sidCookie = await svlUserManager.getInteractiveUserSessionCookieWithRoleScope(role);
       await retry.waitForWithTimeout(

--- a/x-pack/test_serverless/functional/test_suites/observability/role_management/custom_role_access.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/role_management/custom_role_access.ts
@@ -95,7 +95,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('should access console with API key', async () => {
-      roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('customRole');
+      roleAuthc = await samlAuth.createM2mApiKeyWithCustomRoleScope();
       const { body } = await supertestWithoutAuth
         .get('/api/console/api_server')
         .set(roleAuthc.apiKeyHeader)

--- a/x-pack/test_serverless/functional/test_suites/search/custom_role_access.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/custom_role_access.ts
@@ -85,7 +85,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('should access console with API key', async () => {
-      roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('customRole');
+      roleAuthc = await samlAuth.createM2mApiKeyWithCustomRoleScope();
       const { body } = await supertestWithoutAuth
         .get('/api/console/api_server')
         .set(roleAuthc.apiKeyHeader)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[FTR] unify custom role name with Scout (#217882)](https://github.com/elastic/kibana/pull/217882)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Dzmitry Lemechko","email":"dzmitry.lemechko@elastic.co"},"sourceCommit":{"committedDate":"2025-04-14T17:21:49Z","message":"[FTR] unify custom role name with Scout (#217882)\n\n## Summary\n\nIn QAF David added a possibility to spin up MKI project with custom role\nset and ready to use.\n\nOriginally FTR was using reserved name `'customRole'` for internal\nKibana role to be mapped with native custom role in the project.\n\nBoth Scout and FTR use `kbn/test` to simulate SAML authentication, but\nthe new framework will allow to run the tests in parallel. That said, we\nneed to support multiple custom role credentials (one pair per worker)\nand for simplicity we decided to use the same keys:\n\nTo run your tests locally against MKI you need to add a new Cloud user\nentry in `user_roles.json`:\n\n```\n\"custom_role_worker_1\": { \"username\": ..., \"password\": ... }, // FTR requires only the first entry\n\"custom_role_worker_2\": { \"username\": ..., \"password\": ... },\n...\n```\n\nThe test change is minimal:\n<img width=\"559\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/572103a3-13b2-4e6c-b9d2-5e55b03ac51c\"\n/>\n\n---------\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"c4a97e51e3c9040fb0c955913b06aa0e3b5ba791","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","FTR","backport:version","v9.1.0","v8.19.0","v9.0.1"],"title":"[FTR] unify custom role name with Scout","number":217882,"url":"https://github.com/elastic/kibana/pull/217882","mergeCommit":{"message":"[FTR] unify custom role name with Scout (#217882)\n\n## Summary\n\nIn QAF David added a possibility to spin up MKI project with custom role\nset and ready to use.\n\nOriginally FTR was using reserved name `'customRole'` for internal\nKibana role to be mapped with native custom role in the project.\n\nBoth Scout and FTR use `kbn/test` to simulate SAML authentication, but\nthe new framework will allow to run the tests in parallel. That said, we\nneed to support multiple custom role credentials (one pair per worker)\nand for simplicity we decided to use the same keys:\n\nTo run your tests locally against MKI you need to add a new Cloud user\nentry in `user_roles.json`:\n\n```\n\"custom_role_worker_1\": { \"username\": ..., \"password\": ... }, // FTR requires only the first entry\n\"custom_role_worker_2\": { \"username\": ..., \"password\": ... },\n...\n```\n\nThe test change is minimal:\n<img width=\"559\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/572103a3-13b2-4e6c-b9d2-5e55b03ac51c\"\n/>\n\n---------\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"c4a97e51e3c9040fb0c955913b06aa0e3b5ba791"}},"sourceBranch":"main","suggestedTargetBranches":["8.x"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/218152","number":218152,"state":"MERGED","mergeCommit":{"sha":"086804391acca87ea1baa98e97b1e12886e3e42b","message":"[9.0] [FTR] unify custom role name with Scout (#217882) (#218152)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[FTR] unify custom role name with Scout\n(#217882)](https://github.com/elastic/kibana/pull/217882)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Dzmitry Lemechko <dzmitry.lemechko@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217882","number":217882,"mergeCommit":{"message":"[FTR] unify custom role name with Scout (#217882)\n\n## Summary\n\nIn QAF David added a possibility to spin up MKI project with custom role\nset and ready to use.\n\nOriginally FTR was using reserved name `'customRole'` for internal\nKibana role to be mapped with native custom role in the project.\n\nBoth Scout and FTR use `kbn/test` to simulate SAML authentication, but\nthe new framework will allow to run the tests in parallel. That said, we\nneed to support multiple custom role credentials (one pair per worker)\nand for simplicity we decided to use the same keys:\n\nTo run your tests locally against MKI you need to add a new Cloud user\nentry in `user_roles.json`:\n\n```\n\"custom_role_worker_1\": { \"username\": ..., \"password\": ... }, // FTR requires only the first entry\n\"custom_role_worker_2\": { \"username\": ..., \"password\": ... },\n...\n```\n\nThe test change is minimal:\n<img width=\"559\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/572103a3-13b2-4e6c-b9d2-5e55b03ac51c\"\n/>\n\n---------\n\nCo-authored-by: Cesare de Cal <cesare.decal@elastic.co>","sha":"c4a97e51e3c9040fb0c955913b06aa0e3b5ba791"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->