### PR TITLE
[AI4DSOC] Disable CellActions and PreviewLinks on the Attack discovery page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.test.tsx
@@ -11,6 +11,10 @@ import React from 'react';
 import { ActionableSummary } from '.';
 import { TestProviders } from '../../../../../common/mock';
 import { mockAttackDiscovery } from '../../../mock/mock_attack_discovery';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { SECURITY_FEATURE_ID } from '../../../../../../common';
+
+jest.mock('../../../../../common/lib/kibana');
 
 describe('ActionableSummary', () => {
   const mockReplacements = {
@@ -104,6 +108,39 @@ describe('ActionableSummary', () => {
 
     it('renders the View in AI assistant button', () => {
       expect(screen.getByTestId('viewInAiAssistantCompact')).toBeInTheDocument();
+    });
+  });
+
+  describe('when configurations capabilities is defined (for AI4DSOC)', () => {
+    beforeEach(() => {
+      (useKibana as jest.Mock).mockReturnValue({
+        services: {
+          application: {
+            capabilities: {
+              [SECURITY_FEATURE_ID]: {
+                configurations: true,
+              },
+            },
+          },
+        },
+      });
+
+      render(
+        <TestProviders>
+          <ActionableSummary
+            attackDiscovery={mockAttackDiscovery}
+            replacements={mockReplacements}
+          />
+        </TestProviders>
+      );
+    });
+
+    it('renders a disabled badge with the hostname value', () => {
+      expect(screen.getAllByTestId('disabledActionsBadge')[0]).toHaveTextContent('foo.hostname');
+    });
+
+    it('renders a disabled badge with the username value', () => {
+      expect(screen.getAllByTestId('disabledActionsBadge')[1]).toHaveTextContent('bar.username');
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.tsx
@@ -33,8 +33,12 @@ const ActionableSummaryComponent: React.FC<Props> = ({
     application: { capabilities },
   } = useKibana().services;
   // TODO We shouldn't have to check capabilities here, this should be done at a much higher level.
-  //  https://github.com/elastic/kibana/issues/xxxxxx
-  const disabledActions = Boolean(capabilities[SECURITY_FEATURE_ID].configurations);
+  //  https://github.com/elastic/kibana/issues/218731
+  //  For the AI for SOC we need to hide cell actions and all preview links that could open non-AI4DSOC flyouts
+  const disabledActions = useMemo(
+    () => showAnonymized || Boolean(capabilities[SECURITY_FEATURE_ID].configurations),
+    [capabilities, showAnonymized]
+  );
 
   const entitySummary = useMemo(
     () =>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/actionable_summary/index.tsx
@@ -7,12 +7,14 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import {
-  replaceAnonymizedValuesWithOriginalValues,
   type AttackDiscovery,
+  replaceAnonymizedValuesWithOriginalValues,
   type Replacements,
 } from '@kbn/elastic-assistant-common';
 import React, { useMemo } from 'react';
 
+import { SECURITY_FEATURE_ID } from '../../../../../../common';
+import { useKibana } from '../../../../../common/lib/kibana';
 import { AttackDiscoveryMarkdownFormatter } from '../../attack_discovery_markdown_formatter';
 import { ViewInAiAssistant } from '../view_in_ai_assistant';
 
@@ -27,6 +29,13 @@ const ActionableSummaryComponent: React.FC<Props> = ({
   replacements,
   showAnonymized = false,
 }) => {
+  const {
+    application: { capabilities },
+  } = useKibana().services;
+  // TODO We shouldn't have to check capabilities here, this should be done at a much higher level.
+  //  https://github.com/elastic/kibana/issues/xxxxxx
+  const disabledActions = Boolean(capabilities[SECURITY_FEATURE_ID].configurations);
+
   const entitySummary = useMemo(
     () =>
       showAnonymized
@@ -60,7 +69,7 @@ const ActionableSummaryComponent: React.FC<Props> = ({
       <EuiFlexGroup alignItems="center" gutterSize="none" justifyContent="spaceBetween">
         <EuiFlexItem data-test-subj="entitySummaryMarkdown" grow={false}>
           <AttackDiscoveryMarkdownFormatter
-            disableActions={showAnonymized}
+            disableActions={disabledActions}
             markdown={entitySummaryOrTitle}
           />
         </EuiFlexItem>

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.test.tsx
@@ -13,6 +13,10 @@ import type { Replacements } from '@kbn/elastic-assistant-common';
 import { TestProviders } from '../../../../../../common/mock';
 import { mockAttackDiscovery } from '../../../../mock/mock_attack_discovery';
 import { ATTACK_CHAIN, DETAILS, SUMMARY } from './translations';
+import { SECURITY_FEATURE_ID } from '../../../../../../../common';
+import { useKibana } from '../../../../../../common/lib/kibana';
+
+jest.mock('../../../../../../common/lib/kibana');
 
 describe('AttackDiscoveryTab', () => {
   const mockReplacements: Replacements = {
@@ -44,6 +48,8 @@ describe('AttackDiscoveryTab', () => {
       expect(summaryMarkdown).toHaveTextContent(
         'A multi-stage malware attack was detected on foo.hostname involving bar.username. A suspicious application delivered malware, attempted credential theft, and established persistence.'
       );
+      expect(screen.getAllByTestId('entityButton')[0]).toHaveTextContent('foo.hostname');
+      expect(screen.getAllByTestId('entityButton')[1]).toHaveTextContent('bar.username');
     });
 
     it('renders the details using the real host and username', () => {
@@ -53,6 +59,8 @@ describe('AttackDiscoveryTab', () => {
       expect(detailsMarkdown).toHaveTextContent(
         `The following attack progression appears to have occurred on the host foo.hostname involving the user bar.username: A suspicious application named "My Go Application.app" was launched, likely through a malicious download or installation. This application spawned child processes to copy a malicious file named "unix1" to the user's home directory and make it executable. The malicious "unix1" file was then executed, attempting to access the user's login keychain and potentially exfiltrate credentials. The suspicious application also launched the "osascript" utility to display a fake system dialog prompting the user for their password, a technique known as credentials phishing. This appears to be a multi-stage attack involving malware delivery, privilege escalation, credential access, and potentially data exfiltration. The attacker may have used social engineering techniques like phishing to initially compromise the system. The suspicious "My Go Application.app" exhibits behavior characteristic of malware families that attempt to steal user credentials and maintain persistence. Mitigations should focus on removing the malicious files, resetting credentials, and enhancing security controls around application whitelisting, user training, and data protection.`
       );
+      expect(screen.getAllByTestId('entityButton')[0]).toHaveTextContent('foo.hostname');
+      expect(screen.getAllByTestId('entityButton')[1]).toHaveTextContent('bar.username');
     });
   });
 
@@ -192,5 +200,52 @@ The user Administrator opened a malicious Microsoft Word document (C:\\Program F
         expect(content).toHaveStyle('overflow-x: auto');
       }
     );
+  });
+
+  describe('when configurations capabilities is defined (for AI4DSOC)', () => {
+    beforeEach(() => {
+      (useKibana as jest.Mock).mockReturnValue({
+        services: {
+          application: {
+            capabilities: {
+              [SECURITY_FEATURE_ID]: {
+                configurations: true,
+              },
+            },
+          },
+        },
+      });
+
+      render(
+        <TestProviders>
+          <AttackDiscoveryTab
+            attackDiscovery={mockAttackDiscovery}
+            replacements={mockReplacements}
+          />
+        </TestProviders>
+      );
+    });
+
+    it('renders the summary with disabled badges using the host and username', () => {
+      const markdownFormatters = screen.getAllByTestId('attackDiscoveryMarkdownFormatter');
+      const summaryMarkdown = markdownFormatters[0];
+
+      expect(summaryMarkdown).toHaveTextContent(
+        'A multi-stage malware attack was detected on foo.hostname involving bar.username. A suspicious application delivered malware, attempted credential theft, and established persistence.'
+      );
+      expect(screen.getAllByTestId('disabledActionsBadge')[0]).toHaveTextContent('foo.hostname');
+      expect(screen.getAllByTestId('disabledActionsBadge')[1]).toHaveTextContent('bar.username');
+    });
+
+    it('renders the details with disabled badgesusing the host and username', () => {
+      const markdownFormatters = screen.getAllByTestId('attackDiscoveryMarkdownFormatter');
+      const detailsMarkdown = markdownFormatters[1];
+
+      expect(detailsMarkdown).toHaveTextContent(
+        `The following attack progression appears to have occurred on the host foo.hostname involving the user bar.username: A suspicious application named "My Go Application.app" was launched, likely through a malicious download or installation. This application spawned child processes to copy a malicious file named "unix1" to the user's home directory and make it executable. The malicious "unix1" file was then executed, attempting to access the user's login keychain and potentially exfiltrate credentials. The suspicious application also launched the "osascript" utility to display a fake system dialog prompting the user for their password, a technique known as credentials phishing. This appears to be a multi-stage attack involving malware delivery, privilege escalation, credential access, and potentially data exfiltration. The attacker may have used social engineering techniques like phishing to initially compromise the system. The suspicious "My Go Application.app" exhibits behavior characteristic of malware families that attempt to steal user credentials and maintain persistence. Mitigations should focus on removing the malicious files, resetting credentials, and enhancing security controls around application whitelisting, user training, and data protection.`
+      );
+      expect(screen.getAllByTestId('disabledActionsBadge')[0]).toHaveTextContent('foo.hostname');
+      expect(screen.getAllByTestId('disabledActionsBadge')[1]).toHaveTextContent('bar.username');
+    });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.tsx
@@ -41,8 +41,12 @@ const AttackDiscoveryTabComponent: React.FC<Props> = ({
     application: { capabilities },
   } = useKibana().services;
   // TODO We shouldn't have to check capabilities here, this should be done at a much higher level.
-  //  https://github.com/elastic/kibana/issues/xxxxxx
-  const disabledActions = Boolean(capabilities[SECURITY_FEATURE_ID].configurations);
+  //  https://github.com/elastic/kibana/issues/218731
+  //  For the AI for SOC we need to hide cell actions and all preview links that could open non-AI4DSOC flyouts
+  const disabledActions = useMemo(
+    () => showAnonymized || Boolean(capabilities[SECURITY_FEATURE_ID].configurations),
+    [capabilities, showAnonymized]
+  );
 
   const { euiTheme } = useEuiTheme();
   const { detailsMarkdown, summaryMarkdown } = useMemo(() => attackDiscovery, [attackDiscovery]);

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/attack_discovery_tab/index.tsx
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-import { replaceAnonymizedValuesWithOriginalValues } from '@kbn/elastic-assistant-common';
 import type { AttackDiscovery, Replacements } from '@kbn/elastic-assistant-common';
+import { replaceAnonymizedValuesWithOriginalValues } from '@kbn/elastic-assistant-common';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSpacer, EuiTitle, useEuiTheme } from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useMemo } from 'react';
 
+import { useKibana } from '../../../../../../common/lib/kibana';
 import { AttackChain } from './attack/attack_chain';
 import { InvestigateInTimelineButton } from '../../../../../../common/components/event_details/investigate_in_timeline_button';
 import { buildAlertsKqlFilter } from '../../../../../../detections/components/alerts_table/actions';
@@ -18,6 +19,7 @@ import { getTacticMetadata } from '../../../../../helpers';
 import { AttackDiscoveryMarkdownFormatter } from '../../../attack_discovery_markdown_formatter';
 import * as i18n from './translations';
 import { ViewInAiAssistant } from '../../view_in_ai_assistant';
+import { SECURITY_FEATURE_ID } from '../../../../../../../common';
 
 const scrollable: React.CSSProperties = {
   overflowX: 'auto',
@@ -35,6 +37,13 @@ const AttackDiscoveryTabComponent: React.FC<Props> = ({
   replacements,
   showAnonymized = false,
 }) => {
+  const {
+    application: { capabilities },
+  } = useKibana().services;
+  // TODO We shouldn't have to check capabilities here, this should be done at a much higher level.
+  //  https://github.com/elastic/kibana/issues/xxxxxx
+  const disabledActions = Boolean(capabilities[SECURITY_FEATURE_ID].configurations);
+
   const { euiTheme } = useEuiTheme();
   const { detailsMarkdown, summaryMarkdown } = useMemo(() => attackDiscovery, [attackDiscovery]);
 
@@ -73,7 +82,7 @@ const AttackDiscoveryTabComponent: React.FC<Props> = ({
       <EuiSpacer size="s" />
       <div style={scrollable} data-test-subj="summaryContent">
         <AttackDiscoveryMarkdownFormatter
-          disableActions={showAnonymized}
+          disableActions={disabledActions}
           markdown={showAnonymized ? summaryMarkdown : summaryMarkdownWithReplacements}
         />
       </div>
@@ -87,7 +96,7 @@ const AttackDiscoveryTabComponent: React.FC<Props> = ({
 
       <div style={scrollable} data-test-subj="detailsContent">
         <AttackDiscoveryMarkdownFormatter
-          disableActions={showAnonymized}
+          disableActions={disabledActions}
           markdown={showAnonymized ? detailsMarkdown : detailsMarkdownWithReplacements}
         />
       </div>


### PR DESCRIPTION
## Summary

This PR disabled the cell actions and the preview links on the Attack discovery page for the AI4DSOC (searchLakeAI tier) effort.
For the first phase of AI4DSOC (at least for now) we do not have the host, user, network... flyouts available, as the interactions between those flyouts and the normal alert detail flyout are many.
Also, having the cell actions to filter in/out for example don't really make sense at this time, as the other pages do not listen to these. It would be confusing to the user to try to click on elements without any actual actions being performed.

Before fix

https://github.com/user-attachments/assets/46be2f69-ad10-43a8-8c6b-7b56e231cf0b

After fix

https://github.com/user-attachments/assets/aeda65c1-f762-4696-b2fb-5837c6f06c54

## TODO

If the approach looks good to the @elastic/security-generative-ai team, the following items needs to be done before merging:
- [ ] write unit tests
- [ ] create a ticket for the techdebt and link it in the code

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
