### PR TITLE
[Synthetics] Changed embeddable view when only one monitor in one location is selected

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_embeddable_factory.tsx
@@ -51,7 +51,7 @@ export const getMonitorsEmbeddableFactory = (
     deserializeState: (state) => {
       return state.rawState as OverviewEmbeddableState;
     },
-    buildEmbeddable: async (state, buildApi, uuid, parentApi) => {
+    buildEmbeddable: async (state, buildApi) => {
       const [coreStart, pluginStart] = await getStartServices();
 
       const titleManager = initializeTitleManager(state);

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_grid_component.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_grid_component.tsx
@@ -41,21 +41,19 @@ export const StatusGridComponent = ({
   const singleMonitor =
     filters && filters.locations.length === 1 && filters.monitorIds.length === 1;
 
-  if (singleMonitor) {
-    return (
-      <SyntheticsEmbeddableContext reload$={reload$} reduxStore={overviewStore.current}>
-        <MonitorsOverviewList filters={filters} singleMonitor={singleMonitor} />
-      </SyntheticsEmbeddableContext>
-    );
-  }
+  const monitorOverviewListComponent = (
+    <SyntheticsEmbeddableContext reload$={reload$} reduxStore={overviewStore.current}>
+      <MonitorsOverviewList filters={filters} singleMonitor={singleMonitor} />
+    </SyntheticsEmbeddableContext>
+  );
 
-  return (
+  return singleMonitor ? (
+    monitorOverviewListComponent
+  ) : (
     <EmbeddablePanelWrapper
       titleAppend={hasFilters ? <ShowSelectedFilters filters={filters ?? {}} /> : null}
     >
-      <SyntheticsEmbeddableContext reload$={reload$} reduxStore={overviewStore.current}>
-        <MonitorsOverviewList filters={filters} singleMonitor={singleMonitor} />
-      </SyntheticsEmbeddableContext>
+      {monitorOverviewListComponent}
     </EmbeddablePanelWrapper>
   );
 };
@@ -98,11 +96,13 @@ const SingleMonitorView = () => {
     }
   }, [dispatch, monitor, trendData]);
 
-  if (!monitor) return <OverviewLoader rows={1} columns={1} />;
+  const style = { height: '100%' };
+
+  if (!monitor) return <OverviewLoader rows={1} columns={1} style={style} />;
 
   return (
     <>
-      <MetricItem monitor={monitor} onClick={setFlyoutConfigCallback} />
+      <MetricItem monitor={monitor} onClick={setFlyoutConfigCallback} style={style} />
       <MaybeMonitorDetailsFlyout setFlyoutConfigCallback={setFlyoutConfigCallback} />
     </>
   );

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_grid_component.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_grid_component.tsx
@@ -38,13 +38,23 @@ export const StatusGridComponent = ({
   const overviewStore = useRef(getOverviewStore());
 
   const hasFilters = !areFiltersEmpty(filters);
+  const singleMonitor =
+    filters && filters.locations.length === 1 && filters.monitorIds.length === 1;
+
+  if (singleMonitor) {
+    return (
+      <SyntheticsEmbeddableContext reload$={reload$} reduxStore={overviewStore.current}>
+        <MonitorsOverviewList filters={filters} singleMonitor={singleMonitor} />
+      </SyntheticsEmbeddableContext>
+    );
+  }
 
   return (
     <EmbeddablePanelWrapper
       titleAppend={hasFilters ? <ShowSelectedFilters filters={filters ?? {}} /> : null}
     >
       <SyntheticsEmbeddableContext reload$={reload$} reduxStore={overviewStore.current}>
-        <MonitorsOverviewList filters={filters} />
+        <MonitorsOverviewList filters={filters} singleMonitor={singleMonitor} />
       </SyntheticsEmbeddableContext>
     </EmbeddablePanelWrapper>
   );
@@ -98,7 +108,13 @@ const SingleMonitorView = () => {
   );
 };
 
-const MonitorsOverviewList = ({ filters }: { filters: MonitorFilters }) => {
+const MonitorsOverviewList = ({
+  filters,
+  singleMonitor,
+}: {
+  filters: MonitorFilters;
+  singleMonitor?: boolean;
+}) => {
   const dispatch = useDispatch();
   useEffect(() => {
     if (!filters) return;
@@ -113,7 +129,7 @@ const MonitorsOverviewList = ({ filters }: { filters: MonitorFilters }) => {
     );
   }, [dispatch, filters]);
 
-  if (filters && filters.locations.length === 1 && filters.monitorIds.length === 1) {
+  if (singleMonitor) {
     return <SingleMonitorView />;
   }
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -20,6 +20,7 @@ import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { SYNTHETICS_MONITORS_EMBEDDABLE } from '../../../../../embeddables/constants';
 import { useCreateSLO } from '../../hooks/use_create_slo';
 import { TEST_SCHEDULED_LABEL } from '../../../monitor_add_edit/form/run_test_btn';
 import { useCanUsePublicLocById } from '../../hooks/use_can_use_public_loc_id';
@@ -36,6 +37,7 @@ import { setFlyoutConfig } from '../../../../state/overview/actions';
 import { useEditMonitorLocator } from '../../../../hooks/use_edit_monitor_locator';
 import { useMonitorDetailLocator } from '../../../../hooks/use_monitor_detail_locator';
 import { NoPermissionsTooltip } from '../../../common/components/permissions';
+import { useAddToDashboard } from '../../../common/components/add_to_dashboard';
 
 type PopoverPosition = 'relative' | 'default';
 
@@ -178,6 +180,23 @@ export function ActionsPopover({
     },
   };
 
+  const { MaybeSavedObjectSaveModalDashboard, setDashboardAttachmentReady } = useAddToDashboard({
+    type: SYNTHETICS_MONITORS_EMBEDDABLE,
+    embeddableInput: {
+      filters: {
+        monitorIds: [{ label: monitor.name, value: monitor.configId }],
+        tags: [],
+        locations: [{ label: monitor.locationLabel, value: monitor.locationId }],
+        monitorTypes: [],
+        projects: [],
+      },
+    },
+    documentTitle: `${monitor.name} - ${monitor.locationLabel}`,
+    objectType: i18n.translate('xpack.synthetics.overview.actions.addToDashboard.objectTypeLabel', {
+      defaultMessage: 'Monitor Overview',
+    }),
+  });
+
   const alertLoading = alertStatus(monitor.configId) === FETCH_STATUS.LOADING;
   let popoverItems: EuiContextMenuPanelItemDescriptor[] = [
     {
@@ -291,6 +310,14 @@ export function ActionsPopover({
         }
       },
     },
+    {
+      name: addMonitorToDashboardLabel,
+      icon: 'dashboardApp',
+      onClick: () => {
+        setIsPopoverOpen(false);
+        setDashboardAttachmentReady(true);
+      },
+    },
   ];
   if (isInspectView) popoverItems = popoverItems.filter((i) => i !== quickInspectPopoverItem);
 
@@ -331,6 +358,7 @@ export function ActionsPopover({
         </EuiPopover>
       </Container>
       {CreateSLOFlyout}
+      {MaybeSavedObjectSaveModalDashboard}
     </>
   );
 }
@@ -418,6 +446,13 @@ const enableMonitorAlertLabel = i18n.translate(
   'xpack.synthetics.overview.actions.enableLabelDisableAlert',
   {
     defaultMessage: 'Enable status alerts (all locations)',
+  }
+);
+
+const addMonitorToDashboardLabel = i18n.translate(
+  'xpack.synthetics.overview.actions.addToDashboard',
+  {
+    defaultMessage: 'Add to dashboard',
   }
 );
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_grid.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_grid.tsx
@@ -21,7 +21,6 @@ import {
 import { MetricItem } from './metric_item/metric_item';
 import { ShowAllSpaces } from '../../common/show_all_spaces';
 import { OverviewStatusMetaData } from '../../../../../../../common/runtime_types';
-import { quietFetchOverviewStatusAction } from '../../../../state/overview_status';
 import type { TrendRequest } from '../../../../../../../common/types';
 import { SYNTHETICS_MONITORS_EMBEDDABLE } from '../../../../../embeddables/constants';
 import { AddToDashboard } from '../../../common/components/add_to_dashboard';
@@ -39,9 +38,9 @@ import { OverviewLoader } from './overview_loader';
 import { OverviewPaginationInfo } from './overview_pagination_info';
 import { SortFields } from './sort_fields';
 import { NoMonitorsFound } from '../../common/no_monitors_found';
-import { MonitorDetailFlyout } from './monitor_detail_flyout';
 import { useSyntheticsRefreshContext } from '../../../../contexts';
 import { FlyoutParamProps } from './types';
+import { MaybeMonitorDetailsFlyout } from './monitor_detail_flyout';
 
 const ITEM_HEIGHT = 172;
 const ROW_COUNT = 4;
@@ -61,7 +60,6 @@ export const OverviewGrid = memo(() => {
   const monitorsSortedByStatus: OverviewStatusMetaData[] = useMonitorsSortedByStatus();
 
   const {
-    flyoutConfig,
     pageState,
     groupBy: { field: groupField },
   } = useSelector(selectOverviewState);
@@ -77,12 +75,7 @@ export const OverviewGrid = memo(() => {
     (params: FlyoutParamProps) => dispatch(setFlyoutConfig(params)),
     [dispatch]
   );
-  const hideFlyout = useCallback(() => dispatch(setFlyoutConfig(null)), [dispatch]);
   const { lastRefresh } = useSyntheticsRefreshContext();
-  const forceRefreshCallback = useCallback(
-    () => dispatch(quietFetchOverviewStatusAction.get({ pageState })),
-    [dispatch, pageState]
-  );
 
   useEffect(() => {
     if (monitorsSortedByStatus.length) {
@@ -186,7 +179,7 @@ export const OverviewGrid = memo(() => {
                             <EuiFlexGroup
                               data-test-subj={`overview-grid-row-${listIndex}`}
                               gutterSize="m"
-                              style={{ ...style }}
+                              css={{ ...style }}
                             >
                               {listData[listIndex].map((_, idx) => (
                                 <EuiFlexItem
@@ -252,18 +245,7 @@ export const OverviewGrid = memo(() => {
             </EuiFlexGroup>
           </>
         )}
-      {flyoutConfig?.configId && flyoutConfig?.location && (
-        <MonitorDetailFlyout
-          configId={flyoutConfig.configId}
-          id={flyoutConfig.id}
-          location={flyoutConfig.location}
-          locationId={flyoutConfig.locationId}
-          spaceId={flyoutConfig.spaceId}
-          onClose={hideFlyout}
-          onEnabledChange={forceRefreshCallback}
-          onLocationChange={setFlyoutConfigCallback}
-        />
-      )}
+      <MaybeMonitorDetailsFlyout setFlyoutConfigCallback={setFlyoutConfigCallback} />
     </>
   );
 });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_loader.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_loader.tsx
@@ -12,15 +12,17 @@ import { OverviewGridItemLoader } from './overview_grid_item_loader';
 export const OverviewLoader = ({
   rows,
   columns,
+  style,
 }: {
   rows?: number;
   columns?: EuiFlexGridProps['columns'];
+  style?: { height: string };
 }) => {
   const ROWS = rows ?? 4;
   const COLUMNS = columns ?? 4;
   const loaders = Array(ROWS * COLUMNS).fill(null);
   return (
-    <EuiFlexGrid gutterSize="m" columns={COLUMNS}>
+    <EuiFlexGrid gutterSize="m" columns={COLUMNS} css={style}>
       {loaders.map((_, i) => (
         <EuiFlexItem key={i}>
           <OverviewGridItemLoader />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_loader.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_loader.tsx
@@ -6,12 +6,18 @@
  */
 
 import React from 'react';
-import { EuiFlexGrid, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGrid, EuiFlexItem, EuiFlexGridProps } from '@elastic/eui';
 import { OverviewGridItemLoader } from './overview_grid_item_loader';
 
-export const OverviewLoader = ({ rows }: { rows?: number }) => {
+export const OverviewLoader = ({
+  rows,
+  columns,
+}: {
+  rows?: number;
+  columns?: EuiFlexGridProps['columns'];
+}) => {
   const ROWS = rows ?? 4;
-  const COLUMNS = 4;
+  const COLUMNS = columns ?? 4;
   const loaders = Array(ROWS * COLUMNS).fill(null);
   return (
     <EuiFlexGrid gutterSize="m" columns={COLUMNS}>


### PR DESCRIPTION
This PR closes #208981 by adding a new action to the Monitor card to view only that monitor in the dashboard.


https://github.com/user-attachments/assets/f500d220-b57f-4c43-a632-b2383e33988e



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->