### PR TITLE
[Manual Backport] Use `@kbn/handlebars` and `compileAST` over `handlebars.compile` (#218449)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/epm/agent/agent.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import Handlebars from 'handlebars';
+import Handlebars from '@kbn/handlebars';
 import { safeLoad, safeDump } from 'js-yaml';
 import type { Logger } from '@kbn/core/server';
 
@@ -21,7 +21,7 @@ export function compileTemplate(variables: PackagePolicyConfigRecord, templateSt
   const { vars, yamlValues } = buildTemplateVariables(logger, variables);
   let compiledTemplate: string;
   try {
-    const template = handlebars.compile(templateStr, { noEscape: true });
+    const template = handlebars.compileAST(templateStr, { noEscape: true });
     compiledTemplate = template(vars);
   } catch (err) {
     throw new PackageInvalidArchiveError(`Error while compiling agent template: ${err.message}`);

--- a/x-pack/platform/plugins/shared/fleet/tsconfig.json
+++ b/x-pack/platform/plugins/shared/fleet/tsconfig.json
@@ -119,5 +119,6 @@
     "@kbn/field-formats-plugin",
     "@kbn/core-security-server",
     "@kbn/core-http-server-utils",
+    "@kbn/handlebars",
   ]
 }


### PR DESCRIPTION
## Summary

Manual backport of https://github.com/elastic/kibana/pull/218449 to move usage of `handlebars` to `kbn/handlebars`

The changes in the PR to main were on code that doesn't exist in 9.0/8.x/7.17 hence requiring a manual backport to usage of `compileAST`

