### PR TITLE
Allow overrides for comment on PR script

### DIFF
--- a/.buildkite/scripts/lifecycle/comment_on_pr.ts
+++ b/.buildkite/scripts/lifecycle/comment_on_pr.ts
@@ -33,15 +33,23 @@ const ALLOWED_ENV_VARS = [
   'GITHUB_PR_USER',
 ];
 
+interface CommentOnPRArgs {
+  messageTemplate: string;
+  context?: string;
+  clearPrevious: boolean;
+  issueNumber?: string;
+  repository?: string;
+  repositoryOwner?: string;
+}
+
 export function commentOnPR({
   messageTemplate,
   context,
   clearPrevious,
-}: {
-  messageTemplate: string;
-  context?: string;
-  clearPrevious: boolean;
-}) {
+  issueNumber,
+  repository: repositoryBase,
+  repositoryOwner,
+}: CommentOnPRArgs) {
   const message = messageTemplate.replace(/\${([^}]+)}/g, (_, envVar) => {
     if (ALLOWED_ENV_VARS.includes(envVar)) {
       return process.env[envVar] || '';
@@ -51,19 +59,26 @@ export function commentOnPR({
   });
 
   if (context) {
-    return upsertComment({ commentBody: message, commentContext: context, clearPrevious });
+    return upsertComment(
+      { commentBody: message, commentContext: context, clearPrevious },
+      repositoryOwner,
+      repositoryBase,
+      issueNumber
+    );
   } else {
-    return addComment(message);
+    return addComment(message, repositoryOwner, repositoryBase, issueNumber);
   }
 }
 
 if (require.main === module) {
-  const args = parseArgs<{
-    context?: string;
-    message: string;
-    'clear-previous'?: boolean | string;
-  }>(process.argv.slice(2), {
-    string: ['message', 'context'],
+  const args = parseArgs<
+    CommentOnPRArgs & {
+      'clear-previous'?: CommentOnPRArgs['clearPrevious'] | string;
+      'issue-number'?: CommentOnPRArgs['issueNumber'];
+      'repository-owner'?: CommentOnPRArgs['repositoryOwner'];
+    }
+  >(process.argv.slice(2), {
+    string: ['message', 'context', 'issue-number', 'repository', 'repository-owner'],
     boolean: ['clear-previous'],
   });
 
@@ -82,6 +97,9 @@ if (require.main === module) {
       typeof args['clear-previous'] === 'string'
         ? !!args['clear-previous'].match(/(1|true)/i)
         : !!args['clear-previous'],
+    issueNumber: args['issue-number'],
+    repository: args.repository,
+    repositoryOwner: args['repository-owner'],
   }).catch((error) => {
     console.error(error);
     process.exit(1);


### PR DESCRIPTION
## Summary

Culled from the work happening in https://github.com/elastic/kibana/pull/212674. 

Allows passing args to the `comment-on-pr.ts` script to specify overrides, this is useful in cases where the build that want to invoke this script would like to explicitly specify a value other than the values it would previously have default to. 

This allows to use the script in the following manner for example; 

```bash
ts-node .buildkite/scripts/lifecycle/comment_on_pr.ts \
	 --message "Linux headless chromium build started at: https://buildkite.com/elastic/kibana-migration-pipeline-staging/builds/309" \
	--context "chromium-linux-build-job-start" \
	--issue-number 212732 \
	--repository kibana \
	--repository-owner elastic \
	--clear-previous
```

<!--

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


-->
