### PR TITLE
[Draft] Fix query for alert timestamps in ai assistant

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/alerts.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/alerts.ts
@@ -195,7 +195,9 @@ export function registerAlertsFunction({
               filter: [
                 {
                   range: {
-                    '@timestamp': {
+                    // Note, the @timestamp field is the value for when the alert was last updated
+                    // and not when the alert was created
+                    'kibana.alert.start': {
                       gte: start,
                       lte: end,
                     },


### PR DESCRIPTION
## Summary

This fixes the AI assistant's alert function to query `kibana.alert.start` rather than `@timestamp` for alerts. For alerts we continually update documents every time the rule runs, including when the alert closes. This means that if you ask "What alerts started in the past day" it will include all alerts that had new activity within that time period, even if they started a month ago. 

Here's an example of the assistant with this patch, with no new alerts having triggered recently:

<img width="990" alt="image" src="https://github.com/user-attachments/assets/6a8a901a-567a-4d36-ba15-5c70396f8e96" />

And here it is without the patch

<img width="995" alt="image" src="https://github.com/user-attachments/assets/e5fc9bf7-ba43-40e1-b54b-80b5f36828f9" />


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



