### PR TITLE
[ResponseOps][WIP] Cases analytics index

### DIFF
--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/constants.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+
 export const CAI_NUMBER_OF_SHARDS = 1;
 /** Allocate 1 replica if there are enough data nodes, otherwise continue with 0 */
 export const CAI_AUTO_EXPAND_REPLICAS = '0-1';
@@ -25,3 +27,47 @@ export const CAI_DEFAULT_TIMEOUT = '300s';
 export const CAI_CASES_INDEX_NAME = '.internal.cases';
 export const CAI_ATTACHMENTS_INDEX_NAME = '.internal.cases-attachments';
 export const CAI_COMMENTS_INDEX_NAME = '.internal.cases-comments';
+
+export const CAI_CASES_SOURCE_QUERY: QueryDslQueryContainer = {
+  term: {
+    type: 'cases',
+  },
+};
+export const CAI_ATTACHMENTS_SOURCE_QUERY: QueryDslQueryContainer = {
+  bool: {
+    must: {
+      match: {
+        type: 'cases-comments',
+      },
+    },
+    filter: {
+      bool: {
+        must_not: {
+          term: {
+            'cases-comments.type': 'user',
+          },
+        },
+      },
+    },
+  },
+};
+export const CAI_COMMENTS_SOURCE_QUERY: QueryDslQueryContainer = {
+  bool: {
+    filter: [
+      {
+        term: {
+          type: 'cases-comments',
+        },
+      },
+      {
+        term: {
+          'cases-comments.type': 'user',
+        },
+      },
+    ],
+  },
+};
+
+export const CAI_CASES_SOURCE_INDEX = '.kibana_alerting_cases';
+export const CAI_ATTACHMENTS_SOURCE_INDEX = '.kibana_alerting_cases';
+export const CAI_COMMENTS_SOURCE_INDEX = '.kibana_alerting_cases';

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/constants.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/constants.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const CAI_NUMBER_OF_SHARDS = 1;
+/** Allocate 1 replica if there are enough data nodes, otherwise continue with 0 */
+export const CAI_AUTO_EXPAND_REPLICAS = '0-1';
+export const CAI_REFRESH_INTERVAL = '15s';
+export const CAI_INDEX_MODE = 'lookup';
+/**
+ * When a request takes a long time to complete and hits the timeout or the
+ * client aborts that request due to the requestTimeout, our only course of
+ * action is to retry that request. This places our request at the end of the
+ * queue and adds more load to Elasticsearch just making things worse.
+ *
+ * So we want to choose as long a timeout as possible. Some load balancers /
+ * reverse proxies like ELB ignore TCP keep-alive packets so unless there's a
+ * request or response sent over the socket it will be dropped after 60s.
+ */
+export const CAI_DEFAULT_TIMEOUT = '300s';
+
+export const CAI_CASES_INDEX_NAME = '.internal.cases';
+export const CAI_ATTACHMENTS_INDEX_NAME = '.internal.cases-attachments';
+export const CAI_COMMENTS_INDEX_NAME = '.internal.cases-comments';

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index.ts
@@ -5,163 +5,65 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient, Logger } from '@kbn/core/server';
-import type { MappingTypeMapping, StoredScript } from '@elastic/elasticsearch/lib/api/types';
+import type { CoreSetup, ElasticsearchClient, Logger } from '@kbn/core/server';
+import type {
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
 import {
-  CAI_CASES_INDEX_NAME,
-  CAI_ATTACHMENTS_INDEX_NAME,
-  CAI_COMMENTS_INDEX_NAME,
-  CAI_DEFAULT_TIMEOUT,
-  CAI_NUMBER_OF_SHARDS,
-  CAI_AUTO_EXPAND_REPLICAS,
-  CAI_INDEX_MODE,
-  CAI_REFRESH_INTERVAL,
-} from './constants';
-import {
-  CAI_CASES_INDEX_MAPPINGS,
-  CAI_ATTACHMENTS_INDEX_MAPPINGS,
-  CAI_COMMENTS_INDEX_MAPPINGS,
-} from './mappings';
-import {
-  CAI_ATTACHMENTS_INDEX_SCRIPT,
-  CAI_ATTACHMENTS_INDEX_SCRIPT_ID,
-  CAI_CASES_INDEX_SCRIPT,
-  CAI_CASES_INDEX_SCRIPT_ID,
-  CAI_COMMENTS_INDEX_SCRIPT,
-  CAI_COMMENTS_INDEX_SCRIPT_ID,
-} from './painless_scripts';
+  CasesAnalyticsIndexFactory,
+  CasesCommentsAnalyticsIndexFactory,
+  CasesAttachmentsAnalyticsIndexFactory,
+} from './index_factory';
+import type { CasesServerStartDependencies } from '../types';
+import { registerCAIBackfillTask } from './tasks/backfill_task';
 
 export const createCasesAnalyticsIndices = async ({
   esClient,
   logger,
   isServerless,
+  taskManager,
 }: {
   esClient: ElasticsearchClient;
   logger: Logger;
   isServerless: boolean;
+  taskManager: TaskManagerStartContract;
 }) => {
-  logger.debug('initializing factory');
+  logger.debug('initializing factories');
+  const casesIndexFactory = new CasesAnalyticsIndexFactory({
+    logger,
+    esClient,
+    isServerless,
+    taskManager,
+  });
+  const casesAttachmentsIndexFactory = new CasesAttachmentsAnalyticsIndexFactory({
+    logger,
+    esClient,
+    isServerless,
+    taskManager,
+  });
+  const casesCommentsIndexFactory = new CasesCommentsAnalyticsIndexFactory({
+    logger,
+    esClient,
+    isServerless,
+    taskManager,
+  });
 
   return Promise.all([
-    createIndex({
-      esClient,
-      logger,
-      isServerless,
-      indexName: CAI_CASES_INDEX_NAME,
-      mappings: CAI_CASES_INDEX_MAPPINGS,
-      painlessScript: CAI_CASES_INDEX_SCRIPT,
-      painlessScriptId: CAI_CASES_INDEX_SCRIPT_ID,
-    }),
-    createIndex({
-      esClient,
-      logger,
-      isServerless,
-      indexName: CAI_ATTACHMENTS_INDEX_NAME,
-      mappings: CAI_ATTACHMENTS_INDEX_MAPPINGS,
-      painlessScript: CAI_ATTACHMENTS_INDEX_SCRIPT,
-      painlessScriptId: CAI_ATTACHMENTS_INDEX_SCRIPT_ID,
-    }),
-    createIndex({
-      esClient,
-      logger,
-      isServerless,
-      indexName: CAI_COMMENTS_INDEX_NAME,
-      mappings: CAI_COMMENTS_INDEX_MAPPINGS,
-      painlessScript: CAI_COMMENTS_INDEX_SCRIPT,
-      painlessScriptId: CAI_COMMENTS_INDEX_SCRIPT_ID,
-    }),
+    casesIndexFactory.createIndex(),
+    casesAttachmentsIndexFactory.createIndex(),
+    casesCommentsIndexFactory.createIndex(),
   ]);
 };
 
