### PR TITLE
[AI4DSOC] Fix spacing issue on alert summary landing page integration card

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/landing_page/integration_card.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/landing_page/integration_card.tsx
@@ -5,9 +5,9 @@
  * 2.0.
  */
 
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
-import { EuiBadge, EuiCard } from '@elastic/eui';
+import { EuiBadge, EuiCard, useEuiTheme } from '@elastic/eui';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import { INTEGRATIONS_PLUGIN_ID } from '@kbn/fleet-plugin/common';
 import { useLink } from '@kbn/fleet-plugin/public';
@@ -40,6 +40,9 @@ export interface IntegrationCardProps {
  */
 export const IntegrationCard = memo(
   ({ integration, 'data-test-subj': dataTestSubj }: IntegrationCardProps) => {
+    const { euiTheme } = useEuiTheme();
+    const iconStyle = useMemo(() => ({ marginInlineEnd: euiTheme.size.base }), [euiTheme]);
+
     const {
       services: { application },
     } = useKibana();
@@ -66,7 +69,13 @@ export const IntegrationCard = memo(
         display="plain"
         hasBorder
         icon={
-          <IntegrationIcon data-test-subj={dataTestSubj} iconSize="xl" integration={integration} />
+          <div style={iconStyle}>
+            <IntegrationIcon
+              data-test-subj={dataTestSubj}
+              iconSize="xl"
+              integration={integration}
+            />
+          </div>
         }
         layout="horizontal"
         onClick={onClick}


### PR DESCRIPTION
## Summary

This PR a small UI issue with the AI4DSOC alert summary landing page. Originally added via [this PR](https://github.com/elastic/kibana/pull/215246), some of that logic was changed in [this more recent PR](https://github.com/elastic/kibana/pull/218632), where the `IntegrationIcon` logic was extracted into a reusable component, packages with a `EuiSkeletonText` component, which somehow breaks the `inlineMargingEnd` value applied to the icon...

This PR fixes the spacing issue now seen on the integration card.

| Before | After |
| ------------- | ------------- |
| ![Screenshot 2025-04-22 at 12 42 54 PM](https://github.com/user-attachments/assets/402af5e9-69ef-46db-9d53-faf8d617a307) | ![Screenshot 2025-04-22 at 12 38 19 PM](https://github.com/user-attachments/assets/3c290f46-8c79-424c-b478-e55736917429) |

## How to test

This needs to be ran in Serverless:
- `yarn es serverless --projectType security`
- `yarn serverless-security --no-base-path`

You also need to enable the AI for SOC tier, by adding the following to your `serverless.security.dev.yaml` file:
```
xpack.securitySolutionServerless.productTypes:
  [
    { product_line: 'ai_soc', product_tier: 'search_ai_lake' },
  ]
```