### PR TITLE
[Obs AI Assistant] Unskip summarize tests

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/summarize.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/summarize.spec.ts
@@ -24,8 +24,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const es = getService('es');
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
 
-  // Failing test: https://github.com/elastic/kibana/issues/218497
-  describe.skip('summarize', function () {
+  describe('summarize', function () {
     // Fails on MKI: https://github.com/elastic/kibana/issues/205581
     this.tags(['failsOnMKI']);
     let proxy: LlmProxy;

--- a/x-pack/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/knowledge_base_management/index.spec.ts
@@ -48,8 +48,7 @@ export default function ApiTest({ getService, getPageObjects }: FtrProviderConte
     }).expect(200);
   }
 
-  // Failing test: https://github.com/elastic/kibana/issues/218327
-  describe.skip('Knowledge management tab', () => {
+  describe('Knowledge management tab', () => {
     before(async () => {
       await clearKnowledgeBase(es);
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/218497

## Summary

The summarize tests were skipped last week because they were failing and blocking pipelines.

These tests have started to fail after the merge of https://github.com/elastic/elasticsearch/pull/126635
These changes were reverted last week in https://github.com/elastic/elasticsearch/pull/127075

Therefore, this PR unskips the tests.

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->