### PR TITLE
[Security Solution][Alert KPIs] Fix kpi tests

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/kpis/kpis_section.test.tsx
@@ -6,34 +6,41 @@
  */
 
 import React from 'react';
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { KPIsSection } from './kpis_section';
 import { ALERTS_BY_HOST_PANEL } from './alerts_progress_bar_by_host_name_panel';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 import { TestProviders } from '../../../../common/mock';
 import { useDeepEqualSelector } from '../../../../common/hooks/use_selector';
+import { useSummaryChartData } from '../../alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data';
 
 jest.mock('../../../../common/hooks/use_selector');
-
+jest.mock('../../alerts_kpis/alerts_summary_charts_panel/use_summary_chart_data');
 const dataView: DataView = createStubDataView({ spec: {} });
 
 describe('<KPIsSection />', () => {
-  it('should render all components', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSummaryChartData as jest.Mock).mockReturnValue({
+      items: [],
+      isLoading: false,
+    });
+  });
+
+  it('should render all components', () => {
     (useDeepEqualSelector as jest.Mock).mockReturnValue({
       meta: {},
     });
 
-    await act(async () => {
-      const { getByTestId } = render(
-        <TestProviders>
-          <KPIsSection dataView={dataView} />
-        </TestProviders>
-      );
+    const { getByTestId } = render(
+      <TestProviders>
+        <KPIsSection dataView={dataView} />
+      </TestProviders>
+    );
 
-      expect(getByTestId('severty-level-panel')).toBeInTheDocument();
-      expect(getByTestId('alerts-by-rule-panel')).toBeInTheDocument();
-      expect(getByTestId(ALERTS_BY_HOST_PANEL)).toBeInTheDocument();
-    });
+    expect(getByTestId('severty-level-panel')).toBeInTheDocument();
+    expect(getByTestId('alerts-by-rule-panel')).toBeInTheDocument();
+    expect(getByTestId(ALERTS_BY_HOST_PANEL)).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_by_rule_panel/index.test.tsx
@@ -4,12 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { AlertsByRulePanel } from '.';
+import { useSummaryChartData } from '../alerts_summary_charts_panel/use_summary_chart_data';
 
 jest.mock('../../../../common/lib/kibana');
+jest.mock('../alerts_summary_charts_panel/use_summary_chart_data');
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -22,53 +24,47 @@ describe('Alert by rule panel', () => {
     skip: false,
   };
 
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  test('renders correctly', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsByRulePanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(
-        container.querySelector('[data-test-subj="alerts-by-rule-panel"]')
-      ).toBeInTheDocument();
+    (useSummaryChartData as jest.Mock).mockReturnValue({
+      items: [],
+      isLoading: false,
     });
   });
 
-  test('renders HeaderSection', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsByRulePanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector(`[data-test-subj="header-section"]`)).toBeInTheDocument();
-    });
+  test('renders correctly', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsByRulePanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('alerts-by-rule-panel')).toBeInTheDocument();
   });
 
-  test('renders inspect button', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsByRulePanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector('[data-test-subj="inspect-icon-button"]')).toBeInTheDocument();
-    });
+  test('renders HeaderSection', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsByRulePanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('header-section')).toBeInTheDocument();
   });
 
-  test('renders alert by rule chart', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsByRulePanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector('[data-test-subj="alerts-by-rule"]')).toBeInTheDocument();
-    });
+  test('renders inspect button', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsByRulePanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('inspect-icon-button')).toBeInTheDocument();
+  });
+
+  test('renders alert by rule chart', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsByRulePanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('alerts-by-rule')).toBeInTheDocument();
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.test.tsx
@@ -6,8 +6,7 @@
  */
 
 import React from 'react';
-import { act, render } from '@testing-library/react';
-import { mount } from 'enzyme';
+import { act, fireEvent, render } from '@testing-library/react';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import { AlertsCountPanel } from '.';
 
@@ -60,6 +59,10 @@ const defaultProps = {
   extraActions: [{ id: 'resetGroupByFields' }] as Action[],
 };
 
