### PR TITLE
[FIPS][CI] Add 8.19 to daily pipeline

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-fips-daily.yml
@@ -22,14 +22,19 @@ spec:
         SLACK_NOTIFICATIONS_CHANNEL: '#kibana-fips'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
       repository: elastic/kibana
-      branch_configuration: main
+      branch_configuration: main 8.19
       default_branch: main
       pipeline_file: '.buildkite/pipelines/fips.yml'
       provider_settings:
         trigger_mode: none
       schedules:
-        daily:
+        Daily build (main):
+          message: Daily build
           branch: main
+          cronline: 0 5 * * * America/New_York
+        Daily build (8.19):
+          message: Daily build
+          branch: '8.19'
           cronline: 0 5 * * * America/New_York
       teams:
         kibana-operations:


### PR DESCRIPTION
## Summary

We should run this pipeline daily on `8.19` as it is a releasable artifact now as well.

cc @elastic/kibana-security 



