### PR TITLE
[Profiler] Make sure grep pattern includes all node processes

### DIFF
--- a/x-pack/platform/packages/shared/kbn-profiler-cli/src/get_node_processes.ts
+++ b/x-pack/platform/packages/shared/kbn-profiler-cli/src/get_node_processes.ts
@@ -12,7 +12,7 @@ export async function getNodeProcesses(
 ): Promise<Array<{ pid: number; command: string; ports: number[] }>> {
   const candidates = await execa
     .command(
-      `ps -eo pid,command | grep -E '^[[:space:]0-9]+[[:space:]]*node[[:space:]]?' | grep -v grep ${
+      `ps -eo pid,command | grep -E '^[[:space:]]*[0-9]+[[:space:]]+([^[:space:]]+/)*node($|[[:space:]])' | grep -v grep ${
         grep ? `| grep "${grep}" ` : ''
       }`,
       { shell: true, reject: false }


### PR DESCRIPTION
previously we only matched processes that looked like:
`000 node scripts/`

but we should actually match:

`000 /.../node/v20.18.2/bin/node scripts/`

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->