### PR TITLE
[Security Solution] Fix alerts table potentially not applying alert assignees

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2503,7 +2503,6 @@ x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout  @elastic/
 /x-pack/solutions/security/plugins/security_solution/public/detections/mitre @elastic/security-detection-rule-management
 /x-pack/solutions/security/plugins/security_solution/public/detection_engine/common @elastic/security-detection-rule-management
 /x-pack/solutions/security/plugins/security_solution/public/rules @elastic/security-detection-rule-management
-/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions @elastic/security-detection-rule-management
 
 /x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/fleet_integrations @elastic/security-detection-rule-management
 /x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/prebuilt_rules @elastic/security-detection-rule-management
@@ -2528,6 +2527,7 @@ x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout  @elastic/
 /x-pack/test/api_integration/apis/lists @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/public/value_list @elastic/security-detection-engine
 /x-pack/solutions/security/plugins/security_solution/public/detections/components/value_lists_management_flyout @elastic/security-detection-engine
+/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions @elastic/security-detection-engine
 
 /x-pack/solutions/security/plugins/security_solution/public/sourcerer @elastic/security-threat-hunting-investigations
 /x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation @elastic/security-detection-engine

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_set_alert_assignees.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_set_alert_assignees.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useAppToasts } from '../../../hooks/use_app_toasts';
+import { useSetAlertAssignees } from './use_set_alert_assignees';
+
+jest.mock('../../../hooks/use_app_toasts');
+
+describe('useSetAlertAssignees', () => {
+  it('should return a function', () => {
+    (useAppToasts as jest.Mock).mockReturnValue({
+      addSuccess: jest.fn(),
+      addError: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useSetAlertAssignees());
+
+    expect(typeof result.current).toEqual('function');
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements a similar change that was just merged a few hours ago. While [that change](https://github.com/elastic/kibana/pull/219410) was made to the alert tags not always working on the alerts table, this current change is applied to the alert assignees that faced a potential similar issue. The alert assignee code was introduced in [this PR](https://github.com/elastic/kibana/pull/170579), and I believe the code was using the similar logic of [the alert tag PR](https://github.com/elastic/kibana/pull/157786).

The issue is related to the fact that we have a `useRef` for a function that is returned before the `useEffect` in the same hook runs, and setting the value of the function returned is happening within that `useEffect`. This has not caused any issues because the few places where this code is being used (the alerts page alerts table) is extremely not efficient and renders multiple times. This gives enough tries to the hook to actually get a value and return the correct function.

This PR fixes that by returning the function directly.

Here's a video showing that the functionality still works correctly for bulk actions:

https://github.com/user-attachments/assets/b3394ffe-8333-4e0a-9bf7-831ef8ea8aea

And also for normal row actions:

https://github.com/user-attachments/assets/5f8c9d23-f0ef-4c65-b7de-4dc34478a8e7

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios