### PR TITLE
fix(slo): fix instantiation of abort controller in all tasks

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/bulk_delete/bulk_delete_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/bulk_delete/bulk_delete_task.ts
@@ -66,6 +66,7 @@ export class BulkDeleteTask {
                 return;
               }
 
+              this.abortController = new AbortController();
               const [coreStart, pluginStart] = await core.getStartServices();
 
               const scopedClusterClient = coreStart.elasticsearch.client.asScoped(fakeRequest);

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/orphan_summary_cleanup_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/orphan_summary_cleanup_task.ts
@@ -75,50 +75,53 @@ export class SloOrphanSummaryCleanupTask {
     });
   }
 
-  runTask = async () => {
-    if (this.soClient && this.esClient) {
-      let searchAfterKey: AggregationsCompositeAggregateKey | undefined;
+  public async runTask() {
+    if (!this.soClient || !this.esClient) {
+      return;
+    }
 
-      do {
-        const { sloSummaryIds, searchAfter } = await this.fetchSloSummariesIds(searchAfterKey);
+    this.abortController = new AbortController();
+    let searchAfterKey: AggregationsCompositeAggregateKey | undefined;
 
-        if (sloSummaryIds.length === 0) {
-          return;
-        }
+    do {
+      const { sloSummaryIds, searchAfter } = await this.fetchSloSummariesIds(searchAfterKey);
 
-        searchAfterKey = searchAfter;
+      if (sloSummaryIds.length === 0) {
+        return;
+      }
 
-        const ids = sloSummaryIds.map(({ id }) => id);
+      searchAfterKey = searchAfter;
 
-        const sloDefinitions = await this.findSloDefinitions(ids);
+      const ids = sloSummaryIds.map(({ id }) => id);
 
-        const sloSummaryIdsToDelete = sloSummaryIds.filter(
-          ({ id, revision }) =>
-            !sloDefinitions.find(
-              (attributes) => attributes.id === id && attributes.revision === revision
-            )
+      const sloDefinitions = await this.findSloDefinitions(ids);
+
+      const sloSummaryIdsToDelete = sloSummaryIds.filter(
+        ({ id, revision }) =>
+          !sloDefinitions.find(
+            (attributes) => attributes.id === id && attributes.revision === revision
+          )
+      );
+
+      if (sloSummaryIdsToDelete.length > 0) {
+        this.logger.debug(
+          `[SLO] Deleting ${sloSummaryIdsToDelete.length} SLO Summary documents from the summary index`
         );
 
-        if (sloSummaryIdsToDelete.length > 0) {
-          this.logger.debug(
-            `[SLO] Deleting ${sloSummaryIdsToDelete.length} SLO Summary documents from the summary index`
-          );
-
-          await this.esClient.deleteByQuery({
-            index: SUMMARY_DESTINATION_INDEX_PATTERN,
-            wait_for_completion: false,
-            conflicts: 'proceed',
-            slices: 'auto',
-            query: {
-              bool: {
-                should: getDeleteQueryFilter(sloSummaryIdsToDelete.sort()),
-              },
+        await this.esClient.deleteByQuery({
+          index: SUMMARY_DESTINATION_INDEX_PATTERN,
+          wait_for_completion: false,
+          conflicts: 'proceed',
+          slices: 'auto',
+          query: {
+            bool: {
+              should: getDeleteQueryFilter(sloSummaryIdsToDelete.sort()),
             },
-          });
-        }
-      } while (searchAfterKey);
-    }
-  };
+          },
+        });
+      }
+    } while (searchAfterKey);
+  }
 
   fetchSloSummariesIds = async (
     searchAfter?: AggregationsCompositeAggregateKey

--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/temp_summary_cleanup_task.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/temp_summary_cleanup_task.ts
@@ -110,6 +110,7 @@ export class TempSummaryCleanupTask {
 
     this.logger.debug(`runTask started`);
 
+    this.abortController = new AbortController();
     const [coreStart] = await core.getStartServices();
     const esClient = coreStart.elasticsearch.client.asInternalUser;
 


### PR DESCRIPTION
### Summary

This PR fixes the instantiation of the AbortController every time a task runs.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->