### PR TITLE
[ObsUX][Infra] Filter out null values from `sourceDataStreams`

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/server/routes/entities/get_data_stream_types.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/entities/get_data_stream_types.test.ts
@@ -136,7 +136,7 @@ describe('getDataStreamTypes', () => {
   it('should return entity source_data_stream types when has no metrics', async () => {
     (getHasMetricsData as jest.Mock).mockResolvedValue(false);
     (getLatestEntity as jest.Mock).mockResolvedValue({
-      sourceDataStreamType: ['logs', 'traces'],
+      sourceDataStreamType: ['logs'],
     });
 
     const params = {
@@ -153,6 +153,29 @@ describe('getDataStreamTypes', () => {
     };
 
     const result = await getDataStreamTypes(params);
-    expect(result).toEqual(['logs', 'traces']);
+    expect(result).toEqual(['logs']);
+  });
+
+  it('should ignore null values returned from latestEntity', async () => {
+    (getHasMetricsData as jest.Mock).mockResolvedValue(false);
+    (getLatestEntity as jest.Mock).mockResolvedValue({
+      sourceDataStreamType: ['logs', null, 'metrics', null],
+    });
+
+    const params = {
+      entityId: 'entity123',
+      entityType: 'built_in_hosts_from_ecs_data',
+      entityFilterType: 'host',
+      entityCentricExperienceEnabled: true,
+      infraMetricsClient,
+      obsEsClient,
+      entityManagerClient,
+      logger,
+      from: '2024-12-09T10:49:15Z',
+      to: '2024-12-10T10:49:15Z',
+    };
+
+    const result = await getDataStreamTypes(params);
+    expect(result).toEqual(['logs', 'metrics']);
   });
 });

--- a/x-pack/solutions/observability/plugins/infra/server/routes/entities/get_data_stream_types.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/entities/get_data_stream_types.ts
@@ -63,7 +63,13 @@ export async function getDataStreamTypes({
 
   if (latestEntity) {
     castArray(latestEntity.sourceDataStreamType).forEach((item) => {
-      sourceDataStreams.add(item as EntityDataStreamType);
+      if (
+        [EntityDataStreamType.LOGS, EntityDataStreamType.METRICS].includes(
+          item as EntityDataStreamType
+        )
+      ) {
+        sourceDataStreams.add(item as EntityDataStreamType);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Part of #213045

This PR fixes an issue when the `observability:entityCentricExperience` flag is enabled.
By some reason, we may get null values in `sourceDataStreams` and when we try to validate it with the zod schema, it breaks.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->