### PR TITLE
[8.18] [APM] Filter out upstream orphans in waterfall (#214704)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
@@ -808,12 +808,14 @@ describe('waterfall_helpers', () => {
 
   describe('reparentOrphanItems', () => {
     const myTransactionItem = {
+      duration: 150,
       doc: {
         processor: { event: 'transaction' },
         trace: { id: 'myTrace' },
         transaction: {
           id: 'myTransactionId1',
         },
+        timestamp: { us: 1000000000000050 },
       } as WaterfallTransaction,
       docType: 'transaction',
       id: 'myTransactionId1',
@@ -823,6 +825,7 @@ describe('waterfall_helpers', () => {
       const traceItems: IWaterfallSpanOrTransaction[] = [
         myTransactionItem,
         {
+          duration: 150,
           doc: {
             processor: { event: 'span' },
             span: {
@@ -831,23 +834,30 @@ describe('waterfall_helpers', () => {
             parent: {
               id: 'myTransactionId1',
             },
+            timestamp: {
+              us: 1000000000000050,
+            },
           } as WaterfallSpan,
           docType: 'span',
           id: 'mySpanId',
           parentId: 'myTransactionId1',
         } as IWaterfallSpan,
       ];
-      expect(reparentOrphanItems([], traceItems, 'myTransactionId1')).toEqual(traceItems);
+      expect(reparentOrphanItems([], traceItems, myTransactionItem)).toEqual(traceItems);
     });
 
-    it('should reparent orphan items to root transaction', () => {
+    it('should not reparent if orphan starts before or the duration is longer than entry transaction', () => {
       const traceItems: IWaterfallSpanOrTransaction[] = [
         myTransactionItem,
         {
+          duration: 200,
           doc: {
             processor: { event: 'span' },
             span: {
               id: 'myOrphanSpanId',
+            },
+            timestamp: {
+              us: 1000000000000005,
             },
             parent: {
               id: 'myNotExistingTransactionId1',
@@ -858,7 +868,34 @@ describe('waterfall_helpers', () => {
           parentId: 'myNotExistingTransactionId1',
         } as IWaterfallSpan,
       ];
-      expect(reparentOrphanItems(['myOrphanSpanId'], traceItems, 'myTransactionId1')).toEqual([
+      expect(reparentOrphanItems(['myOrphanSpanId'], traceItems, myTransactionItem)).toEqual([
+        myTransactionItem,
+      ]);
+    });
+
+    it('should reparent orphan items to root transaction', () => {
+      const traceItems: IWaterfallSpanOrTransaction[] = [
+        myTransactionItem,
+        {
+          duration: 100,
+          doc: {
+            processor: { event: 'span' },
+            span: {
+              id: 'myOrphanSpanId',
+            },
+            timestamp: {
+              us: 1000000000000100,
+            },
+            parent: {
+              id: 'myNotExistingTransactionId1',
+            },
+          } as WaterfallSpan,
+          docType: 'span',
+          id: 'myOrphanSpanId',
+          parentId: 'myNotExistingTransactionId1',
+        } as IWaterfallSpan,
+      ];
+      expect(reparentOrphanItems(['myOrphanSpanId'], traceItems, myTransactionItem)).toEqual([
         myTransactionItem,
         {
           doc: {
@@ -866,10 +903,14 @@ describe('waterfall_helpers', () => {
             span: {
               id: 'myOrphanSpanId',
             },
+            timestamp: {
+              us: 1000000000000100,
+            },
             parent: {
               id: 'myNotExistingTransactionId1',
             },
           } as WaterfallSpan,
+          duration: 100,
           docType: 'span',
           id: 'myOrphanSpanId',
           parentId: 'myTransactionId1',

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -437,16 +437,34 @@ export function getOrphanItemsIds(
 export function reparentOrphanItems(
   orphanItemsIds: string[],
   waterfallItems: IWaterfallSpanOrTransaction[],
-  newParentId?: string
+  entryWaterfallTransaction?: IWaterfallTransaction
 ) {
   const orphanIdsMap = new Set(orphanItemsIds);
-  return waterfallItems.map((item) => {
+  return waterfallItems.reduce<IWaterfallSpanOrTransaction[]>((acc, item) => {
     if (orphanIdsMap.has(item.id)) {
-      item.parentId = newParentId;
-      item.isOrphan = true;
+      // we need to filter out the orphan item if it's longer or if it has started before the entry transaction
+      // as this means it's a parent of the entry transaction
+      const isLongerThanEntryTransaction =
+        entryWaterfallTransaction && item.duration > entryWaterfallTransaction?.duration;
+      const hasStartedBeforeEntryTransaction =
+        entryWaterfallTransaction &&
+        item.doc.timestamp.us < entryWaterfallTransaction.doc.timestamp.us;
+
+      if (isLongerThanEntryTransaction || hasStartedBeforeEntryTransaction) {
+        return acc;
+      }
+
+      acc.push({
+        ...item,
+        parentId: entryWaterfallTransaction?.id,
+        isOrphan: true,
+      });
+    } else {
+      acc.push(item);
     }
-    return item;
-  });
+
+    return acc;
+  }, []);
 }
 
 export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
@@ -481,11 +499,7 @@ export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
 
   const orphanItemsIds = getOrphanItemsIds(waterfallItems, entryWaterfallTransaction?.id);
   const childrenByParentId = getChildrenGroupedByParentId(
-    reparentOrphanItems(
-      orphanItemsIds,
-      reparentSpans(waterfallItems),
-      entryWaterfallTransaction?.id
-    )
+    reparentOrphanItems(orphanItemsIds, reparentSpans(waterfallItems), entryWaterfallTransaction)
   );
 
   const items = getOrderedWaterfallItems(childrenByParentId, entryWaterfallTransaction);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[APM] Filter out upstream orphans in waterfall (#214704)](https://github.com/elastic/kibana/pull/214704)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-03-18T12:06:36Z","message":"[APM] Filter out upstream orphans in waterfall (#214704)\n\n## Summary\n\nCloses #212797\n\n\nThis PR filters out upstream orphans in the waterfall, which was\nconfusing as we were reparenting to the entry transaction.","sha":"e1f094d1f57037445213e326b6fa01696172d601","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","Team:obs-ux-infra_services","backport:version","v9.1.0","v8.19.0","v9.0.1"],"title":"[APM] Filter out upstream orphans in waterfall","number":214704,"url":"https://github.com/elastic/kibana/pull/214704","mergeCommit":{"message":"[APM] Filter out upstream orphans in waterfall (#214704)\n\n## Summary\n\nCloses #212797\n\n\nThis PR filters out upstream orphans in the waterfall, which was\nconfusing as we were reparenting to the entry transaction.","sha":"e1f094d1f57037445213e326b6fa01696172d601"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214966","number":214966,"state":"MERGED","mergeCommit":{"sha":"c5c18bbe5e2babe06ab11d7cf597541f9db7f0c2","message":"[9.0] [APM] Filter out upstream orphans in waterfall (#214704) (#214966)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[APM] Filter out upstream orphans in waterfall\n(#214704)](https://github.com/elastic/kibana/pull/214704)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214704","number":214704,"mergeCommit":{"message":"[APM] Filter out upstream orphans in waterfall (#214704)\n\n## Summary\n\nCloses #212797\n\n\nThis PR filters out upstream orphans in the waterfall, which was\nconfusing as we were reparenting to the entry transaction.","sha":"e1f094d1f57037445213e326b6fa01696172d601"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/214965","number":214965,"state":"MERGED","mergeCommit":{"sha":"8478f705affb949e35e1d79627abd855f0c06f98","message":"[8.x] [APM] Filter out upstream orphans in waterfall (#214704) (#214965)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[APM] Filter out upstream orphans in waterfall\n(#214704)](https://github.com/elastic/kibana/pull/214704)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}}]}] BACKPORT-->