### PR TITLE
[Spaces] Add defaultSolution to spaces config

### DIFF
--- a/x-pack/platform/plugins/shared/spaces/server/config.test.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/config.test.ts
@@ -96,4 +96,12 @@ describe('config schema', () => {
       )
     ).toThrow();
   });
+
+  it('should not throw error if defaultSolution uses valid value', () => {
+    expect(() => ConfigSchema.validate({ defaultSolution: 'es' })).not.toThrow();
+  });
+
+  it('should throw error if defaultSolution uses invalid value', () => {
+    expect(() => ConfigSchema.validate({ defaultSolution: 'test' })).toThrow();
+  });
 });

--- a/x-pack/platform/plugins/shared/spaces/server/config.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/config.ts
@@ -10,6 +10,13 @@ import type { Observable } from 'rxjs';
 import type { TypeOf } from '@kbn/config-schema';
 import { offeringBasedSchema, schema } from '@kbn/config-schema';
 import type { PluginInitializerContext } from '@kbn/core/server';
+import type { SolutionId } from '@kbn/core-chrome-browser';
+
+const solutions = ['es', 'oblt', 'security'] as const;
+
+const solutionSchemaLiterals = [...solutions].map((s) => schema.literal(s)) as [
+  ReturnType<typeof schema.literal<Exclude<SolutionId, 'chat'>>>
+];
 
 export const ConfigSchema = schema.object({
   enabled: schema.conditional(
@@ -54,6 +61,7 @@ export const ConfigSchema = schema.object({
       defaultValue: true,
     }),
   }),
+  defaultSolution: schema.maybe(schema.oneOf(solutionSchemaLiterals)),
 });
 
 export function createConfig$(context: PluginInitializerContext) {

--- a/x-pack/platform/plugins/shared/spaces/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/spaces/server/plugin.test.ts
@@ -82,7 +82,7 @@ describe('Spaces plugin', () => {
       expect(usageCollection.getCollectorByType('spaces')).toBeDefined();
     });
 
-    it('can setup space with default solution', async () => {
+    it('can setup space with default solution for cloud', async () => {
       const initializerContext = coreMock.createPluginInitializerContext({ maxSpaces: 1000 });
       const core = coreMock.createSetup() as CoreSetup<PluginsStart>;
       const features = featuresPluginMock.createSetup();
@@ -98,6 +98,23 @@ describe('Spaces plugin', () => {
 
       expect(createDefaultSpace).toHaveBeenCalledWith(
         expect.objectContaining({ solution: 'security' })
+      );
+    });
+
+    it('can setup space with default solution for onprem', async () => {
+      const initializerContext = coreMock.createPluginInitializerContext({
+        maxSpaces: 1000,
+        defaultSolution: 'oblt',
+      });
+      const core = coreMock.createSetup() as CoreSetup<PluginsStart>;
+      const features = featuresPluginMock.createSetup();
+      const licensing = licensingMock.createSetup();
+
+      const plugin = new SpacesPlugin(initializerContext);
+      plugin.setup(core, { features, licensing });
+
+      expect(createDefaultSpace).toHaveBeenCalledWith(
+        expect.objectContaining({ solution: 'oblt' })
       );
     });
   });


### PR DESCRIPTION
## Summary

This PR adds new config option `defaultSolution` (`xpack.spaces.defaultSolution`) which lets you specify a default solution, similar to the way cloud plugin does it. 

Closes: #213144




<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->