### PR TITLE
convert links embeddable to serialized state only

### DIFF
--- a/src/platform/plugins/private/links/public/content_management/save_to_library.tsx
+++ b/src/platform/plugins/private/links/public/content_management/save_to_library.tsx
@@ -71,8 +71,8 @@ export const runSaveToLibrary = async (
         });
         resolve({
           ...newState,
-          defaultPanelTitle: newTitle,
-          defaultPanelDescription: newDescription,
+          defaultTitle: newTitle,
+          defaultDescription: newDescription,
           savedObjectId: id,
         });
         return { id };

--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.test.tsx
@@ -12,17 +12,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { embeddablePluginMock } from '@kbn/embeddable-plugin/public/mocks';
 import { setStubKibanaServices } from '@kbn/presentation-panel-plugin/public/mocks';
 import { EuiThemeProvider } from '@elastic/eui';
-import { getLinksEmbeddableFactory } from './links_embeddable';
+import { deserializeState, getLinksEmbeddableFactory } from './links_embeddable';
 import { Link } from '../../common/content_management';
 import { CONTENT_ID } from '../../common';
-import { ReactEmbeddableRenderer } from '@kbn/embeddable-plugin/public';
-import {
-  LinksApi,
-  LinksParentApi,
-  LinksRuntimeState,
-  LinksSerializedState,
-  ResolvedLink,
-} from '../types';
+import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
+import { LinksApi, LinksParentApi, LinksSerializedState, ResolvedLink } from '../types';
 import { linksClient } from '../content_management';
 import { getMockLinksParentApi } from '../mocks';
 
