### PR TITLE
[AI4DSOC][ResponseOps] Fix alerts table not handling undefined maintenanceWindow capability

### DIFF
--- a/src/platform/packages/shared/response-ops/alerts-table/hooks/use_bulk_get_maintenance_windows.tsx
+++ b/src/platform/packages/shared/response-ops/alerts-table/hooks/use_bulk_get_maintenance_windows.tsx
@@ -55,11 +55,7 @@ export const useBulkGetMaintenanceWindowsQuery = (
     ids,
     http,
     notifications: { toasts },
-    application: {
-      capabilities: {
-        maintenanceWindow: { show },
-      },
-    },
+    application: { capabilities },
     licensing,
   }: UseBulkGetMaintenanceWindowsQueryParams,
   {
@@ -69,6 +65,9 @@ export const useBulkGetMaintenanceWindowsQuery = (
 ) => {
   const { isAtLeastPlatinum } = useLicense({ licensing });
   const hasLicense = isAtLeastPlatinum();
+
+  // In AI4DSOC (searchAiLake tier) the maintenanceWindow capability is disabled
+  const show = Boolean(capabilities.maintenanceWindow?.show);
 
   return useQuery({
     queryKey: queryKeys.maintenanceWindowsBulkGet(ids),

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.test.tsx
@@ -46,6 +46,6 @@ describe('<Table />', () => {
       </TestProviders>
     );
 
-    expect(getByTestId('alertsTableErrorPrompt')).toBeInTheDocument();
+    expect(getByTestId('internalAlertsPageLoading')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/wrapper.test.tsx
@@ -6,14 +6,8 @@
  */
 
 import React from 'react';
-import { act, render } from '@testing-library/react';
-import {
-  AiForSOCAlertsTab,
-  CONTENT_TEST_ID,
-  ERROR_TEST_ID,
-  LOADING_PROMPT_TEST_ID,
-  SKELETON_TEST_ID,
-} from './wrapper';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AiForSOCAlertsTab, CONTENT_TEST_ID, ERROR_TEST_ID, SKELETON_TEST_ID } from './wrapper';
 import { useKibana } from '../../../../../../../common/lib/kibana';
 import { TestProviders } from '../../../../../../../common/mock';
 import { useFetchIntegrations } from '../../../../../../../detections/hooks/alert_summary/use_fetch_integrations';
@@ -56,11 +50,10 @@ describe('<AiForSOCAlertsTab />', () => {
       },
     });
 
-    await act(async () => {
-      const { getByTestId } = render(<AiForSOCAlertsTab id={id} query={query} />);
+    render(<AiForSOCAlertsTab id={id} query={query} />);
 
-      expect(getByTestId(LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
     });
   });
 
@@ -81,14 +74,9 @@ describe('<AiForSOCAlertsTab />', () => {
       isLoading: true,
     });
 
-    await act(async () => {
-      const { getByTestId } = render(<AiForSOCAlertsTab id={id} query={query} />);
+    render(<AiForSOCAlertsTab id={id} query={query} />);
 
-      await new Promise(process.nextTick);
-
-      expect(getByTestId(LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
   });
 
   it('should render an error if the dataView fail to be created correctly', async () => {
@@ -108,14 +96,11 @@ describe('<AiForSOCAlertsTab />', () => {
       useEffect: jest.fn((f) => f()),
     }));
 
-    await act(async () => {
-      const { getByTestId } = render(<AiForSOCAlertsTab id={id} query={query} />);
+    render(<AiForSOCAlertsTab id={id} query={query} />);
 
-      await new Promise(process.nextTick);
-
-      expect(getByTestId(LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(ERROR_TEST_ID)).toHaveTextContent('Unable to create data view');
-    });
+    expect(await screen.findByTestId(ERROR_TEST_ID)).toHaveTextContent(
+      'Unable to create data view'
+    );
   });
 
   it('should render the content', async () => {
@@ -138,17 +123,12 @@ describe('<AiForSOCAlertsTab />', () => {
       useEffect: jest.fn((f) => f()),
     }));
 
-    await act(async () => {
-      const { getByTestId } = render(
-        <TestProviders>
-          <AiForSOCAlertsTab id={id} query={query} />
-        </TestProviders>
-      );
+    render(
+      <TestProviders>
+        <AiForSOCAlertsTab id={id} query={query} />
+      </TestProviders>
+    );
 
-      await new Promise(process.nextTick);
-
-      expect(getByTestId(LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/table.test.tsx
@@ -48,6 +48,6 @@ describe('<Table />', () => {
       </TestProviders>
     );
 
-    expect(getByTestId('alertsTableErrorPrompt')).toBeInTheDocument();
+    expect(getByTestId('internalAlertsPageLoading')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.test.tsx
@@ -43,6 +43,6 @@ describe('<Table />', () => {
       </TestProviders>
     );
 
-    expect(getByTestId('alertsTableErrorPrompt')).toBeInTheDocument();
+    expect(getByTestId('internalAlertsPageLoading')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table_section.test.tsx
@@ -39,6 +39,6 @@ describe('<TableSection />', () => {
     );
 
     expect(getByTestId(GROUPED_TABLE_TEST_ID)).toBeInTheDocument();
-    expect(getByTestId('alertsTableErrorPrompt')).toBeInTheDocument();
+    expect(getByTestId('internalAlertsPageLoading')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import type { PackageListItem } from '@kbn/fleet-plugin/common';
 import { installationStatuses } from '@kbn/fleet-plugin/common/constants';
 import {
@@ -64,11 +64,11 @@ describe('<Wrapper />', () => {
       },
     });
 
-    await act(async () => {
-      const { getByTestId } = render(<Wrapper packages={packages} ruleResponse={ruleResponse} />);
+    render(<Wrapper packages={packages} ruleResponse={ruleResponse} />);
 
-      expect(getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
+      expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
     });
   });
 
@@ -89,14 +89,12 @@ describe('<Wrapper />', () => {
       useEffect: jest.fn((f) => f()),
     }));
 
-    await act(async () => {
-      const { getByTestId } = render(<Wrapper packages={packages} ruleResponse={ruleResponse} />);
+    render(<Wrapper packages={packages} ruleResponse={ruleResponse} />);
 
-      await new Promise(process.nextTick);
-
-      expect(getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent('Unable to create data view');
-    });
+    expect(await screen.findByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(DATA_VIEW_ERROR_TEST_ID)).toHaveTextContent(
+      'Unable to create data view'
+    );
   });
 
   it('should render the content if the dataView is created correctly', async () => {
@@ -124,21 +122,17 @@ describe('<Wrapper />', () => {
       useEffect: jest.fn((f) => f()),
     }));
 
-    await act(async () => {
-      const { getByTestId } = render(
-        <TestProviders>
-          <Wrapper packages={packages} ruleResponse={ruleResponse} />
-        </TestProviders>
-      );
+    render(
+      <TestProviders>
+        <Wrapper packages={packages} ruleResponse={ruleResponse} />
+      </TestProviders>
+    );
 
-      await new Promise(process.nextTick);
-
-      expect(getByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(ADD_INTEGRATIONS_BUTTON_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(SEARCH_BAR_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(KPIS_SECTION)).toBeInTheDocument();
-      expect(getByTestId(GROUPED_TABLE_TEST_ID)).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId(DATA_VIEW_LOADING_PROMPT_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(ADD_INTEGRATIONS_BUTTON_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(SEARCH_BAR_TEST_ID)).toBeInTheDocument();
+    expect(await screen.findByTestId(KPIS_SECTION)).toBeInTheDocument();
+    expect(await screen.findByTestId(GROUPED_TABLE_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/wrapper.tsx
@@ -68,16 +68,20 @@ export const Wrapper = memo(({ packages, ruleResponse }: WrapperProps) => {
   useEffect(() => {
     let dv: DataView;
     const createDataView = async () => {
-      dv = await data.dataViews.create(dataViewSpec);
-      setDataView(dv);
-      setLoading(false);
+      try {
+        dv = await data.dataViews.create(dataViewSpec);
+        setDataView(dv);
+        setLoading(false);
+      } catch (err) {
+        setLoading(false);
+      }
     };
     createDataView();
 
     // clearing after leaving the page
     return () => {
       if (dv?.id) {
-        data.dataViews.clearInstanceCache(dv?.id);
+        data.dataViews.clearInstanceCache(dv.id);
       }
     };
   }, [data.dataViews]);


### PR DESCRIPTION
## Summary

This PR fixes an issue with the ResponseOps alerts table not handling the `maintenanceWindow` capability being `undefined`. In the AI4DSOC effort, [we recently disabled](https://github.com/elastic/kibana/pull/214586) the `maintenanceWindow` capability which cause the `useBulkGetMaintenanceWindowsQuery` hook to crash.

Current behavior

https://github.com/user-attachments/assets/8ab8c97f-04a0-45cb-95e7-cc9114e87190

Fixed behavior

https://github.com/user-attachments/assets/0749bda3-7838-47b7-a65b-5c9b6a92a245

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

relates to https://github.com/elastic/security-team/issues/11973