### PR TITLE
[controls] fix option list control making 2 requests on refresh

### DIFF
--- a/src/platform/plugins/shared/controls/public/control_group/get_control_group_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/control_group/get_control_group_factory.tsx
@@ -135,7 +135,7 @@ export const getControlGroupEmbeddableFactory = () => {
         disabledActionIds$,
         ...unsavedChanges.api,
         ...selectionsManager.api,
-        controlFetch$: (controlUuid: string) =>
+        controlFetch$: (controlUuid: string, onReload?: () => void) =>
           controlFetch$(
             chaining$(
               controlUuid,
@@ -143,7 +143,7 @@ export const getControlGroupEmbeddableFactory = () => {
               controlsManager.controlsInOrder$,
               controlsManager.api.children$
             ),
-            controlGroupFetch$(ignoreParentSettings$, parentApi ? parentApi : {})
+            controlGroupFetch$(ignoreParentSettings$, parentApi ? parentApi : {}, onReload)
           ),
         ignoreParentSettings$,
         autoApplySelections$,

--- a/src/platform/plugins/shared/controls/public/control_group/types.ts
+++ b/src/platform/plugins/shared/controls/public/control_group/types.ts
@@ -65,7 +65,7 @@ export type ControlGroupApi = PresentationContainer &
     labelPosition: PublishingSubject<ControlLabelPosition>;
 
     asyncResetUnsavedChanges: () => Promise<void>;
-    controlFetch$: (controlUuid: string) => Observable<ControlFetchContext>;
+    controlFetch$: (controlUuid: string, onReload?: () => void) => Observable<ControlFetchContext>;
     openAddDataControlFlyout: (options?: {
       controlStateTransform?: ControlStateTransform;
       onSave?: () => void;

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/fetch_and_validate.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/fetch_and_validate.tsx
@@ -11,9 +11,7 @@ import {
   BehaviorSubject,
   combineLatest,
   debounceTime,
-  ignoreElements,
   Observable,
-  of,
   startWith,
   switchMap,
   tap,
@@ -21,7 +19,6 @@ import {
 } from 'rxjs';
 
 import { PublishingSubject } from '@kbn/presentation-publishing';
-import { apiPublishesReload } from '@kbn/presentation-publishing/interfaces/fetch/publishes_reload';
 import { OptionsListSuccessResponse } from '../../../../common/options_list/types';
 import { isValidSearch } from '../../../../common/options_list/is_valid_search';
 import { OptionsListSelection } from '../../../../common/options_list/options_list_selections';
@@ -33,10 +30,10 @@ import { OptionsListComponentApi, OptionsListComponentState, OptionsListControlA
 export function fetchAndValidate$({
   api,
   stateManager,
+  controlFetch$,
 }: {
   api: Pick<OptionsListControlApi, 'dataViews$' | 'field$' | 'setBlockingError' | 'parentApi'> &
     Pick<OptionsListComponentApi, 'loadMoreSubject'> & {
-      controlFetch$: Observable<ControlFetchContext>;
       loadingSuggestions$: BehaviorSubject<boolean>;
       debouncedSearchString: Observable<string>;
     };
@@ -45,6 +42,7 @@ export function fetchAndValidate$({
   > & {
     selectedOptions: PublishingSubject<OptionsListSelection[] | undefined>;
   };
+  controlFetch$: (onReload: () => void) => Observable<ControlFetchContext>;
 }): Observable<OptionsListSuccessResponse | { error: Error }> {
   const requestCache = new OptionsListFetchCache();
   let abortController: AbortController | undefined;
@@ -52,7 +50,7 @@ export function fetchAndValidate$({
   return combineLatest([
     api.dataViews$,
     api.field$,
-    api.controlFetch$.pipe(debounceTime(0)), // debounce to allow api.parentApi.reload$ tap to run before emitting
+    controlFetch$(requestCache.clearCache),
     api.parentApi.allowExpensiveQueries$,
     api.parentApi.ignoreParentSettings$,
     api.debouncedSearchString,
@@ -63,15 +61,6 @@ export function fetchAndValidate$({
       startWith(null), // start with null so that `combineLatest` subscription fires
       debounceTime(100) // debounce load more so "loading" state briefly shows
     ),
-    apiPublishesReload(api.parentApi)
-      ? api.parentApi.reload$.pipe(
-          tap(() => requestCache.clearCache()),
-          // api.controlFetch$ already merges with parentApi.reload$
-          // Ignore all emits to avoid double fetching on reload
-          ignoreElements(),
-          startWith(undefined)
-        )
-      : of(undefined),
   ]).pipe(
     tap(() => {
       // abort any in progress requests

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/options_list_control/get_options_list_control_factory.tsx
@@ -185,9 +185,9 @@ export const getOptionsListControlFactory = (): DataControlFactory<
           loadingSuggestions$,
           debouncedSearchString,
           parentApi: controlGroupApi,
-          controlFetch$: controlGroupApi.controlFetch$(uuid),
         },
         stateManager,
+        controlFetch$: (onReload: () => void) => controlGroupApi.controlFetch$(uuid, onReload),
       }).subscribe((result) => {
         // if there was an error during fetch, set blocking error and return early
         if (Object.hasOwn(result, 'error')) {

--- a/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/min_max.ts
+++ b/src/platform/plugins/shared/controls/public/controls/data_controls/range_slider/min_max.ts
@@ -11,8 +11,7 @@ import type { estypes } from '@elastic/elasticsearch';
 import { DataView, DataViewField } from '@kbn/data-views-plugin/public';
 import { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
 import { PublishesDataViews, PublishingSubject } from '@kbn/presentation-publishing';
-import { apiPublishesReload } from '@kbn/presentation-publishing/interfaces/fetch/publishes_reload';
-import { Observable, combineLatest, lastValueFrom, of, startWith, switchMap, tap } from 'rxjs';
+import { Observable, combineLatest, lastValueFrom, switchMap, tap } from 'rxjs';
 import { dataService } from '../../../services/kibana_services';
 import { ControlFetchContext } from '../../../control_group/control_fetch';
 import { ControlGroupApi } from '../../../control_group/types';
@@ -31,14 +30,7 @@ export function minMax$({
   setIsLoading: (isLoading: boolean) => void;
 }) {
   let prevRequestAbortController: AbortController | undefined;
-  return combineLatest([
-    controlFetch$,
-    dataViews$,
-    fieldName$,
-    apiPublishesReload(controlGroupApi)
-      ? controlGroupApi.reload$.pipe(startWith(undefined))
-      : of(undefined),
-  ]).pipe(
+  return combineLatest([controlFetch$, dataViews$, fieldName$]).pipe(
     tap(() => {
       if (prevRequestAbortController) {
         prevRequestAbortController.abort();


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/218663

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->