### PR TITLE
Add "Inventory" link to Security solution navigation

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_ess/public/navigation/navigation_tree.ts
@@ -65,6 +65,10 @@ export const createNavigationTree = (services: Services): NavigationTreeDefiniti
         {
           breadcrumbStatus: 'hidden',
           children: [
+            {
+              id: SecurityPageName.assetInventory,
+              link: securityLink(SecurityPageName.assetInventory),
+            },
             defaultNavigationTree.assets(services),
             defaultNavigationTree.entityAnalytics(),
           ],

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/navigation_tree.ts
@@ -72,6 +72,10 @@ export const createNavigationTree = (services: Services): NavigationTreeDefiniti
         {
           breadcrumbStatus: 'hidden',
           children: [
+            {
+              id: SecurityPageName.assetInventory,
+              link: securityLink(SecurityPageName.assetInventory),
+            },
             defaultNavigationTree.assets(services),
             defaultNavigationTree.entityAnalytics(),
           ],


### PR DESCRIPTION
## Summary

Closes:
- https://github.com/elastic/kibana/issues/219269

Add missing "Inventory" link to Security solution navigation. The link was only present in the classical view, but not in the the Security view. **These changes should affect both ESS and Serverless.**

### Depends on

- https://github.com/elastic/kibana/pull/219285

### Screenshots

<details><summary>Advanced setting enabled</summary>
<img width="272" alt="Screenshot 2025-04-30 at 15 42 25" src="https://github.com/user-attachments/assets/2b81dec5-28e9-4cd9-ab2b-dc2f512441fe" />
</details>

<details><summary>Advanced setting disabled</summary>
<img width="277" alt="Screenshot 2025-04-30 at 15 40 36" src="https://github.com/user-attachments/assets/37d512a6-23d9-477c-be29-38fd5d09c83f" />
</details>

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Risk of exposing the feature if not gated correctly.
