### PR TITLE
Add kbn-ai-assistant folder to paths-labeller

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -31,6 +31,7 @@
 - 'ci:project-deploy-observability':
     - 'packages/kbn-apm-*/**/*.*'
     - 'src/platform/plugins/shared/ai_assistant_management/**/*.*'
+    - 'x-pack/platform/packages/shared/kbn-ai-assistant/**/*.*'
     - 'x-pack/platform/plugins/shared/observability_ai_assistant/**/*.*'
     - 'x-pack/plugins/observability_solution/**/*.*'
     - 'x-pack/solutions/observability/packages/observability-ai/**/*.*'


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/213996

Add `x-pack/platform/packages/shared/kbn-ai-assistant` path to paths-labeller which was not added in the previous PR (https://github.com/elastic/kibana/pull/218450)


### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


