### PR TITLE
[Search] test: es3 navigation fix & updates

### DIFF
--- a/src/platform/test/functional/page_objects/console_page.ts
+++ b/src/platform/test/functional/page_objects/console_page.ts
@@ -279,6 +279,10 @@ export class ConsolePageObject extends FtrService {
     return classAttribute?.includes('euiPopover-isOpen');
   }
 
+  public async isTourPopoverOpen() {
+    return this.testSubjects.isDisplayed('consoleSkipTourButton');
+  }
+
   public async clickSkipTour() {
     await this.testSubjects.click('consoleSkipTourButton');
   }

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { AppDeepLinkId } from '@kbn/core-chrome-browser';
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
@@ -14,13 +15,14 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
   const svlCommonNavigation = getPageObject('svlCommonNavigation');
   const svlCommonPage = getPageObject('svlCommonPage');
   const solutionNavigation = getPageObject('solutionNavigation');
+  const console = getPageObject('console');
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
   const header = getPageObject('header');
 
   describe('navigation', function () {
     // see details: https://github.com/elastic/kibana/issues/218719
-    this.tags(['failsOnMKI']);
+    // this.tags(['failsOnMKI']);
     before(async () => {
       await svlCommonPage.loginWithRole('developer');
       await svlSearchNavigation.navigateToLandingPage();
@@ -33,8 +35,8 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await svlCommonNavigation.breadcrumbs.expectExists();
       await svlSearchLandingPage.assertSvlSearchSideNavExists();
 
-      // check side nav links
       await solutionNavigation.sidenav.expectSectionExists('search_project_nav');
+      // Check landing page / global empty state
       await solutionNavigation.sidenav.expectLinkActive({
         deepLinkId: 'elasticsearchIndexManagement',
       });
@@ -44,109 +46,87 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       });
       await testSubjects.existOrFail(`elasticsearchStartPage`);
 
-      // check Data
-      // > Index Management
-      await solutionNavigation.sidenav.clickLink({
-        deepLinkId: 'elasticsearchIndexManagement',
-      });
-      await solutionNavigation.sidenav.expectLinkActive({
-        deepLinkId: 'elasticsearchIndexManagement',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Data' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Index Management' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Indices' });
+      // Check Side Nav Links
+      const sideNavCases: Array<{
+        deepLinkId: AppDeepLinkId;
+        breadcrumbs: string[];
+        pageTestSubject: string;
+        extraCheck?: () => Promise<void>;
+      }> = [
+        {
+          deepLinkId: 'elasticsearchIndexManagement',
+          breadcrumbs: ['Data', 'Index Management', 'Indices'],
+          pageTestSubject: 'elasticsearchIndexManagement',
+        },
+        {
+          deepLinkId: 'serverlessConnectors',
+          breadcrumbs: ['Data', 'Connectors'],
+          pageTestSubject: 'svlSearchConnectorsPage',
+        },
+        {
+          deepLinkId: 'serverlessWebCrawlers',
+          breadcrumbs: ['Data', 'Web Crawlers'],
+          pageTestSubject: 'serverlessSearchConnectorsTitle', // TODO: this page should have a different test subject
+        },
+        {
+          deepLinkId: 'dev_tools:console',
+          breadcrumbs: ['Build', 'Dev Tools'],
+          pageTestSubject: 'console',
+          extraCheck: async () => {
+            if (await console.isTourPopoverOpen()) {
+              // Skip the tour if it's open. This will prevent the tour popover from staying on the page
+              // and blocking breadcrumbs for other tests.
+              await console.clickSkipTour();
+            }
+          },
+        },
+        {
+          deepLinkId: 'searchPlayground',
+          breadcrumbs: ['Build', 'Playground'],
+          pageTestSubject: 'svlPlaygroundPage',
+        },
+        {
+          deepLinkId: 'searchInferenceEndpoints',
+          breadcrumbs: ['Relevance', 'Inference Endpoints'],
+          pageTestSubject: 'inferenceEndpointsPage',
+        },
+        {
+          deepLinkId: 'searchSynonyms',
+          breadcrumbs: ['Relevance', 'Synonyms'],
+          pageTestSubject: 'searchSynonymsOverviewPage',
+        },
+        {
+          deepLinkId: 'discover',
+          breadcrumbs: ['Analyze', 'Discover'],
+          pageTestSubject: 'queryInput',
+        },
+        {
+          deepLinkId: 'dashboards',
+          breadcrumbs: ['Analyze', 'Dashboards'],
+          pageTestSubject: 'dashboardLandingPage',
+        },
+        {
+          deepLinkId: 'serverlessElasticsearch',
+          breadcrumbs: ['Getting Started'],
+          pageTestSubject: 'svlSearchOverviewPage',
+        },
+      ];
 
-      // > Connectors
-      await solutionNavigation.sidenav.clickLink({
-        deepLinkId: 'serverlessConnectors',
-      });
-      await solutionNavigation.sidenav.expectLinkActive({
-        deepLinkId: 'serverlessConnectors',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Data' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Connectors' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        deepLinkId: 'serverlessConnectors',
-      });
-      // check Build
-      // > Dev Tools
-      await solutionNavigation.sidenav.clickLink({
-        deepLinkId: 'dev_tools:console',
-      });
-      await solutionNavigation.sidenav.expectLinkActive({
-        deepLinkId: 'dev_tools:console',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Build' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Dev Tools' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        deepLinkId: 'dev_tools:console',
-      });
-      // > Playground
-      await solutionNavigation.sidenav.clickLink({
-        deepLinkId: 'searchPlayground',
-      });
-      await solutionNavigation.sidenav.expectLinkActive({
-        deepLinkId: 'searchPlayground',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Build' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Playground' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        deepLinkId: 'searchPlayground',
-      });
-      // check Relevance
-      // > Inference Endpoints
-      await solutionNavigation.sidenav.clickLink({
-        deepLinkId: 'searchInferenceEndpoints',
-      });
-      await solutionNavigation.sidenav.expectLinkActive({
-        deepLinkId: 'searchInferenceEndpoints',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Relevance' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Inference Endpoints' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        deepLinkId: 'searchInferenceEndpoints',
-      });
-
-      // check Analyze
-      // > Discover
-      await solutionNavigation.sidenav.clickLink({
-        deepLinkId: 'discover',
-      });
-      await solutionNavigation.sidenav.expectLinkActive({
-        deepLinkId: 'discover',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Analyze' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Discover' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        deepLinkId: 'discover',
-      });
-      // > Dashboards
-      await solutionNavigation.sidenav.clickLink({
-        deepLinkId: 'dashboards',
-      });
-      await solutionNavigation.sidenav.expectLinkActive({
-        deepLinkId: 'dashboards',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Analyze' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Dashboards' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        deepLinkId: 'dashboards',
-      });
-
-      // check Getting Started
-      await solutionNavigation.sidenav.clickLink({
-        deepLinkId: 'serverlessElasticsearch',
-      });
-      await solutionNavigation.sidenav.expectLinkActive({
-        deepLinkId: 'serverlessElasticsearch',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: 'Getting Started' });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        text: 'Getting Started',
-      });
-      await solutionNavigation.breadcrumbs.expectBreadcrumbExists({
-        deepLinkId: 'serverlessElasticsearch',
-      });
+      for (const testCase of sideNavCases) {
+        await solutionNavigation.sidenav.clickLink({
+          deepLinkId: testCase.deepLinkId,
+        });
+        await solutionNavigation.sidenav.expectLinkActive({
+          deepLinkId: testCase.deepLinkId,
+        });
+        for (const breadcrumb of testCase.breadcrumbs) {
+          await solutionNavigation.breadcrumbs.expectBreadcrumbExists({ text: breadcrumb });
+        }
+        await testSubjects.existOrFail(testCase.pageTestSubject);
+        if (testCase.extraCheck !== undefined) {
+          await testCase.extraCheck();
+        }
+      }
 
       // Open Project Settings
       await solutionNavigation.sidenav.openSection('project_settings_project_nav');

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -21,8 +21,6 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
   const header = getPageObject('header');
 
   describe('navigation', function () {
-    // see details: https://github.com/elastic/kibana/issues/218719
-    // this.tags(['failsOnMKI']);
     before(async () => {
       await svlCommonPage.loginWithRole('developer');
       await svlSearchNavigation.navigateToLandingPage();


### PR DESCRIPTION
## Summary

Fixed the navigation tests for es3 to close the console tour, in addition I abstracted the side nav test cases to be more uniform and wait for a specific test object on the page before moving to the next side nav link.

I tested these against MKI

Closes #218719

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
