### PR TITLE
chore(NA): update pipeline definitions after 8.18.1 bump removing 8.16 branch

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-es-snapshots.yml
@@ -22,7 +22,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 9.0 8.x 8.18 8.17 8.16 7.17
+      branch_configuration: main 9.0 8.x 8.18 8.17 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/build.yml
@@ -64,10 +64,6 @@ spec:
           cronline: 0 22 * * * America/New_York
           message: Daily build
           branch: '8.17'
-        Daily build (8.16):
-          cronline: 0 22 * * * America/New_York
-          message: Daily build
-          branch: '8.16'
         Daily build (7.17):
           cronline: 0 20 * * * America/New_York
           message: Daily build
@@ -99,7 +95,7 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-operations-alerts'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 9.0 8.x 8.18 8.17 8.16 7.17
+      branch_configuration: main 9.0 8.x 8.18 8.17 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/promote.yml
@@ -148,7 +144,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         REPORT_FAILED_TESTS_TO_GITHUB: 'true'
       allow_rebuilds: true
-      branch_configuration: main 9.0 8.x 8.18 8.17 8.16 7.17
+      branch_configuration: main 9.0 8.x 8.18 8.17 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/es_snapshots/verify.yml

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge-unsupported-ftrs.yml
@@ -23,7 +23,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SCOUT_REPORTER_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 9.0 8.x 8.18 8.17 8.16 7.17
+      branch_configuration: main 9.0 8.x 8.18 8.17 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/on_merge_unsupported_ftrs.yml

--- a/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-on-merge.yml
@@ -26,7 +26,7 @@ spec:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
         SCOUT_REPORTER_ENABLED: 'true'
       allow_rebuilds: true
-      branch_configuration: main 9.0 8.x 8.18 8.17 8.16 7.17
+      branch_configuration: main 9.0 8.x 8.18 8.17 7.17
       default_branch: main
       repository: elastic/kibana
       pipeline_file: .buildkite/pipelines/on_merge.yml


### PR DESCRIPTION
This PR updates the pipeline resource definitions to remove the old 8.16 branch.