### PR TITLE
[Security Solution][Users page] a11y:Fix double announcement on tootips

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/query_string_input/add_filter_popover.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/add_filter_popover.tsx
@@ -65,7 +65,7 @@ const AddFilterPopoverComponent = React.memo(function AddFilterPopover({
   const [showAddFilterPopover, setShowAddFilterPopover] = useState(false);
 
   const button = (
-    <EuiToolTip delay="long" content={strings.getAddFilterButtonLabel()}>
+    <EuiToolTip delay="long" content={strings.getAddFilterButtonLabel()} disableScreenReaderOutput>
       <EuiButtonIcon
         display="base"
         iconType="plusInCircleFilled"

--- a/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu.tsx
+++ b/src/platform/plugins/shared/unified_search/public/query_string_input/query_bar_menu.tsx
@@ -153,7 +153,7 @@ function QueryBarMenuComponent({
   };
 
   const button = (
-    <EuiToolTip delay="long" content={strings.getFilterSetButtonLabel()}>
+    <EuiToolTip delay="long" content={strings.getFilterSetButtonLabel()} disableScreenReaderOutput>
       <EuiButtonIcon
         size="m"
         display="empty"


### PR DESCRIPTION
## Summary

Addresses this `a11y` issue: https://github.com/elastic/kibana/issues/205327

## Changes made: 

- Suppress duplicate screen-reader announcements by adding the `disableScreenReaderOutput` prop to the `EuiToolTip` wrapping the “Add filter” button.
- Confirmed the `disableScreenReaderOutput` prop (introduced in EUI v101.2.0) by consulting the official tooltip documentation: https://eui.elastic.co/#/display/tooltip


**How to test:**

1. Navigate to `Security -> Explore -> Users page`.
2. Navigate to `add filter` button by pressing Tab key.
3. Check the button and tooltip announcement on a screen reader.

### Sample


https://github.com/user-attachments/assets/dd4528fd-9ee3-437e-953f-7fc15fdde7ac



### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->