### PR TITLE
[9.0] [Console] Fix output when HTTP request to server fails (#219073)

### DIFF
--- a/src/platform/plugins/shared/console/public/application/hooks/use_send_current_request/send_request.ts
+++ b/src/platform/plugins/shared/console/public/application/hooks/use_send_current_request/send_request.ts
@@ -158,14 +158,14 @@ export function sendRequest(args: RequestArgs): Promise<RequestResult[]> {
         }
       } catch (error) {
         let value;
-        const { response, body } = error as IHttpFetchError;
+        const { response, body: errorBody } = error as IHttpFetchError;
 
         const { statusCode, statusText } = extractStatusCodeAndText(response, path);
 
-        if (statusCode === 200 && !body) {
+        if (statusCode === 200 && !errorBody) {
           value = 'OK';
-        } else if (body) {
-          value = JSON.stringify(body, null, 2);
+        } else if (errorBody) {
+          value = JSON.stringify(errorBody, null, 2);
         } else {
           value = 'Request failed to get to the server (status code: ' + statusCode + ')';
         }

--- a/test/functional/apps/console/_console.ts
+++ b/test/functional/apps/console/_console.ts
@@ -284,5 +284,25 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(actualResponse).to.contain('OK');
       });
     });
+
+    it('Shows error body if HTTP request to server fails', async () => {
+      await PageObjects.console.clearEditorText();
+
+      // This request will return 200 but with an empty body
+      await PageObjects.console.enterText(
+        'POST kbn:/api/alerting/rule/3603c386-9102-4c74-800d-2242e52bec98\n' +
+          '{\n' +
+          '  "name": "Alert on status change",\n' +
+          '  "rule_type_id": ".es-querya"\n' +
+          '}'
+      );
+      await PageObjects.console.clickPlay();
+
+      await retry.try(async () => {
+        const actualResponse = await PageObjects.console.getOutputText();
+        log.debug(actualResponse);
+        expect(actualResponse).to.contain('"statusCode": 400');
+      });
+    });
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Console] Fix output when HTTP request to server fails (#219073)](https://github.com/elastic/kibana/pull/219073)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Stoeva","email":"59341489+ElenaStoeva@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-25T17:09:09Z","message":"[Console] Fix output when HTTP request to server fails (#219073)\n\nFollow-up to\nhttps://github.com/elastic/kibana/pull/218104#issuecomment-2824757130\n\n## Summary\n\nThis PR fixes the Console output when the HTTP request to the server\nfails with a non-empty error body. In\nhttps://github.com/elastic/kibana/pull/218104, we incorrectly set the\noutput to be `Request failed to get to the server (status code: ' +\nstatusCode + ')` even if there is an error body. In this PR, we make\nsure to display the error body if it's non-empty.\n\n**How to test:**\n\nSend a request that fails and verify that the error body is displayed:\n\n```\nPOST kbn:/api/alerting/rule/3603c386-9102-4c74-800d-2242e52bec98\n{\n  \"name\": \"Alert on status change\",\n  \"rule_type_id\": \".es-querya\"\n}\n```\n<img width=\"1160\" alt=\"Screenshot 2025-04-24 at 14 41 57\"\nsrc=\"https://github.com/user-attachments/assets/ced78171-4924-477f-ba2f-d5812bff1678\"\n/>","sha":"cb0acc16ee85e4dccc67dcb69dbbba3f328accad","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Console","Team:Kibana Management","release_note:skip","backport:prev-minor","v9.1.0","v8.19.0","v8.18.1","v9.0.1"],"title":"[Console] Fix output when HTTP request to server fails","number":219073,"url":"https://github.com/elastic/kibana/pull/219073","mergeCommit":{"message":"[Console] Fix output when HTTP request to server fails (#219073)\n\nFollow-up to\nhttps://github.com/elastic/kibana/pull/218104#issuecomment-2824757130\n\n## Summary\n\nThis PR fixes the Console output when the HTTP request to the server\nfails with a non-empty error body. In\nhttps://github.com/elastic/kibana/pull/218104, we incorrectly set the\noutput to be `Request failed to get to the server (status code: ' +\nstatusCode + ')` even if there is an error body. In this PR, we make\nsure to display the error body if it's non-empty.\n\n**How to test:**\n\nSend a request that fails and verify that the error body is displayed:\n\n```\nPOST kbn:/api/alerting/rule/3603c386-9102-4c74-800d-2242e52bec98\n{\n  \"name\": \"Alert on status change\",\n  \"rule_type_id\": \".es-querya\"\n}\n```\n<img width=\"1160\" alt=\"Screenshot 2025-04-24 at 14 41 57\"\nsrc=\"https://github.com/user-attachments/assets/ced78171-4924-477f-ba2f-d5812bff1678\"\n/>","sha":"cb0acc16ee85e4dccc67dcb69dbbba3f328accad"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219073","number":219073,"mergeCommit":{"message":"[Console] Fix output when HTTP request to server fails (#219073)\n\nFollow-up to\nhttps://github.com/elastic/kibana/pull/218104#issuecomment-2824757130\n\n## Summary\n\nThis PR fixes the Console output when the HTTP request to the server\nfails with a non-empty error body. In\nhttps://github.com/elastic/kibana/pull/218104, we incorrectly set the\noutput to be `Request failed to get to the server (status code: ' +\nstatusCode + ')` even if there is an error body. In this PR, we make\nsure to display the error body if it's non-empty.\n\n**How to test:**\n\nSend a request that fails and verify that the error body is displayed:\n\n```\nPOST kbn:/api/alerting/rule/3603c386-9102-4c74-800d-2242e52bec98\n{\n  \"name\": \"Alert on status change\",\n  \"rule_type_id\": \".es-querya\"\n}\n```\n<img width=\"1160\" alt=\"Screenshot 2025-04-24 at 14 41 57\"\nsrc=\"https://github.com/user-attachments/assets/ced78171-4924-477f-ba2f-d5812bff1678\"\n/>","sha":"cb0acc16ee85e4dccc67dcb69dbbba3f328accad"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/219295","number":219295,"state":"MERGED","mergeCommit":{"sha":"cd3c92728e0e6792a2dcf8a39b3d8bf71589c929","message":"[8.19] [Console] Fix output when HTTP request to server fails (#219073) (#219295)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Console] Fix output when HTTP request to server fails\n(#219073)](https://github.com/elastic/kibana/pull/219073)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Elena Stoeva <59341489+ElenaStoeva@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->