### PR TITLE
Revert "[Attack Discovery][Scheduling] Feature flag fix in 8.19 (#218637)"

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant-common/constants.ts
@@ -66,7 +66,7 @@ export const DEFEND_INSIGHTS_BY_ID = `${DEFEND_INSIGHTS}/{id}`;
 
 // Attack Discovery
 export const ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG =
-  'securitySolution-assistantAttackDiscoverySchedulingEnabled' as const;
+  'securitySolution.assistantAttackDiscoverySchedulingEnabled' as const;
 export const ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID = 'attack-discovery' as const;
 
 export const ATTACK_DISCOVERY = `${ELASTIC_AI_ASSISTANT_INTERNAL_URL}/attack_discovery` as const;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/utils/is_feature_available.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/schedules/utils/is_feature_available.test.ts
@@ -6,7 +6,6 @@
  */
 
 import { AwaitedProperties } from '@kbn/utility-types';
-import { ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG } from '@kbn/elastic-assistant-common';
 import { ElasticAssistantRequestHandlerContext } from '../../../../types';
 import { isFeatureAvailable } from './is_feature_available';
 
@@ -28,7 +27,7 @@ describe('isFeatureAvailable', () => {
     void isFeatureAvailable(mockContext);
 
     expect(getBooleanValueMock).toHaveBeenCalledWith(
-      ATTACK_DISCOVERY_SCHEDULES_ENABLED_FEATURE_FLAG,
+      'securitySolution.assistantAttackDiscoverySchedulingEnabled',
       false
     );
   });


### PR DESCRIPTION
## Summary

This reverts commit e4559bd8139581d0318ba8c73a0005b0971a58a5.

The changes that allow using recommended FF naming format `pluginName.featureFlagName` was backported and is available in `8.19` now. Backport https://github.com/elastic/kibana/pull/218722

## NOTES

To enable the feature feature flag, put next lines in `kibana.dev.yml`:

```
feature_flags.overrides:
  securitySolution.assistantAttackDiscoverySchedulingEnabled: true
```
