### PR TITLE
[Search][Playground] Fix: maintain search params when switching views

### DIFF
--- a/x-pack/solutions/search/plugins/search_playground/public/components/playgorund.tsx
+++ b/x-pack/solutions/search/plugins/search_playground/public/components/playgorund.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Route, Routes } from '@kbn/shared-ux-router';
 
 import { useWatch } from 'react-hook-form';
@@ -41,6 +42,7 @@ export interface AppProps {
 
 export const Playground: React.FC<AppProps> = ({ showDocs = false }) => {
   const isSearchModeEnabled = useSearchPlaygroundFeatureFlag();
+  const location = useLocation();
   const { pageMode, viewMode } = usePlaygroundParameters();
   const { application } = useKibana().services;
   const { data: connectors } = useLoadConnectors();
@@ -50,15 +52,21 @@ export const Playground: React.FC<AppProps> = ({ showDocs = false }) => {
     }).length
   );
   const navigateToView = useCallback(
-    (page: PlaygroundPageMode, view?: PlaygroundViewMode) => {
+    (page: PlaygroundPageMode, view?: PlaygroundViewMode, searchParams?: string) => {
+      let path = view && view !== PlaygroundViewMode.preview ? `/${page}/${view}` : `/${page}`;
+      if (searchParams) {
+        path += searchParams;
+      }
       application.navigateToApp(PLUGIN_ID, {
-        path: view && view !== PlaygroundViewMode.preview ? `/${page}/${view}` : `/${page}`,
+        path,
       });
     },
     [application]
   );
-  const handleModeChange = (id: PlaygroundViewMode) => navigateToView(pageMode, id);
-  const handlePageModeChange = (mode: PlaygroundPageMode) => navigateToView(mode, viewMode);
+  const handleModeChange = (id: PlaygroundViewMode) =>
+    navigateToView(pageMode, id, location.search);
+  const handlePageModeChange = (mode: PlaygroundPageMode) =>
+    navigateToView(mode, viewMode, location.search);
   const { showSetupPage } = usePageMode({
     hasSelectedIndices,
     hasConnectors: Boolean(connectors?.length),


### PR DESCRIPTION
## Summary

Updated the navigate callback to maintain search parameters if they exist when navigation between playground views.