### PR TITLE
[9.0] [Security Solution] Add new fields to indices metadata (#219246)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -450,6 +450,14 @@ export const TELEMETRY_INDEX_SETTINGS_EVENT: EventTypeOpts<IndicesSettings> = {
             type: 'keyword',
             _meta: { description: 'The name of the index.' },
           },
+          index_mode: {
+            type: 'keyword',
+            _meta: { optional: true, description: 'Index mode.' },
+          },
+          source_mode: {
+            type: 'keyword',
+            _meta: { optional: true, description: 'Source mode.' },
+          },
           default_pipeline: {
             type: 'keyword',
             _meta: {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/indices.metadata.types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/indices.metadata.types.ts
@@ -89,8 +89,10 @@ export interface IndicesSettings {
 
 export interface IndexSettings {
   index_name: string;
+  index_mode?: string;
   default_pipeline?: string;
   final_pipeline?: string;
+  source_mode?: string;
 }
 
 export interface Index {

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/receiver.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/receiver.ts
@@ -1344,8 +1344,10 @@ export class TelemetryReceiver implements ITelemetryReceiver {
       index: '*',
       expand_wildcards: ['open', 'hidden'],
       filter_path: [
-        '*.settings.index.final_pipeline',
+        '*.mappings._source.mode',
         '*.settings.index.default_pipeline',
+        '*.settings.index.final_pipeline',
+        '*.settings.index.mode',
         '*.settings.index.provided_name',
       ],
     };
@@ -1358,6 +1360,8 @@ export class TelemetryReceiver implements ITelemetryReceiver {
             index_name: index,
             default_pipeline: value.settings?.index?.default_pipeline,
             final_pipeline: value.settings?.index?.final_pipeline,
+            index_mode: value.settings?.index?.mode,
+            source_mode: value.mappings?._source?.mode,
           } as IndexSettings;
         })
       )

--- a/x-pack/test/common/utils/security_solution/detections_response/tasks/indices_metadata.ts
+++ b/x-pack/test/common/utils/security_solution/detections_response/tasks/indices_metadata.ts
@@ -6,6 +6,7 @@
  */
 
 import { Client } from '@elastic/elasticsearch';
+import type { IndicesPutIndexTemplateRequest } from '@elastic/elasticsearch/lib/api/types';
 
 const INGEST_PIPELINE_PREFIX = 'testing-ingest-pipeline';
 const DS_PREFIX = 'testing-datastream';
@@ -28,41 +29,48 @@ export const randomDatastream = async (
 ): Promise<string> => {
   const name = `${DS_PREFIX}-${Date.now()}`;
 
-  let settings = {};
-
-  if (opts.policyName) {
-    settings = {
-      ...settings,
-      'index.lifecycle.name': opts.policyName,
-    };
-  }
-
-  if (opts.defaultPipeline) {
-    settings = {
-      ...settings,
-      'index.default_pipeline': opts.defaultPipeline,
-    };
-  }
-
-  if (opts.finalPipeline) {
-    settings = {
-      ...settings,
-      'index.final_pipeline': opts.finalPipeline,
-    };
-  }
-
-  const indexTemplateBody = {
+  const indexTemplateBody: IndicesPutIndexTemplateRequest = {
+    name: DS_PREFIX,
     index_patterns: [`${DS_PREFIX}-*`],
     data_stream: {},
     template: {
-      settings,
+      settings: {
+        index: {
+          mode: 'standard',
+          mapping: {
+            source: {
+              mode: 'stored',
+            },
+          },
+        },
+      },
     },
   };
 
-  await es.indices.putIndexTemplate({
-    name: DS_PREFIX,
-    body: indexTemplateBody,
-  });
+  if (opts.policyName && indexTemplateBody.template?.settings !== undefined) {
+    indexTemplateBody.template.settings.index = {
+      ...indexTemplateBody.template.settings.index,
+      lifecycle: {
+        name: opts.policyName,
+      },
+    };
+  }
+
+  if (opts.defaultPipeline && indexTemplateBody.template?.settings !== undefined) {
+    indexTemplateBody.template.settings.index = {
+      ...indexTemplateBody.template.settings.index,
+      default_pipeline: opts.defaultPipeline,
+    };
+  }
+
+  if (opts.finalPipeline && indexTemplateBody.template?.settings !== undefined) {
+    indexTemplateBody.template.settings.index = {
+      ...indexTemplateBody.template.settings.index,
+      final_pipeline: opts.finalPipeline,
+    };
+  }
+
+  await es.indices.putIndexTemplate(indexTemplateBody);
 
   await es.indices.createDataStream({ name });
 

--- a/x-pack/test/common/utils/security_solution/detections_response/tasks/indices_metadata.ts
+++ b/x-pack/test/common/utils/security_solution/detections_response/tasks/indices_metadata.ts
@@ -37,11 +37,7 @@ export const randomDatastream = async (
       settings: {
         index: {
           mode: 'standard',
-          mapping: {
-            source: {
-              mode: 'stored',
-            },
-          },
+          mapping: {},
         },
       },
     },

--- a/x-pack/test/security_solution_api_integration/test_suites/telemetry/tasks/indices_metadata.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/telemetry/tasks/indices_metadata.ts
@@ -228,6 +228,16 @@ export default ({ getService }: FtrProviderContext) => {
         expect(events.filter((v) => v.final_pipeline === finalPipeline)).toHaveLength(NUM_INDICES);
       });
 
+      it('should publish index mode as part of index settings', async () => {
+        const events = await launchTaskAndWaitForEvents({
+          eventTypes: [TELEMETRY_INDEX_SETTINGS_EVENT],
+          index: dsName,
+        });
+
+        expect(events.length).toEqual(NUM_INDICES);
+        expect(events.filter((v) => v.index_mode !== undefined)).toHaveLength(NUM_INDICES);
+      });
+
       it('should publish index templates', async () => {
         const events = await launchTaskAndWaitForEvents({
           eventTypes: [TELEMETRY_INDEX_TEMPLATES_EVENT],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Security Solution] Add new fields to indices metadata (#219246)](https://github.com/elastic/kibana/pull/219246)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sebastián Zaffarano","email":"sebastian.zaffarano@elastic.co"},"sourceCommit":{"committedDate":"2025-04-28T18:18:43Z","message":"[Security Solution] Add new fields to indices metadata (#219246)\n\n## Summary\n\nAdds `_source.mode` and `index.mode` fields to the\n[TELEMETRY_INDEX_SETTINGS_EVENT](https://github.com/elastic/kibana/blob/szaffarano/update-indices-metadata/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts#L470C14-L470C44)\nEBT event:\n\n```typescript\nexport interface IndexSettings {\n  index_name: string;\n  index_mode?: string;\n  default_pipeline?: string;\n  final_pipeline?: string;\n  source_mode?: string;\n}\n```\nReferences:\n- https://github.com/elastic/kibana/pull/194004 Initial version for the\nupdated EBT event.\n- https://github.com/elastic/kibana/pull/213822 This is a Similar PR\nupdating the feature.\n\nThe goal is to enhance the index settings EBT event with two new fields\nto enrich the telemetry information we collect about the indices used by\nthe security integrations.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"8c596d32010ad96eeac794f1938e686f9cbdb278","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","backport:all-open","ci:build-cloud-image","v9.1.0"],"title":"[Security Solution] Add new fields to indices metadata","number":219246,"url":"https://github.com/elastic/kibana/pull/219246","mergeCommit":{"message":"[Security Solution] Add new fields to indices metadata (#219246)\n\n## Summary\n\nAdds `_source.mode` and `index.mode` fields to the\n[TELEMETRY_INDEX_SETTINGS_EVENT](https://github.com/elastic/kibana/blob/szaffarano/update-indices-metadata/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts#L470C14-L470C44)\nEBT event:\n\n```typescript\nexport interface IndexSettings {\n  index_name: string;\n  index_mode?: string;\n  default_pipeline?: string;\n  final_pipeline?: string;\n  source_mode?: string;\n}\n```\nReferences:\n- https://github.com/elastic/kibana/pull/194004 Initial version for the\nupdated EBT event.\n- https://github.com/elastic/kibana/pull/213822 This is a Similar PR\nupdating the feature.\n\nThe goal is to enhance the index settings EBT event with two new fields\nto enrich the telemetry information we collect about the indices used by\nthe security integrations.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"8c596d32010ad96eeac794f1938e686f9cbdb278"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219246","number":219246,"mergeCommit":{"message":"[Security Solution] Add new fields to indices metadata (#219246)\n\n## Summary\n\nAdds `_source.mode` and `index.mode` fields to the\n[TELEMETRY_INDEX_SETTINGS_EVENT](https://github.com/elastic/kibana/blob/szaffarano/update-indices-metadata/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/event_based/events.ts#L470C14-L470C44)\nEBT event:\n\n```typescript\nexport interface IndexSettings {\n  index_name: string;\n  index_mode?: string;\n  default_pipeline?: string;\n  final_pipeline?: string;\n  source_mode?: string;\n}\n```\nReferences:\n- https://github.com/elastic/kibana/pull/194004 Initial version for the\nupdated EBT event.\n- https://github.com/elastic/kibana/pull/213822 This is a Similar PR\nupdating the feature.\n\nThe goal is to enhance the index settings EBT event with two new fields\nto enrich the telemetry information we collect about the indices used by\nthe security integrations.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"8c596d32010ad96eeac794f1938e686f9cbdb278"}}]}] BACKPORT-->