@@ -148,7 +142,7 @@ const renderEmbeddable = (
 ) => {
   return render(
     <EuiThemeProvider>
-      <ReactEmbeddableRenderer<LinksSerializedState, LinksRuntimeState, LinksApi>
+      <EmbeddableRenderer<LinksSerializedState, LinksApi>
         type={CONTENT_ID}
         onApiAvailable={jest.fn()}
         getParentApi={jest.fn().mockReturnValue(parent)}
@@ -178,8 +172,8 @@ describe('getLinksEmbeddableFactory', () => {
     } as LinksSerializedState;
 
     const expectedRuntimeState = {
-      defaultPanelTitle: 'links 001',
-      defaultPanelDescription: 'some links',
+      defaultTitle: 'links 001',
+      defaultDescription: 'some links',
       layout: 'vertical',
       links: getResolvedLinks(),
       description: 'just a few links',
@@ -195,7 +189,7 @@ describe('getLinksEmbeddableFactory', () => {
     });
 
     test('deserializeState', async () => {
-      const deserializedState = await factory.deserializeState({
+      const deserializedState = await deserializeState({
         rawState,
         references: [], // no references passed because the panel is by reference
       });
@@ -266,8 +260,8 @@ describe('getLinksEmbeddableFactory', () => {
     } as LinksSerializedState;
 
     const expectedRuntimeState = {
-      defaultPanelTitle: undefined,
-      defaultPanelDescription: undefined,
+      defaultTitle: undefined,
+      defaultDescription: undefined,
       layout: 'horizontal',
       links: getResolvedLinks(),
       description: 'just a few links',
@@ -283,7 +277,7 @@ describe('getLinksEmbeddableFactory', () => {
     });
 
     test('deserializeState', async () => {
-      const deserializedState = await factory.deserializeState({
+      const deserializedState = await deserializeState({
         rawState,
         references,
       });

--- a/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
+++ b/src/platform/plugins/private/links/public/embeddable/links_embeddable.tsx
@@ -9,23 +9,24 @@
 
 import React, { createContext, useMemo } from 'react';
 import { cloneDeep } from 'lodash';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, merge } from 'rxjs';
 import { EuiListGroup, EuiPanel, UseEuiTheme } from '@elastic/eui';
 
-import { PanelIncompatibleError, ReactEmbeddableFactory } from '@kbn/embeddable-plugin/public';
+import { PanelIncompatibleError, EmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import {
   SerializedTitles,
   initializeTitleManager,
   SerializedPanelState,
   useBatchedOptionalPublishingSubjects,
+  initializeStateManager,
+  titleComparators,
 } from '@kbn/presentation-publishing';
 import { css } from '@emotion/react';
 
-import { apiIsPresentationContainer } from '@kbn/presentation-containers';
+import { apiIsPresentationContainer, initializeUnsavedChanges } from '@kbn/presentation-containers';
 import {
   CONTENT_ID,
   DASHBOARD_LINK_TYPE,
-  LinksLayoutType,
   LINKS_HORIZONTAL_LAYOUT,
   LINKS_VERTICAL_LAYOUT,
 } from '../../common/content_management';
@@ -38,7 +39,6 @@ import {
   LinksParentApi,
   LinksRuntimeState,
   LinksSerializedState,
-  ResolvedLink,
 } from '../types';
 import { DISPLAY_NAME } from '../../common';
 import { injectReferences } from '../../common/persistable_state';
@@ -54,172 +54,186 @@ import { isParentApiCompatible } from '../actions/add_links_panel_action';
 
 export const LinksContext = createContext<LinksApi | null>(null);
 
-export const getLinksEmbeddableFactory = () => {
-  const linksEmbeddableFactory: ReactEmbeddableFactory<
-    LinksSerializedState,
-    LinksRuntimeState,
-    LinksApi
-  > = {
-    type: CONTENT_ID,
-    deserializeState: async (serializedState) => {
-      // Clone the state to avoid an object not extensible error when injecting references
-      const state = cloneDeep(serializedState.rawState);
-      const { title, description, hidePanelTitles } = serializedState.rawState;
+export async function deserializeState(
+  serializedState: SerializedPanelState<LinksSerializedState>
+) {
+  // Clone the state to avoid an object not extensible error when injecting references
+  const state = cloneDeep(serializedState.rawState);
+  const { title, description, hidePanelTitles } = serializedState.rawState;
 
-      if (linksSerializeStateIsByReference(state)) {
-        const linksSavedObject = await linksClient.get(state.savedObjectId);
-        const runtimeState = await deserializeLinksSavedObject(linksSavedObject.item);
+  if (linksSerializeStateIsByReference(state)) {
+    const linksSavedObject = await linksClient.get(state.savedObjectId);
+    const runtimeState = await deserializeLinksSavedObject(linksSavedObject.item);
+    return {
+      ...runtimeState,
+      title,
+      description,
+      hidePanelTitles,
+    };
+  }
+
+  const { attributes: attributesWithInjectedIds } = injectReferences({
+    attributes: state.attributes,
+    references: serializedState.references ?? [],
+  });
+
+  const resolvedLinks = await resolveLinks(attributesWithInjectedIds.links ?? []);
+
+  return {
+    title,
+    description,
+    hidePanelTitles,
+    links: resolvedLinks,
+    layout: attributesWithInjectedIds.layout,
+    defaultTitle: attributesWithInjectedIds.title,
+    defaultDescription: attributesWithInjectedIds.description,
+  };
+}
+
+export const getLinksEmbeddableFactory = () => {
+  const linksEmbeddableFactory: EmbeddableFactory<LinksSerializedState, LinksApi> = {
+    type: CONTENT_ID,
+    buildEmbeddable: async ({ initialState, finalizeApi, uuid, parentApi }) => {
+      const titleManager = initializeTitleManager(initialState.rawState);
+      const savedObjectId = linksSerializeStateIsByReference(initialState.rawState)
+        ? initialState.rawState.savedObjectId
+        : undefined;
+      const isByReference = savedObjectId !== undefined;
+
+      const initialRuntimeState = await deserializeState(initialState);
+
+      const blockingError$ = new BehaviorSubject<Error | undefined>(undefined);
+      if (!isParentApiCompatible(parentApi)) blockingError$.next(new PanelIncompatibleError());
+
+      const stateManager = initializeStateManager<
+        Pick<LinksRuntimeState, 'defaultDescription' | 'defaultTitle' | 'layout' | 'links'>
+      >(initialRuntimeState, {
+        defaultDescription: undefined,
+        defaultTitle: undefined,
+        layout: undefined,
+        links: undefined,
+      });
+
+      function serializeByReference(id: string) {
         return {
-          ...runtimeState,
-          title,
-          description,
-          hidePanelTitles,
+          rawState: {
+            ...titleManager.getLatestState(),
+            savedObjectId: id,
+          } as LinksByReferenceSerializedState,
+          references: [],
         };
       }
 
-      const { attributes: attributesWithInjectedIds } = injectReferences({
-        attributes: state.attributes,
-        references: serializedState.references ?? [],
+      function serializeByValue() {
+        const { attributes, references } = serializeLinksAttributes(stateManager.getLatestState());
+        return {
+          rawState: {
+            ...titleManager.getLatestState(),
+            attributes,
+          } as LinksByValueSerializedState,
+          references,
+        };
+      }
+
+      const serializeState = () =>
+        isByReference ? serializeByReference(savedObjectId) : serializeByValue();
+
+      const unsavedChangesApi = initializeUnsavedChanges<LinksSerializedState>({
+        uuid,
+        parentApi,
+        serializeState,
+        anyStateChange$: merge(titleManager.anyStateChange$, stateManager.anyStateChange$),
+        getComparators: () => {
+          return {
+            ...titleComparators,
+            attributes: isByReference ? 'skip' : 'deepEquality',
+            savedObjectId: 'skip',
+          };
+        },
+        onReset: async (lastSaved) => {
+          titleManager.reinitializeState(lastSaved?.rawState);
+          if (lastSaved && !isByReference) {
+            const lastSavedRuntimeState = await deserializeState(lastSaved);
+            stateManager.reinitializeState(lastSavedRuntimeState);
+          }
+        },
       });
 
-      const resolvedLinks = await resolveLinks(attributesWithInjectedIds.links ?? []);
-
-      return {
-        title,
-        description,
-        hidePanelTitles,
-        links: resolvedLinks,
-        layout: attributesWithInjectedIds.layout,
-        defaultPanelTitle: attributesWithInjectedIds.title,
-        defaultPanelDescription: attributesWithInjectedIds.description,
-      };
-    },
-    buildEmbeddable: async (state, buildApi, uuid, parentApi) => {
-      const blockingError$ = new BehaviorSubject<Error | undefined>(state.error);
-      if (!isParentApiCompatible(parentApi)) blockingError$.next(new PanelIncompatibleError());
-
-      const links$ = new BehaviorSubject<ResolvedLink[] | undefined>(state.links);
-      const layout$ = new BehaviorSubject<LinksLayoutType | undefined>(state.layout);
-      const defaultTitle$ = new BehaviorSubject<string | undefined>(state.defaultPanelTitle);
-      const defaultDescription$ = new BehaviorSubject<string | undefined>(
-        state.defaultPanelDescription
-      );
-      const savedObjectId$ = new BehaviorSubject(state.savedObjectId);
-      const isByReference = Boolean(state.savedObjectId);
-
-      const titleManager = initializeTitleManager(state);
-
-      const serializeLinksState = (byReference: boolean, newId?: string) => {
-        if (byReference) {
-          const linksByReferenceState: LinksByReferenceSerializedState = {
-            savedObjectId: newId ?? state.savedObjectId!,
-            ...titleManager.serialize(),
-          };
-          return { rawState: linksByReferenceState, references: [] };
-        }
-        const runtimeState = api.snapshotRuntimeState();
-        const { attributes, references } = serializeLinksAttributes(runtimeState);
-        const linksByValueState: LinksByValueSerializedState = {
-          attributes,
-          ...titleManager.serialize(),
-        };
-        return { rawState: linksByValueState, references };
-      };
-
-      const api = buildApi(
-        {
-          ...titleManager.api,
-          blockingError$,
-          defaultTitle$,
-          defaultDescription$,
-          isEditingEnabled: () => Boolean(blockingError$.value === undefined),
-          getTypeDisplayName: () => DISPLAY_NAME,
-          serializeState: () => serializeLinksState(isByReference),
-          saveToLibrary: async (newTitle: string) => {
-            defaultTitle$.next(newTitle);
-            const runtimeState = api.snapshotRuntimeState();
-            const { attributes, references } = serializeLinksAttributes(runtimeState);
-            const {
-              item: { id },
-            } = await linksClient.create({
-              data: {
-                ...attributes,
-                title: newTitle,
-              },
-              options: { references },
-            });
-            return id;
-          },
-          getSerializedStateByValue: () =>
-            serializeLinksState(false) as SerializedPanelState<LinksByValueSerializedState>,
-          getSerializedStateByReference: (newId: string) =>
-            serializeLinksState(
-              true,
-              newId
-            ) as SerializedPanelState<LinksByReferenceSerializedState>,
-          canLinkToLibrary: async () => !isByReference,
-          canUnlinkFromLibrary: async () => isByReference,
-          checkForDuplicateTitle: async (
-            newTitle: string,
-            isTitleDuplicateConfirmed: boolean,
-            onTitleDuplicate: () => void
-          ) => {
-            await checkForDuplicateTitle({
+      const api = finalizeApi({
+        ...titleManager.api,
+        ...unsavedChangesApi,
+        blockingError$,
+        defaultTitle$: stateManager.api.defaultTitle$,
+        defaultDescription$: stateManager.api.defaultDescription$,
+        isEditingEnabled: () => Boolean(blockingError$.value === undefined),
+        getTypeDisplayName: () => DISPLAY_NAME,
+        serializeState,
+        saveToLibrary: async (newTitle: string) => {
+          stateManager.api.setDefaultTitle(newTitle);
+          const { attributes, references } = serializeLinksAttributes(
+            stateManager.getLatestState()
+          );
+          const {
+            item: { id },
+          } = await linksClient.create({
+            data: {
+              ...attributes,
               title: newTitle,
-              copyOnSave: false,
-              lastSavedTitle: '',
-              isTitleDuplicateConfirmed,
-              onTitleDuplicate,
-            });
-          },
-          onEdit: async () => {
-            const { openEditorFlyout } = await import('../editor/open_editor_flyout');
-            const newState = await openEditorFlyout({
-              initialState: api.snapshotRuntimeState(),
-              parentDashboard: parentApi,
-            });
-            if (!newState) return;
-
-            // if the by reference state has changed during this edit, reinitialize the panel.
-            const nextIsByReference = Boolean(newState?.savedObjectId);
-            if (nextIsByReference !== isByReference && apiIsPresentationContainer(api.parentApi)) {
-              const serializedState = serializeLinksState(
-                nextIsByReference,
-                newState?.savedObjectId
-              );
-              (serializedState.rawState as SerializedTitles).title = newState.title;
-
-              api.parentApi.replacePanel<LinksSerializedState>(api.uuid, {
-                serializedState,
-                panelType: api.type,
-              });
-              return;
-            }
-            links$.next(newState.links);
-            layout$.next(newState.layout);
-            defaultTitle$.next(newState.defaultPanelTitle);
-            defaultDescription$.next(newState.defaultPanelDescription);
-          },
+            },
+            options: { references },
+          });
+          return id;
         },
-        {
-          ...titleManager.comparators,
-          links: [links$, (nextLinks?: ResolvedLink[]) => links$.next(nextLinks ?? [])],
-          layout: [
-            layout$,
-            (nextLayout?: LinksLayoutType) => layout$.next(nextLayout ?? LINKS_VERTICAL_LAYOUT),
-          ],
-          error: [blockingError$, (nextError?: Error) => blockingError$.next(nextError)],
-          defaultPanelDescription: [
-            defaultDescription$,
-            (nextDescription?: string) => defaultDescription$.next(nextDescription),
-          ],
-          defaultPanelTitle: [defaultTitle$, (nextTitle?: string) => defaultTitle$.next(nextTitle)],
-          savedObjectId: [savedObjectId$, (val) => savedObjectId$.next(val)],
-        }
-      );
+        getSerializedStateByValue: serializeByValue,
+        getSerializedStateByReference: (newId: string) => serializeByReference(newId),
+        canLinkToLibrary: async () => !isByReference,
+        canUnlinkFromLibrary: async () => isByReference,
+        checkForDuplicateTitle: async (
+          newTitle: string,
+          isTitleDuplicateConfirmed: boolean,
+          onTitleDuplicate: () => void
+        ) => {
+          await checkForDuplicateTitle({
+            title: newTitle,
+            copyOnSave: false,
+            lastSavedTitle: '',
+            isTitleDuplicateConfirmed,
+            onTitleDuplicate,
+          });
+        },
+        onEdit: async () => {
+          const { openEditorFlyout } = await import('../editor/open_editor_flyout');
+          const newState = await openEditorFlyout({
+            initialState: stateManager.getLatestState(),
+            parentDashboard: parentApi,
+          });
+          if (!newState) return;
+
+          // if the by reference state has changed during this edit, reinitialize the panel.
+          const nextSavedObjectId = newState?.savedObjectId;
+          const nextIsByReference = nextSavedObjectId !== undefined;
+          if (nextIsByReference !== isByReference && apiIsPresentationContainer(api.parentApi)) {
+            const serializedState = nextIsByReference
+              ? serializeByReference(nextSavedObjectId)
+              : serializeByValue();
+            (serializedState.rawState as SerializedTitles).title = newState.title;
+
+            api.parentApi.replacePanel<LinksSerializedState>(api.uuid, {
+              serializedState,
+              panelType: api.type,
+            });
+            return;
+          }
+
+          stateManager.reinitializeState(newState);
+        },
+      });
 
       const Component = () => {
-        const [links, layout] = useBatchedOptionalPublishingSubjects(links$, layout$);
+        const [links, layout] = useBatchedOptionalPublishingSubjects(
+          stateManager.api.links$,
+          stateManager.api.layout$
+        );
 
         const linkItems: { [id: string]: { id: string; content: JSX.Element } } = useMemo(() => {
           if (!links) return {};

--- a/src/platform/plugins/private/links/public/lib/deserialize_from_library.ts
+++ b/src/platform/plugins/private/links/public/lib/deserialize_from_library.ts
@@ -27,13 +27,13 @@ export const deserializeLinksSavedObject = async (
 
   const links = await resolveLinks(attributes.links ?? []);
 
-  const { title: defaultPanelTitle, description: defaultPanelDescription, layout } = attributes;
+  const { title: defaultTitle, description: defaultDescription, layout } = attributes;
 
   return {
     links,
     layout,
     savedObjectId: linksSavedObject.id,
-    defaultPanelTitle,
-    defaultPanelDescription,
+    defaultTitle,
+    defaultDescription,
   };
 };

--- a/src/platform/plugins/private/links/public/lib/serialize_attributes.ts
+++ b/src/platform/plugins/private/links/public/lib/serialize_attributes.ts
@@ -12,7 +12,7 @@ import { extractReferences } from '../../common/persistable_state';
 import { LinksRuntimeState } from '../types';
 
 export const serializeLinksAttributes = (
-  state: LinksRuntimeState,
+  state: Pick<LinksRuntimeState, 'defaultDescription' | 'defaultTitle' | 'layout' | 'links'>,
   shouldExtractReferences: boolean = true
 ) => {
   const linksToSave: Link[] | undefined = state.links
@@ -25,8 +25,8 @@ export const serializeLinksAttributes = (
         ) as unknown as Link
     );
   const attributes = {
-    title: state.defaultPanelTitle,
-    description: state.defaultPanelDescription,
+    title: state.defaultTitle,
+    description: state.defaultDescription,
     layout: state.layout,
     links: linksToSave,
   };

--- a/src/platform/plugins/private/links/public/plugin.ts
+++ b/src/platform/plugins/private/links/public/plugin.ts
@@ -25,7 +25,8 @@ import { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
 
 import { UiActionsPublicStart } from '@kbn/ui-actions-plugin/public/plugin';
 import { ADD_PANEL_TRIGGER } from '@kbn/ui-actions-plugin/public';
-import { LinksRuntimeState, LinksSerializedState } from './types';
+import { SerializedPanelState } from '@kbn/presentation-publishing';
+import { LinksSerializedState } from './types';
 import { APP_ICON, APP_NAME, CONTENT_ID, LATEST_VERSION } from '../common';
 import { LinksCrudTypes } from '../common/content_management';
 import { getLinksClient } from './content_management/links_content_management_client';
@@ -144,8 +145,10 @@ export class LinksPlugin
 
     plugins.dashboard.registerDashboardPanelPlacementSetting(
       CONTENT_ID,
-      async (runtimeState?: LinksRuntimeState) => {
-        if (!runtimeState) return {};
+      async (serializedState?: SerializedPanelState<LinksSerializedState>) => {
+        if (!serializedState) return {};
+        const { deserializeState } = await import('./embeddable/links_embeddable');
+        const runtimeState = await deserializeState(serializedState);
         const isHorizontal = runtimeState.layout === 'horizontal';
         const width = isHorizontal ? DASHBOARD_GRID_COLUMN_COUNT : 8;
         const height = isHorizontal ? 4 : (runtimeState.links?.length ?? 1 * 3) + 4;

--- a/src/platform/plugins/private/links/public/plugin.ts
+++ b/src/platform/plugins/private/links/public/plugin.ts
@@ -25,7 +25,7 @@ import { VisualizationsSetup } from '@kbn/visualizations-plugin/public';
 
 import { UiActionsPublicStart } from '@kbn/ui-actions-plugin/public/plugin';
 import { ADD_PANEL_TRIGGER } from '@kbn/ui-actions-plugin/public';
-import { LinksRuntimeState } from './types';
+import { LinksRuntimeState, LinksSerializedState } from './types';
 import { APP_ICON, APP_NAME, CONTENT_ID, LATEST_VERSION } from '../common';
 import { LinksCrudTypes } from '../common/content_management';
 import { getLinksClient } from './content_management/links_content_management_client';
@@ -64,11 +64,13 @@ export class LinksPlugin
 
       plugins.embeddable.registerAddFromLibraryType({
         onAdd: async (container, savedObject) => {
-          const { deserializeLinksSavedObject } = await import('./lib/deserialize_from_library');
-          const initialState = await deserializeLinksSavedObject(savedObject);
-          container.addNewPanel<LinksRuntimeState>({
+          container.addNewPanel<LinksSerializedState>({
             panelType: CONTENT_ID,
-            initialState,
+            serializedState: {
+              rawState: {
+                savedObjectId: savedObject.id,
+              },
+            },
           });
         },
         savedObjectType: CONTENT_ID,

--- a/src/platform/plugins/private/links/public/types.ts
+++ b/src/platform/plugins/private/links/public/types.ts
@@ -18,7 +18,6 @@ import {
   SerializedTitles,
 } from '@kbn/presentation-publishing';
 import { DefaultEmbeddableApi } from '@kbn/embeddable-plugin/public';
-import { DynamicActionsSerializedState } from '@kbn/embeddable-enhanced-plugin/public/plugin';
 import { HasSerializedChildState, PresentationContainer } from '@kbn/presentation-containers';
 import { LocatorPublic } from '@kbn/share-plugin/common';
 import { DashboardLocatorParams, DASHBOARD_API_TYPE } from '@kbn/dashboard-plugin/public';
@@ -38,7 +37,7 @@ export type LinksParentApi = PresentationContainer &
   };
 
 export type LinksApi = HasType<typeof CONTENT_ID> &
-  DefaultEmbeddableApi<LinksSerializedState, LinksRuntimeState> &
+  DefaultEmbeddableApi<LinksSerializedState> &
   HasEditCapabilities &
   HasLibraryTransforms<LinksByReferenceSerializedState, LinksByValueSerializedState>;
 
@@ -51,7 +50,6 @@ export interface LinksByValueSerializedState {
 }
 
 export type LinksSerializedState = SerializedTitles &
-  Partial<DynamicActionsSerializedState> &
   (LinksByReferenceSerializedState | LinksByValueSerializedState);
 
 export interface LinksRuntimeState
@@ -60,8 +58,8 @@ export interface LinksRuntimeState
   error?: Error;
   links?: ResolvedLink[];
   layout?: LinksLayoutType;
-  defaultPanelTitle?: string;
-  defaultPanelDescription?: string;
+  defaultTitle?: string;
+  defaultDescription?: string;
 }
 
 export type ResolvedLink = Link & {

--- a/src/platform/plugins/private/links/public/types.ts
+++ b/src/platform/plugins/private/links/public/types.ts
@@ -55,7 +55,6 @@ export type LinksSerializedState = SerializedTitles &
 export interface LinksRuntimeState
   extends Partial<LinksByReferenceSerializedState>,
     SerializedTitles {
-  error?: Error;
   links?: ResolvedLink[];
   layout?: LinksLayoutType;
   defaultTitle?: string;

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/panels_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/panels_manager.ts
@@ -112,7 +112,8 @@ export function initializePanelsManager(
   };
 
   const resetPanels = (lastSavedPanels: DashboardPanelMap) => {
-    const { layout: lastSavedLayout, childState: lstSavedChildState } = deserializePanels(lastSavedPanels);
+    const { layout: lastSavedLayout, childState: lstSavedChildState } =
+      deserializePanels(lastSavedPanels);
 
     layout$.next(lastSavedLayout);
     currentChildState = lstSavedChildState;
@@ -158,7 +159,7 @@ export function initializePanelsManager(
     }
     const getCustomPlacementSettingFunc = getDashboardPanelPlacementSetting(type);
     const customPlacementSettings = getCustomPlacementSettingFunc
-      ? await getCustomPlacementSettingFunc(serializedState?.rawState)
+      ? await getCustomPlacementSettingFunc(serializedState)
       : undefined;
     const { newPanelPlacement, otherPanels } = runPanelPlacementStrategy(
       customPlacementSettings?.strategy ?? PanelPlacementStrategy.findTopLeftMostOpenSpace,

--- a/src/platform/plugins/shared/dashboard/public/panel_placement/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/panel_placement/types.ts
@@ -8,6 +8,7 @@
  */
 
 import { MaybePromise } from '@kbn/utility-types';
+import { SerializedPanelState } from '@kbn/presentation-publishing';
 import type { GridData } from '../../server/content_management';
 import { PanelPlacementStrategy } from '../plugin_constants';
 import { DashboardLayout } from '../dashboard_api/types';
@@ -30,5 +31,5 @@ export interface PanelPlacementProps {
 }
 
 export type GetPanelPlacementSettings<SerializedState extends object = object> = (
-  serializedState?: SerializedState
+  serializedState?: SerializedPanelState<SerializedState>
 ) => MaybePromise<PanelPlacementSettings>;


### PR DESCRIPTION
This PR does not need to be reviewed by external teams. This PR merges into a feature branch that Kibana presentation team is working on to convert the embeddable framework to only expose serialized state. Your team will be pinged for review once the work is complete and the final PR opens that merges the feature branch into main