### PR TITLE
[Oblt Onboarding][K8S OTel] Override docker image in values.yml for serverless

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -78,6 +78,9 @@ export const OtelKubernetesPanel: React.FC = () => {
 
   const elasticEndpointVarName = isServerless ? 'elastic_otlp_endpoint' : 'elastic_endpoint';
   const valuesFileSubfolder = isServerless ? '/managed_otlp' : '';
+  const dockerImageOverride = isServerless
+    ? '--set defaultCRConfig.image.repository="docker.elastic.co/elastic-agent/elastic-agent"'
+    : '';
 
   const otelKubeStackValuesFileUrl = data
     ? `https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v${data.elasticAgentVersionInfo.agentBaseVersion}/deploy/helm/edot-collector/kube-stack${valuesFileSubfolder}/values.yaml`
@@ -92,7 +95,7 @@ kubectl create secret generic elastic-secret-otel \\
   --from-literal=elastic_api_key='${data.apiKeyEncoded}'
 helm upgrade --install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \\
   --namespace ${namespace} \\
-  --values '${otelKubeStackValuesFileUrl}' \\
+  --values '${otelKubeStackValuesFileUrl}' ${dockerImageOverride} \\
   --version '${OTEL_KUBE_STACK_VERSION}'`
     : undefined;
 


### PR DESCRIPTION
The current `values.yml` on serverless uses `docker.elastic.co/beats/elastic-agent:9.0.0` which doesn't exist. [The actual fix](https://github.com/elastic/elastic-agent/pull/7882) will be in v9.0.1 but in the meantime we have to do a workaround on the Kibana side and override the broken value in the code snippet.

![CleanShot 2025-04-17 at 09 25 18@2x](https://github.com/user-attachments/assets/134af691-0417-4a46-86d7-1efbac75f02a)
