### PR TITLE
Add workchat-eng group as codeowners for chat plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -947,12 +947,12 @@ x-pack/solutions/chat/packages/wc-integration-utils @elastic/search-kibana
 x-pack/solutions/chat/packages/wci-browser @elastic/search-kibana
 x-pack/solutions/chat/packages/wci-common @elastic/search-kibana
 x-pack/solutions/chat/packages/wci-server @elastic/search-kibana
-x-pack/solutions/chat/plugins/serverless_chat @elastic/search-kibana
-x-pack/solutions/chat/plugins/wci-external-server @elastic/search-kibana
-x-pack/solutions/chat/plugins/wci-index-source @elastic/search-kibana
-x-pack/solutions/chat/plugins/wci-salesforce @elastic/search-kibana
-x-pack/solutions/chat/plugins/workchat-app @elastic/search-kibana
-x-pack/solutions/chat/plugins/workchat-framework @elastic/search-kibana
+x-pack/solutions/chat/plugins/serverless_chat @elastic/search-kibana @elastic/workchat-eng
+x-pack/solutions/chat/plugins/wci-external-server @elastic/search-kibana @elastic/workchat-eng
+x-pack/solutions/chat/plugins/wci-index-source @elastic/search-kibana @elastic/workchat-eng
+x-pack/solutions/chat/plugins/wci-salesforce @elastic/search-kibana @elastic/workchat-eng
+x-pack/solutions/chat/plugins/workchat-app @elastic/search-kibana @elastic/workchat-eng
+x-pack/solutions/chat/plugins/workchat-framework @elastic/search-kibana @elastic/workchat-eng
 x-pack/solutions/observability/packages/alert-details @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/alerting-test-data @elastic/obs-ux-management-team
 x-pack/solutions/observability/packages/get-padded-alert-time-range-util @elastic/obs-ux-management-team

--- a/x-pack/solutions/chat/plugins/serverless_chat/kibana.jsonc
+++ b/x-pack/solutions/chat/plugins/serverless_chat/kibana.jsonc
@@ -1,7 +1,10 @@
 {
   "type": "plugin",
   "id": "@kbn/serverless-chat",
-  "owner": "@elastic/search-kibana",
+  "owner": [
+    "@elastic/search-kibana",
+    "@elastic/workchat-eng"
+   ],
   "group": "chat",
   "visibility": "private",
   "description": "Serverless customizations for chat.",

--- a/x-pack/solutions/chat/plugins/wci-external-server/kibana.jsonc
+++ b/x-pack/solutions/chat/plugins/wci-external-server/kibana.jsonc
@@ -1,7 +1,10 @@
 {
   "type": "plugin",
   "id": "@kbn/wci-external-server",
-  "owner": "@elastic/search-kibana",
+  "owner": [
+    "@elastic/search-kibana",
+    "@elastic/workchat-eng"
+   ],
   "group": "chat",
   "visibility": "private",
   "description": "WorkChat External Server Integration plugin",

--- a/x-pack/solutions/chat/plugins/wci-index-source/kibana.jsonc
+++ b/x-pack/solutions/chat/plugins/wci-index-source/kibana.jsonc
@@ -1,7 +1,10 @@
 {
   "type": "plugin",
   "id": "@kbn/wci-index-source",
-  "owner": "@elastic/search-kibana",
+  "owner": [
+    "@elastic/search-kibana",
+    "@elastic/workchat-eng"
+   ],
   "group": "chat",
   "visibility": "private",
   "description": "WorkChat Index Source Integration plugin",

--- a/x-pack/solutions/chat/plugins/wci-salesforce/kibana.jsonc
+++ b/x-pack/solutions/chat/plugins/wci-salesforce/kibana.jsonc
@@ -1,7 +1,10 @@
 {
   "type": "plugin",
   "id": "@kbn/wci-salesforce",
-  "owner": "@elastic/search-kibana",
+  "owner": [
+    "@elastic/search-kibana",
+    "@elastic/workchat-eng"
+   ],
   "group": "chat",
   "visibility": "private",
   "description": "WorkChat Salesforce Integration plugin",

--- a/x-pack/solutions/chat/plugins/workchat-app/kibana.jsonc
+++ b/x-pack/solutions/chat/plugins/workchat-app/kibana.jsonc
@@ -1,7 +1,10 @@
 {
   "type": "plugin",
   "id": "@kbn/workchat-app",
-  "owner": "@elastic/search-kibana",
+  "owner": [
+    "@elastic/search-kibana",
+    "@elastic/workchat-eng"
+   ],
   "group": "chat",
   "visibility": "private",
   "description": "WorkChat application",

--- a/x-pack/solutions/chat/plugins/workchat-framework/kibana.jsonc
+++ b/x-pack/solutions/chat/plugins/workchat-framework/kibana.jsonc
@@ -1,7 +1,10 @@
 {
   "type": "plugin",
   "id": "@kbn/workchat-framework-plugin",
-  "owner": "@elastic/search-kibana",
+  "owner": [
+    "@elastic/search-kibana",
+    "@elastic/workchat-eng"
+   ],
   "group": "chat",
   "visibility": "private",
   "description": "WorkChat framework",


### PR DESCRIPTION
## Summary

I'd tried to do this in https://github.com/elastic/kibana/pull/218662, but was thwarted by 1a921667492c7715632440e0d8d650795fb0f57a (which I'd missed). 

Looking at slack, this is the right way to set codeowners for plugins. 



