### PR TITLE
[Serialized State Only] single-metric-viewer embeddable

### DIFF
--- a/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_controls_initializer.ts
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_controls_initializer.ts
@@ -6,7 +6,6 @@
  */
 
 import type { StateComparators, TitlesApi } from '@kbn/presentation-publishing';
-import fastIsEqual from 'fast-deep-equal';
 import { BehaviorSubject } from 'rxjs';
 import type { JobId } from '../../../common/types/anomaly_detection_jobs';
 import type {

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_controls_initializer.ts
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_controls_initializer.ts
@@ -59,15 +59,23 @@ export const initializeSingleMetricViewerControls = (
   };
 
   const singleMetricViewerComparators: StateComparators<SingleMetricViewerControlsState> = {
-    jobIds: [jobIds, (ids) => jobIds.next(ids), fastIsEqual],
-    forecastId: [forecastId, (id) => forecastId.next(id)],
-    selectedDetectorIndex: [selectedDetectorIndex, (index) => selectedDetectorIndex.next(index)],
-    selectedEntities: [selectedEntities, (items) => selectedEntities.next(items), fastIsEqual],
-    functionDescription: [
-      functionDescription,
-      (description) => functionDescription.next(description),
-    ],
+    jobIds: 'referenceEquality',
+    forecastId: 'referenceEquality',
+    selectedDetectorIndex: 'referenceEquality',
+    selectedEntities: 'referenceEquality',
+    functionDescription: 'referenceEquality',
   };
+
+  // const singleMetricViewerComparators: StateComparators<SingleMetricViewerControlsState> = {
+  //   jobIds: [jobIds, (ids) => jobIds.next(ids), fastIsEqual],
+  //   forecastId: [forecastId, (id) => forecastId.next(id)],
+  //   selectedDetectorIndex: [selectedDetectorIndex, (index) => selectedDetectorIndex.next(index)],
+  //   selectedEntities: [selectedEntities, (items) => selectedEntities.next(items), fastIsEqual],
+  //   functionDescription: [
+  //     functionDescription,
+  //     (description) => functionDescription.next(description),
+  //   ],
+  // };
 
   return {
     singleMetricViewerControlsApi: {

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.tsx
@@ -7,21 +7,24 @@
 
 import type { StartServicesAccessor } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
-
-import type { ReactEmbeddableFactory } from '@kbn/embeddable-plugin/public';
+import { initializeUnsavedChanges } from '@kbn/presentation-containers';
+import type { EmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import React from 'react';
 import useUnmount from 'react-use/lib/useUnmount';
 import {
+  // type StateComparators,
   apiHasExecutionContext,
-  initializeTimeRange,
+  initializeTimeRangeManager,
+  timeRangeComparators,
   initializeTitleManager,
   useStateFromPublishingSubject,
+  titleComparators,
 } from '@kbn/presentation-publishing';
-import { BehaviorSubject, Subscription } from 'rxjs';
+import { BehaviorSubject, Subscription, merge, map } from 'rxjs';
 import { ANOMALY_SINGLE_METRIC_VIEWER_EMBEDDABLE_TYPE } from '..';
 import type { MlPluginStart, MlStartDependencies } from '../../plugin';
 import type {
-  SingleMetricViewerRuntimeState,
+  // SingleMetricViewerRuntimeState,
   SingleMetricViewerEmbeddableApi,
   SingleMetricViewerEmbeddableState,
 } from '../types';
@@ -31,34 +34,86 @@ import { getServices } from './get_services';
 import { useReactEmbeddableExecutionContext } from '../common/use_embeddable_execution_context';
 import { getSingleMetricViewerComponent } from '../../shared_components/single_metric_viewer';
 
+// const SingleMetricViewerComparators: StateComparators<MarkdownEditorState> = { content: 'referenceEquality' };
+
 export const getSingleMetricViewerEmbeddableFactory = (
   getStartServices: StartServicesAccessor<MlStartDependencies, MlPluginStart>
 ) => {
-  const factory: ReactEmbeddableFactory<
+  const factory: EmbeddableFactory<
     SingleMetricViewerEmbeddableState,
-    SingleMetricViewerRuntimeState,
+    // SingleMetricViewerRuntimeState,
     SingleMetricViewerEmbeddableApi
   > = {
     type: ANOMALY_SINGLE_METRIC_VIEWER_EMBEDDABLE_TYPE,
-    deserializeState: (state) => state.rawState,
-    buildEmbeddable: async (state, buildApi, uuid, parentApi) => {
+    // deserializeState: (state) => state.rawState,
+    buildEmbeddable: async ({ initialState, finalizeApi, parentApi, uuid }) => {
       const services = await getServices(getStartServices);
       const subscriptions = new Subscription();
-      const titleManager = initializeTitleManager(state);
-      const timeRangeManager = initializeTimeRange(state);
+      const titleManager = initializeTitleManager(initialState.rawState);
+      const timeRangeManager = initializeTimeRangeManager(initialState.rawState);
+      // const titleManager = initializeTitleManager(state);
+      // const timeRangeManager = initializeTimeRange(state);
 
       const {
         singleMetricViewerControlsApi,
         serializeSingleMetricViewerState,
         singleMetricViewerComparators,
         onSingleMetricViewerDestroy,
-      } = initializeSingleMetricViewerControls(state, titleManager.api);
+      } = initializeSingleMetricViewerControls(initialState.rawState, titleManager.api);
 
       const dataLoading$ = new BehaviorSubject<boolean | undefined>(true);
       const blockingError$ = new BehaviorSubject<Error | undefined>(undefined);
 
-      const api = buildApi(
+      function serializeState() {
+        return {
+          rawState: {
+            timeRange: undefined,
+            ...titleManager.getLatestState(),
+            ...timeRangeManager.getLatestState(),
+            ...serializeSingleMetricViewerState(),
+          },
+          references: [],
+        };
+      }
+
+      const unsavedChangesApi = initializeUnsavedChanges({
+        uuid,
+        parentApi,
+        serializeState,
+        anyStateChange$: merge(
+          titleManager.anyStateChange$
+          // timeRangeManager.anyStateChange$
+        ).pipe(map(() => undefined)),
+        // getComparators: () => {
+        //   /**
+        //    * comparators are provided in a callback to allow embeddables to change how their state is compared based
+        //    * on the values of other state. For instance, if a saved object ID is present (by reference), the embeddable
+        //    * may want to skip comparison of certain state.
+        //    */
+        //   // return { ...titleComparators, ...SingleMetricViewerComparators };
+        //   return {  ...titleComparators, ...timeRangeManager.comparators, ...singleMetricViewerComparators }
+        // },
+        getComparators: () => {
+          return {
+            ...titleComparators,
+            ...timeRangeComparators,
+            ...singleMetricViewerComparators,
+          };
+        },
+        onReset: (lastSaved) => {
+          /**
+           * if this embeddable had a difference between its runtime and serialized state, we could run the 'deserializeState'
+           * function here before resetting. onReset can be async so to support a potential async deserialize function.
+           */
+
+          titleManager.reinitializeState(lastSaved?.rawState);
+          timeRangeManager.reinitializeState(lastSaved?.rawState);
+        },
+      });
+
+      const api = finalizeApi(
         {
+          ...unsavedChangesApi,
           isEditingEnabled: () => true,
           getTypeDisplayName: () =>
             i18n.translate('xpack.ml.singleMetricViewerEmbeddable.typeDisplayName', {
@@ -77,7 +132,8 @@ export const getSingleMetricViewerEmbeddableFactory = (
                 { data, share },
                 mlApi,
                 {
-                  ...titleManager.serialize(),
+                  ...titleManager.getLatestState(),
+                  // ...titleManager.serialize(),
                   ...serializeSingleMetricViewerState(),
                 }
               );
@@ -92,23 +148,14 @@ export const getSingleMetricViewerEmbeddableFactory = (
           ...singleMetricViewerControlsApi,
           dataLoading$,
           blockingError$,
-          serializeState: () => {
-            return {
-              rawState: {
-                timeRange: undefined,
-                ...titleManager.serialize(),
-                ...timeRangeManager.serialize(),
-                ...serializeSingleMetricViewerState(),
-              },
-              references: [],
-            };
-          },
-        },
-        {
-          ...timeRangeManager.comparators,
-          ...titleManager.comparators,
-          ...singleMetricViewerComparators,
+          // ?????
+          serializeState,
         }
+        // {
+        //   ...timeRangeManager.comparators,
+        //   ...titleManager.comparators,
+        //   ...singleMetricViewerComparators,
+        // }
       );
 
       const { singleMetricViewerData$, onDestroy } = initializeSingleMetricViewerDataFetcher(
@@ -157,6 +204,7 @@ export const getSingleMetricViewerEmbeddableFactory = (
               onError={(error) => blockingError$.next(error)}
               selectedDetectorIndex={singleMetricViewerData?.selectedDetectorIndex}
               selectedEntities={singleMetricViewerData?.selectedEntities}
+              // ??
               selectedJobId={singleMetricViewerData?.jobIds[0]}
               forecastId={singleMetricViewerData?.forecastId}
               uuid={api.uuid}


### PR DESCRIPTION
This PR does not need to be reviewed by external teams. This PR merges into a feature branch that Kibana presentation team is working on to convert the embeddable framework to only expose serialized state. Your team will be pinged for review once the work is complete and the final PR opens that merges the feature branch into main

This removes runtime state from the single-metric-viewer embeddable.

## Testing this PR
We can use functional test fixtures to set up ML jobs for the embeddable

1. If necessary, start Elasticsearch with `yarn es snapshot --license trial`
2. Start Kibana with no base path, `yarn start --no-base-path`.
3. Use the es archiver to load functional test fixtures from [these functional tests](https://github.com/elastic/kibana/blob/e73c8ddcb96aaaa2f2e3e5b47da9e6d5680ffbcf/x-pack/test/functional/apps/ml/anomaly_detection_integrations/single_metric_viewer_dashboard_embeddables.ts#L34). 
```
node scripts/es_archiver load x-pack/test/functional/es_archives/ml/farequote \
--es-url="http://elastic:changeme@localhost:9200" \
--kibana-url="http://elastic:changeme@localhost:5601"
```
4. Create a data view with the `ft_farequote` pattern.
6. Go to Stack Management - Anomaly Detection Jobs and click the "Import jobs" button.
7. Import this [jobs file](https://gist.github.com/nickpeihl/b708e5b75325bffe0f713ce85e349e29)
8. Find the imported job in Stack Management - Anomaly Detection and "Start the datafeed" from the "Actions" menu.
9. Choose "Start at beginning of data" click "Start"
10. Open a new Dashboard and add a Single metric chart panel.