### PR TITLE
[Oblt Onboarding] Switch to GA 9.x version of EDOT collector

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_service.mock.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_service.mock.ts
@@ -17,6 +17,7 @@ const createClientMock = (): jest.Mocked<AgentClient> => ({
   getLatestAgentAvailableVersion: jest.fn(),
   getLatestAgentAvailableBaseVersion: jest.fn(),
   getLatestAgentAvailableDockerImageVersion: jest.fn(),
+  getAvailableVersions: jest.fn(),
   getByIds: jest.fn(async (..._) => []),
 });
 

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_service.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agent_service.ts
@@ -29,7 +29,7 @@ import { getCurrentNamespace } from '../spaces/get_current_namespace';
 
 import { getAgentsByKuery, getAgentById, getByIds } from './crud';
 import { getAgentStatusById, getAgentStatusForAgentPolicy } from './status';
-import { getLatestAvailableAgentVersion } from './versions';
+import { getLatestAvailableAgentVersion, getAvailableVersions } from './versions';
 
 /**
  * A service for interacting with Agent data. See {@link AgentClient} for more information.
@@ -116,6 +116,11 @@ export interface AgentClient {
    * Return the latest agent available version formatted for the docker image
    */
   getLatestAgentAvailableDockerImageVersion(includeCurrentVersion?: boolean): Promise<string>;
+
+  /**
+   * Return all available agent versions
+   */
+  getAvailableVersions(): Promise<string[]>;
 }
 
 /**
@@ -184,6 +189,10 @@ class AgentClientImpl implements AgentClient {
   public async getLatestAgentAvailableVersion(includeCurrentVersion?: boolean) {
     await this.#runPreflight();
     return getLatestAvailableAgentVersion({ includeCurrentVersion });
+  }
+
+  public async getAvailableVersions() {
+    return await getAvailableVersions();
   }
 
   #runPreflight = async () => {

--- a/x-pack/solutions/observability/plugins/observability_onboarding/common/types.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/common/types.ts
@@ -9,4 +9,5 @@ export interface ElasticAgentVersionInfo {
   agentVersion: string;
   agentBaseVersion: string;
   agentDockerImageVersion: string;
+  agentTargetVersion?: string;
 }

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/use_kubernetes_flow.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/kubernetes/use_kubernetes_flow.ts
@@ -12,7 +12,13 @@ import { ObservabilityOnboardingAppServices } from '../../..';
 import { useFetcher } from '../../../hooks/use_fetcher';
 
 export function useKubernetesFlow(
-  onboardingFlowType: 'kubernetes_otel' | 'kubernetes' = 'kubernetes'
+  onboardingFlowType: 'kubernetes_otel' | 'kubernetes' = 'kubernetes',
+  options?: {
+    agentVersionRange?: {
+      versionFrom: string;
+      versionUpTo: string;
+    };
+  }
 ) {
   const {
     services: {
@@ -26,11 +32,12 @@ export function useKubernetesFlow(
         params: {
           body: {
             pkgName: onboardingFlowType,
+            agentVersionRange: options?.agentVersionRange,
           },
         },
       });
     },
-    [onboardingFlowType],
+    [onboardingFlowType, options?.agentVersionRange],
     { showToastOnError: false }
   );
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -37,9 +37,25 @@ import { useKubernetesFlow } from '../kubernetes/use_kubernetes_flow';
 const OTEL_HELM_CHARTS_REPO = 'https://open-telemetry.github.io/opentelemetry-helm-charts';
 const OTEL_KUBE_STACK_VERSION = '0.3.9';
 const CLUSTER_OVERVIEW_DASHBOARD_ID = 'kubernetes_otel-cluster-overview';
+const AGENT_VERSION_RANGE = {
+  versionFrom: '9.0.0',
+  versionUpTo: '10.0.0',
+};
 
 export const OtelKubernetesPanel: React.FC = () => {
-  const { data, error, refetch } = useKubernetesFlow('kubernetes_otel');
+  const { data, error, refetch } = useKubernetesFlow('kubernetes_otel', {
+    /**
+     * This only needed for stateful deployments
+     * of the stack version >=v8.18.0.
+     * On those clusters we cannot reference agent version
+     * v8.x because those versions are not GA.
+     * Instead we need to "manually" point to the GA
+     * version, which starts from v9.0.0. Additionally,
+     * we're clamping to v10.0.0 to avoid potential breaking changes
+     * in the future.
+     */
+    agentVersionRange: AGENT_VERSION_RANGE,
+  });
   const [idSelected, setIdSelected] = useState('nodejs');
   const {
     services: { share },
@@ -65,8 +81,9 @@ export const OtelKubernetesPanel: React.FC = () => {
     );
   }
 
-  const otelKubeStackValuesFileUrl = data
-    ? `https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v${data.elasticAgentVersionInfo.agentBaseVersion}/deploy/helm/edot-collector/kube-stack/values.yaml`
+  const agentVersion = data?.elasticAgentVersionInfo.agentTargetVersion;
+  const otelKubeStackValuesFileUrl = agentVersion
+    ? `https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v${agentVersion}/deploy/helm/edot-collector/kube-stack/values.yaml`
     : '';
   const namespace = 'opentelemetry-operator-system';
   const addRepoCommand = `helm repo add open-telemetry '${OTEL_HELM_CHARTS_REPO}' --force-update`;

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -81,15 +81,14 @@ export const OtelKubernetesPanel: React.FC = () => {
     );
   }
 
