### PR TITLE
feat(streams): validate child on fork

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -253,6 +253,10 @@ export class StreamsClient {
     if: Condition;
   }): Promise<ForkStreamResponse> {
     const parentDefinition = asWiredStreamDefinition(await this.getStream(parent));
+    const childExistsAlready = await this.existsStream(name);
+    if (childExistsAlready) {
+      throw new StatusError(`Child stream ${name} already exists`, 409);
+    }
 
     const result = await State.attemptChanges(
       [

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/full_flow.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/full_flow.ts
@@ -183,6 +183,21 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         expect(response).to.have.property('acknowledged', true);
       });
 
+      it('fails to fork logs to logs.nginx when already forked', async () => {
+        const body = {
+          stream: {
+            name: 'logs.nginx',
+          },
+          if: {
+            field: 'log.logger',
+            operator: 'eq' as const,
+            value: 'nginx',
+          },
+        };
+        const response = await forkStream(apiClient, 'logs', body, 409);
+        expect(response).to.have.property('message', 'Child stream logs.nginx already exists');
+      });
+
       it('Index an Nginx access log message, should goto logs.nginx', async () => {
         const doc = {
           '@timestamp': '2024-01-01T00:00:10.000Z',

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/helpers/requests.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/helpers/requests.ts
@@ -55,7 +55,8 @@ export async function forkStream(
   body: ClientRequestParamsOf<
     StreamsRouteRepository,
     'POST /api/streams/{name}/_fork 2023-10-31'
-  >['params']['body']
+  >['params']['body'],
+  expectedStatusCode: number = 200
 ) {
   return client
     .fetch(`POST /api/streams/{name}/_fork 2023-10-31`, {
@@ -66,7 +67,7 @@ export async function forkStream(
         body,
       },
     })
-    .expect(200)
+    .expect(expectedStatusCode)
     .then((response) => response.body);
 }
 


### PR DESCRIPTION
### 🍒 Summary

Resolves https://github.com/elastic/streams-program/issues/248

This PR validates that a child does not already exist when forking a stream. If a child stream already exists, we return a 409.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->