### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/extend/interpreting-ci-failures.md
+++ b/docs/extend/interpreting-ci-failures.md
@@ -21,9 +21,7 @@ Clicking the link next to the check in the conversation tab of a pull request wi
 
 To view the results of a job execution in Buildkite, either click the link in the comment left by `@elasticmachine` or search for the `kibana-ci` check in the list at the bottom of the PR. This link will take you to the top-level page for the specific job execution that failed.
 
-:::{image} images/job_view.png
-:alt: Buildkite pipeline view showing a few test failures
-:::
+![Buildkite pipeline view showing a few test failures](images/job_view.png)
 
 1. **Git commit:** the git commit that caused this build.
 2. **Test Results:** A link to the test results screen, and shortcuts to the logs and jobs of the failed tests. Functional tests capture and store the log output from each specific test, and make it visible at these links.
@@ -34,9 +32,7 @@ To view the results of a job execution in Buildkite, either click the link in th
 
 The logs in Pipeline Steps contain `Info` level logging. To debug Functional UI tests it’s usually helpful to see the debug logging. You can go to the test failure details by clicking on the **logs** (1).
 
-:::{image} images/test_results.png
-:alt: Buildkite build screenshot
-:::
+![Buildkite build screenshot](images/test_results.png)
 
 Looking at the failure, we first look at the Error and stack trace. In the example below, this test failed to find an element within the timeout; `Error: retry.try timeout: TimeoutError: Waiting for element to be located By(css selector, [data-test-subj="createSpace"])`
 
@@ -69,15 +65,11 @@ Just above the `✖ fail:` line, there is a line `info Taking screenshot ...` wh
 
 Clicking the `[Download]` link for that png shows this image:
 
-:::{image} images/a11y_screenshot.png
-:alt: Kibana spaces page meets a11y validations a11y test for click on create space page.png
-:::
+![Kibana spaces page meets a11y validations a11y test for click on create space page.png](images/a11y_screenshot.png)
 
 If we use a running Kibana instance and inspect elements, we find that the `createSpace` data-test-subj attribute is on this button in the Spaces page in Stack Management:
 
-:::{image} images/inspect_element.png
-:alt: Kibana screenshot of Spaces page with developer tools open
-:::
+![Kibana screenshot of Spaces page with developer tools open](images/inspect_element.png)
 
 We know the test was not on the correct page to find the element to click. We see in the debug log the repeated attempts to find the element. If we scroll to the start of those repeated attempts, we see that the first thing the test did was this attempt to click on the `createSpace` element.
 

--- a/docs/extend/kibana-debugging.md
+++ b/docs/extend/kibana-debugging.md
@@ -21,9 +21,7 @@ With an application as varied and complex as Kibana has become, it’s not pract
 
 For example, say you implement a brand new feature, plugin or service but don’t quite know how it will impact Kibana’s performance as a whole. APM allows us to not only spot that something is slow, but also hints at why it might be performing slowly. For example, if a function is slow on specific types of inputs, we can see where the time is spent by viewing the trace for that function call in the APM UI.
 
-:::{image} images/apm_example_trace.png
-:alt: apm example trace
-:::
+![apm example trace](images/apm_example_trace.png)
 
 The net of metrics captured by APM are both a wide and deep because the entire application is instrumented at runtime and we simply take a sample of these metrics. This means that we don’t have to know what we need to measure ahead of time, we’ll instead just get (most) of the data we’re likely going to need by default.
 
@@ -103,9 +101,7 @@ The easiest and recommended way of running Kibana with the APM agent locally is 
 
 9. After Kibana starts up, navigate to the APM app, where you should see some transactions.
 
-:::{image} images/apm_ui_transactions.png
-:alt: apm ui transactions
-:::
+![apm ui transactions](images/apm_ui_transactions.png)
 
 You can now continue doing what you want to in Kibana (e.g. install sample data sets, issue queries in dashboards, build new visualizations etc). Once you’re finished, you can stop Kibana normally, then stop the {{es}} and APM servers in the apm-integration-testing clone with the following script:
 

