### PR TITLE
[ci][8.18] increase disk size to 80 for typecheck

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -102,7 +102,7 @@ steps:
       diskType: 'hyperdisk-balanced'
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c
-      diskSizeGb: 75
+      diskSizeGb: 80
     timeout_in_minutes: 60
     retry:
       automatic:

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -94,7 +94,7 @@ steps:
       diskType: 'hyperdisk-balanced'
       preemptible: true
       spotZones: us-central1-a,us-central1-b,us-central1-c
-      diskSizeGb: 75
+      diskSizeGb: 80
     key: check_types
     timeout_in_minutes: 60
     retry:


### PR DESCRIPTION
## Summary
Type-check seems to run out of disk space on 8.18. (it's not running out on main, probably because most caches are warmed up for main, and 8.18 needs to get other packages besides the mainline) 