### PR TITLE
Convert change point embeddable to expose serialized state only

### DIFF
--- a/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/components/change_point_detection/fields_config.tsx
@@ -38,7 +38,7 @@ import {
   CHANGE_POINT_DETECTION_VIEW_TYPE,
   EMBEDDABLE_CHANGE_POINT_CHART_TYPE,
 } from '@kbn/aiops-change-point-detection/constants';
-import type { ChangePointEmbeddableRuntimeState } from '../../embeddables/change_point_chart/types';
+import type { ChangePointEmbeddableState } from '../../embeddables/change_point_chart/types';
 import { MaxSeriesControl } from './max_series_control';
 import { useCasesModal } from '../../hooks/use_cases_modal';
 import { useDataSource } from '../../hooks/use_data_source';
@@ -481,7 +481,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
     ({ dashboardId, newTitle, newDescription }) => {
       const stateTransfer = embeddable!.getStateTransfer();
 
-      const embeddableInput: Partial<ChangePointEmbeddableRuntimeState> = {
+      const embeddableInput: Partial<ChangePointEmbeddableState> = {
         title: newTitle,
         description: newDescription,
         viewType: dashboardAttachment.viewType,

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/change_point_chart_initializer.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/change_point_chart_initializer.tsx
@@ -43,11 +43,11 @@ import { useAiopsAppContext } from '../../hooks/use_aiops_app_context';
 import { DataSourceContextProvider } from '../../hooks/use_data_source';
 import { FilterQueryContextProvider } from '../../hooks/use_filters_query';
 import { DEFAULT_SERIES } from './const';
-import type { ChangePointEmbeddableRuntimeState } from './types';
+import type { ChangePointEmbeddableState } from './types';
 
 export interface AnomalyChartsInitializerProps {
-  initialInput?: Partial<ChangePointEmbeddableRuntimeState>;
-  onCreate: (props: ChangePointEmbeddableRuntimeState) => void;
+  initialInput?: Partial<ChangePointEmbeddableState>;
+  onCreate: (props: ChangePointEmbeddableState) => void;
   onCancel: () => void;
 }
 
@@ -204,7 +204,7 @@ export const ChangePointChartInitializer: FC<AnomalyChartsInitializerProps> = ({
 };
 
 export type FormControlsProps = Pick<
-  ChangePointEmbeddableRuntimeState,
+  ChangePointEmbeddableState,
   'metricField' | 'splitField' | 'fn' | 'maxSeriesToPlot' | 'partitions'
 >;
 

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/embeddable_change_point_chart_factory.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/embeddable_change_point_chart_factory.tsx
@@ -11,66 +11,64 @@ import {
 } from '@kbn/aiops-change-point-detection/constants';
 import type { StartServicesAccessor } from '@kbn/core-lifecycle-browser';
 import type { DataView } from '@kbn/data-views-plugin/common';
-import type { ReactEmbeddableFactory } from '@kbn/embeddable-plugin/public';
+import type { EmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import { i18n } from '@kbn/i18n';
+import type { SerializedPanelState } from '@kbn/presentation-publishing';
 import {
   apiHasExecutionContext,
   fetch$,
-  initializeTimeRange,
+  initializeTimeRangeManager,
   initializeTitleManager,
   useBatchedPublishingSubjects,
   apiPublishesFilters,
+  titleComparators,
+  timeRangeComparators,
 } from '@kbn/presentation-publishing';
+import { initializeUnsavedChanges } from '@kbn/presentation-containers';
 
 import fastIsEqual from 'fast-deep-equal';
 import { cloneDeep } from 'lodash';
 import React, { useMemo } from 'react';
 import useObservable from 'react-use/lib/useObservable';
-import { BehaviorSubject, distinctUntilChanged, map, skipWhile } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, map, merge, skipWhile } from 'rxjs';
 import { getChangePointDetectionComponent } from '../../shared_components';
 import type { AiopsPluginStart, AiopsPluginStartDeps } from '../../types';
-import { initializeChangePointControls } from './initialize_change_point_controls';
-import type {
-  ChangePointEmbeddableApi,
-  ChangePointEmbeddableRuntimeState,
-  ChangePointEmbeddableState,
-} from './types';
+import {
+  changePointComparators,
+  initializeChangePointControls,
+} from './initialize_change_point_controls';
+import type { ChangePointEmbeddableApi, ChangePointEmbeddableState } from './types';
 import { getDataviewReferences } from '../get_dataview_references';
 
 export type EmbeddableChangePointChartType = typeof EMBEDDABLE_CHANGE_POINT_CHART_TYPE;
 
+function injectReferences(state: SerializedPanelState<ChangePointEmbeddableState>) {
+  const serializedState = cloneDeep(state.rawState);
+  // inject the reference
+  const dataViewIdRef = state.references?.find(
+    (ref) => ref.name === CHANGE_POINT_CHART_DATA_VIEW_REF_NAME
+  );
+  // if the serializedState already contains a dataViewId, we don't want to overwrite it. (Unsaved state can cause this)
+  if (dataViewIdRef && serializedState && !serializedState.dataViewId) {
+    serializedState.dataViewId = dataViewIdRef?.id;
+  }
+  return serializedState;
+}
+
 export const getChangePointChartEmbeddableFactory = (
   getStartServices: StartServicesAccessor<AiopsPluginStartDeps, AiopsPluginStart>
 ) => {
-  const factory: ReactEmbeddableFactory<
-    ChangePointEmbeddableState,
-    ChangePointEmbeddableRuntimeState,
-    ChangePointEmbeddableApi
-  > = {
+  const factory: EmbeddableFactory<ChangePointEmbeddableState, ChangePointEmbeddableApi> = {
     type: EMBEDDABLE_CHANGE_POINT_CHART_TYPE,
-    deserializeState: (state) => {
-      const serializedState = cloneDeep(state.rawState);
-      // inject the reference
-      const dataViewIdRef = state.references?.find(
-        (ref) => ref.name === CHANGE_POINT_CHART_DATA_VIEW_REF_NAME
-      );
-      // if the serializedState already contains a dataViewId, we don't want to overwrite it. (Unsaved state can cause this)
-      if (dataViewIdRef && serializedState && !serializedState.dataViewId) {
-        serializedState.dataViewId = dataViewIdRef?.id;
-      }
-      return serializedState;
-    },
-    buildEmbeddable: async (state, buildApi, uuid, parentApi) => {
+    buildEmbeddable: async ({ initialState, finalizeApi, uuid, parentApi }) => {
       const [coreStart, pluginStart] = await getStartServices();
 
-      const timeRangeManager = initializeTimeRange(state);
-      const titleManager = initializeTitleManager(state);
+      const timeRangeManager = initializeTimeRangeManager(initialState.rawState);
+      const titleManager = initializeTitleManager(initialState.rawState);
 
-      const {
-        changePointControlsApi,
-        changePointControlsComparators,
-        serializeChangePointChartState,
-      } = initializeChangePointControls(state);
+      const state = injectReferences(initialState);
+
+      const changePointManager = initializeChangePointControls(state);
 
       const dataLoading$ = new BehaviorSubject<boolean | undefined>(true);
       const blockingError$ = new BehaviorSubject<Error | undefined>(undefined);
@@ -81,57 +79,72 @@ export const getChangePointChartEmbeddableFactory = (
 
       const filtersApi = apiPublishesFilters(parentApi) ? parentApi : undefined;
 
-      const api = buildApi(
-        {
-          ...timeRangeManager.api,
-          ...titleManager.api,
-          ...changePointControlsApi,
-          getTypeDisplayName: () =>
-            i18n.translate('xpack.aiops.changePointDetection.typeDisplayName', {
-              defaultMessage: 'change point charts',
-            }),
-          isEditingEnabled: () => true,
-          onEdit: async () => {
-            try {
-              const { resolveEmbeddableChangePointUserInput } = await import(
-                './resolve_change_point_config_input'
-              );
-
-              const result = await resolveEmbeddableChangePointUserInput(
-                coreStart,
-                pluginStart,
-                parentApi,
-                uuid,
-                serializeChangePointChartState()
-              );
-
-              changePointControlsApi.updateUserInput(result);
-            } catch (e) {
-              return Promise.reject();
-            }
+      function serializeState() {
+        const dataViewId = changePointManager.api.dataViewId.getValue();
+        return {
+          rawState: {
+            timeRange: undefined,
+            ...titleManager.getLatestState(),
+            ...timeRangeManager.getLatestState(),
+            ...changePointManager.getLatestState(),
           },
-          dataLoading$,
-          blockingError$,
-          dataViews$,
-          serializeState: () => {
-            const dataViewId = changePointControlsApi.dataViewId.getValue();
-            return {
-              rawState: {
-                timeRange: undefined,
-                ...titleManager.serialize(),
-                ...timeRangeManager.serialize(),
-                ...serializeChangePointChartState(),
-              },
-              references: getDataviewReferences(dataViewId, CHANGE_POINT_CHART_DATA_VIEW_REF_NAME),
-            };
-          },
+          references: getDataviewReferences(dataViewId, CHANGE_POINT_CHART_DATA_VIEW_REF_NAME),
+        };
+      }
+
+      const unsavedChangesApi = initializeUnsavedChanges<ChangePointEmbeddableState>({
+        uuid,
+        parentApi,
+        serializeState,
+        anyStateChange$: merge(titleManager.anyStateChange$, timeRangeManager.anyStateChange$),
+        getComparators: () => {
+          return {
+            ...titleComparators,
+            ...timeRangeComparators,
+            ...changePointComparators,
+          };
         },
-        {
-          ...timeRangeManager.comparators,
-          ...titleManager.comparators,
-          ...changePointControlsComparators,
-        }
-      );
+        onReset: (lastSaved) => {
+          timeRangeManager.reinitializeState(lastSaved?.rawState);
+          titleManager.reinitializeState(lastSaved?.rawState);
+          if (lastSaved) changePointManager.reinitializeState(lastSaved.rawState);
+        },
+      });
+
+      const api = finalizeApi({
+        ...timeRangeManager.api,
+        ...titleManager.api,
+        ...changePointManager.api,
+        ...unsavedChangesApi,
+        getTypeDisplayName: () =>
+          i18n.translate('xpack.aiops.changePointDetection.typeDisplayName', {
+            defaultMessage: 'change point charts',
+          }),
+        isEditingEnabled: () => true,
+        onEdit: async () => {
+          try {
+            const { resolveEmbeddableChangePointUserInput } = await import(
+              './resolve_change_point_config_input'
+            );
+
+            const result = await resolveEmbeddableChangePointUserInput(
+              coreStart,
+              pluginStart,
+              parentApi,
+              uuid,
+              changePointManager.getLatestState()
+            );
+
+            changePointManager.api.updateUserInput(result);
+          } catch (e) {
+            return Promise.reject();
+          }
+        },
+        dataLoading$,
+        blockingError$,
+        dataViews$,
+        serializeState,
+      });
 
       const ChangePointDetectionComponent = getChangePointDetectionComponent(
         coreStart,

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/types.ts
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/types.ts
@@ -42,5 +42,3 @@ export interface ChangePointEmbeddableState extends SerializedTitles, Serialized
   partitions?: string[];
   maxSeriesToPlot?: number;
 }
-
-export type ChangePointEmbeddableRuntimeState = ChangePointEmbeddableState;

--- a/x-pack/platform/plugins/shared/aiops/public/hooks/use_cases_modal.ts
+++ b/x-pack/platform/plugins/shared/aiops/public/hooks/use_cases_modal.ts
@@ -9,7 +9,7 @@ import { useCallback, useMemo } from 'react';
 import { stringHash } from '@kbn/ml-string-hash';
 import { AttachmentType } from '@kbn/cases-plugin/common';
 import { i18n } from '@kbn/i18n';
-import type { ChangePointEmbeddableRuntimeState } from '../embeddables/change_point_chart/types';
+import type { ChangePointEmbeddableState } from '../embeddables/change_point_chart/types';
 import type { EmbeddableChangePointChartType } from '../embeddables/change_point_chart/embeddable_change_point_chart_factory';
 import { useAiopsAppContext } from './use_aiops_app_context';
 import type { EmbeddablePatternAnalysisType } from '../embeddables/pattern_analysis/embeddable_pattern_analysis_factory';
@@ -24,7 +24,7 @@ type SupportedEmbeddableTypes =
 
 type EmbeddableRuntimeState<T extends SupportedEmbeddableTypes> =
   T extends EmbeddableChangePointChartType
-    ? ChangePointEmbeddableRuntimeState
+    ? ChangePointEmbeddableState
     : T extends EmbeddablePatternAnalysisType
     ? PatternAnalysisEmbeddableRuntimeState
     : T extends EmbeddableLogRateAnalysisType

--- a/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_change_point_chart.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_change_point_chart.tsx
@@ -68,7 +68,9 @@ export function createAddChangePointChartAction(
 
         presentationContainerParent.addNewPanel({
           panelType: EMBEDDABLE_CHANGE_POINT_CHART_TYPE,
-          initialState,
+          serializedState: {
+            rawState: initialState,
+          },
         });
       } catch (e) {
         return Promise.reject();

--- a/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_change_point_chart.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/ui_actions/create_change_point_chart.tsx
@@ -16,6 +16,7 @@ import type { CoreStart } from '@kbn/core-lifecycle-browser';
 import type { AiopsPluginStartDeps } from '../types';
 
 import type { ChangePointChartActionContext } from './change_point_action_context';
+import { ChangePointEmbeddableState } from '../embeddables/change_point_chart/types';
 
 const parentApiIsCompatible = async (
   parentApi: unknown
@@ -66,7 +67,7 @@ export function createAddChangePointChartAction(
           context.embeddable.uuid
         );
 
-        presentationContainerParent.addNewPanel({
+        presentationContainerParent.addNewPanel<ChangePointEmbeddableState>({
           panelType: EMBEDDABLE_CHANGE_POINT_CHART_TYPE,
           serializedState: {
             rawState: initialState,


### PR DESCRIPTION
This PR does not need to be reviewed by external teams. This PR merges into a feature branch that Kibana presentation team is working on to convert the embeddable framework to only expose serialized state. Your team will be pinged for review once the work is complete and the final PR opens that merges the feature branch into main