### PR TITLE
fix(slo): purge data test

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/purge_rollup_data.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/purge_rollup_data.test.ts
@@ -19,6 +19,8 @@ describe('purge rollup data', () => {
   let mockEsClient: jest.Mocked<ElasticsearchClient>;
   let purgeRollupData: BulkPurgeRollupData;
 
+  jest.useFakeTimers().setSystemTime(new Date('2025-04-24'));
+
   beforeEach(() => {
     mockRepository = createSLORepositoryMock();
     mockEsClient = elasticsearchServiceMock.createElasticsearchClient();


### PR DESCRIPTION
## Summary

This PR addresses an issue with date handling that could lead to miscalculations in scenarios involving calendar-based SLOs. 

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->