### PR TITLE
[8.19][Automatic Import] Remove check for unused Connector role (#219358)

### DIFF
--- a/x-pack/platform/plugins/shared/integration_assistant/server/constants.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/constants.ts
@@ -17,4 +17,3 @@ export enum LogFormat {
 }
 export const FLEET_ALL_ROLE = 'fleet-all' as const;
 export const INTEGRATIONS_ALL_ROLE = 'integrations-all' as const;
-export const ACTIONS_AND_CONNECTORS_ALL_ROLE = 'actions:execute-advanced-connectors' as const;

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/analyze_logs_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/analyze_logs_routes.ts
@@ -10,12 +10,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { ANALYZE_LOGS_PATH, AnalyzeLogsRequestBody, AnalyzeLogsResponse } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getLogFormatDetectionGraph } from '../graphs/log_type_detection/graph';
 import type { IntegrationAssistantRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -47,7 +42,6 @@ export function registerAnalyzeLogsRoutes(
             requiredPrivileges: [
               FLEET_ALL_ROLE,
               INTEGRATIONS_ALL_ROLE,
-              ACTIONS_AND_CONNECTORS_ALL_ROLE,
             ],
           },
         },

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/analyze_logs_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/analyze_logs_routes.ts
@@ -39,10 +39,7 @@ export function registerAnalyzeLogsRoutes(
         version: '1',
         security: {
           authz: {
-            requiredPrivileges: [
-              FLEET_ALL_ROLE,
-              INTEGRATIONS_ALL_ROLE,
-            ],
+            requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
           },
         },
         validate: {

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/build_integration_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/build_integration_routes.ts
@@ -28,10 +28,7 @@ export function registerIntegrationBuilderRoutes(
         version: '1',
         security: {
           authz: {
-            requiredPrivileges: [
-              FLEET_ALL_ROLE,
-              INTEGRATIONS_ALL_ROLE,
-            ],
+            requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
           },
         },
         validate: {

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/build_integration_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/build_integration_routes.ts
@@ -14,11 +14,7 @@ import { withAvailability } from './with_availability';
 import { isErrorThatHandlesItsOwnResponse } from '../lib/errors';
 import { handleCustomErrors } from './routes_util';
 import { GenerationErrorCode } from '../../common/constants';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE } from '../constants';
 export function registerIntegrationBuilderRoutes(
   router: IRouter<IntegrationAssistantRouteHandlerContext>
 ) {
@@ -35,7 +31,6 @@ export function registerIntegrationBuilderRoutes(
             requiredPrivileges: [
               FLEET_ALL_ROLE,
               INTEGRATIONS_ALL_ROLE,
-              ACTIONS_AND_CONNECTORS_ALL_ROLE,
             ],
           },
         },

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/categorization_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/categorization_routes.ts
@@ -42,10 +42,7 @@ export function registerCategorizationRoutes(
         version: '1',
         security: {
           authz: {
-            requiredPrivileges: [
-              FLEET_ALL_ROLE,
-              INTEGRATIONS_ALL_ROLE,
-            ],
+            requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
           },
         },
         validate: {

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/categorization_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/categorization_routes.ts
@@ -14,12 +14,7 @@ import {
   CategorizationRequestBody,
   CategorizationResponse,
 } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getCategorizationGraph } from '../graphs/categorization';
 import type { IntegrationAssistantRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -50,7 +45,6 @@ export function registerCategorizationRoutes(
             requiredPrivileges: [
               FLEET_ALL_ROLE,
               INTEGRATIONS_ALL_ROLE,
-              ACTIONS_AND_CONNECTORS_ALL_ROLE,
             ],
           },
         },

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/cel_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/cel_routes.ts
@@ -10,12 +10,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { CEL_INPUT_GRAPH_PATH, CelInputRequestBody, CelInputResponse } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getCelGraph } from '../graphs/cel';
 import type { IntegrationAssistantRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -42,7 +37,6 @@ export function registerCelInputRoutes(router: IRouter<IntegrationAssistantRoute
             requiredPrivileges: [
               FLEET_ALL_ROLE,
               INTEGRATIONS_ALL_ROLE,
-              ACTIONS_AND_CONNECTORS_ALL_ROLE,
             ],
           },
         },

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/cel_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/cel_routes.ts
@@ -34,10 +34,7 @@ export function registerCelInputRoutes(router: IRouter<IntegrationAssistantRoute
         version: '1',
         security: {
           authz: {
-            requiredPrivileges: [
-              FLEET_ALL_ROLE,
-              INTEGRATIONS_ALL_ROLE,
-            ],
+            requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
           },
         },
         validate: {

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/ecs_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/ecs_routes.ts
@@ -36,10 +36,7 @@ export function registerEcsRoutes(router: IRouter<IntegrationAssistantRouteHandl
         version: '1',
         security: {
           authz: {
-            requiredPrivileges: [
-              FLEET_ALL_ROLE,
-              INTEGRATIONS_ALL_ROLE,
-            ],
+            requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
           },
         },
         validate: {

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/ecs_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/ecs_routes.ts
@@ -10,12 +10,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { ECS_GRAPH_PATH, EcsMappingRequestBody, EcsMappingResponse } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getEcsGraph } from '../graphs/ecs';
 import type { IntegrationAssistantRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -44,7 +39,6 @@ export function registerEcsRoutes(router: IRouter<IntegrationAssistantRouteHandl
             requiredPrivileges: [
               FLEET_ALL_ROLE,
               INTEGRATIONS_ALL_ROLE,
-              ACTIONS_AND_CONNECTORS_ALL_ROLE,
             ],
           },
         },

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/pipeline_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/pipeline_routes.ts
@@ -7,11 +7,7 @@
 
 import type { IKibanaResponse, IRouter } from '@kbn/core/server';
 import { CheckPipelineRequestBody, CheckPipelineResponse, CHECK_PIPELINE_PATH } from '../../common';
-import {
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import type { IntegrationAssistantRouteHandlerContext } from '../plugin';
 import { testPipeline } from '../util/pipeline';
 import { buildRouteValidationWithZod } from '../util/route_validation';
@@ -36,10 +32,7 @@ export function registerPipelineRoutes(router: IRouter<IntegrationAssistantRoute
         version: '1',
         security: {
           authz: {
-            requiredPrivileges: [
-              FLEET_ALL_ROLE,
-              INTEGRATIONS_ALL_ROLE,
-            ],
+            requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
           },
         },
         validate: {

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/pipeline_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/pipeline_routes.ts
@@ -8,7 +8,6 @@
 import type { IKibanaResponse, IRouter } from '@kbn/core/server';
 import { CheckPipelineRequestBody, CheckPipelineResponse, CHECK_PIPELINE_PATH } from '../../common';
 import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
   FLEET_ALL_ROLE,
   INTEGRATIONS_ALL_ROLE,
   ROUTE_HANDLER_TIMEOUT,
@@ -40,7 +39,6 @@ export function registerPipelineRoutes(router: IRouter<IntegrationAssistantRoute
             requiredPrivileges: [
               FLEET_ALL_ROLE,
               INTEGRATIONS_ALL_ROLE,
-              ACTIONS_AND_CONNECTORS_ALL_ROLE,
             ],
           },
         },

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/related_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/related_routes.ts
@@ -10,12 +10,7 @@ import { getRequestAbortedSignal } from '@kbn/data-plugin/server';
 import { APMTracer } from '@kbn/langchain/server/tracers/apm';
 import { getLangSmithTracer } from '@kbn/langchain/server/tracers/langsmith';
 import { RELATED_GRAPH_PATH, RelatedRequestBody, RelatedResponse } from '../../common';
-import {
-  ACTIONS_AND_CONNECTORS_ALL_ROLE,
-  FLEET_ALL_ROLE,
-  INTEGRATIONS_ALL_ROLE,
-  ROUTE_HANDLER_TIMEOUT,
-} from '../constants';
+import { FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE, ROUTE_HANDLER_TIMEOUT } from '../constants';
 import { getRelatedGraph } from '../graphs/related';
 import type { IntegrationAssistantRouteHandlerContext } from '../plugin';
 import { getLLMClass, getLLMType } from '../util/llm';
@@ -44,7 +39,6 @@ export function registerRelatedRoutes(router: IRouter<IntegrationAssistantRouteH
             requiredPrivileges: [
               FLEET_ALL_ROLE,
               INTEGRATIONS_ALL_ROLE,
-              ACTIONS_AND_CONNECTORS_ALL_ROLE,
             ],
           },
         },

--- a/x-pack/platform/plugins/shared/integration_assistant/server/routes/related_routes.ts
+++ b/x-pack/platform/plugins/shared/integration_assistant/server/routes/related_routes.ts
@@ -36,10 +36,7 @@ export function registerRelatedRoutes(router: IRouter<IntegrationAssistantRouteH
         version: '1',
         security: {
           authz: {
-            requiredPrivileges: [
-              FLEET_ALL_ROLE,
-              INTEGRATIONS_ALL_ROLE,
-            ],
+            requiredPrivileges: [FLEET_ALL_ROLE, INTEGRATIONS_ALL_ROLE],
           },
         },
         validate: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Automatic Import] Remove check for unused Connector role (#219358)](https://github.com/elastic/kibana/pull/219358)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Marius Iversen","email":"marius.iversen@elastic.co"},"sourceCommit":{"committedDate":"2025-04-28T11:30:02Z","message":"[Automatic Import] Remove check for unused Connector role (#219358)\n\n## Summary\n\nThis PR removes some unused ACTION connector capability checks that was\nremoved in https://github.com/elastic/kibana/pull/203503.\n\nThe actionClient will do permission checks already as the user when\nfetching the connector, so removing this while keeping the checks for\nFleet/Integration capabilities is fine.\n\nThis resolves a bug in 9.x and 8.18.x when visiting the UI or using the\nAPI for automatic import will try to resolve an unushed capability.\n\nI manually tested the following on the changed code:\n1. Ran one working with elastic superuser.\n2. Ran one working with custom users that has connector, integration and\nfleet role.\n3. Ran one that should not work with custom user that does not have\nconnector privileges but has integration and fleet.\n\n\nThis is how it looks like when the connector privileges do not exist for\nthe user:\n\n![image](https://github.com/user-attachments/assets/cade4ccc-bfd5-4583-8ca7-af4920cf85ac)\n\nWhen calling the API when missing action client connector:\n```\n{\n    \"statusCode\": 400,\n    \"error\": \"Bad Request\",\n    \"message\": \"Unauthorized to get actions\"\n}\n```","sha":"db250c45f271a3db67ef2c590f7bbdddb26e7ba3","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","backport missing","Team:Security-Scalability","backport:version","Feature:AutomaticImport","v9.1.0","v8.19.0","v8.18.1","v9.0.1"],"title":"[Automatic Import] Remove check for unused Connector role","number":219358,"url":"https://github.com/elastic/kibana/pull/219358","mergeCommit":{"message":"[Automatic Import] Remove check for unused Connector role (#219358)\n\n## Summary\n\nThis PR removes some unused ACTION connector capability checks that was\nremoved in https://github.com/elastic/kibana/pull/203503.\n\nThe actionClient will do permission checks already as the user when\nfetching the connector, so removing this while keeping the checks for\nFleet/Integration capabilities is fine.\n\nThis resolves a bug in 9.x and 8.18.x when visiting the UI or using the\nAPI for automatic import will try to resolve an unushed capability.\n\nI manually tested the following on the changed code:\n1. Ran one working with elastic superuser.\n2. Ran one working with custom users that has connector, integration and\nfleet role.\n3. Ran one that should not work with custom user that does not have\nconnector privileges but has integration and fleet.\n\n\nThis is how it looks like when the connector privileges do not exist for\nthe user:\n\n![image](https://github.com/user-attachments/assets/cade4ccc-bfd5-4583-8ca7-af4920cf85ac)\n\nWhen calling the API when missing action client connector:\n```\n{\n    \"statusCode\": 400,\n    \"error\": \"Bad Request\",\n    \"message\": \"Unauthorized to get actions\"\n}\n```","sha":"db250c45f271a3db67ef2c590f7bbdddb26e7ba3"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","8.18","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219358","number":219358,"mergeCommit":{"message":"[Automatic Import] Remove check for unused Connector role (#219358)\n\n## Summary\n\nThis PR removes some unused ACTION connector capability checks that was\nremoved in https://github.com/elastic/kibana/pull/203503.\n\nThe actionClient will do permission checks already as the user when\nfetching the connector, so removing this while keeping the checks for\nFleet/Integration capabilities is fine.\n\nThis resolves a bug in 9.x and 8.18.x when visiting the UI or using the\nAPI for automatic import will try to resolve an unushed capability.\n\nI manually tested the following on the changed code:\n1. Ran one working with elastic superuser.\n2. Ran one working with custom users that has connector, integration and\nfleet role.\n3. Ran one that should not work with custom user that does not have\nconnector privileges but has integration and fleet.\n\n\nThis is how it looks like when the connector privileges do not exist for\nthe user:\n\n![image](https://github.com/user-attachments/assets/cade4ccc-bfd5-4583-8ca7-af4920cf85ac)\n\nWhen calling the API when missing action client connector:\n```\n{\n    \"statusCode\": 400,\n    \"error\": \"Bad Request\",\n    \"message\": \"Unauthorized to get actions\"\n}\n```","sha":"db250c45f271a3db67ef2c590f7bbdddb26e7ba3"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->