### PR TITLE
[8.18] [Cloud Security] Remove check for latest agent available version in AgentlessDeploymentUpgrade task (#215248)

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.test.ts
@@ -531,12 +531,10 @@ describe('Agentless Agent service', () => {
         },
       },
     } as any);
+    jest.spyOn(appContextService, 'getKibanaVersion').mockReturnValue('8.18.0');
     jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isCloudEnabled: true } as any);
 
-    await agentlessAgentService.upgradeAgentlessDeployment(
-      'mocked-agentless-agent-policy-id',
-      '8.17.0'
-    );
+    await agentlessAgentService.upgradeAgentlessDeployment('mocked-agentless-agent-policy-id');
 
     expect(axios).toHaveBeenCalledTimes(1);
 
@@ -546,7 +544,7 @@ describe('Agentless Agent service', () => {
         httpsAgent: expect.anything(),
         method: 'PUT',
         data: {
-          stack_version: '8.17.0',
+          stack_version: '8.18.0',
         },
         url: 'http://api.agentless.com/api/v1/ess/deployments/mocked-agentless-agent-policy-id',
       })

--- a/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agents/agentless_agent.ts
@@ -211,10 +211,11 @@ class AgentlessAgentService {
     return response;
   }
 
-  public async upgradeAgentlessDeployment(policyId: string, version: string) {
+  public async upgradeAgentlessDeployment(policyId: string) {
     const logger = appContextService.getLogger();
     const traceId = apm.currentTransaction?.traceparent;
     const agentlessConfig = appContextService.getConfig()?.agentless;
+    const kibanaVersion = appContextService.getKibanaVersion();
     const tlsConfig = this.createTlsConfig(agentlessConfig);
     const urlEndpoint = prependAgentlessApiBasePathToEndpoint(
       agentlessConfig,
@@ -227,7 +228,7 @@ class AgentlessAgentService {
       url: prependAgentlessApiBasePathToEndpoint(agentlessConfig, `/deployments/${policyId}`),
       method: 'PUT',
       data: {
-        stack_version: version,
+        stack_version: kibanaVersion,
       },
       ...this.getHeaders(tlsConfig, traceId),
     };

--- a/x-pack/platform/plugins/shared/fleet/server/tasks/upgrade_agentless_deployment.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/tasks/upgrade_agentless_deployment.test.ts
@@ -18,7 +18,7 @@ import type { AgentPolicy } from '../types';
 
 import { agentlessAgentService } from '../services/agents/agentless_agent';
 
-import { getAgentsByKuery, getLatestAvailableAgentVersion } from '../services/agents';
+import { getAgentsByKuery } from '../services/agents';
 
 import {
   UPGRADE_AGENT_DEPLOYMENTS_TASK_VERSION,
@@ -170,7 +170,6 @@ describe('Upgrade Agentless Deployments', () => {
       },
     ];
     const mockedGetAgentsByKuery = getAgentsByKuery as jest.Mock;
-    const mockedGetLatestAvailableAgentVersion = getLatestAvailableAgentVersion as jest.Mock;
 
     beforeEach(() => {
       mockAgentPolicyService.fetchAllAgentPolicies = getMockAgentPolicyFetchAllAgentPolicies([
@@ -183,8 +182,6 @@ describe('Upgrade Agentless Deployments', () => {
       mockedGetAgentsByKuery.mockResolvedValue({
         agents,
       });
-
-      mockedGetLatestAvailableAgentVersion.mockResolvedValue('8.17.0');
 
       jest
         .spyOn(agentlessAgentService, 'upgradeAgentlessDeployment')
@@ -202,27 +199,7 @@ describe('Upgrade Agentless Deployments', () => {
       expect(agentlessAgentService.upgradeAgentlessDeployment).toHaveBeenCalled();
     });
 
-    it('should not upgrade agentless deployments when the latest version is up to date', async () => {
-      mockedGetAgentsByKuery.mockResolvedValue({
-        agents: [
-          {
-            id: 'agent-1',
-            policy_id: '93c46720-c217-11ea-9906-b5b8a21b268e',
-            status: 'online',
-            agent: {
-              version: '8.17.0',
-            },
-          },
-        ],
-      });
-      await runTask();
-
-      expect(mockAgentPolicyService.fetchAllAgentPolicies).toHaveBeenCalled();
-      expect(agentlessAgentService.upgradeAgentlessDeployment).not.toHaveBeenCalled();
-    });
-
     it('should not upgrade agentless deployments when agent status is updating', async () => {
-      mockedGetLatestAvailableAgentVersion.mockResolvedValue('8.17.1');
       mockedGetAgentsByKuery.mockResolvedValue({
         agents: [
           {
@@ -242,7 +219,6 @@ describe('Upgrade Agentless Deployments', () => {
     });
 
     it('should not upgrade agentless deployments when agent status is unhealthy', async () => {
-      mockedGetLatestAvailableAgentVersion.mockResolvedValue('8.17.1');
       mockedGetAgentsByKuery.mockResolvedValue({
         agents: [
           {
@@ -262,7 +238,6 @@ describe('Upgrade Agentless Deployments', () => {
     });
 
     it('should upgrade agentless deployments when agent status is online', async () => {
-      mockedGetLatestAvailableAgentVersion.mockResolvedValue('8.17.1');
       mockedGetAgentsByKuery.mockResolvedValue({
         agents: [
           {
@@ -282,7 +257,6 @@ describe('Upgrade Agentless Deployments', () => {
     });
 
     it('should not upgrade agentless deployments when agent status is unenroll', async () => {
-      mockedGetLatestAvailableAgentVersion.mockResolvedValue('8.17.1');
       mockedGetAgentsByKuery.mockResolvedValue({
         agents: [
           {
@@ -299,46 +273,6 @@ describe('Upgrade Agentless Deployments', () => {
 
       expect(mockAgentPolicyService.fetchAllAgentPolicies).toHaveBeenCalled();
       expect(agentlessAgentService.upgradeAgentlessDeployment).not.toHaveBeenCalled();
-    });
-
-    it('should upgrade agentless deployments when agent for target bg task release', async () => {
-      mockedGetLatestAvailableAgentVersion.mockResolvedValue('8.18.1');
-      mockedGetAgentsByKuery.mockResolvedValue({
-        agents: [
-          {
-            id: 'agent-1',
-            policy_id: '93c46720-c217-11ea-9906-b5b8a21b268e',
-            status: 'online',
-            agent: {
-              version: '8.18.0',
-            },
-          },
-        ],
-      });
-      await runTask();
-
-      expect(mockAgentPolicyService.fetchAllAgentPolicies).toHaveBeenCalled();
-      expect(agentlessAgentService.upgradeAgentlessDeployment).toHaveBeenCalled();
-    });
-
-    it('should upgrade agentless deployments when agent version is up to date', async () => {
-      mockedGetLatestAvailableAgentVersion.mockResolvedValue('8.17.1');
-      mockedGetAgentsByKuery.mockResolvedValue({
-        agents: [
-          {
-            id: 'agent-1',
-            policy_id: '93c46720-c217-11ea-9906-b5b8a21b268e',
-            status: 'online',
-            agent: {
-              version: '8.17.0',
-            },
-          },
-        ],
-      });
-      await runTask();
-
-      expect(mockAgentPolicyService.fetchAllAgentPolicies).toHaveBeenCalled();
-      expect(agentlessAgentService.upgradeAgentlessDeployment).toHaveBeenCalled();
     });
 
     it('should not call upgrade agentless api to upgrade when 0 agents', async () => {
@@ -363,7 +297,7 @@ describe('Upgrade Agentless Deployments', () => {
       expect(mockTask.abortController.signal.throwIfAborted).toHaveBeenCalled();
     });
 
-    it('should not called upgrade agentless api to upgrade when agent policy is not found', async () => {
+    it('should not call upgrade agentless api to upgrade when agent policy is not found', async () => {
       jest
         .spyOn(appContextService, 'getExperimentalFeatures')
         .mockReturnValue({ enabledUpgradeAgentlessDeploymentsTask: false } as any);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Cloud Security] Remove check for latest agent available version in AgentlessDeploymentUpgrade task (#215248)](https://github.com/elastic/kibana/pull/215248)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"seanrathier","email":"sean.rathier@gmail.com"},"sourceCommit":{"committedDate":"2025-04-02T17:00:09Z","message":"[Cloud Security] Remove check for latest agent available version in AgentlessDeploymentUpgrade task (#215248)","sha":"2b987bea61cdbc13840dfbbf9f8ad33e0a2acf70","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","Team:Fleet","Team:Cloud Security","backport:prev-minor","ci:build-cloud-image","v9.1.0","v8.19.0","v8.18.1","v9.0.1"],"title":"[Cloud Security] Remove check for latest agent available version in AgentlessDeploymentUpgrade task","number":215248,"url":"https://github.com/elastic/kibana/pull/215248","mergeCommit":{"message":"[Cloud Security] Remove check for latest agent available version in AgentlessDeploymentUpgrade task (#215248)","sha":"2b987bea61cdbc13840dfbbf9f8ad33e0a2acf70"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/215248","number":215248,"mergeCommit":{"message":"[Cloud Security] Remove check for latest agent available version in AgentlessDeploymentUpgrade task (#215248)","sha":"2b987bea61cdbc13840dfbbf9f8ad33e0a2acf70"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/216894","number":216894,"state":"MERGED","mergeCommit":{"sha":"be204d783fb2dd657e8d99453839f34edfb238dd","message":"[8.x] [Cloud Security] Remove check for latest agent available version in AgentlessDeploymentUpgrade task (#215248) (#216894)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[Cloud Security] Remove check for latest agent available version in\nAgentlessDeploymentUpgrade task\n(#215248)](https://github.com/elastic/kibana/pull/215248)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: seanrathier <sean.rathier@gmail.com>"}},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->