### PR TITLE
[SecuritySolutions][Endpoint] Fix false wildcard warnings on TA entries

### DIFF
--- a/x-pack/solutions/security/packages/kbn-securitysolution-utils/src/path_validations/index.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-utils/src/path_validations/index.ts
@@ -199,7 +199,7 @@ const isWindowsWildcardPathValid = (path: string): boolean => {
     trimmedValue.length !== path.length ||
     firstCharacter === '^' ||
     lastCharacter === '\\' ||
-    !hasWildcard({ path, isWindowsPath: true })
+    !hasWildcardInPath({ path, isWindowsPath: true })
   ) {
     return false;
   } else {
@@ -219,7 +219,7 @@ const isLinuxMacWildcardPathValid = (path: string): boolean => {
     lastCharacter === '/' ||
     path.length > 1024 === true ||
     path.includes('//') === true ||
-    !hasWildcard({ path, isWindowsPath: false })
+    !hasWildcardInPath({ path, isWindowsPath: false })
   ) {
     return false;
   } else {
@@ -227,7 +227,7 @@ const isLinuxMacWildcardPathValid = (path: string): boolean => {
   }
 };
 
-const hasWildcard = ({
+const hasWildcardInPath = ({
   path,
   isWindowsPath,
 }: {

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/components/form.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/components/form.test.tsx
@@ -316,6 +316,36 @@ describe('Trusted apps form', () => {
       expect(screen.getByText(INPUT_ERRORS.pathWarning(0))).not.toBeNull();
     });
 
+    it('should show path malformed path warning for linux/mac without an executable name', () => {
+      render();
+      expect(screen.queryByText(INPUT_ERRORS.pathWarning(0))).toBeNull();
+      expect(screen.queryByText(INPUT_ERRORS.wildcardPathWarning(0))).toBeNull();
+
+      const propsItem: Partial<ArtifactFormComponentProps['item']> = {
+        os_types: [OperatingSystem.LINUX],
+        entries: [createEntry(ConditionEntryField.PATH, 'match', '/')],
+      };
+      formProps.item = { ...formProps.item, ...propsItem };
+      render();
+      expect(screen.getByText(INPUT_ERRORS.pathWarning(0))).not.toBeNull();
+      expect(screen.queryByText(INPUT_ERRORS.wildcardPathWarning(0))).toBeNull();
+    });
+
+    it('should show path malformed path warning for windows with no executable name', () => {
+      render();
+      expect(screen.queryByText(INPUT_ERRORS.pathWarning(0))).toBeNull();
+      expect(screen.queryByText(INPUT_ERRORS.wildcardPathWarning(0))).toBeNull();
+
+      const propsItem: Partial<ArtifactFormComponentProps['item']> = {
+        os_types: [OperatingSystem.WINDOWS],
+        entries: [createEntry(ConditionEntryField.PATH, 'match', 'c:\\fold\\')],
+      };
+      formProps.item = { ...formProps.item, ...propsItem };
+      render();
+      expect(screen.getByText(INPUT_ERRORS.pathWarning(0))).not.toBeNull();
+      expect(screen.queryByText(INPUT_ERRORS.wildcardPathWarning(0))).toBeNull();
+    });
+
     it('should show wildcard in path warning', () => {
       render();
       expect(screen.queryByText(INPUT_ERRORS.wildcardPathWarning(0))).toBeNull();

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/components/form.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/trusted_apps/view/components/form.tsx
@@ -195,12 +195,16 @@ const validateValues = (values: ArtifactFormComponentProps['item']): ValidationR
           type: entry.type as EntryTypes,
         })
       ) {
-        addResultToValidation(
-          validation,
-          'entries',
-          'warnings',
-          INPUT_ERRORS.wildcardPathWarning(index)
-        );
+        if (entry.type === 'wildcard') {
+          addResultToValidation(
+            validation,
+            'entries',
+            'warnings',
+            INPUT_ERRORS.wildcardPathWarning(index)
+          );
+        } else {
+          addResultToValidation(validation, 'entries', 'warnings', INPUT_ERRORS.pathWarning(index));
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary

Fixes a bug where TA entries for linux/mac for matching path entries such as `/` or `/fold/` were showing a `A wildcard in the filename will affect the endpoint's performance` warning instead of `Path may be formed incorrectly; verify value` warning.

Note: Since trusted app entries should have an executable name in the path the warning should
1. for exact path match, inform the user that path may be malformed or `Path may be formed incorrectly; verify value`.
2. for wildcard path match, inform the user that there maybe performance issues with wildcard in executable name or `A wildcard in the filename will affect the endpoint's performance` warning

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



