### PR TITLE
[ftr] split svl common configs with 4 extra groups

### DIFF
--- a/.buildkite/ftr_oblt_serverless_configs.yml
+++ b/.buildkite/ftr_oblt_serverless_configs.yml
@@ -27,6 +27,10 @@ enabled:
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group6.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group7.ts
   - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group8.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group10.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group11.ts
+  - x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group12.ts
   - x-pack/test_serverless/functional/test_suites/observability/config.screenshots.ts
   - x-pack/test_serverless/functional/test_suites/observability/config.telemetry.ts
   # serverless config files that run deployment-agnostic tests

--- a/.buildkite/ftr_search_serverless_configs.yml
+++ b/.buildkite/ftr_search_serverless_configs.yml
@@ -21,5 +21,9 @@ enabled:
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group6.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group7.ts
   - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group8.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group10.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group11.ts
+  - x-pack/test_serverless/functional/test_suites/search/common_configs/config.group12.ts
   # serverless config files that run deployment-agnostic tests
   - x-pack/test/api_integration/deployment_agnostic/configs/serverless/search.serverless.config.ts

--- a/.buildkite/ftr_security_serverless_configs.yml
+++ b/.buildkite/ftr_security_serverless_configs.yml
@@ -49,6 +49,10 @@ enabled:
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group7.ts
   - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group8.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts
+  - x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/actions/trial_license_complete_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/basic_license_essentials_tier/configs/serverless.config.ts
   - x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/alerts/trial_license_complete_tier/configs/serverless.config.ts

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group10.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group10.ts
@@ -13,11 +13,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/context'),
+      require.resolve('../../common/discover/esql'),
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Observability Functional Tests - Common Group 6',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group11.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group11.ts
@@ -13,11 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover/group3'),
+      require.resolve('../../common/discover/group4'),
+      require.resolve('../../common/discover/group5'),
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Observability Functional Tests - Common Group 11',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group12.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group12.ts
@@ -12,12 +12,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
-    ],
+    testFiles: [require.resolve('../../common/discover/group6')],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Observability Functional Tests - Common Group 12',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group5.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group5.ts
@@ -15,10 +15,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     testFiles: [
       require.resolve('../../common/discover/group1'),
       require.resolve('../../common/discover/group2'),
-      require.resolve('../../common/discover/group3'),
-      require.resolve('../../common/discover/group4'),
-      require.resolve('../../common/discover/group5'),
-      require.resolve('../../common/discover/group6'),
     ],
     junit: {
       reportName: 'Serverless Observability Functional Tests - Common Group 5',

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group6.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group6.ts
@@ -15,9 +15,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     testFiles: [
       require.resolve('../../common/discover/embeddable'),
       require.resolve('../../common/discover/x_pack'),
-      require.resolve('../../common/discover_ml_uptime/discover'),
-      require.resolve('../../common/context'),
-      require.resolve('../../common/discover/esql'),
     ],
     junit: {
       reportName: 'Serverless Observability Functional Tests - Common Group 6',

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group9.ts
@@ -12,12 +12,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
-    ],
+    testFiles: [require.resolve('../../common/discover_ml_uptime/discover')],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Observability Functional Tests - Common Group 6',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group10.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group10.ts
@@ -13,11 +13,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/context'),
+      require.resolve('../../common/discover/esql'),
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Search Functional Tests - Common Group 10',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group11.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group11.ts
@@ -13,11 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover/group3'), // 4 min
+      require.resolve('../../common/discover/group4'), // 4 min
+      require.resolve('../../common/discover/group5'), // 2 min
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Search Functional Tests - Common Group 11',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group12.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group12.ts
@@ -13,11 +13,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover/group6'), // 13 min
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Search Functional Tests - Common Group 12',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/common_configs/config.group9.ts
@@ -12,12 +12,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
-    ],
+    testFiles: [require.resolve('../../common/discover_ml_uptime/discover')],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Search Functional Tests - Common Group 9',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts
@@ -13,11 +13,11 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/context'), // 5 min
+      require.resolve('../../common/discover/esql'), // 7 min
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Security Functional Tests - Common Group 10',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts
@@ -13,11 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover/group3'),
+      require.resolve('../../common/discover/group4'),
+      require.resolve('../../common/discover/group5'),
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Security Functional Tests - Common Group 11',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts
@@ -12,12 +12,9 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
 
   return {
     ...baseTestConfig.getAll(),
-    testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
-    ],
+    testFiles: [require.resolve('../../common/discover/group6')],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Security Functional Tests - Common Group 12',
     },
   };
 }

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts
@@ -15,10 +15,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
     testFiles: [
       require.resolve('../../common/discover/group1'),
       require.resolve('../../common/discover/group2'),
-      require.resolve('../../common/discover/group3'),
-      require.resolve('../../common/discover/group4'),
-      require.resolve('../../common/discover/group5'),
-      require.resolve('../../common/discover/group6'),
     ],
     junit: {
       reportName: 'Serverless Security Functional Tests - Common Group 5',

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts
@@ -13,11 +13,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/embeddable'),
-      require.resolve('../../common/discover/x_pack'),
-      require.resolve('../../common/discover_ml_uptime/discover'),
-      require.resolve('../../common/context'),
-      require.resolve('../../common/discover/esql'),
+      require.resolve('../../common/discover/embeddable'), // 6 min
+      require.resolve('../../common/discover/x_pack'), // 8 min
     ],
     junit: {
       reportName: 'Serverless Security Functional Tests - Common Group 6',

--- a/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts
@@ -13,11 +13,10 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/discover/group1'), // 7 min
-      require.resolve('../../common/discover/group2'), // 4 min
+      require.resolve('../../common/discover_ml_uptime/discover'), // 8 min
     ],
     junit: {
-      reportName: 'Serverless Search Functional Tests - Common Group 5',
+      reportName: 'Serverless Security Functional Tests - Common Group 9',
     },
   };
 }


### PR DESCRIPTION
## Summary

These 2 configs for all solutions take 35-39 minutes:

```
x-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group5.ts
x-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group6.ts
```

I added 4 additional groups under each solution and relocated some configs to split original runtime by ~3: 

```
x-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group9.ts
x-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group10.ts
x-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group11.ts
x-pack/test_serverless/functional/test_suites/<solution>/common_configs/config.group12.ts
```

It should help balancing configs better and retry failed ones faster.

After this PR groups runtime
|config path| runtime |
| ------------- | ------------- |
|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group5.ts| 16m 15s |
|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group6.ts| 18m 7s |
|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group9.ts| 12m 7s |
|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group10.ts | 16m 13s |
|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group11.ts| 14m 3s |
|x-pack/test_serverless/functional/test_suites/security/common_configs/config.group12.ts| 17m 47s |








<!--ONMERGE {"backportTargets":["8.x"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->