### PR TITLE
[Ai4dSoc] Add security project tier specific config files to serverless project archives

### DIFF
--- a/src/dev/build/tasks/create_archives_sources_task.ts
+++ b/src/dev/build/tasks/create_archives_sources_task.ts
@@ -54,7 +54,11 @@ export const CreateArchivesSources: Task = {
             resolve(REPO_ROOT, 'config'),
             build.resolvePathForPlatform(platform, 'config'),
             {
-              select: ['serverless.yml', 'serverless.{es,oblt,security}.yml'],
+              select: [
+                'serverless.yml',
+                'serverless.{es,oblt,security}.yml',
+                'serverless.security.{search_ai_lake,essentials,complete}.yml',
+              ],
             }
           );
           log.debug(`Adjustments made in serverless specific build directory`);

--- a/src/dev/build/tasks/create_archives_sources_task.ts
+++ b/src/dev/build/tasks/create_archives_sources_task.ts
@@ -56,7 +56,7 @@ export const CreateArchivesSources: Task = {
             {
               select: [
                 'serverless.yml',
-                'serverless.{es,oblt,security}.yml',
+                'serverless.{chat,es,oblt,security}.yml',
                 'serverless.security.{search_ai_lake,essentials,complete}.yml',
               ],
             }


### PR DESCRIPTION
## Summary

Adds the missing changes to allow overriding serverless security project settings for ai4soc product line.

follow up of https://github.com/elastic/kibana/pull/213577

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->