### PR TITLE
[8.17] [data.search] Collect telemetry when search times out (#218187)

### DIFF
--- a/src/plugins/data/public/plugin.ts
+++ b/src/plugins/data/public/plugin.ts
@@ -15,6 +15,11 @@ import {
   IStorageWrapper,
   createStartServicesGetter,
 } from '@kbn/kibana-utils-plugin/public';
+import {
+  EVENT_PROPERTY_EXECUTION_CONTEXT,
+  EVENT_PROPERTY_SEARCH_TIMEOUT_MS,
+  EVENT_TYPE_DATA_SEARCH_TIMEOUT,
+} from './search/constants';
 import type { ConfigSchema } from '../server/config';
 import type {
   DataPublicPluginSetup,
@@ -114,6 +119,25 @@ export class DataPublicPlugin
         startServices().plugins.fieldFormats.deserialize(serializedFieldFormat)
       )
     );
+
+    core.analytics.registerEventType({
+      eventType: EVENT_TYPE_DATA_SEARCH_TIMEOUT,
+      schema: {
+        [EVENT_PROPERTY_SEARCH_TIMEOUT_MS]: {
+          type: 'long',
+          _meta: {
+            description:
+              'The time (in ms) before the search request was aborted due to timeout (search:timeout advanced setting)',
+          },
+        },
+        [EVENT_PROPERTY_EXECUTION_CONTEXT]: {
+          type: 'pass_through',
+          _meta: {
+            description: 'Execution context of the search request that timed out',
+          },
+        },
+      },
+    });
 
     return {
       search: searchService,

--- a/src/plugins/data/public/search/constants.ts
+++ b/src/plugins/data/public/search/constants.ts
@@ -1,9 +1,10 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
 export const EVENT_TYPE_DATA_SEARCH_TIMEOUT = 'data_search_timeout';

--- a/src/plugins/data/public/search/constants.ts
+++ b/src/plugins/data/public/search/constants.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const EVENT_TYPE_DATA_SEARCH_TIMEOUT = 'data_search_timeout';
+export const EVENT_PROPERTY_SEARCH_TIMEOUT_MS = 'timeout_ms';
+export const EVENT_PROPERTY_EXECUTION_CONTEXT = 'execution_context';

--- a/src/plugins/data/public/search/search_interceptor/search_interceptor.test.ts
+++ b/src/plugins/data/public/search/search_interceptor/search_interceptor.test.ts
@@ -468,16 +468,14 @@ describe('SearchInterceptor', () => {
     });
 
     test('should report telemetry on timeout', async () => {
-      mockCoreSetup.http.post.mockResolvedValue(
-        getMockSearchResponse({
-          isPartial: true,
-          isRunning: true,
-          rawResponse: {
-            foo: 'bar',
-          },
-          id: '1',
-        })
-      );
+      fetchMock.mockResolvedValue({
+        isPartial: true,
+        isRunning: true,
+        rawResponse: {
+          foo: 'bar',
+        },
+        id: '1',
+      });
 
       const response = searchInterceptor.search({}, { pollInterval: 0 });
       response.subscribe({ next, error });

--- a/src/plugins/data/public/search/search_interceptor/search_interceptor.test.ts
+++ b/src/plugins/data/public/search/search_interceptor/search_interceptor.test.ts
@@ -467,6 +467,35 @@ describe('SearchInterceptor', () => {
       expect(mockCoreSetup.http.delete).toHaveBeenCalledTimes(1);
     });
 
+    test('should report telemetry on timeout', async () => {
+      mockCoreSetup.http.post.mockResolvedValue(
+        getMockSearchResponse({
+          isPartial: true,
+          isRunning: true,
+          rawResponse: {
+            foo: 'bar',
+          },
+          id: '1',
+        })
+      );
+
+      const response = searchInterceptor.search({}, { pollInterval: 0 });
+      response.subscribe({ next, error });
+
+      await timeTravel(1000);
+
+      expect(mockCoreStart.analytics.reportEvent).toBeCalled();
+      expect(mockCoreStart.analytics.reportEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          "data_search_timeout",
+          Object {
+            "execution_context": undefined,
+            "timeout_ms": 1000,
+          },
+        ]
+      `);
+    });
+
     test('should not leak unresolved promises if DELETE fails', async () => {
       mockCoreSetup.http.delete.mockRejectedValueOnce({ status: 404, statusText: 'Not Found' });
       const responses = [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[data.search] Collect telemetry when search times out (#218187)](https://github.com/elastic/kibana/pull/218187)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lukas Olson","email":"lukas@elastic.co"},"sourceCommit":{"committedDate":"2025-04-17T16:38:06Z","message":"[data.search] Collect telemetry when search times out (#218187)\n\n## Summary\n\nAdds EBT collection when a search request times out (due to the\n`search:timeout` advanced setting).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"2f4f3cae4f416929f94f296bceb390976f1596ca","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Search","Feature:Telemetry","release_note:skip","backport missing","Team:DataDiscovery","backport:all-open","v9.1.0"],"title":"[data.search] Collect telemetry when search times out","number":218187,"url":"https://github.com/elastic/kibana/pull/218187","mergeCommit":{"message":"[data.search] Collect telemetry when search times out (#218187)\n\n## Summary\n\nAdds EBT collection when a search request times out (due to the\n`search:timeout` advanced setting).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"2f4f3cae4f416929f94f296bceb390976f1596ca"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218187","number":218187,"mergeCommit":{"message":"[data.search] Collect telemetry when search times out (#218187)\n\n## Summary\n\nAdds EBT collection when a search request times out (due to the\n`search:timeout` advanced setting).\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...","sha":"2f4f3cae4f416929f94f296bceb390976f1596ca"}},{"url":"https://github.com/elastic/kibana/pull/218857","number":218857,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->