### PR TITLE
[ci][8.18] Increase disk 80 for jest tests

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -488,7 +488,7 @@ export async function pickTestGroupRunOrder() {
             key: 'jest',
             agents: {
               ...expandAgentQueue('n2-4-spot'),
-              diskSizeGb: 75,
+              diskSizeGb: 80,
             },
             retry: {
               automatic: [


### PR DESCRIPTION
## Summary
Similarly to https://github.com/elastic/kibana/pull/219506 - increase the disk size for jest tests.

Context: https://elastic.slack.com/archives/C013B57RRGE/p1745911271021589