### PR TITLE
[8.19] [Lens] fix toEsql test use all-year UTC timezone (#216425)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/to_esql.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/to_esql.test.ts
@@ -282,7 +282,7 @@ describe('to_esql', () => {
     expect(esql).toEqual(undefined);
   });
 
-  it('should work with iana timezones that fall udner utc+0', () => {
+  it('should work with iana timezones that fall under UTC+0', () => {
     uiSettings.get.mockImplementation((key: string) => {
       // There are only few countries that falls under UTC all year round, others just fall into that configuration half hear when not in DST
       if (key === 'dateFormat:tz') return 'Atlantic/Reykjavik';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Lens] fix toEsql test use all-year UTC timezone (#216425)](https://github.com/elastic/kibana/pull/216425)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marco Vettorello","email":"marco.vettorello@elastic.co"},"sourceCommit":{"committedDate":"2025-03-31T09:05:34Z","message":"[Lens] fix toEsql test use all-year UTC timezone (#216425)\n\n## Summary\n\nThe test should verify if a timezone that falls under UTC offset can\ncorrectly transform a formBased lens configuation to an ESQL query.\nUnfortunately the choosen timezone (Europe/London) falls under UTC only\nwhen not in DST.\nI've selected one of the few countries that falls under UTC all year\nround to have this test pass correctly independently on when it is\nexecuted.","sha":"7bea0478312a9284bbf5b606baed1c3de3011cf1","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["test","Team:Visualizations","release_note:skip","backport:skip","v9.1.0"],"title":"[Lens] fix toEsql test use all-year UTC timezone","number":216425,"url":"https://github.com/elastic/kibana/pull/216425","mergeCommit":{"message":"[Lens] fix toEsql test use all-year UTC timezone (#216425)\n\n## Summary\n\nThe test should verify if a timezone that falls under UTC offset can\ncorrectly transform a formBased lens configuation to an ESQL query.\nUnfortunately the choosen timezone (Europe/London) falls under UTC only\nwhen not in DST.\nI've selected one of the few countries that falls under UTC all year\nround to have this test pass correctly independently on when it is\nexecuted.","sha":"7bea0478312a9284bbf5b606baed1c3de3011cf1"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216425","number":216425,"mergeCommit":{"message":"[Lens] fix toEsql test use all-year UTC timezone (#216425)\n\n## Summary\n\nThe test should verify if a timezone that falls under UTC offset can\ncorrectly transform a formBased lens configuation to an ESQL query.\nUnfortunately the choosen timezone (Europe/London) falls under UTC only\nwhen not in DST.\nI've selected one of the few countries that falls under UTC all year\nround to have this test pass correctly independently on when it is\nexecuted.","sha":"7bea0478312a9284bbf5b606baed1c3de3011cf1"}}]}] BACKPORT-->