### PR TITLE
[Oblt Onboarding][K8S OTel E2E Test] Wait for pods to create before instrumenting the app

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
@@ -51,8 +51,13 @@ test('Otel Kubernetes', async ({ page, onboardingHomePage, otelKubernetesFlowPag
     ?.split('\n')[0]
     ?.replace('myapp', INSTRUMENTED_APP_NAME)
     ?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
+  /**
+   * Adding timeout so Ensemble waits for t
+   * he pods to be created before instrumenting the app
+   */
+  const sleepSnippet = `sleep 60`;
 
-  const codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}\n${annotateAllResourceSnippet}\n${restartDeploymentSnippet}`;
+  const codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}\n${sleepSnippet}\n${annotateAllResourceSnippet}\n${restartDeploymentSnippet}`;
 
   /**
    * Ensemble story watches for the code snippet file

--- a/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/e2e/playwright/stateful/kubernetes_otel.spec.ts
@@ -52,10 +52,10 @@ test('Otel Kubernetes', async ({ page, onboardingHomePage, otelKubernetesFlowPag
     ?.replace('myapp', INSTRUMENTED_APP_NAME)
     ?.replace('my-namespace', INSTRUMENTED_APP_CONTAINER_NAMESPACE);
   /**
-   * Adding timeout so Ensemble waits for t
-   * he pods to be created before instrumenting the app
+   * Adding timeout so Ensemble waits for the
+   * pods to be created before instrumenting the app
    */
-  const sleepSnippet = `sleep 60`;
+  const sleepSnippet = `sleep 120`;
 
   const codeSnippet = `${helmRepoSnippet}\n${installStackSnippet}\n${sleepSnippet}\n${annotateAllResourceSnippet}\n${restartDeploymentSnippet}`;
 


### PR DESCRIPTION
This change adds an artificial wait between installing otel containers onto the cluster and instrumenting the test app. Because in Ensemble story all commands are executed automatically in one go, the test would often fail because the app was instrumented and restarted before otel containers were ready.

For the context. I first tried to use `kubectl wait` but it exists once any of the 5 containers in the namespace is ready and doesn't wait for all of them. Ideally, I'd want to avoid injecting another bash script that does something fancy to wait for pods.