### PR TITLE
[Search] Fix: serverless search connector types

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -139,4 +139,4 @@ xpack.searchSynonyms.enabled: true
 xpack.searchQueryRules.enabled: false
 
 ## Search Connectors in stack management
-xpack.contentConnectors.enabled: false
+xpack.contentConnectors.ui.enabled: false

--- a/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/src/platform/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -256,6 +256,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.cloud.serverless.project_type (string?)',
         'xpack.cloud.serverless.orchestrator_target (string?)',
         'xpack.cloud.onboarding.default_solution (string?)',
+        'xpack.contentConnectors.ui.enabled (boolean?)',
         'xpack.discoverEnhanced.actions.exploreDataInChart.enabled (boolean?)',
         'xpack.discoverEnhanced.actions.exploreDataInContextMenu.enabled (boolean?)',
         'xpack.fleet.agents.enabled (boolean?)',

--- a/x-pack/platform/plugins/shared/content_connectors/common/types/config.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/common/types/config.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface ClientConfigType {
+  ui: { enabled: boolean };
+}

--- a/x-pack/platform/plugins/shared/content_connectors/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/public/plugin.ts
@@ -8,6 +8,7 @@
 import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/public';
 import { docLinks } from '@kbn/search-connectors/constants/doc_links';
 import { ManagementAppMountParams } from '@kbn/management-plugin/public';
