### PR TITLE
[EDR Workflows] Add macOS security events

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/models/policy_config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/models/policy_config.ts
@@ -98,6 +98,7 @@ export const policyFactory = ({
         process: true,
         file: true,
         network: true,
+        security: true,
       },
       malware: {
         mode: ProtectionModes.prevent,

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/models/policy_config_helpers.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/models/policy_config_helpers.test.ts
@@ -103,6 +103,7 @@ describe('Policy Config helpers', () => {
         file: false,
         process: false,
         network: false,
+        security: false,
       };
 
       const linuxEvents: typeof defaultPolicy.linux.events = {
@@ -331,7 +332,7 @@ describe('Policy Config helpers', () => {
 
 // This constant makes sure that if the type `PolicyConfig` is ever modified,
 // the logic for disabling protections is also modified due to type check.
-export const eventsOnlyPolicy = (): PolicyConfig => ({
+const eventsOnlyPolicy = (): PolicyConfig => ({
   global_manifest_version: 'latest',
   global_telemetry_enabled: false,
   meta: {
@@ -369,7 +370,7 @@ export const eventsOnlyPolicy = (): PolicyConfig => ({
     attack_surface_reduction: { credential_hardening: { enabled: false } },
   },
   mac: {
-    events: { process: true, file: true, network: true },
+    events: { process: true, file: true, network: true, security: true },
     malware: { mode: ProtectionModes.off, blocklist: false, on_write_scan: false },
     behavior_protection: { mode: ProtectionModes.off, supported: true, reputation_service: false },
     memory_protection: { mode: ProtectionModes.off, supported: true },

--- a/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/endpoint/types/index.ts
@@ -1036,6 +1036,7 @@ export interface PolicyConfig {
       file: boolean;
       process: boolean;
       network: boolean;
+      security: boolean;
     };
     malware: ProtectionFields & BlocklistFields & OnWriteScanFields;
     behavior_protection: BehaviorProtectionFields & SupportedFields;

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
@@ -331,7 +331,7 @@ describe('policy details: ', () => {
                     },
                   },
                   mac: {
-                    events: { process: true, file: true, network: true },
+                    events: { process: true, file: true, network: true, security: true },
                     malware: { mode: 'prevent', blocklist: true, on_write_scan: true },
                     behavior_protection: {
                       mode: 'off',

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/mac_event_collection_card.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/mac_event_collection_card.test.tsx
@@ -40,7 +40,7 @@ describe('Policy Mac Event Collection Card', () => {
 
     expect(
       getByTestId(testSubj.optionsContainer).querySelectorAll('input[type="checkbox"]')
-    ).toHaveLength(3);
+    ).toHaveLength(4);
     expect(getByTestId(testSubj.fileCheckbox)).toBeChecked();
     expect(getByTestId(testSubj.networkCheckbox)).toBeChecked();
     expect(getByTestId(testSubj.processCheckbox)).toBeChecked();
@@ -63,11 +63,12 @@ describe('Policy Mac Event Collection Card', () => {
             'Event collection' +
             'Operating system' +
             'Mac ' +
-            '3 / 3 event collections enabled' +
+            '4 / 4 event collections enabled' +
             'Events' +
             'File' +
             'Process' +
-            'Network'
+            'Network' +
+            'Security'
         )
       );
     });
@@ -85,11 +86,12 @@ describe('Policy Mac Event Collection Card', () => {
             'Event collection' +
             'Operating system' +
             'Mac ' +
-            '2 / 3 event collections enabled' +
+            '3 / 4 event collections enabled' +
             'Events' +
             'File' +
             'Process' +
-            'Network'
+            'Network' +
+            'Security'
         )
       );
     });

--- a/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/mac_event_collection_card.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/mac_event_collection_card.tsx
@@ -31,6 +31,15 @@ const OPTIONS: ReadonlyArray<EventFormOption<OperatingSystem.MAC>> = [
     }),
     protectionField: 'network',
   },
+  {
+    name: i18n.translate(
+      'xpack.securitySolution.endpoint.policyDetailsConfig.mac.events.security',
+      {
+        defaultMessage: 'Security',
+      }
+    ),
+    protectionField: 'security',
+  },
 ];
 
 export type MacEventCollectionCardProps = PolicyFormComponentCommonProps;


### PR DESCRIPTION
 This PR introduces a new "Security" event type for Event Collection on macOS. The UI now includes a checkbox for this event, and the policy generator logic has been updated: if the integration configuration is "EDR Complete," the checkbox is checked by default; otherwise, it is initialized as disabled (unchecked in the UI).

It was confirmed that no migration is needed.

![Screenshot 2025-04-23 at 11 59 23](https://github.com/user-attachments/assets/4c47c6cf-b9b3-4e87-a59e-961a1d3ffe33)

Agent policy with "Essential" configuration.
![Screenshot 2025-04-23 at 11 58 27](https://github.com/user-attachments/assets/d545410b-cdd5-4e7d-99e8-7df993c5f25b)

Agent policy with "Complete" configuration
![Screenshot 2025-04-23 at 11 58 11](https://github.com/user-attachments/assets/b90cd1e5-ebc9-496f-9780-43be9ce410f0)




<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->