### PR TITLE
[Synthetics] Disable use logical AND when filter is removed

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/monitor_filters/use_filters.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/monitor_filters/use_filters.ts
@@ -120,7 +120,8 @@ export function useMonitorFiltersState() {
         const currentUseLogicalAndFor = urlParams.useLogicalAndFor || [];
         newUrlParams.useLogicalAndFor = serializeFilterValue(
           'useLogicalAndFor',
-          isLogicalAND
+          // When all the values are deselected remove the useLogicalAndFor for the field
+          isLogicalAND && selectedValues?.length
             ? [...currentUseLogicalAndFor, field]
             : currentUseLogicalAndFor.filter((item: string) => item !== field)
         );


### PR DESCRIPTION
This PR fixes an issue found in #217985 


https://github.com/user-attachments/assets/3b995e0f-1b33-4740-99ca-29b3760c46da



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->