### PR TITLE
[AI4DSOC] Remove assistant button from alerts table

### DIFF
--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/context_pills/index.test.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/context_pills/index.test.tsx
@@ -54,6 +54,30 @@ describe('ContextPills', () => {
     });
   });
 
+  it('does not render item if description is empty', () => {
+    render(
+      <TestProviders>
+        <ContextPills
+          {...defaultProps}
+          promptContexts={{
+            ...mockPromptContexts,
+            context3: {
+              category: 'event',
+              description: '',
+              getPromptContext: () => Promise.resolve('Context 2 data'),
+              id: 'context3',
+              tooltip: 'Context 2 tooltip',
+            },
+          }}
+          selectedPromptContexts={{}}
+          setSelectedPromptContexts={jest.fn()}
+        />
+      </TestProviders>
+    );
+    expect(screen.getByTestId(`pillButton-context2`)).toBeInTheDocument();
+    expect(screen.queryByTestId(`pillButton-context3`)).not.toBeInTheDocument();
+  });
+
   it('invokes setSelectedPromptContexts() when the prompt is NOT already selected', async () => {
     const context = mockPromptContexts.context1;
     const setSelectedPromptContexts = jest.fn();

--- a/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/context_pills/index.tsx
+++ b/x-pack/platform/packages/shared/kbn-elastic-assistant/impl/assistant/context_pills/index.tsx
@@ -67,7 +67,7 @@ const ContextPillsComponent: React.FC<Props> = ({
             {description}
           </EuiButtonEmpty>
         );
-        return (
+        return description.length > 0 ? (
           <EuiFlexItem grow={false} key={id}>
             {selectedPromptContexts[id] != null ? (
               button
@@ -75,7 +75,7 @@ const ContextPillsComponent: React.FC<Props> = ({
               <EuiToolTip content={tooltip}>{button}</EuiToolTip>
             )}
           </EuiFlexItem>
-        );
+        ) : null;
       })}
     </EuiFlexGroup>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/actions_cell.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/actions_cell.test.tsx
@@ -12,7 +12,6 @@ import { ActionsCell } from './actions_cell';
 import { useExpandableFlyoutApi } from '@kbn/expandable-flyout';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { MORE_ACTIONS_BUTTON_TEST_ID } from './more_actions_row_control_column';
-import { useAssistant } from '../../../hooks/alert_summary/use_assistant';
 import { useAddToCaseActions } from '../../alerts_table/timeline_actions/use_add_to_case_actions';
 import { useAlertTagsActions } from '../../alerts_table/timeline_actions/use_alert_tags_actions';
 import { ROW_ACTION_FLYOUT_ICON_TEST_ID } from './open_flyout_row_control_column';
@@ -26,10 +25,6 @@ describe('ActionsCell', () => {
   it('should render icons', () => {
     (useExpandableFlyoutApi as jest.Mock).mockReturnValue({
       openFlyout: jest.fn(),
-    });
-    (useAssistant as jest.Mock).mockReturnValue({
-      showAssistant: true,
-      showAssistantOverlay: jest.fn(),
     });
     (useAddToCaseActions as jest.Mock).mockReturnValue({
       addToCaseActionItems: [],
@@ -51,7 +46,6 @@ describe('ActionsCell', () => {
     const { getByTestId } = render(<ActionsCell alert={alert} ecsAlert={ecsAlert} />);
 
     expect(getByTestId(ROW_ACTION_FLYOUT_ICON_TEST_ID)).toBeInTheDocument();
-    expect(getByTestId('newChatByTitle')).toBeInTheDocument();
     expect(getByTestId(MORE_ACTIONS_BUTTON_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/actions_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/actions_cell.tsx
@@ -9,7 +9,6 @@ import React, { memo } from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import type { Alert } from '@kbn/alerting-types';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
-import { AssistantRowControlColumn } from './assistant_row_control_column';
 import { MoreActionsRowControlColumn } from './more_actions_row_control_column';
 import { OpenFlyoutRowControlColumn } from './open_flyout_row_control_column';
 
@@ -38,10 +37,7 @@ export const ActionsCell = memo(({ alert, ecsAlert }: ActionsCellProps) => (
       <OpenFlyoutRowControlColumn alert={alert} />
     </EuiFlexItem>
     <EuiFlexItem>
-      <AssistantRowControlColumn alert={alert} />
-    </EuiFlexItem>
-    <EuiFlexItem>
-      <MoreActionsRowControlColumn ecsAlert={ecsAlert} />
+      <MoreActionsRowControlColumn alert={alert} ecsAlert={ecsAlert} />
     </EuiFlexItem>
   </EuiFlexGroup>
 ));

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/actions_cell.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/actions_cell.tsx
@@ -37,7 +37,7 @@ export const ActionsCell = memo(({ alert, ecsAlert }: ActionsCellProps) => (
       <OpenFlyoutRowControlColumn alert={alert} />
     </EuiFlexItem>
     <EuiFlexItem>
-      <MoreActionsRowControlColumn alert={alert} ecsAlert={ecsAlert} />
+      <MoreActionsRowControlColumn ecsAlert={ecsAlert} />
     </EuiFlexItem>
   </EuiFlexGroup>
 ));

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/assistant_row_control_column.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/assistant_row_control_column.tsx
@@ -20,6 +20,7 @@ export interface AssistantRowControlColumnProps {
 /**
  * Renders the assistant icon and opens the assistant flyout for the current alert when clicked.
  * This is used in the AI for SOC alert summary table.
+ * TODO: reimplement in the alert table once context issue is resolved https://github.com/elastic/kibana/issues/219142
  */
 export const AssistantRowControlColumn = memo(({ alert }: AssistantRowControlColumnProps) => {
   const { showAssistantOverlay } = useAssistant({ alert });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/more_actions_row_control_column.tsx
@@ -9,10 +9,8 @@ import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EuiButtonIcon, EuiContextMenu, EuiPopover } from '@elastic/eui';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import { i18n } from '@kbn/i18n';
-import type { Alert } from '@kbn/alerting-types';
-import { useAssistant } from '../../../hooks/alert_summary/use_assistant';
-import { useAddToCaseActions } from '../../alerts_table/timeline_actions/use_add_to_case_actions';
 import { useAlertTagsActions } from '../../alerts_table/timeline_actions/use_alert_tags_actions';
+import { useAddToCaseActions } from '../../alerts_table/timeline_actions/use_add_to_case_actions';
 
 export const MORE_ACTIONS_BUTTON_TEST_ID = 'alert-summary-table-row-action-more-actions';
 
@@ -29,23 +27,12 @@ export const ADD_TO_CASE_ARIA_LABEL = i18n.translate(
   }
 );
 
-export const ASK_ASSISTANT = i18n.translate(
-  'xpack.securitySolution.alertSummary.table.askAssistant',
-  {
-    defaultMessage: 'Ask AI assistant',
-  }
-);
-
 export interface MoreActionsRowControlColumnProps {
   /**
    * Alert data
    * The Ecs type is @deprecated but needed for the case actions within the more action dropdown
    */
   ecsAlert: Ecs;
-  /**
-   * Alert data passed from the renderCellValue callback via the AlertWithLegacyFormats interface
-   */
-  alert: Alert;
 }
 
 /**
@@ -57,7 +44,7 @@ export interface MoreActionsRowControlColumnProps {
  * - apply alert tags
  */
 export const MoreActionsRowControlColumn = memo(
-  ({ alert, ecsAlert }: MoreActionsRowControlColumnProps) => {
+  ({ ecsAlert }: MoreActionsRowControlColumnProps) => {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
     const togglePopover = useCallback(() => setIsPopoverOpen((value) => !value), []);
@@ -82,18 +69,6 @@ export const MoreActionsRowControlColumn = memo(
       ariaLabel: ADD_TO_CASE_ARIA_LABEL,
       isInDetections: true,
     });
-    const { showAssistantOverlay } = useAssistant({ alert });
-    const assistantChatItem = useMemo(
-      () => ({
-        'aria-label': ASK_ASSISTANT,
-        'data-test-subj': 'open-assistant-chat',
-        key: 'open-assistant-chat',
-        onClick: showAssistantOverlay,
-        size: 's',
-        name: ASK_ASSISTANT,
-      }),
-      [showAssistantOverlay]
-    );
 
     const { alertTagsItems, alertTagsPanels } = useAlertTagsActions({
       closePopover,
@@ -104,11 +79,11 @@ export const MoreActionsRowControlColumn = memo(
       () => [
         {
           id: 0,
-          items: [assistantChatItem, ...addToCaseActionItems, ...alertTagsItems],
+          items: [...addToCaseActionItems, ...alertTagsItems],
         },
         ...alertTagsPanels,
       ],
-      [addToCaseActionItems, alertTagsItems, alertTagsPanels, assistantChatItem]
+      [addToCaseActionItems, alertTagsItems, alertTagsPanels]
     );
 
     return (

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/table.tsx
@@ -75,7 +75,7 @@ export const columns: EuiDataGridProps['columns'] = [
   },
 ];
 
-export const ACTION_COLUMN_WIDTH = 98; // px
+export const ACTION_COLUMN_WIDTH = 72; // px
 export const ALERT_TABLE_CONSUMERS: AlertsTableProps['consumers'] = [AlertConsumers.SIEM];
 export const RULE_TYPE_IDS = [ESQL_RULE_TYPE_ID, QUERY_RULE_TYPE_ID];
 export const ROW_HEIGHTS_OPTIONS = { defaultHeight: 40 };


### PR DESCRIPTION
## Summary

There is an issue in how we handle prompt context that causes as many alert contexts to appear as there are alerts in the DOM when we include the button in the table:

![Image](https://github.com/user-attachments/assets/0b689e92-b2f8-4e7a-84fb-8d3198aa8313)

We've removed the button from the table for now and opened an issue to come up with a better solution long term: https://github.com/elastic/kibana/issues/219142

I also noticed that when the assistant is opened from a different launch point than the suggested prompt, and the suggested prompt is still in the DOM, its prompt context shows up empty:
<img width="600" alt="Screenshot 2025-04-24 at 11 41 23 AM" src="https://github.com/user-attachments/assets/0ceb3ffc-72e5-425c-b550-9b8d5896f359" />

I resolved this by adding a check in the ContextPills component for `description.length > 0`. This would be resolved by the on click issue, so might be worth coming back to.
