### PR TITLE
[Search] Fix content Indices documents error on paginate

### DIFF
--- a/x-pack/platform/packages/shared/kbn-search-index-documents/lib/fetch_search_results.test.ts
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/lib/fetch_search_results.test.ts
@@ -86,7 +86,7 @@ describe('fetchSearchResults lib function', () => {
       index: indexName,
       q: query,
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: false,
+      track_total_hits: undefined,
     });
   });
 
@@ -108,7 +108,7 @@ describe('fetchSearchResults lib function', () => {
       index: indexName,
       q: '\\"yellow banana\\"',
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: false,
+      track_total_hits: undefined,
     });
   });
 
@@ -123,7 +123,7 @@ describe('fetchSearchResults lib function', () => {
       from: DEFAULT_FROM_VALUE,
       index: indexName,
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: false,
+      track_total_hits: undefined,
     });
   });
 
@@ -151,7 +151,7 @@ describe('fetchSearchResults lib function', () => {
       index: indexName,
       q: query,
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: false,
+      track_total_hits: undefined,
     });
   });
 

--- a/x-pack/platform/packages/shared/kbn-search-index-documents/lib/fetch_search_results.ts
+++ b/x-pack/platform/packages/shared/kbn-search-index-documents/lib/fetch_search_results.ts
@@ -17,7 +17,7 @@ export const fetchSearchResults = async (
   query?: string,
   from: number = 0,
   size: number = DEFAULT_DOCS_PER_PAGE,
-  trackTotalHits: boolean = false
+  trackTotalHits?: boolean
 ): Promise<Paginate<SearchHit>> => {
   return fetchWithPagination(
     () =>


### PR DESCRIPTION
Initially added fix in `8.17` branch in [PR](https://github.com/elastic/kibana/pull/219411), but need this change in `main`, `8.18`, `8.19` & `9.0.0` and the file's paths are different in all versions(main, 8.18/8.19, 8.17, 9.0.0). 

Created this new PR, adding fix in `main` & will try to backport to other versions. 

## Summary
When `track_total_hits` is not provided to `fetchSearchResults`, the value is set to `false`. As a result, the `search` api does not include total hit count in its response. Thus, the total count of hit is 0 and onPaginate results in error. This PR sets  `track_total_hits` as an optional argument in `fetchSearchResults`

**Note**
One other option would be to set  `track_total_hits`  to true but,  based on this [documentation](https://www.elastic.co/docs/solutions/search/the-search-api#track-total-hits) setting `track_total_hits`  to true would affect query performance. 

```
Setting track_total_hits to true will cause Elasticsearch to return exact hit counts, which could hurt query performance because it disables the [Max WAND](https://www.elastic.co/blog/faster-retrieval-of-top-hits-in-elasticsearch-with-block-max-wand) optimization.

````


https://github.com/user-attachments/assets/4284e88f-2614-4fbe-a0eb-1980355f5bff




### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->