+  const agentVersion = data?.elasticAgentVersionInfo.agentTargetVersion ?? '';
   /**
    * Extracting the base version in case it has any suffix like `+build12345678`,
    * as in this flow agent version is used to reference the git tag without any
    * suffixes.
    */
-  const agentVersion = data?.elasticAgentVersionInfo.agentTargetVersion.split('+')[0];
-  const otelKubeStackValuesFileUrl = agentVersion
-    ? `https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v${agentVersion}/deploy/helm/edot-collector/kube-stack/values.yaml`
-    : '';
+  const agentBaseVersion = agentVersion.split('+')[0];
+  const otelKubeStackValuesFileUrl = `https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v${agentBaseVersion}/deploy/helm/edot-collector/kube-stack/values.yaml`;
   const namespace = 'opentelemetry-operator-system';
   const addRepoCommand = `helm repo add open-telemetry '${OTEL_HELM_CHARTS_REPO}' --force-update`;
   const installStackCommand = data

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_kubernetes/otel_kubernetes_panel.tsx
@@ -81,7 +81,12 @@ export const OtelKubernetesPanel: React.FC = () => {
     );
   }
 
-  const agentVersion = data?.elasticAgentVersionInfo.agentTargetVersion;
+  /**
+   * Extracting the base version in case it has any suffix like `+build12345678`,
+   * as in this flow agent version is used to reference the git tag without any
+   * suffixes.
+   */
+  const agentVersion = data?.elasticAgentVersionInfo.agentTargetVersion.split('+')[0];
   const otelKubeStackValuesFileUrl = agentVersion
     ? `https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v${agentVersion}/deploy/helm/edot-collector/kube-stack/values.yaml`
     : '';

--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/otel_logs/index.tsx
@@ -30,6 +30,7 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { usePerformanceContext } from '@kbn/ebt-tools';
+import { ElasticAgentVersionInfo } from '../../../../common/types';
 import { ObservabilityOnboardingAppServices } from '../../..';
 import { useFetcher } from '../../../hooks/use_fetcher';
 import { MultiIntegrationInstallBanner } from './multi_integration_install_banner';
@@ -59,7 +60,24 @@ export const OtelLogsPanel: React.FC = () => {
   );
 
   const { data: setup } = useFetcher((callApi) => {
-    return callApi('GET /internal/observability_onboarding/logs/setup/environment');
+    return callApi('GET /internal/observability_onboarding/logs/setup/environment', {
+      params: {
+        query: {
+          /**
+           * This only needed for stateful deployments
+           * of the stack version >=v8.18.0.
+           * On those clusters we cannot reference agent version
+           * v8.x because those versions are not GA.
+           * Instead we need to "manually" point to the GA
+           * version, which starts from v9.0.0. Additionally,
+           * we're clamping to v10.0.0 to avoid potential breaking changes
+           * in the future.
+           */
+          agentVersionFrom: '9.0.0',
+          agentVersionUpTo: '10.0.0',
+        },
+      },
+    });
   }, []);
 
   const {
@@ -81,8 +99,11 @@ export const OtelLogsPanel: React.FC = () => {
   }, [apiKeyData, onPageReady, setup]);
 
   const AGENT_CDN_BASE_URL = 'artifacts.elastic.co/downloads/beats/elastic-agent';
-  const agentVersion =
-    isServerless && setup ? setup.elasticAgentVersionInfo.agentVersion : stackVersion;
+  const agentVersion = selectAgentVersion(
+    isServerless,
+    stackVersion,
+    setup?.elasticAgentVersionInfo
+  );
   const urlEncodedAgentVersion = encodeURIComponent(agentVersion);
 
   const allDatasetsLocator =
@@ -382,4 +403,20 @@ function CopyableCodeBlock({ content }: { content: string }) {
       </EuiCopy>
     </>
   );
