### PR TITLE
[8.17][ObsUX][Infra] Filter out null values from `sourceDataStreams`

### DIFF
--- a/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.test.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.test.ts
@@ -125,7 +125,7 @@ describe('getDataStreamTypes', () => {
   it('should return entity source_data_stream types when has no metrics', async () => {
     (getHasMetricsData as jest.Mock).mockResolvedValue(false);
     (getLatestEntity as jest.Mock).mockResolvedValue({
-      sourceDataStreamType: ['logs', 'traces'],
+      sourceDataStreamType: ['logs'],
     });
 
     const params = {
@@ -139,6 +139,6 @@ describe('getDataStreamTypes', () => {
     };
 
     const result = await getDataStreamTypes(params);
-    expect(result).toEqual(['logs', 'traces']);
+    expect(result).toEqual(['logs']);
   });
 });

--- a/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.test.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.test.ts
@@ -141,4 +141,24 @@ describe('getDataStreamTypes', () => {
     const result = await getDataStreamTypes(params);
     expect(result).toEqual(['logs']);
   });
+
+  it('should ignore null values returned from latestEntity', async () => {
+    (getHasMetricsData as jest.Mock).mockResolvedValue(false);
+    (getLatestEntity as jest.Mock).mockResolvedValue({
+      sourceDataStreamType: ['logs', null, 'metrics', null],
+    });
+
+    const params = {
+      entityId: 'entity123',
+      entityType: 'host' as EntityType,
+      entityCentriExperienceEnabled: true,
+      infraMetricsClient,
+      obsEsClient,
+      entityManagerClient,
+      logger,
+    };
+
+    const result = await getDataStreamTypes(params);
+    expect(result).toEqual(['logs', 'metrics']);
+  });
 });

--- a/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.ts
@@ -56,12 +56,7 @@ export async function getDataStreamTypes({
 
   if (latestEntity) {
     castArray(latestEntity.sourceDataStreamType).forEach((item) => {
-      if (
-        item !== null &&
-        [EntityDataStreamType.LOGS, EntityDataStreamType.METRICS].includes(
-          item as EntityDataStreamType
-        )
-      ) {
+      if (item in [EntityDataStreamType.LOGS, EntityDataStreamType.METRICS]) {
         sourceDataStreams.add(item as EntityDataStreamType);
       }
     });

--- a/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.ts
@@ -56,7 +56,14 @@ export async function getDataStreamTypes({
 
   if (latestEntity) {
     castArray(latestEntity.sourceDataStreamType).forEach((item) => {
-      sourceDataStreams.add(item as EntityDataStreamType);
+      if (
+        item !== null &&
+        [EntityDataStreamType.LOGS, EntityDataStreamType.METRICS].includes(
+          item as EntityDataStreamType
+        )
+      ) {
+        sourceDataStreams.add(item as EntityDataStreamType);
+      }
     });
   }
 

--- a/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/entities/get_data_stream_types.ts
@@ -56,7 +56,11 @@ export async function getDataStreamTypes({
 
   if (latestEntity) {
     castArray(latestEntity.sourceDataStreamType).forEach((item) => {
-      if (item in [EntityDataStreamType.LOGS, EntityDataStreamType.METRICS]) {
+      if (
+        [EntityDataStreamType.LOGS, EntityDataStreamType.METRICS].includes(
+          item as EntityDataStreamType
+        )
+      ) {
         sourceDataStreams.add(item as EntityDataStreamType);
       }
     });


### PR DESCRIPTION
## Summary

Part of #213045

This PR fixes an issue on 8.17 when the `observability:entityCentricExperience` flag was enabled. 
By some reason, we get null values in `sourceDataStreams` and when we try to validate it with the zod schema, it breaks.