### PR TITLE
[AI4DSOC] Alert summary table truncates long values and display the field/value pair in tooltip

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/basic_cell_renderer.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/basic_cell_renderer.test.tsx
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type { Alert } from '@kbn/alerting-types';
-import { BasicCellRenderer } from './basic_cell_renderer';
+import { BASIC_CELL_RENDERER_TRUNCATE_TEST_ID, BasicCellRenderer } from './basic_cell_renderer';
 import { TestProviders } from '../../../../common/mock';
 import { getEmptyValue } from '../../../../common/components/empty_value';
 
@@ -130,5 +130,25 @@ describe('BasicCellRenderer', () => {
     );
 
     expect(getByText('[object Object]')).toBeInTheDocument();
+  });
+
+  it('should truncate long values and show tooltip', async () => {
+    const alert: Alert = {
+      _id: '_id',
+      _index: '_index',
+      field1: 'value1',
+    };
+    const field = 'field1';
+
+    render(
+      <TestProviders>
+        <BasicCellRenderer alert={alert} field={field} />
+      </TestProviders>
+    );
+
+    const cell = screen.getByTestId(BASIC_CELL_RENDERER_TRUNCATE_TEST_ID);
+
+    expect(cell).toBeInTheDocument();
+    expect(cell.firstChild).toHaveClass('euiToolTipAnchor');
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/basic_cell_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/table/basic_cell_renderer.tsx
@@ -7,8 +7,13 @@
 
 import React, { memo, useMemo } from 'react';
 import type { Alert } from '@kbn/alerting-types';
+import { EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { getOrEmptyTagFromValue } from '../../../../common/components/empty_value';
+import { TruncatableText } from '../../../../common/components/truncatable_text';
 import { getAlertFieldValueAsStringOrNull } from '../../../utils/type_utils';
+
+export const BASIC_CELL_RENDERER_TRUNCATE_TEST_ID =
+  'alert-summary-table-basic-call-rendered-truncate';
 
 export interface BasicCellRendererProps {
   /**
@@ -31,7 +36,25 @@ export const BasicCellRenderer = memo(({ alert, field }: BasicCellRendererProps)
     [alert, field]
   );
 
-  return <>{getOrEmptyTagFromValue(displayValue)}</>;
+  return (
+    <TruncatableText dataTestSubj={BASIC_CELL_RENDERER_TRUNCATE_TEST_ID}>
+      <EuiToolTip
+        position="bottom"
+        content={
+          <EuiFlexGroup direction="column" gutterSize="none">
+            <EuiFlexItem grow={false}>
+              <span>{field}</span>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <span>{displayValue}</span>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+      >
+        <span>{getOrEmptyTagFromValue(displayValue)}</span>
+      </EuiToolTip>
+    </TruncatableText>
+  );
 });
 
 BasicCellRenderer.displayName = 'BasicCellRenderer';


### PR DESCRIPTION
## Summary

This PR fixes a small rendering issue in the AI4DSOC alert summary alerts table (those changes will also be automatically applied to the alerts table in the Cases and Attack discovery pages also for AI4DSOC). The basic cell renderer (which renders all values outside of a couple of selected custom renderers we have) was not truncating values, which sometimes lead to weird renders, as seen in the video below.

https://github.com/user-attachments/assets/efcca0b7-5f0e-46d6-be85-85a9e824835c

This PR reuses the same logic used today in the Alerts page alerts table: it truncates the values and show the field and value pairs in a tooltip.

https://github.com/user-attachments/assets/3941ba38-1ecc-49d9-9989-20015f219677

## How to test

This needs to be ran in Serverless:
- `yarn es serverless --projectType security`
- `yarn serverless-security --no-base-path`

You also need to enable the AI for SOC tier, by adding the following to your `serverless.security.dev.yaml` file:
```
xpack.securitySolutionServerless.productTypes:
  [
    { product_line: 'ai_soc', product_tier: 'search_ai_lake' },
  ]
```

Use one of these Serverless users:
- `platform_engineer`
- `endpoint_operations_analyst`
- `endpoint_policy_manager`
- `admin`
- `system_indices_superuser`

Then:
- generate data: `yarn test:generate:serverless-dev`
- create 4 catch all rules, each with a name of a AI for SOC integration (`google_secops`, `microsoft_sentinel`,, `sentinel_one` and `crowdstrike`) => to do that you'll need to temporary comment the `serverless.security.dev.yaml` config changes as the rules page is not accessible in AI for SOC.
-  change [this line](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alert_summary/use_fetch_integrations.ts#L73) to `installedPackages: availablePackages` to force having some packages installed

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

Relates to https://github.com/elastic/security-team/issues/11973