+}
+
+function selectAgentVersion(
+  isServerless: boolean,
+  stackVersion: string,
+  agentVersionInfo?: ElasticAgentVersionInfo
+): string {
+  if (!agentVersionInfo) {
+    return stackVersion;
+  }
+
+  if (isServerless) {
+    return agentVersionInfo.agentVersion;
+  }
+
+  return agentVersionInfo.agentTargetVersion ?? stackVersion;
 }

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getLatestAgentVersionInRange } from './get_agent_version';
+
+describe('getLatestAgentVersionInRange()', () => {
+  it('returns agent version within the specified range', () => {
+    const agentVersionList = [
+      '10.0.0',
+      '9.1.0',
+      '9.0.1',
+      '9.0.0',
+      '8.18.1',
+      '8.18.0',
+      '8.17.1',
+      '8.17.0',
+    ];
+    const kibanaVersion = '8.18.0';
+    const fromVersion = '9.0.0';
+    const upToVersion = '10.0.0';
+
+    const result = getLatestAgentVersionInRange(
+      agentVersionList,
+      kibanaVersion,
+      fromVersion,
+      upToVersion
+    );
+
+    expect(result).toBe('9.1.0');
+  });
+
+  it('returns the kibana version if there is no compatible agent version', () => {
+    const agentVersionList = ['10.0.0', '9.1.0', '9.0.1', '9.0.0'];
+    const kibanaVersion = '8.18.0';
+    const fromVersion = '8.0.0';
+    const upToVersion = '9.0.0';
+
+    const result = getLatestAgentVersionInRange(
+      agentVersionList,
+      kibanaVersion,
+      fromVersion,
+      upToVersion
+    );
+
+    expect(result).toBe('8.18.0');
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.test.ts
@@ -48,20 +48,4 @@ describe('getLatestAgentVersionInRange()', () => {
 
     expect(result).toBe('8.18.0');
   });
-
-  it('returns the base version in case the matched version has a build suffix', () => {
-    const agentVersionList = ['10.0.0', '9.1.0+build123', '9.0.1', '9.0.0'];
-    const kibanaVersion = '8.18.0';
-    const fromVersion = '9.0.0';
-    const upToVersion = '10.0.0';
-
-    const result = getLatestAgentVersionInRange(
-      agentVersionList,
-      kibanaVersion,
-      fromVersion,
-      upToVersion
-    );
-
-    expect(result).toBe('9.1.0');
-  });
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.test.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.test.ts
@@ -48,4 +48,20 @@ describe('getLatestAgentVersionInRange()', () => {
 
     expect(result).toBe('8.18.0');
   });
+
+  it('returns the base version in case the matched version has a build suffix', () => {
+    const agentVersionList = ['10.0.0', '9.1.0+build123', '9.0.1', '9.0.0'];
+    const kibanaVersion = '8.18.0';
+    const fromVersion = '9.0.0';
+    const upToVersion = '10.0.0';
+
+    const result = getLatestAgentVersionInRange(
+      agentVersionList,
+      kibanaVersion,
+      fromVersion,
+      upToVersion
+    );
+
+    expect(result).toBe('9.1.0');
+  });
 });

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.ts
@@ -50,9 +50,10 @@ export function getLatestAgentVersionInRange(
   fromVersion: string,
   upToVersion: string
 ): string {
-  return (
+  const targetVersion =
     agentVersionList.find((version) => {
       return semver.satisfies(version, `>=${fromVersion} <${upToVersion}`);
-    }) ?? kibanaVersion
-  );
+    }) ?? kibanaVersion;
+
+  return targetVersion.split('+')[0];
 }

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/get_agent_version.ts
@@ -50,10 +50,9 @@ export function getLatestAgentVersionInRange(
   fromVersion: string,
   upToVersion: string
 ): string {
-  const targetVersion =
+  return (
     agentVersionList.find((version) => {
       return semver.satisfies(version, `>=${fromVersion} <${upToVersion}`);
-    }) ?? kibanaVersion;
-
-  return targetVersion.split('+')[0];
+    }) ?? kibanaVersion
+  );
 }

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/logs/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/logs/route.ts
@@ -36,6 +36,12 @@ const logMonitoringPrivilegesRoute = createObservabilityOnboardingServerRoute({
 
 const installShipperSetupRoute = createObservabilityOnboardingServerRoute({
   endpoint: 'GET /internal/observability_onboarding/logs/setup/environment',
+  params: t.partial({
+    query: t.type({
+      agentVersionFrom: t.string,
+      agentVersionUpTo: t.string,
+    }),
+  }),
   options: { tags: [] },
   async handler(resources): Promise<{
     apiEndpoint: string;
@@ -48,10 +54,16 @@ const installShipperSetupRoute = createObservabilityOnboardingServerRoute({
       plugins,
       kibanaVersion,
       services: { esLegacyConfigService },
+      params,
     } = resources;
 
     const fleetPluginStart = await plugins.fleet.start();
-    const elasticAgentVersionInfo = await getAgentVersionInfo(fleetPluginStart, kibanaVersion);
+    const elasticAgentVersionInfo = await getAgentVersionInfo(
+      fleetPluginStart,
+      kibanaVersion,
+      params?.query?.agentVersionFrom,
+      params?.query?.agentVersionUpTo
+    );
     const kibanaUrl = getKibanaUrl(core.setup, plugins.cloud?.setup);
     const scriptDownloadUrl = new URL(
       core.setup.http.staticAssets.getPluginAssetHref('standalone_agent_setup.sh'),


### PR DESCRIPTION
Because 8.18 version of EDOT collector is not GA, we should not use the latest agent version matching the current stack version as we do normally. Instead this change adds an option to set the preferred agent version range which in this case is `>=9.0.0 <10.0.0`.

After this change is merged, I'll create another PR for 8.19, because it should follow the same logic.

# How to test

1. Run locally
2. Go to Host OTel onboarding flow and make sure is uses 9.0.0 agent version in the command snippet
3. Go to Kubernetes OTel onboarding flow and make sure is uses 9.0.0 agent version in the command snippet
4. Make sure other quickstart flows still use the 8.x version