### PR TITLE
fix: [IngestPipelines:Edit pipeline page]Flyouts, dialog modals missing title from announcement

### DIFF
--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/load_from_json/modal_provider.tsx
@@ -8,7 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React, { FunctionComponent, useRef, useState, useCallback } from 'react';
-import { EuiConfirmModal, EuiSpacer, EuiText, EuiCallOut } from '@elastic/eui';
+import { EuiConfirmModal, EuiSpacer, EuiText, EuiCallOut, useGeneratedHtmlId } from '@elastic/eui';
 
 import { JsonEditor, OnJsonEditorUpdateHandler } from '../../../../../shared_imports';
 
@@ -74,16 +74,20 @@ export const ModalProvider: FunctionComponent<Props> = ({ onDone, children }) =>
     jsonContent.current = jsonUpdateData;
   }, []);
 
+  const modalTitleId = useGeneratedHtmlId();
+
   return (
     <>
       {children(() => setIsModalVisible(true))}
       {isModalVisible ? (
         <EuiConfirmModal
+          aria-labelledby={modalTitleId}
           data-test-subj="loadJsonConfirmationModal"
           title={i18nTexts.modalTitle}
           onCancel={() => {
             setIsModalVisible(false);
           }}
+          titleProps={{ id: modalTitleId }}
           onConfirm={async () => {
             try {
               const json = jsonContent.current.data.format();

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/add_processor_form.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/add_processor_form.tsx
@@ -18,6 +18,7 @@ import {
   EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { Form, FormDataProvider, FormHook, useFormIsModified } from '../../../../../shared_imports';
@@ -76,16 +77,23 @@ export const AddProcessorForm: FunctionComponent<Props> = ({
   );
 
   const isFormDirty = useFormIsModified({ form });
+  const pipelineTitleId = useGeneratedHtmlId();
 
   return (
     <Form data-test-subj="addProcessorForm" form={form} onSubmit={handleSubmit}>
-      <EuiFlyout size="m" maxWidth={720} onClose={closeFlyout} outsideClickCloses={!isFormDirty}>
+      <EuiFlyout
+        size="m"
+        maxWidth={720}
+        onClose={closeFlyout}
+        outsideClickCloses={!isFormDirty}
+        aria-labelledby={pipelineTitleId}
+      >
         <EuiFlyoutHeader>
           <EuiFlexGroup gutterSize="xs">
             <EuiFlexItem>
               <div>
                 <EuiTitle size="m" data-test-subj="configurePipelineHeader">
-                  <h2>{getFlyoutTitle(isOnFailure)}</h2>
+                  <h2 id={pipelineTitleId}>{getFlyoutTitle(isOnFailure)}</h2>
                 </EuiTitle>
               </div>
             </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/edit_processor_form.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_form/edit_processor_form.tsx
@@ -21,6 +21,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { Form, FormDataProvider, FormHook, useFormIsModified } from '../../../../../shared_imports';
@@ -154,6 +155,8 @@ export const EditProcessorForm: FunctionComponent<Props> = ({
   }
 
   const isFormDirty = useFormIsModified({ form });
+  const flyoutTitleId = useGeneratedHtmlId();
+
   return (
     <Form data-test-subj="editProcessorForm" form={form} onSubmit={handleSubmit}>
       <EuiFlyout
@@ -164,13 +167,14 @@ export const EditProcessorForm: FunctionComponent<Props> = ({
           closeFlyout();
         }}
         outsideClickCloses={!isFormDirty}
+        aria-labelledby={flyoutTitleId}
       >
         <EuiFlyoutHeader>
           <EuiFlexGroup gutterSize="xs">
             <EuiFlexItem>
               <div>
                 <EuiTitle size="m">
-                  <h2>{getFlyoutTitle(isOnFailure)}</h2>
+                  <h2 id={flyoutTitleId}>{getFlyoutTitle(isOnFailure)}</h2>
                 </EuiTitle>
               </div>
             </EuiFlexItem>

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_remove_modal.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/processor_remove_modal.tsx
@@ -7,7 +7,7 @@
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
-import { EuiConfirmModal } from '@elastic/eui';
+import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
 import { ProcessorInternal, ProcessorSelector } from '../types';
 
 interface Props {
@@ -17,10 +17,14 @@ interface Props {
 }
 
 export const ProcessorRemoveModal = ({ processor, onResult, selector }: Props) => {
+  const modalTitleId = useGeneratedHtmlId();
+
   return (
     <EuiConfirmModal
+      aria-labelledby={modalTitleId}
       buttonColor="danger"
       data-test-subj="removeProcessorConfirmationModal"
+      titleProps={{ id: modalTitleId }}
       title={
         <FormattedMessage
           id="xpack.ingestPipelines.pipelineEditor.removeProcessorModal.titleText"

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/test_pipeline_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/test_pipeline_flyout.tsx
@@ -15,6 +15,7 @@ import {
   EuiSpacer,
   EuiTitle,
   EuiCallOut,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import { FormHook } from '../../../../../shared_imports';
@@ -62,6 +63,8 @@ export const TestPipelineFlyout: React.FunctionComponent<Props> = ({
 }) => {
   let tabContent;
 
+  const pipelineTitleId = useGeneratedHtmlId();
+
   if (selectedTab === 'output') {
     tabContent = (
       <OutputTab
@@ -85,10 +88,15 @@ export const TestPipelineFlyout: React.FunctionComponent<Props> = ({
   }
 
   return (
-    <EuiFlyout maxWidth={550} onClose={onClose} data-test-subj="testPipelineFlyout">
+    <EuiFlyout
+      maxWidth={550}
+      onClose={onClose}
+      data-test-subj="testPipelineFlyout"
+      aria-labelledby={pipelineTitleId}
+    >
       <EuiFlyoutHeader>
         <EuiTitle>
-          <h2 data-test-subj="title">
+          <h2 data-test-subj="title" id={pipelineTitleId}>
             <FormattedMessage
               id="xpack.ingestPipelines.testPipelineFlyout.title"
               defaultMessage="Test pipeline"

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/test_pipeline_tabs/tab_documents/reset_documents_modal.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/components/pipeline_editor/components/test_pipeline/test_pipeline_tabs/tab_documents/reset_documents_modal.tsx
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import React, { FunctionComponent } from 'react';
-import { EuiConfirmModal } from '@elastic/eui';
+import { EuiConfirmModal, useGeneratedHtmlId } from '@elastic/eui';
 
 interface Props {
   confirmResetTestOutput: () => void;
@@ -45,11 +45,15 @@ export const ResetDocumentsModal: FunctionComponent<Props> = ({
   confirmResetTestOutput,
   closeModal,
 }) => {
+  const modalTitleId = useGeneratedHtmlId();
+
   return (
     <EuiConfirmModal
+      aria-labelledby={modalTitleId}
       buttonColor="danger"
       data-test-subj="resetDocumentsConfirmationModal"
       title={i18nTexts.modalTitle}
+      titleProps={{ id: modalTitleId }}
       onCancel={closeModal}
       onConfirm={confirmResetTestOutput}
       cancelButtonText={i18nTexts.cancelButtonLabel}

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/delete_modal.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/delete_modal.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { EuiConfirmModal, EuiSpacer, EuiBadge } from '@elastic/eui';
+import { EuiConfirmModal, EuiSpacer, EuiBadge, useGeneratedHtmlId } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
@@ -82,10 +82,14 @@ export const PipelineDeleteModal = ({
     callback();
   };
 
+  const modalTitleId = useGeneratedHtmlId();
+
   return (
     <EuiConfirmModal
+      aria-labelledby={modalTitleId}
       buttonColor="danger"
       data-test-subj="deletePipelinesConfirmation"
+      titleProps={{ id: modalTitleId }}
       title={
         <FormattedMessage
           id="xpack.ingestPipelines.deleteModal.modalTitleText"

--- a/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/not_found_flyout.tsx
+++ b/x-pack/platform/plugins/shared/ingest_pipelines/public/application/sections/pipelines_list/not_found_flyout.tsx
@@ -7,7 +7,14 @@
 
 import React, { FunctionComponent } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiFlyout, EuiFlyoutBody, EuiCallOut, EuiCode, EuiButton } from '@elastic/eui';
+import {
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiCallOut,
+  EuiCode,
+  EuiButton,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 import { EuiFlyoutHeader, EuiTitle } from '@elastic/eui';
 import { reactRouterNavigate } from '@kbn/kibana-react-plugin/public';
 import { Error, useKibana } from '../../../shared_imports';
@@ -83,13 +90,20 @@ export const PipelineNotFoundFlyout: FunctionComponent<Props> = ({
       </EuiCallOut>
     );
   };
+  const pipelineErrorTitleId = useGeneratedHtmlId();
 
   return (
-    <EuiFlyout onClose={onClose} size="m" maxWidth={550} data-test-subj="pipelineErrorFlyout">
+    <EuiFlyout
+      onClose={onClose}
+      size="m"
+      maxWidth={550}
+      data-test-subj="pipelineErrorFlyout"
+      aria-labelledby={pipelineErrorTitleId}
+    >
       <EuiFlyoutHeader>
         {pipelineName && (
           <EuiTitle id="notFoundFlyoutTitle" data-test-subj="title">
-            <h2>{pipelineName}</h2>
+            <h2 id={pipelineErrorTitleId}>{pipelineName}</h2>
           </EuiTitle>
         )}
       </EuiFlyoutHeader>


### PR DESCRIPTION
Closes: #218128

**Description**
Dialog modal, flyout, field visible title should be announced for the users, especially using assistive technology to know what dialog modal, flyout opened, what field is active and what is needed to enter in it.

**Changes made:**
1. Added required aria-attributes for mentioned places 


<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->