+import { type ClientConfigType } from '../common/types/config';
 import { getConnectorFullTypes, getConnectorTypes } from '../common/lib/connector_types';
 import {
   SearchConnectorsPluginSetup,
@@ -29,10 +30,12 @@ export class SearchConnectorsPlugin
 {
   private readonly isServerless: boolean;
   private readonly kibanaVersion: string;
+  private readonly config: ClientConfigType;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.isServerless = initializerContext.env.packageInfo.buildFlavor === 'serverless';
     this.kibanaVersion = initializerContext.env.packageInfo.version;
+    this.config = initializerContext.config.get<ClientConfigType>();
   }
 
   public setup(
@@ -43,7 +46,7 @@ export class SearchConnectorsPlugin
     const connectorTypes = getConnectorTypes(core.http.staticAssets);
     const kibanaVersion = this.kibanaVersion;
 
-    if (this.isServerless === true) {
+    if (this.config.ui.enabled && this.isServerless === true) {
       management.sections.section.data.registerApp({
         id: PLUGIN_ID,
         title: PLUGIN_NAME,

--- a/x-pack/platform/plugins/shared/content_connectors/server/config.ts
+++ b/x-pack/platform/plugins/shared/content_connectors/server/config.ts
@@ -12,11 +12,17 @@ export * from './types';
 
 const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: true }),
+  ui: schema.object({
+    enabled: schema.boolean({ defaultValue: true }),
+  }),
 });
 
 type ConfigType = TypeOf<typeof configSchema>;
 
 export const config: PluginConfigDescriptor<ConfigType> = {
+  exposeToBrowser: {
+    ui: true,
+  },
   schema: configSchema,
 };
 

--- a/x-pack/solutions/search/plugins/enterprise_search/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/enterprise_search/kibana.jsonc
@@ -34,7 +34,7 @@
       "usageCollection",
       "guidedOnboarding",
       "console",
-      "searchConnectors",
+      "contentConnectors",
       "searchNavigation",
       "searchPlayground",
       "embeddable",

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/index.test.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/index.test.tsx
@@ -39,6 +39,7 @@ describe('renderApp', () => {
     params: coreMock.createAppMountParameters(),
     plugins: {
       charts: chartPluginMock.createStartContract(),
+      contentConnectors: searchConnectorsMock.createStart(),
       data: dataPluginMock.createStartContract(),
       guidedOnboarding: guidedOnboardingMock.createStart(),
       indexManagement: {
@@ -47,7 +48,6 @@ describe('renderApp', () => {
       lens: lensPluginMock.createStartContract(),
       licensing: licensingMock.createStart(),
       navigation: navigationPluginMock.createStartContract(),
-      searchConnectors: searchConnectorsMock.createStart(),
       security: securityMock.createStart(),
       share: sharePluginMock.createStartContract(),
       ml: mlPluginMock.createStartContract(),

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/index.tsx
@@ -82,7 +82,7 @@ export const renderApp = (
   const store = getContext().store;
   const indexMappingComponent = indexManagementPlugin?.getIndexMappingComponent({ history });
 
-  const connectorTypes = plugins.searchConnectors?.getConnectorTypes() || [];
+  const connectorTypes = plugins.contentConnectors?.getConnectorTypes() || [];
 
   const unmountKibanaLogic = mountKibanaLogic({
     application,

--- a/x-pack/solutions/search/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/plugin.ts
@@ -82,6 +82,7 @@ export interface PluginsStart {
   charts?: ChartsPluginStart;
   cloud?: CloudSetup & CloudStart;
   console?: ConsolePluginStart;
+  contentConnectors?: SearchConnectorsPluginStart;
   data?: DataPublicPluginStart;
   fleet?: FleetStart;
   guidedOnboarding?: GuidedOnboardingPluginStart;
@@ -90,7 +91,6 @@ export interface PluginsStart {
   licensing?: LicensingPluginStart;
   ml?: MlPluginStart;
   navigation: NavigationPublicPluginStart;
-  searchConnectors?: SearchConnectorsPluginStart;
   searchNavigation?: SearchNavigationPluginStart;
   searchPlayground?: SearchPlaygroundPluginStart;
   security?: SecurityPluginStart;

--- a/x-pack/solutions/search/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/plugin.ts
@@ -100,7 +100,7 @@ export class EnterpriseSearchPlugin implements Plugin<void, void, PluginsSetup, 
       licensing,
       guidedOnboarding,
       cloud,
-      searchConnectors,
+      contentConnectors,
     }: PluginsSetup
   ) {
     this.globalConfigService.setup(elasticsearch.legacy.config$, cloud);
@@ -317,7 +317,7 @@ export class EnterpriseSearchPlugin implements Plugin<void, void, PluginsSetup, 
 
     if (globalSearch) {
       globalSearch.registerResultProvider(
-        getSearchResultProvider(config, searchConnectors?.getConnectorTypes() || [])
+        getSearchResultProvider(config, contentConnectors?.getConnectorTypes() || [])
       );
       globalSearch.registerResultProvider(getIndicesSearchResultProvider(http.staticAssets));
       globalSearch.registerResultProvider(getConnectorsSearchResultProvider(http.staticAssets));

--- a/x-pack/solutions/search/plugins/enterprise_search/server/types.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/types.ts
@@ -33,6 +33,7 @@ import type { ConfigType } from '.';
 
 export interface PluginsSetup {
   cloud?: CloudSetup;
+  contentConnectors?: SearchConnectorsPluginSetup;
   customIntegrations?: CustomIntegrationsPluginSetup;
   features: FeaturesPluginSetup;
   globalSearch: GlobalSearchPluginSetup;
@@ -40,7 +41,6 @@ export interface PluginsSetup {
   licensing: LicensingPluginStart;
   logsShared: LogsSharedPluginSetup;
   ml?: MlPluginSetup;
-  searchConnectors?: SearchConnectorsPluginSetup;
   security: SecurityPluginSetup;
   usageCollection?: UsageCollectionSetup;
 }

--- a/x-pack/solutions/search/plugins/serverless_search/kibana.jsonc
+++ b/x-pack/solutions/search/plugins/serverless_search/kibana.jsonc
@@ -33,7 +33,7 @@
     ],
     "optionalPlugins": [
       "indexManagement",
-      "searchConnectors",
+      "contentConnectors",
       "searchInferenceEndpoints",
       "searchPlayground",
       "usageCollection"

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_connector_types.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/api/use_connector_types.tsx
@@ -8,7 +8,7 @@
 import { useKibanaServices } from '../use_kibana';
 
 export const useConnectorTypes = () => {
-  const { searchConnectors } = useKibanaServices();
+  const { contentConnectors } = useKibanaServices();
 
-  return searchConnectors?.getConnectorTypes() || [];
+  return contentConnectors?.getConnectorTypes() || [];
 };

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/use_kibana.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/hooks/use_kibana.tsx
@@ -18,7 +18,7 @@ export interface ServerlessSearchContext {
   cloud: CloudStart;
   console: ConsolePluginStart;
   history: AppMountParameters['history'];
-  searchConnectors?: SearchConnectorsPluginStart;
+  contentConnectors?: SearchConnectorsPluginStart;
   security: SecurityPluginStart;
   share: SharePluginStart;
   user?: AuthenticatedUser;

--- a/x-pack/solutions/search/plugins/serverless_search/public/test/test_utils.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/test/test_utils.tsx
@@ -21,7 +21,7 @@ import { searchConnectorsMock } from '@kbn/content-connectors-plugin/public/plug
 export const core = coreMock.createStart();
 export const services = {
   cloud: cloudMock.createStart(),
-  searchConnectors: searchConnectorsMock.createStart(),
+  contentConnectors: searchConnectorsMock.createStart(),
   share: sharePluginMock.createStartContract(),
   userProfile: userProfileMock.createWithSecurity(),
 };


### PR DESCRIPTION
## Summary

Fixes bug introduced by: https://github.com/elastic/kibana/pull/213509 where serverless search & enterprise search could not load list of available connector types from the connectors plugin. This was caused by 2 things in serverless, 1) the entire plugin was disabled and 2) the plugin id was renamed.

Updated the `contentConnectors` plugin to have a `ui.enabled` config value to override just disabling the management UI from being registered for Serverless Search, while still allowing the plugin to be enabled. And updated the usages of the `searchConnectors` plugin in `enteprise_search` & `serverless_search` to account for it being renamed to `contentConnectors`

Of note this bug would have been caught by FTRs, but they have been skipped for being [flakey](https://github.com/elastic/kibana/issues/203462) for some time, and have proven [hard fix](https://github.com/elastic/kibana/pull/205971) given the current UX 😔 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
