### PR TITLE
[AI4DSOC] Disable actions and replace alerts table on the rule details page for AI4DSOC

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/ai_for_soc/table.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/ai_for_soc/table.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
+import { TestProviders } from '../../../../../common/mock';
+import { Table } from './table';
+import type { PackageListItem } from '@kbn/fleet-plugin/common';
+import { installationStatuses } from '@kbn/fleet-plugin/common/constants';
+import type { Filter, Query } from '@kbn/es-query';
+
+const dataView: DataView = createStubDataView({ spec: {} });
+const packages: PackageListItem[] = [
+  {
+    id: 'splunk',
+    icons: [{ src: 'icon.svg', path: 'mypath/icon.svg', type: 'image/svg+xml' }],
+    name: 'splunk',
+    status: installationStatuses.NotInstalled,
+    title: 'Splunk',
+    version: '0.1.0',
+  },
+];
+const query: Query = {
+  query: '',
+  language: '',
+};
+const filters: Filter[] = [];
+const from = '';
+const to = '';
+const ruleResponse = {
+  rules: [],
+  isLoading: false,
+};
+
+describe('<Table />', () => {
+  it('should render all components', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <Table
+          dataView={dataView}
+          filters={filters}
+          from={from}
+          packages={packages}
+          query={query}
+          ruleResponse={ruleResponse}
+          to={to}
+        />
+      </TestProviders>
+    );
+
+    expect(getByTestId('internalAlertsPageLoading')).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/ai_for_soc/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/ai_for_soc/table.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useCallback, useMemo, useRef } from 'react';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import { AlertsTable } from '@kbn/response-ops-alerts-table';
+import type { PackageListItem } from '@kbn/fleet-plugin/common';
+import type {
+  AlertsTableImperativeApi,
+  AlertsTableProps,
+} from '@kbn/response-ops-alerts-table/types';
+import { TableId } from '@kbn/securitysolution-data-table';
+import { getEsQueryConfig } from '@kbn/data-service';
+import type { Filter, Query } from '@kbn/es-query';
+import { buildTimeRangeFilter } from '../../../../../detections/components/alerts_table/helpers';
+import { combineQueries } from '../../../../../common/lib/kuery';
+import type { AdditionalTableContext } from '../../../../../detections/components/alert_summary/table/table';
+import {
+  ACTION_COLUMN_WIDTH,
+  ALERT_TABLE_CONSUMERS,
+  CASES_CONFIGURATION,
+  columns,
+  EuiDataGridStyleWrapper,
+  GRID_STYLE,
+  ROW_HEIGHTS_OPTIONS,
+  RULE_TYPE_IDS,
+  TOOLBAR_VISIBILITY,
+} from '../../../../../detections/components/alert_summary/table/table';
+import { ActionsCell } from '../../../../../detections/components/alert_summary/table/actions_cell';
+import { getDataViewStateFromIndexFields } from '../../../../../common/containers/source/use_data_view';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { CellValue } from '../../../../../detections/components/alert_summary/table/render_cell';
+import type { RuleResponse } from '../../../../../../common/api/detection_engine';
+import { useAdditionalBulkActions } from '../../../../../detections/hooks/alert_summary/use_additional_bulk_actions';
+
+export interface TableProps {
+  /**
+   * DataView created for the alert summary page
+   */
+  dataView: DataView;
+  /**
+   * Filters passed from the rule details page.
+   * These contain the default filters (alerts, show building block, status and threat match) as well
+   * as the ones from the KQL bar.
+   */
+  filters: Filter[];
+  /**
+   * From value retrieved from the global KQL bar
+   */
+  from: string;
+  /**
+   * List of installed AI for SOC integrations
+   */
+  packages: PackageListItem[];
+  /**
+   * Query retrieved from the global KQL bar
+   */
+  query: Query;
+  /**
+   * Result from the useQuery to fetch the rule
+   */
+  ruleResponse: {
+    /**
+     * Result from fetching all rules
+     */
+    rules: RuleResponse[];
+    /**
+     * True while rules are being fetched
+     */
+    isLoading: boolean;
+  };
+  /**
+   * To value retrieved from the global KQL bar
+   */
+  to: string;
+}
+
+/**
+ * Component used in the Cases page under Alerts tab, only in the AI4DSOC tier.
+ * It leverages a lot of configurations and constants from the Alert summary page alerts table, and renders the ResponseOps AlertsTable.
+ */
+export const Table = memo(
+  ({ dataView, filters, from, packages, query, ruleResponse, to }: TableProps) => {
+    const {
+      services: {
+        application,
+        cases,
+        data,
+        fieldFormats,
+        http,
+        licensing,
+        notifications,
+        settings,
+        uiSettings,
+      },
+    } = useKibana();
+    const services = useMemo(
+      () => ({
+        cases,
+        data,
+        http,
+        notifications,
+        fieldFormats,
+        application,
+        licensing,
+        settings,
+      }),
+      [application, cases, data, fieldFormats, http, licensing, notifications, settings]
+    );
+
+    const dataViewSpec = useMemo(() => dataView.toSpec(), [dataView]);
+
+    const { browserFields } = useMemo(
+      () => getDataViewStateFromIndexFields('', dataViewSpec.fields),
+      [dataViewSpec.fields]
+    );
+
+    const timeRangeFilter = useMemo(() => buildTimeRangeFilter(from, to), [from, to]);
+    const finalFilters = useMemo(
+      () => [...filters, ...timeRangeFilter],
+      [filters, timeRangeFilter]
+    );
+
+    const finalQuery: AlertsTableProps['query'] = useMemo(() => {
+      const combinedQuery = combineQueries({
+        config: getEsQueryConfig(uiSettings),
+        dataProviders: [],
+        dataViewSpec,
+        browserFields,
+        filters: finalFilters,
+        kqlQuery: query,
+        kqlMode: query.language,
+      });
+
+      if (combinedQuery?.kqlError || !combinedQuery?.filterQuery) {
+        return { bool: {} };
+      }
+
+      try {
+        const filter = JSON.parse(combinedQuery?.filterQuery);
+        return { bool: { filter } };
+      } catch {
+        return { bool: {} };
+      }
+    }, [browserFields, dataViewSpec, finalFilters, query, uiSettings]);
+
+    const additionalContext: AdditionalTableContext = useMemo(
+      () => ({
+        packages,
+        ruleResponse,
+      }),
+      [packages, ruleResponse]
+    );
+
+    const refetchRef = useRef<AlertsTableImperativeApi>(null);
+    const refetch = useCallback(() => {
+      refetchRef.current?.refresh();
+    }, []);
+
+    const bulkActions = useAdditionalBulkActions({ refetch });
+
+    return (
+      <EuiDataGridStyleWrapper>
+        <AlertsTable
+          actionsColumnWidth={ACTION_COLUMN_WIDTH}
+          additionalBulkActions={bulkActions}
+          additionalContext={additionalContext}
+          browserFields={browserFields}
+          casesConfiguration={CASES_CONFIGURATION}
+          columns={columns}
+          consumers={ALERT_TABLE_CONSUMERS}
+          gridStyle={GRID_STYLE}
+          id={TableId.alertsOnRuleDetailsPage}
+          query={finalQuery}
+          ref={refetchRef}
+          renderActionsCell={ActionsCell}
+          renderCellValue={CellValue}
+          rowHeightsOptions={ROW_HEIGHTS_OPTIONS}
+          ruleTypeIds={RULE_TYPE_IDS}
+          services={services}
+          toolbarVisibility={TOOLBAR_VISIBILITY}
+        />
+      </EuiDataGridStyleWrapper>
+    );
+  }
+);
+
+Table.displayName = 'Table';

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/ai_for_soc/wrapper.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/ai_for_soc/wrapper.test.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AiForSOCAlertsTable, CONTENT_TEST_ID, ERROR_TEST_ID, SKELETON_TEST_ID } from './wrapper';
+import { useKibana } from '../../../../../common/lib/kibana';
+import { TestProviders } from '../../../../../common/mock';
+import { useFetchIntegrations } from '../../../../../detections/hooks/alert_summary/use_fetch_integrations';
+import type { Filter, Query } from '@kbn/es-query';
+import type { RuleResponse } from '../../../../../../common/api/detection_engine';
+
+jest.mock('./table', () => ({
+  Table: () => <div />,
+}));
+jest.mock('../../../../../common/lib/kibana');
+jest.mock('../../../../../detections/hooks/alert_summary/use_fetch_integrations');
+
+const query: Query = {
+  query: '',
+  language: '',
+};
+const filters: Filter[] = [];
+const from = '';
+const to = '';
+const ruleResponse: RuleResponse = {
+  id: 'id',
+  name: 'name',
+  description: 'description',
+} as RuleResponse;
+
+describe('<AiForSOCAlertsTab />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useFetchIntegrations as jest.Mock).mockReturnValue({
+      installedPackages: [],
+      isLoading: false,
+    });
+  });
+
+  it('should render a loading skeleton while creating the dataView', async () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        data: {
+          dataViews: {
+            create: jest.fn(),
+            clearInstanceCache: jest.fn(),
+          },
+        },
+        http: { basePath: { prepend: jest.fn() } },
+      },
+    });
+
+    render(
+      <AiForSOCAlertsTable
+        filters={filters}
+        from={from}
+        query={query}
+        rule={ruleResponse}
+        to={to}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
+    });
+  });
+
+  it('should render a loading skeleton while fetching packages (integrations)', async () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        data: {
+          dataViews: {
+            create: jest.fn(),
+            clearInstanceCache: jest.fn(),
+          },
+        },
+        http: { basePath: { prepend: jest.fn() } },
+      },
+    });
+    (useFetchIntegrations as jest.Mock).mockReturnValue({
+      installedPackages: [],
+      isLoading: true,
+    });
+
+    render(
+      <AiForSOCAlertsTable
+        filters={filters}
+        from={from}
+        query={query}
+        rule={ruleResponse}
+        to={to}
+      />
+    );
+
+    expect(await screen.findByTestId(SKELETON_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should render an error if the dataView fail to be created correctly', async () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        data: {
+          dataViews: {
+            create: jest.fn().mockReturnValue(undefined),
+            clearInstanceCache: jest.fn(),
+          },
+        },
+      },
+    });
+
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useEffect: jest.fn((f) => f()),
+    }));
+
+    render(
+      <AiForSOCAlertsTable
+        filters={filters}
+        from={from}
+        query={query}
+        rule={ruleResponse}
+        to={to}
+      />
+    );
+
+    expect(await screen.findByTestId(ERROR_TEST_ID)).toHaveTextContent(
+      'Unable to create data view'
+    );
+  });
+
+  it('should render the content', async () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        data: {
+          dataViews: {
+            create: jest
+              .fn()
+              .mockReturnValue({ getIndexPattern: jest.fn(), id: 'id', toSpec: jest.fn() }),
+            clearInstanceCache: jest.fn(),
+          },
+          query: { filterManager: { getFilters: jest.fn() } },
+        },
+      },
+    });
+
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useEffect: jest.fn((f) => f()),
+    }));
+
+    render(
+      <TestProviders>
+        <AiForSOCAlertsTable
+          filters={filters}
+          from={from}
+          query={query}
+          rule={ruleResponse}
+          to={to}
+        />
+      </TestProviders>
+    );
+
+    expect(await screen.findByTestId(CONTENT_TEST_ID)).toBeInTheDocument();
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/ai_for_soc/wrapper.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/ai_for_soc/wrapper.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { memo, useEffect, useMemo, useState } from 'react';
+import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
+import { EuiEmptyPrompt, EuiSkeletonRectangle } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { Filter, Query } from '@kbn/es-query';
+import type { RuleResponse } from '../../../../../../common/api/detection_engine';
+import { Table } from './table';
+import { useFetchIntegrations } from '../../../../../detections/hooks/alert_summary/use_fetch_integrations';
+import { useKibana } from '../../../../../common/lib/kibana';
+
+const DATAVIEW_ERROR = i18n.translate(
+  'xpack.securitySolution.attackDiscovery.aiForSocTableTab.dataViewError',
+  {
+    defaultMessage: 'Unable to create data view',
+  }
+);
+
+export const ERROR_TEST_ID = 'cases-alert-error';
+export const SKELETON_TEST_ID = 'cases-alert-skeleton';
+export const CONTENT_TEST_ID = 'cases-alert-content';
+
+const dataViewSpec: DataViewSpec = { title: '.alerts-security.alerts-default' };
+
+interface AiForSOCAlertsTableProps {
+  /**
+   * Filters passed from the rule details page.
+   * These contain the default filters (alerts, show building block, status and threat match) as well
+   * as the ones from the KQL bar.
+   */
+  filters: Filter[];
+  /**
+   * From value retrieved from the global KQL bar
+   */
+  from: string;
+  /**
+   * Query retrieved from the global KQL bar
+   */
+  query: Query;
+  /**
+   * Result from the useQuery to fetch the rule
+   */
+  rule: RuleResponse;
+  /**
+   * To value retrieved from the global KQL bar
+   */
+  to: string;
+}
+
+/**
+ * Component used in the Cases page under the Alerts tab, only in the AI4DSOC tier.
+ * It fetches rules, packages (integrations) and creates a local dataView.
+ * It renders a loading skeleton while packages are being fetched and while the dataView is being created.
+ */
+export const AiForSOCAlertsTable = memo(
+  ({ filters, from, query, rule, to }: AiForSOCAlertsTableProps) => {
+    const { data } = useKibana().services;
+    const [dataView, setDataView] = useState<DataView | undefined>(undefined);
+    const [dataViewLoading, setDataViewLoading] = useState<boolean>(true);
+
+    // Fetch all integrations
+    const { installedPackages, isLoading: integrationIsLoading } = useFetchIntegrations();
+
+    const ruleResponse = useMemo(
+      () => ({
+        rules: [rule],
+        isLoading: false,
+      }),
+      [rule]
+    );
+
+    useEffect(() => {
+      let dv: DataView;
+      const createDataView = async () => {
+        try {
+          dv = await data.dataViews.create(dataViewSpec);
+          setDataView(dv);
+          setDataViewLoading(false);
+        } catch (err) {
+          setDataViewLoading(false);
+        }
+      };
+      createDataView();
+
+      // clearing after leaving the page
+      return () => {
+        if (dv?.id) {
+          data.dataViews.clearInstanceCache(dv.id);
+        }
+      };
+    }, [data.dataViews]);
+
+    return (
+      <EuiSkeletonRectangle
+        data-test-subj={SKELETON_TEST_ID}
+        height={400}
+        isLoading={integrationIsLoading || dataViewLoading}
+        width="100%"
+      >
+        <>
+          {!dataView || !dataView.id ? (
+            <EuiEmptyPrompt
+              color="danger"
+              data-test-subj={ERROR_TEST_ID}
+              iconType="error"
+              title={<h2>{DATAVIEW_ERROR}</h2>}
+            />
+          ) : (
+            <div data-test-subj={CONTENT_TEST_ID}>
+              <Table
+                dataView={dataView}
+                filters={filters}
+                from={from}
+                packages={installedPackages}
+                query={query}
+                ruleResponse={ruleResponse}
+                to={to}
+              />
+            </div>
+          )}
+        </>
+      </EuiSkeletonRectangle>
+    );
+  }
+);
+
+AiForSOCAlertsTable.displayName = 'AiForSOCAlertsTable';


### PR DESCRIPTION
## Summary

This PR makes modifications to the rules details page when used in AI4DSOC (`searchAiLake` tier). It's a follow up to these recently merged PRs ([this one](https://github.com/elastic/kibana/pull/219111) and [that one](https://github.com/elastic/kibana/pull/219260)).

The PR applies the following changes:
- disables the `Edit rule settings` button as this is not allowed in AI4DSOC. The button was not disabled but clicking on it navigated the user to a `Page not found` page which is not user friendly
- disabled the `Duplicate rule` and `Delete rule` options in the action menu, as these actions should not be allowed in AI4DSOC either
- replaces the content of the `Alerts` tab with the same alerts table we have in the Alert summary page. This prevents users from accessible flyouts like the user/host/network/alerts/event... This change is similar to the ones made in these previous PRs ([this one](https://github.com/elastic/kibana/pull/218742) for Cases and [that one](https://github.com/elastic/kibana/pull/218736) for Attack discovery). A follow up PR will clean all of these table up and merge them into a more reusable one.

https://github.com/user-attachments/assets/38697098-5661-45de-ae33-95a1dee480b4

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
