### PR TITLE
Fix ES3 image promotion when passing full images

### DIFF
--- a/.buildkite/scripts/steps/es_serverless/promote_es_serverless_image.sh
+++ b/.buildkite/scripts/steps/es_serverless/promote_es_serverless_image.sh
@@ -8,7 +8,7 @@ BASE_ES_SERVERLESS_REPO=docker.elastic.co/elasticsearch-ci/elasticsearch-serverl
 TARGET_IMAGE=docker.elastic.co/kibana-ci/elasticsearch-serverless:latest-verified
 
 SOURCE_IMAGE_OR_TAG=$1
-if [[ $SOURCE_IMAGE_OR_TAG =~ :[a-zA-Z_-]+$ ]]; then
+if [[ $SOURCE_IMAGE_OR_TAG =~ :[a-zA-Z0-9_.-]+$ ]]; then
   # $SOURCE_IMAGE_OR_TAG was a full image
   SOURCE_IMAGE=$SOURCE_IMAGE_OR_TAG
 else


### PR DESCRIPTION
## Summary

When trying to promote a specific image of ES, it failed due to the regex setting up an invalid source image

```bash
ES_SERVERLESS_IMAGE="docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:git-75f3c1f58b72"

Re-tagging docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:git-75f3c1f58b72 -> docker.elastic.co/kibana-ci/elasticsearch-serverless:latest-verified
```

https://buildkite.com/elastic/kibana-elasticsearch-serverless-verify-and-promote/builds/3401#01965ef6-a809-44d0-b51d-3eae599c95d3/190-191

## Testing

Duplicated part of the promotion script locally to test the changes:

#### Before Changes:
```bash
➜ kibana (main) ✗ ./test.sh docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:git-75f3c1f58b72
docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:git-75f3c1f58b72
➜ kibana (main) ✗ ./test.sh latest                                                                      
docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:latest
➜ kibana (main) ✗ ./test.sh git-75f3c1f58b72 
docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:git-75f3c1f58b72
```

#### After Changes:
```bash
➜ kibana (main) ✗ ./test.sh git-75f3c1f58b72
docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:git-75f3c1f58b72
➜ kibana (main) ✗ ./test.sh latest          
docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:latest
➜ kibana (main) ✗ ./test.sh docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:git-75f3c1f58b72
docker.elastic.co/elasticsearch-ci/elasticsearch-serverless:git-75f3c1f58b72
```