### PR TITLE
fix type issue from merge race on timefilter type changes

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { ReactEmbeddableRenderer } from '@kbn/embeddable-plugin/public';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -36,15 +36,11 @@ export const Trace = ({
 }: TraceProps) => {
   const { data } = getUnifiedDocViewerServices();
 
-  const { absoluteTimeRange } = data.query.timefilter.timefilter.useTimefilter();
-
-  const { rangeFrom, rangeTo } = useMemo(
-    () => ({
-      rangeFrom: new Date(absoluteTimeRange.start).toISOString(),
-      rangeTo: new Date(absoluteTimeRange.end).toISOString(),
-    }),
-    [absoluteTimeRange]
-  );
+  const {
+    timeState: {
+      asAbsoluteTimeRange: { from: rangeFrom, to: rangeTo },
+    },
+  } = data.query.timefilter.timefilter.useTimefilter();
 
   const getParentApi = useCallback(
     () => ({


### PR DESCRIPTION
## Summary
A race issue resulted from https://github.com/elastic/kibana/pull/217910 + https://github.com/elastic/kibana/pull/217568

This defuses the issue, removes the unneded `useMemo`