--- a/docs/extend/kibana-expressions-plugin.md
+++ b/docs/extend/kibana-expressions-plugin.md
@@ -34,9 +34,7 @@ filters
 [/source]
 ```
 
-:::{image} images/expressions_plugin.png
-:alt: Rendered metric
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Rendered metric](images/expressions_plugin.png)
 
 

--- a/docs/extend/sharing-saved-objects.md
+++ b/docs/extend/sharing-saved-objects.md
@@ -13,9 +13,7 @@ From 8.7.0, as a step towards *zero downtime upgrades*, plugins are no longer al
 
 [Saved objects](/extend/saved-objects-service.md) (hereinafter "objects") are used to store all sorts of things in {{kib}}, from Dashboards to Index Patterns to Machine Learning Jobs. The effort to make objects shareable can be summarized in a single picture:
 
-:::{image} images/sharing-saved-objects-overview.png
-:alt: Sharing Saved Objects overview
-:::
+![Sharing Saved Objects overview](images/sharing-saved-objects-overview.png)
 
 Each plugin can register different object types to be used in {{kib}}. Historically, objects could be *isolated* (existing in a single [space](docs-content://deploy-manage/manage-spaces.md)) or *global* (existing in all spaces), there was no in-between. As of the 7.12 release, {{kib}} now supports two additional types of objects:
 
@@ -57,9 +55,7 @@ External plugins can also convert their objects, but [they don’t have to do so
 
 If you’re still reading this page, you’re probably developing a {{kib}} plugin that registers an object type, and you want to know what steps you need to take to prepare for the 8.0 release and mitigate any breaking changes! Depending on how you are using saved objects, you may need to take up to 5 steps, which are detailed in separate sections below. Refer to this flowchart:
 
-:::{image} images/sharing-saved-objects-phase-1-dev-flowchart.png
-:alt: Sharing Saved Objects phase 1 - developer flowchart
-:::
+![Sharing Saved Objects phase 1 - developer flowchart](images/sharing-saved-objects-phase-1-dev-flowchart.png)
 
 ::::{tip}
 There is a proof-of-concept (POC) pull request to demonstrate these changes. It first adds a simple test plugin that allows users to create and view notes. Then, it goes through the steps of the flowchart to convert the isolated "note" objects to become share-capable. As you read this guide, you can [follow along in the POC](https://github.com/elastic/kibana/pull/107256) to see exactly how to take these steps.
@@ -81,9 +77,7 @@ If you answered "Yes" to [Question 1](#sharing-saved-objects-q1), you need to ma
 
 The image below shows two different examples of object links from a "case" object to an "action" object. The top shows the incorrect way to link to another object, and the bottom shows the correct way.
 
-:::{image} images/sharing-saved-objects-step-1.png
-:alt: Sharing Saved Objects step 1
-:::
+![Sharing Saved Objects step 1](images/sharing-saved-objects-step-1.png)
 
 If your objects *do not* use the root-level `references` field, you’ll need to [add a migration](/extend/saved-objects-service.md#saved-objects-service-writing-migrations) *before the 8.0 release* to fix that. Here’s a migration function for the example above:
 
@@ -124,9 +118,7 @@ Reminder, don’t forget to add unit tests and integration tests!
 [TBC: QUOTE]
 A deep link is a URL to a page that shows a specific object. End-users may bookmark these URLs or schedule reports with them, so it is critical to ensure that these URLs continue working. The image below shows an example of a deep link to a Canvas workpad object:
 
-:::{image} images/sharing-saved-objects-q2.png
-:alt: Sharing Saved Objects deep link example
-:::
+![Sharing Saved Objects deep link example](images/sharing-saved-objects-q2.png)
 
 Note that some URLs may contain [deep links to multiple objects](#sharing-saved-objects-faq-multiple-deep-link-objects), for example, a Dashboard *and* a filter for an Index Pattern.
 
@@ -180,9 +172,7 @@ The Spaces plugin API exposes React components and functions that you should use
 
 Your page should change [according to the outcome](#sharing-saved-objects-faq-resolve-outcomes):
 
-:::{image} images/sharing-saved-objects-step-3.png
-:alt: Sharing Saved Objects resolve outcomes overview
-:::
+![Sharing Saved Objects resolve outcomes overview](images/sharing-saved-objects-step-3.png)
 
 ::::{tip}
 See an example of this in [step 3 of the POC](https://github.com/elastic/kibana/pull/107256#user-content-example-steps)!
@@ -309,9 +299,7 @@ The previous steps can be backported to the 7.x branch, but this step — th
 
 When you register your object, you need to change the `namespaceType` and also add a `convertToMultiNamespaceTypeVersion` field. This special field will trigger the actual conversion that will take place during the Core migration upgrade process when a user installs the Kibana 8.0 release:
 
-:::{image} images/sharing-saved-objects-step-4.png
-:alt: Sharing Saved Objects conversion code
-:::
+![Sharing Saved Objects conversion code](images/sharing-saved-objects-step-4.png)
 
 ::::{tip}
 See an example of this in [step 4 of the POC](https://github.com/elastic/kibana/pull/107256#user-content-example-steps)!
@@ -339,9 +327,7 @@ If you answered "Yes" to [Question 3](#sharing-saved-objects-q3), you need to ta
 
 To mitigate this, you need to add a "no-op" ESO migration that will be applied immediately after the object is converted during the 8.0 upgrade process. This will decrypt the object using its old ID and then re-encrypt it using its new ID:
 
-:::{image} images/sharing-saved-objects-step-5.png
-:alt: Sharing Saved Objects ESO migration
-:::
+![Sharing Saved Objects ESO migration](images/sharing-saved-objects-step-5.png)
 
 ::::{note}
 Reminder, don’t forget to add unit tests and integration tests!
@@ -354,18 +340,14 @@ Reminder, don’t forget to add unit tests and integration tests!
 
 This section covers switching a share-capable object type into a shareable one *or* creating a new shareable saved object type. Refer to this flowchart:
 
-:::{image} images/sharing-saved-objects-phase-2-dev-flowchart.png
-:alt: Sharing Saved Objects phase 2 - developer flowchart
-:::
+![Sharing Saved Objects phase 2 - developer flowchart](images/sharing-saved-objects-phase-2-dev-flowchart.png)
 
 ### Step 6 [sharing-saved-objects-step-6]
 
 [TBC: QUOTE]
 When you register your object, you need to set the proper `namespaceType`. If you have an existing object type that is "share-capable", you can simply change it:
 
-:::{image} images/sharing-saved-objects-step-6.png
-:alt: Sharing Saved Objects registration (shareable)
-:::
+![Sharing Saved Objects registration (shareable)](images/sharing-saved-objects-step-6.png)
 
 
 ### Step 7 [sharing-saved-objects-step-7]
@@ -388,9 +370,7 @@ const warningMessage =
 
 The [Data Views page](docs-content://explore-analyze/find-and-organize/data-views.md) in [Stack Management](docs-content://deploy-manage/index.md) uses a [similar approach](https://github.com/elastic/kibana/blob/master/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/edit_index_pattern.tsx) to show a warning in its delete confirmation modal:
 
-:::{image} images/sharing-saved-objects-step-7.png
-:alt: Sharing Saved Objects deletion warning
-:::
+![Sharing Saved Objects deletion warning](images/sharing-saved-objects-step-7.png)
 
 
 ### Step 8 [sharing-saved-objects-step-8]
@@ -490,15 +470,11 @@ A developer can easily flip a switch to make a share-capable object into a share
 
 This is because of how isolated objects are serialized to raw Elasticsearch documents. Each raw document ID today contains its space ID (*namespace*) as a prefix. When objects are copied or imported to other spaces, they keep the same object ID, they just have a different prefix when they are serialized to Elasticsearch. This has resulted in a situation where many Kibana installations have saved objects in different spaces with the same object ID:
 
-:::{image} images/sharing-saved-objects-faq-changing-object-ids-1.png
-:alt: Sharing Saved Objects object ID diagram (before conversion)
-:::
+![Sharing Saved Objects object ID diagram (before conversion)](images/sharing-saved-objects-faq-changing-object-ids-1.png)
 
 Once an object is converted, we need to remove this prefix. Because of limitations with our migration process, we cannot actively check if this would result in a conflict. Therefore, we decided to pre-emptively regenerate the object ID for every object in a non-Default space to ensure that every object ID becomes globally unique:
 
-:::{image} images/sharing-saved-objects-faq-changing-object-ids-2.png
-:alt: Sharing Saved Objects object ID diagram (after conversion)
-:::
+![Sharing Saved Objects object ID diagram (after conversion)](images/sharing-saved-objects-faq-changing-object-ids-2.png)
 
 
 ### 3. What if one page has deep links to multiple objects? [sharing-saved-objects-faq-multiple-deep-link-objects]
@@ -510,15 +486,11 @@ As mentioned in [Question 2](#sharing-saved-objects-q2), some URLs may contain m
 
     * Embeddables should use `spacesApi.ui.components.getEmbeddableLegacyUrlConflict` to render conflict errors:
 
-        :::{image} images/sharing-saved-objects-faq-multiple-deep-link-objects-1.png
-        :alt: Sharing Saved Objects embeddable legacy URL conflict
-        :::
+![Sharing Saved Objects embeddable legacy URL conflict](images/sharing-saved-objects-faq-multiple-deep-link-objects-1.png)
 
         Viewing details shows the user how to disable the alias and fix the problem using the [_disable_legacy_url_aliases API](https://www.elastic.co/docs/api/doc/kibana/v8/group/endpoint-spaces):
 
-        :::{image} images/sharing-saved-objects-faq-multiple-deep-link-objects-2.png
-        :alt: Sharing Saved Objects embeddable legacy URL conflict (showing details)
-        :::
+![Sharing Saved Objects embeddable legacy URL conflict (showing details)](images/sharing-saved-objects-faq-multiple-deep-link-objects-2.png)
 
     * If the secondary object is resolved by an external service (such as the index pattern service), the service should simply make the full outcome available to consumers.
 
@@ -545,9 +517,7 @@ The `resolve()` function checks both if an object with the given ID exists, *and
 
 When you resolve an object with its current ID, the outcome is an `'exactMatch'`:
 
-:::{image} images/sharing-saved-objects-faq-resolve-outcomes-1.png
-:alt: Sharing Saved Objects resolve outcome 1 (exactMatch)
-:::
+![Sharing Saved Objects resolve outcome 1 (exactMatch)](images/sharing-saved-objects-faq-resolve-outcomes-1.png)
 
 This can happen in the Default space *and* in non-Default spaces.
 
@@ -555,9 +525,7 @@ This can happen in the Default space *and* in non-Default spaces.
 
 When you resolve an object with its old ID (the ID of its alias), the outcome is an `'aliasMatch'`:
 
-:::{image} images/sharing-saved-objects-faq-resolve-outcomes-2.png
-:alt: Sharing Saved Objects resolve outcome 2 (aliasMatch)
-:::
+![Sharing Saved Objects resolve outcome 2 (aliasMatch)](images/sharing-saved-objects-faq-resolve-outcomes-2.png)
 
 This outcome can only happen in non-Default spaces.
 
@@ -565,9 +533,7 @@ This outcome can only happen in non-Default spaces.
 
 The third outcome is an edge case that is a combination of the others. If you resolve an object ID and two objects are found — one as an exact match, the other as an alias match — the outcome is a `'conflict'`:
 
-:::{image} images/sharing-saved-objects-faq-resolve-outcomes-3.png
-:alt: Sharing Saved Objects resolve outcome 3 (conflict)
-:::
+![Sharing Saved Objects resolve outcome 3 (conflict)](images/sharing-saved-objects-faq-resolve-outcomes-3.png)
 
 We actually have controls in place to prevent this scenario from happening when you share, import, or copy objects. However, this scenario *could* still happen in a few different situations, if objects are created a certain way or if a user tampers with an object’s raw ES document. Since we can’t 100% rule out this scenario, we must handle it gracefully, but we do expect this will be a rare occurrence.
 

--- a/docs/reference/advanced-settings.md
+++ b/docs/reference/advanced-settings.md
@@ -19,10 +19,8 @@ The `Advanced Settings` {{kib}} privilege is required to access **Advanced Setti
 
 When you have insufficient privileges to edit advanced settings, the edit options are not visible, and the following indicator is displayed:
 
-:::{image} images/settings-read-only-badge.png
-:alt: Example of Advanced Settings Management's read only access indicator in Kibana's header
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Example of Advanced Settings Management's read only access indicator in Kibana's header](images/settings-read-only-badge.png)
 
 To add the privilege, go to the **Roles** management page using the navigation menu or the [global search field](docs-content://get-started/the-stack.md#kibana-navigation-search).
 

--- a/docs/reference/connectors-kibana.md
+++ b/docs/reference/connectors-kibana.md
@@ -46,10 +46,8 @@ Some connector types are paid commercial features, while others are free. For a 
 
 Rules use connectors to route actions to different destinations like log files, ticketing systems, and messaging tools. While each {{kib}} app can offer their own types of rules, they typically share connectors. **{{stack-manage-app}} > {{connectors-ui}}** offers a central place to view and manage all the connectors in the current space.
 
-:::{image} images/connector-listing.png
-:alt: Example connector listing in the {{rules-ui}} UI
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Example connector listing in the {{rules-ui}} UI](images/connector-listing.png)
 
 
 ## Required permissions [_required_permissions_2]
@@ -66,17 +64,13 @@ Use the [action configuration settings](/reference/configuration-reference/alert
 
 In **{{stack-manage-app}} > {{connectors-ui}}**, you can find a list of the connectors in the current space. You can use the search bar to find specific connectors by name and type. The **Type** dropdown also enables you to filter to a subset of connector types.
 
-:::{image} images/connector-filter-by-type.png
-:alt: Filtering the connector list by types of connectors
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Filtering the connector list by types of connectors](images/connector-filter-by-type.png)
 
 You can delete individual connectors using the trash icon. Alternatively, select multiple connectors and delete them in bulk using the **Delete** button.
 
-:::{image} images/connector-delete.png
-:alt: Deleting connectors individually or in bulk
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Deleting connectors individually or in bulk](images/connector-delete.png)
 
 ::::{note}
 You can delete a connector even if there are still actions referencing it. When this happens the action will fail to run and errors appear in the {{kib}} logs.
@@ -89,10 +83,8 @@ You can delete a connector even if there are still actions referencing it. When 
 
 New connectors can be created with the **Create connector** button, which guides you to select the type of connector and configure its properties.
 
-:::{image} images/connector-select-type.png
-:alt: Connector select type
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Connector select type](images/connector-select-type.png)
 
 After you create a connector, it is available for use any time you set up an action in the current space.
 
@@ -108,17 +100,13 @@ You can also manage connectors as resources with the [Elasticstack provider](htt
 
 To import and export connectors, use the [Saved Objects Management UI](docs-content://explore-analyze/find-and-organize/saved-objects.md).
 
-:::{image} images/connectors-import-banner.png
-:alt: Connectors import banner
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Connectors import banner](images/connectors-import-banner.png)
 
 If a connector is missing sensitive information after the import, a **Fix** button appears in **{{connectors-ui}}**.
 
-:::{image} images/connectors-with-missing-secrets.png
-:alt: Connectors with missing secrets
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Connectors with missing secrets](images/connectors-with-missing-secrets.png)
 
 
 ## Monitoring connectors [monitoring-connectors]

--- a/docs/reference/connectors-kibana/bedrock-action-type.md
+++ b/docs/reference/connectors-kibana/bedrock-action-type.md
@@ -14,10 +14,8 @@ The {{bedrock}} connector uses [axios](https://github.com/axios/axios) to send a
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.  For example:
 
-:::{image} /reference/images/bedrock-connector.png
-:alt: {{bedrock}} connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{bedrock}} connector](../images/bedrock-connector.png)
 
 
 ### Connector configuration [bedrock-connector-configuration]
@@ -44,10 +42,8 @@ Secret
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/bedrock-params.png
-:alt: {{bedrock}} params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{bedrock}} params test](../images/bedrock-params.png)
 
 The {{bedrock}} actions have the following configuration properties.
 

--- a/docs/reference/connectors-kibana/cases-action-type.md
+++ b/docs/reference/connectors-kibana/cases-action-type.md
@@ -16,10 +16,8 @@ To use this connector you must have `All` {{kib}} privileges for the **Cases** f
 
 You cannot manage this connector in **{{stack-manage-app}} > {{connectors-ui}}** or by using APIs. You also cannot create a Cases [preconfigured connector](/reference/connectors-kibana/pre-configured-connectors.md). It is available only when you’re creating a rule in {{kib}}. For example:
 
-:::{image} /reference/images/cases-action.png
-:alt: Add a cases action while creating a rule in {{kib}} {{rules-ui}}
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Add a cases action while creating a rule in {{kib}} {{rules-ui}}](../images/cases-action.png)
 
 ::::{note}
 You can have only one Cases action in each rule.

--- a/docs/reference/connectors-kibana/cases-webhook-action-type.md
+++ b/docs/reference/connectors-kibana/cases-webhook-action-type.md
@@ -14,31 +14,23 @@ The {{webhook-cm}} connector uses [axios](https://github.com/axios/axios) to sen
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. In the first step, you must provide a name for the connector and its authentication details. For example:
 
-:::{image} /reference/images/cases-webhook-connector.png
-:alt: Set authentication details in the {{webhook-cm}} connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Set authentication details in the {{webhook-cm}} connector](../images/cases-webhook-connector.png)
 
 In the second step, you must provide the information necessary to create cases in the external system. For example:
 
-:::{image} /reference/images/cases-webhook-connector-create-case.png
-:alt: Add case creation details in the {{webhook-cm}} connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Add case creation details in the {{webhook-cm}} connector](../images/cases-webhook-connector-create-case.png)
 
 In the third step, you must provide information related to retrieving case details from the external system. For example:
 
-:::{image} /reference/images/cases-webhook-connector-get-case.png
-:alt: Add case retrieval details in the {{webhook-cm}} connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Add case retrieval details in the {{webhook-cm}} connector](../images/cases-webhook-connector-get-case.png)
 
 In the fourth step, you must provide information necessary to update cases in the external system. You can also optionally provide information to add comments to cases. For example:
 
-:::{image} /reference/images/cases-webhook-connector-comments.png
-:alt: Add case update and comment details in the {{webhook-cm}} connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Add case update and comment details in the {{webhook-cm}} connector](../images/cases-webhook-connector-comments.png)
 
 
 ### Connector configuration [cases-webhook-connector-configuration]
@@ -168,10 +160,8 @@ Update case URL
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/cases-webhook-test.png
-:alt: {{webhook-cm}} params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{webhook-cm}} params test](../images/cases-webhook-test.png)
 
 {{webhook-cm}} actions have the following configuration properties:
 

--- a/docs/reference/connectors-kibana/crowdstrike-action-type.md
+++ b/docs/reference/connectors-kibana/crowdstrike-action-type.md
@@ -21,10 +21,8 @@ To use this connector, you must have authority to run {{endpoint-sec}} connector
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**. For example:
 
-:::{image} /reference/images/crowdstrike-connector.png
-:alt: CrowdStrike connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![CrowdStrike connector](../images/crowdstrike-connector.png)
 
 
 ### Connector configuration [crowdstrike-connector-configuration]

--- a/docs/reference/connectors-kibana/d3security-action-type.md
+++ b/docs/reference/connectors-kibana/d3security-action-type.md
@@ -16,10 +16,8 @@ To create this connector, you must first configure a webhook key in your D3 SOAR
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.  For example:
 
-:::{image} /reference/images/d3security-connector.png
-:alt: D3 Security connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![D3 Security connector](../images/d3security-connector.png)
 
 
 ### Connector configuration [d3security-connector-configuration]
@@ -40,10 +38,8 @@ Token
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/d3security-params-test.png
-:alt: D3 Security params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![D3 Security params test](../images/d3security-params-test.png)
 
 The D3 Security actions have the following configuration properties.
 

--- a/docs/reference/connectors-kibana/email-action-type.md
+++ b/docs/reference/connectors-kibana/email-action-type.md
@@ -21,10 +21,8 @@ The email connector uses the SMTP protocol to send mail messages. Email message 
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/email-connector.png
-:alt: Email connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Email connector](../images/email-connector.png)
 
 
 ### Connector configuration [email-connector-configuration]
@@ -72,10 +70,8 @@ Password
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/email-params-test.png
-:alt: Email params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Email params test](../images/email-params-test.png)
 
 Email actions have the following configuration properties.
 
@@ -158,48 +154,36 @@ The email connector uses Microsoft Graph REST API v1.0, in particular the [sendM
 
 Before you create an email connector for Microsoft Exchange, you must create and register the client integration application on the [Azure portal](https://go.microsoft.com/fwlink/?linkid=2083908):
 
-:::{image} /reference/images/exchange-register-app.png
-:alt: Register client application for MS Exchange
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Register client application for MS Exchange](../images/exchange-register-app.png)
 
 Next, open **Manage > API permissions**, and then define the permissions for the registered application to send emails. Refer to the [documentation](https://docs.microsoft.com/en-us/graph/api/user-sendmail?view=graph-rest-1.0&tabs=http#permissions) for the Microsoft Graph API.
 
-:::{image} /reference/images/exchange-api-permissions.png
-:alt: MS Exchange API permissions
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![MS Exchange API permissions](../images/exchange-api-permissions.png)
 
 Add the "Mail.Send" permission for Microsoft Graph. The permission appears in the list with the status "Not granted for <your Azure active directory>":
 
-:::{image} /reference/images/exchange-not-granted.png
-:alt: MS Exchange "Mail.Send" not granted
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![MS Exchange "Mail.Send" not granted](../images/exchange-not-granted.png)
 
 Click **Grant admin consent for <your Azure active directory>**.
 
-:::{image} /reference/images/exchange-grant-confirm.png
-:alt: MS Exchange grant confirmation
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![MS Exchange grant confirmation](../images/exchange-grant-confirm.png)
 
 Confirm that the status for the "Mail.Send" permission is now granted.
 
-:::{image} /reference/images/exchange-granted.png
-:alt: MS Exchange grant confirmation
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![MS Exchange grant confirmation](../images/exchange-granted.png)
 
 
 #### Configure the Microsoft Exchange Client secret [exchange-client-secret]
 
 To configure the Microsoft Exchange Client secret, open **Manage > Certificates & secrets**:
 
-:::{image} /reference/images/exchange-secrets.png
-:alt: MS Exchange secrets configuration
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![MS Exchange secrets configuration](../images/exchange-secrets.png)
 
 Add a new client secret, then copy the value and put it to the proper field in the Microsoft Exchange email connector.
 
@@ -208,9 +192,7 @@ Add a new client secret, then copy the value and put it to the proper field in t
 
 To find the Microsoft Exchange client and tenant IDs, open the **Overview** page:
 
-:::{image} /reference/images/exchange-client-tenant.png
-:alt: MS Exchange Client ID and Tenant ID configuration
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![MS Exchange Client ID and Tenant ID configuration](../images/exchange-client-tenant.png)
 
 Create a connector and set the **Service** to `MS Exchange Server`. Copy and paste the values into the proper fields.

--- a/docs/reference/connectors-kibana/gemini-action-type.md
+++ b/docs/reference/connectors-kibana/gemini-action-type.md
@@ -14,10 +14,8 @@ The {{gemini}} connector uses [axios](https://github.com/axios/axios) to send a 
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.  For example:
 
-:::{image} /reference/images/gemini-connector.png
-:alt: {{gemini}} connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{gemini}} connector](../images/gemini-connector.png)
 
 
 ### Connector configuration [gemini-connector-configuration]
@@ -47,10 +45,8 @@ Credentials JSON
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/gemini-params.png
-:alt: {{gemini}} params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{gemini}} params test](../images/gemini-params.png)
 
 The {{gemini}} actions have the following configuration properties.
 

--- a/docs/reference/connectors-kibana/index-action-type.md
+++ b/docs/reference/connectors-kibana/index-action-type.md
@@ -14,10 +14,8 @@ An index connector indexes a document into {{es}}.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/index-connector.png
-:alt: Index connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Index connector](../images/index-connector.png)
 
 
 ### Connector configuration [index-connector-configuration]
@@ -29,10 +27,8 @@ Index connectors must have a name and an {{es}} index. You can optionally choose
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/index-params-test.png
-:alt: Index params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Index params test](../images/index-params-test.png)
 
 Index connector actions contain a document in JSON format. For example, if you have an index with the following properties:
 

--- a/docs/reference/connectors-kibana/jira-action-type.md
+++ b/docs/reference/connectors-kibana/jira-action-type.md
@@ -19,10 +19,8 @@ Jira Cloud and Jira Data Center are supported. Jira on-premise deployments are n
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/jira-connector.png
-:alt: Jira connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Jira connector](../images/jira-connector.png)
 
 
 ### Connector configuration [jira-connector-configuration]
@@ -49,10 +47,8 @@ API token
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/jira-params-test.png
-:alt: Jira params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Jira params test](../images/jira-params-test.png)
 
 Jira actions have the following configuration properties.
 

--- a/docs/reference/connectors-kibana/obs-ai-assistant-action-type.md
+++ b/docs/reference/connectors-kibana/obs-ai-assistant-action-type.md
@@ -21,10 +21,8 @@ To learn how to interact with the assistant through this connector, refer to the
 
 To use this connector, you must have been granted access to use the Observability AI Assistant feature. You cannot manage this connector in **{{stack-manage-app}} > {{connectors-ui}}** or by using APIs. You also cannot create an Observability AI Assistant [preconfigured connector](/reference/connectors-kibana/pre-configured-connectors.md). It is available only when you’re creating a rule in {{kib}}. For example:
 
-:::{image} /reference/images/obs-ai-assistant-action.png
-:alt: Add an Observability AI Assistant action while creating a rule in the Observability UI
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Add an Observability AI Assistant action while creating a rule in the Observability UI](../images/obs-ai-assistant-action.png)
 
 ::::{note}
 You can have only one Observability AI Assistant action in each rule.

--- a/docs/reference/connectors-kibana/openai-action-type.md
+++ b/docs/reference/connectors-kibana/openai-action-type.md
@@ -14,10 +14,8 @@ The OpenAI connector uses [axios](https://github.com/axios/axios) to send a POST
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**.  For example:
 
-:::{image} /reference/images/gen-ai-connector.png
-:alt: OpenAI connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![OpenAI connector](../images/gen-ai-connector.png)
 
 ::::{important}
 Elastic provides no official support for connecting to the Azure OpenAI service through a proxy. However if you must use a proxy, ensure that the proxy supports streaming and is SSE-compatible. Elastic will only parse streamed responses.
@@ -52,10 +50,8 @@ API key
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/gen-ai-params-test.png
-:alt: OpenAI params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![OpenAI params test](../images/gen-ai-params-test.png)
 
 The OpenAI actions have the following configuration properties.
 

--- a/docs/reference/connectors-kibana/opsgenie-action-type.md
+++ b/docs/reference/connectors-kibana/opsgenie-action-type.md
@@ -16,10 +16,8 @@ To create this connector, you must have a valid {{opsgenie}} URL and API key. Fo
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/opsgenie-connector.png
-:alt: Opsgenie connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Opsgenie connector](../images/opsgenie-connector.png)
 
 
 ### Connector configuration [opsgenie-connector-configuration]
@@ -53,10 +51,8 @@ After you create a connector, use the **Test** tab to test its actions:
 
 When you create a rule that uses an {{opsgenie}} connector, its actions (with the exception of recovery actions) create {{opsgenie}} alerts. You can test this type of action when you create or edit your connector:
 
-:::{image} /reference/images/opsgenie-create-alert-test.png
-:alt: {{opsgenie}} create alert action test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{opsgenie}} create alert action test](../images/opsgenie-create-alert-test.png)
 
 You can configure the create alert action through the form view or using a JSON editor.
 
@@ -146,10 +142,8 @@ Example JSON editor contents
 
 When you create a rule that uses an {{opsgenie}} connector, its recovery actions close {{opsgenie}} alerts. You can test this type of action when you create or edit your connector:
 
-:::{image} /reference/images/opsgenie-close-alert-test.png
-:alt: {{opsgenie}} close alert action test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{opsgenie}} close alert action test](../images/opsgenie-close-alert-test.png)
 
 The close alert action has the following configuration properties.
 
@@ -177,25 +171,17 @@ After obtaining an Opsgenie instance, configure the API integration. For details
 
 If you’re using a free trial, go to the `Teams` dashboard and select the appropriate team.
 
-:::{image} /reference/images/opsgenie-teams.png
-:alt: Opsgenie teams dashboard
-:::
+![Opsgenie teams dashboard](../images/opsgenie-teams.png)
 
 Select the `Integrations` menu item, then select `Add integration`.
 
-:::{image} /reference/images/opsgenie-integrations.png
-:alt: Opsgenie teams integrations
-:::
+![Opsgenie teams integrations](../images/opsgenie-integrations.png)
 
 Search for `API` and select the `API` integration.
 
-:::{image} /reference/images/opsgenie-add-api-integration.png
-:alt: Opsgenie API integration
-:::
+![Opsgenie API integration](../images/opsgenie-add-api-integration.png)
 
 Configure the integration and ensure you record the `API Key`. This key will be used to populate the `API Key` field when creating the Kibana Opsgenie connector. Click `Save Integration` after you finish configuring the integration.
 
-:::{image} /reference/images/opsgenie-save-integration.png
-:alt: Opsgenie save integration
-:::
+![Opsgenie save integration](../images/opsgenie-save-integration.png)
 

--- a/docs/reference/connectors-kibana/pagerduty-action-type.md
+++ b/docs/reference/connectors-kibana/pagerduty-action-type.md
@@ -16,10 +16,8 @@ To create this connector, you must have a valid PagerDuty integration key. For c
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/pagerduty-connector.png
-:alt: PagerDuty connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![PagerDuty connector](../images/pagerduty-connector.png)
 
 
 ### Connector configuration [pagerduty-connector-configuration]
@@ -51,30 +49,24 @@ When you create a rule that uses a PagerDuty connector, you can use any of these
 
 When you test the acknowlege action, you must provide the de-duplication key for a PagerDuty alert:
 
-:::{image} /reference/images/pagerduty-acknowledge-test.png
-:alt: PagerDuty params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![PagerDuty params test](../images/pagerduty-acknowledge-test.png)
 
 
 ### Resolve action [pagerduty-action-resolve]
 
 Likewise when you test the resolve action, you must provide the de-duplication key:
 
-:::{image} /reference/images/pagerduty-resolve-test.png
-:alt: PagerDuty params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![PagerDuty params test](../images/pagerduty-resolve-test.png)
 
 
 ### Trigger action [pagerduty-action-trigger]
 
 When you test the trigger action, you must provide a summary for the PagerDuty alert:
 
-:::{image} /reference/images/pagerduty-trigger-test.png
-:alt: PagerDuty params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![PagerDuty params test](../images/pagerduty-trigger-test.png)
 
 This action has the following properties:
 
@@ -144,10 +136,8 @@ To set up PagerDuty:
 
     You will be redirected to the **Integrations** tab for your service. An Integration Key is generated on this screen.
 
-    :::{image} /reference/images/pagerduty-integration.png
-    :alt: PagerDuty Integrations tab
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![PagerDuty Integrations tab](../images/pagerduty-integration.png)
 
 5. Save this key for use when you configure the connector in {{kib}}.
 

--- a/docs/reference/connectors-kibana/pre-configured-connectors.md
+++ b/docs/reference/connectors-kibana/pre-configured-connectors.md
@@ -66,10 +66,8 @@ Sensitive properties, such as passwords, can also be stored in the [{{kib}} keys
 
 go to the **{{connectors-ui}}** page using the navigation menu or the [global search field](docs-content://get-started/the-stack.md#kibana-navigation-search). Preconfigured connectors appear regardless of which space you are in. They are tagged as “preconfigured”, and you cannot delete them.
 
-:::{image} /reference/images/preconfigured-connectors-managing.png
-:alt: Connectors managing tab with pre-configured
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Connectors managing tab with pre-configured](../images/preconfigured-connectors-managing.png)
 
 Clicking a preconfigured connector shows the description, but not the configuration.
 
@@ -93,10 +91,8 @@ This functionality is in technical preview and may be changed or removed in a fu
 
 When you subsequently create rules, you can use the `Alert history Elasticsearch index (preconfigured)` connector.
 
-:::{image} /reference/images/pre-configured-alert-history-connector.png
-:alt: Creating a rule action that uses the pre-configured alert history connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Creating a rule action that uses the pre-configured alert history connector](../images/pre-configured-alert-history-connector.png)
 
 Documents are indexed using a preconfigured schema that captures the [action variables](docs-content://explore-analyze/alerts-cases/alerts/create-manage-rules.md#defining-rules-actions-variables) available for the rule. By default, these documents are indexed into the `kibana-alert-history-default` index, but you can specify a different index. Index names must start with `kibana-alert-history-` to take advantage of the preconfigured alert history index template.
 

--- a/docs/reference/connectors-kibana/resilient-action-type.md
+++ b/docs/reference/connectors-kibana/resilient-action-type.md
@@ -14,10 +14,8 @@ The {{ibm-r}} connector uses the [RESILIENT REST v2](https://developer.ibm.com/s
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/resilient-connector.png
-:alt: {{ibm-r}} connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{ibm-r}} connector](../images/resilient-connector.png)
 
 
 ### Connector configuration [resilient-connector-configuration]
@@ -41,10 +39,8 @@ URL
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/resilient-params-test.png
-:alt: IBM Resilient connector test options
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![IBM Resilient connector test options](../images/resilient-params-test.png)
 
 {{ibm-r}} actions have the following configuration properties.
 

--- a/docs/reference/connectors-kibana/sentinelone-action-type.md
+++ b/docs/reference/connectors-kibana/sentinelone-action-type.md
@@ -21,10 +21,8 @@ To use this connector, you must have authority to run {{endpoint-sec}} connector
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}**. For example:
 
-:::{image} /reference/images/sentinelone-connector.png
-:alt: SentinelOne connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![SentinelOne connector](../images/sentinelone-connector.png)
 
 
 ### Connector configuration [sentinelone-connector-configuration]

--- a/docs/reference/connectors-kibana/server-log-action-type.md
+++ b/docs/reference/connectors-kibana/server-log-action-type.md
@@ -14,10 +14,8 @@ A server log connector writes an entry to the {{kib}} server log.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/serverlog-connector.png
-:alt: Server log connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Server log connector](../images/serverlog-connector.png)
 
 
 ### Connector configuration [server-log-connector-configuration]
@@ -29,10 +27,8 @@ Server log connectors do not have any configuration properties other than a name
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/serverlog-params-test.png
-:alt: Server log connector test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Server log connector test](../images/serverlog-params-test.png)
 
 Server log connector actions contain a message and a log level, which defaults to `info`. Valid log level values are `trace`, `debug`, `info`, `warn`, `error`, and `fatal`.
 

--- a/docs/reference/connectors-kibana/servicenow-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-action-type.md
@@ -14,15 +14,11 @@ The {{sn-itsm}} connector uses the [import set API](https://developer.servicenow
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You must choose whether to use OAuth for authentication.
 
-:::{image} /reference/images/servicenow-connector-basic.png
-:alt: ServiceNow connector using basic auth
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![ServiceNow connector using basic auth](../images/servicenow-connector-basic.png)
 
-:::{image} /reference/images/servicenow-connector-oauth.png
-:alt: ServiceNow connector using OAuth
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![ServiceNow connector using OAuth](../images/servicenow-connector-oauth.png)
 
 
 ### Connector configuration [servicenow-connector-configuration]
@@ -64,10 +60,8 @@ Username
 
 When you create or edit a connector, use the **Test** tab to test its actions:
 
-:::{image} /reference/images/servicenow-params-test.png
-:alt: ServiceNow params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![ServiceNow params test](../images/servicenow-params-test.png)
 
 {{sn-itsm}} actions have the following configuration properties.
 
@@ -245,10 +239,8 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the certificate.
     * **PEM Certificate**: Copy the generated public key into this text field.
 
-    :::{image} /reference/images/servicenow-new-certificate.png
-    :alt: Shows new certificate form in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows new certificate form in ServiceNow](../images/servicenow-new-certificate.png)
 
 5. Click **Submit** to create the certificate.
 
@@ -260,20 +252,16 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 1. In your {{sn}} instance, go to **Application Registry** and select **New**.
 2. Select **Create an OAuth JWT API endpoint for external clients** from the list of options.
 
-    :::{image} /reference/images/servicenow-jwt-endpoint.png
-    :alt: Shows application type selection
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows application type selection](../images/servicenow-jwt-endpoint.png)
 
 3. Configure the application as follows:
 
     * **Name**: Name the application.
     * **User field**: Select the field to use as the user identifier.
 
-    :::{image} /reference/images/servicenow-new-application.png
-    :alt: Shows new application form in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows new application form in ServiceNow](../images/servicenow-new-application.png)
 
     ::::{important}
     Remember the selected user field. You will use this as the **User Identifier Value** when creating the connector. For example, if you selected **Email** for **User field**, you will use the user’s email for the **User Identifier Value**.
@@ -287,18 +275,14 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the JWT Verifier Map.
     * **Sys certificate**: Click the search icon and select the name of the certificate created in the previous step.
 
-    :::{image} /reference/images/servicenow-new-jwt-verifier-map.png
-    :alt: Shows new JWT Verifier Map form in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows new JWT Verifier Map form in ServiceNow](../images/servicenow-new-jwt-verifier-map.png)
 
 8. Click **Submit** to create the verifier map.
 9. Note the **Client ID**, **Client Secret** and **JWT Key ID**. You will need these values to create your {{sn}} connector.
 
-    :::{image} /reference/images/servicenow-oauth-values.png
-    :alt: Shows where to find OAuth values in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows where to find OAuth values in ServiceNow](../images/servicenow-oauth-values.png)
 
 
 
@@ -306,10 +290,8 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 
 {{sn-itsm}} connectors created in {{stack}} version 7.15.0 or earlier are marked as deprecated after you upgrade to version 7.16.0 or later. Deprecated connectors have a yellow icon after their name and display a warning message when selected.
 
-:::{image} /reference/images/servicenow-sir-update-connector.png
-:alt: Shows deprecated ServiceNow connectors
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Shows deprecated ServiceNow connectors](../images/servicenow-sir-update-connector.png)
 
 ::::{important}
 Deprecated connectors will continue to function with the rules they were added to and can be assigned to new rules. However, it is strongly recommended to update deprecated connectors or [create new ones](/reference/connectors-kibana.md#creating-new-connector) to ensure you have access to connector enhancements, such as updating incidents.

--- a/docs/reference/connectors-kibana/servicenow-itom-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-itom-action-type.md
@@ -14,15 +14,11 @@ The {{sn-itom}} connector uses the [event API](https://docs.servicenow.com/bundl
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You must choose whether to use OAuth for authentication.
 
-:::{image} /reference/images/servicenow-itom-connector-basic.png
-:alt: {{sn-itom}} connector using basic auth
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{sn-itom}} connector using basic auth](../images/servicenow-itom-connector-basic.png)
 
-:::{image} /reference/images/servicenow-itom-connector-oauth.png
-:alt: {{sn-itom}} connector using OAuth
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{sn-itom}} connector using OAuth](../images/servicenow-itom-connector-oauth.png)
 
 
 ### Connector configuration [servicenow-itom-connector-configuration]
@@ -64,10 +60,8 @@ Username
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/servicenow-itom-params-test.png
-:alt: {{sn-itom}} params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{sn-itom}} params test](../images/servicenow-itom-params-test.png)
 
 {{sn-itom}} actions have the following configuration properties.
 
@@ -172,10 +166,8 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the certificate.
     * **PEM Certificate**: Copy the generated public key into this text field.
 
-    :::{image} /reference/images/servicenow-new-certificate.png
-    :alt: Shows new certificate form in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows new certificate form in ServiceNow](../images/servicenow-new-certificate.png)
 
 3. Click **Submit** to create the certificate.
 
@@ -187,20 +179,16 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 1. In your {{sn}} instance, go to **Application Registry** and select **New**.
 2. Select **Create an OAuth JWT API endpoint for external clients** from the list of options.
 
-    :::{image} /reference/images/servicenow-jwt-endpoint.png
-    :alt: Shows application type selection
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows application type selection](../images/servicenow-jwt-endpoint.png)
 
 3. Configure the application as follows:
 
     * **Name**: Name the application.
     * **User field**: Select the field to use as the user identifier.
 
-    :::{image} /reference/images/servicenow-new-application.png
-    :alt: Shows new application form in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows new application form in ServiceNow](../images/servicenow-new-application.png)
 
     ::::{important}
     Remember the selected user field. You will use this as the **User Identifier Value** when creating the connector. For example, if you selected **Email** for **User field**, you will use the user’s email for the **User Identifier Value**.
@@ -214,17 +202,13 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the JWT Verifier Map.
     * **Sys certificate**: Click the search icon and select the name of the certificate created in the previous step.
 
-    :::{image} /reference/images/servicenow-new-jwt-verifier-map.png
-    :alt: Shows new JWT Verifier Map form in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows new JWT Verifier Map form in ServiceNow](../images/servicenow-new-jwt-verifier-map.png)
 
 8. Click **Submit** to create the verifier map.
 9. Note the **Client ID**, **Client Secret** and **JWT Key ID**. You will need these values to create your {{sn}} connector.
 
-    :::{image} /reference/images/servicenow-oauth-values.png
-    :alt: Shows where to find OAuth values in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows where to find OAuth values in ServiceNow](../images/servicenow-oauth-values.png)
 
 

--- a/docs/reference/connectors-kibana/servicenow-sir-action-type.md
+++ b/docs/reference/connectors-kibana/servicenow-sir-action-type.md
@@ -14,15 +14,11 @@ The {{sn-sir}} connector uses the [import set API](https://developer.servicenow.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You must choose whether to use OAuth for authentication.
 
-:::{image} /reference/images/servicenow-sir-connector-basic.png
-:alt: {{sn-sir}} connector using basic auth
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{sn-sir}} connector using basic auth](../images/servicenow-sir-connector-basic.png)
 
-:::{image} /reference/images/servicenow-sir-connector-oauth.png
-:alt: {{sn-sir}} connector using OAuth
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{sn-sir}} connector using OAuth](../images/servicenow-sir-connector-oauth.png)
 
 
 ### Connector configuration [servicenow-sir-connector-configuration]
@@ -64,10 +60,8 @@ Username
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/servicenow-sir-params-test.png
-:alt: {{sn-sir}} params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{sn-sir}} params test](../images/servicenow-sir-params-test.png)
 
 {{sn-sir}} actions have the following configuration properties.
 
@@ -241,10 +235,8 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the certificate.
     * **PEM Certificate**: Copy the generated public key into this text field.
 
-    :::{image} /reference/images/servicenow-new-certificate.png
-    :alt: Shows new certificate form in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows new certificate form in ServiceNow](../images/servicenow-new-certificate.png)
 
 3. Click **Submit** to create the certificate.
 
@@ -256,20 +248,16 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 1. In your {{sn}} instance, go to **Application Registry** and select **New**.
 2. Select **Create an OAuth JWT API endpoint for external clients** from the list of options.
 
-    :::{image} /reference/images/servicenow-jwt-endpoint.png
-    :alt: Shows application type selection
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows application type selection](../images/servicenow-jwt-endpoint.png)
 
 3. Configure the application as follows:
 
     * **Name**: Name the application.
     * **User field**: Select the field to use as the user identifier.
 
-    :::{image} /reference/images/servicenow-new-application.png
-    :alt: Shows new application form in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows new application form in ServiceNow](../images/servicenow-new-application.png)
 
     ::::{important}
     Remember the selected user field. You will use this as the **User Identifier Value** when creating the connector. For example, if you selected **Email** for **User field**, you will use the user’s email for the **User Identifier Value**.
@@ -283,18 +271,14 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
     * **Name**: Name the JWT Verifier Map.
     * **Sys certificate**: Click the search icon and select the name of the certificate created in the previous step.
 
-    :::{image} /reference/images/servicenow-new-jwt-verifier-map.png
-    :alt: Shows new JWT Verifier Map form in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows new JWT Verifier Map form in ServiceNow](../images/servicenow-new-jwt-verifier-map.png)
 
 8. Click **Submit** to create the verifier map.
 9. Note the **Client ID**, **Client Secret** and **JWT Key ID**. You will need these values to create your {{sn}} connector.
 
-    :::{image} /reference/images/servicenow-oauth-values.png
-    :alt: Shows where to find OAuth values in ServiceNow
-    :class: screenshot
-    :::
+% TO DO: Use `:class: screenshot`
+![Shows where to find OAuth values in ServiceNow](../images/servicenow-oauth-values.png)
 
 
 
@@ -302,10 +286,8 @@ This step is required to use OAuth for authentication between Elastic and {{sn}}
 
 {{sn-sir}} connectors created in {{stack}} version 7.15.0 or earlier are marked as deprecated after you upgrade to version 7.16.0 or later. Deprecated connectors have a yellow icon after their name and display a warning message when selected.
 
-:::{image} /reference/images/servicenow-sir-update-connector.png
-:alt: Shows deprecated ServiceNow connectors
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Shows deprecated ServiceNow connectors](../images/servicenow-sir-update-connector.png)
 
 ::::{important}
 Deprecated connectors will continue to function with the rules they were added to and can be assigned to new rules. However, it is strongly recommended to update deprecated connectors or [create new ones](/reference/connectors-kibana.md#creating-new-connector) to ensure you have access to connector enhancements, such as updating incidents.

--- a/docs/reference/connectors-kibana/slack-action-type.md
+++ b/docs/reference/connectors-kibana/slack-action-type.md
@@ -13,17 +13,13 @@ The Slack connector uses incoming webhooks or an API method to send Slack messag
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You can choose to use a webhook URL that’s specific to a single channel. For example:
 
-:::{image} /reference/images/slack-webhook-connector.png
-:alt: Slack connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Slack connector](../images/slack-webhook-connector.png)
 
 Alternatively, you can create a connector that supports multiple channels. For example:
 
-:::{image} /reference/images/slack-api-connector.png
-:alt: Slack API connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Slack API connector](../images/slack-api-connector.png)
 
 If you use the latter method, you must provide a valid list of Slack channel IDs. When you create a rule, each action can communicate with one of these channels.
 
@@ -34,17 +30,13 @@ For Slack setup details, go to [Configure a Slack account](#configuring-slack).
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For the webhook type of connector, its message text cannot contain Markdown, images, or other advanced formatting:
 
-:::{image} /reference/images/slack-webhook-params.png
-:alt: Slack webhook connector test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Slack webhook connector test](../images/slack-webhook-params.png)
 
 For the web API type of connector, you must choose one of the channel IDs. You can then test either plain text or block kit messages:
 
-:::{image} /reference/images/slack-api-connector-test.png
-:alt: Slack web API connector test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Slack web API connector test](../images/slack-api-connector-test.png)
 
 After you add block kit messages you can click a link to preview them in the Slack block kit builder.
 

--- a/docs/reference/connectors-kibana/swimlane-action-type.md
+++ b/docs/reference/connectors-kibana/swimlane-action-type.md
@@ -14,10 +14,8 @@ The Swimlane connector uses the [Swimlane REST API](https://swimlane.com/knowled
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/swimlane-connector.png
-:alt: Swimlane connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Swimlane connector](../images/swimlane-connector.png)
 
 
 ### Connector configuration [swimlane-connector-configuration]
@@ -41,10 +39,8 @@ API token
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/swimlane-params-test.png
-:alt: Swimlane params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Swimlane params test](../images/swimlane-params-test.png)
 
 Swimlane actions have the following configuration properties.
 

--- a/docs/reference/connectors-kibana/teams-action-type.md
+++ b/docs/reference/connectors-kibana/teams-action-type.md
@@ -14,10 +14,8 @@ The Microsoft Teams connector uses a webhook to send notifications.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/teams-connector.png
-:alt: Teams connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Teams connector](../images/teams-connector.png)
 
 
 ### Connector configuration [teams-connector-configuration]
@@ -35,10 +33,8 @@ Webhook URL
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/teams-params-test.png
-:alt: Teams params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Teams params test](../images/teams-params-test.png)
 
 Microsoft Teams actions have the following properties.
 

--- a/docs/reference/connectors-kibana/thehive-action-type.md
+++ b/docs/reference/connectors-kibana/thehive-action-type.md
@@ -17,10 +17,8 @@ If you use this connector with [cases](docs-content://explore-analyze/alerts-cas
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/thehive-connector.png
-:alt: {{hive}} connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{hive}} connector](../images/thehive-connector.png)
 
 
 ### Connector configuration [thehive-connector-configuration]
@@ -44,15 +42,11 @@ API key
 
 You can test connectors for creating a case or an alert with the [run connector API](https://www.elastic.co/docs/api/doc/kibana/v8/group/endpoint-connectors) or as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/thehive-params-case-test.png
-:alt: {{hive}} case params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{hive}} case params test](../images/thehive-params-case-test.png)
 
-:::{image} /reference/images/thehive-params-alert-test.png
-:alt: {{hive}} alert params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![{{hive}} alert params test](../images/thehive-params-alert-test.png)
 
 {{hive}} actions have the following configuration properties.
 

--- a/docs/reference/connectors-kibana/tines-action-type.md
+++ b/docs/reference/connectors-kibana/tines-action-type.md
@@ -14,10 +14,8 @@ The Tines connector uses Tines’s [Webhook actions](https://www.tines.com/docs/
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/tines-connector.png
-:alt: Tines connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Tines connector](../images/tines-connector.png)
 
 
 ### Connector configuration [tines-connector-configuration]
@@ -38,10 +36,8 @@ API Token
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/tines-params-test.png
-:alt: Tines params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Tines params test](../images/tines-params-test.png)
 
 If you create a rule action that uses the Tines connector, you can likewise configure the POST request that is sent to the Tines webhook action when the rule conditions are met.
 
@@ -52,20 +48,16 @@ It is possible that requests to the Tines API to get the stories and webhooks fo
 
 When the webhook URL is defined, the connector will use it directly when an action runs, and the story and webhook selectors will be disabled and ignored. To re-enable the story and webhook selectors, remove the webhook URL value.
 
-:::{image} /reference/images/tines-webhook-url-fallback.png
-:alt: Tines Webhook URL fallback
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Tines Webhook URL fallback](../images/tines-webhook-url-fallback.png)
 
 
 ## Tines story library [tines-story-library]
 
 In order to simplify the integration with Elastic, Tines offers a set of pre-defined Elastic stories in the Story library. They can be found by searching for "Elastic" in the [Tines Story library](https://www.tines.com/story-library?s=elastic):
 
-:::{image} /reference/images/tines_elastic_stories.png
-:alt: Tines Elastic stories
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Tines Elastic stories](../images/tines_elastic_stories.png)
 
 They can be imported directly into your Tines tenant.
 

--- a/docs/reference/connectors-kibana/torq-action-type.md
+++ b/docs/reference/connectors-kibana/torq-action-type.md
@@ -14,10 +14,8 @@ The Torq connector uses a Torq webhook to trigger workflows with Kibana actions.
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/torq-configured-connector.png
-:alt: configured Torq connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![configured Torq connector](../images/torq-configured-connector.png)
 
 
 ### Connector configuration [torq-connector-configuration]
@@ -38,10 +36,8 @@ Torq authentication header secret
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/torq-connector-test.png
-:alt: Torq connector test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Torq connector test](../images/torq-connector-test.png)
 
 Torq actions have the following configuration properties.
 

--- a/docs/reference/connectors-kibana/webhook-action-type.md
+++ b/docs/reference/connectors-kibana/webhook-action-type.md
@@ -14,10 +14,8 @@ The Webhook connector uses [axios](https://github.com/axios/axios) to send a POS
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. For example:
 
-:::{image} /reference/images/webhook-connector.png
-:alt: Webhook connector
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Webhook connector](../images/webhook-connector.png)
 
 
 ### Connector configuration [webhook-connector-configuration]
@@ -58,10 +56,8 @@ Certificate authority
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/webhook-params-test.png
-:alt: Webhook params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Webhook params test](../images/webhook-params-test.png)
 
 Webhook actions have the following properties.
 

--- a/docs/reference/connectors-kibana/xmatters-action-type.md
+++ b/docs/reference/connectors-kibana/xmatters-action-type.md
@@ -14,15 +14,11 @@ The xMatters connector uses the [xMatters Workflow for Elastic](https://help.xma
 
 You can create connectors in **{{stack-manage-app}} > {{connectors-ui}}** or as needed when you’re creating a rule. You must choose between basic and URL authentication for the requests.
 
-:::{image} /reference/images/xmatters-connector-basic.png
-:alt: xMatters connector with basic authentication
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![xMatters connector with basic authentication](../images/xmatters-connector-basic.png)
 
-:::{image} /reference/images/xmatters-connector-url.png
-:alt: xMatters connector with url authentication
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![xMatters connector with url authentication](../images/xmatters-connector-url.png)
 
 
 ### Connector configuration [xmatters-connector-configuration]
@@ -49,10 +45,8 @@ Password
 
 You can test connectors as you’re creating or editing the connector in {{kib}}. For example:
 
-:::{image} /reference/images/xmatters-params-test.png
-:alt: xMatters params test
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![xMatters params test](../images/xmatters-params-test.png)
 
 xMatters rules have the following properties:
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 
* Can you please add the appropriate labels needed for backporting? 

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->