### PR TITLE
[8.19] chore/slo: add cursor based pagination fields to slo schema, show slo definition api (#213835)

### DIFF
--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -45764,6 +45764,16 @@ paths:
           name: kqlQuery
           schema:
             type: string
+        - description: Size provided for cursor based pagination
+          example: 25
+          in: query
+          name: size
+          schema:
+            type: integer
+        - in: query
+          name: searchAfter
+          schema:
+            type: string
         - description: The page to use for pagination, must be greater or equal than 1
           example: 1
           in: query
@@ -46248,6 +46258,70 @@ paths:
       summary: Get the SLO definitions
       tags:
         - slo
+      x-beta: true
+  /s/{spaceId}/internal/observability/slos/_definitions:
+    get:
+      description: |
+        You must have the `read` privileges for the **SLOs** feature in the **Observability** section of the Kibana feature privileges.
+      operationId: getDefinitionsOp
+      parameters:
+        - $ref: '#/components/parameters/SLOs_kbn_xsrf'
+        - $ref: '#/components/parameters/SLOs_space_id'
+        - description: Indicates if the API returns only outdated SLO or all SLO definitions
+          example: true
+          in: query
+          name: includeOutdatedOnly
+          schema:
+            type: boolean
+        - description: Filters the SLOs by name
+          example: my service availability
+          in: query
+          name: search
+          schema:
+            type: string
+        - description: The page to use for pagination, must be greater or equal than 1
+          example: 1
+          in: query
+          name: page
+          schema:
+            type: number
+        - description: Number of SLOs returned by page
+          example: 100
+          in: query
+          name: perPage
+          schema:
+            default: 100
+            maximum: 1000
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_find_slo_definitions_response'
+          description: Successful request
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_400_response'
+          description: Bad request
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_401_response'
+          description: Unauthorized response
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_403_response'
+          description: Unauthorized response
+      summary: Get the SLO definitions
+      tags:
+        - slo
+      x-beta: true
 components:
   examples:
     Data_views_create_data_view_request:
@@ -62113,6 +62187,25 @@ components:
           type: string
       title: FilterMeta
       type: object
+    SLOs_find_slo_definitions_response:
+      description: |
+        A paginated response of SLO definitions matching the query.
+      properties:
+        page:
+          example: 2
+          type: number
+        perPage:
+          example: 100
+          type: number
+        results:
+          items:
+            $ref: '#/components/schemas/SLOs_slo_definition_response'
+          type: array
+        total:
+          example: 123
+          type: number
+      title: Find SLO definitions response
+      type: object
     SLOs_find_slo_response:
       description: |
         A paginated response of SLOs matching the query.
@@ -62127,6 +62220,12 @@ components:
           items:
             $ref: '#/components/schemas/SLOs_slo_with_summary_response'
           type: array
+        searchAfter:
+          type: string
+        size:
+          description: Size provided for cursor based pagination
+          example: 25
+          type: number
         total:
           example: 34
           type: number

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -24765,6 +24765,16 @@ paths:
           name: kqlQuery
           schema:
             type: string
+        - description: Size provided for cursor based pagination
+          example: 25
+          in: query
+          name: size
+          schema:
+            type: integer
+        - in: query
+          name: searchAfter
+          schema:
+            type: string
         - description: The page to use for pagination, must be greater or equal than 1
           example: 1
           in: query
@@ -25180,6 +25190,68 @@ paths:
                 $ref: '#/components/schemas/SLOs_404_response'
           description: Not found response
       summary: Enable an SLO
+      tags:
+        - slo
+  /s/{spaceId}/internal/observability/slos/_definitions:
+    get:
+      description: |
+        You must have the `read` privileges for the **SLOs** feature in the **Observability** section of the Kibana feature privileges.
+      operationId: getDefinitionsOp
+      parameters:
+        - $ref: '#/components/parameters/SLOs_kbn_xsrf'
+        - $ref: '#/components/parameters/SLOs_space_id'
+        - description: Indicates if the API returns only outdated SLO or all SLO definitions
+          example: true
+          in: query
+          name: includeOutdatedOnly
+          schema:
+            type: boolean
+        - description: Filters the SLOs by name
+          example: my service availability
+          in: query
+          name: search
+          schema:
+            type: string
+        - description: The page to use for pagination, must be greater or equal than 1
+          example: 1
+          in: query
+          name: page
+          schema:
+            type: number
+        - description: Number of SLOs returned by page
+          example: 100
+          in: query
+          name: perPage
+          schema:
+            default: 100
+            maximum: 1000
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_find_slo_definitions_response'
+          description: Successful request
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_400_response'
+          description: Bad request
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_401_response'
+          description: Unauthorized response
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SLOs_403_response'
+          description: Unauthorized response
+      summary: Get the SLO definitions
       tags:
         - slo
 components:
@@ -46132,6 +46204,25 @@ components:
           type: string
       title: FilterMeta
       type: object
+    SLOs_find_slo_definitions_response:
+      description: |
+        A paginated response of SLO definitions matching the query.
+      properties:
+        page:
+          example: 2
+          type: number
+        perPage:
+          example: 100
+          type: number
+        results:
+          items:
+            $ref: '#/components/schemas/SLOs_slo_definition_response'
+          type: array
+        total:
+          example: 123
+          type: number
+      title: Find SLO definitions response
+      type: object
     SLOs_find_slo_response:
       description: |
         A paginated response of SLOs matching the query.
@@ -46146,6 +46237,12 @@ components:
           items:
             $ref: '#/components/schemas/SLOs_slo_with_summary_response'
           type: array
+        searchAfter:
+          type: string
+        size:
+          description: Size provided for cursor based pagination
+          example: 25
+          type: number
         total:
           example: 34
           type: number

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -24765,16 +24765,20 @@ paths:
           name: kqlQuery
           schema:
             type: string
-        - description: Size provided for cursor based pagination
-          example: 25
+        - description: The page size to use for cursor-based pagination, must be greater or equal than 1
+          example: 1
           in: query
           name: size
           schema:
+            default: 1
             type: integer
-        - in: query
+        - description: The cursor to use for fetching the results from, when using a cursor-base pagination.
+          in: query
           name: searchAfter
           schema:
-            type: string
+            items:
+              type: string
+            type: array
         - description: The page to use for pagination, must be greater or equal than 1
           example: 1
           in: query
@@ -25206,6 +25210,11 @@ paths:
           name: includeOutdatedOnly
           schema:
             type: boolean
+        - description: Filters the SLOs by tag
+          in: query
+          name: tags
+          schema:
+            type: string
         - description: Filters the SLOs by name
           example: my service availability
           in: query
@@ -46207,20 +46216,50 @@ components:
     SLOs_find_slo_definitions_response:
       description: |
         A paginated response of SLO definitions matching the query.
-      properties:
-        page:
-          example: 2
-          type: number
-        perPage:
-          example: 100
-          type: number
-        results:
-          items:
-            $ref: '#/components/schemas/SLOs_slo_definition_response'
-          type: array
-        total:
-          example: 123
-          type: number
+      oneOf:
+        - type: object
+          properties:
+            page:
+              example: 1
+              type: number
+            perPage:
+              example: 25
+              type: number
+            results:
+              items:
+                $ref: '#/components/schemas/SLOs_slo_with_summary_response'
+              type: array
+            total:
+              example: 34
+              type: number
+        - type: object
+          properties:
+            page:
+              default: 1
+              description: for backward compability
+              type: number
+            perPage:
+              description: for backward compability
+              example: 25
+              type: number
+            results:
+              items:
+                $ref: '#/components/schemas/SLOs_slo_with_summary_response'
+              type: array
+            searchAfter:
+              description: the cursor to provide to get the next paged results
+              example:
+                - some-slo-id
+                - other-cursor-id
+              items:
+                type: string
+              type: array
+            size:
+              example: 25
+              type: number
+            total:
+              example: 34
+              type: number
       title: Find SLO definitions response
       type: object
     SLOs_find_slo_response:

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.json
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "SLOs",
     "description": "OpenAPI schema for SLOs endpoints",
-    "version": "1.0",
+    "version": "1.1",
     "contact": {
       "name": "Actionable Observability Team"
     },
@@ -130,6 +130,27 @@
               "type": "string"
             },
             "example": "slo.name:latency* and slo.tags : \"prod\""
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "The page size to use for cursor-based pagination, must be greater or equal than 1",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            },
+            "example": 1
+          },
+          {
+            "name": "searchAfter",
+            "in": "query",
+            "description": "The cursor to use for fetching the results from, when using a cursor-base pagination.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           },
           {
             "name": "page",
@@ -704,11 +725,10 @@
           {
             "name": "tags",
             "in": "query",
-            "description": "Specify which SLO tags to query by (comma-separated values)",
+            "description": "Filters the SLOs by tag",
             "schema": {
               "type": "string"
-            },
-            "example": true
+            }
           },
           {
             "name": "search",
@@ -2002,6 +2022,14 @@
         "description": "A paginated response of SLOs matching the query.\n",
         "type": "object",
         "properties": {
+          "size": {
+            "type": "number",
+            "example": 25,
+            "description": "Size provided for cursor based pagination"
+          },
+          "searchAfter": {
+            "type": "string"
+          },
           "page": {
             "type": "number",
             "example": 1
@@ -2398,6 +2426,76 @@
             "example": 2
           }
         }
+      },
+      "find_slo_definitions_response": {
+        "title": "Find SLO definitions response",
+        "description": "A paginated response of SLO definitions matching the query.\n",
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number",
+                "example": 1
+              },
+              "perPage": {
+                "type": "number",
+                "example": 25
+              },
+              "total": {
+                "type": "number",
+                "example": 34
+              },
+              "results": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/slo_with_summary_response"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "number",
+                "default": 1,
+                "description": "for backward compability"
+              },
+              "perPage": {
+                "type": "number",
+                "example": 25,
+                "description": "for backward compability"
+              },
+              "size": {
+                "type": "number",
+                "example": 25
+              },
+              "searchAfter": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "example": [
+                  "some-slo-id",
+                  "other-cursor-id"
+                ],
+                "description": "the cursor to provide to get the next paged results"
+              },
+              "total": {
+                "type": "number",
+                "example": 34
+              },
+              "results": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/slo_with_summary_response"
+                }
+              }
+            }
+          }
+        ]
       },
       "delete_slo_instances_request": {
         "title": "Delete SLO instances request",

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/bundled.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: SLOs
   description: OpenAPI schema for SLOs endpoints
-  version: '1.0'
+  version: '1.1'
   contact:
     name: Actionable Observability Team
   license:
@@ -81,6 +81,20 @@ paths:
           schema:
             type: string
           example: 'slo.name:latency* and slo.tags : "prod"'
+        - name: size
+          in: query
+          description: The page size to use for cursor-based pagination, must be greater or equal than 1
+          schema:
+            type: integer
+            default: 1
+          example: 1
+        - name: searchAfter
+          in: query
+          description: The cursor to use for fetching the results from, when using a cursor-base pagination.
+          schema:
+            type: array
+            items:
+              type: string
         - name: page
           in: query
           description: The page to use for pagination, must be greater or equal than 1
@@ -410,6 +424,73 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
+  /s/{spaceId}/internal/observability/slos/_definitions:
+    get:
+      summary: Get the SLO definitions
+      operationId: getDefinitionsOp
+      description: |
+        You must have the `read` privileges for the **SLOs** feature in the **Observability** section of the Kibana feature privileges.
+      tags:
+        - slo
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+        - $ref: '#/components/parameters/space_id'
+        - name: includeOutdatedOnly
+          in: query
+          description: Indicates if the API returns only outdated SLO or all SLO definitions
+          schema:
+            type: boolean
+          example: true
+        - name: tags
+          in: query
+          description: Filters the SLOs by tag
+          schema:
+            type: string
+        - name: search
+          in: query
+          description: Filters the SLOs by name
+          schema:
+            type: string
+          example: my service availability
+        - name: page
+          in: query
+          description: The page to use for pagination, must be greater or equal than 1
+          schema:
+            type: number
+          example: 1
+        - name: perPage
+          in: query
+          description: Number of SLOs returned by page
+          schema:
+            type: integer
+            default: 100
+            maximum: 1000
+          example: 100
+      responses:
+        '200':
+          description: Successful request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/find_slo_definitions_response'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400_response'
+        '401':
+          description: Unauthorized response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401_response'
+        '403':
+          description: Unauthorized response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/403_response'
   /s/{spaceId}/api/observability/slos/_delete_instances:
     post:
       summary: Batch delete rollup and summary data
@@ -1317,6 +1398,12 @@ components:
         A paginated response of SLOs matching the query.
       type: object
       properties:
+        size:
+          type: number
+          example: 25
+          description: Size provided for cursor based pagination
+        searchAfter:
+          type: string
         page:
           type: number
           example: 1
@@ -1346,7 +1433,7 @@ components:
           example: Bad Request
         message:
           type: string
-          example: "Invalid value 'foo' supplied to: [...]"
+          example: 'Invalid value ''foo'' supplied to: [...]'
     401_response:
       title: Unauthorized
       type: object
@@ -1589,6 +1676,55 @@ components:
           description: The internal SLO version
           type: number
           example: 2
+    find_slo_definitions_response:
+      title: Find SLO definitions response
+      description: |
+        A paginated response of SLO definitions matching the query.
+      type: object
+      oneOf:
+        - type: object
+          properties:
+            page:
+              type: number
+              example: 1
+            perPage:
+              type: number
+              example: 25
+            total:
+              type: number
+              example: 34
+            results:
+              type: array
+              items:
+                $ref: '#/components/schemas/slo_with_summary_response'
+        - type: object
+          properties:
+            page:
+              type: number
+              default: 1
+              description: for backward compability
+            perPage:
+              type: number
+              example: 25
+              description: for backward compability
+            size:
+              type: number
+              example: 25
+            searchAfter:
+              type: array
+              items:
+                type: string
+              example:
+                - some-slo-id
+                - other-cursor-id
+              description: the cursor to provide to get the next paged results
+            total:
+              type: number
+              example: 34
+            results:
+              type: array
+              items:
+                $ref: '#/components/schemas/slo_with_summary_response'
     delete_slo_instances_request:
       title: Delete SLO instances request
       description: |

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/find_slo_definitions_response.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/find_slo_definitions_response.yaml
@@ -2,17 +2,45 @@ title: Find SLO definitions response
 description: >
   A paginated response of SLO definitions matching the query.
 type: object
-properties:
-  page:
-    type: number
-    example: 2
-  perPage:
-    type: number
-    example: 100
-  total:
-    type: number
-    example: 123
-  results:
-    type: array
-    items:
-      $ref: 'slo_definition_response.yaml'
+oneOf:
+  - type: object
+    properties:
+      page:
+        type: number
+        example: 1
+      perPage:
+        type: number
+        example: 25
+      total:
+        type: number
+        example: 34
+      results:
+        type: array
+        items:
+          $ref: 'slo_with_summary_response.yaml'
+  - type: object
+    properties:
+      page:
+        type: number
+        default: 1
+        description: for backward compability
+      perPage:
+        type: number
+        example: 25
+        description: for backward compability
+      size:
+        type: number
+        example: 25
+      searchAfter:
+        type: array
+        items:
+          type: string
+        example: ['some-slo-id', 'other-cursor-id']
+        description: the cursor to provide to get the next paged results
+      total:
+        type: number
+        example: 34
+      results:
+        type: array
+        items:
+          $ref: 'slo_with_summary_response.yaml'

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/find_slo_response.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/components/schemas/find_slo_response.yaml
@@ -3,6 +3,12 @@ description: >
   A paginated response of SLOs matching the query.
 type: object
 properties:
+  size:
+    type: number
+    example: 25
+    description: Size provided for cursor based pagination
+  searchAfter:
+    type: string
   page:
     type: number
     example: 1

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/entrypoint.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/entrypoint.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: SLOs
   description: OpenAPI schema for SLOs endpoints
-  version: "1.0"
+  version: '1.1'
   contact:
     name: Actionable Observability Team
   license:
@@ -17,19 +17,19 @@ servers:
       kibana_url:
         default: localhost:5601
 paths:
-  "/s/{spaceId}/api/observability/slos":
-    $ref: "paths/s@{spaceid}@api@slos.yaml"
-  "/s/{spaceId}/api/observability/slos/{sloId}":
-    $ref: "paths/s@{spaceid}@api@slos@{sloid}.yaml"
-  "/s/{spaceId}/api/observability/slos/{sloId}/enable":
-    $ref: "paths/s@{spaceid}@api@slos@{sloid}@enable.yaml"
-  "/s/{spaceId}/api/observability/slos/{sloId}/disable":
-    $ref: "paths/s@{spaceid}@api@slos@{sloid}@disable.yaml"
-  "/s/{spaceId}/api/observability/slos/{sloId}/_reset":
-    $ref: "paths/s@{spaceid}@api@slos@{sloid}@_reset.yaml"
+  '/s/{spaceId}/api/observability/slos':
+    $ref: 'paths/s@{spaceid}@api@slos.yaml'
+  '/s/{spaceId}/api/observability/slos/{sloId}':
+    $ref: 'paths/s@{spaceid}@api@slos@{sloid}.yaml'
+  '/s/{spaceId}/api/observability/slos/{sloId}/enable':
+    $ref: 'paths/s@{spaceid}@api@slos@{sloid}@enable.yaml'
+  '/s/{spaceId}/api/observability/slos/{sloId}/disable':
+    $ref: 'paths/s@{spaceid}@api@slos@{sloid}@disable.yaml'
+  '/s/{spaceId}/api/observability/slos/{sloId}/_reset':
+    $ref: 'paths/s@{spaceid}@api@slos@{sloid}@_reset.yaml'
   # "/s/{spaceId}/internal/observability/slos/_historical_summary":
   #   $ref: "paths/s@{spaceid}@api@slos@_historical_summary.yaml"
-  # "/s/{spaceId}/internal/observability/slos/_definitions":
-  #   $ref: "paths/s@{spaceid}@api@slos@_definitions.yaml"
-  "/s/{spaceId}/api/observability/slos/_delete_instances":
-    $ref: "paths/s@{spaceid}@api@slos@_delete_instances.yaml"
+  '/s/{spaceId}/internal/observability/slos/_definitions':
+    $ref: 'paths/s@{spaceid}@api@slos@_definitions.yaml'
+  '/s/{spaceId}/api/observability/slos/_delete_instances':
+    $ref: 'paths/s@{spaceid}@api@slos@_delete_instances.yaml'

--- a/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
+++ b/x-pack/solutions/observability/plugins/slo/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
@@ -63,6 +63,20 @@ get:
       schema:
         type: string
       example: 'slo.name:latency* and slo.tags : "prod"'
+    - name: size
+      in: query
+      description: The page size to use for cursor-based pagination, must be greater or equal than 1
+      schema:
+        type: integer
+        default: 1
+      example: 1
+    - name: searchAfter
+      in: query
+      description: The cursor to use for fetching the results from, when using a cursor-base pagination.
+      schema:
+        type: array
+        items:
+          type: string
     - name: page
       in: query
       description: The page to use for pagination, must be greater or equal than 1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore/slo: add cursor based pagination fields to slo schema, show slo definition api (#213835)](https://github.com/elastic/kibana/pull/213835)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2025-03-12T15:18:23Z","message":"chore/slo: add cursor based pagination fields to slo schema, show slo definition api (#213835)\n\n## Summary\n\nResolves #213238 \n\n- Adds SLO definition API doc\n- Adds fields for cursor based pagination to Find SLO docs\n\n\n[bundled.json](https://github.com/user-attachments/files/19186322/bundled.json)\n\n---------\n\nCo-authored-by: Kevin Delemme <kdelemme@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"256817b281f318697fef2ca5cf8d7893e6d2b4d2","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","Team:obs-ux-management","v9.1.0"],"title":"chore/slo: add cursor based pagination fields to slo schema, show slo definition api","number":213835,"url":"https://github.com/elastic/kibana/pull/213835","mergeCommit":{"message":"chore/slo: add cursor based pagination fields to slo schema, show slo definition api (#213835)\n\n## Summary\n\nResolves #213238 \n\n- Adds SLO definition API doc\n- Adds fields for cursor based pagination to Find SLO docs\n\n\n[bundled.json](https://github.com/user-attachments/files/19186322/bundled.json)\n\n---------\n\nCo-authored-by: Kevin Delemme <kdelemme@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"256817b281f318697fef2ca5cf8d7893e6d2b4d2"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214202","number":214202,"state":"MERGED","mergeCommit":{"sha":"0ea2d52163cbdc0125c5b63e646e9d1ff87c4c06","message":"[9.0] chore/slo: add cursor based pagination fields to slo schema, show slo definition api (#213835) (#214202)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [chore/slo: add cursor based pagination fields to slo schema, show slo\ndefinition api (#213835)](https://github.com/elastic/kibana/pull/213835)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Bailey Cash <bailey.cash@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213835","number":213835,"mergeCommit":{"message":"chore/slo: add cursor based pagination fields to slo schema, show slo definition api (#213835)\n\n## Summary\n\nResolves #213238 \n\n- Adds SLO definition API doc\n- Adds fields for cursor based pagination to Find SLO docs\n\n\n[bundled.json](https://github.com/user-attachments/files/19186322/bundled.json)\n\n---------\n\nCo-authored-by: Kevin Delemme <kdelemme@gmail.com>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"256817b281f318697fef2ca5cf8d7893e6d2b4d2"}}]}] BACKPORT-->