### PR TITLE
[Docs] Add link to dependencies page

### DIFF
--- a/docs/extend/dependencies-versions.md
+++ b/docs/extend/dependencies-versions.md
@@ -1,0 +1,3 @@
+# List of dependencies [dependencies-versions]
+
+Refer to [Elastic Stack third-party dependencies](https://artifacts.elastic.co/reports/dependencies/dependencies-current.html) for the complete list of dependencies.

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -14,5 +14,6 @@ Contributing to {{kib}} can be daunting at first, but it doesn’t have to be. T
 * [External plugin development](./external-plugin-development.md)
 * [Advanced](./advanced.md)
 * [List of {{kib}} plugins](./plugin-list.md)
+* [List of dependencies](./dependencies-versions.md)
 * [Development Telemetry](./development-telemetry.md)
 

--- a/docs/extend/toc.yml
+++ b/docs/extend/toc.yml
@@ -65,4 +65,5 @@ toc:
       - file: dashboard-enhanced-plugin.md
       - file: enhanced-embeddables-plugin.md
       - file: translations-plugin.md
+  - file: dependencies-versions.md
   - file: development-telemetry.md


### PR DESCRIPTION
## Summary

[Take 2] Adding in a page that was missing from the new docs.

Failing due to ongoing docs build issue. Closing this for now.