### PR TITLE
pass serializedState when adding ESQL control

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/use_esql_variables.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/use_esql_variables.ts
@@ -6,7 +6,6 @@
  */
 
 import { useMemo, useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { useStateFromPublishingSubject } from '@kbn/presentation-publishing';
 import { BehaviorSubject } from 'rxjs';
 import {
@@ -51,11 +50,12 @@ export const useESQLVariables = ({
       }
 
       // add a new control
-      controlGroupApi?.addNewPanel({
+      controlGroupApi?.addNewPanel?.({
         panelType: 'esqlControl',
-        initialState: {
-          ...controlState,
-          id: uuidv4(),
+        serializedState: {
+          rawState: {
+            ...controlState,
+          },
         },
       });
       if (panel && updatedQuery && attributes) {

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
@@ -64,6 +64,7 @@ import type { AllowedPartitionOverrides } from '@kbn/expression-partition-vis-pl
 import type { AllowedXYOverrides } from '@kbn/expression-xy-plugin/common';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import { PublishesSearchSession } from '@kbn/presentation-publishing/interfaces/fetch/publishes_search_session';
+import { CanAddNewPanel } from '@kbn/presentation-containers';
 import type { LegacyMetricState } from '../../common';
 import type { LensDocument } from '../persistence';
 import type { LensInspector } from '../lens_inspector_service';
@@ -523,13 +524,9 @@ export type TypedLensByValueInput = Omit<LensRendererProps, 'savedObjectId'>;
 export type LensEmbeddableInput = LensByValueInput | LensByReferenceInput;
 export type LensEmbeddableOutput = LensApi;
 
-export interface ControlGroupApi {
-  addNewPanel: (panelState: Record<string, unknown>) => void;
-}
-
 interface ESQLVariablesCompatibleDashboardApi {
   esqlVariables$: PublishingSubject<ESQLControlVariable[]>;
-  controlGroupApi$: PublishingSubject<ControlGroupApi | undefined>;
+  controlGroupApi$: PublishingSubject<Partial<CanAddNewPanel> | undefined>;
   children$: PublishingSubject<{ [key: string]: unknown }>;
 }
 


### PR DESCRIPTION
This PR does not need to be reviewed by external teams. This PR merges into a feature branch that Kibana presentation team is working on to convert the embeddable framework to only expose serialized state. Your team will be pinged for review once the work is complete and the final PR opens that merges the feature branch into main