### PR TITLE
Renovate Update Active Branches for `8.x` and `8.16`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,10 +18,9 @@
   "baseBranches": [
     "main",
     "9.0",
-    "8.x",
+    "8.19",
     "8.18",
     "8.17",
-    "8.16",
     "7.17"
   ],
   "prConcurrentLimit": 0,
@@ -135,8 +134,7 @@
       "matchBaseBranches": [
         "main",
         "/^[9].*/",
-        "8.x",
-        "8.18"
+        "8.19"
       ],
       "labels": [
         "Team:Operations",
@@ -1044,7 +1042,7 @@
       ],
       "allowedVersions": "<9.0.0",
       "matchBaseBranches": [
-        "8.x"
+        "8.19"
       ],
       "labels": [
         "release_note:skip",


### PR DESCRIPTION
## Summary

- Remove dep updates for `8.16`
- Transition `8.x` to `8.19`



