### PR TITLE
[UA] Add aria-labelledby missing on flyouts

### DIFF
--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/es_deprecation_logs_flyout.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/es_deprecation_logs/fix_deprecation_logs/es_deprecation_logs_flyout.tsx
@@ -193,7 +193,7 @@ export const EsDeprecationLogsFlyout = ({
     <>
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="s" data-test-subj="flyoutTitle">
-          <h2>
+          <h2 id="esDeprecationLogsFlyoutTitle">
             <FormattedMessage
               id="xpack.upgradeAssistant.esDeprecationLogs.pageTitle"
               defaultMessage="Elasticsearch deprecation logs"

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/logs_step/logs_step.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/logs_step/logs_step.tsx
@@ -183,6 +183,8 @@ const LogsStep = ({ setIsComplete, hasPrivileges, privilegesMissing }: LogStepPr
         },
         flyoutProps: {
           onClose: closeFlyout,
+          'data-test-subj': 'esDeprecationLogsFlyout',
+          'aria-labelledby': 'esDeprecationLogsFlyoutTitle',
         },
       });
     }

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/migrate_system_indices/flyout.tsx
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/migrate_system_indices/flyout.tsx
@@ -250,7 +250,7 @@ export const SystemIndicesFlyout = ({
     <>
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="s" data-test-subj="flyoutTitle">
-          <h2>{i18nTexts.flyoutTitle}</h2>
+          <h2 id="migrateSystemIndicesFlyoutTitle">{i18nTexts.flyoutTitle}</h2>
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody data-test-subj="flyoutDetails">

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/migrate_system_indices/use_migrate_system_indices.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/overview/migrate_system_indices/use_migrate_system_indices.ts
@@ -77,6 +77,8 @@ export const useMigrateSystemIndices = () => {
         },
         flyoutProps: {
           onClose: closeFlyout,
+          'data-test-subj': 'migrateSystemIndicesFlyout',
+          'aria-labelledby': 'migrateSystemIndicesFlyoutTitle',
         },
       });
     }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/218028

## Summary
This PR introduces the `aria-labelledby` missing in Migrate system indices flyout. It also introduces it in the ES deprecation logs (this wasn't requested in the Issue but was also missed). The changes are correctly displayed with Voiceover in Safari.

<img width="1508" alt="Screenshot 2025-04-16 at 11 13 29" src="https://github.com/user-attachments/assets/400e9416-6f74-4cda-94f6-52a69c37799d" />
<img width="1109" alt="Screenshot 2025-04-16 at 11 39 57" src="https://github.com/user-attachments/assets/e834967d-b4ab-4d2d-9b3d-c218203bb98a" />

<img width="1511" alt="Screenshot 2025-04-16 at 15 39 07" src="https://github.com/user-attachments/assets/cabd9feb-5b6c-4005-9d41-25e2a9ab80f3" />

<img width="1508" alt="Screenshot 2025-04-16 at 15 38 29" src="https://github.com/user-attachments/assets/cc61db5b-d642-48c9-931f-b696b3367774" />
