### PR TITLE
[8.19] Upgrade EUI to v101.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@elastic/ecs": "^8.11.5",
     "@elastic/elasticsearch": "^8.17.1",
     "@elastic/ems-client": "8.6.3",
-    "@elastic/eui": "101.3.0-classic.0",
+    "@elastic/eui": "101.4.0-amsterdam.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "^1.2.3",
     "@elastic/numeral": "^2.5.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -88,7 +88,7 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.6.3': ['Elastic License 2.0'],
-  '@elastic/eui@101.2.0-classic.1': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
+  '@elastic/eui@101.4.0-amsterdam.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
   'buffers@0.1.1': ['MIT'], // license in importing module https://www.npmjs.com/package/binary
   '@bufbuild/protobuf@1.2.1': ['Apache-2.0'], // license (Apache-2.0 AND BSD-3-Clause)

--- a/src/platform/plugins/shared/data/public/utils/table_inspector_view/components/__snapshots__/data_view.test.tsx.snap
+++ b/src/platform/plugins/shared/data/public/utils/table_inspector_view/components/__snapshots__/data_view.test.tsx.snap
@@ -347,7 +347,6 @@ Array [
               />
             </button>
             <ul
-              aria-label="Pagination for table: "
               class="euiPagination__list emotion-euiPagination__list"
             >
               <li
@@ -355,7 +354,7 @@ Array [
               >
                 <button
                   aria-controls="__table_generated-id"
-                  aria-current="true"
+                  aria-current="page"
                   aria-label="Page 1 of 1"
                   class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
                   data-test-subj="pagination-button-0"
@@ -629,7 +628,6 @@ Array [
               />
             </button>
             <ul
-              aria-label="Pagination for table: "
               class="euiPagination__list emotion-euiPagination__list"
             >
               <li
@@ -637,7 +635,7 @@ Array [
               >
                 <button
                   aria-controls="__table_generated-id"
-                  aria-current="true"
+                  aria-current="page"
                   aria-label="Page 1 of 1"
                   class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
                   data-test-subj="pagination-button-0"

--- a/src/platform/test/functional/services/data_grid.ts
+++ b/src/platform/test/functional/services/data_grid.ts
@@ -948,7 +948,7 @@ export class DataGridService extends FtrService {
   }
 
   public async getCurrentPageNumber() {
-    const currentPage = await this.find.byCssSelector('.euiPaginationButton[aria-current="true"]');
+    const currentPage = await this.find.byCssSelector('.euiPaginationButton[aria-current="page"]');
     return await currentPage.getVisibleText();
   }
 

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/components/table_basic.test.tsx
@@ -518,7 +518,7 @@ describe('DatatableComponent', () => {
       expect(screen.queryByTestId('tablePaginationPopoverButton')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: `Page 1 of ${numberOfPages}` })).toHaveAttribute(
         'aria-current',
-        'true'
+        'page'
       );
       const newIndex = 3;
       await userEvent.click(
@@ -526,7 +526,7 @@ describe('DatatableComponent', () => {
       );
       expect(
         screen.getByRole('button', { name: `Page ${newIndex} of ${numberOfPages}` })
-      ).toHaveAttribute('aria-current', 'true');
+      ).toHaveAttribute('aria-current', 'page');
     });
     it('dynamically toggles pagination', async () => {
       const argsWithoutPagination = copyData(args);
@@ -599,7 +599,7 @@ describe('DatatableComponent', () => {
       );
       expect(
         screen.getByRole('button', { name: `Page ${newIndex} of ${numberOfPages}` })
-      ).toHaveAttribute('aria-current', 'true');
+      ).toHaveAttribute('aria-current', 'page');
 
       await act(async () => {
         rerender({
@@ -614,7 +614,7 @@ describe('DatatableComponent', () => {
       // keeps existing page if more data is added
       expect(
         screen.getByRole('button', { name: `Page ${newIndex} of ${newNumberOfPages}` })
-      ).toHaveAttribute('aria-current', 'true');
+      ).toHaveAttribute('aria-current', 'page');
     });
 
     it('resets page position if rows change so page will be empty', async () => {
@@ -639,7 +639,7 @@ describe('DatatableComponent', () => {
       );
       expect(
         screen.getByRole('button', { name: `Page ${newIndex} of ${numberOfPages}` })
-      ).toHaveAttribute('aria-current', 'true');
+      ).toHaveAttribute('aria-current', 'page');
 
       await act(async () => {
         rerender({

--- a/x-pack/solutions/observability/packages/kbn-alerts-grouping/src/components/alerts_grouping.test.tsx
+++ b/x-pack/solutions/observability/packages/kbn-alerts-grouping/src/components/alerts_grouping.test.tsx
@@ -240,7 +240,7 @@ describe('AlertsGrouping', () => {
       ).toEqual(null);
       expect(
         within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
-      ).toEqual('true');
+      ).toEqual('page');
     });
 
     await userEvent.click(screen.getAllByTestId('group-selector-dropdown')[0]);
@@ -254,7 +254,7 @@ describe('AlertsGrouping', () => {
     ].forEach((pagination) => {
       expect(
         within(pagination).getByTestId('pagination-button-0').getAttribute('aria-current')
-      ).toEqual('true');
+      ).toEqual('page');
       expect(
         within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
       ).toEqual(null);
@@ -307,7 +307,7 @@ describe('AlertsGrouping', () => {
     ].forEach((pagination) => {
       expect(
         within(pagination).getByTestId('pagination-button-0').getAttribute('aria-current')
-      ).toEqual('true');
+      ).toEqual('page');
       expect(
         within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
       ).toEqual(null);
@@ -366,7 +366,7 @@ describe('AlertsGrouping', () => {
       ).toEqual(null);
       expect(
         within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
-      ).toEqual('true');
+      ).toEqual('page');
     });
 
     // level 2 pagination is reset
@@ -374,7 +374,7 @@ describe('AlertsGrouping', () => {
       within(screen.getByTestId('grouping-level-2-pagination'))
         .getByTestId('pagination-button-0')
         .getAttribute('aria-current')
-    ).toEqual('true');
+    ).toEqual('page');
     expect(
       within(screen.getByTestId('grouping-level-2-pagination'))
         .getByTestId('pagination-button-1')
@@ -429,11 +429,11 @@ describe('AlertsGrouping', () => {
         ).toEqual(null);
         expect(
           within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
-        ).toEqual('true');
+        ).toEqual('page');
       } else {
         expect(
           within(pagination).getByTestId('pagination-button-0').getAttribute('aria-current')
-        ).toEqual('true');
+        ).toEqual('page');
         expect(within(pagination).queryByTestId('pagination-button-1')).not.toBeInTheDocument();
       }
     });
@@ -484,11 +484,11 @@ describe('AlertsGrouping', () => {
         ).toEqual(null);
         expect(
           within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
-        ).toEqual('true');
+        ).toEqual('page');
       } else {
         expect(
           within(pagination).getByTestId('pagination-button-0').getAttribute('aria-current')
-        ).toEqual('true');
+        ).toEqual('page');
         expect(within(pagination).queryByTestId('pagination-button-1')).not.toBeInTheDocument();
       }
     });

--- a/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/src/exception_item_card/comments/__snapshots__/comments.test.tsx.snap
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-exception-list-components/src/exception_item_card/comments/__snapshots__/comments.test.tsx.snap
@@ -133,7 +133,7 @@ Object {
                         >
                           <span
                             class="euiAvatar__icon"
-                            data-euiicon-type="userAvatar"
+                            data-euiicon-type="user"
                           />
                         </div>
                       </div>
@@ -172,7 +172,7 @@ Object {
                         >
                           <span
                             class="euiAvatar__icon"
-                            data-euiicon-type="userAvatar"
+                            data-euiicon-type="user"
                           />
                         </div>
                       </div>
@@ -270,7 +270,7 @@ Object {
                       >
                         <span
                           class="euiAvatar__icon"
-                          data-euiicon-type="userAvatar"
+                          data-euiicon-type="user"
                         />
                       </div>
                     </div>
@@ -309,7 +309,7 @@ Object {
                       >
                         <span
                           class="euiAvatar__icon"
-                          data-euiicon-type="userAvatar"
+                          data-euiicon-type="user"
                         />
                       </div>
                     </div>
@@ -463,7 +463,7 @@ Object {
                         >
                           <span
                             class="euiAvatar__icon"
-                            data-euiicon-type="userAvatar"
+                            data-euiicon-type="user"
                           />
                         </div>
                       </div>
@@ -502,7 +502,7 @@ Object {
                         >
                           <span
                             class="euiAvatar__icon"
-                            data-euiicon-type="userAvatar"
+                            data-euiicon-type="user"
                           />
                         </div>
                       </div>
@@ -599,7 +599,7 @@ Object {
                       >
                         <span
                           class="euiAvatar__icon"
-                          data-euiicon-type="userAvatar"
+                          data-euiicon-type="user"
                         />
                       </div>
                     </div>
@@ -638,7 +638,7 @@ Object {
                       >
                         <span
                           class="euiAvatar__icon"
-                          data-euiicon-type="userAvatar"
+                          data-euiicon-type="user"
                         />
                       </div>
                     </div>

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
@@ -320,7 +320,7 @@ describe('GroupedAlertsTable', () => {
       ).toEqual(null);
       expect(
         within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
-      ).toEqual('true');
+      ).toEqual('page');
     });
 
     fireEvent.click(getAllByTestId('group-selector-dropdown')[0]);
@@ -333,7 +333,7 @@ describe('GroupedAlertsTable', () => {
     ].forEach((pagination) => {
       expect(
         within(pagination).getByTestId('pagination-button-0').getAttribute('aria-current')
-      ).toEqual('true');
+      ).toEqual('page');
       expect(
         within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
       ).toEqual(null);
@@ -381,7 +381,7 @@ describe('GroupedAlertsTable', () => {
     ].forEach((pagination) => {
       expect(
         within(pagination).getByTestId('pagination-button-0').getAttribute('aria-current')
-      ).toEqual('true');
+      ).toEqual('page');
       expect(
         within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
       ).toEqual(null);
@@ -430,7 +430,7 @@ describe('GroupedAlertsTable', () => {
       ).toEqual(null);
       expect(
         within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
-      ).toEqual('true');
+      ).toEqual('page');
     });
 
     // level 2 pagination is reset
@@ -438,7 +438,7 @@ describe('GroupedAlertsTable', () => {
       within(getByTestId('grouping-level-2-pagination'))
         .getByTestId('pagination-button-0')
         .getAttribute('aria-current')
-    ).toEqual('true');
+    ).toEqual('page');
     expect(
       within(getByTestId('grouping-level-2-pagination'))
         .getByTestId('pagination-button-1')
@@ -484,11 +484,11 @@ describe('GroupedAlertsTable', () => {
         ).toEqual(null);
         expect(
           within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
-        ).toEqual('true');
+        ).toEqual('page');
       } else {
         expect(
           within(pagination).getByTestId('pagination-button-0').getAttribute('aria-current')
-        ).toEqual('true');
+        ).toEqual('page');
         expect(within(pagination).queryByTestId('pagination-button-1')).not.toBeInTheDocument();
       }
     });
@@ -533,11 +533,11 @@ describe('GroupedAlertsTable', () => {
         ).toEqual(null);
         expect(
           within(pagination).getByTestId('pagination-button-1').getAttribute('aria-current')
-        ).toEqual('true');
+        ).toEqual('page');
       } else {
         expect(
           within(pagination).getByTestId('pagination-button-0').getAttribute('aria-current')
-        ).toEqual('true');
+        ).toEqual('page');
         expect(within(pagination).queryByTestId('pagination-button-1')).not.toBeInTheDocument();
       }
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/entity_store/entities_list.test.tsx
@@ -126,7 +126,7 @@ describe('EntitiesList', () => {
 
     await waitFor(() => {
       const firstPageButton = screen.getByTestId('pagination-button-0');
-      expect(firstPageButton).toHaveAttribute('aria-current', 'true');
+      expect(firstPageButton).toHaveAttribute('aria-current', 'page');
     });
   });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/__snapshots__/authentications_host_table.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/__snapshots__/authentications_host_table.test.tsx.snap
@@ -402,7 +402,7 @@ exports[`Authentication Host Table Component rendering it renders the host authe
             class="euiPagination__item"
           >
             <button
-              aria-current="true"
+              aria-current="page"
               aria-label="Page 1 of 5"
               class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
               data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/__snapshots__/authentications_user_table.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/authentication/__snapshots__/authentications_user_table.test.tsx.snap
@@ -402,7 +402,7 @@ exports[`Authentication User Table Component rendering it renders the user authe
             class="euiPagination__item"
           >
             <button
-              aria-current="true"
+              aria-current="page"
               aria-label="Page 1 of 5"
               class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
               data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/paginated_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/paginated_table/__snapshots__/index.test.tsx.snap
@@ -455,7 +455,7 @@ exports[`Paginated Table Component rendering it renders the default load more ta
                 class="euiPagination__item"
               >
                 <button
-                  aria-current="true"
+                  aria-current="page"
                   aria-label="Page 1 of 10"
                   class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
                   data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/components/paginated_table/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/components/paginated_table/index.test.tsx
@@ -99,7 +99,7 @@ describe('Paginated Table Component', () => {
       expect(screen.getByTestId('numberedPagination')).toBeInTheDocument();
 
       const firstButton = screen.getByTestId('pagination-button-0');
-      expect(firstButton).toHaveAttribute('aria-current', 'true');
+      expect(firstButton).toHaveAttribute('aria-current', 'page');
       expect(firstButton).toHaveAttribute('aria-label', 'Page 1 of 10');
     });
 
@@ -177,7 +177,7 @@ describe('Paginated Table Component', () => {
     test('should update the page when the activePage is changed from redux', async () => {
       const { rerender } = renderComponent({ activePage: 3 });
       const beforeActiveButton = screen.getByTestId('pagination-button-3');
-      expect(beforeActiveButton).toHaveAttribute('aria-current', 'true');
+      expect(beforeActiveButton).toHaveAttribute('aria-current', 'page');
       expect(beforeActiveButton).toHaveAttribute('aria-label', 'Page 4 of 10');
 
       rerender(
@@ -188,7 +188,7 @@ describe('Paginated Table Component', () => {
 
       await waitFor(() => {
         const afterActiveButton = screen.getByTestId('pagination-button-0');
-        expect(afterActiveButton).toHaveAttribute('aria-current', 'true');
+        expect(afterActiveButton).toHaveAttribute('aria-current', 'page');
         expect(afterActiveButton).toHaveAttribute('aria-label', 'Page 1 of 10');
       });
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/uncommon_process_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/hosts/components/uncommon_process_table/__snapshots__/index.test.tsx.snap
@@ -873,7 +873,7 @@ exports[`Uncommon Process Table Component rendering it renders the default Uncom
             class="euiPagination__item"
           >
             <button
-              aria-current="true"
+              aria-current="page"
               aria-label="Page 1 of 5"
               class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
               data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_dns_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_dns_table/__snapshots__/index.test.tsx.snap
@@ -937,7 +937,7 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
             class="euiPagination__item"
           >
             <button
-              aria-current="true"
+              aria-current="page"
               aria-label="Page 1 of 5"
               class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
               data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_http_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_http_table/__snapshots__/index.test.tsx.snap
@@ -793,7 +793,7 @@ exports[`NetworkHttp Table Component rendering it renders the default NetworkHtt
               class="euiPagination__item"
             >
               <button
-                aria-current="true"
+                aria-current="page"
                 aria-label="Page 1 of 1"
                 class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
                 data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/__snapshots__/index.test.tsx.snap
@@ -531,7 +531,7 @@ exports[`NetworkTopCountries Table Component rendering it renders the IP Details
               class="euiPagination__item"
             >
               <button
-                aria-current="true"
+                aria-current="page"
                 aria-label="Page 1 of 5"
                 class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
                 data-test-subj="pagination-button-0"
@@ -1229,7 +1229,7 @@ exports[`NetworkTopCountries Table Component rendering it renders the default Ne
               class="euiPagination__item"
             >
               <button
-                aria-current="true"
+                aria-current="page"
                 aria-label="Page 1 of 5"
                 class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
                 data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/__snapshots__/index.test.tsx.snap
@@ -628,7 +628,7 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               class="euiPagination__item"
             >
               <button
-                aria-current="true"
+                aria-current="page"
                 aria-label="Page 1 of 5"
                 class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
                 data-test-subj="pagination-button-0"
@@ -1423,7 +1423,7 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               class="euiPagination__item"
             >
               <button
-                aria-current="true"
+                aria-current="page"
                 aria-label="Page 1 of 5"
                 class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
                 data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/tls_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/tls_table/__snapshots__/index.test.tsx.snap
@@ -557,7 +557,7 @@ exports[`Tls Table Component Rendering it renders the default Domains table 1`] 
               class="euiPagination__item"
             >
               <button
-                aria-current="true"
+                aria-current="page"
                 aria-label="Page 1 of 5"
                 class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
                 data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/users_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/users_table/__snapshots__/index.test.tsx.snap
@@ -539,7 +539,7 @@ exports[`Users Table Component Rendering it renders the default Users table 1`] 
             class="euiPagination__item"
           >
             <button
-              aria-current="true"
+              aria-current="page"
               aria-label="Page 1 of 1"
               class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
               data-test-subj="pagination-button-0"

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/response_actions/view/response_actions_list_page.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/response_actions/view/response_actions_list_page.test.tsx
@@ -214,7 +214,7 @@ describe('Response actions history page', () => {
 
       expect(history.location.search).toEqual('?page=3&pageSize=20');
       expect(getByTestId('tablePaginationPopoverButton').textContent).toContain('20');
-      expect(getByTestId('pagination-button-2').getAttribute('aria-current')).toStrictEqual('true');
+      expect(getByTestId('pagination-button-2').getAttribute('aria-current')).toStrictEqual('page');
     });
 
     it('should read and set command filter values from URL params', async () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/index.test.tsx
@@ -267,7 +267,7 @@ describe('EQL Tab', () => {
 
           expect(screen.getByTestId('pagination-button-previous')).toBeVisible();
 
-          expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+          expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'page');
           expect(fetchNotesMock).toHaveBeenCalledWith(['1']);
 
           // Page : 2
@@ -280,7 +280,7 @@ describe('EQL Tab', () => {
           await waitFor(() => {
             expect(screen.getByTestId('pagination-button-1')).toHaveAttribute(
               'aria-current',
-              'true'
+              'page'
             );
 
             expect(fetchNotesMock).toHaveBeenNthCalledWith(1, [mockTimelineData[1]._id]);
@@ -295,7 +295,7 @@ describe('EQL Tab', () => {
           await waitFor(() => {
             expect(screen.getByTestId('pagination-button-2')).toHaveAttribute(
               'aria-current',
-              'true'
+              'page'
             );
 
             expect(fetchNotesMock).toHaveBeenNthCalledWith(1, [mockTimelineData[2]._id]);
@@ -339,7 +339,7 @@ describe('EQL Tab', () => {
 
           expect(screen.getByTestId('pagination-button-previous')).toBeVisible();
 
-          expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+          expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'page');
           expect(screen.getByTestId('tablePaginationPopoverButton')).toHaveTextContent(
             'Rows per page: 1'
           );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/query/index.test.tsx
@@ -364,14 +364,14 @@ describe('query tab with unified timeline', () => {
           'Rows per page: 1'
         );
 
-        expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+        expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'page');
         expect(screen.getByTestId('pagination-button-2')).toBeVisible();
         expect(screen.queryByTestId('pagination-button-3')).toBeNull();
 
         fireEvent.click(screen.getByTestId('pagination-button-2'));
 
         await waitFor(() => {
-          expect(screen.getByTestId('pagination-button-2')).toHaveAttribute('aria-current', 'true');
+          expect(screen.getByTestId('pagination-button-2')).toHaveAttribute('aria-current', 'page');
         });
       },
       SPECIAL_TEST_TIMEOUT
@@ -393,7 +393,7 @@ describe('query tab with unified timeline', () => {
         expect(await screen.findByTestId('discoverDocTable')).toBeVisible();
 
         await waitFor(() => {
-          expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+          expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'page');
           expect(screen.getByTestId('pagination-button-2')).toBeVisible();
         });
         // Go to last page
@@ -403,7 +403,7 @@ describe('query tab with unified timeline', () => {
         });
         fireEvent.click(screen.getByTestId('dscGridSampleSizeFetchMoreLink'));
         await waitFor(() => {
-          expect(screen.getByTestId('pagination-button-2')).toHaveAttribute('aria-current', 'true');
+          expect(screen.getByTestId('pagination-button-2')).toHaveAttribute('aria-current', 'page');
           expect(screen.getByTestId('pagination-button-5')).toBeVisible();
         });
       },
@@ -427,7 +427,7 @@ describe('query tab with unified timeline', () => {
 
         expect(screen.getByTestId('pagination-button-previous')).toBeVisible();
 
-        expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+        expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'page');
         expect(fetchNotesSpy).toHaveBeenCalledWith(['1']);
 
         // Page : 2
@@ -438,7 +438,7 @@ describe('query tab with unified timeline', () => {
         fireEvent.click(screen.getByTestId('pagination-button-1'));
 
         await waitFor(() => {
-          expect(screen.getByTestId('pagination-button-1')).toHaveAttribute('aria-current', 'true');
+          expect(screen.getByTestId('pagination-button-1')).toHaveAttribute('aria-current', 'page');
 
           expect(fetchNotesSpy).toHaveBeenNthCalledWith(1, [mockTimelineData[1]._id]);
         });
@@ -450,7 +450,7 @@ describe('query tab with unified timeline', () => {
         fireEvent.click(screen.getByTestId('pagination-button-2'));
 
         await waitFor(() => {
-          expect(screen.getByTestId('pagination-button-2')).toHaveAttribute('aria-current', 'true');
+          expect(screen.getByTestId('pagination-button-2')).toHaveAttribute('aria-current', 'page');
 
           expect(fetchNotesSpy).toHaveBeenNthCalledWith(1, [mockTimelineData[2]._id]);
         });
@@ -475,7 +475,7 @@ describe('query tab with unified timeline', () => {
 
         expect(screen.getByTestId('pagination-button-previous')).toBeVisible();
 
-        expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'true');
+        expect(screen.getByTestId('pagination-button-0')).toHaveAttribute('aria-current', 'page');
         expect(screen.getByTestId('tablePaginationPopoverButton')).toHaveTextContent(
           'Rows per page: 1'
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,22 +2157,22 @@
   resolved "https://registry.yarnpkg.com/@elastic/eslint-plugin-eui/-/eslint-plugin-eui-0.0.2.tgz#56b9ef03984a05cc213772ae3713ea8ef47b0314"
   integrity sha512-IoxURM5zraoQ7C8f+mJb9HYSENiZGgRVcG4tLQxE61yHNNRDXtGDWTZh8N1KIHcsqN1CEPETjuzBXkJYF/fDiQ==
 
-"@elastic/eui-theme-common@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui-theme-common/-/eui-theme-common-0.1.0.tgz#fa74c7f72b4ca69ff1f7a5cf45e55c979064ab73"
-  integrity sha512-2Pm9PeEr4QXjtL/YYM6faXbQ2Fm/mJXzV7QLBxUW8iHov70IHZy1e3xJOio0lI1IbO3S7t79EIS6J3/uNffJfA==
+"@elastic/eui-theme-common@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui-theme-common/-/eui-theme-common-0.2.0.tgz#570a988f58c24076c6f867475e70930769f3cff5"
+  integrity sha512-g2n38Uk4G9UqQU/wim+ZKWusWtO1bdudvDy/7+sdCYaxtgbINT5hhMHoU9M49D+7FJSsPuHn7gVfdYKMN9bTdQ==
   dependencies:
     "@types/lodash" "^4.14.202"
     chroma-js "^2.4.2"
     lodash "^4.17.21"
 
-"@elastic/eui@101.3.0-classic.0":
-  version "101.3.0-classic.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-101.3.0-classic.0.tgz#c7b0632b062257342210850a958d2e353e829026"
-  integrity sha512-REt71u2yfnVyXX3+2MWLk3VzBdHAbCeSiPcs5MHY6h4TQR1WsD8+qs9RGFFfvW9ZSXTtyimrwOjQFt6Ph64s2Q==
+"@elastic/eui@101.4.0-amsterdam.0":
+  version "101.4.0-amsterdam.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-101.4.0-amsterdam.0.tgz#27360ebeb71e86052f99f5e88814b197ae97558e"
+  integrity sha512-zhWSRQYFFk2lm6mycBnpX8SJOeNzKjYJ7XwTv9RFfRUR6MGe/GfUIjHGCAg52NDNUTcYPlLuPhJKcNtAMasEOQ==
   dependencies:
-    "@elastic/eui-theme-common" "0.1.0"
-    "@elastic/prismjs-esql" "^1.0.0"
+    "@elastic/eui-theme-common" "0.2.0"
+    "@elastic/prismjs-esql" "^1.1.0"
     "@hello-pangea/dnd" "^16.6.0"
     "@types/lodash" "^4.14.202"
     "@types/numeral" "^2.0.5"
@@ -2235,10 +2235,10 @@
   resolved "https://registry.yarnpkg.com/@elastic/numeral/-/numeral-2.5.1.tgz#96acf39c3d599950646ef8ccfd24a3f057cf4932"
   integrity sha512-Tby6TKjixRFY+atVNeYUdGr9m0iaOq8230KTwn8BbUhkh7LwozfgKq0U98HRX7n63ZL62szl+cDKTYzh5WPCFQ==
 
-"@elastic/prismjs-esql@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/prismjs-esql/-/prismjs-esql-1.0.0.tgz#370c996536dcea8840f2c2288a97aca4982e13c5"
-  integrity sha512-kEQcj9wg7pUaFkW7m7zs0fz4cmg0kWUMQv6SyENXKvLGMecgDjNciEoN3CMg22PYURelbnhM7ii6nFv9hAr2NA==
+"@elastic/prismjs-esql@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/prismjs-esql/-/prismjs-esql-1.1.0.tgz#c7f84de21bb453831df7e8565be7430b1b078836"
+  integrity sha512-k2zZfCL4l+qCXfmc9jrnDdEWW2jDPFAHlCq1JAh3x7zWN6Eyc6ACn3oj9oy49xsuAO+BAhQ345uueL8K/3UIKg==
 
 "@elastic/react-search-ui-views@1.20.2", "@elastic/react-search-ui-views@^1.20.2":
   version "1.20.2"


### PR DESCRIPTION
`101.3.0` ⏩ `101.4.0`

[Questions? Please see our Kibana upgrade FAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)

>[!IMPORTANT]
This PR is a direct sibling to this [upgrade PR](https://github.com/elastic/kibana/pull/218778) to `main`. The difference is that it adds a standalone EUI package with the previous "Amsterdam" theme. 
Apart from the theme difference, **there are no further changes added**.

## Changes

This PR only updates tests and snapshots related to changes on EUI side:
- updated `aria-current="true"` to `aria-current="page"`
- updated icon usage `userAvatar` to `user`

## Package updates

### `@elastic/eui`

#### [`v101.4.0`](https://github.com/elastic/eui/releases/v101.4.0)

- Spread `labelProps` to the `label` element in `EuiCheckableCard` ([#8586](https://github.com/elastic/eui/pull/8586))
- Add `controls`, `flask`, `comment`, and `readOnly` glyphs to `EuiIcon` ([#8580](https://github.com/elastic/eui/pull/8580))
- Refactored `EuiExpression`, `EuiFacetGroup`, `EuiFacetButton`, `EuiFilterGroup`, `EuiHeader`, `EuiImage` and `EuiListGroup` to memoize their internal Emotion styles ([#8565](https://github.com/elastic/eui/pull/8565))
- Updated global `border.radius.medium` token value for default `Borealis` theme to `4px` ([#8563](https://github.com/elastic/eui/pull/8563))
- Updated `EuiProvider` to build themes including `highContrastMode` ([#8558](https://github.com/elastic/eui/pull/8558))

**Accessibility**

- Removed the `aria-label` attribute from the `ul` element in `EuiPagination` to avoid duplicate screen reader output ([#8597](https://github.com/elastic/eui/pull/8597))
- Set a more specific `aria-current="page"` on list items in `EuiPagination` ([#8597](https://github.com/elastic/eui/pull/8597))
- Added `aria-modal` to `EuiFlyout` with `type="overlay"` ([#8591](https://github.com/elastic/eui/pull/8591))

**Dependency updates**

- Updated `@elastic/prismjs-esql` to v1.1.0 ([#8587](https://github.com/elastic/eui/pull/8587))

### `@elastic/eui-theme-borealis@0.2.0`

- Updated component tokens to use `computed` values to ensure correct inheritance from theme overrides ([#8558](https://github.com/elastic/eui/pull/8558))
- Added `overrides.HCM` to `euiThemeBorealis` to support theme internal overrides ([#8558](https://github.com/elastic/eui/pull/8558))
- Updated `border.radius.medium` token value to `4px` ([#8563](https://github.com/elastic/eui/pull/8563))

### `@elastic/eui-theme-common@0.2.0`

- Added support for theme `overrides` as optional part of `EuiThemeShape` ([#8558](https://github.com/elastic/eui/pull/8558))
- Updated `getComputed` to support high contrast mode overrides defined on `overrides.HCM` ([#8558](https://github.com/elastic/eui/pull/8558))