### PR TITLE
[8.19] [Response Ops][Task Manager] Pass fakeRequest for tasks with associated API key instead of actual key (#217327)

### DIFF
--- a/x-pack/examples/triggers_actions_ui_example/server/plugin.ts
+++ b/x-pack/examples/triggers_actions_ui_example/server/plugin.ts
@@ -5,12 +5,10 @@
  * 2.0.
  */
 
-import { Plugin, CoreSetup, FakeRawRequest } from '@kbn/core/server';
+import { Plugin, CoreSetup } from '@kbn/core/server';
 
 import { PluginSetupContract as ActionsSetup } from '@kbn/actions-plugin/server';
 import { AlertingServerSetup } from '@kbn/alerting-plugin/server';
-import { addSpaceIdToPath } from '@kbn/spaces-plugin/common';
-import { kibanaRequestFactory } from '@kbn/core-http-server-utils';
 import {
   TaskManagerSetupContract,
   TaskManagerStartContract,
@@ -140,22 +138,8 @@ export class TriggersActionsUiExamplePlugin
     taskManager.registerTaskDefinitions({
       taskWithApiKey: {
         title: 'taskWithApiKey',
-        createTaskRunner: ({ taskInstance }) => ({
+        createTaskRunner: ({ taskInstance, fakeRequest }) => ({
           run: async () => {
-            const services = await core.getStartServices();
-            const fakeRawRequest: FakeRawRequest = {
-              headers: {
-                authorization: `ApiKey ${taskInstance?.apiKey}`,
-              },
-              path: '/',
-            };
-
-            const path = addSpaceIdToPath('/', taskInstance.userScope?.spaceId || 'default');
-
-            // Fake request from the API key
-            const fakeRequest = kibanaRequestFactory(fakeRawRequest);
-            services[0].http.basePath.set(fakeRequest, path);
-
             return {
               state: {},
             };

--- a/x-pack/examples/triggers_actions_ui_example/tsconfig.json
+++ b/x-pack/examples/triggers_actions_ui_example/tsconfig.json
@@ -34,8 +34,6 @@
     "@kbn/field-formats-plugin",
     "@kbn/licensing-plugin",
     "@kbn/response-ops-rule-form",
-    "@kbn/spaces-plugin",
-    "@kbn/core-http-server-utils",
     "@kbn/task-manager-plugin",
     "@kbn/fields-metadata-plugin",
     "@kbn/response-ops-alerts-filters-form",

--- a/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/plugin.ts
@@ -291,7 +291,7 @@ export class TaskManagerPlugin
   }
 
   public start(
-    { savedObjects, elasticsearch, executionContext, security }: CoreStart,
+    { http, savedObjects, elasticsearch, executionContext, security }: CoreStart,
     { cloud, spaces }: TaskManagerPluginsStart
   ): TaskManagerStartContract {
     const savedObjectsRepository = savedObjects.createInternalRepository([
@@ -371,6 +371,7 @@ export class TaskManagerPlugin
       });
 
       this.taskPollingLifecycle = new TaskPollingLifecycle({
+        basePathService: http.basePath,
         config: this.config!,
         definitions: this.definitions,
         logger: this.logger,

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.test.ts
@@ -23,7 +23,7 @@ import type {
 import type { Err, Ok } from './lib/result_type';
 import { asOk, isErr, isOk } from './lib/result_type';
 import { FillPoolResult } from './lib/fill_pool';
-import { executionContextServiceMock } from '@kbn/core/server/mocks';
+import { executionContextServiceMock, httpServiceMock } from '@kbn/core/server/mocks';
 import { TaskCost } from './task';
 import { CLAIM_STRATEGY_MGET, DEFAULT_KIBANAS_PER_PARTITION } from './config';
 import { TaskPartitioner } from './lib/task_partitioner';
@@ -109,6 +109,7 @@ describe('TaskPollingLifecycle', () => {
       },
       auto_calculate_default_ech_capacity: false,
     },
+    basePathService: httpServiceMock.createBasePath(),
     taskStore: mockTaskStore,
     logger: taskManagerLogger,
     definitions: new TaskTypeDictionary(taskManagerLogger),

--- a/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/polling_lifecycle.ts
@@ -12,7 +12,7 @@ import { pipe } from 'fp-ts/lib/pipeable';
 import { map as mapOptional, none } from 'fp-ts/lib/Option';
 import { tap } from 'rxjs';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
-import type { Logger, ExecutionContextStart } from '@kbn/core/server';
+import type { Logger, ExecutionContextStart, IBasePath } from '@kbn/core/server';
 
 import type { Result } from './lib/result_type';
 import { asErr, mapErr, asOk, map, mapOk, isOk } from './lib/result_type';
@@ -70,6 +70,7 @@ export interface ITaskEventEmitter<T> {
 }
 
 export interface TaskPollingLifecycleOpts {
+  basePathService: IBasePath;
   logger: Logger;
   definitions: TaskTypeDictionary;
   taskStore: TaskStore;
@@ -101,6 +102,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
   private store: TaskStore;
   private taskClaiming: TaskClaiming;
   private bufferedStore: BufferedTaskStore;
+  private readonly basePathService: IBasePath;
   private readonly executionContext: ExecutionContextStart;
 
   private logger: Logger;
@@ -128,6 +130,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
    * mechanism.
    */
   constructor({
+    basePathService,
     logger,
     middleware,
     config,
@@ -140,6 +143,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
     taskPartitioner,
     startingCapacity,
   }: TaskPollingLifecycleOpts) {
+    this.basePathService = basePathService;
     this.logger = logger;
     this.middleware = middleware;
     this.definitions = definitions;
@@ -253,6 +257,7 @@ export class TaskPollingLifecycle implements ITaskEventEmitter<TaskLifecycleEven
 
   private createTaskRunnerForTask = (instance: ConcreteTaskInstance) => {
     return new TaskManagerRunner({
+      basePathService: this.basePathService,
       logger: this.logger,
       instance,
       store: this.bufferedStore,

--- a/x-pack/platform/plugins/shared/task_manager/server/task.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task.ts
@@ -55,6 +55,12 @@ export interface RunContext {
    * The document describing the task instance, its params, state, id, etc.
    */
   taskInstance: ConcreteTaskInstance;
+
+  /**
+   * If an API key is associated with the task, a fake KibanaRequest object
+   * is generated using the API key and passed as part of the run context.
+   */
+  fakeRequest?: KibanaRequest;
 }
 
 /**

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -34,6 +34,7 @@
     "@kbn/spaces-plugin",
     "@kbn/encrypted-saved-objects-shared",
     "@kbn/core-saved-objects-api-server-mocks",
+    "@kbn/core-http-server-utils",
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Response Ops][Task Manager] Pass fakeRequest for tasks with associated API key instead of actual key (#217327)](https://github.com/elastic/kibana/pull/217327)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-04-14T14:10:17Z","message":"[Response Ops][Task Manager] Pass fakeRequest for tasks with associated API key instead of actual key (#217327)\n\nResolves https://github.com/elastic/kibana/issues/216808\n\n## Summary\n\nInstead of directly passing the `apiKey` and `userScope` (when\navailable) into each task type runner, we create a fake Kibana Request\nwith an Authorization ApiKey header in the task manager and pass that\nrequest into the task type runner.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cc95f115c3f381b83fd0408faa90708f33ca4133","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:Task Manager","backport:skip","Team:ResponseOps","v9.1.0"],"title":"[Response Ops][Task Manager] Pass fakeRequest for tasks with associated API key instead of actual key","number":217327,"url":"https://github.com/elastic/kibana/pull/217327","mergeCommit":{"message":"[Response Ops][Task Manager] Pass fakeRequest for tasks with associated API key instead of actual key (#217327)\n\nResolves https://github.com/elastic/kibana/issues/216808\n\n## Summary\n\nInstead of directly passing the `apiKey` and `userScope` (when\navailable) into each task type runner, we create a fake Kibana Request\nwith an Authorization ApiKey header in the task manager and pass that\nrequest into the task type runner.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cc95f115c3f381b83fd0408faa90708f33ca4133"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217327","number":217327,"mergeCommit":{"message":"[Response Ops][Task Manager] Pass fakeRequest for tasks with associated API key instead of actual key (#217327)\n\nResolves https://github.com/elastic/kibana/issues/216808\n\n## Summary\n\nInstead of directly passing the `apiKey` and `userScope` (when\navailable) into each task type runner, we create a fake Kibana Request\nwith an Authorization ApiKey header in the task manager and pass that\nrequest into the task type runner.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"cc95f115c3f381b83fd0408faa90708f33ca4133"}}]}] BACKPORT-->