### PR TITLE
[8.19] [Synthetics] Changed embeddable view when only one monitor in one location is selected (#218402)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_embeddable_factory.tsx
@@ -51,7 +51,7 @@ export const getMonitorsEmbeddableFactory = (
     deserializeState: (state) => {
       return state.rawState as OverviewEmbeddableState;
     },
-    buildEmbeddable: async (state, buildApi, uuid, parentApi) => {
+    buildEmbeddable: async (state, buildApi) => {
       const [coreStart, pluginStart] = await getStartServices();
 
       const titleManager = initializeTitleManager(state);

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_grid_component.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_grid_component.tsx
@@ -5,17 +5,28 @@
  * 2.0.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { Subject } from 'rxjs';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { areFiltersEmpty } from '../common/utils';
 import { getOverviewStore } from './redux_store';
 import { ShowSelectedFilters } from '../common/show_selected_filters';
-import { setOverviewPageStateAction } from '../../synthetics/state';
+import {
+  selectOverviewTrends,
+  setFlyoutConfig,
+  setOverviewPageStateAction,
+  trendStatsBatch,
+} from '../../synthetics/state';
 import { MonitorFilters } from './types';
 import { EmbeddablePanelWrapper } from '../../synthetics/components/common/components/embeddable_panel_wrapper';
 import { SyntheticsEmbeddableContext } from '../synthetics_embeddable_context';
 import { OverviewGrid } from '../../synthetics/components/monitors_page/overview/overview/overview_grid';
+import { useMonitorsSortedByStatus } from '../../synthetics/hooks/use_monitors_sorted_by_status';
+import { MetricItem } from '../../synthetics/components/monitors_page/overview/overview/metric_item/metric_item';
+import { FlyoutParamProps } from '../../synthetics/components/monitors_page/overview/overview/types';
+import { MaybeMonitorDetailsFlyout } from '../../synthetics/components/monitors_page/overview/overview/monitor_detail_flyout';
+import { useOverviewStatus } from '../../synthetics/components/monitors_page/hooks/use_overview_status';
+import { OverviewLoader } from '../../synthetics/components/monitors_page/overview/overview/overview_loader';
 
 export const StatusGridComponent = ({
   reload$,
@@ -27,19 +38,83 @@ export const StatusGridComponent = ({
   const overviewStore = useRef(getOverviewStore());
 
   const hasFilters = !areFiltersEmpty(filters);
+  const singleMonitor =
+    filters && filters.locations.length === 1 && filters.monitorIds.length === 1;
 
-  return (
+  const monitorOverviewListComponent = (
+    <SyntheticsEmbeddableContext reload$={reload$} reduxStore={overviewStore.current}>
+      <MonitorsOverviewList filters={filters} singleMonitor={singleMonitor} />
+    </SyntheticsEmbeddableContext>
+  );
+
+  return singleMonitor ? (
+    monitorOverviewListComponent
+  ) : (
     <EmbeddablePanelWrapper
       titleAppend={hasFilters ? <ShowSelectedFilters filters={filters ?? {}} /> : null}
     >
-      <SyntheticsEmbeddableContext reload$={reload$} reduxStore={overviewStore.current}>
-        <MonitorsOverviewList filters={filters} />
-      </SyntheticsEmbeddableContext>
+      {monitorOverviewListComponent}
     </EmbeddablePanelWrapper>
   );
 };
 
-const MonitorsOverviewList = ({ filters }: { filters: MonitorFilters }) => {
+const SingleMonitorView = () => {
+  const trendData = useSelector(selectOverviewTrends);
+  const dispatch = useDispatch();
+
+  const setFlyoutConfigCallback = useCallback(
+    (params: FlyoutParamProps) => {
+      dispatch(setFlyoutConfig(params));
+    },
+    [dispatch]
+  );
+
+  const { loaded } = useOverviewStatus({
+    scopeStatusByLocation: true,
+  });
+  const monitorsSortedByStatus = useMonitorsSortedByStatus();
+
+  if (loaded && monitorsSortedByStatus.length !== 1) {
+    throw new Error(
+      'One and only one monitor should always be returned by useMonitorsSortedByStatus in this component, this should never happen'
+    );
+  }
+
+  const monitor = monitorsSortedByStatus.length === 1 ? monitorsSortedByStatus[0] : undefined;
+
+  useEffect(() => {
+    if (monitor && !trendData[monitor.configId + monitor.locationId]) {
+      dispatch(
+        trendStatsBatch.get([
+          {
+            configId: monitor.configId,
+            locationId: monitor.locationId,
+            schedule: monitor.schedule,
+          },
+        ])
+      );
+    }
+  }, [dispatch, monitor, trendData]);
+
+  const style = { height: '100%' };
+
+  if (!monitor) return <OverviewLoader rows={1} columns={1} style={style} />;
+
+  return (
+    <>
+      <MetricItem monitor={monitor} onClick={setFlyoutConfigCallback} style={style} />
+      <MaybeMonitorDetailsFlyout setFlyoutConfigCallback={setFlyoutConfigCallback} />
+    </>
+  );
+};
+
+const MonitorsOverviewList = ({
+  filters,
+  singleMonitor,
+}: {
+  filters: MonitorFilters;
+  singleMonitor?: boolean;
+}) => {
   const dispatch = useDispatch();
   useEffect(() => {
     if (!filters) return;
@@ -53,6 +128,10 @@ const MonitorsOverviewList = ({ filters }: { filters: MonitorFilters }) => {
       })
     );
   }, [dispatch, filters]);
+
+  if (singleMonitor) {
+    return <SingleMonitorView />;
+  }
 
   return <OverviewGrid />;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -20,6 +20,7 @@ import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { SYNTHETICS_MONITORS_EMBEDDABLE } from '../../../../../embeddables/constants';
 import { useCreateSLO } from '../../hooks/use_create_slo';
 import { TEST_SCHEDULED_LABEL } from '../../../monitor_add_edit/form/run_test_btn';
 import { useCanUsePublicLocById } from '../../hooks/use_can_use_public_loc_id';
@@ -36,6 +37,7 @@ import { setFlyoutConfig } from '../../../../state/overview/actions';
 import { useEditMonitorLocator } from '../../../../hooks/use_edit_monitor_locator';
 import { useMonitorDetailLocator } from '../../../../hooks/use_monitor_detail_locator';
 import { NoPermissionsTooltip } from '../../../common/components/permissions';
+import { useAddToDashboard } from '../../../common/components/add_to_dashboard';
 
 type PopoverPosition = 'relative' | 'default';
 
@@ -178,6 +180,23 @@ export function ActionsPopover({
     },
   };
 
+  const { MaybeSavedObjectSaveModalDashboard, setDashboardAttachmentReady } = useAddToDashboard({
+    type: SYNTHETICS_MONITORS_EMBEDDABLE,
+    embeddableInput: {
+      filters: {
+        monitorIds: [{ label: monitor.name, value: monitor.configId }],
+        tags: [],
+        locations: [{ label: monitor.locationLabel, value: monitor.locationId }],
+        monitorTypes: [],
+        projects: [],
+      },
+    },
+    documentTitle: `${monitor.name} - ${monitor.locationLabel}`,
+    objectType: i18n.translate('xpack.synthetics.overview.actions.addToDashboard.objectTypeLabel', {
+      defaultMessage: 'Monitor Overview',
+    }),
+  });
+
   const alertLoading = alertStatus(monitor.configId) === FETCH_STATUS.LOADING;
   let popoverItems: EuiContextMenuPanelItemDescriptor[] = [
     {
@@ -291,6 +310,14 @@ export function ActionsPopover({
         }
       },
     },
+    {
+      name: addMonitorToDashboardLabel,
+      icon: 'dashboardApp',
+      onClick: () => {
+        setIsPopoverOpen(false);
+        setDashboardAttachmentReady(true);
+      },
+    },
   ];
   if (isInspectView) popoverItems = popoverItems.filter((i) => i !== quickInspectPopoverItem);
 
@@ -331,6 +358,7 @@ export function ActionsPopover({
         </EuiPopover>
       </Container>
       {CreateSLOFlyout}
+      {MaybeSavedObjectSaveModalDashboard}
     </>
   );
 }
@@ -418,6 +446,13 @@ const enableMonitorAlertLabel = i18n.translate(
   'xpack.synthetics.overview.actions.enableLabelDisableAlert',
   {
     defaultMessage: 'Enable status alerts (all locations)',
+  }
+);
+
+const addMonitorToDashboardLabel = i18n.translate(
+  'xpack.synthetics.overview.actions.addToDashboard',
+  {
+    defaultMessage: 'Add to dashboard',
   }
 );
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.tsx
@@ -41,6 +41,7 @@ import { ActionsPopover } from './actions_popover';
 import {
   getMonitorAction,
   selectMonitorUpsertStatus,
+  selectOverviewState,
   selectServiceLocationsState,
   selectSyntheticsMonitor,
   selectSyntheticsMonitorError,
@@ -52,6 +53,7 @@ import { ConfigKey, EncryptedSyntheticsMonitor, OverviewStatusMetaData } from '.
 import { useMonitorDetailLocator } from '../../../../hooks/use_monitor_detail_locator';
 import { MonitorStatus } from '../../../common/components/monitor_status';
 import { MonitorLocationSelect } from '../../../common/components/monitor_location_select';
+import { quietFetchOverviewStatusAction } from '../../../../state/overview_status';
 
 interface Props {
   configId: string;
@@ -209,7 +211,7 @@ function DetailedFlyoutHeader({
 
 export function LoadingState() {
   return (
-    <EuiFlexGroup alignItems="center" justifyContent="center" style={{ height: '100%' }}>
+    <EuiFlexGroup alignItems="center" justifyContent="center" css={{ height: '100%' }}>
       <EuiFlexItem grow={false}>
         <EuiLoadingSpinner size="xl" />
       </EuiFlexItem>
@@ -369,6 +371,34 @@ export function MonitorDetailFlyout(props: Props) {
     </EuiFlyout>
   );
 }
+
+export const MaybeMonitorDetailsFlyout = ({
+  setFlyoutConfigCallback,
+}: {
+  setFlyoutConfigCallback: (params: FlyoutParamProps) => void;
+}) => {
+  const dispatch = useDispatch();
+
+  const { flyoutConfig, pageState } = useSelector(selectOverviewState);
+  const hideFlyout = useCallback(() => dispatch(setFlyoutConfig(null)), [dispatch]);
+  const forceRefreshCallback = useCallback(
+    () => dispatch(quietFetchOverviewStatusAction.get({ pageState })),
+    [dispatch, pageState]
+  );
+
+  return flyoutConfig?.configId && flyoutConfig?.location ? (
+    <MonitorDetailFlyout
+      configId={flyoutConfig.configId}
+      id={flyoutConfig.id}
+      location={flyoutConfig.location}
+      locationId={flyoutConfig.locationId}
+      spaceId={flyoutConfig.spaceId}
+      onClose={hideFlyout}
+      onEnabledChange={forceRefreshCallback}
+      onLocationChange={setFlyoutConfigCallback}
+    />
+  ) : null;
+};
 
 const DURATION_HEADER_TEXT = i18n.translate('xpack.synthetics.monitorList.durationHeaderText', {
   defaultMessage: 'Duration',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_grid.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_grid.tsx
@@ -21,7 +21,6 @@ import {
 import { MetricItem } from './metric_item/metric_item';
 import { ShowAllSpaces } from '../../common/show_all_spaces';
 import { OverviewStatusMetaData } from '../../../../../../../common/runtime_types';
-import { quietFetchOverviewStatusAction } from '../../../../state/overview_status';
 import type { TrendRequest } from '../../../../../../../common/types';
 import { SYNTHETICS_MONITORS_EMBEDDABLE } from '../../../../../embeddables/constants';
 import { AddToDashboard } from '../../../common/components/add_to_dashboard';
@@ -39,9 +38,9 @@ import { OverviewLoader } from './overview_loader';
 import { OverviewPaginationInfo } from './overview_pagination_info';
 import { SortFields } from './sort_fields';
 import { NoMonitorsFound } from '../../common/no_monitors_found';
-import { MonitorDetailFlyout } from './monitor_detail_flyout';
 import { useSyntheticsRefreshContext } from '../../../../contexts';
 import { FlyoutParamProps } from './types';
+import { MaybeMonitorDetailsFlyout } from './monitor_detail_flyout';
 
 const ITEM_HEIGHT = 172;
 const ROW_COUNT = 4;
@@ -61,7 +60,6 @@ export const OverviewGrid = memo(() => {
   const monitorsSortedByStatus: OverviewStatusMetaData[] = useMonitorsSortedByStatus();
 
   const {
-    flyoutConfig,
     pageState,
     groupBy: { field: groupField },
   } = useSelector(selectOverviewState);
@@ -77,12 +75,7 @@ export const OverviewGrid = memo(() => {
     (params: FlyoutParamProps) => dispatch(setFlyoutConfig(params)),
     [dispatch]
   );
-  const hideFlyout = useCallback(() => dispatch(setFlyoutConfig(null)), [dispatch]);
   const { lastRefresh } = useSyntheticsRefreshContext();
-  const forceRefreshCallback = useCallback(
-    () => dispatch(quietFetchOverviewStatusAction.get({ pageState })),
-    [dispatch, pageState]
-  );
 
   useEffect(() => {
     if (monitorsSortedByStatus.length) {
@@ -252,18 +245,7 @@ export const OverviewGrid = memo(() => {
             </EuiFlexGroup>
           </>
         )}
-      {flyoutConfig?.configId && flyoutConfig?.location && (
-        <MonitorDetailFlyout
-          configId={flyoutConfig.configId}
-          id={flyoutConfig.id}
-          location={flyoutConfig.location}
-          locationId={flyoutConfig.locationId}
-          spaceId={flyoutConfig.spaceId}
-          onClose={hideFlyout}
-          onEnabledChange={forceRefreshCallback}
-          onLocationChange={setFlyoutConfigCallback}
-        />
-      )}
+      <MaybeMonitorDetailsFlyout setFlyoutConfigCallback={setFlyoutConfigCallback} />
     </>
   );
 });

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_loader.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_loader.tsx
@@ -6,15 +6,23 @@
  */
 
 import React from 'react';
-import { EuiFlexGrid, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGrid, EuiFlexItem, EuiFlexGridProps } from '@elastic/eui';
 import { OverviewGridItemLoader } from './overview_grid_item_loader';
 
-export const OverviewLoader = ({ rows }: { rows?: number }) => {
+export const OverviewLoader = ({
+  rows,
+  columns,
+  style,
+}: {
+  rows?: number;
+  columns?: EuiFlexGridProps['columns'];
+  style?: { height: string };
+}) => {
   const ROWS = rows ?? 4;
-  const COLUMNS = 4;
+  const COLUMNS = columns ?? 4;
   const loaders = Array(ROWS * COLUMNS).fill(null);
   return (
-    <EuiFlexGrid gutterSize="m" columns={COLUMNS}>
+    <EuiFlexGrid gutterSize="m" columns={COLUMNS} css={style}>
       {loaders.map((_, i) => (
         <EuiFlexItem key={i}>
           <OverviewGridItemLoader />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Changed embeddable view when only one monitor in one location is selected (#218402)](https://github.com/elastic/kibana/pull/218402)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-04-17T12:03:40Z","message":"[Synthetics] Changed embeddable view when only one monitor in one location is selected (#218402)\n\nThis PR closes #208981 by adding a new action to the Monitor card to\nview only that monitor in the dashboard.\n\n\n\nhttps://github.com/user-attachments/assets/f500d220-b57f-4c43-a632-b2383e33988e\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"ec939b6718dee6969f3fc57707d46778cc833393","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Synthetics] Changed embeddable view when only one monitor in one location is selected","number":218402,"url":"https://github.com/elastic/kibana/pull/218402","mergeCommit":{"message":"[Synthetics] Changed embeddable view when only one monitor in one location is selected (#218402)\n\nThis PR closes #208981 by adding a new action to the Monitor card to\nview only that monitor in the dashboard.\n\n\n\nhttps://github.com/user-attachments/assets/f500d220-b57f-4c43-a632-b2383e33988e\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"ec939b6718dee6969f3fc57707d46778cc833393"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218402","number":218402,"mergeCommit":{"message":"[Synthetics] Changed embeddable view when only one monitor in one location is selected (#218402)\n\nThis PR closes #208981 by adding a new action to the Monitor card to\nview only that monitor in the dashboard.\n\n\n\nhttps://github.com/user-attachments/assets/f500d220-b57f-4c43-a632-b2383e33988e\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"ec939b6718dee6969f3fc57707d46778cc833393"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->