### PR TITLE
[AI4DSOC] Fix logic that renders the group title when grouping by integrations

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_get_integration_from_rule_id.test.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_get_integration_from_rule_id.test.ts
@@ -26,6 +26,30 @@ describe('useGetIntegrationFromRuleId', () => {
     expect(result.current.integration).toBe(undefined);
   });
 
+  it('should return undefined integration when the rule does not have the expected related_integrations', () => {
+    const packages: PackageListItem[] = [
+      {
+        id: 'splunk',
+        icons: [{ src: 'icon.svg', path: 'mypath/icon.svg', type: 'image/svg+xml' }],
+        name: 'splunk',
+        status: installationStatuses.NotInstalled,
+        title: 'Splunk',
+        version: '0.1.0',
+      },
+    ];
+    const ruleId = 'rule_id';
+    const rules: RuleResponse[] = [
+      {
+        id: 'rule_id',
+        related_integrations: [{ package: 'wrong_integrations' }],
+      } as RuleResponse,
+    ];
+
+    const { result } = renderHook(() => useGetIntegrationFromRuleId({ packages, ruleId, rules }));
+
+    expect(result.current.integration).toBe(undefined);
+  });
+
   it('should render a matching integration', () => {
     const packages: PackageListItem[] = [
       {
@@ -38,7 +62,12 @@ describe('useGetIntegrationFromRuleId', () => {
       },
     ];
     const ruleId = 'rule_id';
-    const rules: RuleResponse[] = [{ id: 'rule_id', name: 'splunk' } as RuleResponse];
+    const rules: RuleResponse[] = [
+      {
+        id: 'rule_id',
+        related_integrations: [{ package: 'splunk' }],
+      } as RuleResponse,
+    ];
 
     const { result } = renderHook(() => useGetIntegrationFromRuleId({ packages, ruleId, rules }));
 

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_get_integration_from_rule_id.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_get_integration_from_rule_id.ts
@@ -51,7 +51,7 @@ export const useGetIntegrationFromRuleId = ({
       return undefined;
     }
 
-    return packages.find((p) => p.name === rule.name);
+    return packages.find((p) => rule.related_integrations.map((ri) => ri.package).includes(p.name));
   }, [packages, rules, ruleId]);
 
   return useMemo(


### PR DESCRIPTION
## Summary

This PR makes a small changes to the logic originally introduced in [this PR](https://github.com/elastic/kibana/pull/216744). Previously we were expecting the rule to have its name being identical to the name of the integration it would be installed along with. This was a bad assumption. Instead we should look at the `related_integrations` field of the rule and check that it has the package (integration) name that we expect.

This is a more robust solution, and this logic is actually already being use in [this other hook](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_integrations.ts#L75), so it seems that it was an oversight on my end...

If the rule name is not identical, the UI falls back to rendering the id of the rule
![Screenshot 2025-04-28 at 11 28 27 AM](https://github.com/user-attachments/assets/2d99cf37-b648-466a-aa9e-97132b0a8c59)

But with this change, this is how the UI will look
![Screenshot 2025-04-28 at 10 54 22 AM](https://github.com/user-attachments/assets/7bb1f77d-0c83-4fae-9ce2-0a082ebb5ac1)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

Relates to https://github.com/elastic/security-team/issues/11973