### PR TITLE
[Security Solution][AI4DSOC] Fix table not applying alert tags for Attack discovery and Cases pages in AI4DSOC

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.tsx
@@ -67,7 +67,6 @@ export interface TableProps {
  * It leverages a lot of configurations and constants from the Alert summary page alerts table, and renders the ResponseOps AlertsTable.
  */
 export const Table = memo(({ dataView, id, packages, query, ruleResponse }: TableProps) => {
-  console.log('//////////////////// rendering Table');
   const {
     services: { application, cases, data, fieldFormats, http, licensing, notifications, settings },
   } = useKibana();

--- a/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/attack_discovery/pages/results/attack_discovery_panel/tabs/alerts_tab/ai_for_soc/table.tsx
@@ -67,6 +67,7 @@ export interface TableProps {
  * It leverages a lot of configurations and constants from the Alert summary page alerts table, and renders the ResponseOps AlertsTable.
  */
 export const Table = memo(({ dataView, id, packages, query, ruleResponse }: TableProps) => {
+  console.log('//////////////////// rendering Table');
   const {
     services: { application, cases, data, fieldFormats, http, licensing, notifications, settings },
   } = useKibana();
@@ -119,6 +120,7 @@ export const Table = memo(({ dataView, id, packages, query, ruleResponse }: Tabl
         gridStyle={GRID_STYLE}
         id={id}
         query={query}
+        ref={refetchRef}
         renderActionsCell={ActionsCell}
         renderCellValue={CellValue}
         rowHeightsOptions={ROW_HEIGHTS_OPTIONS}

--- a/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/cases/components/ai_for_soc/table.tsx
@@ -136,6 +136,7 @@ export const Table = memo(
           id={id}
           onLoaded={onLoaded}
           query={query}
+          ref={refetchRef}
           renderActionsCell={ActionsCell}
           renderCellValue={CellValue}
           rowHeightsOptions={ROW_HEIGHTS_OPTIONS}

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_set_alert_tags.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_set_alert_tags.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useSetAlertTags } from './use_set_alert_tags';
+import { useAppToasts } from '../../../hooks/use_app_toasts';
+
+jest.mock('../../../hooks/use_app_toasts');
+
+describe('useSetAlertTags', () => {
+  it('should return a function', () => {
+    (useAppToasts as jest.Mock).mockReturnValue({
+      addSuccess: jest.fn(),
+      addError: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useSetAlertTags());
+
+    expect(typeof result.current).toEqual('function');
+  });
+});

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_set_alert_tags.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_set_alert_tags.tsx
@@ -5,9 +5,7 @@
  * 2.0.
  */
 
-import type { CoreStart } from '@kbn/core/public';
-import { useKibana } from '@kbn/kibana-react-plugin/public';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AlertTags } from '../../../../../common/api/detection_engine';
 import { useAppToasts } from '../../../hooks/use_app_toasts';
 import * as i18n from './translations';
@@ -33,9 +31,11 @@ export type ReturnSetAlertTags = SetAlertTagsFunc | null;
  * @throws An error if response is not OK
  */
 export const useSetAlertTags = (): ReturnSetAlertTags => {
-  const { http } = useKibana<CoreStart>().services;
   const { addSuccess, addError } = useAppToasts();
-  const setAlertTagsRef = useRef<SetAlertTagsFunc | null>(null);
+
+  const [ignore, setIgnore] = useState<boolean>(false);
+
+  const abortCtrl = useRef<AbortController>(new AbortController());
 
   const onUpdateSuccess = useCallback(
     (updated: number = 0) => addSuccess(i18n.UPDATE_ALERT_TAGS_SUCCESS_TOAST(updated)),
@@ -49,14 +49,11 @@ export const useSetAlertTags = (): ReturnSetAlertTags => {
     [addError]
   );
 
-  useEffect(() => {
-    let ignore = false;
-    const abortCtrl = new AbortController();
-
-    const onSetAlertTags: SetAlertTagsFunc = async (tags, ids, onSuccess, setTableLoading) => {
+  const onSetAlertTags: SetAlertTagsFunc = useCallback(
+    async (tags, ids, onSuccess, setTableLoading) => {
       try {
         setTableLoading(true);
-        const response = await setAlertTags({ tags, ids, signal: abortCtrl.signal });
+        const response = await setAlertTags({ tags, ids, signal: abortCtrl.current.signal });
         if (!ignore) {
           onSuccess();
           setTableLoading(false);
@@ -68,14 +65,17 @@ export const useSetAlertTags = (): ReturnSetAlertTags => {
           onUpdateFailure(error);
         }
       }
-    };
+    },
+    [ignore, onUpdateFailure, onUpdateSuccess]
+  );
 
-    setAlertTagsRef.current = onSetAlertTags;
+  useEffect(() => {
+    const currentAbortCtrl = abortCtrl.current;
     return (): void => {
-      ignore = true;
-      abortCtrl.abort();
+      setIgnore(true);
+      currentAbortCtrl.abort();
     };
-  }, [http, onUpdateFailure, onUpdateSuccess]);
+  }, [abortCtrl]);
 
-  return setAlertTagsRef.current;
+  return onSetAlertTags;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_set_alert_tags.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_set_alert_tags.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { AlertTags } from '../../../../../common/api/detection_engine';
 import { useAppToasts } from '../../../hooks/use_app_toasts';
 import * as i18n from './translations';
@@ -33,8 +33,6 @@ export type ReturnSetAlertTags = SetAlertTagsFunc | null;
 export const useSetAlertTags = (): ReturnSetAlertTags => {
   const { addSuccess, addError } = useAppToasts();
 
-  const [ignore, setIgnore] = useState<boolean>(false);
-
   const abortCtrl = useRef<AbortController>(new AbortController());
 
   const onUpdateSuccess = useCallback(
@@ -54,25 +52,20 @@ export const useSetAlertTags = (): ReturnSetAlertTags => {
       try {
         setTableLoading(true);
         const response = await setAlertTags({ tags, ids, signal: abortCtrl.current.signal });
-        if (!ignore) {
-          onSuccess();
-          setTableLoading(false);
-          onUpdateSuccess(response.updated);
-        }
+        onSuccess();
+        setTableLoading(false);
+        onUpdateSuccess(response.updated);
       } catch (error) {
-        if (!ignore) {
-          setTableLoading(false);
-          onUpdateFailure(error);
-        }
+        setTableLoading(false);
+        onUpdateFailure(error);
       }
     },
-    [ignore, onUpdateFailure, onUpdateSuccess]
+    [onUpdateFailure, onUpdateSuccess]
   );
 
   useEffect(() => {
     const currentAbortCtrl = abortCtrl.current;
     return (): void => {
-      setIgnore(true);
       currentAbortCtrl.abort();
     };
   }, [abortCtrl]);


### PR DESCRIPTION
## Summary

This PR fixes an issue with the `apply alert tags` functionality. This [setAlertTags](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_set_alert_tags.tsx) hook introduced in [this PR](https://github.com/elastic/kibana/pull/157786) was making use of a `useRef` and a `useCallback` which lead to the table having a `null` reference when it was expecting a `function`.

This meant that for parent table components that were written efficiently (meaning that do not render too many times), the set alert tags bulk actions was just plain not working. As can be seen in the following video:

https://github.com/user-attachments/assets/50545677-d7a7-4d45-828e-89bdd7b2de34

And this is with the fix in this PR 

https://github.com/user-attachments/assets/b1f07e55-43bb-4d01-bfd9-3b0dd23e30cc

The PR also makes 2 very small adjustments to the AI4DSOC alerts table in the Cases and Attack discovery pages, to make sure that the table refreshes after applying alert tags.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
