### PR TITLE
[Attack Discovery][Scheduling] Feature flag fix in 8.19

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
@@ -66,7 +66,7 @@ export const DEFEND_INSIGHTS_BY_ID = `${DEFEND_INSIGHTS}/{id}`;
 
 // Attack Discovery
 export const ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG =
-  'securitySolution.assistantAttackDiscoverySchedulingEnabled' as const;
+  'securitySolution-assistantAttackDiscoverySchedulingEnabled' as const;
 export const ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID = 'attack-discovery' as const;
 
 export const ATTACK_DISCOVERY = `${ELASTIC_AI_ASSISTANT_INTERNAL_URL}/attack_discovery` as const;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/utils/is_feature_available.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/utils/is_feature_available.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { AwaitedProperties } from '@kbn/utility-types';
+import { ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG } from '@kbn/elastic-assistant-common';
 import { ElasticAssistantRequestHandlerContext } from '../../../../types';
 import { isFeatureAvailable } from './is_feature_available';
 
@@ -27,7 +28,7 @@ describe('isFeatureAvailable', () => {
     void isFeatureAvailable(mockContext);
 
     expect(getBooleanValueMock).toHaveBeenCalledWith(
-      'securitySolution.assistantAttackDiscoverySchedulingEnabled',
+      ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG,
       false
     );
   });


### PR DESCRIPTION
## Summary

There is a bug in 8.19 within attack discovery schedule feature where new endpoints return NotFound error response even when feature flag is enabled.

The issue is the format of the feature flag which is recommended to be `pluginName.featureFlagName` and thus we used `securitySolution.assistantAttackDiscoverySchedulingEnabled`. However, this format is not supported in `8.x` branches and was fixed only in `9.x` [by this PR](https://github.com/elastic/kibana/pull/196535). ([internal discussion](https://elastic.slack.com/archives/C5TQ33ND8/p1744929237323229))

As a workaround, we will switch the feature flag in `8.19` to the supported format `securitySolution-assistantAttackDiscoverySchedulingEnabled`.

## NOTES

To enable the feature feature flag, put next lines in `kibana.dev.yml`:

```
feature_flags.overrides:
  securitySolution-assistantAttackDiscoverySchedulingEnabled: true
```
