### PR TITLE
[APM][Dashboards] Prevent setting up filters when embeddable dashboard is destroyed

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/service_dashboards/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/service_dashboards/index.tsx
@@ -18,11 +18,7 @@ import {
 } from '@elastic/eui';
 
 import { ViewMode } from '@kbn/embeddable-plugin/public';
-import {
-  DashboardApi,
-  DashboardCreationOptions,
-  DashboardRenderer,
-} from '@kbn/dashboard-plugin/public';
+import { DashboardCreationOptions, DashboardRenderer } from '@kbn/dashboard-plugin/public';
 import { SerializableRecord } from '@kbn/utility-types';
 
 import { EmptyDashboards } from './empty_dashboards';
@@ -59,7 +55,6 @@ export function ServiceDashboards() {
   const checkForEntities = serviceEntitySummary?.dataStreamTypes
     ? isLogsOnlySignal(serviceEntitySummary.dataStreamTypes)
     : false;
-  const [dashboard, setDashboard] = useState<DashboardApi | undefined>();
   const [serviceDashboards, setServiceDashboards] = useState<MergedServiceDashboard[]>([]);
   const [currentDashboard, setCurrentDashboard] = useState<MergedServiceDashboard>();
   const { data: allAvailableDashboards } = useDashboardFetcher();
@@ -106,25 +101,18 @@ export function ServiceDashboards() {
     const getInitialInput = () => ({
       viewMode: ViewMode.VIEW,
       timeRange: { from: rangeFrom, to: rangeTo },
+      query: { query: kuery, language: 'kuery' },
+      filters:
+        dataView &&
+        currentDashboard?.serviceEnvironmentFilterEnabled &&
+        currentDashboard?.serviceNameFilterEnabled
+          ? getFilters(serviceName, environment, dataView)
+          : [],
     });
     return Promise.resolve<DashboardCreationOptions>({
       getInitialInput,
     });
-  }, [rangeFrom, rangeTo]);
-
-  useEffect(() => {
-    if (!dashboard) return;
-
-    dashboard.setFilters(
-      dataView &&
-        currentDashboard?.serviceEnvironmentFilterEnabled &&
-        currentDashboard?.serviceNameFilterEnabled
-        ? getFilters(serviceName, environment, dataView)
-        : []
-    );
-    dashboard.setQuery({ query: kuery, language: 'kuery' });
-    dashboard.setTimeRange({ from: rangeFrom, to: rangeTo });
-  }, [dataView, serviceName, environment, kuery, dashboard, rangeFrom, rangeTo, currentDashboard]);
+  }, [dataView, serviceName, environment, rangeFrom, rangeTo, currentDashboard, kuery]);
 
   const getLocatorParams = useCallback(
     (params: any) => {
@@ -217,7 +205,6 @@ export function ServiceDashboards() {
                 locator={locator}
                 savedObjectId={dashboardId}
                 getCreationOptions={getCreationOptions}
-                onApiAvailable={setDashboard}
               />
             )}
           </EuiFlexItem>


### PR DESCRIPTION
Closes #204329

### Summary

We can't use Dashboard API to set up filters because embeddable dashboards are destroyed (reloaded) every time when filters are applied, which is causing the page to crash with `Embeddable has been destroyed` error. Legacy API doesn't provide a way to verify if dashboard is destroyed before calling their methods, therefore we switched over to initiating filters via `getCreationOptions` component property. 

The issue is present in `v8.16` and `v8.17`, from `v.8.18` and onward embeddable dashboards were [refactored](https://github.com/elastic/kibana/pull/186642) which fixed the issue. 

**Before:**

https://github.com/user-attachments/assets/838896be-e8f1-46d0-883b-2e3d6b92ca5c

**After:**

https://github.com/user-attachments/assets/079d37b5-754e-4b87-815c-2f8817afc6cd

### How to test:
1. Create dashboard in **Analytics -> Dashboard**
2. Link your dashboard in **APM -> Dashboards**
3. Refresh date filters