-const createIndex = async ({
-  esClient,
+export const registerCasesAnalyticsIndicesTasks = ({
+  taskManagerSetup,
   logger,
-  isServerless,
-  indexName,
-  mappings,
-  painlessScript,
-  painlessScriptId,
+  core,
 }: {
-  esClient: ElasticsearchClient;
-  indexName: string;
-  mappings: MappingTypeMapping;
+  taskManagerSetup: TaskManagerSetupContract;
   logger: Logger;
-  isServerless: boolean;
-  painlessScript: StoredScript;
-  painlessScriptId: string;
+  core: CoreSetup<CasesServerStartDependencies>;
 }) => {
-  const indexSettings = {
-    // settings are not supported on serverless ES
-    ...(isServerless
-      ? {}
-      : {
-          number_of_shards: CAI_NUMBER_OF_SHARDS,
-          auto_expand_replicas: CAI_AUTO_EXPAND_REPLICAS,
-          refresh_interval: CAI_REFRESH_INTERVAL,
-          'index.mode': CAI_INDEX_MODE,
-        }),
-  };
-
-  try {
-    logger.info(`Checking if ${indexName} exists.`);
-    const isLatestIndexExists = await esClient.indices.exists({
-      index: indexName,
-    });
-
-    if (!isLatestIndexExists) {
-      logger.info(`Creating ${indexName} painless script.`);
-      await esClient.putScript({
-        id: painlessScriptId,
-        script: painlessScript,
-      });
-
-      logger.info(`Creating ${indexName} index.`);
-      await esClient.indices.create({
-        index: indexName,
-        timeout: CAI_DEFAULT_TIMEOUT,
-        mappings, // do we want to pass the script id?
-        settings: {
-          index: indexSettings,
-        },
-      });
-
-      scheduleBackfillTask();
-    } else {
-      logger.info(`${indexName} index exists. Skipping creation.`);
-      const currentMapping = await esClient.indices.getMapping({
-        index: indexName,
-      });
-
-      console.log(JSON.stringify(currentMapping, null, 4));
-
-      logger.info('Comparing mapping versions.');
-      if (
-        currentMapping[indexName].mappings._meta?.mapping_version < mappings._meta?.mapping_version
-      ) {
-        logger.info(`Old version detected. Updating ${indexName} mapping.`);
-        logger.info(`Updating ${indexName} painless script.`);
-        // create painless script
-        await esClient.putScript({
-          id: painlessScriptId,
-          script: painlessScript,
-        });
-
-        logger.info(`Updating ${indexName} mapping.`);
-        await esClient.indices.putMapping({
-          index: indexName,
-          ...mappings,
-        });
-
-        scheduleBackfillTask();
-      } else {
-        logger.info(`${indexName} mapping version is up to date. Skipping mapping update.`);
-        logger.debug(`${indexName} mapping version is up to date. Skipping mapping update.`);
-      }
-    }
-  } catch (err) {
-    logger.error(`Failed to create the index template: ${indexName}`);
-    logger.error(err.message);
-  }
+  registerCAIBackfillTask({ taskManagerSetup, logger, core });
 };
-
-const scheduleBackfillTask = () => {};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { MappingTypeMapping, StoredScript } from '@elastic/elasticsearch/lib/api/types';
+import {
+  CAI_CASES_INDEX_NAME,
+  CAI_ATTACHMENTS_INDEX_NAME,
+  CAI_COMMENTS_INDEX_NAME,
+  CAI_DEFAULT_TIMEOUT,
+  CAI_NUMBER_OF_SHARDS,
+  CAI_AUTO_EXPAND_REPLICAS,
+  CAI_INDEX_MODE,
+  CAI_REFRESH_INTERVAL,
+} from './constants';
+import {
+  CAI_CASES_INDEX_MAPPINGS,
+  CAI_ATTACHMENTS_INDEX_MAPPINGS,
+  CAI_COMMENTS_INDEX_MAPPINGS,
+} from './mappings';
+import {
+  CAI_ATTACHMENTS_INDEX_SCRIPT,
+  CAI_ATTACHMENTS_INDEX_SCRIPT_ID,
+  CAI_CASES_INDEX_SCRIPT,
+  CAI_CASES_INDEX_SCRIPT_ID,
+  CAI_COMMENTS_INDEX_SCRIPT,
+  CAI_COMMENTS_INDEX_SCRIPT_ID,
+} from './painless_scripts';
+
+export const createCasesAnalyticsIndices = async ({
+  esClient,
+  logger,
+  isServerless,
+}: {
+  esClient: ElasticsearchClient;
+  logger: Logger;
+  isServerless: boolean;
+}) => {
+  logger.debug('initializing factory');
+
+  return Promise.all([
+    createIndex({
+      esClient,
+      logger,
+      isServerless,
+      indexName: CAI_CASES_INDEX_NAME,
+      mappings: CAI_CASES_INDEX_MAPPINGS,
+      painlessScript: CAI_CASES_INDEX_SCRIPT,
+      painlessScriptId: CAI_CASES_INDEX_SCRIPT_ID,
+    }),
+    createIndex({
+      esClient,
+      logger,
+      isServerless,
+      indexName: CAI_ATTACHMENTS_INDEX_NAME,
+      mappings: CAI_ATTACHMENTS_INDEX_MAPPINGS,
+      painlessScript: CAI_ATTACHMENTS_INDEX_SCRIPT,
+      painlessScriptId: CAI_ATTACHMENTS_INDEX_SCRIPT_ID,
+    }),
+    createIndex({
+      esClient,
+      logger,
+      isServerless,
+      indexName: CAI_COMMENTS_INDEX_NAME,
+      mappings: CAI_COMMENTS_INDEX_MAPPINGS,
+      painlessScript: CAI_COMMENTS_INDEX_SCRIPT,
+      painlessScriptId: CAI_COMMENTS_INDEX_SCRIPT_ID,
+    }),
+  ]);
+};
+
+const createIndex = async ({
+  esClient,
+  logger,
+  isServerless,
+  indexName,
+  mappings,
+  painlessScript,
+  painlessScriptId,
+}: {
+  esClient: ElasticsearchClient;
+  indexName: string;
+  mappings: MappingTypeMapping;
+  logger: Logger;
+  isServerless: boolean;
+  painlessScript: StoredScript;
+  painlessScriptId: string;
+}) => {
+  const indexSettings = {
+    // settings are not supported on serverless ES
+    ...(isServerless
+      ? {}
+      : {
+          number_of_shards: CAI_NUMBER_OF_SHARDS,
+          auto_expand_replicas: CAI_AUTO_EXPAND_REPLICAS,
+          refresh_interval: CAI_REFRESH_INTERVAL,
+          'index.mode': CAI_INDEX_MODE,
+        }),
+  };
+
+  try {
+    logger.info(`Checking if ${indexName} exists.`);
+    const isLatestIndexExists = await esClient.indices.exists({
+      index: indexName,
+    });
+
+    if (!isLatestIndexExists) {
+      logger.info(`Creating ${indexName} painless script.`);
+      await esClient.putScript({
+        id: painlessScriptId,
+        script: painlessScript,
+      });
+
+      logger.info(`Creating ${indexName} index.`);
+      await esClient.indices.create({
+        index: indexName,
+        timeout: CAI_DEFAULT_TIMEOUT,
+        mappings, // do we want to pass the script id?
+        settings: {
+          index: indexSettings,
+        },
+      });
+
+      scheduleBackfillTask();
+    } else {
+      logger.info(`${indexName} index exists. Skipping creation.`);
+      const currentMapping = await esClient.indices.getMapping({
+        index: indexName,
+      });
+
+      console.log(JSON.stringify(currentMapping, null, 4));
+
+      logger.info('Comparing mapping versions.');
+      if (
+        currentMapping[indexName].mappings._meta?.mapping_version < mappings._meta?.mapping_version
+      ) {
+        logger.info(`Old version detected. Updating ${indexName} mapping.`);
+        logger.info(`Updating ${indexName} painless script.`);
+        // create painless script
+        await esClient.putScript({
+          id: painlessScriptId,
+          script: painlessScript,
+        });
+
+        logger.info(`Updating ${indexName} mapping.`);
+        await esClient.indices.putMapping({
+          index: indexName,
+          ...mappings,
+        });
+
+        scheduleBackfillTask();
+      } else {
+        logger.info(`${indexName} mapping version is up to date. Skipping mapping update.`);
+        logger.debug(`${indexName} mapping version is up to date. Skipping mapping update.`);
+      }
+    }
+  } catch (err) {
+    logger.error(`Failed to create the index template: ${indexName}`);
+    logger.error(err.message);
+  }
+};
+
+const scheduleBackfillTask = () => {};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/cases_attachments_index_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/cases_attachments_index_factory.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { AnalyticsIndexFactory } from './index_factory';
+import { CAI_ATTACHMENTS_INDEX_MAPPINGS } from '../mappings';
+import {
+  CAI_ATTACHMENTS_INDEX_NAME,
+  CAI_ATTACHMENTS_SOURCE_INDEX,
+  CAI_ATTACHMENTS_SOURCE_QUERY,
+} from '../constants';
+import { CAI_ATTACHMENTS_INDEX_SCRIPT, CAI_ATTACHMENTS_INDEX_SCRIPT_ID } from '../painless_scripts';
+import { scheduleCAIBackfillTask } from '../tasks/backfill_task';
+
+interface CasesAttachmentsAnalyticsIndexFactoryParams {
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  isServerless: boolean;
+  taskManager: TaskManagerStartContract;
+}
+
+export class CasesAttachmentsAnalyticsIndexFactory extends AnalyticsIndexFactory {
+  private taskManager: TaskManagerStartContract;
+
+  constructor({
+    logger,
+    esClient,
+    isServerless,
+    taskManager,
+  }: CasesAttachmentsAnalyticsIndexFactoryParams) {
+    super({
+      logger,
+      esClient,
+      isServerless,
+      indexName: CAI_ATTACHMENTS_INDEX_NAME,
+      mappings: CAI_ATTACHMENTS_INDEX_MAPPINGS,
+      painlessScriptId: CAI_ATTACHMENTS_INDEX_SCRIPT_ID,
+      painlessScript: CAI_ATTACHMENTS_INDEX_SCRIPT,
+    });
+    this.taskManager = taskManager;
+  }
+
+  protected async scheduleBackfillTask() {
+    await scheduleCAIBackfillTask({
+      taskId: 'cai_attachments_backfill_task',
+      sourceIndex: CAI_ATTACHMENTS_SOURCE_INDEX,
+      sourceQuery: CAI_ATTACHMENTS_SOURCE_QUERY,
+      destIndex: this.indexName,
+      logger: this.logger,
+      taskManager: this.taskManager,
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/cases_comments_index_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/cases_comments_index_factory.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { AnalyticsIndexFactory } from './index_factory';
+import { CAI_COMMENTS_INDEX_MAPPINGS } from '../mappings';
+import {
+  CAI_COMMENTS_INDEX_NAME,
+  CAI_COMMENTS_SOURCE_INDEX,
+  CAI_COMMENTS_SOURCE_QUERY,
+} from '../constants';
+import { CAI_COMMENTS_INDEX_SCRIPT, CAI_COMMENTS_INDEX_SCRIPT_ID } from '../painless_scripts';
+import { scheduleCAIBackfillTask } from '../tasks/backfill_task';
+
+interface CasesCommentsAnalyticsIndexFactoryParams {
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  isServerless: boolean;
+  taskManager: TaskManagerStartContract;
+}
+
+export class CasesCommentsAnalyticsIndexFactory extends AnalyticsIndexFactory {
+  private taskManager: TaskManagerStartContract;
+
+  constructor({
+    logger,
+    esClient,
+    isServerless,
+    taskManager,
+  }: CasesCommentsAnalyticsIndexFactoryParams) {
+    super({
+      logger,
+      esClient,
+      isServerless,
+      indexName: CAI_COMMENTS_INDEX_NAME,
+      mappings: CAI_COMMENTS_INDEX_MAPPINGS,
+      painlessScriptId: CAI_COMMENTS_INDEX_SCRIPT_ID,
+      painlessScript: CAI_COMMENTS_INDEX_SCRIPT,
+    });
+    this.taskManager = taskManager;
+  }
+
+  protected async scheduleBackfillTask() {
+    await scheduleCAIBackfillTask({
+      taskId: 'cai_comments_backfill_task',
+      sourceIndex: CAI_COMMENTS_SOURCE_INDEX,
+      sourceQuery: CAI_COMMENTS_SOURCE_QUERY,
+      destIndex: this.indexName,
+      logger: this.logger,
+      taskManager: this.taskManager,
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/cases_index_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/cases_index_factory.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type { TaskManagerStartContract } from '@kbn/task-manager-plugin/server';
+import { AnalyticsIndexFactory } from './index_factory';
+import { CAI_CASES_INDEX_MAPPINGS } from '../mappings';
+import { CAI_CASES_INDEX_NAME, CAI_CASES_SOURCE_INDEX, CAI_CASES_SOURCE_QUERY } from '../constants';
+import { CAI_CASES_INDEX_SCRIPT, CAI_CASES_INDEX_SCRIPT_ID } from '../painless_scripts';
+import { scheduleCAIBackfillTask } from '../tasks/backfill_task';
+
+interface CasesAnalyticsIndexFactoryParams {
+  logger: Logger;
+  esClient: ElasticsearchClient;
+  isServerless: boolean;
+  taskManager: TaskManagerStartContract;
+}
+
+export class CasesAnalyticsIndexFactory extends AnalyticsIndexFactory {
+  private taskManager: TaskManagerStartContract;
+
+  constructor({ logger, esClient, isServerless, taskManager }: CasesAnalyticsIndexFactoryParams) {
+    super({
+      logger,
+      esClient,
+      isServerless,
+      indexName: CAI_CASES_INDEX_NAME,
+      mappings: CAI_CASES_INDEX_MAPPINGS,
+      painlessScriptId: CAI_CASES_INDEX_SCRIPT_ID,
+      painlessScript: CAI_CASES_INDEX_SCRIPT,
+    });
+    this.taskManager = taskManager;
+  }
+
+  protected async scheduleBackfillTask() {
+    await scheduleCAIBackfillTask({
+      taskId: 'cai_cases_backfill_task',
+      sourceIndex: CAI_CASES_SOURCE_INDEX,
+      sourceQuery: CAI_CASES_SOURCE_QUERY,
+      destIndex: this.indexName,
+      taskManager: this.taskManager,
+      logger: this.logger,
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { CasesAttachmentsAnalyticsIndexFactory } from './cases_attachments_index_factory';
+export { CasesCommentsAnalyticsIndexFactory } from './cases_comments_index_factory';
+export { CasesAnalyticsIndexFactory } from './cases_index_factory';

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/index_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/index_factory/index_factory.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
+import type {
+  IndicesIndexSettings,
+  MappingTypeMapping,
+  StoredScript,
+} from '@elastic/elasticsearch/lib/api/types';
+import {
+  CAI_NUMBER_OF_SHARDS,
+  CAI_AUTO_EXPAND_REPLICAS,
+  CAI_REFRESH_INTERVAL,
+  CAI_INDEX_MODE,
+  CAI_DEFAULT_TIMEOUT,
+} from '../constants';
+
+interface AnalyticsIndexFactoryParams {
+  logger: Logger;
+  isServerless: boolean;
+  esClient: ElasticsearchClient;
+  indexName: string;
+  mappings: MappingTypeMapping;
+  painlessScriptId: string;
+  painlessScript: StoredScript;
+}
+
+export class AnalyticsIndexFactory {
+  protected readonly logger: Logger;
+  protected readonly indexName: string;
+  private readonly esClient: ElasticsearchClient;
+  private readonly mappings: MappingTypeMapping;
+  private readonly indexSettings?: IndicesIndexSettings;
+  private readonly painlessScriptId: string;
+  private readonly painlessScript: StoredScript;
+
+  constructor({
+    logger,
+    esClient,
+    isServerless,
+    indexName,
+    mappings,
+    painlessScriptId,
+    painlessScript,
+  }: AnalyticsIndexFactoryParams) {
+    this.logger = logger;
+    this.esClient = esClient;
+    this.indexName = indexName;
+    this.mappings = mappings;
+    this.painlessScriptId = painlessScriptId;
+    this.painlessScript = painlessScript;
+    this.indexSettings = {
+      // settings are not supported on serverless ES
+      ...(isServerless
+        ? {}
+        : {
+            number_of_shards: CAI_NUMBER_OF_SHARDS,
+            auto_expand_replicas: CAI_AUTO_EXPAND_REPLICAS,
+            refresh_interval: CAI_REFRESH_INTERVAL,
+            mode: CAI_INDEX_MODE,
+          }),
+    };
+  }
+
+  public async createIndex() {
+    try {
+      const indexExists = await this.indexExists();
+
+      if (!indexExists) {
+        this.logger.info(`[${this.indexName}] Index does not exist. Creating.`);
+        await this.createIndexMapping();
+      } else {
+        this.logger.info(`[${this.indexName}] Index exists. Updating mapping.`);
+        await this.updateIndexMapping();
+      }
+    } catch (err) {
+      this.logger.error(`[${this.indexName}] Failed to create the index template.`);
+      this.logger.error(err.message);
+    }
+  }
+
+  private async updateIndexMapping() {
+    try {
+      const shouldUpdateMapping = await this.shouldUpdateMapping();
+
+      if (shouldUpdateMapping) {
+        await this.updateMapping();
+      } else {
+        this.logger.debug(`${this.indexName} mapping version is up to date. Skipping update.`);
+      }
+    } catch (err) {
+      this.logger.error(`[${this.indexName}] Failed to create the index template.`);
+      this.logger.error(err.message);
+    }
+  }
+
+  private async getCurrentMapping() {
+    return this.esClient.indices.getMapping({
+      index: this.indexName,
+    });
+  }
+
+  private async updateMapping() {
+    this.logger.info(`[${this.indexName}] Updating the painless script.`);
+    await this.esClient.putScript({
+      id: this.painlessScriptId,
+      script: this.painlessScript,
+    });
+
+    this.logger.info(`[${this.indexName}] Updating index mapping.`);
+    await this.esClient.indices.putMapping({
+      index: this.indexName,
+      ...this.mappings,
+    });
+
+    this.logger.info(`[${this.indexName}] Scheduling the backfill task.`);
+    await this.scheduleBackfillTask();
+  }
+
+  private async createIndexMapping() {
+    this.logger.info(`[${this.indexName}] Creating painless script.`);
+    await this.esClient.putScript({
+      id: this.painlessScriptId,
+      script: this.painlessScript,
+    });
+
+    this.logger.info(`[${this.indexName}] Creating index.`);
+    await this.esClient.indices.create({
+      index: this.indexName,
+      timeout: CAI_DEFAULT_TIMEOUT,
+      mappings: this.mappings,
+      settings: {
+        index: this.indexSettings,
+      },
+    });
+
+    this.logger.info(`[${this.indexName}] Scheduling the backfill task.`);
+    await this.scheduleBackfillTask();
+  }
+
+  private async indexExists(): Promise<boolean> {
+    this.logger.info(`[${this.indexName}] Checking if index exists.`);
+    return this.esClient.indices.exists({
+      index: this.indexName,
+    });
+  }
+
+  private async shouldUpdateMapping(): Promise<boolean> {
+    const currentMapping = await this.getCurrentMapping();
+    return (
+      currentMapping[this.indexName].mappings._meta?.mapping_version <
+      this.mappings._meta?.mapping_version
+    );
+  }
+
+  // Needs to be implemented by child class
+  protected async scheduleBackfillTask() {
+    this.logger.error(`[${this.indexName}] scheduleBackfillTask not implemented`);
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/mappings.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/mappings.ts
@@ -6,22 +6,174 @@
  */
 
 import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+import {
+  CAI_ATTACHMENTS_INDEX_SCRIPT_ID,
+  CAI_CASES_INDEX_SCRIPT_ID,
+  CAI_COMMENTS_INDEX_SCRIPT_ID,
+} from './painless_scripts';
 
 export const CAI_CASES_INDEX_MAPPINGS: MappingTypeMapping = {
   dynamic: false,
   _meta: {
     mapping_version: 1,
+    painless_script_id: CAI_CASES_INDEX_SCRIPT_ID,
   },
   properties: {
     '@timestamp': {
       type: 'date',
     },
-    id: {
+    title: {
       type: 'keyword',
     },
-    actual_title: {
+    description: {
       type: 'keyword',
     },
+    tags: {
+      type: 'keyword',
+    },
+    category: {
+      type: 'keyword',
+    },
+    status: {
+      type: 'keyword',
+    },
+    status_sort: {
+      type: 'short', // document says long, mapping is currently short
+    },
+    severity: {
+      type: 'keyword',
+    },
+    severity_sort: {
+      type: 'short', // document says long, mapping is currently short
+    },
+    created_at: {
+      type: 'date',
+    },
+    created_at_ms: {
+      type: 'long',
+    },
+    created_by: {
+      properties: {
+        username: {
+          type: 'keyword',
+        },
+        profile_uid: {
+          type: 'keyword',
+        },
+        full_name: {
+          type: 'keyword',
+        },
+        email: {
+          type: 'keyword',
+        },
+      },
+    },
+    updated_at: {
+      type: 'date',
+    },
+    updated_at_ms: {
+      type: 'long',
+    },
+    updated_by: {
+      properties: {
+        username: {
+          type: 'keyword',
+        },
+        profile_uid: {
+          type: 'keyword',
+        },
+        full_name: {
+          type: 'keyword',
+        },
+        email: {
+          type: 'keyword',
+        },
+      },
+    },
+    closed_at: {
+      type: 'date',
+    },
+    closed_at_ms: {
+      type: 'long',
+    },
+    closed_by: {
+      properties: {
+        username: {
+          type: 'keyword',
+        },
+        profile_uid: {
+          type: 'keyword',
+        },
+        full_name: {
+          type: 'keyword',
+        },
+        email: {
+          type: 'keyword',
+        },
+      },
+    },
+    assignees: {
+      type: 'keyword',
+    },
+    // Application level
+    time_to_resolve: {
+      type: 'long', // in seconds, calculated by case.closed_at - case.created_at
+    },
+    // leaving these commented out for that since in_progress_at does not exist.
+    // time_to_acknowledge: {
+    //   type: 'long', // in seconds, calculated by case.in_progress_at - case.created_at
+    // },
+    // time_to_investigaste: {
+    //   type: 'long', // in seconds, calculated by case.closed_at - case.in_progress_at
+    // },
+    // custom_fields might change to type: 'nested' like in cases
+    custom_fields: {
+      properties: {
+        type: {
+          type: 'keyword',
+        },
+        // Application level
+        // label: {
+        //   type: 'keyword',
+        // },
+        value: {
+          type: 'keyword',
+        },
+      },
+    },
+    observables: {
+      properties: {
+        type: {
+          // called typeKey in the cases mapping
+          type: 'keyword',
+        },
+        value: {
+          // called typeKey in the cases mapping
+          type: 'keyword',
+        },
+        // Application level
+        // label: {
+        //   type: 'keyword',
+        // },
+      },
+    },
+    // Application level
+    // total_comments: {
+    //   type: 'integer',
+    // },
+    // total_alerts: {
+    //   type: 'integer',
+    // },
+    total_assignees: {
+      type: 'integer',
+    },
+    owner: {
+      type: 'keyword',
+    },
+    // Where does this come from?
+    // spaceId: {
+    //   type: 'keyword',
+    // },
   },
 };
 
@@ -29,21 +181,118 @@ export const CAI_ATTACHMENTS_INDEX_MAPPINGS: MappingTypeMapping = {
   dynamic: false,
   _meta: {
     mapping_version: 1,
+    painless_script_id: CAI_ATTACHMENTS_INDEX_SCRIPT_ID,
   },
   properties: {
-    id: {
+    '@timestamp': {
+      type: 'date',
+    },
+    case_id: {
       type: 'keyword',
     },
-    title: {
+    type: {
       type: 'keyword',
     },
-    NEW_FIELD: {
+    created_at: {
+      type: 'date',
+    },
+    created_by: {
+      properties: {
+        username: {
+          type: 'keyword',
+        },
+        profile_uid: {
+          type: 'keyword',
+        },
+        full_name: {
+          type: 'keyword',
+        },
+        email: {
+          type: 'keyword',
+        },
+      },
+    },
+    payload: {
+      properties: {
+        alerts: {
+          properties: {
+            id: {
+              type: 'keyword',
+            },
+            index: {
+              type: 'keyword',
+            },
+          },
+        },
+        file: {
+          properties: {
+            id: {
+              type: 'keyword',
+            },
+            extension: {
+              type: 'keyword',
+            },
+            mimeType: {
+              type: 'keyword',
+            },
+            name: {
+              type: 'keyword',
+            },
+          },
+        },
+      },
+    },
+    owner: {
       type: 'keyword',
     },
+    // Where does this come from?
+    // spaceId: {
+    //   type: 'keyword',
+    // },
   },
 };
 
 export const CAI_COMMENTS_INDEX_MAPPINGS: MappingTypeMapping = {
   dynamic: false,
-  properties: {},
+  _meta: {
+    mapping_version: 1,
+    painless_script_id: CAI_COMMENTS_INDEX_SCRIPT_ID,
+  },
+  properties: {
+    '@timestamp': {
+      type: 'date',
+    },
+    case_id: {
+      type: 'keyword',
+    },
+    comment: {
+      type: 'keyword',
+    },
+    created_at: {
+      type: 'date',
+    },
+    created_by: {
+      properties: {
+        username: {
+          type: 'keyword',
+        },
+        profile_uid: {
+          type: 'keyword',
+        },
+        full_name: {
+          type: 'keyword',
+        },
+        email: {
+          type: 'keyword',
+        },
+      },
+    },
+    owner: {
+      type: 'keyword',
+    },
+    // Where does this come from?
+    // spaceId: {
+    //   type: 'keyword',
+    // },
+  },
 };

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/mappings.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/mappings.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
+
+export const CAI_CASES_INDEX_MAPPINGS: MappingTypeMapping = {
+  dynamic: false,
+  _meta: {
+    mapping_version: 1,
+  },
+  properties: {
+    '@timestamp': {
+      type: 'date',
+    },
+    id: {
+      type: 'keyword',
+    },
+    actual_title: {
+      type: 'keyword',
+    },
+  },
+};
+
+export const CAI_ATTACHMENTS_INDEX_MAPPINGS: MappingTypeMapping = {
+  dynamic: false,
+  _meta: {
+    mapping_version: 1,
+  },
+  properties: {
+    id: {
+      type: 'keyword',
+    },
+    title: {
+      type: 'keyword',
+    },
+    NEW_FIELD: {
+      type: 'keyword',
+    },
+  },
+};
+
+export const CAI_COMMENTS_INDEX_MAPPINGS: MappingTypeMapping = {
+  dynamic: false,
+  properties: {},
+};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/painless_scripts.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/painless_scripts.ts
@@ -7,23 +7,169 @@
 
 import type { StoredScript } from '@elastic/elasticsearch/lib/api/types';
 
-export const CAI_CASES_INDEX_SCRIPT_ID = 'internal_cases_index_painless_script';
+export const CAI_CASES_INDEX_SCRIPT_ID = 'cai_cases_script_1';
 export const CAI_CASES_INDEX_SCRIPT: StoredScript = {
   lang: 'painless',
   source: `
-    ctx._source.updated_title = ctx._source.cases.remove("title");
+    String statusDecoder(def x) {
+      if (x == 0) {
+        return "Open"
+      }
+      if (x == 10) {
+        return "In progress"
+      }
+      if (x == 20) {
+        return "Closed"
+      }
+      return ""
+    }
+
+    String severityDecoder(def x) {
+      if (x == 0) {
+        return "Low"
+      }
+      if (x == 10) {
+        return "Medium"
+      }
+      if (x == 20) {
+        return "High"
+      }
+      if (x == 30) {
+        return "Critical"
+      }
+      return ""
+    }
+
+    long milliSinceEpoch = new Date().getTime();
+    Instant instant = Instant.ofEpochMilli(milliSinceEpoch);
+    ctx._source['@timestamp'] = ZonedDateTime.ofInstant(instant, ZoneId.of('Z'));
+
+    ctx._source.title = ctx._source.cases.remove("title");
+    ctx._source.description = ctx._source.cases.remove("description");
+    ctx._source.tags = ctx._source.cases.remove("tags");
+    ctx._source.category = ctx._source.cases.remove("category");
+    
+    ctx._source.status_sort = ctx._source.cases.remove("status");
+    ctx._source.status = statusDecoder(ctx._source.status_sort);
+
+    ctx._source.severity_sort = ctx._source.cases.remove("severity");
+    ctx._source.severity = severityDecoder(ctx._source.severity_sort);
+
+    ZonedDateTime zdt_created =
+      ZonedDateTime.parse(ctx._source.cases.created_at);
+    ctx._source.created_at_ms = zdt_created.toInstant().toEpochMilli();
+    ctx._source.created_at = ctx._source.cases.remove("created_at");
+    ctx._source.created_by = ctx._source.cases.remove("created_by");
+
+    if ( ctx._source.cases.updated_at != null ) {
+      ZonedDateTime zdt_updated =
+        ZonedDateTime.parse(ctx._source.cases.updated_at);
+      ctx._source.updated_at_ms = zdt_updated.toInstant().toEpochMilli();
+      ctx._source.updated_at = ctx._source.cases.remove("updated_at");
+      ctx._source.updated_by = ctx._source.cases.remove("updated_by");
+    }
+
+    if ( ctx._source.cases.closed_at != null ) {
+      ZonedDateTime zdt_closed =
+        ZonedDateTime.parse(ctx._source.cases.closed_at);
+      ctx._source.closed_at_ms = zdt_closed.toInstant().toEpochMilli();
+      ctx._source.closed_at = ctx._source.cases.remove("closed_at");
+      ctx._source.closed_by = ctx._source.cases.remove("closed_by");
+    }
+
+    ctx._source.assignees = [];
+    for (item in ctx._source.cases.assignees) {
+      ctx._source.assignees.add(item.uid);
+    }
+    ctx._source.total_assignees = ctx._source.cases.assignees.size();
+
+    ctx._source.custom_fields = [];
+    for (item in ctx._source.cases.customFields) {
+      item.remove("key");
+      ctx._source.custom_fields.add(item);
+    }
+
+    ctx._source.observables = [];
+    for (item in ctx._source.cases.observables) {
+      item.type = item.remove("typeKey");
+      ctx._source.observables.add(item);
+    }
+    
+    ctx._source.owner = ctx._source.cases.remove("owner");
+
+    if (ctx._source.created_at_ms != null && ctx._source.closed_at_ms != null){
+      ctx._source.time_to_resolve = (ctx._source.closed_at_ms - ctx._source.created_at_ms) / 1000;
+    }
+
     ctx._source.remove("cases");
-    ctx._source.remove("type")`,
+    ctx._source.remove("type");
+    ctx._source.remove("references"); // ?
+  `,
 };
 
-export const CAI_ATTACHMENTS_INDEX_SCRIPT_ID = 'internal_cases_attachments_index_painless_script';
+export const CAI_ATTACHMENTS_INDEX_SCRIPT_ID = 'cai_attachments_script_1';
 export const CAI_ATTACHMENTS_INDEX_SCRIPT: StoredScript = {
   lang: 'painless',
-  source: '',
+  source: `
+    long milliSinceEpoch = new Date().getTime();
+    Instant instant = Instant.ofEpochMilli(milliSinceEpoch);
+    ctx._source['@timestamp'] = ZonedDateTime.ofInstant(instant, ZoneId.of('Z'));
+
+    ctx._source.type = ctx._source["cases-comments"].remove("type");
+
+    if (ctx._source.type == "alert") {
+      ctx._source.payload = new HashMap();
+      ctx._source.payload.alerts = new HashMap();
+      ctx._source.payload.alerts.id = ctx._source["cases-comments"].remove("alertId");
+      ctx._source.payload.alerts.index = ctx._source["cases-comments"].remove("index");
+    }
+    
+    if (ctx._source["cases-comments"].externalReferenceAttachmentTypeId == ".files") {
+      ctx._source.payload = new HashMap();
+      ctx._source.payload.file = new HashMap();
+      ctx._source.payload.file.extension = ctx._source["cases-comments"].externalReferenceMetadata.files[0].extension;
+      ctx._source.payload.file.mimeType = ctx._source["cases-comments"].externalReferenceMetadata.files[0].mimeType;
+      ctx._source.payload.file.name = ctx._source["cases-comments"].externalReferenceMetadata.files[0].name;
+
+      for (item in ctx._source.references) {
+        if (item.type == "file") {
+          ctx._source.payload.file.id = item.id;
+        }
+      }
+    }
+    
+    ctx._source.owner = ctx._source["cases-comments"].remove("owner");
+    
+    ctx._source.remove("cases-comments");
+    ctx._source.remove("updated_at");
+    ctx._source.remove("type");
+    ctx._source.remove("references"); // ?
+  
+  `,
 };
 
-export const CAI_COMMENTS_INDEX_SCRIPT_ID = 'internal_cases_comments_index_painless_script';
+export const CAI_COMMENTS_INDEX_SCRIPT_ID = 'cai_comments_script_1';
 export const CAI_COMMENTS_INDEX_SCRIPT: StoredScript = {
   lang: 'painless',
-  source: '',
+  source: `
+    long milliSinceEpoch = new Date().getTime();
+    Instant instant = Instant.ofEpochMilli(milliSinceEpoch);
+    ctx._source['@timestamp'] = ZonedDateTime.ofInstant(instant, ZoneId.of('Z'));
+
+    ctx._source.comment = ctx._source["cases-comments"].remove("comment");
+    ctx._source.created_at = ctx._source["cases-comments"].remove("created_at");
+    ctx._source.created_by = ctx._source["cases-comments"].remove("created_by");
+    ctx._source.owner = ctx._source["cases-comments"].remove("owner");
+
+    for (item in ctx._source.references) {
+      if (item.type == "cases") {
+        ctx._source.case_id = item.id;
+      }
+    }
+
+    ctx._source.remove("updated_at");
+    ctx._source.remove("cases-comments");
+    ctx._source.remove("type");
+    ctx._source.remove("references"); // ?
+  `,
 };

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/painless_scripts.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/painless_scripts.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { StoredScript } from '@elastic/elasticsearch/lib/api/types';
+
+export const CAI_CASES_INDEX_SCRIPT_ID = 'internal_cases_index_painless_script';
+export const CAI_CASES_INDEX_SCRIPT: StoredScript = {
+  lang: 'painless',
+  source: `
+    ctx._source.updated_title = ctx._source.cases.remove("title");
+    ctx._source.remove("cases");
+    ctx._source.remove("type")`,
+};
+
+export const CAI_ATTACHMENTS_INDEX_SCRIPT_ID = 'internal_cases_attachments_index_painless_script';
+export const CAI_ATTACHMENTS_INDEX_SCRIPT: StoredScript = {
+  lang: 'painless',
+  source: '',
+};
+
+export const CAI_COMMENTS_INDEX_SCRIPT_ID = 'internal_cases_comments_index_painless_script';
+export const CAI_COMMENTS_INDEX_SCRIPT: StoredScript = {
+  lang: 'painless',
+  source: '',
+};

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/tasks/backfill_task/backfill_task_factory.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/tasks/backfill_task/backfill_task_factory.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { Logger } from '@kbn/logging';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { RunContext } from '@kbn/task-manager-plugin/server';
+import { CaseAnalyticsIndexBackfillTaskRunner } from './backfill_task_runner';
+
+interface CaseAnalyticsIndexBackfillTaskFactoryParams {
+  logger: Logger;
+  getESClient: () => Promise<ElasticsearchClient>;
+}
+
+export class CaseAnalyticsIndexBackfillTaskFactory {
+  private readonly logger: Logger;
+  private readonly getESClient: () => Promise<ElasticsearchClient>;
+
+  constructor({ logger, getESClient }: CaseAnalyticsIndexBackfillTaskFactoryParams) {
+    this.logger = logger;
+    this.getESClient = getESClient;
+  }
+
+  public create(context: RunContext) {
+    return new CaseAnalyticsIndexBackfillTaskRunner({
+      taskInstance: context.taskInstance,
+      logger: this.logger,
+      getESClient: this.getESClient,
+    });
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/tasks/backfill_task/backfill_task_runner.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/tasks/backfill_task/backfill_task_runner.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type { ConcreteTaskInstance } from '@kbn/task-manager-plugin/server';
+import type { ElasticsearchClient } from '@kbn/core/server';
+import type { CancellableTask } from '@kbn/task-manager-plugin/server/task';
+import type {
+  IndicesGetMappingResponse,
+  QueryDslQueryContainer,
+} from '@elastic/elasticsearch/lib/api/types';
+
+interface BackfillTaskRunnerFactoryConstructorParams {
+  taskInstance: ConcreteTaskInstance;
+  getESClient: () => Promise<ElasticsearchClient>;
+  logger: Logger;
+}
+
+export class CaseAnalyticsIndexBackfillTaskRunner implements CancellableTask {
+  private readonly sourceIndex: string;
+  private readonly destIndex: string;
+  private readonly sourceQuery: QueryDslQueryContainer;
+  private readonly getESClient: () => Promise<ElasticsearchClient>;
+  private readonly logger: Logger;
+
+  constructor({ taskInstance, getESClient, logger }: BackfillTaskRunnerFactoryConstructorParams) {
+    this.sourceIndex = taskInstance.params.sourceIndex;
+    this.destIndex = taskInstance.params.destIndex;
+    this.sourceQuery = taskInstance.params.sourceQuery;
+    this.getESClient = getESClient;
+    this.logger = logger;
+  }
+
+  public async run() {
+    try {
+      await this.backfillReindex();
+      return {
+        state: {},
+      };
+    } catch (e) {
+      this.logger.error(`Backfill reindex of ${this.destIndex} failed. Error: ${e.message}`);
+      return {
+        state: {},
+      };
+    }
+  }
+
+  private async backfillReindex() {
+    const esClient = await this.getESClient();
+    const painlessScript = await this.getPainlessScript();
+
+    if (painlessScript.found) {
+      this.logger.info(`Reindexing from ${this.sourceIndex} to ${this.destIndex}.`);
+      await esClient.reindex({
+        source: {
+          index: this.sourceIndex,
+          query: this.sourceQuery,
+        },
+        dest: { index: this.destIndex },
+        script: painlessScript.script,
+        /** If `true`, the request refreshes affected shards to make this operation visible to search. */
+        refresh: true,
+        // make sure the indexes are created?
+        wait_for_active_shards: 'all',
+      });
+    } else {
+      // log error?
+    }
+  }
+
+  private async getPainlessScript() {
+    const esClient = await this.getESClient();
+    const painlessScriptId = await this.getPainlessScriptId();
+    this.logger.info(`Getting painless script with id ${painlessScriptId}.`);
+    return esClient.getScript({
+      id: painlessScriptId,
+    });
+  }
+
+  private async getPainlessScriptId() {
+    const currentMapping = await this.getCurrentMapping();
+    return currentMapping[this.destIndex].mappings._meta?.painless_script_id;
+  }
+
+  private async getCurrentMapping(): Promise<IndicesGetMappingResponse> {
+    const esClient = await this.getESClient();
+
+    this.logger.info(`Getting mapping of index ${this.destIndex}.`);
+    return esClient.indices.getMapping({
+      index: this.destIndex,
+    });
+  }
+
+  public async cancel() {}
+}

--- a/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/tasks/backfill_task/index.ts
+++ b/x-pack/platform/plugins/shared/cases/server/cases_analytics_index/tasks/backfill_task/index.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Logger } from '@kbn/logging';
+import type {
+  RunContext,
+  TaskManagerSetupContract,
+  TaskManagerStartContract,
+} from '@kbn/task-manager-plugin/server';
+import type { CoreSetup, ElasticsearchClient } from '@kbn/core/server';
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+import type { CasesServerStartDependencies } from '../../../types';
+import { CaseAnalyticsIndexBackfillTaskFactory } from './backfill_task_factory';
+
+const TASK_TYPE = 'cai:cases_analytics_index_backfill';
+
+export function registerCAIBackfillTask({
+  taskManagerSetup,
+  logger,
+  core,
+}: {
+  taskManagerSetup: TaskManagerSetupContract;
+  logger: Logger;
+  core: CoreSetup<CasesServerStartDependencies>;
+}) {
+  const getESClient = async (): Promise<ElasticsearchClient> => {
+    const [{ elasticsearch }] = await core.getStartServices();
+    return elasticsearch.client.asInternalUser;
+  };
+
+  taskManagerSetup.registerTaskDefinitions({
+    [TASK_TYPE]: {
+      title: 'Backfill cases analytics index',
+      maxAttempts: 3,
+      createTaskRunner: (context: RunContext) => {
+        return new CaseAnalyticsIndexBackfillTaskFactory({ getESClient, logger }).create(context);
+      },
+    },
+  });
+}
+
+export async function scheduleCAIBackfillTask({
+  taskId,
+  sourceIndex,
+  sourceQuery,
+  destIndex,
+  taskManager,
+  logger,
+}: {
+  taskId: string;
+  sourceIndex: string;
+  sourceQuery: QueryDslQueryContainer;
+  destIndex: string;
+  taskManager: TaskManagerStartContract;
+  logger: Logger;
+}) {
+  try {
+    await taskManager.ensureScheduled({
+      id: taskId,
+      taskType: TASK_TYPE,
+      params: { sourceIndex, destIndex, sourceQuery },
+      runAt: new Date(Date.now() + 5 * 1000), // todo, value is short for testing but should run after 5 minutes
+      state: {},
+    });
+  } catch (e) {
+    logger.error(`Error scheduling ${taskId} task, received ${e.message}`);
+  }
+}

--- a/x-pack/platform/plugins/shared/cases/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/cases/server/plugin.ts
@@ -47,6 +47,7 @@ import { registerCaseFileKinds } from './files';
 import type { ConfigType } from './config';
 import { registerConnectorTypes } from './connectors';
 import { registerSavedObjects } from './saved_object_types';
+import { createCasesAnalyticsIndices } from './cases_analytics_index';
 
 export class CasePlugin
   implements
@@ -189,6 +190,13 @@ export class CasePlugin
     if (plugins.taskManager) {
       scheduleCasesTelemetryTask(plugins.taskManager, this.logger);
     }
+
+    createCasesAnalyticsIndices({
+      esClient: core.elasticsearch.client.asInternalUser,
+      logger: this.logger,
+      // TODO
+      isServerless: false,
+    });
 
     this.userProfileService.initialize({
       spaces: plugins.spaces,

--- a/x-pack/platform/plugins/shared/cases/server/types.ts
+++ b/x-pack/platform/plugins/shared/cases/server/types.ts
@@ -44,7 +44,7 @@ export interface CasesServerSetupDependencies {
   files: FilesSetup;
   security: SecurityPluginSetup;
   licensing: LicensingPluginSetup;
-  taskManager?: TaskManagerSetupContract;
+  taskManager: TaskManagerSetupContract;
   usageCollection?: UsageCollectionSetup;
   spaces?: SpacesPluginSetup;
   cloud?: CloudSetup;
@@ -55,7 +55,7 @@ export interface CasesServerStartDependencies {
   features: FeaturesPluginStart;
   files: FilesStart;
   licensing: LicensingPluginStart;
-  taskManager?: TaskManagerStartContract;
+  taskManager: TaskManagerStartContract;
   security: SecurityPluginStart;
   spaces?: SpacesPluginStart;
   notifications: NotificationsPluginStart;


### PR DESCRIPTION
## Summary

**No tests yet.**

This PR adds:
- The index creation step happens when the cases plugin starts.
- Backfill task registration.
- Backfill task scheduling.
- Mapping version 1 for:
  - .internal.cases
  - .internal.cases-comments
  - .internal.cases-attachments
- All corresponding painless scripts.

## Testing

A few things are needed.

1. Create a role that has index creation permission. Below is what works for me; it might be overkill.
<img width="1030" alt="Screenshot 2025-04-25 at 11 30 45" src="https://github.com/user-attachments/assets/cbb7b384-e438-43ec-bbca-a18e62243523" />

2. Create a user with the role created in step 1. Let's call the user `index_creator`. **The password should be** `changeme`.
<img width="842" alt="Screenshot 2025-04-25 at 11 31 27" src="https://github.com/user-attachments/assets/a9547c96-086e-43b4-a442-a18f558dcb96" />

4. Start Kibana with this user as the Elasticsearch user - `yarn start` with the option `--elasticsearch.username=index_creator`.

6. Kibana startup logs should show relevant messages:
```
[INFO ][plugins.cases] [.internal.cases] Checking if index exists.
[INFO ][plugins.cases] [.internal.cases-attachments] Checking if index exists.
[INFO ][plugins.cases] [.internal.cases-comments] Checking if index exists.
```

7. You can check the content of these indexes in the Dev Tools.
```
GET /.internal.cases/_search
GET /.internal.cases-comments/_search
GET /.internal.cases-attachments/_search
```
