### PR TITLE
[Discover] Add 'Copy value' button to field value cells (#217457)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/index.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/index.ts
@@ -29,6 +29,7 @@ export {
   IgnoredReason,
   buildDataTableRecord,
   buildDataTableRecordList,
+  convertValueToString,
   createLogsContextService,
   createTracesContextService,
   createDegradedDocsControl,

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.test.tsx
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
+import { convertValueToString } from './convert_value_to_string';
+import { formatFieldValue } from './format_value';
+import { DataView, DataViewField } from '@kbn/data-views-plugin/common';
+import { buildDataViewMock } from '../__mocks__';
+
+export const mockSourceField = {
+  name: '_source',
+  type: '_source',
+  esTypes: ['_source'],
+  scripted: false,
+  searchable: false,
+  aggregatable: false,
+  readFromDocValues: false,
+} as DataViewField;
+
+export const mockStringField = {
+  count: 0,
+  name: 'array_objects.description.keyword',
+  type: 'string',
+  esTypes: ['keyword'],
+  scripted: false,
+  searchable: true,
+  aggregatable: true,
+  readFromDocValues: true,
+  subType: {
+    multi: {
+      parent: 'array_objects.description',
+    },
+  },
+} as DataViewField;
+
+export const dataViewComplexMock = buildDataViewMock({
+  name: 'data-view-with-various-field-types',
+  fields: [mockSourceField, mockStringField] as DataView['fields'],
+  timeFieldName: 'data',
+});
+
+// The format_value file has its own test suite, so we can mock it here to avoid duplication.
+jest.mock('./format_value');
+const mockFormatFieldValue = jest.mocked(formatFieldValue);
+
+describe('convertValueToString', () => {
+  describe('when the data view field type is _source', () => {
+    it('should stringify the flattened value', () => {
+      const result = convertValueToString({
+        dataView: dataViewComplexMock,
+        dataViewField: mockSourceField,
+        flattenedValue: 'test',
+        dataTableRecord: {
+          id: '1',
+          raw: {},
+          flattened: { testKey: 'testValue' },
+        },
+        fieldFormats: fieldFormatsMock,
+        options: { compatibleWithCSV: true },
+      });
+
+      expect(result).toEqual({
+        formattedString: `{\"testKey\":\"testValue\"}`,
+        withFormula: false,
+      });
+    });
+  });
+
+  describe('when the data view field type is not _source', () => {
+    describe('when the flattened value is an array', () => {
+      it('should format the values and join them with a comma', () => {
+        mockFormatFieldValue.mockReturnValueOnce('value1').mockReturnValueOnce('value2');
+
+        const result = convertValueToString({
+          dataView: dataViewComplexMock,
+          dataViewField: mockStringField,
+          flattenedValue: ['value1', 'value2'],
+          dataTableRecord: {
+            id: '1',
+            raw: {},
+            flattened: { testKey: 'testValue' },
+          },
+          fieldFormats: fieldFormatsMock,
+          options: { compatibleWithCSV: true },
+        });
+
+        expect(result).toEqual({
+          formattedString: `value1, value2`,
+          withFormula: false,
+        });
+      });
+    });
+
+    describe('when the flattened value is not an array', () => {
+      it('should format the value', () => {
+        mockFormatFieldValue.mockReturnValue('formattedValue');
+
+        const result = convertValueToString({
+          dataView: dataViewComplexMock,
+          dataViewField: mockStringField,
+          flattenedValue: 'value',
+          dataTableRecord: {
+            id: '1',
+            raw: {},
+            flattened: { testKey: 'testValue' },
+          },
+          fieldFormats: fieldFormatsMock,
+          options: { compatibleWithCSV: true },
+        });
+
+        expect(result).toEqual({
+          formattedString: `formattedValue`,
+          withFormula: false,
+        });
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.test.tsx
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.test.tsx
@@ -10,7 +10,7 @@
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 import { convertValueToString } from './convert_value_to_string';
 import { formatFieldValue } from './format_value';
-import { DataView, DataViewField } from '@kbn/data-views-plugin/common';
+import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import { buildDataViewMock } from '../__mocks__';
 
 export const mockSourceField = {

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
+import { cellHasFormulas, createEscapeValue } from '@kbn/data-plugin/common';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+import type { DataTableRecord } from '../../types';
+import { formatFieldValue } from './format_value';
+
+interface ConvertedResult {
+  formattedString: string;
+  withFormula: boolean;
+}
+
+const separator = ',';
+
+export const convertValueToString = ({
+  dataView,
+  dataViewField,
+  flattenedValue,
+  dataTableRecord,
+  fieldFormats,
+  options,
+}: {
+  dataView: DataView;
+  dataViewField?: DataViewField;
+  flattenedValue: unknown;
+  dataTableRecord: DataTableRecord;
+  fieldFormats: FieldFormatsStart;
+  options?: {
+    compatibleWithCSV?: boolean; // values as one-liner + escaping formulas + adding wrapping quotes
+  };
+}): ConvertedResult => {
+  const disableMultiline = options?.compatibleWithCSV ?? false;
+
+  if (dataViewField?.type === '_source') {
+    return {
+      formattedString: stringify(dataTableRecord.flattened, disableMultiline),
+      withFormula: false,
+    };
+  }
+
+  const valuesArray = Array.isArray(flattenedValue) ? flattenedValue : [flattenedValue];
+  const enableEscapingForValue = options?.compatibleWithCSV ?? false;
+  let withFormula = false;
+
+  const formatted = valuesArray
+    .map((subValue) => {
+      const formattedValue = formatFieldValue(
+        subValue,
+        dataTableRecord.raw,
+        fieldFormats,
+        dataView,
+        dataViewField,
+        'text',
+        {
+          skipFormattingInStringifiedJSON: disableMultiline,
+        }
+      );
+
+      if (typeof formattedValue === 'string') {
+        withFormula = withFormula || cellHasFormulas(formattedValue);
+        return enableEscapingForValue ? escapeFormattedValue(formattedValue) : formattedValue;
+      }
+
+      return stringify(formattedValue, disableMultiline) || '';
+    })
+    .join(`${separator} `);
+
+  return {
+    formattedString: formatted,
+    withFormula,
+  };
+};
+
+const stringify = (val: object | string, disableMultiline: boolean) => {
+  // it can wrap "strings" with quotes
+  return disableMultiline ? JSON.stringify(val) : JSON.stringify(val, null, 2);
+};
+
+const escapeValueFn = createEscapeValue({
+  separator,
+  quoteValues: true,
+  escapeFormulaValues: true,
+});
+
+const escapeFormattedValue = (formattedValue: string): string => {
+  return escapeValueFn(formattedValue);
+};

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/index.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/index.ts
@@ -22,4 +22,5 @@ export * from './get_stack_trace_fields';
 export * from './nested_fields';
 export * from './get_field_value';
 export * from './get_visible_columns';
+export * from './convert_value_to_string';
 export { DiscoverFlyouts, dismissAllFlyoutsExceptFor, dismissFlyouts } from './dismiss_flyouts';

--- a/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
@@ -25,5 +25,6 @@
     "@kbn/i18n-react",
     "@kbn/navigation-plugin",
     "@kbn/apm-sources-access-plugin",
+    "@kbn/data-plugin",
   ]
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/__mocks__/services.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/__mocks__/services.ts
@@ -17,6 +17,7 @@ import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 import type { UnifiedDocViewerServices, UnifiedDocViewerStart } from '../types';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
+import { notificationServiceMock } from '@kbn/core/public/mocks';
 
 export const mockUnifiedDocViewer: jest.Mocked<UnifiedDocViewerStart> = {
   registry: new DocViewsRegistry(),
@@ -27,6 +28,7 @@ export const mockUnifiedDocViewerServices: jest.Mocked<UnifiedDocViewerServices>
   data: dataPluginMock.createStartContract(),
   fieldFormats: fieldFormatsMock,
   fieldsMetadata: fieldsMetadataPluginPublicMock.createStartContract(),
+  toasts: notificationServiceMock.createStartContract().toasts,
   storage: new Storage(localStorage),
   uiSettings: uiSettingsServiceMock.createStartContract(),
   unifiedDocViewer: mockUnifiedDocViewer,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/__snapshots__/table_cell_actions.test.tsx.snap
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/__snapshots__/table_cell_actions.test.tsx.snap
@@ -75,7 +75,29 @@ Array [
 ]
 `;
 
-exports[`TableActions getFieldValueCellActions should render correctly for undefined functions 1`] = `Array []`;
+exports[`TableActions getFieldValueCellActions should render correctly for undefined functions 1`] = `
+Array [
+  <Copy
+    Component={[Function]}
+    row={
+      FieldRow {
+        "columnsMeta": undefined,
+        "dataViewField": Object {
+          "aggregatable": false,
+          "displayName": "message",
+          "filterable": false,
+          "name": "message",
+          "scripted": false,
+          "type": "string",
+        },
+        "flattenedValue": "test",
+        "isPinned": false,
+        "name": "message",
+      }
+    }
+  />,
+]
+`;
 
 exports[`TableActions getFieldValueCellActions should render the panels correctly for defined onFilter function 1`] = `
 Array [
@@ -104,6 +126,25 @@ Array [
     Component={[Function]}
     isEsqlMode={false}
     onFilter={[MockFunction]}
+    row={
+      FieldRow {
+        "columnsMeta": undefined,
+        "dataViewField": Object {
+          "aggregatable": false,
+          "displayName": "message",
+          "filterable": false,
+          "name": "message",
+          "scripted": false,
+          "type": "string",
+        },
+        "flattenedValue": "test",
+        "isPinned": false,
+        "name": "message",
+      }
+    }
+  />,
+  <Copy
+    Component={[Function]}
     row={
       FieldRow {
         "columnsMeta": undefined,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/__snapshots__/table_cell_actions.test.tsx.snap
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/__snapshots__/table_cell_actions.test.tsx.snap
@@ -95,6 +95,18 @@ Array [
         "name": "message",
       }
     }
+    toasts={
+      Object {
+        "add": [MockFunction],
+        "addDanger": [MockFunction],
+        "addError": [MockFunction],
+        "addInfo": [MockFunction],
+        "addSuccess": [MockFunction],
+        "addWarning": [MockFunction],
+        "get$": [MockFunction],
+        "remove": [MockFunction],
+      }
+    }
   />,
 ]
 `;
@@ -159,6 +171,18 @@ Array [
         "flattenedValue": "test",
         "isPinned": false,
         "name": "message",
+      }
+    }
+    toasts={
+      Object {
+        "add": [MockFunction],
+        "addDanger": [MockFunction],
+        "addError": [MockFunction],
+        "addInfo": [MockFunction],
+        "addSuccess": [MockFunction],
+        "addWarning": [MockFunction],
+        "get$": [MockFunction],
+        "remove": [MockFunction],
       }
     }
   />,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/field_row.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/field_row.ts
@@ -10,6 +10,7 @@
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils/types';
 import {
+  convertValueToString,
   formatFieldValue,
   getIgnoredReason,
   IgnoredReason,
@@ -92,16 +93,16 @@ export class FieldRow {
   // format as text in a lazy way
   public get formattedAsText(): string | undefined {
     if (!this.#isFormattedAsText) {
-      this.#formattedAsText = String(
-        formatFieldValue(
-          this.flattenedValue,
-          this.#hit.raw,
-          this.#fieldFormats,
-          this.#dataView,
-          this.dataViewField,
-          'text'
-        )
-      );
+      this.#formattedAsText = convertValueToString({
+        dataView: this.#dataView,
+        dataViewField: this.dataViewField,
+        flattenedValue: this.flattenedValue,
+        dataTableRecord: this.#hit,
+        fieldFormats: this.#fieldFormats,
+        options: {
+          compatibleWithCSV: true,
+        },
+      }).formattedString;
       this.#isFormattedAsText = true;
     }
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
@@ -133,7 +133,7 @@ export const DocViewerTable = ({
   const { euiTheme } = useEuiTheme();
   const isEsqlMode = Array.isArray(textBasedHits);
   const [containerRef, setContainerRef] = useState<HTMLDivElement | null>(null);
-  const { fieldFormats, storage, uiSettings } = getUnifiedDocViewerServices();
+  const { fieldFormats, storage, uiSettings, toasts } = getUnifiedDocViewerServices();
   const showMultiFields = uiSettings.get(SHOW_MULTIFIELDS);
   const currentDataViewId = dataView.id!;
 
@@ -330,8 +330,8 @@ export const DocViewerTable = ({
     [rows, isEsqlMode, filter, onToggleColumn]
   );
   const fieldValueCellActions = useMemo(
-    () => getFieldValueCellActions({ rows, isEsqlMode, onFilter: filter }),
-    [rows, isEsqlMode, filter]
+    () => getFieldValueCellActions({ rows, isEsqlMode, toasts, onFilter: filter }),
+    [rows, isEsqlMode, toasts, filter]
   );
 
   useWindowSize(); // trigger re-render on window resize to recalculate the grid container height

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
@@ -358,7 +358,7 @@ export const DocViewerTable = ({
           defaultMessage: 'Value',
         }),
         actions: false,
-        visibleCellActions: 2,
+        visibleCellActions: 3,
         cellActions: fieldValueCellActions,
       },
     ],

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@elastic/eui', () => ({
 }));
 const mockCopyToClipboard = jest.mocked(copyToClipboard);
 
-afterAll(() => {
+afterEach(() => {
   jest.clearAllMocks();
 });
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
@@ -118,8 +118,7 @@ describe('TableActions', () => {
     });
 
     describe('when clicking "Copy value"', () => {
-      it('should call the copy function', () => {
-        // Given
+      beforeEach(() => {
         const actions = getFieldValueCellActions({
           rows: getRows(),
           toasts: toastsMock,
@@ -133,8 +132,11 @@ describe('TableActions', () => {
           />
         ));
 
-        // When
         render(<>{actions}</>);
+      });
+
+      it('should call the copy function', () => {
+        // When
         fireEvent.click(screen.getByText('Copy value'));
 
         // Then
@@ -144,22 +146,9 @@ describe('TableActions', () => {
       describe('when the copy fails', () => {
         it('should show a warning toast', () => {
           // Given
-          const actions = getFieldValueCellActions({
-            rows: getRows(),
-            toasts: toastsMock,
-            isEsqlMode: false,
-            onFilter: undefined,
-          }).map((Action, i) => (
-            <Action
-              key={i}
-              {...EuiCellParams}
-              Component={(props: any) => <div {...props}>{props.children}</div>}
-            />
-          ));
           mockCopyToClipboard.mockReturnValue(false);
 
           // When
-          render(<>{actions}</>);
           fireEvent.click(screen.getByText('Copy value'));
 
           // Then
@@ -170,22 +159,9 @@ describe('TableActions', () => {
       describe('when the copy succeeds', () => {
         it('should show an info toast', () => {
           // Given
-          const actions = getFieldValueCellActions({
-            rows: getRows(),
-            toasts: toastsMock,
-            isEsqlMode: false,
-            onFilter: undefined,
-          }).map((Action, i) => (
-            <Action
-              key={i}
-              {...EuiCellParams}
-              Component={(props: any) => <div {...props}>{props.children}</div>}
-            />
-          ));
           mockCopyToClipboard.mockReturnValue(true);
 
           // When
-          render(<>{actions}</>);
           fireEvent.click(screen.getByText('Copy value'));
 
           // Then

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
@@ -12,7 +12,8 @@ import { getFieldCellActions, getFieldValueCellActions } from './table_cell_acti
 import { FieldRow } from './field_row';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { dataViewMockWithTimeField } from '@kbn/discover-utils/src/__mocks__';
 import { copyToClipboard } from '@elastic/eui';
 import { notificationServiceMock } from '@kbn/core/public/mocks';
@@ -135,21 +136,23 @@ describe('TableActions', () => {
         render(<>{actions}</>);
       });
 
-      it('should call the copy function', () => {
+      it('should call the copy function', async () => {
         // When
-        fireEvent.click(screen.getByText('Copy value'));
+        const user = userEvent.setup();
+        await user.click(screen.getByText('Copy value'));
 
         // Then
         expect(mockCopyToClipboard).toHaveBeenCalledWith(EuiCellParams.columnId);
       });
 
       describe('when the copy fails', () => {
-        it('should show a warning toast', () => {
+        it('should show a warning toast', async () => {
           // Given
           mockCopyToClipboard.mockReturnValue(false);
+          const user = userEvent.setup();
 
           // When
-          fireEvent.click(screen.getByText('Copy value'));
+          await user.click(screen.getByText('Copy value'));
 
           // Then
           expect(toastsMock.addWarning).toHaveBeenCalledTimes(1);
@@ -157,12 +160,13 @@ describe('TableActions', () => {
       });
 
       describe('when the copy succeeds', () => {
-        it('should show an info toast', () => {
+        it('should show an info toast', async () => {
           // Given
           mockCopyToClipboard.mockReturnValue(true);
+          const user = userEvent.setup();
 
           // When
-          fireEvent.click(screen.getByText('Copy value'));
+          await user.click(screen.getByText('Copy value'));
 
           // Then
           expect(toastsMock.addInfo).toHaveBeenCalledTimes(1);

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.test.tsx
@@ -142,7 +142,7 @@ describe('TableActions', () => {
       });
 
       describe('when the copy fails', () => {
-        it('should show a toast', () => {
+        it('should show a warning toast', () => {
           // Given
           const actions = getFieldValueCellActions({
             rows: getRows(),
@@ -168,7 +168,7 @@ describe('TableActions', () => {
       });
 
       describe('when the copy succeeds', () => {
-        it('should not show a toast', () => {
+        it('should show an info toast', () => {
           // Given
           const actions = getFieldValueCellActions({
             rows: getRows(),

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
@@ -85,9 +85,12 @@ const Copy: React.FC<TableActionsProps & { toasts: IToasts }> = ({ Component, ro
       title={copyLabel}
       flush="left"
       onClick={() => {
-        const errorMessage = i18n.translate('tableCellActions.copyFailedErrorText', {
-          defaultMessage: 'Unable to copy to clipboard in this browser',
-        });
+        const errorMessage = i18n.translate(
+          'unifiedDocViewer.tableCellActions.copyFailedErrorText',
+          {
+            defaultMessage: 'Unable to copy to clipboard in this browser',
+          }
+        );
 
         if (!formattedAsText) {
           toasts.addWarning({
@@ -105,9 +108,12 @@ const Copy: React.FC<TableActionsProps & { toasts: IToasts }> = ({ Component, ro
         }
 
         toasts.addInfo({
-          title: i18n.translate('tableCellActions.copyValueToClipboard.toastTitle', {
-            defaultMessage: 'Copied to clipboard',
-          }),
+          title: i18n.translate(
+            'unifiedDocViewer.tableCellActions.copyValueToClipboard.toastTitle',
+            {
+              defaultMessage: 'Copied to clipboard',
+            }
+          ),
         });
       }}
     >

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
@@ -67,7 +67,11 @@ const esqlMultivalueFilteringDisabled = i18n.translate(
   }
 );
 
-const Copy: React.FC<TableActionsProps & { toasts: IToasts }> = ({ Component, row, toasts }) => {
+const Copy: React.FC<Omit<TableActionsProps, 'isEsqlMode'> & { toasts: IToasts }> = ({
+  Component,
+  row,
+  toasts,
+}) => {
   if (!row) {
     return null;
   }
@@ -386,15 +390,7 @@ export function getFieldValueCellActions({
     : [];
 
   const copyAction = ({ Component, rowIndex }: EuiDataGridColumnCellActionProps) => {
-    return (
-      <Copy
-        toasts={toasts}
-        row={rows[rowIndex]}
-        Component={Component}
-        // The copy action doesn't need this flag but we still want to keep it in the type so we don't forget about it
-        isEsqlMode={undefined}
-      />
-    );
+    return <Copy toasts={toasts} row={rows[rowIndex]} Component={Component} />;
   };
 
   return [...filterActions, copyAction];

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
@@ -85,7 +85,6 @@ const Copy: React.FC<TableActionsProps> = ({ Component, row }) => {
       flush="left"
       onClick={() => copyToClipboard(String(flattenedValue))}
     >
-      <div data-testid="another test" />
       {copyLabel}
     </Component>
   );

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
@@ -17,7 +17,7 @@ import { FieldRow } from './field_row';
 interface TableActionsProps {
   Component: EuiDataGridColumnCellActionProps['Component'];
   row: FieldRow | undefined; // as we pass `rows[rowIndex]` it's safer to assume that `row` prop can be undefined
-  isEsqlMode?: boolean | undefined;
+  isEsqlMode: boolean | undefined;
 }
 
 function isFilterInOutPairDisabled(
@@ -72,7 +72,7 @@ const Copy: React.FC<TableActionsProps & { toasts: IToasts }> = ({ Component, ro
     return null;
   }
 
-  const { formattedAsText, name } = row;
+  const { name } = row;
 
   const copyLabel = i18n.translate('unifiedDocViewer.docViews.table.copyValue', {
     defaultMessage: 'Copy value',
@@ -92,14 +92,14 @@ const Copy: React.FC<TableActionsProps & { toasts: IToasts }> = ({ Component, ro
           }
         );
 
-        if (!formattedAsText) {
+        if (!row.formattedAsText) {
           toasts.addWarning({
             title: errorMessage,
           });
           return;
         }
 
-        const copied = copyToClipboard(formattedAsText);
+        const copied = copyToClipboard(row.formattedAsText);
         if (!copied) {
           toasts.addWarning({
             title: errorMessage,
@@ -386,7 +386,15 @@ export function getFieldValueCellActions({
     : [];
 
   const copyAction = ({ Component, rowIndex }: EuiDataGridColumnCellActionProps) => {
-    return <Copy toasts={toasts} row={rows[rowIndex]} Component={Component} />;
+    return (
+      <Copy
+        toasts={toasts}
+        row={rows[rowIndex]}
+        Component={Component}
+        // The copy action doesn't need this flag but we still want to keep it in the type so we don't forget about it
+        isEsqlMode={undefined}
+      />
+    );
   };
 
   return [...filterActions, copyAction];

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table_cell_actions.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { EuiDataGridColumnCellActionProps } from '@elastic/eui';
+import { EuiDataGridColumnCellActionProps, copyToClipboard } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import { FieldRow } from './field_row';
@@ -16,7 +16,7 @@ import { FieldRow } from './field_row';
 interface TableActionsProps {
   Component: EuiDataGridColumnCellActionProps['Component'];
   row: FieldRow | undefined; // as we pass `rows[rowIndex]` it's safer to assume that `row` prop can be undefined
-  isEsqlMode: boolean | undefined;
+  isEsqlMode?: boolean | undefined;
 }
 
 function isFilterInOutPairDisabled(
@@ -65,6 +65,31 @@ const esqlMultivalueFilteringDisabled = i18n.translate(
     defaultMessage: 'Multivalue filtering is not supported in ES|QL',
   }
 );
+
+const Copy: React.FC<TableActionsProps> = ({ Component, row }) => {
+  if (!row) {
+    return null;
+  }
+
+  const { flattenedValue, name } = row;
+
+  const copyLabel = i18n.translate('unifiedDocViewer.docViews.table.copyValue', {
+    defaultMessage: 'Copy value',
+  });
+
+  return (
+    <Component
+      data-test-subj={`copyValueButton-${name}`}
+      iconType="copyClipboard"
+      title={copyLabel}
+      flush="left"
+      onClick={() => copyToClipboard(String(flattenedValue))}
+    >
+      <div data-testid="another test" />
+      {copyLabel}
+    </Component>
+  );
+};
 
 const FilterIn: React.FC<TableActionsProps & { onFilter: DocViewFilterFn | undefined }> = ({
   Component,
@@ -302,7 +327,7 @@ export function getFieldValueCellActions({
   isEsqlMode: boolean | undefined;
   onFilter?: DocViewFilterFn;
 }) {
-  return onFilter
+  const filterActions = onFilter
     ? [
         ({ Component, rowIndex }: EuiDataGridColumnCellActionProps) => {
           return (
@@ -326,4 +351,10 @@ export function getFieldValueCellActions({
         },
       ]
     : [];
+
+  const copyAction = ({ Component, rowIndex }: EuiDataGridColumnCellActionProps) => {
+    return <Copy row={rows[rowIndex]} Component={Component} />;
+  };
+
+  return [...filterActions, copyAction];
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
@@ -94,7 +94,11 @@ export class UnifiedDocViewerPublicPlugin
   }
 
   public start(core: CoreStart, deps: UnifiedDocViewerStartDeps) {
-    const { analytics, uiSettings } = core;
+    const {
+      analytics,
+      uiSettings,
+      notifications: { toasts },
+    } = core;
     const { data, fieldFormats, fieldsMetadata, share } = deps;
     const storage = new Storage(localStorage);
     const unifiedDocViewer = {
@@ -105,6 +109,7 @@ export class UnifiedDocViewerPublicPlugin
       data,
       fieldFormats,
       fieldsMetadata,
+      toasts,
       storage,
       uiSettings,
       unifiedDocViewer,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/types.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/types.ts
@@ -19,6 +19,7 @@ import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/publ
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
+import type { IToasts } from '@kbn/core/public';
 import type { UnifiedDocViewerStart } from './plugin';
 
 export interface UnifiedDocViewerServices {
@@ -26,6 +27,7 @@ export interface UnifiedDocViewerServices {
   data: DataPublicPluginStart;
   fieldFormats: FieldFormatsStart;
   fieldsMetadata: FieldsMetadataPublicStart;
+  toasts: IToasts;
   storage: Storage;
   uiSettings: IUiSettingsClient;
   unifiedDocViewer: UnifiedDocViewerStart;


### PR DESCRIPTION
## Summary

Added a "Copy value" button to the field value cells.

![chrome-capture-2025-4-23](https://github.com/user-attachments/assets/fb8d4815-9acd-47ab-b266-22008c9d22ac)

Solves https://github.com/elastic/kibana/issues/217457


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->