### PR TITLE
[AI4DSOC] [Attack discovery] Fixes Attack discovery alerts count aggregation

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_find_attack_discovery_alerts_aggregation/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_find_attack_discovery_alerts_aggregation/index.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getFindAttackDiscoveryAlertsAggregation } from '.';
+
+describe('getFindAttackDiscoveryAlertsAggregation', () => {
+  it('returns the expected alert_ids terms aggregation', () => {
+    const result = getFindAttackDiscoveryAlertsAggregation();
+    expect(result.alert_ids).toEqual({
+      terms: {
+        field: 'kibana.alert.attack_discovery.alert_ids',
+        size: 1000,
+      },
+    });
+  });
+
+  it('returns the expected api_config_name terms aggregation', () => {
+    const result = getFindAttackDiscoveryAlertsAggregation();
+    expect(result.api_config_name).toEqual({
+      terms: {
+        field: 'kibana.alert.attack_discovery.api_config.name',
+        size: 100,
+      },
+    });
+  });
+
+  it('returns the expected unique_alert_ids_count sum_bucket aggregation the with correct buckets_path', () => {
+    const result = getFindAttackDiscoveryAlertsAggregation();
+    expect(result.unique_alert_ids_count).toEqual({
+      sum_bucket: {
+        buckets_path: 'alert_ids>_count',
+      },
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_find_attack_discovery_alerts_aggregation/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/get_find_attack_discovery_alerts_aggregation/index.ts
@@ -22,11 +22,13 @@ export const getFindAttackDiscoveryAlertsAggregation = (): Record<
   alert_ids: {
     terms: {
       field: ALERT_ATTACK_DISCOVERY_ALERT_IDS, // kibana.alert.attack_discovery.alert_ids
+      size: 1000, // up to 1000 unique alert IDs
     },
   },
   api_config_name: {
     terms: {
       field: ALERT_ATTACK_DISCOVERY_API_CONFIG_NAME, // kibana.alert.attack_discovery.api_config.name
+      size: 100, // up to 100 unique connector names
     },
   },
   unique_alert_ids_count: {

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/summary_count/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/summary_count/index.test.tsx
@@ -48,4 +48,18 @@ describe('SummaryCount', () => {
 
     expect(lastGenerated).not.toBeInTheDocument();
   });
+
+  it.each([
+    [0, '0 alerts'],
+    [1, '1 alert'],
+    [999, '999 alerts'],
+    [1000, '1000+ alerts'],
+    [1001, '1001+ alerts'],
+  ])('renders the expected alerts text for %p alert(s)', (count, expected) => {
+    render(<SummaryCount {...defaultProps} alertsCount={count} />);
+
+    const alertsCount = screen.getByTestId('alertsCount');
+
+    expect(alertsCount).toHaveTextContent(expected);
+  });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/summary_count/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/summary_count/index.tsx
@@ -11,9 +11,12 @@ import React, { useEffect, useState } from 'react';
 import moment from 'moment';
 
 import { Separator } from '../separator';
-import { ALERTS, DISCOVERIES, LAST_GENERATED } from './translations';
+import { ALERTS, PLUS_ALERTS, DISCOVERIES, LAST_GENERATED } from './translations';
 
 export const EMPTY_LAST_UPDATED_DATE = '--';
+
+/** We don't know the exact count above this threshold */
+const EXACT_COUNT_THRESHOLD = 1000;
 
 interface Props {
   alertsCount: number;
@@ -60,7 +63,7 @@ const SummaryCountComponent: React.FC<Props> = ({
         <Separator />
 
         <EuiFlexItem data-test-subj="alertsCount" grow={false}>
-          {ALERTS(alertsCount)}
+          {alertsCount >= EXACT_COUNT_THRESHOLD ? PLUS_ALERTS(alertsCount) : ALERTS(alertsCount)}
         </EuiFlexItem>
 
         {lastUpdated != null && (

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/summary_count/translations.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/summary/summary_count/translations.ts
@@ -13,6 +13,13 @@ export const ALERTS = (alertsCount: number) =>
     values: { alertsCount },
   });
 
+/** For displaying alert counts where the exact count is unknown */
+export const PLUS_ALERTS = (alertsCount: number) =>
+  i18n.translate('xpack.securitySolution.attackDiscovery.summaryCount.plusAlertsLabel', {
+    defaultMessage: `{alertsCount}+ alerts`,
+    values: { alertsCount },
+  });
+
 export const DISCOVERIES = (attackDiscoveriesCount: number) =>
   i18n.translate('xpack.securitySolution.attackDiscovery.summaryCount.discoveriesLabel', {
     defaultMessage: `{attackDiscoveriesCount} {attackDiscoveriesCount, plural, =1 {discovery} other {discoveries}}`,


### PR DESCRIPTION

### [AI4DSOC] [Attack discovery] Fixes Attack discovery alerts count aggregation

This PR fixes a in issue in [[AI4DSOC] [Attack discovery] Attack discovery alerts #218906](https://github.com/elastic/kibana/pull/218906) where the alerts count aggregation may return a smaller than expected count.

The issue and fix are illustrated by the screenshots below, where the alerts count should be the sum of the unique alerts per attack discovery (for the current search results):

**Before:**

![before](https://github.com/user-attachments/assets/ddc5de97-1015-4718-b134-4072846b4138)

**After:**

![after](https://github.com/user-attachments/assets/1950681c-7393-4668-8bb0-d7bcf395838e)

When the alerts count is greater than 1000, a `+` is appended to the count, as illustrated by the screenshot below:

![plus_alerts](https://github.com/user-attachments/assets/c5ff3c6c-93e9-4423-a372-384b5b0824d0)

#### Feature flags

This feature is effected by the following required, recommended, and optional features flags:

### required: `securitySolution.attackDiscoveryAlertsEnabled`

Enable the required `securitySolution.attackDiscoveryAlertsEnabled` feature flag in `config/kibana.dev.yml`:

```yaml
feature_flags.overrides:
  securitySolution.attackDiscoveryAlertsEnabled: true
```

### recommended: `securitySolution.assistantAttackDiscoverySchedulingEnabled: true`

Also enable the recommended `assistantAttackDiscoverySchedulingEnabled` feature flag in `config/kibana.dev.yml`:

```yaml
feature_flags.overrides:
  securitySolution.attackDiscoveryAlertsEnabled: true
  securitySolution.assistantAttackDiscoverySchedulingEnabled: true
```

### optional

- To (optionally) test in the AI for SOC tier, add the following setting to `config/serverless.security.dev.yaml`:

```yaml
xpack.securitySolutionServerless.productTypes:
[
  { product_line: 'ai_soc', product_tier: 'search_ai_lake' },
]
```


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->