### PR TITLE
[8.18] [EDR Workflows][Fleet] Disable ATP only on endpoint package updates (#219224)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -1116,14 +1116,15 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     logger.debug(`Bumping revision of associated agent policies ${associatedPolicyIds}`);
     const bumpPromises = [];
     for (const policyId of associatedPolicyIds) {
-      // Check if the agent policy is in both old and updated package policies
+      const isEndpointPolicy = newPolicy.package?.name === 'endpoint';// Check if the agent policy is in both old and updated package policies
       const assignedInOldPolicy = oldPackagePolicy.policy_ids.includes(policyId);
       const assignedInNewPolicy = newPolicy.policy_ids.includes(policyId);
 
       // Remove protection if policy is unassigned (in old but not in updated) or policy is assigned (in updated but not in old)
       const removeProtection =
-        (assignedInOldPolicy && !assignedInNewPolicy) ||
-        (!assignedInOldPolicy && assignedInNewPolicy);
+        isEndpointPolicy &&
+          ((assignedInOldPolicy && !assignedInNewPolicy) ||
+        (!assignedInOldPolicy && assignedInNewPolicy));
 
       bumpPromises.push(
         agentPolicyService.bumpRevision(soClient, esClient, policyId, {

--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -1116,15 +1116,15 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     logger.debug(`Bumping revision of associated agent policies ${associatedPolicyIds}`);
     const bumpPromises = [];
     for (const policyId of associatedPolicyIds) {
-      const isEndpointPolicy = newPolicy.package?.name === 'endpoint';// Check if the agent policy is in both old and updated package policies
+      const isEndpointPolicy = newPolicy.package?.name === 'endpoint'; // Check if the agent policy is in both old and updated package policies
       const assignedInOldPolicy = oldPackagePolicy.policy_ids.includes(policyId);
       const assignedInNewPolicy = newPolicy.policy_ids.includes(policyId);
 
       // Remove protection if policy is unassigned (in old but not in updated) or policy is assigned (in updated but not in old)
       const removeProtection =
         isEndpointPolicy &&
-          ((assignedInOldPolicy && !assignedInNewPolicy) ||
-        (!assignedInOldPolicy && assignedInNewPolicy));
+        ((assignedInOldPolicy && !assignedInNewPolicy) ||
+          (!assignedInOldPolicy && assignedInNewPolicy));
 
       bumpPromises.push(
         agentPolicyService.bumpRevision(soClient, esClient, policyId, {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[EDR Workflows][Fleet] Disable ATP only on endpoint package updates (#219224)](https://github.com/elastic/kibana/pull/219224)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Konrad Szwarc","email":"konrad.szwarc@elastic.co"},"sourceCommit":{"committedDate":"2025-04-28T10:19:51Z","message":"[EDR Workflows][Fleet] Disable ATP only on endpoint package updates (#219224)\n\nThis PR fixes an issue where Agent Tamper Protection could be disabled\nwhen updating integration packages other than Endpoint.\n\nExtended test coverage.\n\n`8.17` backport PR https://github.com/elastic/kibana/pull/219225","sha":"2ff21aa7aab74e88801c60df89ff67007b454a2b","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Fleet","Team:Defend Workflows","ci:all-cypress-suites","backport:version","v8.17.0","v8.18.0","v9.1.0","v8.19.0","v9.0.1"],"title":"[EDR Workflows][Fleet] Disable ATP only on endpoint package updates","number":219224,"url":"https://github.com/elastic/kibana/pull/219224","mergeCommit":{"message":"[EDR Workflows][Fleet] Disable ATP only on endpoint package updates (#219224)\n\nThis PR fixes an issue where Agent Tamper Protection could be disabled\nwhen updating integration packages other than Endpoint.\n\nExtended test coverage.\n\n`8.17` backport PR https://github.com/elastic/kibana/pull/219225","sha":"2ff21aa7aab74e88801c60df89ff67007b454a2b"}},"sourceBranch":"main","suggestedTargetBranches":["8.17","8.18"],"targetPullRequestStates":[{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219224","number":219224,"mergeCommit":{"message":"[EDR Workflows][Fleet] Disable ATP only on endpoint package updates (#219224)\n\nThis PR fixes an issue where Agent Tamper Protection could be disabled\nwhen updating integration packages other than Endpoint.\n\nExtended test coverage.\n\n`8.17` backport PR https://github.com/elastic/kibana/pull/219225","sha":"2ff21aa7aab74e88801c60df89ff67007b454a2b"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/219372","number":219372,"state":"OPEN"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/219368","number":219368,"state":"OPEN"}]}] BACKPORT-->