### PR TITLE
[Core Deps] Add `prev-major` backports

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1308,7 +1308,8 @@
         "release_note:skip",
         "Team:Security",
         "Team:Core",
-        "backport:prev-minor"
+        "backport:prev-minor",
+        "backport:prev-major"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -1331,7 +1332,8 @@
         "release_note:skip",
         "Team:Security",
         "Team:Core",
-        "backport:prev-minor"
+        "backport:prev-minor",
+        "backport:prev-major"
       ],
       "minimumReleaseAge": "7 days",
       "enabled": true
@@ -1353,7 +1355,8 @@
       "labels": [
         "release_note:skip",
         "Team:Core",
-        "backport:prev-minor"
+        "backport:prev-minor",
+        "backport:prev-major"
       ],
       "enabled": true
     },


### PR DESCRIPTION
## Summary

Adding `backport:prev-major` to the OpenFeature and APM dependencies. They weren't needed before because OpenFeature was only a thing of late 8.x so `prev-minor` was enough. Since we moved to 9.x, we need to backport to `prev-major` as well.



