### PR TITLE
[8.18] [EDR Workflows] Remove matches optimization from endpoint artifacts (#216437)

### DIFF
--- a/x-pack/solutions/security/packages/kbn-securitysolution-list-constants/index.ts
+++ b/x-pack/solutions/security/packages/kbn-securitysolution-list-constants/index.ts
@@ -95,7 +95,7 @@ export const ENDPOINT_ARTIFACT_LISTS = deepFreeze({
     name: 'Endpoint Security Blocklists List',
     description: 'Endpoint Security Blocklists List',
   },
-});
+} as const);
 
 /**
  * The IDs of all Endpoint artifact lists

--- a/x-pack/solutions/security/plugins/security_solution/public/exceptions/hooks/use_list_detail_view/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/exceptions/hooks/use_list_detail_view/index.ts
@@ -114,7 +114,8 @@ export const useListDetailsView = (exceptionListId: string) => {
 
   const initializeList = useCallback(async () => {
     try {
-      if (ALL_ENDPOINT_ARTIFACT_LIST_IDS.includes(exceptionListId)) return setInvalidListId(true);
+      if ((ALL_ENDPOINT_ARTIFACT_LIST_IDS as string[]).includes(exceptionListId))
+        return setInvalidListId(true);
       setIsLoading(true);
 
       const result = await getListById({

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/fixtures/artifacts_page.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/fixtures/artifacts_page.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { ENDPOINT_ARTIFACT_LIST_IDS } from '@kbn/securitysolution-list-constants';
 import { ENDPOINT_ARTIFACT_LISTS } from '@kbn/securitysolution-list-constants';
 import type { FormAction } from '../tasks/perform_user_actions';
 
@@ -36,7 +37,7 @@ export interface ArtifactsFixtureType {
   };
 
   createRequestBody: {
-    list_id: string;
+    list_id: (typeof ENDPOINT_ARTIFACT_LIST_IDS)[number];
     entries: object[];
     os_types: string[];
   };

--- a/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/artifacts.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/management/cypress/tasks/artifacts.ts
@@ -63,7 +63,7 @@ const ENDPOINT_ARTIFACT_LIST_TYPES = {
   [ENDPOINT_ARTIFACT_LISTS.blocklists.id]: ExceptionListTypeEnum.ENDPOINT_BLOCKLISTS,
 };
 
-export const createArtifactList = (listId: string) => {
+export const createArtifactList = (listId: keyof typeof ENDPOINT_ARTIFACT_LIST_TYPES) => {
   request<ExceptionListSchema>({
     method: 'POST',
     url: EXCEPTION_LIST_URL,

--- a/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/artifacts/lists.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/endpoint/lib/artifacts/lists.test.ts
@@ -18,14 +18,7 @@ import {
 } from './lists';
 import type { TranslatedEntry, TranslatedExceptionListItem } from '../../schemas/artifacts';
 import { ArtifactConstants } from './common';
-import {
-  ENDPOINT_ARTIFACT_LISTS,
-  ENDPOINT_BLOCKLISTS_LIST_ID,
-  ENDPOINT_EVENT_FILTERS_LIST_ID,
-  ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID,
-  ENDPOINT_LIST_ID,
-  ENDPOINT_TRUSTED_APPS_LIST_ID,
-} from '@kbn/securitysolution-list-constants';
+import { ENDPOINT_ARTIFACT_LISTS, ENDPOINT_LIST_ID } from '@kbn/securitysolution-list-constants';
 import { FILTER_PROCESS_DESCENDANTS_TAG } from '../../../../common/endpoint/service/artifacts/constants';
 import type { ExperimentalFeatures } from '../../../../common';
 import { allowedExperimentalValues } from '../../../../common';
@@ -737,616 +730,99 @@ describe('artifacts lists', () => {
     const getOsFilter = (os: 'macos' | 'linux' | 'windows') =>
       `exception-list-agnostic.attributes.os_types:"${os} "`;
 
-    describe('linux', () => {
-      test('it should add process.name entry when wildcard process.executable entry has filename', async () => {
-        const os = 'linux';
-        const testEntries: EntriesArray = [
-          {
-            field: 'process.executable.caseless',
-            operator: 'included',
-            type: 'wildcard',
-            value: '/usr/bi*/doc.md',
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
+    describe.each`
+      os           | value                    | exceptionOperatorType
+      ${'linux'}   | ${'/usr/bi*/doc.md'}     | ${'wildcard_cased'}
+      ${'macos'}   | ${'C:\\My Doc*\\doc.md'} | ${'wildcard_caseless'}
+      ${'windows'} | ${'/usr/bi*/doc.md'}     | ${'wildcard_caseless'}
+    `(
+      '$os',
+      ({
+        os,
+        value,
+        exceptionOperatorType,
+      }: {
+        os: 'linux' | 'macos' | 'windows';
+        value: string;
+        exceptionOperatorType: string;
+      }) => {
+        test('it should translate wildcard process.executable entry without modifications', async () => {
+          const testEntries: EntriesArray = [
             {
-              field: 'process.executable',
+              field: 'process.executable.caseless',
               operator: 'included',
-              type: 'wildcard_cased',
-              value: '/usr/bi*/doc.md',
-            },
-            {
-              field: 'process.name',
-              operator: 'included',
-              type: 'exact_cased',
-              value: 'doc.md',
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-
-      test('it should add file.name entry when wildcard file.path.text entry has filename', async () => {
-        const os = 'linux';
-        const testEntries: EntriesArray = [
-          {
-            field: 'file.path.text',
-            operator: 'included',
-            type: 'wildcard',
-            value: '/usr/bi*/doc.md',
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'file.path',
-              operator: 'included',
-              type: 'wildcard_cased',
-              value: '/usr/bi*/doc.md',
-            },
-            {
-              field: 'file.name',
-              operator: 'included',
-              type: 'exact_cased',
-              value: 'doc.md',
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-
-      test('it should not add process.name entry when wildcard process.executable entry has wildcard filename', async () => {
-        const os = 'linux';
-        const testEntries: EntriesArray = [
-          {
-            field: 'process.executable.caseless',
-            operator: 'included',
-            type: 'wildcard',
-            value: '/usr/bin/*.md',
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'process.executable',
-              operator: 'included',
-              type: 'wildcard_cased',
-              value: '/usr/bin/*.md',
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-
-      test('it should not add process.name entry when process.name entry already exists', async () => {
-        const os = 'linux';
-        const testEntries: EntriesArray = [
-          {
-            field: 'process.executable.caseless',
-            operator: 'included',
-            type: 'wildcard',
-            value: '/usr/bi*/donotadd.md',
-          },
-          {
-            field: 'process.name',
-            operator: 'included',
-            type: 'match',
-            value: 'appname.exe',
-          },
-          {
-            field: 'process.name',
-            operator: 'included',
-            type: 'match_any',
-            value: ['one.exe', 'two.exe'],
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'process.executable',
-              operator: 'included',
-              type: 'wildcard_cased',
-              value: '/usr/bi*/donotadd.md',
-            },
-            {
-              field: 'process.name',
-              operator: 'included',
-              type: 'exact_cased',
-              value: 'appname.exe',
-            },
-            {
-              field: 'process.name',
-              operator: 'included',
-              type: 'exact_cased_any',
-              value: ['one.exe', 'two.exe'],
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-
-      test('it should not add file.name entry when wildcard file.path.text entry has wildcard filename', async () => {
-        const os = 'linux';
-        const testEntries: EntriesArray = [
-          {
-            field: 'file.path.text',
-            operator: 'included',
-            type: 'wildcard',
-            value: '/usr/bin/*.md',
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'file.path',
-              operator: 'included',
-              type: 'wildcard_cased',
-              value: '/usr/bin/*.md',
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-
-      test('it should not add file.name entry when file.name entry already exists', async () => {
-        const os = 'linux';
-        const testEntries: EntriesArray = [
-          {
-            field: 'file.path.text',
-            operator: 'included',
-            type: 'wildcard',
-            value: '/usr/b*/donotadd.md',
-          },
-          {
-            field: 'file.name',
-            operator: 'included',
-            type: 'match',
-            value: 'filename.app',
-          },
-          {
-            field: 'file.name',
-            operator: 'included',
-            type: 'match_any',
-            value: ['one.app', 'two.app'],
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'file.path',
-              operator: 'included',
-              type: 'wildcard_cased',
-              value: '/usr/b*/donotadd.md',
-            },
-            {
-              field: 'file.name',
-              operator: 'included',
-              type: 'exact_cased',
-              value: 'filename.app',
-            },
-            {
-              field: 'file.name',
-              operator: 'included',
-              type: 'exact_cased_any',
-              value: ['one.app', 'two.app'],
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-    });
-
-    describe('macos/windows', () => {
-      test('it should add process.name entry for process.executable entry with wildcard type', async () => {
-        const os = Math.floor(Math.random() * 2) === 0 ? 'windows' : 'macos';
-        const value = os === 'windows' ? 'C:\\My Doc*\\doc.md' : '/usr/bi*/doc.md';
-
-        const testEntries: EntriesArray = [
-          {
-            field: 'process.executable.caseless',
-            operator: 'included',
-            type: 'wildcard',
-            value,
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'process.executable',
-              operator: 'included',
-              type: 'wildcard_caseless',
+              type: 'wildcard',
               value,
             },
-            {
-              field: 'process.name',
-              operator: 'included',
-              type: 'exact_caseless',
-              value: 'doc.md',
-            },
-          ],
-        };
+          ];
 
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
+          const expectedEndpointExceptions = {
+            type: 'simple',
+            entries: [
+              {
+                field: 'process.executable',
+                operator: 'included',
+                type: exceptionOperatorType,
+                value,
+              },
+            ],
+          };
 
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
+          const first = getFoundExceptionListItemSchemaMock();
+          first.data[0].entries = testEntries;
+          first.data[0].os_types = [os];
+          mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
+
+          const resp = await getFilteredEndpointExceptionListRaw({
+            elClient: mockExceptionClient,
+            filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
+            listId: ENDPOINT_ARTIFACT_LISTS.trustedApps.id,
+          });
+          const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
+          expect(translated).toEqual({
+            entries: [expectedEndpointExceptions],
+          });
         });
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
 
-      test('it should add file.name entry when wildcard file.path.text entry has filename', async () => {
-        const os = Math.floor(Math.random() * 2) === 0 ? 'windows' : 'macos';
-        const value = os === 'windows' ? 'C:\\My Doc*\\doc.md' : '/usr/bi*/doc.md';
-
-        const testEntries: EntriesArray = [
-          {
-            field: 'file.path.text',
-            operator: 'included',
-            type: 'wildcard',
-            value,
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
+        test('it should translate wildcard file.path.text entry without modifications', async () => {
+          const testEntries: EntriesArray = [
             {
-              field: 'file.path',
+              field: 'file.path.text',
               operator: 'included',
-              type: 'wildcard_caseless',
+              type: 'wildcard',
               value,
             },
-            {
-              field: 'file.name',
-              operator: 'included',
-              type: 'exact_caseless',
-              value: 'doc.md',
-            },
-          ],
-        };
+          ];
 
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
+          const expectedEndpointExceptions = {
+            type: 'simple',
+            entries: [
+              {
+                field: 'file.path',
+                operator: 'included',
+                type: exceptionOperatorType,
+                value,
+              },
+            ],
+          };
 
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
+          const first = getFoundExceptionListItemSchemaMock();
+          first.data[0].entries = testEntries;
+          first.data[0].os_types = [os];
+          mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
+
+          const resp = await getFilteredEndpointExceptionListRaw({
+            elClient: mockExceptionClient,
+            filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
+            listId: ENDPOINT_ARTIFACT_LISTS.trustedApps.id,
+          });
+          const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
+          expect(translated).toEqual({
+            entries: [expectedEndpointExceptions],
+          });
         });
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-
-      test('it should not add process.name entry when wildcard process.executable entry has wildcard filename', async () => {
-        const os = Math.floor(Math.random() * 2) === 0 ? 'windows' : 'macos';
-        const value = os === 'windows' ? 'C:\\My Doc*\\*.md' : '/usr/bin/*.md';
-
-        const testEntries: EntriesArray = [
-          {
-            field: 'process.executable.caseless',
-            operator: 'included',
-            type: 'wildcard',
-            value,
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'process.executable',
-              operator: 'included',
-              type: 'wildcard_caseless',
-              value,
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-
-      test('it should not add process.name entry when process.name entry already exists', async () => {
-        const os = Math.floor(Math.random() * 2) === 0 ? 'windows' : 'macos';
-        const value = os === 'windows' ? 'C:\\My Doc*\\donotadd.md' : '/usr/bin/donotadd.md';
-
-        const testEntries: EntriesArray = [
-          {
-            field: 'process.executable.caseless',
-            operator: 'included',
-            type: 'wildcard',
-            value,
-          },
-          {
-            field: 'process.name',
-            operator: 'included',
-            type: 'match',
-            value: 'appname.exe',
-          },
-          {
-            field: 'process.name',
-            operator: 'included',
-            type: 'match_any',
-            value: ['one.exe', 'two.exe'],
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'process.executable',
-              operator: 'included',
-              type: 'wildcard_caseless',
-              value,
-            },
-            {
-              field: 'process.name',
-              operator: 'included',
-              type: 'exact_caseless',
-              value: 'appname.exe',
-            },
-            {
-              field: 'process.name',
-              operator: 'included',
-              type: 'exact_caseless_any',
-              value: ['one.exe', 'two.exe'],
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-
-      test('it should not add file.name entry when wildcard file.path.text entry has wildcard filename', async () => {
-        const os = Math.floor(Math.random() * 2) === 0 ? 'windows' : 'macos';
-        const value = os === 'windows' ? 'C:\\My Doc*\\*.md' : '/usr/bin/*.md';
-        const testEntries: EntriesArray = [
-          {
-            field: 'file.path.text',
-            operator: 'included',
-            type: 'wildcard',
-            value,
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'file.path',
-              operator: 'included',
-              type: 'wildcard_caseless',
-              value,
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-
-      test('it should not add file.name entry when file.name entry already exists', async () => {
-        const os = Math.floor(Math.random() * 2) === 0 ? 'windows' : 'macos';
-        const value = os === 'windows' ? 'C:\\My Doc*\\donotadd.md' : '/usr/bin/donotadd.md';
-
-        const testEntries: EntriesArray = [
-          {
-            field: 'file.path.text',
-            operator: 'included',
-            type: 'wildcard',
-            value,
-          },
-          {
-            field: 'file.name',
-            operator: 'included',
-            type: 'match',
-            value: 'filename.app',
-          },
-          {
-            field: 'file.name',
-            operator: 'included',
-            type: 'match_any',
-            value: ['one.app', 'two.app'],
-          },
-        ];
-
-        const expectedEndpointExceptions = {
-          type: 'simple',
-          entries: [
-            {
-              field: 'file.path',
-              operator: 'included',
-              type: 'wildcard_caseless',
-              value,
-            },
-            {
-              field: 'file.name',
-              operator: 'included',
-              type: 'exact_caseless',
-              value: 'filename.app',
-            },
-            {
-              field: 'file.name',
-              operator: 'included',
-              type: 'exact_caseless_any',
-              value: ['one.app', 'two.app'],
-            },
-          ],
-        };
-
-        const first = getFoundExceptionListItemSchemaMock();
-        first.data[0].entries = testEntries;
-        first.data[0].os_types = [os];
-
-        mockExceptionClient.findExceptionListItem = jest.fn().mockReturnValueOnce(first);
-
-        const resp = await getFilteredEndpointExceptionListRaw({
-          elClient: mockExceptionClient,
-          filter: `${getOsFilter(os)} and (exception-list-agnostic.attributes.tags:"policy:all")`,
-          listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
-        });
-
-        const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
-        expect(translated).toEqual({
-          entries: [expectedEndpointExceptions],
-        });
-      });
-    });
+      }
+    );
   });
 
   const TEST_EXCEPTION_LIST_ITEM = {
@@ -1411,14 +887,14 @@ describe('artifacts lists', () => {
       const resp = await getAllItemsFromEndpointExceptionList({
         elClient: mockExceptionClient,
         os: 'macos',
-        listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
+        listId: ENDPOINT_ARTIFACT_LISTS.trustedApps.id,
       });
       const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
 
       expect(translated).toEqual(TEST_EXCEPTION_LIST_ITEM);
 
       expect(mockExceptionClient.findExceptionListItem).toHaveBeenCalledWith({
-        listId: ENDPOINT_TRUSTED_APPS_LIST_ID,
+        listId: ENDPOINT_ARTIFACT_LISTS.trustedApps.id,
         namespaceType: 'agnostic',
         filter: 'exception-list-agnostic.attributes.os_types:"macos"',
         perPage: 1000,
@@ -1436,14 +912,14 @@ describe('artifacts lists', () => {
       const resp = await getAllItemsFromEndpointExceptionList({
         elClient: mockExceptionClient,
         os: 'macos',
-        listId: ENDPOINT_EVENT_FILTERS_LIST_ID,
+        listId: ENDPOINT_ARTIFACT_LISTS.eventFilters.id,
       });
 
       const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
       expect(translated).toEqual(TEST_EXCEPTION_LIST_ITEM);
 
       expect(mockExceptionClient.findExceptionListItem).toHaveBeenCalledWith({
-        listId: ENDPOINT_EVENT_FILTERS_LIST_ID,
+        listId: ENDPOINT_ARTIFACT_LISTS.eventFilters.id,
         namespaceType: 'agnostic',
         filter: 'exception-list-agnostic.attributes.os_types:"macos"',
         perPage: 1000,
@@ -1461,14 +937,14 @@ describe('artifacts lists', () => {
       const resp = await getAllItemsFromEndpointExceptionList({
         elClient: mockExceptionClient,
         os: 'macos',
-        listId: ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID,
+        listId: ENDPOINT_ARTIFACT_LISTS.hostIsolationExceptions.id,
       });
 
       const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
       expect(translated).toEqual(TEST_EXCEPTION_LIST_ITEM);
 
       expect(mockExceptionClient.findExceptionListItem).toHaveBeenCalledWith({
-        listId: ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID,
+        listId: ENDPOINT_ARTIFACT_LISTS.hostIsolationExceptions.id,
         namespaceType: 'agnostic',
         filter: 'exception-list-agnostic.attributes.os_types:"macos"',
         perPage: 1000,
@@ -1486,14 +962,14 @@ describe('artifacts lists', () => {
       const resp = await getAllItemsFromEndpointExceptionList({
         elClient: mockExceptionClient,
         os: 'macos',
-        listId: ENDPOINT_BLOCKLISTS_LIST_ID,
+        listId: ENDPOINT_ARTIFACT_LISTS.blocklists.id,
       });
 
       const translated = convertExceptionsToEndpointFormat(resp, 'v1', defaultFeatures);
       expect(translated).toEqual(TEST_EXCEPTION_LIST_ITEM);
 
       expect(mockExceptionClient.findExceptionListItem).toHaveBeenCalledWith({
-        listId: ENDPOINT_BLOCKLISTS_LIST_ID,
+        listId: ENDPOINT_ARTIFACT_LISTS.blocklists.id,
         namespaceType: 'agnostic',
         filter: 'exception-list-agnostic.attributes.os_types:"macos"',
         perPage: 1000,

--- a/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/handlers/exceptions_pre_import_handler.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lists_integration/endpoint/handlers/exceptions_pre_import_handler.ts
@@ -14,7 +14,7 @@ export const getExceptionsPreImportHandler = (): ValidatorCallback => {
   return async ({ data }) => {
     const hasEndpointArtifactListOrListItems = [...data.lists, ...data.items].some((item) => {
       if ('list_id' in item) {
-        return ALL_ENDPOINT_ARTIFACT_LIST_IDS.includes(item.list_id);
+        return (ALL_ENDPOINT_ARTIFACT_LIST_IDS as string[]).includes(item.list_id);
       }
 
       return false;

--- a/x-pack/test/security_solution_endpoint/services/endpoint_artifacts.ts
+++ b/x-pack/test/security_solution_endpoint/services/endpoint_artifacts.ts
@@ -13,6 +13,7 @@ import type {
 import {
   ENDPOINT_ARTIFACT_LISTS,
   ENDPOINT_ARTIFACT_LIST_IDS,
+  ENDPOINT_LIST_ID,
   EXCEPTION_LIST_ITEM_URL,
   EXCEPTION_LIST_URL,
 } from '@kbn/securitysolution-list-constants';
@@ -128,7 +129,7 @@ export class EndpointArtifactsTestResources extends FtrService {
   }
 
   async createArtifact(
-    listId: (typeof ENDPOINT_ARTIFACT_LIST_IDS)[number],
+    listId: (typeof ENDPOINT_ARTIFACT_LIST_IDS)[number] | typeof ENDPOINT_LIST_ID,
     overrides: Partial<CreateExceptionListItemSchema> = {}
   ): Promise<ArtifactTestData | undefined> {
     switch (listId) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[EDR Workflows] Remove matches optimization from endpoint artifacts (#216437)](https://github.com/elastic/kibana/pull/216437)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gergő Ábrahám","email":"gergo.abraham@elastic.co"},"sourceCommit":{"committedDate":"2025-04-24T07:00:24Z","message":"[EDR Workflows] Remove matches optimization from endpoint artifacts (#216437)\n\n## Summary\n\nThis PR fixes the 'matches' bug: `process.name` won't be added to\nexceptions containing `file.path` or `process.executable` when using\n`matches` operator.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/current/contributing.html#kibana-release-notes-process)\n\n## Release note\nFixes incorrect optimization for Trusted Apps, Event Filters and\nEndpoint Exceptions: `process.name` won't be added to exceptions\ncontaining `file.path` or `process.executable` when using `matches`\noperator.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"fc18447ce0a1da3174340bb745bac03aaed096b1","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","backport:prev-major","v9.1.0","v9.0.1"],"title":"[EDR Workflows] Remove matches optimization from endpoint artifacts","number":216437,"url":"https://github.com/elastic/kibana/pull/216437","mergeCommit":{"message":"[EDR Workflows] Remove matches optimization from endpoint artifacts (#216437)\n\n## Summary\n\nThis PR fixes the 'matches' bug: `process.name` won't be added to\nexceptions containing `file.path` or `process.executable` when using\n`matches` operator.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/current/contributing.html#kibana-release-notes-process)\n\n## Release note\nFixes incorrect optimization for Trusted Apps, Event Filters and\nEndpoint Exceptions: `process.name` won't be added to exceptions\ncontaining `file.path` or `process.executable` when using `matches`\noperator.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"fc18447ce0a1da3174340bb745bac03aaed096b1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216437","number":216437,"mergeCommit":{"message":"[EDR Workflows] Remove matches optimization from endpoint artifacts (#216437)\n\n## Summary\n\nThis PR fixes the 'matches' bug: `process.name` won't be added to\nexceptions containing `file.path` or `process.executable` when using\n`matches` operator.\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/current/contributing.html#kibana-release-notes-process)\n\n## Release note\nFixes incorrect optimization for Trusted Apps, Event Filters and\nEndpoint Exceptions: `process.name` won't be added to exceptions\ncontaining `file.path` or `process.executable` when using `matches`\noperator.\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"fc18447ce0a1da3174340bb745bac03aaed096b1"}},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/219036","number":219036,"state":"MERGED","mergeCommit":{"sha":"64b084a5835fed33282ca98fd834731a9363e6ee","message":"[9.0] [EDR Workflows] Remove matches optimization from endpoint artifacts (#216437) (#219036)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[EDR Workflows] Remove matches optimization from endpoint artifacts\n(#216437)](https://github.com/elastic/kibana/pull/216437)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Gergő Ábrahám <gergo.abraham@elastic.co>"}}]}] BACKPORT-->