### PR TITLE
[Siem Migrations] Fix capability required for Siem Migrations Topic

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/onboarding/config.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/onboarding/config.ts
@@ -29,6 +29,6 @@ export const onboardingConfig: TopicConfig[] = [
     }),
     body: siemMigrationsBodyConfig,
     disabledExperimentalFlagRequired: 'siemMigrationsDisabled',
-    capabilitiesRequired: `${SECURITY_FEATURE_ID}.advancedInsights`,
+    capabilitiesRequired: `${SECURITY_FEATURE_ID}.detections`,
   },
 ];


### PR DESCRIPTION
## Summary

PR #218122 mistakenly removes the SIEM Migration `capabilitiesRequired` config. This PR adds it back.