### PR TITLE
[8.x] Fix issue with "Let Us Know" button getting hidden when Management Menu is open (#211728)

### DIFF
--- a/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/navigation.tsx
+++ b/src/platform/packages/shared/shared-ux/chrome/navigation/src/ui/navigation.tsx
@@ -16,7 +16,7 @@ import type {
   NavigationTreeDefinitionUI,
 } from '@kbn/core-chrome-browser';
 import type { Observable } from 'rxjs';
-import { EuiCollapsibleNavBeta, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiCollapsibleNavBeta, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import {
   RecentlyAccessed,
   NavigationPanel,
@@ -94,14 +94,16 @@ const NavigationComp: FC<Props> = ({ navigationTree$, dataTestSubj, panelContent
         <EuiCollapsibleNavBeta.Body data-test-subj={dataTestSubj}>
           <EuiFlexGroup direction="column" justifyContent="spaceBetween" css={{ height: '100%' }}>
             <EuiFlexItem>{renderNodes(navigationTree.body)}</EuiFlexItem>
-            {isFeedbackBtnVisible && (
-              <EuiFlexItem grow={false}>
-                <FeedbackBtn solutionId={solutionId} />
-              </EuiFlexItem>
-            )}
           </EuiFlexGroup>
         </EuiCollapsibleNavBeta.Body>
-
+        {isFeedbackBtnVisible && (
+          <EuiFlexGroup>
+            <EuiFlexItem grow={false}>
+              <EuiSpacer size="s" />
+              <FeedbackBtn solutionId={solutionId} />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        )}
         {/* Footer */}
         {navigationTree.footer && (
           <EuiCollapsibleNavBeta.Footer>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix issue with "Let Us Know" button getting hidden when Management Menu is open (#211728)](https://github.com/elastic/kibana/pull/211728)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-19T17:55:27Z","message":"Fix issue with \"Let Us Know\" button getting hidden when Management Menu is open (#211728)\n\n## Summary\n\nCloses  #210919\n\n## Visuals\n\n\nhttps://github.com/user-attachments/assets/0a2f3306-5e85-42f5-a28f-b3e9ca18f1a4\n\n","sha":"5027fd6d5526506e9befd28fca98e2cf2936944d","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:SharedUX","backport:prev-minor","v9.1.0"],"title":"Fix issue with \"Let Us Know\" button getting hidden when Management Menu is open","number":211728,"url":"https://github.com/elastic/kibana/pull/211728","mergeCommit":{"message":"Fix issue with \"Let Us Know\" button getting hidden when Management Menu is open (#211728)\n\n## Summary\n\nCloses  #210919\n\n## Visuals\n\n\nhttps://github.com/user-attachments/assets/0a2f3306-5e85-42f5-a28f-b3e9ca18f1a4\n\n","sha":"5027fd6d5526506e9befd28fca98e2cf2936944d"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/211823","number":211823,"state":"MERGED","mergeCommit":{"sha":"70f1501af556694815b4162fa4834758861b8ad6","message":"[9.0] Fix issue with \"Let Us Know\" button getting hidden when Management Menu is open (#211728) (#211823)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [Fix issue with \"Let Us Know\" button getting hidden when Management\nMenu is open (#211728)](https://github.com/elastic/kibana/pull/211728)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Eyo O. Eyo <7893459+eokoneyo@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211728","number":211728,"mergeCommit":{"message":"Fix issue with \"Let Us Know\" button getting hidden when Management Menu is open (#211728)\n\n## Summary\n\nCloses  #210919\n\n## Visuals\n\n\nhttps://github.com/user-attachments/assets/0a2f3306-5e85-42f5-a28f-b3e9ca18f1a4\n\n","sha":"5027fd6d5526506e9befd28fca98e2cf2936944d"}}]}] BACKPORT-->