### PR TITLE
[Automatic Import] Remove check for unused Connector role

### DIFF
--- a/x-pack/platform/plugins/shared/automatic_import/server/constants.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/constants.ts
@@ -17,4 +17,3 @@ export enum LogFormat {
 }
 export const FLEET_ALL_ROLE = 'fleet-all' as const;
 export const INTEGRATIONS_ALL_ROLE = 'integrations-all' as const;
-export const ACTIONS_AND_CONNECTORS_ALL_ROLE = 'actions:execute-advanced-connectors' as const;

--- a/x-pack/platform/plugins/shared/automatic_import/server/routes/analyze_api_route.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/routes/analyze_api_route.ts
@@ -10,12 +10,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { ANALYZE_API_PATH, AnalyzeApiRequestBody, AnalyzeApiResponse } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getApiAnalysisGraph } from '../graphs/api_analysis';
 import type { AutomaticImportRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -35,11 +30,7 @@ export function registerApiAnalysisRoutes(router: IRouter<AutomaticImportRouteHa
       },
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_ALL_ROLE,
-            INTEGRATIONS_ALL_ROLE,
-            ACTIONS_AND_CONNECTORS_ALL_ROLE,
-          ],
+          requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
         },
       },
     })

--- a/x-pack/platform/plugins/shared/automatic_import/server/routes/analyze_logs_routes.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/routes/analyze_logs_routes.ts
@@ -10,12 +10,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { ANALYZE_LOGS_PATH, AnalyzeLogsRequestBody, AnalyzeLogsResponse } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getLogFormatDetectionGraph } from '../graphs/log_type_detection/graph';
 import type { AutomaticImportRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -38,11 +33,7 @@ export function registerAnalyzeLogsRoutes(router: IRouter<AutomaticImportRouteHa
       },
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_ALL_ROLE,
-            INTEGRATIONS_ALL_ROLE,
-            ACTIONS_AND_CONNECTORS_ALL_ROLE,
-          ],
+          requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
         },
       },
     })

--- a/x-pack/platform/plugins/shared/automatic_import/server/routes/build_integration_routes.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/routes/build_integration_routes.ts
@@ -14,11 +14,7 @@ import { withAvailability } from './with_availability';
 import { isErrorThatHandlesItsOwnResponse } from '../lib/errors';
 import { handleCustomErrors } from './routes_util';
 import { GenerationErrorCode } from '../../common/constants';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE } from '../constants';
 export function registerIntegrationBuilderRoutes(
   router: IRouter<AutomaticImportRouteHandlerContext>
 ) {
@@ -28,11 +24,7 @@ export function registerIntegrationBuilderRoutes(
       access: 'internal',
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_ALL_ROLE,
-            INTEGRATIONS_ALL_ROLE,
-            ACTIONS_AND_CONNECTORS_ALL_ROLE,
-          ],
+          requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
         },
       },
     })

--- a/x-pack/platform/plugins/shared/automatic_import/server/routes/categorization_routes.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/routes/categorization_routes.ts
@@ -14,12 +14,7 @@ import {
   CategorizationRequestBody,
   CategorizationResponse,
 } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getCategorizationGraph } from '../graphs/categorization';
 import type { AutomaticImportRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -41,11 +36,7 @@ export function registerCategorizationRoutes(router: IRouter<AutomaticImportRout
       },
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_ALL_ROLE,
-            INTEGRATIONS_ALL_ROLE,
-            ACTIONS_AND_CONNECTORS_ALL_ROLE,
-          ],
+          requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
         },
       },
     })

--- a/x-pack/platform/plugins/shared/automatic_import/server/routes/cel_routes.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/routes/cel_routes.ts
@@ -10,12 +10,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { CEL_INPUT_GRAPH_PATH, CelInputRequestBody, CelInputResponse } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getCelGraph } from '../graphs/cel';
 import type { AutomaticImportRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -35,11 +30,7 @@ export function registerCelInputRoutes(router: IRouter<AutomaticImportRouteHandl
       },
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_ALL_ROLE,
-            INTEGRATIONS_ALL_ROLE,
-            ACTIONS_AND_CONNECTORS_ALL_ROLE,
-          ],
+          requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
         },
       },
     })

--- a/x-pack/platform/plugins/shared/automatic_import/server/routes/ecs_routes.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/routes/ecs_routes.ts
@@ -10,12 +10,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { ECS_GRAPH_PATH, EcsMappingRequestBody, EcsMappingResponse } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getEcsGraph } from '../graphs/ecs';
 import type { AutomaticImportRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -37,11 +32,7 @@ export function registerEcsRoutes(router: IRouter<AutomaticImportRouteHandlerCon
       },
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_ALL_ROLE,
-            INTEGRATIONS_ALL_ROLE,
-            ACTIONS_AND_CONNECTORS_ALL_ROLE,
-          ],
+          requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
         },
       },
     })

--- a/x-pack/platform/plugins/shared/automatic_import/server/routes/pipeline_routes.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/routes/pipeline_routes.ts
@@ -7,12 +7,7 @@
 
 import type { IKibanaResponse, IRouter } from '@kbn/core/server';
 import { CheckPipelineRequestBody, CheckPipelineResponse, CHECK_PIPELINE_PATH } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import type { AutomaticImportRouteHandlerContext } from '../plugin';
 import { testPipeline } from '../util/pipeline';
 import { buildRouteValidationWithZod } from '../util/route_validation';
@@ -33,11 +28,7 @@ export function registerPipelineRoutes(router: IRouter<AutomaticImportRouteHandl
       },
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_ALL_ROLE,
-            INTEGRATIONS_ALL_ROLE,
-            ACTIONS_AND_CONNECTORS_ALL_ROLE,
-          ],
+          requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
         },
       },
     })

--- a/x-pack/platform/plugins/shared/automatic_import/server/routes/related_routes.ts
+++ b/x-pack/platform/plugins/shared/automatic_import/server/routes/related_routes.ts
@@ -10,12 +10,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { RELATED_GRAPH_PATH, RelatedRequestBody, RelatedResponse } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getRelatedGraph } from '../graphs/related';
 import type { AutomaticImportRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -37,11 +32,7 @@ export function registerRelatedRoutes(router: IRouter<AutomaticImportRouteHandle
       },
       security: {
         authz: {
-          requiredPrivileges: [
-            FLEET_ALL_ROLE,
-            INTEGRATIONS_ALL_ROLE,
-            ACTIONS_AND_CONNECTORS_ALL_ROLE,
-          ],
+          requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
         },
       },
     })


### PR DESCRIPTION
## Summary

This PR removes some unused ACTION connector capability checks that was removed in https://github.com/elastic/kibana/pull/203503.

The actionClient will do permission checks already as the user when fetching the connector, so removing this while keeping the checks for Fleet/Integration capabilities is fine.

This resolves a bug in 9.x and 8.18.x when visiting the UI or using the API for automatic import will try to resolve an unushed capability.

I manually tested the following on the changed code:
1. Ran one working with elastic superuser.
2. Ran one working with custom users that has connector, integration and fleet role.
3. Ran one that should not work with custom user that does not have connector privileges but has integration and fleet.


This is how it looks like when the connector privileges do not exist for the user:
![image](https://github.com/user-attachments/assets/cade4ccc-bfd5-4583-8ca7-af4920cf85ac)

When calling the API when missing action client connector:
```
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "Unauthorized to get actions"
}
```

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->