### PR TITLE
[Fleet] updated readme, added doc link to flyout

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/remote_clusters_ccr.md
+++ b/x-pack/platform/plugins/shared/fleet/dev_docs/local_setup/remote_clusters_ccr.md
@@ -176,3 +176,17 @@ GET fleet-synced-integrations/_search
 ```
 GET remote1:metrics-*/_search
 ```
+
+## Cloud testing
+
+- Create 2 deployments in https://console.qa.cld.elstc.co called main and remote
+- Manage the deployments and add `xpack.fleet.enableExperimental: ['enableSyncIntegrationsOnRemote']` to kibana configuration to enable the feature flag
+
+- On remote cluster:
+  - Go to Stack Management / Remote Clusters
+  - Add a remote cluster, use the proxy address of the main cluster (Find in manage deployment UI / Security / Proxy address at the bottom)  
+  - Add a follower index in Cross Cluster Replication, leader index: `fleet-synced-integrations`, follower index: `fleet-synced-integrations-ccr-main`
+  - Resume replication
+- On main cluster:
+  - Add a remote elasticsearch output to point to the remote cluster, fill out required fields (hosts, service_token) and enable sync integrations (fill kibana url and API key)
+  - Monitor the integration sync status by clicking on the status badge in the outputs table

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/outputs_table/integration_sync_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/outputs_table/integration_sync_flyout.test.tsx
@@ -17,7 +17,7 @@ import {
   SyncStatus,
   type GetRemoteSyncedIntegrationsStatusResponse,
 } from '../../../../../../../common/types';
-import { sendGetPackageInfoByKeyForRq } from '../../../../hooks';
+import { sendGetPackageInfoByKeyForRq, useStartServices } from '../../../../hooks';
 
 import { IntegrationSyncFlyout } from './integration_sync_flyout';
 
@@ -27,6 +27,7 @@ jest.mock('../../../../../../components', () => ({
 }));
 
 const mockSendGetPackageInfoByKeyForRq = sendGetPackageInfoByKeyForRq as jest.Mock;
+const mockUseStartServices = useStartServices as jest.Mock;
 
 describe('IntegrationSyncFlyout', () => {
   const mockOnClose = jest.fn();
@@ -103,6 +104,15 @@ describe('IntegrationSyncFlyout', () => {
         title: startCase(packageName),
       })
     );
+    mockUseStartServices.mockReturnValue({
+      docLinks: {
+        links: {
+          fleet: {
+            remoteESOoutput: 'https://www.elastic.co/guide/en/fleet/current/remote-output.html',
+          },
+        },
+      },
+    });
   });
 
   it('render accordion per integration', async () => {

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/outputs_table/integration_sync_flyout.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/settings/components/outputs_table/integration_sync_flyout.tsx
@@ -15,6 +15,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiLink,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -23,6 +24,8 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import type { GetRemoteSyncedIntegrationsStatusResponse } from '../../../../../../../common/types';
+
+import { useStartServices } from '../../../../hooks';
 
 import { IntegrationStatus } from './integration_status';
 
@@ -34,6 +37,7 @@ interface Props {
 
 export const IntegrationSyncFlyout: React.FunctionComponent<Props> = memo(
   ({ onClose, syncedIntegrationsStatus, outputName }) => {
+    const { docLinks } = useStartServices();
     return (
       <EuiFlyout onClose={onClose}>
         <EuiFlyoutHeader hasBorder>
@@ -49,9 +53,20 @@ export const IntegrationSyncFlyout: React.FunctionComponent<Props> = memo(
           <EuiText color="subdued" size="s" data-test-subj="integrationSyncFlyoutHeaderText">
             <FormattedMessage
               id="xpack.fleet.integrationSyncFlyout.headerText"
-              defaultMessage="You're viewing sync activity for {outputName}. Check overall progress and view individual sync statuses from custom assets."
+              defaultMessage="You're viewing sync activity for {outputName}. Check overall progress and view individual sync statuses from custom assets. {documentationLink}."
               values={{
                 outputName,
+                documentationLink: (
+                  <EuiLink
+                    href={`${docLinks.links.fleet.remoteESOoutput}#automatic-integrations-synchronization`}
+                    target="_blank"
+                  >
+                    <FormattedMessage
+                      id="xpack.fleet.integrationSyncFlyout.documentationLink"
+                      defaultMessage="Learn more"
+                    />
+                  </EuiLink>
+                ),
               }}
             />
           </EuiText>


### PR DESCRIPTION
## Summary

Relates https://github.com/elastic/kibana/issues/217154

- Updated remote integration sync readme with steps to test in cloud
- Added doc link to status flyout

<img width="1647" alt="image" src="https://github.com/user-attachments/assets/d08769da-b100-435d-8821-bed14acb398f" />
