### PR TITLE
Revert "[8.17][Search] Fix content Indices documents error on paginate (#21…

### DIFF
--- a/packages/kbn-search-index-documents/lib/fetch_search_results.test.ts
+++ b/packages/kbn-search-index-documents/lib/fetch_search_results.test.ts
@@ -88,7 +88,7 @@ describe('fetchSearchResults lib function', () => {
       index: indexName,
       q: query,
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: undefined,
+      track_total_hits: false,
     });
   });
 
@@ -110,7 +110,7 @@ describe('fetchSearchResults lib function', () => {
       index: indexName,
       q: '\\"yellow banana\\"',
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: undefined,
+      track_total_hits: false,
     });
   });
 
@@ -125,7 +125,7 @@ describe('fetchSearchResults lib function', () => {
       from: DEFAULT_FROM_VALUE,
       index: indexName,
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: undefined,
+      track_total_hits: false,
     });
   });
 
@@ -153,7 +153,7 @@ describe('fetchSearchResults lib function', () => {
       index: indexName,
       q: query,
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: undefined,
+      track_total_hits: false,
     });
   });
 

--- a/packages/kbn-search-index-documents/lib/fetch_search_results.ts
+++ b/packages/kbn-search-index-documents/lib/fetch_search_results.ts
@@ -19,7 +19,7 @@ export const fetchSearchResults = async (
   query?: string,
   from: number = 0,
   size: number = DEFAULT_DOCS_PER_PAGE,
-  trackTotalHits?: boolean
+  trackTotalHits: boolean = false
 ): Promise<Paginate<SearchHit>> => {
   const result = await fetchWithPagination(
     async () =>


### PR DESCRIPTION

This reverts commit 0e9c857a211c8a4f844d737d020774f9d96d6bc0.

## Summary

Reverting changes from [PR](https://github.com/elastic/kibana/pull/219471) that adds changes to `8.17 ` branch directly. reverting to have clean history. Will try manual backport from [PR](https://github.com/elastic/kibana/pull/219471) that went into main, other 8.x branches. 


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



