### PR TITLE
[8.19] 🌊 Streams: Use better default field (#217478)

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/index.tsx
@@ -23,7 +23,7 @@ import {
 import { useSelector } from '@xstate5/react';
 import { i18n } from '@kbn/i18n';
 import { isEmpty } from 'lodash';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useCallback } from 'react';
 import { useForm, SubmitHandler, FormProvider, useWatch } from 'react-hook-form';
 import { css } from '@emotion/react';
 import { DiscardPromptOptions, useDiscardConfirm } from '../../../../hooks/use_discard_confirm';
@@ -46,11 +46,13 @@ import {
   useStreamsEnrichmentSelector,
   useSimulatorSelector,
   StreamEnrichmentContextType,
+  useGetStreamEnrichmentState,
 } from '../state_management/stream_enrichment_state_machine';
 import { ProcessorMetrics } from '../state_management/simulation_state_machine';
 import { DateProcessorForm } from './date';
 import { ConfigDrivenProcessorFields } from './config_driven/components/fields';
 import { ConfigDrivenProcessorType } from './config_driven/types';
+import { selectPreviewDocuments } from '../state_management/simulation_state_machine/selectors';
 
 export function AddProcessorPanel() {
   const { euiTheme } = useEuiTheme();
@@ -63,20 +65,31 @@ export function AddProcessorPanel() {
   const processorMetrics = useSimulatorSelector(
     (state) => processorRef && state.context.simulation?.processors_metrics[processorRef.id]
   );
+  const getEnrichmentState = useGetStreamEnrichmentState();
 
   const isOpen = Boolean(processorRef);
+  const defaultValuesGetter = useCallback(
+    () =>
+      getDefaultFormStateByType(
+        'grok',
+        selectPreviewDocuments(getEnrichmentState().context.simulatorRef?.getSnapshot().context)
+      ),
+    [getEnrichmentState]
+  );
+  const initialDefaultValues = useMemo(() => defaultValuesGetter(), [defaultValuesGetter]);
 
-  const defaultValues = useMemo(() => getDefaultFormStateByType('grok'), []);
-
-  const methods = useForm<ProcessorFormState>({ defaultValues, mode: 'onChange' });
+  const methods = useForm<ProcessorFormState>({
+    defaultValues: initialDefaultValues,
+    mode: 'onChange',
+  });
 
   const type = useWatch({ control: methods.control, name: 'type' });
 
   useEffect(() => {
     if (!processorRef) {
-      methods.reset(defaultValues);
+      methods.reset(defaultValuesGetter());
     }
-  }, [defaultValues, methods, processorRef]);
+  }, [defaultValuesGetter, methods, processorRef]);
 
   useEffect(() => {
     if (processorRef) {
@@ -99,6 +112,8 @@ export function AddProcessorPanel() {
   };
 
   const handleOpen = () => {
+    const defaultValues = defaultValuesGetter();
+    methods.reset(defaultValues);
     const draftProcessor = createDraftProcessorFromForm(defaultValues);
     addProcessor(draftProcessor);
   };
@@ -207,6 +222,7 @@ export interface EditProcessorPanelProps {
 export function EditProcessorPanel({ processorRef, processorMetrics }: EditProcessorPanelProps) {
   const { euiTheme } = useEuiTheme();
   const state = useSelector(processorRef, (s) => s);
+  const getEnrichmentState = useGetStreamEnrichmentState();
   const canEdit = useStreamsEnrichmentSelector((s) => s.context.definition.privileges.simulate);
   const previousProcessor = state.context.previousProcessor;
   const processor = state.context.processor;
@@ -217,7 +233,14 @@ export function EditProcessorPanel({ processorRef, processorMetrics }: EditProce
   const isNew = state.context.isNew;
   const isUnsaved = isNew || state.context.isUpdated;
 
-  const defaultValues = useMemo(() => getFormStateFrom(processor), [processor]);
+  const defaultValues = useMemo(
+    () =>
+      getFormStateFrom(
+        selectPreviewDocuments(getEnrichmentState().context.simulatorRef?.getSnapshot().context),
+        processor
+      ),
+    [getEnrichmentState, processor]
+  );
 
   const methods = useForm<ProcessorFormState>({
     defaultValues,
@@ -239,11 +262,16 @@ export function EditProcessorPanel({ processorRef, processorMetrics }: EditProce
 
   useEffect(() => {
     const subscription = processorRef.on('processor.changesDiscarded', () => {
-      methods.reset(getFormStateFrom(previousProcessor));
+      methods.reset(
+        getFormStateFrom(
+          selectPreviewDocuments(getEnrichmentState().context.simulatorRef?.getSnapshot().context),
+          previousProcessor
+        )
+      );
     });
 
     return () => subscription.unsubscribe();
-  }, [methods, previousProcessor, processorRef]);
+  }, [getEnrichmentState, methods, previousProcessor, processorRef]);
 
   const handleCancel = useDiscardConfirm(
     () => processorRef?.send({ type: 'processor.cancel' }),

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/processor_type_selector.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/processors/processor_type_selector.tsx
@@ -15,6 +15,8 @@ import { useKibana } from '../../../../hooks/use_kibana';
 import { getDefaultFormStateByType } from '../utils';
 import { ProcessorFormState } from '../types';
 import { configDrivenProcessors } from './config_driven';
+import { useGetStreamEnrichmentState } from '../state_management/stream_enrichment_state_machine';
+import { selectPreviewDocuments } from '../state_management/simulation_state_machine/selectors';
 
 interface TAvailableProcessor {
   type: ProcessorType;
@@ -29,6 +31,7 @@ export const ProcessorTypeSelector = ({
 }: Pick<EuiSuperSelectProps, 'disabled'>) => {
   const { core } = useKibana();
   const esDocUrl = core.docLinks.links.elasticsearch.docsBase;
+  const getEnrichmentState = useGetStreamEnrichmentState();
 
   const { reset } = useFormContext();
   const { field, fieldState } = useController<ProcessorFormState, 'type'>({
@@ -39,7 +42,10 @@ export const ProcessorTypeSelector = ({
   const processorType = useWatch<{ type: ProcessorType }>({ name: 'type' });
 
   const handleChange = (type: ProcessorType) => {
-    const formState = getDefaultFormStateByType(type);
+    const formState = getDefaultFormStateByType(
+      type,
+      selectPreviewDocuments(getEnrichmentState().context.simulatorRef?.getSnapshot().context)
+    );
     reset(formState);
   };
 

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/simulation_state_machine/selectors.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/simulation_state_machine/selectors.ts
@@ -20,15 +20,15 @@ const EMPTY_ARRAY: [] = [];
  */
 export const selectPreviewDocuments = createSelector(
   [
-    (context: SimulationContext) => context.samples,
-    (context: SimulationContext) => context.previewDocsFilter,
-    (context: SimulationContext) => context.simulation?.documents,
+    (context: SimulationContext | undefined) => context?.samples,
+    (context: SimulationContext | undefined) => context?.previewDocsFilter,
+    (context: SimulationContext | undefined) => context?.simulation?.documents,
   ],
   (samples, previewDocsFilter, documents) => {
     return (
       ((previewDocsFilter && documents
         ? filterSimulationDocuments(documents, previewDocsFilter)
-        : samples.map(flattenObjectNestedLast)) as FlattenRecord[]) || EMPTY_ARRAY
+        : samples?.map(flattenObjectNestedLast)) as FlattenRecord[]) || EMPTY_ARRAY
     );
   }
 );

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/use_stream_enrichment.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/state_management/stream_enrichment_state_machine/use_stream_enrichment.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { createActorContext, useSelector } from '@xstate5/react';
 import { createConsoleInspector } from '@kbn/xstate-utils';
 import {
@@ -25,6 +25,11 @@ const StreamEnrichmentContext = createActorContext(streamEnrichmentMachine);
 export const useStreamsEnrichmentSelector = StreamEnrichmentContext.useSelector;
 
 export type StreamEnrichmentEvents = ReturnType<typeof useStreamEnrichmentEvents>;
+
+export const useGetStreamEnrichmentState = () => {
+  const service = StreamEnrichmentContext.useActorRef();
+  return useCallback(() => service.getSnapshot(), [service]);
+};
 
 export const useStreamEnrichmentEvents = () => {
   const service = StreamEnrichmentContext.useActorRef();

--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_enrichment/utils.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FlattenRecord } from '@kbn/streams-schema';
+import { getDefaultFormStateByType } from './utils';
+import { ALWAYS_CONDITION } from '../../../util/condition';
+
+describe('utils', () => {
+  describe('defaultGrokProcessorFormState', () => {
+    it('should return default form state with empty field when no well known text fields are present', () => {
+      const sampleDocs: FlattenRecord[] = [
+        {
+          'unknown.field': 'some value',
+          'another.field': 'another value',
+        },
+        {
+          'random.field': 'random value',
+        },
+      ];
+
+      const result = getDefaultFormStateByType('grok', sampleDocs);
+
+      expect(result).toEqual({
+        type: 'grok',
+        field: '',
+        patterns: [{ value: '' }],
+        pattern_definitions: {},
+        ignore_failure: true,
+        ignore_missing: true,
+        if: ALWAYS_CONDITION,
+      });
+    });
+
+    it('should select the only well known text field present', () => {
+      const sampleDocs: FlattenRecord[] = [
+        {
+          'error.message': 'This is an error',
+          'another.field': 'another value',
+        },
+        {
+          'error.message': 'Another error',
+          'random.field': 'random value',
+        },
+      ];
+
+      const result = getDefaultFormStateByType('grok', sampleDocs);
+
+      expect(result).toEqual({
+        type: 'grok',
+        field: 'error.message',
+        patterns: [{ value: '' }],
+        pattern_definitions: {},
+        ignore_failure: true,
+        ignore_missing: true,
+        if: ALWAYS_CONDITION,
+      });
+    });
+
+    it('should select the most common well known text field when multiple are present', () => {
+      const sampleDocs: FlattenRecord[] = [
+        {
+          message: 'Log message 1',
+          'error.message': 'Error message 1',
+        },
+        {
+          message: 'Log message 2',
+          'error.message': 'Error message 2',
+        },
+        {
+          'error.message': 'Error message 3',
+        },
+      ];
+
+      const result = getDefaultFormStateByType('grok', sampleDocs);
+
+      expect(result).toEqual({
+        type: 'grok',
+        field: 'error.message', // 'error.message' appears 3 times vs 'message' 2 times
+        patterns: [{ value: '' }],
+        pattern_definitions: {},
+        ignore_failure: true,
+        ignore_missing: true,
+        if: ALWAYS_CONDITION,
+      });
+    });
+
+    it('should select based on WELL_KNOWN_TEXT_FIELDS order when frequencies are equal', () => {
+      const sampleDocs: FlattenRecord[] = [
+        {
+          message: 'Log message 1',
+          'error.message': 'Error message 1',
+          'event.original': 'Original event 1',
+        },
+        {
+          message: 'Log message 2',
+          'error.message': 'Error message 2',
+          'event.original': 'Original event 2',
+        },
+      ];
+
+      const result = getDefaultFormStateByType('grok', sampleDocs);
+
+      // In WELL_KNOWN_TEXT_FIELDS, 'message' comes before 'error.message' and 'event.original'
+      expect(result).toEqual({
+        type: 'grok',
+        field: 'message',
+        patterns: [{ value: '' }],
+        pattern_definitions: {},
+        ignore_failure: true,
+        ignore_missing: true,
+        if: ALWAYS_CONDITION,
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [🌊 Streams: Use better default field (#217478)](https://github.com/elastic/kibana/pull/217478)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Joe Reuter","email":"johannes.reuter@elastic.co"},"sourceCommit":{"committedDate":"2025-04-15T12:29:09Z","message":"🌊 Streams: Use better default field (#217478)\n\nThis PR passes the current sample documents to the default form state\ngeneration for new processors to pick a good default field.\n\nThe logic that's actually employed for `dissect` and `grok` is the\nfollowing:\n* Go through all docs and order string fields occurring by how many\nvalues they have\n* Pick the top one from a list of \"well known\" fields that probably make\nsense (in case of a tie, go by a the ordering of the well known fields)\n* If no field is found this way, just leave it empty - this still shows\nthe full table and the user can pick the field they care about\n\nEspecially for otel this should be helpful.","sha":"e6cdba65ed8263cf0ffcd2ba6b14d7caa579432b","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-ux-logs","backport:version","Feature:Streams","v9.1.0","v8.19.0"],"title":"🌊 Streams: Use better default field","number":217478,"url":"https://github.com/elastic/kibana/pull/217478","mergeCommit":{"message":"🌊 Streams: Use better default field (#217478)\n\nThis PR passes the current sample documents to the default form state\ngeneration for new processors to pick a good default field.\n\nThe logic that's actually employed for `dissect` and `grok` is the\nfollowing:\n* Go through all docs and order string fields occurring by how many\nvalues they have\n* Pick the top one from a list of \"well known\" fields that probably make\nsense (in case of a tie, go by a the ordering of the well known fields)\n* If no field is found this way, just leave it empty - this still shows\nthe full table and the user can pick the field they care about\n\nEspecially for otel this should be helpful.","sha":"e6cdba65ed8263cf0ffcd2ba6b14d7caa579432b"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217478","number":217478,"mergeCommit":{"message":"🌊 Streams: Use better default field (#217478)\n\nThis PR passes the current sample documents to the default form state\ngeneration for new processors to pick a good default field.\n\nThe logic that's actually employed for `dissect` and `grok` is the\nfollowing:\n* Go through all docs and order string fields occurring by how many\nvalues they have\n* Pick the top one from a list of \"well known\" fields that probably make\nsense (in case of a tie, go by a the ordering of the well known fields)\n* If no field is found this way, just leave it empty - this still shows\nthe full table and the user can pick the field they care about\n\nEspecially for otel this should be helpful.","sha":"e6cdba65ed8263cf0ffcd2ba6b14d7caa579432b"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->