### PR TITLE
[ci] Remove duplicate peggy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1228,7 +1228,6 @@
     "papaparse": "^5.2.0",
     "pbf": "3.2.1",
     "pdfmake": "^0.2.15",
-    "peggy": "^1.2.0",
     "polished": "^4.3.1",
     "pretty-ms": "6.0.0",
     "prop-types": "^15.8.1",

--- a/src/platform/plugins/private/vis_types/timeseries/server/lib/vis_data/response_processors/series/math.test.js
+++ b/src/platform/plugins/private/vis_types/timeseries/server/lib/vis_data/response_processors/series/math.test.js
@@ -254,7 +254,7 @@ describe('math(resp, panel, series)', () => {
       )(await mathAgg(resp, panel, series)((results) => results))([]);
     } catch (e) {
       expect(e.message).toMatchInlineSnapshot(
-        `"Failed to parse expression. Expected \\"*\\", \\"+\\", \\"-\\", \\"/\\", \\"<\\", \\"=\\", \\">\\", end of input, or whitespace but \\"(\\" found."`
+        `"Failed to parse expression. Expected \\"=\\", [*/], [+\\\\-], [<>], end of input, or whitespace but \\"(\\" found."`
       );
     }
   });

--- a/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/workspace_panel/__snapshots__/workspace_panel.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/lens/public/editor_frame_service/editor_frame/workspace_panel/__snapshots__/workspace_panel.test.tsx.snap
@@ -20,7 +20,7 @@ Array [
           />
         </p>
         <p>
-          Error: Unable to parse expression: Expected "/*", "//", [ ,\\t,\\r,\\n], or function but "|" found.
+          Error: Unable to parse expression: Expected "/*", "//", [ \\t\\r\\n], or function but "|" found.
         </p>
       </React.Fragment>,
       "severity": "error",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9015,6 +9015,13 @@
   dependencies:
     third-party-web latest
 
+"@peggyjs/from-mem@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@peggyjs/from-mem/-/from-mem-1.3.5.tgz#d6294c588517728f73cc6c091706e147f8824be0"
+  integrity sha512-oRyzXE7nirAn+5yYjCdWQHg3EG2XXcYRoYNOK8Quqnmm+9FyK/2YWVunwudlYl++M3xY+gIAdf0vAYS+p0nKfQ==
+  dependencies:
+    semver "7.6.3"
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -25002,10 +25009,14 @@ pdfmake@^0.2.15:
     iconv-lite "^0.6.3"
     xmldoc "^1.3.0"
 
-peggy@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/peggy/-/peggy-1.2.0.tgz#657ba45900cbef1dc9f52356704bdbb193c2021c"
-  integrity sha512-PQ+NKpAobImfMprYQtc4Egmyi29bidRGEX0kKjCU5uuW09s0Cthwqhfy7mLkwcB4VcgacE5L/ZjruD/kOPCUUw==
+peggy@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/peggy/-/peggy-4.2.0.tgz#9ce13fef2710357e881b57c41d426dbe90e9a001"
+  integrity sha512-ZjzyJYY8NqW8JOZr2PbS/J0UH/hnfGALxSDsBUVQg5Y/I+ZaPuGeBJ7EclUX2RvWjhlsi4pnuL1C/K/3u+cDeg==
+  dependencies:
+    "@peggyjs/from-mem" "1.3.5"
+    commander "^12.1.0"
+    source-map-generator "0.8.0"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -27770,6 +27781,11 @@ semver@7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+
 semver@^6.0.0, semver@^6.1.0, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
@@ -28315,6 +28331,11 @@ sort-package-json@^1.53.1:
     globby "10.0.0"
     is-plain-obj "2.1.0"
     sort-object-keys "^1.1.3"
+
+source-map-generator@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/source-map-generator/-/source-map-generator-0.8.0.tgz#10d5ca0651e2c9302ea338739cbd4408849c5d00"
+  integrity sha512-psgxdGMwl5MZM9S3FWee4EgsEaIjahYV5AzGnwUvPhWeITz/j6rKpysQHlQ4USdxvINlb8lKfWGIXwfkrgtqkA==
 
 source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Summary
On 8.x, we had both peggy 1.2 and 4.2 requested. This PR removes the old peggy ref.