### PR TITLE
[Docs] Release notes ID structure template

### DIFF
--- a/docs/extend/development-visualize-index.md
+++ b/docs/extend/development-visualize-index.md
@@ -17,7 +17,7 @@ As a result, starting in `7.5` we have removed the documentation for the legacy 
 
 We would recommend waiting until later in `7.x` to upgrade your plugins if possible. If you would like to keep up with progress on the visualizations plugin in the meantime, here are a few resources:
 
-* The [breaking changes](/release-notes/breaking-changes.md#kibana-900-breaking-changes) documentation, where we try to capture any changes to the APIs as they occur across minors.
+* The [breaking changes](/release-notes/breaking-changes.md#kibana-9.0.0-breaking-changes) documentation, where we try to capture any changes to the APIs as they occur across minors.
 * [Meta issue](https://github.com/elastic/kibana/issues/44121) which is tracking the move of the plugin to the new {{kib}} platform
 * Our [Elastic Stack workspace on Slack](https://www.elastic.co/blog/join-our-elastic-stack-workspace-on-slack).
 * The [source code](https://github.com/elastic/kibana/blob/master/src/platform/plugins/shared/visualizations), which will continue to be the most accurate source of information.

--- a/docs/extend/development-visualize-index.md
+++ b/docs/extend/development-visualize-index.md
@@ -17,7 +17,7 @@ As a result, starting in `7.5` we have removed the documentation for the legacy 
 
 We would recommend waiting until later in `7.x` to upgrade your plugins if possible. If you would like to keep up with progress on the visualizations plugin in the meantime, here are a few resources:
 
-* The [breaking changes](/release-notes/breaking-changes.md#kibana-9.0.0-breaking-changes) documentation, where we try to capture any changes to the APIs as they occur across minors.
+* The [breaking changes](/release-notes/breaking-changes.md#kibana-900-breaking-changes) documentation, where we try to capture any changes to the APIs as they occur across minors.
 * [Meta issue](https://github.com/elastic/kibana/issues/44121) which is tracking the move of the plugin to the new {{kib}} platform
 * Our [Elastic Stack workspace on Slack](https://www.elastic.co/blog/join-our-elastic-stack-workspace-on-slack).
 * The [source code](https://github.com/elastic/kibana/blob/master/src/platform/plugins/shared/visualizations), which will continue to be the most accurate source of information.

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -36,7 +36,7 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 % 4. You can then call the link from any Kibana code. For example: `href: docLinks.links.upgradeAssistant.id`
 % Check https://docs.elastic.dev/docs/kibana-doc-links (internal) for more details about the Doc links service.
 
-## 9.0.0 [kibana-900-breaking-changes]
+## 9.0.0 [kibana-9.0.0-breaking-changes]
 
 
 $$$kibana-193792$$$

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -9,7 +9,7 @@ Breaking changes can impact your Elastic applications, potentially disrupting no
 
 If you are migrating from a version prior to version 9.0, you must first upgrade to the last 8.x version available. To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrade.md).
 
-% ## Next version [kibana-nextversion-breaking-changes]
+% ## Next version [kibana-X.X.X-breaking-changes]
 
 % Use the following template to add entries to this document.
 
@@ -36,7 +36,7 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 % 4. You can then call the link from any Kibana code. For example: `href: docLinks.links.upgradeAssistant.id`
 % Check https://docs.elastic.dev/docs/kibana-doc-links (internal) for more details about the Doc links service.
 
-## 9.0.0 [kibana-9.0.0-breaking-changes]
+## 9.0.0 [kibana-900-breaking-changes]
 
 
 $$$kibana-193792$$$

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -34,7 +34,7 @@ Review the deprecated functionality for Kibana. While deprecations have no immed
 % 4. You can then call the link from any Kibana code. For example: `href: docLinks.links.upgradeAssistant.id`
 % Check https://docs.elastic.dev/docs/kibana-doc-links (internal) for more details about the Doc links service.
 
-## 9.0.0 [kibana-900-deprecations]
+## 9.0.0 [kibana-9.0.0-deprecations]
 
 ::::{dropdown} HTTP/2 becomes the default protocol when TLS is enabled
 :name: known-issue-204384

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -7,7 +7,7 @@ Over time, certain Elastic functionality becomes outdated and is replaced or rem
 
 Review the deprecated functionality for Kibana. While deprecations have no immediate impact, we strongly encourage you update your implementation after you upgrade. To learn how to upgrade, check out [Upgrade](docs-content://deploy-manage/upgrade.md).
 
-% ## Next version [kibana-versionnext-deprecations]
+% ## Next version [kibana-X.X.X-deprecations]
 
 % Use the following template to add entries to this document.
 
@@ -34,7 +34,7 @@ Review the deprecated functionality for Kibana. While deprecations have no immed
 % 4. You can then call the link from any Kibana code. For example: `href: docLinks.links.upgradeAssistant.id`
 % Check https://docs.elastic.dev/docs/kibana-doc-links (internal) for more details about the Doc links service.
 
-## 9.0.0 [kibana-9.0.0-deprecations]
+## 9.0.0 [kibana-900-deprecations]
 
 ::::{dropdown} HTTP/2 becomes the default protocol when TLS is enabled
 :name: known-issue-204384

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -23,11 +23,11 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [kibana-next-fixes]
 % *
 
-## 9.0.0 [kibana-900-release-notes]
+## 9.0.0 [kibana-9.0.0-release-notes]
 
 If you're upgrading to version 9.0.0, you first need to upgrade to version 8.18. We recommend checking the [8.18 release notes](https://www.elastic.co/guide/en/kibana/8.18/release-notes-8.18.0.html).
 
-### Features and enhancements [kibana-900-features-enhancements]
+### Features and enhancements [kibana-9.0.0-features-enhancements]
 
 **Theme**:
 
@@ -64,7 +64,7 @@ If you're upgrading to version 9.0.0, you first need to upgrade to version 8.18.
 * Sets HTTP2 as default if SSL is enabled and adds deprecation log if SSL is not enabled or protocol is set to HTTP1 [#204384]({{kib-pull}}204384).
 
 
-### Fixes [kibana-900-fixes]
+### Fixes [kibana-9.0.0-fixes]
 
 **Dashboards & Visualizations**:
 * Fixes an issue in Lens where colors behind text were not correctly assigned, such as in `Pie`, `Treemap` and `Mosaic` charts [#209632]({{kib-pull}}209632).

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -15,19 +15,19 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 % Release notes include only features, enhancements, and fixes. Add breaking changes, deprecations, and known issues to the applicable release notes sections.
 
-% ## version.next [kibana-next-release-notes]
+% ## version.next [kibana-X.X.X-release-notes]
 
-% ### Features and enhancements [kibana-next-features-enhancements]
+% ### Features and enhancements [kibana-X.X.X-features-enhancements]
 % *
 
-% ### Fixes [kibana-next-fixes]
+% ### Fixes [kibana-X.X.X-fixes]
 % *
 
-## 9.0.0 [kibana-9.0.0-release-notes]
+## 9.0.0 [kibana-900-release-notes]
 
 If you're upgrading to version 9.0.0, you first need to upgrade to version 8.18. We recommend checking the [8.18 release notes](https://www.elastic.co/guide/en/kibana/8.18/release-notes-8.18.0.html).
 
-### Features and enhancements [kibana-9.0.0-features-enhancements]
+### Features and enhancements [kibana-900-features-enhancements]
 
 **Theme**:
 
@@ -64,7 +64,7 @@ If you're upgrading to version 9.0.0, you first need to upgrade to version 8.18.
 * Sets HTTP2 as default if SSL is enabled and adds deprecation log if SSL is not enabled or protocol is set to HTTP1 [#204384]({{kib-pull}}204384).
 
 
-### Fixes [kibana-9.0.0-fixes]
+### Fixes [kibana-900-fixes]
 
 **Dashboards & Visualizations**:
 * Fixes an issue in Lens where colors behind text were not correctly assigned, such as in `Pie`, `Treemap` and `Mosaic` charts [#209632]({{kib-pull}}209632).


### PR DESCRIPTION
For future release notes, section IDs should follow a specific pattern. This PR updates the ID template in related files.

Rel: https://github.com/elastic/docs-content/issues/1152

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->