### PR TITLE
[Discover] Make pin button focusable with keyboard (#214343)

### DIFF
--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.mocks.ts
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.mocks.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { DocumentField } from './field_list';
+
+export const documentFieldMock = (params: Partial<DocumentField> = {}): DocumentField => {
+  return {
+    key: 'field',
+    value: 'value',
+    isPinned: false,
+    ...params,
+  };
+};

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.scss
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.scss
@@ -33,11 +33,11 @@ $previewShowMoreHeight: 40px; /* [2] */
       pointer-events: none;
     }
 
-    &--pinned .indexPatternFieldEditor__previewFieldList__item__actionsBtn,
-    &:hover .indexPatternFieldEditor__previewFieldList__item__actionsBtn,
-    &:focus-within .indexPatternFieldEditor__previewFieldList__item__actionsBtn {
-      opacity: 1;
-      pointer-events: auto;
+    &--pinned, &:hover, &:focus-within {
+      .indexPatternFieldEditor__previewFieldList__item__actionsBtn {
+        opacity: 1;
+        pointer-events: auto;
+      }
     }
 
     &__value .euiToolTipAnchor {

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.scss
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.scss
@@ -29,12 +29,15 @@ $previewShowMoreHeight: 40px; /* [2] */
     }
 
     &__actionsBtn {
-      display: none;
+      opacity: 0;
+      pointer-events: none;
     }
 
     &--pinned .indexPatternFieldEditor__previewFieldList__item__actionsBtn,
-    &:hover .indexPatternFieldEditor__previewFieldList__item__actionsBtn {
-      display: block;
+    &:hover .indexPatternFieldEditor__previewFieldList__item__actionsBtn,
+    &:focus-within .indexPatternFieldEditor__previewFieldList__item__actionsBtn {
+      opacity: 1;
+      pointer-events: auto;
     }
 
     &__value .euiToolTipAnchor {

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.scss
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.scss
@@ -28,18 +28,6 @@ $previewShowMoreHeight: 40px; /* [2] */
       flex-basis: 24px !important;
     }
 
-    &__actionsBtn {
-      opacity: 0;
-      pointer-events: none;
-    }
-
-    &--pinned, &:hover, &:focus-within {
-      .indexPatternFieldEditor__previewFieldList__item__actionsBtn {
-        opacity: 1;
-        pointer-events: auto;
-      }
-    }
-
     &__value .euiToolTipAnchor {
       width: 100%; /* [3] */
     }

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.tsx
@@ -209,7 +209,7 @@ export const PreviewFieldList: React.FC<Props> = ({ height, clearSearch, searchV
       if (!keyboardEvent.isKeyboardEvent) return;
       const newIndex = getPositionAfterToggling(fieldName, pinnedFields, fieldList);
       // If the field is currently pinned and it goes over the limit of the fields to show we need to show all of them
-      if (newIndex > INITIAL_MAX_NUMBER_OF_FIELDS && !showAllFields) toggleShowAllFields();
+      if (newIndex >= INITIAL_MAX_NUMBER_OF_FIELDS && !showAllFields) toggleShowAllFields();
       requestAnimationFrame(() => {
         virtualListRef.current?.scrollToItem(newIndex, 'smart');
         // We need to wait for the scroll to finish so the element is in the DOM before focusing it

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useRef } from 'react';
 import { FixedSizeList as VirtualList, areEqual } from 'react-window';
 import { i18n } from '@kbn/i18n';
 import { get, isEqual } from 'lodash';
@@ -19,8 +19,8 @@ import type { FieldPreview, PreviewState } from '../types';
 import { PreviewListItem } from './field_list_item';
 import type { PreviewListItemProps } from './field_list_item';
 import { useStateSelector } from '../../../state_utils';
-
 import './field_list.scss';
+import { getPositionAfterToggling } from './get_item_position';
 
 const ITEM_HEIGHT = 40;
 const SHOW_MORE_HEIGHT = 40;
@@ -75,6 +75,7 @@ const Row = React.memo<RowProps>(({ data, index, style }) => {
 export const PreviewFieldList: React.FC<Props> = ({ height, clearSearch, searchValue = '' }) => {
   const { dataView } = useFieldEditorContext();
   const { controller } = useFieldPreviewContext();
+  const virtualListRef = useRef<VirtualList>(null);
   const pinnedFields = useStateSelector(controller.state$, pinnedFieldsSelector, isEqual);
   const currentDocument = useStateSelector(controller.state$, currentDocumentSelector);
   const fieldMap = useStateSelector(controller.state$, fieldMapSelector);
@@ -201,9 +202,31 @@ export const PreviewFieldList: React.FC<Props> = ({ height, clearSearch, searchV
       </div>
     );
 
+  const toggleIsPinnedItem = useCallback(
+    (fieldName: string, keyboardEvent: { isKeyboardEvent: boolean; buttonId: string }) => {
+      controller.togglePinnedField(fieldName);
+
+      if (!keyboardEvent.isKeyboardEvent) return;
+      const newIndex = getPositionAfterToggling(fieldName, pinnedFields, fieldList);
+      // If the field is currently pinned and it goes over the limit of the fields to show we need to show all of them
+      if (newIndex > INITIAL_MAX_NUMBER_OF_FIELDS && !showAllFields) toggleShowAllFields();
+      requestAnimationFrame(() => {
+        virtualListRef.current?.scrollToItem(newIndex, 'smart');
+        // We need to wait for the scroll to finish so the element is in the DOM before focusing it
+        requestAnimationFrame(() => {
+          document.getElementById(keyboardEvent.buttonId)?.focus();
+        });
+      });
+    },
+    [controller, showAllFields, pinnedFields, fieldList, toggleShowAllFields]
+  );
+
   const itemData = useMemo(
-    () => ({ filteredFields, toggleIsPinned: controller.togglePinnedField }),
-    [filteredFields, controller.togglePinnedField]
+    () => ({
+      filteredFields,
+      toggleIsPinned: toggleIsPinnedItem,
+    }),
+    [filteredFields, toggleIsPinnedItem]
   );
 
   if (currentDocument === undefined || height === -1) {
@@ -219,6 +242,7 @@ export const PreviewFieldList: React.FC<Props> = ({ height, clearSearch, searchV
           className="eui-scrollBar"
           style={{ overflowX: 'hidden' }}
           width="100%"
+          ref={virtualListRef}
           height={listHeight}
           itemData={itemData}
           itemCount={filteredFields.length}

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.test.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PreviewListItem } from './field_list_item';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { useFieldPreviewContext } from '../field_preview_context';
+import { PreviewController } from '../preview_controller';
+import { BehaviorSubject } from 'rxjs';
+
+jest.mock('../field_preview_context', () => ({
+  ...jest.requireActual('../field_preview_context'),
+  useFieldPreviewContext: jest.fn(),
+}));
+const mockUseFieldPreviewContext = jest.mocked(useFieldPreviewContext);
+
+const previewController = {
+  state$: new BehaviorSubject({
+    isLoadingPreview: false,
+  }),
+} as any as PreviewController;
+
+type ComponentProps = React.ComponentProps<typeof PreviewListItem>;
+
+const setup = (props: Partial<ComponentProps>) => {
+  mockUseFieldPreviewContext.mockReturnValue({
+    controller: previewController,
+  } as any);
+
+  const finalProps: ComponentProps = {
+    field: { key: 'test', value: 'test', formattedValue: 'test', isPinned: false },
+    toggleIsPinned: jest.fn(),
+    hasScriptError: false,
+    isFromScript: false,
+    ...props,
+  };
+
+  render(
+    <IntlProvider locale="en">
+      <PreviewListItem {...finalProps} />
+    </IntlProvider>
+  );
+
+  return { props: finalProps };
+};
+
+afterAll(() => {
+  jest.clearAllMocks();
+});
+
+describe('<PreviewListItem />', () => {
+  describe('when toggleIsPinned is not provided', () => {
+    it('should not render the pin button', () => {
+      // When
+      setup({ toggleIsPinned: undefined });
+
+      // Then
+      expect(screen.queryByRole('button', { name: /pin field/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when toggleIsPinned is provided', () => {
+    it('should render the pin button', () => {
+      // When
+      setup({ toggleIsPinned: jest.fn() });
+
+      // Then
+      expect(screen.getByRole('button', { name: /pin field/i })).toBeInTheDocument();
+    });
+
+    describe('when clicked', () => {
+      it('should call toggleIsPined', () => {
+        // When
+        const toggleIsPinned = jest.fn();
+        const { props } = setup({ toggleIsPinned });
+
+        // Then
+        const pinButton = screen.getByRole('button', { name: /pin field/i });
+        fireEvent.click(pinButton);
+
+        expect(toggleIsPinned).toHaveBeenCalledWith(props.field.key);
+      });
+    });
+  });
+});

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.test.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.test.tsx
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { PreviewListItem } from './field_list_item';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { useFieldPreviewContext } from '../field_preview_context';
@@ -29,6 +30,8 @@ const previewController = {
 type ComponentProps = React.ComponentProps<typeof PreviewListItem>;
 
 const setup = (props: Partial<ComponentProps>) => {
+  const user = userEvent.setup();
+
   mockUseFieldPreviewContext.mockReturnValue({
     controller: previewController,
   } as any);
@@ -47,7 +50,7 @@ const setup = (props: Partial<ComponentProps>) => {
     </IntlProvider>
   );
 
-  return { props: finalProps };
+  return { props: finalProps, user };
 };
 
 afterAll(() => {
@@ -75,14 +78,28 @@ describe('<PreviewListItem />', () => {
     });
 
     describe('when clicked', () => {
-      it('should call toggleIsPined', () => {
+      it('should call toggleIsPined', async () => {
         // When
         const toggleIsPinned = jest.fn();
-        const { props } = setup({ toggleIsPinned });
+        const { props, user } = setup({ toggleIsPinned });
 
         // Then
         const pinButton = screen.getByRole('button', { name: /pin field/i });
-        fireEvent.click(pinButton);
+        await user.click(pinButton);
+
+        expect(toggleIsPinned).toHaveBeenCalledWith(props.field.key);
+      });
+    });
+
+    describe('when the user tabs to the button and presses Enter', () => {
+      it('should call toggleIsPinned', async () => {
+        // When
+        const toggleIsPinned = jest.fn();
+        const { props, user } = setup({ toggleIsPinned });
+
+        // Then
+        await user.tab();
+        await user.keyboard('{enter}');
 
         expect(toggleIsPinned).toHaveBeenCalledWith(props.field.key);
       });

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.test.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.test.tsx
@@ -87,7 +87,10 @@ describe('<PreviewListItem />', () => {
         const pinButton = screen.getByRole('button', { name: /pin field/i });
         await user.click(pinButton);
 
-        expect(toggleIsPinned).toHaveBeenCalledWith(props.field.key);
+        expect(toggleIsPinned).toHaveBeenCalledWith(props.field.key, {
+          isKeyboardEvent: false,
+          buttonId: `fieldPreview.pinFieldButtonLabel.${props.field.key}`,
+        });
       });
     });
 
@@ -101,7 +104,10 @@ describe('<PreviewListItem />', () => {
         await user.tab();
         await user.keyboard('{enter}');
 
-        expect(toggleIsPinned).toHaveBeenCalledWith(props.field.key);
+        expect(toggleIsPinned).toHaveBeenCalledWith(props.field.key, {
+          isKeyboardEvent: true,
+          buttonId: `fieldPreview.pinFieldButtonLabel.${props.field.key}`,
+        });
       });
     });
   });

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.tsx
@@ -51,6 +51,11 @@ export const PreviewListItem: React.FC<PreviewListItemProps> = ({
 
   const [isPreviewImageModalVisible, setIsPreviewImageModalVisible] = useState(false);
 
+  const [isPinHovered, setIsPinHovered] = useState(false);
+  const [isPinFocused, setIsPinFocused] = useState(false);
+
+  const showPinIcon = isPinHovered || isPinFocused || isPinned;
+
   const classes = classnames('indexPatternFieldEditor__previewFieldList__item', {
     'indexPatternFieldEditor__previewFieldList__item--highlighted': isFromScript,
     'indexPatternFieldEditor__previewFieldList__item--pinned': isPinned,
@@ -184,8 +189,12 @@ export const PreviewListItem: React.FC<PreviewListItemProps> = ({
               onClick={() => {
                 toggleIsPinned(key);
               }}
+              onMouseEnter={() => setIsPinHovered(true)}
+              onMouseLeave={() => setIsPinHovered(false)}
+              onFocus={() => setIsPinFocused(true)}
+              onBlur={() => setIsPinFocused(false)}
               color="text"
-              iconType="pinFilled"
+              iconType={showPinIcon ? 'pinFilled' : 'empty'}
               data-test-subj="pinFieldButton"
               aria-label={i18n.translate(
                 'indexPatternFieldEditor.fieldPreview.pinFieldButtonLabel',
@@ -193,7 +202,6 @@ export const PreviewListItem: React.FC<PreviewListItemProps> = ({
                   defaultMessage: 'Pin field',
                 }
               )}
-              className="indexPatternFieldEditor__previewFieldList__item__actionsBtn"
             />
           )}
         </EuiFlexItem>

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/field_list_item.tsx
@@ -31,7 +31,10 @@ import { useStateSelector } from '../../../state_utils';
 
 export interface PreviewListItemProps {
   field: DocumentField;
-  toggleIsPinned?: (name: string) => void;
+  toggleIsPinned?: (
+    name: string,
+    keyboardEvent: { isKeyboardEvent: boolean; buttonId: string }
+  ) => void;
   hasScriptError?: boolean;
   /** Indicates whether the field list item comes from the Painless script */
   isFromScript?: boolean;
@@ -45,6 +48,8 @@ export const PreviewListItem: React.FC<PreviewListItemProps> = ({
   hasScriptError,
   isFromScript = false,
 }) => {
+  const pinButtonId = `fieldPreview.pinFieldButtonLabel.${key}`;
+
   const { euiTheme } = useEuiTheme();
   const { controller } = useFieldPreviewContext();
   const isLoadingPreview = useStateSelector(controller.state$, isLoadingPreviewSelector);
@@ -164,6 +169,8 @@ export const PreviewListItem: React.FC<PreviewListItemProps> = ({
         }
         gutterSize="none"
         data-test-subj="listItem"
+        onMouseEnter={() => setIsPinHovered(true)}
+        onMouseLeave={() => setIsPinHovered(false)}
       >
         <EuiFlexItem className="indexPatternFieldEditor__previewFieldList__item__key">
           <div
@@ -186,11 +193,11 @@ export const PreviewListItem: React.FC<PreviewListItemProps> = ({
         >
           {toggleIsPinned && (
             <EuiButtonIcon
-              onClick={() => {
-                toggleIsPinned(key);
+              onClick={(e: { detail: number }) => {
+                const isKeyboardEvent = e.detail === 0; // Mouse = non-zero, Keyboard = 0
+                toggleIsPinned(key, { isKeyboardEvent, buttonId: pinButtonId });
               }}
-              onMouseEnter={() => setIsPinHovered(true)}
-              onMouseLeave={() => setIsPinHovered(false)}
+              id={pinButtonId}
               onFocus={() => setIsPinFocused(true)}
               onBlur={() => setIsPinFocused(false)}
               color="text"

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/get_item_position.test.ts
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/get_item_position.test.ts
@@ -1,0 +1,272 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { documentFieldMock } from './field_list.mocks';
+import { getPositionAfterToggling } from './get_item_position';
+
+describe('getPositionAfterToggling', () => {
+  describe('when the field goes from pinned to unpinned', () => {
+    describe('when there are no other pinned fields', () => {
+      it.each([
+        {
+          fieldList: [documentFieldMock({ key: 'field1', isPinned: true })],
+          fieldName: 'field1',
+          pinnedFields: { field1: true },
+          expectedPosition: 0,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: false }),
+          ],
+          fieldName: 'field1',
+          pinnedFields: { field1: true },
+          expectedPosition: 0,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: false }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+          ],
+          fieldName: 'field2',
+          pinnedFields: { field2: true },
+          expectedPosition: 1,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: false }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+            documentFieldMock({ key: 'field3', isPinned: false }),
+          ],
+          fieldName: 'field2',
+          pinnedFields: { field2: true },
+          expectedPosition: 1,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: false }),
+            documentFieldMock({ key: 'field2', isPinned: false }),
+            documentFieldMock({ key: 'field3', isPinned: true }),
+          ],
+          fieldName: 'field3',
+          pinnedFields: { field3: true },
+          expectedPosition: 2,
+        },
+      ])(
+        'should return $expectedPosition',
+        ({ fieldList, fieldName, pinnedFields, expectedPosition }) => {
+          const result = getPositionAfterToggling(
+            fieldName,
+            pinnedFields as unknown as Record<string, boolean>,
+            fieldList
+          );
+          expect(result).toBe(expectedPosition);
+        }
+      );
+    });
+
+    describe('when there are other pinned fields', () => {
+      it.each([
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+          ],
+          fieldName: 'field1',
+          pinnedFields: { field1: true, field2: true },
+          expectedPosition: 1,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+            documentFieldMock({ key: 'field3', isPinned: true }),
+          ],
+          fieldName: 'field1',
+          pinnedFields: { field1: true, field2: true, field3: true },
+          expectedPosition: 2,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+            documentFieldMock({ key: 'field3', isPinned: true }),
+            documentFieldMock({ key: 'field4', isPinned: false }),
+          ],
+          fieldName: 'field1',
+          pinnedFields: { field1: true, field2: true, field3: true },
+          expectedPosition: 2,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+            documentFieldMock({ key: 'field3', isPinned: true }),
+          ],
+          fieldName: 'field2',
+          pinnedFields: { field1: true, field2: true, field3: true },
+          expectedPosition: 2,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+            documentFieldMock({ key: 'field3', isPinned: false }),
+          ],
+          fieldName: 'field2',
+          pinnedFields: { field1: true, field2: true },
+          expectedPosition: 1,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+            documentFieldMock({ key: 'field3', isPinned: false }),
+            documentFieldMock({ key: 'field4', isPinned: true }),
+          ],
+          fieldName: 'field2',
+          pinnedFields: { field1: true, field2: true, field4: true },
+          expectedPosition: 2,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+          ],
+          fieldName: 'field2',
+          pinnedFields: { field1: true, field2: true },
+          expectedPosition: 1,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: false }),
+            documentFieldMock({ key: 'field3', isPinned: true }),
+          ],
+          fieldName: 'field3',
+          pinnedFields: { field1: true, field3: true },
+          expectedPosition: 2,
+        },
+      ])(
+        'should return $expectedPosition ($fieldList)',
+        ({ fieldList, fieldName, pinnedFields, expectedPosition }) => {
+          const result = getPositionAfterToggling(
+            fieldName,
+            pinnedFields as unknown as Record<string, boolean>,
+            fieldList
+          );
+          expect(result).toBe(expectedPosition);
+        }
+      );
+    });
+  });
+
+  describe('when the field goes from unpinned to pinned', () => {
+    describe('when there are no other pinned fields', () => {
+      const fieldList = [
+        documentFieldMock({ key: 'field1', isPinned: false }),
+        documentFieldMock({ key: 'field2', isPinned: false }),
+        documentFieldMock({ key: 'field3', isPinned: false }),
+      ];
+
+      it('should return 0', () => {
+        const result = getPositionAfterToggling('field1', {}, fieldList);
+        expect(result).toBe(0);
+      });
+    });
+
+    describe('when there are other pinned fields', () => {
+      it.each([
+        {
+          fieldList: [documentFieldMock({ key: 'field1', isPinned: false })],
+          fieldName: 'field1',
+          pinnedFields: {},
+          expectedPosition: 0,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: false }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+          ],
+          fieldName: 'field1',
+          pinnedFields: { field2: true },
+          expectedPosition: 0,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: false }),
+          ],
+          fieldName: 'field2',
+          pinnedFields: { field1: true },
+          expectedPosition: 1,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+            documentFieldMock({ key: 'field3', isPinned: false }),
+          ],
+          fieldName: 'field3',
+          pinnedFields: { field1: true, field2: true },
+          expectedPosition: 2,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+            documentFieldMock({ key: 'field3', isPinned: false }),
+            documentFieldMock({ key: 'field4', isPinned: true }),
+          ],
+          fieldName: 'field3',
+          pinnedFields: { field1: true, field2: true },
+          expectedPosition: 2,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: false }),
+            documentFieldMock({ key: 'field2', isPinned: false }),
+          ],
+          fieldName: 'field2',
+          pinnedFields: {},
+          expectedPosition: 0,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: false }),
+          ],
+          fieldName: 'field2',
+          pinnedFields: { field1: true },
+          expectedPosition: 1,
+        },
+        {
+          fieldList: [
+            documentFieldMock({ key: 'field1', isPinned: true }),
+            documentFieldMock({ key: 'field2', isPinned: true }),
+            documentFieldMock({ key: 'field3', isPinned: false }),
+          ],
+          fieldName: 'field3',
+          pinnedFields: { field1: true, field2: true },
+          expectedPosition: 2,
+        },
+      ])(
+        'should return $expectedPosition',
+        ({ fieldList, fieldName, pinnedFields, expectedPosition }) => {
+          const result = getPositionAfterToggling(
+            fieldName,
+            pinnedFields as Record<string, boolean>,
+            fieldList
+          );
+          expect(result).toBe(expectedPosition);
+        }
+      );
+    });
+  });
+});

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/get_item_position.ts
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/get_item_position.ts
@@ -26,7 +26,7 @@ function getItemPositionAfterUnpinning(
   fieldList: DocumentField[]
 ) {
   // There's one pinned field less since we are unpinning the item
-  const pinnedFieldsLength = Object.keys(pinnedFields).length - 1;
+  const pinnedFieldsLength = Object.values(pinnedFields).filter(Boolean).length - 1;
   const unpinnedItems = fieldList.filter(
     (item) => !pinnedFields[item.key] || item.key === fieldName
   );

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/get_item_position.ts
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/field_list/get_item_position.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { DocumentField } from './field_list';
+
+export function getPositionAfterToggling(
+  fieldName: string,
+  pinnedFields: Record<string, boolean>,
+  fieldList: DocumentField[]
+) {
+  const isPinned = pinnedFields[fieldName];
+  return isPinned
+    ? getItemPositionAfterUnpinning(fieldName, pinnedFields, fieldList)
+    : getItemPositionAfterPinning(fieldName, fieldList);
+}
+
+function getItemPositionAfterUnpinning(
+  fieldName: string,
+  pinnedFields: Record<string, boolean>,
+  fieldList: DocumentField[]
+) {
+  // There's one pinned field less since we are unpinning the item
+  const pinnedFieldsLength = Object.keys(pinnedFields).length - 1;
+  const unpinnedItems = fieldList.filter(
+    (item) => !pinnedFields[item.key] || item.key === fieldName
+  );
+
+  // The unpinned items are placed after the pinned items so we can just find the index of the item in the unpinned items
+  // and add the number of pinned items to it
+  const newItemIndex =
+    pinnedFieldsLength + unpinnedItems.findIndex((item) => item.key === fieldName);
+  return newItemIndex;
+}
+
+function getItemPositionAfterPinning(fieldName: string, fieldList: DocumentField[]) {
+  const pinnedItems = [];
+
+  for (const item of fieldList) {
+    if (item.isPinned) {
+      pinnedItems.push(fieldName);
+    }
+
+    // If we reach the item we are pinning, we stop since that's the position it will be in
+    if (item.key === fieldName) {
+      break;
+    }
+  }
+
+  return pinnedItems.length;
+}


### PR DESCRIPTION
## Summary

The pin button wasn't accesible with just the keyboard, the user needed to hover over the position and click on it.

| Before | After |
|--------|------|
| ![chrome-capture-2025-4-25 (1)](https://github.com/user-attachments/assets/1684f0e9-f3e4-4142-acec-6f3938bebf1a) | ![chrome-capture-2025-4-25](https://github.com/user-attachments/assets/bf6d533e-febf-4c2a-9c5c-a82f405a76ed) |

Fixes the original problem from https://github.com/elastic/kibana/issues/214343

#### Keyboard interactions

| Scenario | Gif |
|----------|----|
| Pinning something in view | ![chrome-capture-2025-5-20](https://github.com/user-attachments/assets/7a32fec7-90bb-4dd4-96dc-10d402a2a00c) |
| Pinning something from really far | ![chrome-capture-2025-5-20 (1)](https://github.com/user-attachments/assets/4164bac5-f2dc-4d1d-b342-7d3996488838) |
| Unpinning something in view | ![chrome-capture-2025-5-20 (2)](https://github.com/user-attachments/assets/46c71134-3904-4966-bbb1-15a4d920a9dd) |
| Unpinning something that goes really far (table not expanded) | ![chrome-capture-2025-5-20 (3)](https://github.com/user-attachments/assets/8827f0ce-1188-44d5-aa25-9448d3298ef0) |
| Unpinning something that goes really far (table expanded) | ![chrome-capture-2025-5-20 (4)](https://github.com/user-attachments/assets/37525fbf-8b55-4c4c-9197-add5758156f1) |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->