### PR TITLE
[ML] Fix vCPU usage message in the Start deployment dialog 

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/application/model_management/deployment_setup.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/model_management/deployment_setup.tsx
@@ -243,7 +243,7 @@ export const DeploymentSetup: FC<DeploymentSetupProps> = ({
               'xpack.ml.trainedModels.modelsList.startDeployment.cloudAutoscaling.lowCpuAdaptiveHelp',
               {
                 defaultMessage:
-                  'This level limits resources to the minimum required for model to run if supported by your Cloud console selection. It may not be sufficient for a production application.',
+                  'This level limits resources to the minimum required for the model to run if supported by your Cloud console selection. It may not be sufficient for a production application.',
               }
             );
           case 'medium':
@@ -274,7 +274,7 @@ export const DeploymentSetup: FC<DeploymentSetupProps> = ({
               'xpack.ml.trainedModels.modelsList.startDeployment.cloudAutoscaling.lowCpuStaticHelp',
               {
                 defaultMessage:
-                  'This level sets resources to the minimum required for model to run if supported by your Cloud console selection. It may not be sufficient for a production application.',
+                  'This level sets resources to the minimum required for the model to run if supported by your Cloud console selection. It may not be sufficient for a production application.',
               }
             );
           case 'medium':
@@ -341,7 +341,7 @@ export const DeploymentSetup: FC<DeploymentSetupProps> = ({
               'xpack.ml.trainedModels.modelsList.startDeployment.hardwareLimits.lowCpuStaticHelp',
               {
                 defaultMessage:
-                  'This level sets resources to the minimum required for model to run. It may not be sufficient for a production application.',
+                  'This level sets resources to the minimum required for the model to run. It may not be sufficient for a production application.',
               }
             );
           case 'medium':

--- a/x-pack/platform/plugins/shared/ml/public/application/model_management/deployment_setup.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/application/model_management/deployment_setup.tsx
@@ -243,7 +243,7 @@ export const DeploymentSetup: FC<DeploymentSetupProps> = ({
               'xpack.ml.trainedModels.modelsList.startDeployment.cloudAutoscaling.lowCpuAdaptiveHelp',
               {
                 defaultMessage:
-                  'This level limits resources to the minimum required for ELSER to run if supported by your Cloud console selection. It may not be sufficient for a production application.',
+                  'This level limits resources to the minimum required for model to run if supported by your Cloud console selection. It may not be sufficient for a production application.',
               }
             );
           case 'medium':
@@ -274,7 +274,7 @@ export const DeploymentSetup: FC<DeploymentSetupProps> = ({
               'xpack.ml.trainedModels.modelsList.startDeployment.cloudAutoscaling.lowCpuStaticHelp',
               {
                 defaultMessage:
-                  'This level sets resources to the minimum required for ELSER to run if supported by your Cloud console selection. It may not be sufficient for a production application.',
+                  'This level sets resources to the minimum required for model to run if supported by your Cloud console selection. It may not be sufficient for a production application.',
               }
             );
           case 'medium':
@@ -341,7 +341,7 @@ export const DeploymentSetup: FC<DeploymentSetupProps> = ({
               'xpack.ml.trainedModels.modelsList.startDeployment.hardwareLimits.lowCpuStaticHelp',
               {
                 defaultMessage:
-                  'This level sets resources to the minimum required for ELSER to run. It may not be sufficient for a production application.',
+                  'This level sets resources to the minimum required for model to run. It may not be sufficient for a production application.',
               }
             );
           case 'medium':


### PR DESCRIPTION
## Summary

Fixes the info callout message in the “Start model deployment” dialog by replacing the hardcoded ELSER name with a generic model reference.

The message is shown when the user selects _Low_ VCU usage in the following environments:
1. Cloud deployment with ML autoscaling enabled and adaptive resources enabled
2. Cloud deployment with ML autoscaling enabled and adaptive resources disabled
3. Cloud deployment with ML autoscaling disabled, or an on-prem deployment, with adaptive resources disabled

<img width="639" alt="image" src="https://github.com/user-attachments/assets/caeedea2-07c0-4bbd-b575-9e007773a958" />


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->