### PR TITLE
[8.18] chore(deps): bump `formidable` from to 3.5.1 to 3.5.4 (#219385)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19721,12 +19721,12 @@ formdata-polyfill@^4.0.10:
     fetch-blob "^3.1.2"
 
 formidable@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-3.5.1.tgz#9360a23a656f261207868b1484624c4c8d06ee1a"
-  integrity sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-3.5.4.tgz#ac9a593b951e829b3298f21aa9a2243932f32ed9"
+  integrity sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==
   dependencies:
+    "@paralleldrive/cuid2" "^2.2.2"
     dezalgo "^1.0.4"
-    hexoid "^1.0.0"
     once "^1.4.0"
 
 formik@^2.4.6:
@@ -20868,11 +20868,6 @@ headers-polyfill@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-4.0.3.tgz#922a0155de30ecc1f785bcf04be77844ca95ad07"
   integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
-
-hexoid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
-  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 history@^4.9.0:
   version "4.9.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [chore(deps): bump `formidable` from to 3.5.2 to 3.5.4 (#219385)](https://github.com/elastic/kibana/pull/219385)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2025-04-28T14:41:26Z","message":"chore(deps): bump `formidable` from to 3.5.2 to 3.5.4 (#219385)\n\n## Summary\n\nBump `formidable` from to 3.5.2 to 3.5.4.","sha":"ce94d8acc8ae167cd70aa4c6ee5fd00bd9055e6c","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","dependencies","backport:all-open","v9.1.0"],"title":"chore(deps): bump `formidable` from to 3.5.2 to 3.5.4","number":219385,"url":"https://github.com/elastic/kibana/pull/219385","mergeCommit":{"message":"chore(deps): bump `formidable` from to 3.5.2 to 3.5.4 (#219385)\n\n## Summary\n\nBump `formidable` from to 3.5.2 to 3.5.4.","sha":"ce94d8acc8ae167cd70aa4c6ee5fd00bd9055e6c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219385","number":219385,"mergeCommit":{"message":"chore(deps): bump `formidable` from to 3.5.2 to 3.5.4 (#219385)\n\n## Summary\n\nBump `formidable` from to 3.5.2 to 3.5.4.","sha":"ce94d8acc8ae167cd70aa4c6ee5fd00bd9055e6c"}},{"url":"https://github.com/elastic/kibana/pull/219413","number":219413,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->