### PR TITLE
try global jest perf fix

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -228,11 +228,13 @@ export async function pickTestGroupRunOrder() {
    * For example in code coverage pipeline definition, it is "limited"
    * to 'unit,integration'.  This means FTR tests will not be executed.
    */
-  const LIMIT_CONFIG_TYPE = process.env.LIMIT_CONFIG_TYPE
-    ? process.env.LIMIT_CONFIG_TYPE.split(',')
-        .map((t) => t.trim())
-        .filter(Boolean)
-    : ['unit', 'integration', 'functional'];
+  // const LIMIT_CONFIG_TYPE = process.env.LIMIT_CONFIG_TYPE
+  //   ? process.env.LIMIT_CONFIG_TYPE.split(',')
+  //       .map((t) => t.trim())
+  //       .filter(Boolean)
+  //   : ['unit', 'integration', 'functional'];
+
+  const LIMIT_CONFIG_TYPE = ['unit'];
 
   const FTR_CONFIG_PATTERNS = process.env.FTR_CONFIG_PATTERNS
     ? process.env.FTR_CONFIG_PATTERNS.split(',')

--- a/src/platform/packages/shared/kbn-test/src/jest/setup/polyfills.jsdom.js
+++ b/src/platform/packages/shared/kbn-test/src/jest/setup/polyfills.jsdom.js
@@ -71,3 +71,47 @@ if (!Object.hasOwn(global, 'Worker')) {
 if (!Object.hasOwn(global, 'MessagePort')) {
   global.MessagePort = {};
 }
+
+export const getJsDomPerformanceFix = () => {
+  // eslint-disable-next-line prefer-object-spread
+  const originalGetComputedStyle = Object.assign({}, window.getComputedStyle);
+
+  return {
+    fix: () => {
+      // The JSDOM implementation is too slow
+      // Especially for dropdowns that try to position themselves
+      // perf issue - https://github.com/jsdom/jsdom/issues/3234
+      Object.defineProperty(window, 'getComputedStyle', {
+        value: (el) => {
+          /**
+           * This is based on the jsdom implementation of getComputedStyle
+           * https://github.com/jsdom/jsdom/blob/9dae17bf0ad09042cfccd82e6a9d06d3a615d9f4/lib/jsdom/browser/Window.js#L779-L820
+           *
+           * It is missing global style parsing and will only return styles applied directly to an element.
+           * Will not return styles that are global or from emotion
+           */
+          const declaration = new CSSStyleDeclaration();
+          const { style } = el;
+
+          Array.prototype.forEach.call(style, (property) => {
+            declaration.setProperty(
+              property,
+              style.getPropertyValue(property),
+              style.getPropertyPriority(property)
+            );
+          });
+
+          return declaration;
+        },
+        configurable: true,
+        writable: true,
+      });
+    },
+    cleanup: () => {
+      Object.defineProperty(window, 'getComputedStyle', originalGetComputedStyle);
+    },
+  };
+};
+
+const { fix } = getJsDomPerformanceFix();
+fix();


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



