### PR TITLE
Exclude dev-only `kbn-inference-cli` package from CodeQL scans

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -97,6 +97,7 @@ paths-ignore:
   - typings
   - x-pack/examples
   - x-pack/packages/ai-infra/product-doc-artifact-builder
+  - x-pack/platform/packages/shared/kbn-inference-cli
   - x-pack/performance
   - x-pack/scripts
   - x-pack/test


### PR DESCRIPTION
## Summary

The `kbn-inference-cli` package is marked as dev-only in its manifest and should be excluded from CodeQL scans.




<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->