+const MockedVisualizationEmbeddable = VisualizationEmbeddable as jest.MockedFunction<
+  typeof VisualizationEmbeddable
+>;
+
 describe('AlertsCountPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -76,15 +79,13 @@ describe('AlertsCountPanel', () => {
   });
 
   it('renders with the specified `alignHeader` alignment', () => {
-    const wrapper = mount(
+    const { getByTestId } = render(
       <TestProviders>
         <AlertsCountPanel {...defaultProps} alignHeader="flexEnd" />
       </TestProviders>
     );
 
-    expect(
-      wrapper.find('[data-test-subj="headerSectionInnerFlexGroup"]').last().getDOMNode().className
-    ).toContain('flexEnd');
+    expect(getByTestId('headerSectionInnerFlexGroup').className).toContain('flexEnd');
   });
 
   it('renders the inspect button by default', () => {
@@ -121,12 +122,12 @@ it('it does NOT render the inspect button when a `chartOptionsContextMenu` is pr
 describe('toggleQuery', () => {
   it('toggles', async () => {
     await act(async () => {
-      const wrapper = mount(
+      const { getByTestId } = render(
         <TestProviders>
           <AlertsCountPanel {...defaultProps} />
         </TestProviders>
       );
-      wrapper.find('[data-test-subj="query-toggle-header"]').first().simulate('click');
+      fireEvent.click(getByTestId('query-toggle-header'));
       expect(mockSetIsExpanded).toBeCalledWith(false);
     });
   });
@@ -160,33 +161,33 @@ describe('Visualization', () => {
   });
 
   it('should render with provided height', () => {
-    mount(
+    render(
       <TestProviders>
         <AlertsCountPanel {...defaultProps} />
       </TestProviders>
     );
-    expect((VisualizationEmbeddable as unknown as jest.Mock).mock.calls[0][0].height).toEqual(218);
+    expect(MockedVisualizationEmbeddable.mock.calls[0][0].height).toEqual(218);
   });
 
   it('should render with extra actions', () => {
-    mount(
+    render(
       <TestProviders>
         <AlertsCountPanel {...defaultProps} />
       </TestProviders>
     );
-    expect(
-      (VisualizationEmbeddable as unknown as jest.Mock).mock.calls[0][0].extraActions[0].id
-    ).toEqual('resetGroupByFields');
+    expect(MockedVisualizationEmbeddable.mock.calls[0][0].extraActions?.[0]?.id).toEqual(
+      'resetGroupByFields'
+    );
   });
 
   it('should render with extra options', () => {
-    mount(
+    render(
       <TestProviders>
         <AlertsCountPanel {...defaultProps} />
       </TestProviders>
     );
-    expect(
-      (VisualizationEmbeddable as unknown as jest.Mock).mock.calls[0][0].extraOptions.breakdownField
-    ).toEqual(defaultProps.stackByField1);
+    expect(MockedVisualizationEmbeddable.mock.calls[0][0].extraOptions?.breakdownField).toEqual(
+      defaultProps.stackByField1
+    );
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { act } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { mount } from 'enzyme';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import { AlertsCountPanel } from '.';
@@ -65,155 +65,128 @@ describe('AlertsCountPanel', () => {
     jest.clearAllMocks();
   });
 
-  it('renders correctly', async () => {
+  it('renders correctly', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsCountPanel {...defaultProps} />
+      </TestProviders>
+    );
+
+    expect(getByTestId('alertsCountPanel')).toBeInTheDocument();
+  });
+
+  it('renders with the specified `alignHeader` alignment', () => {
+    const wrapper = mount(
+      <TestProviders>
+        <AlertsCountPanel {...defaultProps} alignHeader="flexEnd" />
+      </TestProviders>
+    );
+
+    expect(
+      wrapper.find('[data-test-subj="headerSectionInnerFlexGroup"]').last().getDOMNode().className
+    ).toContain('flexEnd');
+  });
+
+  it('renders the inspect button by default', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsCountPanel {...defaultProps} alignHeader="flexEnd" />
+      </TestProviders>
+    );
+
+    expect(getByTestId('inspect-icon-button')).toBeInTheDocument();
+  });
+});
+
+it('it does NOT render the inspect button when a `chartOptionsContextMenu` is provided', () => {
+  const chartOptionsContextMenu = (queryId: string) => (
+    <ChartContextMenu
+      defaultStackByField={DEFAULT_STACK_BY_FIELD}
+      defaultStackByField1={DEFAULT_STACK_BY_FIELD1}
+      queryId={queryId}
+      setStackBy={jest.fn()}
+      setStackByField1={jest.fn()}
+    />
+  );
+
+  const { queryByTestId } = render(
+    <TestProviders>
+      <AlertsCountPanel {...defaultProps} chartOptionsContextMenu={chartOptionsContextMenu} />
+    </TestProviders>
+  );
+
+  expect(queryByTestId('inspect-icon-button')).not.toBeInTheDocument();
+});
+
+describe('toggleQuery', () => {
+  it('toggles', async () => {
     await act(async () => {
       const wrapper = mount(
         <TestProviders>
           <AlertsCountPanel {...defaultProps} />
         </TestProviders>
       );
-
-      expect(wrapper.find('[data-test-subj="alertsCountPanel"]').exists()).toBeTruthy();
+      wrapper.find('[data-test-subj="query-toggle-header"]').first().simulate('click');
+      expect(mockSetIsExpanded).toBeCalledWith(false);
     });
   });
 
-  it('renders with the specified `alignHeader` alignment', async () => {
-    await act(async () => {
-      const wrapper = mount(
-        <TestProviders>
-          <AlertsCountPanel {...defaultProps} alignHeader="flexEnd" />
-        </TestProviders>
-      );
-
-      expect(
-        wrapper.find('[data-test-subj="headerSectionInnerFlexGroup"]').last().getDOMNode().className
-      ).toContain('flexEnd');
-    });
-  });
-
-  it('renders the inspect button by default', async () => {
-    await act(async () => {
-      const wrapper = mount(
-        <TestProviders>
-          <AlertsCountPanel {...defaultProps} alignHeader="flexEnd" />
-        </TestProviders>
-      );
-
-      expect(wrapper.find('button[data-test-subj="inspect-icon-button"]').first().exists()).toBe(
-        true
-      );
-    });
-  });
-
-  it('it does NOT render the inspect button when a `chartOptionsContextMenu` is provided', async () => {
-    const chartOptionsContextMenu = (queryId: string) => (
-      <ChartContextMenu
-        defaultStackByField={DEFAULT_STACK_BY_FIELD}
-        defaultStackByField1={DEFAULT_STACK_BY_FIELD1}
-        queryId={queryId}
-        setStackBy={jest.fn()}
-        setStackByField1={jest.fn()}
-      />
+  it('when isExpanded is true, render counts panel', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsCountPanel {...defaultProps} />
+      </TestProviders>
     );
+    expect(getByTestId('visualization-embeddable')).toBeInTheDocument();
+  });
+  it('when isExpanded is false, hide counts panel', () => {
+    const { queryByTestId } = render(
+      <TestProviders>
+        <AlertsCountPanel {...defaultProps} isExpanded={false} />
+      </TestProviders>
+    );
+    expect(queryByTestId('visualization-embeddable')).not.toBeInTheDocument();
+  });
+});
 
-    await act(async () => {
-      const wrapper = mount(
-        <TestProviders>
-          <AlertsCountPanel {...defaultProps} chartOptionsContextMenu={chartOptionsContextMenu} />
-        </TestProviders>
-      );
-
-      expect(wrapper.find('button[data-test-subj="inspect-icon-button"]').first().exists()).toBe(
-        false
-      );
-    });
+describe('Visualization', () => {
+  it('should render embeddable', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsCountPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('visualization-embeddable')).toBeInTheDocument();
   });
 
-  describe('toggleQuery', () => {
-    it('toggles', async () => {
-      await act(async () => {
-        const wrapper = mount(
-          <TestProviders>
-            <AlertsCountPanel {...defaultProps} />
-          </TestProviders>
-        );
-        wrapper.find('[data-test-subj="query-toggle-header"]').first().simulate('click');
-        expect(mockSetIsExpanded).toBeCalledWith(false);
-      });
-    });
-
-    it('when isExpanded is true, render counts panel', async () => {
-      await act(async () => {
-        const wrapper = mount(
-          <TestProviders>
-            <AlertsCountPanel {...defaultProps} />
-          </TestProviders>
-        );
-        expect(wrapper.find('[data-test-subj="visualization-embeddable"]').exists()).toEqual(true);
-      });
-    });
-    it('when isExpanded is false, hide counts panel', async () => {
-      await act(async () => {
-        const wrapper = mount(
-          <TestProviders>
-            <AlertsCountPanel {...defaultProps} isExpanded={false} />
-          </TestProviders>
-        );
-        expect(wrapper.find('[data-test-subj="visualization-embeddable"]').exists()).toEqual(false);
-      });
-    });
+  it('should render with provided height', () => {
+    mount(
+      <TestProviders>
+        <AlertsCountPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect((VisualizationEmbeddable as unknown as jest.Mock).mock.calls[0][0].height).toEqual(218);
   });
 
-  describe('Visualization', () => {
-    it('should render embeddable', async () => {
-      await act(async () => {
-        const wrapper = mount(
-          <TestProviders>
-            <AlertsCountPanel {...defaultProps} />
-          </TestProviders>
-        );
-        expect(wrapper.find('[data-test-subj="visualization-embeddable"]').exists()).toBeTruthy();
-      });
-    });
+  it('should render with extra actions', () => {
+    mount(
+      <TestProviders>
+        <AlertsCountPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(
+      (VisualizationEmbeddable as unknown as jest.Mock).mock.calls[0][0].extraActions[0].id
+    ).toEqual('resetGroupByFields');
+  });
 
-    it('should render with provided height', async () => {
-      await act(async () => {
-        mount(
-          <TestProviders>
-            <AlertsCountPanel {...defaultProps} />
-          </TestProviders>
-        );
-        expect((VisualizationEmbeddable as unknown as jest.Mock).mock.calls[0][0].height).toEqual(
-          218
-        );
-      });
-    });
-
-    it('should render with extra actions', async () => {
-      await act(async () => {
-        mount(
-          <TestProviders>
-            <AlertsCountPanel {...defaultProps} />
-          </TestProviders>
-        );
-        expect(
-          (VisualizationEmbeddable as unknown as jest.Mock).mock.calls[0][0].extraActions[0].id
-        ).toEqual('resetGroupByFields');
-      });
-    });
-
-    it('should render with extra options', async () => {
-      await act(async () => {
-        mount(
-          <TestProviders>
-            <AlertsCountPanel {...defaultProps} />
-          </TestProviders>
-        );
-        expect(
-          (VisualizationEmbeddable as unknown as jest.Mock).mock.calls[0][0].extraOptions
-            .breakdownField
-        ).toEqual(defaultProps.stackByField1);
-      });
-    });
+  it('should render with extra options', () => {
+    mount(
+      <TestProviders>
+        <AlertsCountPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(
+      (VisualizationEmbeddable as unknown as jest.Mock).mock.calls[0][0].extraOptions.breakdownField
+    ).toEqual(defaultProps.stackByField1);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/alerts_progress_bar.test.tsx
@@ -12,6 +12,10 @@ import { parsedAlerts } from './mock_data';
 import type { GroupBySelection } from './types';
 
 jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../../common/components/cell_actions', () => ({
+  ...jest.requireActual('../../../../common/components/cell_actions'),
+  SecurityCellActions: jest.fn(() => <div data-test-subj="cell-actions-component" />),
+}));
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_progress_bar_panel/index.test.tsx
@@ -11,13 +11,19 @@ import { AlertsProgressBarPanel } from '.';
 import { useSummaryChartData } from '../alerts_summary_charts_panel/use_summary_chart_data';
 import { STACK_BY_ARIA_LABEL } from '../common/translations';
 import type { GroupBySelection } from './types';
+import { useStackByFields } from '../common/hooks';
 
-jest.mock('../../../../common/lib/kibana');
+jest.mock('../common/hooks');
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
   return { ...actual, useLocation: jest.fn().mockReturnValue({ pathname: '' }) };
 });
+
+jest.mock('../../../../common/components/cell_actions', () => ({
+  ...jest.requireActual('../../../../common/components/cell_actions'),
+  SecurityCellActions: jest.fn(() => <div data-test-subj="cell-actions-component" />),
+}));
 
 jest.mock('../alerts_summary_charts_panel/use_summary_chart_data');
 const mockUseSummaryChartData = useSummaryChartData as jest.Mock;
@@ -33,64 +39,52 @@ describe('Alert by grouping', () => {
   };
 
   beforeEach(() => {
-    mockUseSummaryChartData.mockReturnValue({ items: [], isLoading: false });
-  });
-
-  afterEach(() => {
     jest.clearAllMocks();
+    mockUseSummaryChartData.mockReturnValue({ items: [], isLoading: false });
+    (useStackByFields as jest.Mock).mockReturnValue(jest.fn());
   });
 
-  test('renders correctly', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsProgressBarPanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(
-        container.querySelector('[data-test-subj="alerts-progress-bar-panel"]')
-      ).toBeInTheDocument();
-    });
+  test('renders correctly', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsProgressBarPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('alerts-progress-bar-panel')).toBeInTheDocument();
   });
 
-  test('render HeaderSection', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsProgressBarPanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector(`[data-test-subj="header-section"]`)).toBeInTheDocument();
-    });
+  test('render HeaderSection', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsProgressBarPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('header-section')).toBeInTheDocument();
   });
 
-  test('renders inspect button', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsProgressBarPanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector('[data-test-subj="inspect-icon-button"]')).toBeInTheDocument();
-    });
+  test('renders inspect button', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsProgressBarPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('inspect-icon-button')).toBeInTheDocument();
   });
 
   describe('combo box', () => {
     const setGroupBySelection = jest.fn();
 
-    test('renders combo box', async () => {
-      await act(async () => {
-        const { container } = render(
-          <TestProviders>
-            <AlertsProgressBarPanel {...defaultProps} />
-          </TestProviders>
-        );
-        expect(container.querySelector('[data-test-subj="stackByComboBox"]')).toBeInTheDocument();
-      });
+    test('renders combo box', () => {
+      const { getByTestId } = render(
+        <TestProviders>
+          <AlertsProgressBarPanel {...defaultProps} />
+        </TestProviders>
+      );
+      expect(getByTestId('stackByComboBox')).toBeInTheDocument();
     });
 
     test('combo box renders corrected options', async () => {
-      await act(async () => {
+      act(() => {
         render(
           <TestProviders>
             <AlertsProgressBarPanel {...defaultProps} setGroupBySelection={setGroupBySelection} />
@@ -109,7 +103,7 @@ describe('Alert by grouping', () => {
 
     test('it invokes setGroupBySelection when an option is selected', async () => {
       const toBeSelected = 'user.name';
-      await act(async () => {
+      act(() => {
         render(
           <TestProviders>
             <AlertsProgressBarPanel {...defaultProps} setGroupBySelection={setGroupBySelection} />

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_summary_charts_panel/index.test.tsx
@@ -4,22 +4,39 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { act, render, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { AlertsSummaryChartsPanel } from '.';
 import type { GroupBySelection } from '../alerts_progress_bar_panel/types';
+import { useSummaryChartData } from './use_summary_chart_data';
+import { useStackByFields } from '../common/hooks';
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../../common/containers/query_toggle');
+jest.mock('./use_summary_chart_data');
+jest.mock('../common/hooks');
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
   return { ...actual, useLocation: jest.fn().mockReturnValue({ pathname: '' }) };
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/218302
-describe.skip('AlertsSummaryChartsPanel', () => {
+jest.mock('../../../../common/components/cell_actions', () => ({
+  ...jest.requireActual('../../../../common/components/cell_actions'),
+  SecurityCellActions: jest.fn(() => <div data-test-subj="cell-actions-component" />),
+}));
+
+describe('AlertsSummaryChartsPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSummaryChartData as jest.Mock).mockReturnValue({
+      items: [],
+      isLoading: false,
+    });
+    (useStackByFields as jest.Mock).mockReturnValue(jest.fn());
+  });
+
   const mockSetIsExpanded = jest.fn();
   const defaultProps = {
     signalIndexName: 'signalIndexName',
@@ -29,48 +46,41 @@ describe.skip('AlertsSummaryChartsPanel', () => {
     setGroupBySelection: jest.fn(),
   };
 
-  test('renders correctly', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsSummaryChartsPanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector('[data-test-subj="alerts-charts-panel"]')).toBeInTheDocument();
-    });
+  test('renders correctly', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <AlertsSummaryChartsPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('alerts-charts-panel')).toBeInTheDocument();
   });
 
-  test('it renders the header with the specified `alignHeader` alignment', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <AlertsSummaryChartsPanel {...defaultProps} alignHeader="flexEnd" />
-        </TestProviders>
-      );
-      expect(
-        container.querySelector('[data-test-subj="headerSectionInnerFlexGroup"]')?.classList[1]
-      ).toContain('flexEnd');
-    });
+  test('it renders the header with the specified `alignHeader` alignment', () => {
+    const { container } = render(
+      <TestProviders>
+        <AlertsSummaryChartsPanel {...defaultProps} alignHeader="flexEnd" />
+      </TestProviders>
+    );
+    expect(
+      container.querySelector('[data-test-subj="headerSectionInnerFlexGroup"]')?.classList[1]
+    ).toContain('flexEnd');
   });
 
   describe('Query', () => {
-    test('it render with a illegal KQL', async () => {
+    test('it render with a illegal KQL', () => {
       jest.mock('@kbn/es-query', () => ({
         buildEsQuery: jest.fn().mockImplementation(() => {
           throw new Error('Something went wrong');
         }),
       }));
       const props = { ...defaultProps, query: { query: 'host.name: "', language: 'kql' } };
-      const { container } = render(
+      const { getByTestId } = render(
         <TestProviders>
           <AlertsSummaryChartsPanel {...props} />
         </TestProviders>
       );
-      await waitFor(() => {
-        expect(
-          container.querySelector('[data-test-subj="alerts-charts-panel"]')
-        ).toBeInTheDocument();
-      });
+
+      expect(getByTestId('alerts-charts-panel')).toBeInTheDocument();
     });
   });
 
@@ -90,30 +100,22 @@ describe.skip('AlertsSummaryChartsPanel', () => {
       });
     });
 
-    it('when isExpanded is true, render summary chart', async () => {
-      await act(async () => {
-        const { container } = render(
-          <TestProviders>
-            <AlertsSummaryChartsPanel {...defaultProps} />
-          </TestProviders>
-        );
-        expect(
-          container.querySelector('[data-test-subj="alerts-charts-container"]')
-        ).toBeInTheDocument();
-      });
+    it('when isExpanded is true, render summary chart', () => {
+      const { getByTestId } = render(
+        <TestProviders>
+          <AlertsSummaryChartsPanel {...defaultProps} />
+        </TestProviders>
+      );
+      expect(getByTestId('alerts-charts-container')).toBeInTheDocument();
     });
 
-    it('when isExpanded is false, hide summary chart', async () => {
-      await act(async () => {
-        const { container } = render(
-          <TestProviders>
-            <AlertsSummaryChartsPanel {...defaultProps} isExpanded={false} />
-          </TestProviders>
-        );
-        expect(
-          container.querySelector('[data-test-subj="alerts-charts-container"]')
-        ).not.toBeInTheDocument();
-      });
+    it('when isExpanded is false, hide summary chart', () => {
+      const { queryByTestId } = render(
+        <TestProviders>
+          <AlertsSummaryChartsPanel {...defaultProps} isExpanded={false} />
+        </TestProviders>
+      );
+      expect(queryByTestId('alerts-charts-container')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/alerts_treemap/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/alerts_treemap/index.test.tsx
@@ -20,6 +20,11 @@ import * as i18n from './translations';
 import type { Props } from '.';
 import { AlertsTreemap } from '.';
 
+jest.mock('../../../../../common/components/cell_actions', () => ({
+  ...jest.requireActual('../../../../../common/components/cell_actions'),
+  SecurityCellActions: jest.fn(() => <div data-test-subj="cell-actions-component" />),
+}));
+
 const defaultProps: Props = {
   data: mockAlertSearchResponse,
   maxBuckets: 1000,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/alerts_treemap_panel/index.test.tsx
@@ -22,6 +22,11 @@ import type { Props } from '.';
 import { AlertsTreemapPanel } from '.';
 import { mockAlertSearchResponse } from './alerts_treemap/lib/mocks/mock_alert_search_response';
 
+jest.mock('../../../../common/components/cell_actions', () => ({
+  ...jest.requireActual('../../../../common/components/cell_actions'),
+  SecurityCellActions: jest.fn(() => <div data-test-subj="cell-actions-component" />),
+}));
+
 const from = '2022-07-28T08:20:18.966Z';
 const to = '2022-07-28T08:20:18.966Z';
 jest.mock('../../../../common/containers/use_global_time', () => {

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/common/components.test.tsx
@@ -13,7 +13,9 @@ import 'jest-styled-components';
 import { TestProviders } from '../../../../common/mock';
 import { KpiPanel, StackByComboBox } from './components';
 import * as i18n from './translations';
+import { useStackByFields } from './hooks';
 
+jest.mock('./hooks');
 jest.mock('react-router-dom', () => {
   const originalModule = jest.requireActual('react-router-dom');
   return {
@@ -58,6 +60,11 @@ jest.mock('../../../../common/lib/kibana/kibana_react', () => {
 });
 
 describe('components', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useStackByFields as jest.Mock).mockReturnValue(jest.fn());
+  });
+
   describe('KpiPanel', () => {
     test('it has a hidden overflow-x', () => {
       render(
@@ -107,6 +114,10 @@ describe('components', () => {
             data-test-subj="stackByComboBox"
             onSelect={onSelect}
             selected="agent.ephemeral_id"
+            dropDownoptions={[
+              { label: 'agent.ephemeral_id', value: 'agent.ephemeral_id' },
+              { label: 'agent.hostname', value: 'agent.hostname' },
+            ]}
           />
         </TestProviders>
       );

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/index.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_kpis/severity_level_panel/index.test.tsx
@@ -4,12 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../../common/mock';
 import { SeverityLevelPanel } from '.';
+import { useSummaryChartData } from '../alerts_summary_charts_panel/use_summary_chart_data';
 
 jest.mock('../../../../common/lib/kibana');
+jest.mock('../alerts_summary_charts_panel/use_summary_chart_data');
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
@@ -22,53 +24,47 @@ describe('Severity level panel', () => {
     skip: false,
   };
 
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  test('renders correctly', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <SeverityLevelPanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector('[data-test-subj="severty-level-panel"]')).toBeInTheDocument();
+    (useSummaryChartData as jest.Mock).mockReturnValue({
+      items: [],
+      isLoading: false,
     });
   });
 
-  test('render HeaderSection', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <SeverityLevelPanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector(`[data-test-subj="header-section"]`)).toBeInTheDocument();
-    });
+  test('renders correctly', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <SeverityLevelPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('severty-level-panel')).toBeInTheDocument();
   });
 
-  test('inspect button renders correctly', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <SeverityLevelPanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(container.querySelector('[data-test-subj="inspect-icon-button"]')).toBeInTheDocument();
-    });
+  test('render HeaderSection', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <SeverityLevelPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('header-section')).toBeInTheDocument();
   });
 
-  test('renders severity chart correctly', async () => {
-    await act(async () => {
-      const { container } = render(
-        <TestProviders>
-          <SeverityLevelPanel {...defaultProps} />
-        </TestProviders>
-      );
-      expect(
-        container.querySelector(`[data-test-subj="severity-level-chart"]`)
-      ).toBeInTheDocument();
-    });
+  test('inspect button renders correctly', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <SeverityLevelPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('inspect-icon-button')).toBeInTheDocument();
+  });
+
+  test('renders severity chart correctly', () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <SeverityLevelPanel {...defaultProps} />
+      </TestProviders>
+    );
+    expect(getByTestId('severity-level-chart')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Ref: 
- https://github.com/elastic/kibana/issues/216902
- https://github.com/elastic/kibana/issues/218302
- https://github.com/elastic/kibana/issues/217398
- https://github.com/elastic/kibana/issues/219515
- https://github.com/elastic/kibana/issues/219619

In reviewing the failed tests, I noticed many have unnecessary `await act` wrappers. This PR cleans up tests in the kpis folder:
- Removed unnecessary `act` calls
- Rewrote some test in RTL instead of `enzyme` (only those that are easy to convert)
- Added mocks to remove console errors

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/31a1b36c-c261-4cf6-ab55-d440b577ef3f" />


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->