### PR TITLE
[Security Solution][Users page] a11y:Fix modal dialog title

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/modal.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/inspect/modal.tsx
@@ -17,6 +17,7 @@ import {
   EuiModalFooter,
   EuiSpacer,
   EuiTabbedContent,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import numeral from '@elastic/numeral';
 import type { ReactNode } from 'react';
@@ -121,6 +122,8 @@ export const ModalInspectQuery = ({
   const { selectedPatterns } = useSourcererDataView(
     inputId === 'timeline' ? SourcererScopeName.timeline : getScopeFromPath(pathname)
   );
+
+  const modalTitleId = useGeneratedHtmlId();
 
   const requests: string[] = useMemo(
     () => [request, ...(additionalRequests != null ? additionalRequests : [])],
@@ -284,9 +287,13 @@ export const ModalInspectQuery = ({
   );
 
   return (
-    <MyEuiModal onClose={closeModal} data-test-subj="modal-inspect-euiModal">
+    <MyEuiModal
+      aria-labelledby={modalTitleId}
+      onClose={closeModal}
+      data-test-subj="modal-inspect-euiModal"
+    >
       <EuiModalHeader>
-        <EuiModalHeaderTitle>
+        <EuiModalHeaderTitle id={modalTitleId}>
           {i18n.INSPECT} {title}
         </EuiModalHeaderTitle>
       </EuiModalHeader>


### PR DESCRIPTION
## Summary

Addresses this `a11y` issue: https://github.com/elastic/kibana/issues/205329

## Changes made: 

1. Added `aria-labelledb` to the `<ModalInspectQuery />` component in order to show more meaningful message.

**How to test:**

1. Navigate to `Security -> Explore -> Users page`.
2. Navigate to Inspect button by pressing Tab key.
3. Check the dialog announcement on a screen reader.

### Sample

https://github.com/user-attachments/assets/cdc4bb54-1dae-4ef6-807e-038dbf45cdb4


https://github.com/user-attachments/assets/727d2123-95f5-4d6a-9896-1ead20a01fbc



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->