### PR TITLE
[Serialized State Only] Button embeddable

### DIFF
--- a/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_with_embeddable_example/drilldowns_with_embeddable_example.tsx
+++ b/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_with_embeddable_example/drilldowns_with_embeddable_example.tsx
@@ -95,7 +95,7 @@ export const DrilldownsWithEmbeddableExample: React.FC = () => {
         <EuiFlexItem grow={false}>{openManagerButton}</EuiFlexItem>
         <EuiFlexItem grow={false}>
           <div style={{ maxWidth: 200 }}>
-            <EmbeddableRenderer<{}>
+            <EmbeddableRenderer
               type={BUTTON_EMBEDDABLE}
               getParentApi={() => ({
                 getSerializedStateForChild: () => undefined,

--- a/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_with_embeddable_example/drilldowns_with_embeddable_example.tsx
+++ b/x-pack/examples/ui_actions_enhanced_examples/public/containers/drilldowns_with_embeddable_example/drilldowns_with_embeddable_example.tsx
@@ -18,7 +18,7 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
 } from '@elastic/eui';
-import { ReactEmbeddableRenderer, VALUE_CLICK_TRIGGER } from '@kbn/embeddable-plugin/public';
+import { EmbeddableRenderer, VALUE_CLICK_TRIGGER } from '@kbn/embeddable-plugin/public';
 import { useUiActions } from '../../context';
 import { BUTTON_EMBEDDABLE } from '../../embeddables/register_button_embeddable';
 
@@ -95,7 +95,7 @@ export const DrilldownsWithEmbeddableExample: React.FC = () => {
         <EuiFlexItem grow={false}>{openManagerButton}</EuiFlexItem>
         <EuiFlexItem grow={false}>
           <div style={{ maxWidth: 200 }}>
-            <ReactEmbeddableRenderer<{}, {}>
+            <EmbeddableRenderer<{}>
               type={BUTTON_EMBEDDABLE}
               getParentApi={() => ({
                 getSerializedStateForChild: () => undefined,

--- a/x-pack/examples/ui_actions_enhanced_examples/public/embeddables/button_embeddable.tsx
+++ b/x-pack/examples/ui_actions_enhanced_examples/public/embeddables/button_embeddable.tsx
@@ -13,61 +13,21 @@ import {
 } from '@kbn/embeddable-plugin/public';
 import { EuiCard, EuiFlexItem, EuiIcon } from '@elastic/eui';
 import { AdvancedUiActionsStart } from '@kbn/ui-actions-enhanced-plugin/public';
-import {
-  initializeTitleManager,
-  initializeStateManager,
-  titleComparators,
-} from '@kbn/presentation-publishing';
-import { map, merge } from 'rxjs';
-import { initializeUnsavedChanges } from '@kbn/presentation-containers';
 import { BUTTON_EMBEDDABLE } from './register_button_embeddable';
 
 export const getButtonEmbeddableFactory = (uiActionsEnhanced: AdvancedUiActionsStart) => {
   const factory: EmbeddableFactory<{}, DefaultEmbeddableApi<{}>> = {
     type: BUTTON_EMBEDDABLE,
     buildEmbeddable: async ({ initialState, finalizeApi, parentApi, uuid }) => {
-      const titleManager = initializeTitleManager(initialState.rawState);
-      const buttonStateManager = initializeStateManager(initialState.rawState, {});
       function serializeState() {
         return {
-          rawState: {
-            ...titleManager.getLatestState(),
-            ...buttonStateManager.getLatestState(),
-          },
+          rawState: {},
           references: [],
           // references: if this embeddable had any references - this is where we would extract them.
         };
       }
-      const unsavedChangesApi = initializeUnsavedChanges({
-        uuid,
-        parentApi,
-        serializeState,
-        anyStateChange$: merge(
-          titleManager.anyStateChange$,
-          buttonStateManager.anyStateChange$
-        ).pipe(map(() => undefined)),
-        getComparators: () => {
-          /**
-           * comparators are provided in a callback to allow embeddables to change how their state is compared based
-           * on the values of other state. For instance, if a saved object ID is present (by reference), the embeddable
-           * may want to skip comparison of certain state.
-           */
-          return { ...titleComparators };
-        },
-        onReset: (lastSaved) => {
-          /**
-           * if this embeddable had a difference between its runtime and serialized state, we could run the 'deserializeState'
-           * function here before resetting. onReset can be async so to support a potential async deserialize function.
-           */
-
-          titleManager.reinitializeState(lastSaved?.rawState);
-          buttonStateManager.reinitializeState(lastSaved?.rawState);
-        },
-      });
 
       const api = finalizeApi({
-        ...unsavedChangesApi,
-        ...titleManager.api,
         serializeState,
       });
       return {


### PR DESCRIPTION
This PR does not need to be reviewed by external teams. This PR merges into a feature branch that Kibana presentation team is working on to convert the embeddable framework to only expose serialized state. Your team will be pinged for review once the work is complete and the final PR opens that merges the feature branch into main

This removes runtime state from the button example embeddable.