### PR TITLE
[9.0] [Console] Fix test for opening documentation (#218318)

### DIFF
--- a/test/functional/apps/console/_misc_console_behavior.ts
+++ b/test/functional/apps/console/_misc_console_behavior.ts
@@ -18,8 +18,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const browser = getService('browser');
   const PageObjects = getPageObjects(['common', 'console', 'header']);
 
-  // Failing: See https://github.com/elastic/kibana/issues/213784
-  describe.skip('misc console behavior', function testMiscConsoleBehavior() {
+  describe('misc console behavior', function testMiscConsoleBehavior() {
     before(async () => {
       await browser.setWindowSize(1200, 800);
       await PageObjects.common.navigateToApp('console');
@@ -128,7 +127,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             // Retry until the documentation is loaded
             await retry.try(async () => {
               const url = await browser.getCurrentUrl();
-              expect(url).to.contain('search-search.html');
+              // The url that is open is https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html
+              // but it redirects to https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search
+              expect(url).to.contain('operation-search');
             });
           });
         });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Console] Fix test for opening documentation (#218318)](https://github.com/elastic/kibana/pull/218318)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Stoeva","email":"59341489+ElenaStoeva@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-17T09:28:01Z","message":"[Console] Fix test for opening documentation (#218318)\n\nFixes https://github.com/elastic/kibana/issues/218255\n\n## Summary\n\nThis PR fixes the Console tests for opening documentation which were\nfailing because the doc link\nhttps://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html\nis now redirecting to\nhttps://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search.","sha":"5ce6ce575f25fa93a89234e1a5431627209d989b","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","backport:prev-minor","v9.1.0","v9.0.1"],"title":"[Console] Fix test for opening documentation","number":218318,"url":"https://github.com/elastic/kibana/pull/218318","mergeCommit":{"message":"[Console] Fix test for opening documentation (#218318)\n\nFixes https://github.com/elastic/kibana/issues/218255\n\n## Summary\n\nThis PR fixes the Console tests for opening documentation which were\nfailing because the doc link\nhttps://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html\nis now redirecting to\nhttps://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search.","sha":"5ce6ce575f25fa93a89234e1a5431627209d989b"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218318","number":218318,"mergeCommit":{"message":"[Console] Fix test for opening documentation (#218318)\n\nFixes https://github.com/elastic/kibana/issues/218255\n\n## Summary\n\nThis PR fixes the Console tests for opening documentation which were\nfailing because the doc link\nhttps://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html\nis now redirecting to\nhttps://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search.","sha":"5ce6ce575f25fa93a89234e1a5431627209d989b"}},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->