### PR TITLE
[8.18] [ResponseOps] Flapping alerts are not being marked as recovered (#218888)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/lib/get_alerts_for_notification.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/get_alerts_for_notification.test.ts
@@ -112,7 +112,7 @@ describe('getAlertsForNotification', () => {
       Object {
         "3": Object {
           "meta": Object {
-            "activeCount": 0,
+            "activeCount": 1,
             "flapping": true,
             "flappingHistory": Array [],
             "maintenanceWindowIds": Array [],
@@ -137,7 +137,7 @@ describe('getAlertsForNotification', () => {
       Object {
         "3": Object {
           "meta": Object {
-            "activeCount": 0,
+            "activeCount": 1,
             "flapping": true,
             "flappingHistory": Array [],
             "maintenanceWindowIds": Array [],
@@ -440,7 +440,7 @@ describe('getAlertsForNotification', () => {
       getAlertsForNotification(
         DEFAULT_FLAPPING_SETTINGS,
         'default',
-        0,
+        1,
         {},
         {},
         {
@@ -554,7 +554,7 @@ describe('getAlertsForNotification', () => {
     expect(delayedAlertsCount).toBe(2);
   });
 
-  test('should remove the alert from recoveredAlerts and should not return the alert in currentRecoveredAlerts if the activeCount is less than the rule alertDelay', () => {
+  test('should remove the alert from recoveredAlerts and should not return the alert in currentRecoveredAlerts if the activeCount is less than the rule alertDelay and greater than 0', () => {
     const alert1 = new Alert('1', {
       meta: { activeCount: 1, uuid: 'uuid-1' },
     });
@@ -578,8 +578,32 @@ describe('getAlertsForNotification', () => {
           '2': alert2,
         }
       );
-    expect(recoveredAlerts).toMatchInlineSnapshot(`Object {}`);
-    expect(currentRecoveredAlerts).toMatchInlineSnapshot(`Object {}`);
+    expect(recoveredAlerts).toMatchInlineSnapshot(`
+      Object {
+        "2": Object {
+          "meta": Object {
+            "activeCount": 0,
+            "flappingHistory": Array [],
+            "maintenanceWindowIds": Array [],
+            "uuid": "uuid-2",
+          },
+          "state": Object {},
+        },
+      }
+    `);
+    expect(currentRecoveredAlerts).toMatchInlineSnapshot(`
+      Object {
+        "2": Object {
+          "meta": Object {
+            "activeCount": 0,
+            "flappingHistory": Array [],
+            "maintenanceWindowIds": Array [],
+            "uuid": "uuid-2",
+          },
+          "state": Object {},
+        },
+      }
+    `);
     expect(delayedAlertsCount).toBe(0);
   });
 

--- a/x-pack/platform/plugins/shared/alerting/server/lib/get_alerts_for_notification.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/get_alerts_for_notification.ts
@@ -54,12 +54,12 @@ export function getAlertsForNotification<
   for (const id of keys(currentRecoveredAlerts)) {
     const alert = recoveredAlerts[id];
     // if alert has not reached the alertDelay threshold don't recover the alert
-    if (alert.getActiveCount() < alertDelay) {
+    const activeCount = alert.getActiveCount();
+    if (activeCount > 0 && activeCount < alertDelay) {
       // remove from recovered alerts
       delete recoveredAlerts[id];
       delete currentRecoveredAlerts[id];
     }
-    alert.resetActiveCount();
     if (flappingSettings.enabled) {
       const flapping = alert.getFlapping();
       if (flapping) {
@@ -71,6 +71,7 @@ export function getAlertsForNotification<
           const lastActionGroupId = alert.getLastScheduledActions()?.group;
 
           const newAlert = new Alert<State, Context, ActionGroupIds>(id, alert.toRaw());
+          alert.incrementActiveCount();
           // unset the end time in the alert state
           const state = newAlert.getState();
           delete state.end;
@@ -88,10 +89,14 @@ export function getAlertsForNotification<
           delete recoveredAlerts[id];
           delete currentRecoveredAlerts[id];
         } else {
+          alert.resetActiveCount();
           alert.resetPendingRecoveredCount();
         }
+      } else {
+        alert.resetActiveCount();
       }
     } else {
+      alert.resetActiveCount();
       alert.resetPendingRecoveredCount();
     }
   }

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/event_log.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/event_log.ts
@@ -700,7 +700,7 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
             .send(
               getTestRuleData({
                 rule_type_id: 'test.patternFiring',
-                schedule: { interval: '1s' },
+                schedule: { interval: '1d' },
                 throttle: null,
                 params: {
                   pattern,
@@ -718,6 +718,9 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                   },
                 ],
                 notify_when: RuleNotifyWhen.CHANGE,
+                alert_delay: {
+                  active: 1,
+                },
               })
             );
 
@@ -726,24 +729,24 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
           objectRemover.add(space.id, alertId, 'rule', 'alerting');
 
           // get the events we're expecting
-          const events = await retry.try(async () => {
-            return await getEventLog({
-              getService,
-              spaceId: space.id,
-              type: 'alert',
-              id: alertId,
-              provider: 'alerting',
-              actions: new Map([
-                // make sure the counts of the # of events per type are as expected
-                ['execute-start', { gte: 6 }],
-                ['execute', { gte: 6 }],
-                ['execute-action', { equal: 6 }],
-                ['new-instance', { equal: 3 }],
-                ['active-instance', { gte: 6 }],
-                ['recovered-instance', { equal: 3 }],
-              ]),
-            });
-          });
+          let run = 1;
+          await waitForEventLog(space.id, alertId, new Map([['execute', { equal: 1 }]]));
+          // Run the rule 14 more times
+          for (let i = 0; i < 14; i++) {
+            await runSoon(alertId, space.id);
+            await waitForEventLog(space.id, alertId, new Map([['execute', { equal: ++run }]]));
+          }
+
+          const events = await waitForEventLog(
+            space.id,
+            alertId,
+            new Map([
+              ['execute', { equal: 15 }],
+              ['active-instance', { equal: 12 }],
+              ['new-instance', { equal: 3 }],
+              ['recovered-instance', { equal: 2 }],
+            ])
+          );
 
           const flapping = events
             .filter(
@@ -752,12 +755,7 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                 event?.event?.action === 'recovered-instance'
             )
             .map((event) => event?.kibana?.alert?.flapping);
-          const result = [false, false, false, false, false].concat(
-            new Array(9).fill(true),
-            false,
-            false,
-            false
-          );
+          const result = [false, false, false, false, false].concat(new Array(9).fill(true));
           expect(flapping).to.eql(result);
         });
 
@@ -802,7 +800,7 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
             .send(
               getTestRuleData({
                 rule_type_id: 'test.patternFiring',
-                schedule: { interval: '1s' },
+                schedule: { interval: '1d' },
                 throttle: null,
                 notify_when: null,
                 params: {
@@ -830,6 +828,9 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                     },
                   },
                 ],
+                alert_delay: {
+                  active: 1,
+                },
               })
             );
 
@@ -838,24 +839,24 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
           objectRemover.add(space.id, alertId, 'rule', 'alerting');
 
           // get the events we're expecting
-          const events = await retry.try(async () => {
-            return await getEventLog({
-              getService,
-              spaceId: space.id,
-              type: 'alert',
-              id: alertId,
-              provider: 'alerting',
-              actions: new Map([
-                // make sure the counts of the # of events per type are as expected
-                ['execute-start', { gte: 6 }],
-                ['execute', { gte: 6 }],
-                ['execute-action', { equal: 6 }],
-                ['new-instance', { equal: 3 }],
-                ['active-instance', { gte: 6 }],
-                ['recovered-instance', { equal: 3 }],
-              ]),
-            });
-          });
+          let run = 1;
+          await waitForEventLog(space.id, alertId, new Map([['execute', { equal: 1 }]]));
+          // Run the rule 14 more times
+          for (let i = 0; i < 14; i++) {
+            await runSoon(alertId, space.id);
+            await waitForEventLog(space.id, alertId, new Map([['execute', { equal: ++run }]]));
+          }
+
+          const events = await waitForEventLog(
+            space.id,
+            alertId,
+            new Map([
+              ['execute', { equal: 15 }],
+              ['active-instance', { equal: 12 }],
+              ['new-instance', { equal: 3 }],
+              ['recovered-instance', { equal: 2 }],
+            ])
+          );
 
           const flapping = events
             .filter(
@@ -864,12 +865,7 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                 event?.event?.action === 'recovered-instance'
             )
             .map((event) => event?.kibana?.alert?.flapping);
-          const result = [false, false, false, false, false].concat(
-            new Array(9).fill(true),
-            false,
-            false,
-            false
-          );
+          const result = [false, false, false, false, false].concat(new Array(9).fill(true));
           expect(flapping).to.eql(result);
         });
 
@@ -913,7 +909,7 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
             .send(
               getTestRuleData({
                 rule_type_id: 'test.patternFiring',
-                schedule: { interval: '1s' },
+                schedule: { interval: '1d' },
                 throttle: null,
                 params: {
                   pattern,
@@ -931,6 +927,9 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                   },
                 ],
                 notify_when: RuleNotifyWhen.CHANGE,
+                alert_delay: {
+                  active: 1,
+                },
               })
             );
 
@@ -939,24 +938,24 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
           objectRemover.add(space.id, alertId, 'rule', 'alerting');
 
           // get the events we're expecting
-          const events = await retry.try(async () => {
-            return await getEventLog({
-              getService,
-              spaceId: space.id,
-              type: 'alert',
-              id: alertId,
-              provider: 'alerting',
-              actions: new Map([
-                // make sure the counts of the # of events per type are as expected
-                ['execute-start', { gte: 6 }],
-                ['execute', { gte: 6 }],
-                ['execute-action', { equal: 6 }],
-                ['new-instance', { equal: 3 }],
-                ['active-instance', { gte: 3 }],
-                ['recovered-instance', { equal: 3 }],
-              ]),
-            });
-          });
+          let run = 1;
+          await waitForEventLog(space.id, alertId, new Map([['execute', { equal: 1 }]]));
+          // Run the rule 13 more times
+          for (let i = 0; i < 13; i++) {
+            await runSoon(alertId, space.id);
+            await waitForEventLog(space.id, alertId, new Map([['execute', { equal: ++run }]]));
+          }
+
+          const events = await waitForEventLog(
+            space.id,
+            alertId,
+            new Map([
+              ['execute', { equal: 14 }],
+              ['active-instance', { equal: 10 }],
+              ['new-instance', { equal: 3 }],
+              ['recovered-instance', { equal: 3 }],
+            ])
+          );
 
           const flapping = events
             .filter(
@@ -1010,7 +1009,7 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
             .send(
               getTestRuleData({
                 rule_type_id: 'test.patternFiring',
-                schedule: { interval: '1s' },
+                schedule: { interval: '1d' },
                 throttle: null,
                 notify_when: null,
                 params: {
@@ -1038,6 +1037,9 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
                     },
                   },
                 ],
+                alert_delay: {
+                  active: 1,
+                },
               })
             );
 
@@ -1046,24 +1048,24 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
           objectRemover.add(space.id, alertId, 'rule', 'alerting');
 
           // get the events we're expecting
-          const events = await retry.try(async () => {
-            return await getEventLog({
-              getService,
-              spaceId: space.id,
-              type: 'alert',
-              id: alertId,
-              provider: 'alerting',
-              actions: new Map([
-                // make sure the counts of the # of events per type are as expected
-                ['execute-start', { gte: 6 }],
-                ['execute', { gte: 6 }],
-                ['execute-action', { equal: 6 }],
-                ['new-instance', { equal: 3 }],
-                ['active-instance', { gte: 3 }],
-                ['recovered-instance', { equal: 3 }],
-              ]),
-            });
-          });
+          let run = 1;
+          await waitForEventLog(space.id, alertId, new Map([['execute', { equal: 1 }]]));
+          // Run the rule 13 more times
+          for (let i = 0; i < 13; i++) {
+            await runSoon(alertId, space.id);
+            await waitForEventLog(space.id, alertId, new Map([['execute', { equal: ++run }]]));
+          }
+
+          const events = await waitForEventLog(
+            space.id,
+            alertId,
+            new Map([
+              ['execute', { equal: 14 }],
+              ['active-instance', { equal: 10 }],
+              ['new-instance', { equal: 3 }],
+              ['recovered-instance', { equal: 3 }],
+            ])
+          );
 
           const flapping = events
             .filter(
@@ -2128,6 +2130,30 @@ export default function eventLogTests({ getService }: FtrProviderContext) {
       });
     }
   });
+
+  async function runSoon(ruleId: string, spaceId: string) {
+    const response = await supertest
+      .post(`${getUrlPrefix(spaceId)}/internal/alerting/rule/${ruleId}/_run_soon`)
+      .set('kbn-xsrf', 'foo');
+    expect(response.status).to.eql(204);
+  }
+
+  async function waitForEventLog(
+    spaceId: string,
+    id: string,
+    actions: Map<string, { gte: number } | { equal: number }>
+  ) {
+    return await retry.try(async () => {
+      return await getEventLog({
+        getService,
+        spaceId,
+        type: 'alert',
+        id,
+        provider: 'alerting',
+        actions,
+      });
+    });
+  }
 }
 
 interface SavedObject {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_flapping.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/alerts_as_data/alerts_as_data_flapping.ts
@@ -86,6 +86,9 @@ export default function createAlertsAsDataFlappingTest({ getService }: FtrProvid
             params: ruleParameters,
             actions: [],
             notify_when: RuleNotifyWhen.CHANGE,
+            alert_delay: {
+              active: 1,
+            },
           })
         );
 
@@ -218,6 +221,9 @@ export default function createAlertsAsDataFlappingTest({ getService }: FtrProvid
             params: ruleParameters,
             actions: [],
             notify_when: RuleNotifyWhen.CHANGE,
+            alert_delay: {
+              active: 1,
+            },
           })
         );
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.0` to `8.18`:
 - [[ResponseOps] Flapping alerts are not being marked as recovered (#218888)](https://github.com/elastic/kibana/pull/218888)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alexi Doak","email":"109488926+doakalexi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-28T21:13:35Z","message":"[ResponseOps] Flapping alerts are not being marked as recovered (#218888)\n\nResolves https://github.com/elastic/kibana/issues/218879\n\n## Summary\n\nThis PR fixes a bug for flapping alerts where the recovering alerts are\nnot marked as recovered. This has been fixed already in main. I updated\nthe functional tests to help catch bugs like this in the future, and\nwill add the testing changes on main too.\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n\n### To verify\nThis happens when the alert delay > 0, so by default when you create the\nrule from the ui the alert delay is set to 1.\n1. Create a rule from the ui\n2. Get it to start flapping\n3. \"Recover\" the alert and verify that on the 4th execution (using\ndefault flapping settings) that the event log and aad documents are\nupdated to be recovered.","sha":"7311c268dc9a339a02e203e1c2523fedee70cb50","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","backport:version","v8.18.1","v8.17.6"],"title":"[ResponseOps] Flapping alerts are not being marked as recovered","number":218888,"url":"https://github.com/elastic/kibana/pull/218888","mergeCommit":{"message":"[ResponseOps] Flapping alerts are not being marked as recovered (#218888)\n\nResolves https://github.com/elastic/kibana/issues/218879\n\n## Summary\n\nThis PR fixes a bug for flapping alerts where the recovering alerts are\nnot marked as recovered. This has been fixed already in main. I updated\nthe functional tests to help catch bugs like this in the future, and\nwill add the testing changes on main too.\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\n\n\n### To verify\nThis happens when the alert delay > 0, so by default when you create the\nrule from the ui the alert delay is set to 1.\n1. Create a rule from the ui\n2. Get it to start flapping\n3. \"Recover\" the alert and verify that on the 4th execution (using\ndefault flapping settings) that the event log and aad documents are\nupdated to be recovered.","sha":"7311c268dc9a339a02e203e1c2523fedee70cb50"}},"sourceBranch":"9.0","suggestedTargetBranches":["8.18","8.17"],"targetPullRequestStates":[{"branch":"8.18","label":"v8.18.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.6","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->