### PR TITLE
revert useBatchedPublishingSubjects for vis embeddable

### DIFF
--- a/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx
@@ -34,6 +34,7 @@ import {
   timeRangeComparators,
   titleComparators,
   useBatchedPublishingSubjects,
+  useStateFromPublishingSubject,
 } from '@kbn/presentation-publishing';
 import { apiPublishesSearchSession } from '@kbn/presentation-publishing/interfaces/fetch/publishes_search_session';
 import { get, isEmpty, isEqual, isNil, omitBy } from 'lodash';
@@ -440,11 +441,11 @@ export const getVisualizeEmbeddableFactory: (deps: {
     return {
       api,
       Component: () => {
-        const [expressionParams, renderCount, hasRendered, hideTitle, title, defaultTitle] =
+        const expressionParams = useStateFromPublishingSubject(expressionParams$);
+        const renderCount = useStateFromPublishingSubject(renderCount$);
+        const hasRendered = useStateFromPublishingSubject(hasRendered$);
+        const [hideTitle, title, defaultTitle] =
           useBatchedPublishingSubjects(
-            expressionParams$,
-            renderCount$,
-            hasRendered$,
             api.hideTitle$,
             api.title$,
             api.defaultTitle$


### PR DESCRIPTION
This PR does not need to be reviewed by external teams. This PR merges into a feature branch that Kibana presentation team is working on to convert the embeddable framework to only expose serialized state. Your team will be pinged for review once the work is complete and the final PR opens that merges the feature branch into main