### PR TITLE
[Security Solution] Show banner to promote prebuilt rule customization in both Serverless and ESS

### DIFF
--- a/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
+++ b/src/platform/packages/shared/kbn-doc-links/src/get_doc_links.ts
@@ -464,9 +464,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       updatePrebuiltDetectionRules: isServerless
         ? `${SERVERLESS_DOCS}security-prebuilt-rules-management.html#update-prebuilt-rules`
         : `${SECURITY_SOLUTION_DOCS}prebuilt-rules-management.html#update-prebuilt-rules`,
-      prebuiltRuleCustomizationPromoBlog: isServerless
-        ? '' // URL for Serverless to be added later, once the blog post is published. Issue: https://github.com/elastic/kibana/issues/209000
-        : `${ELASTIC_WEBSITE_URL}blog/security-prebuilt-rules-editing`,
+      prebuiltRuleCustomizationPromoBlog: `${ELASTIC_WEBSITE_URL}blog/security-prebuilt-rules-editing`,
       createEsqlRuleType: `${SECURITY_SOLUTION_DOCS}rules-ui-create.html#create-esql-rule`,
       ruleUiAdvancedParams: `${SECURITY_SOLUTION_DOCS}rules-ui-create.html#rule-ui-advanced-params`,
       entityAnalytics: {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/callouts/blog_post_prebuilt_rule_customization_callout/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/callouts/blog_post_prebuilt_rule_customization_callout/index.tsx
@@ -15,7 +15,6 @@ import { useKibana } from '../../../../common/lib/kibana';
 import { BackgroundImageCallout } from '../background_image_callout';
 
 export function BlogPostPrebuiltRuleCustomizationCallout() {
-  // URL is currently only available in ESS. So we are only showing this callout in ESS for now.
   const blogPostUrl =
     useKibana().services.docLinks.links.securitySolution.prebuiltRuleCustomizationPromoBlog;
 
@@ -43,7 +42,7 @@ export function BlogPostPrebuiltRuleCustomizationCallout() {
     dismiss(calloutMessage);
   }, [dismiss, calloutMessage]);
 
-  if (blogPostUrl && isVisible(calloutMessage)) {
+  if (isVisible(calloutMessage)) {
     return (
       <>
         <BackgroundImageCallout

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/callouts/blog_post_prebuilt_rule_customization_callout/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/callouts/blog_post_prebuilt_rule_customization_callout/translations.ts
@@ -18,7 +18,7 @@ export const CALLOUT_DESCRIPTION = i18n.translate(
   'xpack.securitySolution.detectionEngine.blogPostPrebuiltRuleCustomizationCallout.calloutDescription',
   {
     defaultMessage:
-      'Learn how to customize prebuilt rules and update them with the latest improvements.',
+      'Learn how to customize prebuilt rules and update them to get the latest improvements.',
   }
 );
 


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/209000**
**Related PR: https://github.com/elastic/kibana/pull/213750**

## Summary

This PR updates the code to show a promo banner in the rules table. With this change, this banner will be shown in both ESS (8.18+) and Serverless. Previously it was shown only in ESS. In both ESS and Serverless the blog link is the same – this is expected and correct.

We couldn't add a banner for Serverless earlier, because the blog post was published on the 8.18/9.0 release day. If we would have added it earlier, Serverless users would click on a link at get a 404 page.

Expected behaviour for both ESS and Serverless:
 - Banner is visible above the rules table
 - The link leads to https://www.elastic.co/blog/security-prebuilt-rules-editing

<img width="1006" alt="Scherm­afbeelding 2025-03-11 om 12 25 45" src="https://github.com/user-attachments/assets/41d83db9-4bc4-433e-a7e2-c5ef1049a20c" />

**Changes:**
 - Adds a rule management table banner to promote prebuilt rule customization in Serverless. Previously this banner was only shown in ESS. Banner is dismissible. Its state is stored in localStorage.
 - Tweaks banner wording a bit as per docs suggestion ([comment](https://github.com/elastic/kibana/pull/213750/files#r1989313701))


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->