### PR TITLE
[Discover] Stop keydown event propagation when unified doc tabs are focused (#218131)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiTabbedContent, EuiTabbedContentTab, keys } from '@elastic/eui';
+import { EuiTabbedContent, EuiTabbedContentTab } from '@elastic/eui';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { DocViewerTab } from './doc_viewer_tab';
 import type { DocView, DocViewRenderProps } from '../../types';
@@ -68,14 +68,6 @@ export function DocViewer({ docViews, ...renderProps }: DocViewerProps) {
         tabs={tabs}
         initialSelectedTab={initialSelectedTab}
         onTabClick={onTabClick}
-        onKeyDown={(evt) => {
-          // When the tabs are focused we want to use the right and left keys to move between them instead of the documents.
-          const isTabButton = (evt.target as HTMLElement).getAttribute('role') === 'tab';
-          if (isTabButton && (evt.key === keys.ARROW_LEFT || evt.key === keys.ARROW_RIGHT)) {
-            evt.preventDefault();
-            evt.stopPropagation();
-          }
-        }}
       />
     </div>
   );

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
@@ -68,6 +68,7 @@ export function DocViewer({ docViews, ...renderProps }: DocViewerProps) {
         tabs={tabs}
         initialSelectedTab={initialSelectedTab}
         onTabClick={onTabClick}
+        onKeyDown={(evt) => evt.stopPropagation()}
       />
     </div>
   );

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
@@ -69,7 +69,9 @@ export function DocViewer({ docViews, ...renderProps }: DocViewerProps) {
         initialSelectedTab={initialSelectedTab}
         onTabClick={onTabClick}
         onKeyDown={(evt) => {
-          if (evt.key === keys.ARROW_LEFT || evt.key === keys.ARROW_RIGHT) {
+          // When the tabs are focused we want to use the right and left keys to move between them instead of the documents.
+          const isTabButton = (evt.target as HTMLElement).getAttribute('role') === 'tab';
+          if (isTabButton && (evt.key === keys.ARROW_LEFT || evt.key === keys.ARROW_RIGHT)) {
             evt.preventDefault();
             evt.stopPropagation();
           }

--- a/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
+++ b/src/platform/packages/shared/kbn-unified-doc-viewer/src/components/doc_viewer/doc_viewer.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { EuiTabbedContent, EuiTabbedContentTab } from '@elastic/eui';
+import { EuiTabbedContent, EuiTabbedContentTab, keys } from '@elastic/eui';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { DocViewerTab } from './doc_viewer_tab';
 import type { DocView, DocViewRenderProps } from '../../types';
@@ -68,7 +68,12 @@ export function DocViewer({ docViews, ...renderProps }: DocViewerProps) {
         tabs={tabs}
         initialSelectedTab={initialSelectedTab}
         onTabClick={onTabClick}
-        onKeyDown={(evt) => evt.stopPropagation()}
+        onKeyDown={(evt) => {
+          if (evt.key === keys.ARROW_LEFT || evt.key === keys.ARROW_RIGHT) {
+            evt.preventDefault();
+            evt.stopPropagation();
+          }
+        }}
       />
     </div>
   );

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -147,6 +147,12 @@ export function UnifiedDocViewerFlyout({
         return;
       }
 
+      const isTabButton = (ev.target as HTMLElement).getAttribute('role') === 'tab';
+      if (isTabButton) {
+        // ignore events triggered when the tab buttons are focused
+        return;
+      }
+
       if (ev.key === keys.ARROW_LEFT || ev.key === keys.ARROW_RIGHT) {
         ev.preventDefault();
         ev.stopPropagation();

--- a/src/platform/test/functional/apps/discover/group9/_doc_viewer.ts
+++ b/src/platform/test/functional/apps/discover/group9/_doc_viewer.ts
@@ -507,6 +507,17 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-2`);
         });
 
+        it('should not navigate between documents with arrow keys when the tabs are focused', async () => {
+          await dataGrid.clickRowToggle({ defaultTabId: false });
+          await discover.isShowingDocViewer();
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-0`);
+          await browser.pressKeys(browser.keys.ARROW_RIGHT);
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-1`);
+          await testSubjects.click('docViewerTab-doc_view_source');
+          await browser.pressKeys(browser.keys.ARROW_RIGHT);
+          await testSubjects.existOrFail(`docViewerFlyoutNavigationPage-1`);
+        });
+
         it('should close the flyout with the escape key', async () => {
           await dataGrid.clickRowToggle({ defaultTabId: false });
           expect(await discover.isShowingDocViewer()).to.be(true);


### PR DESCRIPTION
## Summary

When a tab was focused and the right or left arrow keys were used it was changing the focused tab and the selected document, it should only change the selected tab.

Fixes https://github.com/elastic/kibana/issues/218131

![chrome-capture-2025-4-15](https://github.com/user-attachments/assets/052313e1-aa1e-4d60-9b48-2a22f9b0d90b)

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->