### PR TITLE
[7.17] chore(deps): bump `formidable` from to 2.1.2 to 2.1.3 (#219385)

### DIFF
--- a/package.json
+++ b/package.json
@@ -452,7 +452,7 @@
     "@jest/reporters": "^29.6.1",
     "@jest/transform": "^29.6.1",
     "@jest/types": "^29.6.1",
-    "@kayahr/text-encoding": "^2.0.0",
+    "@kayahr/text-encoding": "^1.3.0",
     "@kbn/babel-code-parser": "link:bazel-bin/packages/kbn-babel-code-parser",
     "@kbn/babel-preset": "link:bazel-bin/packages/kbn-babel-preset",
     "@kbn/babel-register": "link:bazel-bin/packages/kbn-babel-register",

--- a/package.json
+++ b/package.json
@@ -452,6 +452,7 @@
     "@jest/reporters": "^29.6.1",
     "@jest/transform": "^29.6.1",
     "@jest/types": "^29.6.1",
+    "@kayahr/text-encoding": "^2.0.0",
     "@kbn/babel-code-parser": "link:bazel-bin/packages/kbn-babel-code-parser",
     "@kbn/babel-preset": "link:bazel-bin/packages/kbn-babel-preset",
     "@kbn/babel-register": "link:bazel-bin/packages/kbn-babel-register",

--- a/packages/kbn-test/src/jest/setup/polyfills.jsdom.js
+++ b/packages/kbn-test/src/jest/setup/polyfills.jsdom.js
@@ -24,6 +24,7 @@ if (!global.URL.hasOwnProperty('createObjectURL')) {
 
 // https://github.com/jsdom/jsdom/issues/2524
 if (!Object.hasOwn(global, 'TextEncoder')) {
+  // eslint-disable-next-line import/no-unresolved
   const customTextEncoding = require('@kayahr/text-encoding');
   global.TextEncoder = customTextEncoding.TextEncoder;
   global.TextDecoder = customTextEncoding.TextDecoder;

--- a/packages/kbn-test/src/jest/setup/polyfills.jsdom.js
+++ b/packages/kbn-test/src/jest/setup/polyfills.jsdom.js
@@ -22,6 +22,13 @@ if (!global.URL.hasOwnProperty('createObjectURL')) {
   Object.defineProperty(global.URL, 'createObjectURL', { value: () => '' });
 }
 
+// https://github.com/jsdom/jsdom/issues/2524
+if (!Object.hasOwn(global, 'TextEncoder')) {
+  const customTextEncoding = require('@kayahr/text-encoding');
+  global.TextEncoder = customTextEncoding.TextEncoder;
+  global.TextDecoder = customTextEncoding.TextDecoder;
+}
+
 // Will be replaced with a better solution in EUI
 // https://github.com/elastic/eui/issues/3713
 global._isJest = true;

--- a/x-pack/plugins/ml/common/util/es_utils.test.ts
+++ b/x-pack/plugins/ml/common/util/es_utils.test.ts
@@ -52,7 +52,6 @@ describe('Util: isValidIndexName()', () => {
     expect(isValidIndexName('a'.repeat(255))).toBe(true);
     expect(isValidIndexName('a'.repeat(256))).toBe(false);
     // multi-byte character test
-    // because jest doesn't have TextEncoder this will still be true
-    expect(isValidIndexName('あ'.repeat(255))).toBe(true);
+    expect(isValidIndexName('あ'.repeat(255))).toBe(false);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3487,6 +3487,11 @@
   dependencies:
     eslint-scope "5.1.1"
 
+"@noble/hashes@^1.1.5":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -3824,6 +3829,13 @@
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.1.tgz#3d745996b2bd11095b515515fd3d68d46092a02d"
   integrity sha512-n8Kur1/CZlYG32YCEj30CoUqA8R7UyDVZzoEU6SDP+13+kXDT2kFVu6MpcnEUTyGP3i058ID6Qjp5h6IJxdPPQ==
+
+"@paralleldrive/cuid2@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz#7f91364d53b89e2c9cb9e02e8dd0f129e834455f"
+  integrity sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==
+  dependencies:
+    "@noble/hashes" "^1.1.5"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -13828,12 +13840,12 @@ formdata-polyfill@^4.0.10:
     fetch-blob "^3.1.2"
 
 formidable@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.1.2.tgz#fa973a2bec150e4ce7cac15589d7a25fc30ebd89"
-  integrity sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.1.3.tgz#83aefd6464bf1447bcd5deabc9c059ed45d6e011"
+  integrity sha512-vDI5JjeALeGXpyL8v71ZG2VgHY5zD6qg1IvypU7aJCYvREZyhawrYJxMdsWO+m5DIGLiMiDH71yEN8RO4wQAMQ==
   dependencies:
+    "@paralleldrive/cuid2" "^2.2.2"
     dezalgo "^1.0.4"
-    hexoid "^1.0.0"
     once "^1.4.0"
     qs "^6.11.0"
 
@@ -15021,11 +15033,6 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-hexoid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
-  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 highlight.js@^10.1.1, highlight.js@~10.4.0:
   version "10.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2864,6 +2864,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kayahr/text-encoding@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@kayahr/text-encoding/-/text-encoding-2.0.0.tgz#637361c318048c4e7419364990d59b155eaa98bc"
+  integrity sha512-BCKXxcPHXJhgisp+SohA3MvoOQ/Kec1QEjo3LVH0lh4eFPEF9kGsGsn3GYaTdgFBRc2YkgDhND/39t+3oqU7Yw==
+
 "@kbn/ace@link:bazel-bin/packages/kbn-ace":
   version "0.0.0"
   uid ""

--- a/yarn.lock
+++ b/yarn.lock
@@ -2864,10 +2864,12 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@kayahr/text-encoding@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@kayahr/text-encoding/-/text-encoding-2.0.0.tgz#637361c318048c4e7419364990d59b155eaa98bc"
-  integrity sha512-BCKXxcPHXJhgisp+SohA3MvoOQ/Kec1QEjo3LVH0lh4eFPEF9kGsGsn3GYaTdgFBRc2YkgDhND/39t+3oqU7Yw==
+"@kayahr/text-encoding@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@kayahr/text-encoding/-/text-encoding-1.3.0.tgz#90ae1007dc86d35a977cd709dfa9fe21cc2bc8c6"
+  integrity sha512-JjQVFXnN/ynXN+GDgpwNM+PJ4NwDFZwRolgSu4bYG1JKuRreVFY5uss5K/lsH6qY38+WgU7M40M2SHoiWQHKgQ==
+  dependencies:
+    tslib "^2.6.2"
 
 "@kbn/ace@link:bazel-bin/packages/kbn-ace":
   version "0.0.0"
@@ -26136,10 +26138,10 @@ tslib@^1.0.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.5.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.5.0, tslib@^2.6.2:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@~2.3.1:
   version "2.3.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [chore(deps): bump `formidable` from to 3.5.2 to 3.5.4 (#219385)](https://github.com/elastic/kibana/pull/219385)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2025-04-28T14:41:26Z","message":"chore(deps): bump `formidable` from to 3.5.2 to 3.5.4 (#219385)\n\n## Summary\n\nBump `formidable` from to 3.5.2 to 3.5.4.","sha":"ce94d8acc8ae167cd70aa4c6ee5fd00bd9055e6c","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","dependencies","backport:all-open","v9.1.0"],"title":"chore(deps): bump `formidable` from to 3.5.2 to 3.5.4","number":219385,"url":"https://github.com/elastic/kibana/pull/219385","mergeCommit":{"message":"chore(deps): bump `formidable` from to 3.5.2 to 3.5.4 (#219385)\n\n## Summary\n\nBump `formidable` from to 3.5.2 to 3.5.4.","sha":"ce94d8acc8ae167cd70aa4c6ee5fd00bd9055e6c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219385","number":219385,"mergeCommit":{"message":"chore(deps): bump `formidable` from to 3.5.2 to 3.5.4 (#219385)\n\n## Summary\n\nBump `formidable` from to 3.5.2 to 3.5.4.","sha":"ce94d8acc8ae167cd70aa4c6ee5fd00bd9055e6c"}},{"url":"https://github.com/elastic/kibana/pull/219413","number":219413,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->