### PR TITLE
[9.0] [Obs AI Assistant]fixing error - Display results and Visualize query Bedrock Error (#218213)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/chat/chat_body.tsx
@@ -275,75 +275,74 @@ export function ChatBody({
     navigator.clipboard?.writeText(content || '');
   };
 
-  const handleActionClick = ({
-    message,
-    payload,
-  }: {
-    message: Message;
-    payload: ChatActionClickPayload;
-  }) => {
-    setStickToBottom(true);
-    switch (payload.type) {
-      case ChatActionClickType.executeEsqlQuery:
-        next(
-          messages.concat({
-            '@timestamp': new Date().toISOString(),
-            message: {
-              role: MessageRole.Assistant,
-              content: '',
-              function_call: {
-                name: 'execute_query',
-                arguments: JSON.stringify({
-                  query: payload.query,
-                }),
-                trigger: MessageRole.User,
+  const handleActionClick = useCallback(
+    ({ message, payload }: { message: Message; payload: ChatActionClickPayload }) => {
+      setStickToBottom(true);
+      switch (payload.type) {
+        case ChatActionClickType.executeEsqlQuery:
+          next(
+            messages.concat({
+              '@timestamp': new Date().toISOString(),
+              message: {
+                role: MessageRole.Assistant,
+                content: '',
+                function_call: {
+                  name: 'execute_query',
+                  arguments: JSON.stringify({
+                    query: payload.query,
+                  }),
+                  trigger: MessageRole.User,
+                },
               },
-            },
-          })
-        );
-        break;
+            })
+          );
+          break;
 
-      case ChatActionClickType.updateVisualization:
-        const visualizeQueryResponse = message;
+        case ChatActionClickType.updateVisualization:
+          const visualizeQueryResponse = message;
 
-        const visualizeQueryResponseData = JSON.parse(visualizeQueryResponse.message.data ?? '{}');
+          const visualizeQueryResponseData = JSON.parse(
+            visualizeQueryResponse.message.data ?? '{}'
+          );
 
-        next(
-          messages.slice(0, messages.indexOf(visualizeQueryResponse)).concat({
-            '@timestamp': new Date().toISOString(),
-            message: {
-              name: 'visualize_query',
-              content: visualizeQueryResponse.message.content,
-              data: JSON.stringify({
-                ...visualizeQueryResponseData,
-                userOverrides: payload.userOverrides,
-              }),
-              role: MessageRole.User,
-            },
-          })
-        );
-        break;
-      case ChatActionClickType.visualizeEsqlQuery:
-        next(
-          messages.concat({
-            '@timestamp': new Date().toISOString(),
-            message: {
-              role: MessageRole.Assistant,
-              content: '',
-              function_call: {
+          next(
+            messages.slice(0, messages.indexOf(visualizeQueryResponse)).concat({
+              '@timestamp': new Date().toISOString(),
+              message: {
                 name: 'visualize_query',
-                arguments: JSON.stringify({
-                  query: payload.query,
-                  intention: VisualizeESQLUserIntention.visualizeAuto,
+                content: visualizeQueryResponse.message.content,
+                data: JSON.stringify({
+                  ...visualizeQueryResponseData,
+                  userOverrides: payload.userOverrides,
                 }),
-                trigger: MessageRole.User,
+                role: MessageRole.User,
               },
-            },
-          })
-        );
-        break;
-    }
-  };
+            })
+          );
+          break;
+        case ChatActionClickType.visualizeEsqlQuery:
+          next(
+            messages.concat({
+              '@timestamp': new Date().toISOString(),
+              message: {
+                role: MessageRole.Assistant,
+                content: '',
+                function_call: {
+                  name: 'visualize_query',
+                  arguments: JSON.stringify({
+                    query: payload.query,
+                    intention: VisualizeESQLUserIntention.visualizeAuto,
+                  }),
+                  trigger: MessageRole.User,
+                },
+              },
+            })
+          );
+          break;
+      }
+    },
+    [messages, next]
+  );
 
   if (!hasCorrectLicense && !initialConversationId) {
     footer = (

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/message_panel/message_text.tsx
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/components/message_panel/message_text.tsx
@@ -18,7 +18,7 @@ import {
 import { css } from '@emotion/css';
 import classNames from 'classnames';
 import type { Code, InlineCode, Parent, Text } from 'mdast';
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import type { Node } from 'unist';
 import { ChatActionClickHandler } from '../chat/types';
 import { CodeBlock, EsqlCodeBlock } from './esql_code_block';
@@ -120,10 +120,6 @@ export function MessageText({ loading, content, onActionClick }: Props) {
     overflow-wrap: anywhere;
   `;
 
-  const onActionClickRef = useRef(onActionClick);
-
-  onActionClickRef.current = onActionClick;
-
   const { parsingPluginList, processingPluginList } = useMemo(() => {
     const parsingPlugins = getDefaultEuiMarkdownParsingPlugins();
 
@@ -148,7 +144,7 @@ export function MessageText({ loading, content, onActionClick }: Props) {
             <EsqlCodeBlock
               value={props.value}
               actionsDisabled={loading}
-              onActionClick={onActionClickRef.current}
+              onActionClick={onActionClick}
             />
             <EuiSpacer size="m" />
           </>
@@ -186,7 +182,7 @@ export function MessageText({ loading, content, onActionClick }: Props) {
       parsingPluginList: [loadingCursorPlugin, esqlLanguagePlugin, ...parsingPlugins],
       processingPluginList: processingPlugins,
     };
-  }, [loading]);
+  }, [loading, onActionClick]);
 
   return (
     <EuiText size="s" className={containerClassName}>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Obs AI Assistant]fixing error - Display results and Visualize query Bedrock Error (#218213)](https://github.com/elastic/kibana/pull/218213)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Arturo Lidueña","email":"arturo.liduena@elastic.co"},"sourceCommit":{"committedDate":"2025-04-21T08:51:18Z","message":"[Obs AI Assistant]fixing error - Display results and Visualize query Bedrock Error (#218213)\n\n### Fix: Bedrock Streaming Error on ES|QL Actions\n\n#### Summary\n\nWhen an ES|QL is generated, we present two action buttons:\n- Visualize Query\n- Display Results\n\nThese actions were not working as expected when using Bedrock as the\nmodel provider.\n\n#### Error Details\n```txt\nEncountered error in Bedrock stream of type validationException messages.8: Did not find 1 `tool_result` block(s) at the beginning of this message. Messages following `tool_use` blocks must begin with a matching number of `tool_result` blocks.\n```\n#### Root Cause\n\nWe were sending a tool_use block in the assistant message without\nimmediately following it with the corresponding tool_result block. This\nviolates Bedrock’s message protocol.","sha":"33993b7123bc0d6c85d9c42b15610cc0d5092281","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","Team:Obs AI Assistant","ci:project-deploy-observability","v9.1.0"],"title":"[Obs AI Assistant]fixing error - Display results and Visualize query Bedrock Error","number":218213,"url":"https://github.com/elastic/kibana/pull/218213","mergeCommit":{"message":"[Obs AI Assistant]fixing error - Display results and Visualize query Bedrock Error (#218213)\n\n### Fix: Bedrock Streaming Error on ES|QL Actions\n\n#### Summary\n\nWhen an ES|QL is generated, we present two action buttons:\n- Visualize Query\n- Display Results\n\nThese actions were not working as expected when using Bedrock as the\nmodel provider.\n\n#### Error Details\n```txt\nEncountered error in Bedrock stream of type validationException messages.8: Did not find 1 `tool_result` block(s) at the beginning of this message. Messages following `tool_use` blocks must begin with a matching number of `tool_result` blocks.\n```\n#### Root Cause\n\nWe were sending a tool_use block in the assistant message without\nimmediately following it with the corresponding tool_result block. This\nviolates Bedrock’s message protocol.","sha":"33993b7123bc0d6c85d9c42b15610cc0d5092281"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218213","number":218213,"mergeCommit":{"message":"[Obs AI Assistant]fixing error - Display results and Visualize query Bedrock Error (#218213)\n\n### Fix: Bedrock Streaming Error on ES|QL Actions\n\n#### Summary\n\nWhen an ES|QL is generated, we present two action buttons:\n- Visualize Query\n- Display Results\n\nThese actions were not working as expected when using Bedrock as the\nmodel provider.\n\n#### Error Details\n```txt\nEncountered error in Bedrock stream of type validationException messages.8: Did not find 1 `tool_result` block(s) at the beginning of this message. Messages following `tool_use` blocks must begin with a matching number of `tool_result` blocks.\n```\n#### Root Cause\n\nWe were sending a tool_use block in the assistant message without\nimmediately following it with the corresponding tool_result block. This\nviolates Bedrock’s message protocol.","sha":"33993b7123bc0d6c85d9c42b15610cc0d5092281"}}]}] BACKPORT-->