### PR TITLE
[Console] Fix test for opening documentation

### DIFF
--- a/src/platform/test/functional/apps/console/_misc_console_behavior.ts
+++ b/src/platform/test/functional/apps/console/_misc_console_behavior.ts
@@ -19,8 +19,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'console', 'header']);
   const toasts = getService('toasts');
 
-  // Failing: See https://github.com/elastic/kibana/issues/218255
-  describe.skip('misc console behavior', function testMiscConsoleBehavior() {
+  describe('misc console behavior', function testMiscConsoleBehavior() {
     before(async () => {
       await browser.setWindowSize(1200, 800);
       await PageObjects.common.navigateToApp('console');
@@ -129,7 +128,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             // Retry until the documentation is loaded
             await retry.try(async () => {
               const url = await browser.getCurrentUrl();
-              expect(url).to.contain('search-search.html');
+              expect(url).to.contain('operation-search');
             });
           });
         });

--- a/src/platform/test/functional/apps/console/_misc_console_behavior.ts
+++ b/src/platform/test/functional/apps/console/_misc_console_behavior.ts
@@ -128,6 +128,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             // Retry until the documentation is loaded
             await retry.try(async () => {
               const url = await browser.getCurrentUrl();
+              // The url that is open is https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html
+              // but it redirects to https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search
               expect(url).to.contain('operation-search');
             });
           });


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/218255

## Summary

This PR fixes the Console tests for opening documentation which were failing because the doc link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html is now redirecting to https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->