### PR TITLE
[8.17] [Search] Fix content Indices documents error on paginate (#219471)

### DIFF
--- a/packages/kbn-search-index-documents/lib/fetch_search_results.test.ts
+++ b/packages/kbn-search-index-documents/lib/fetch_search_results.test.ts
@@ -88,7 +88,7 @@ describe('fetchSearchResults lib function', () => {
       index: indexName,
       q: query,
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: false,
+      track_total_hits: undefined,
     });
   });
 
@@ -110,7 +110,7 @@ describe('fetchSearchResults lib function', () => {
       index: indexName,
       q: '\\"yellow banana\\"',
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: false,
+      track_total_hits: undefined,
     });
   });
 
@@ -125,7 +125,7 @@ describe('fetchSearchResults lib function', () => {
       from: DEFAULT_FROM_VALUE,
       index: indexName,
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: false,
+      track_total_hits: undefined,
     });
   });
 
@@ -153,7 +153,7 @@ describe('fetchSearchResults lib function', () => {
       index: indexName,
       q: query,
       size: DEFAULT_DOCS_PER_PAGE,
-      track_total_hits: false,
+      track_total_hits: undefined,
     });
   });
 

--- a/packages/kbn-search-index-documents/lib/fetch_search_results.ts
+++ b/packages/kbn-search-index-documents/lib/fetch_search_results.ts
@@ -19,7 +19,7 @@ export const fetchSearchResults = async (
   query?: string,
   from: number = 0,
   size: number = DEFAULT_DOCS_PER_PAGE,
-  trackTotalHits: boolean = false
+  trackTotalHits?: boolean
 ): Promise<Paginate<SearchHit>> => {
   const result = await fetchWithPagination(
     async () =>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Search] Fix content Indices documents error on paginate (#219471)](https://github.com/elastic/kibana/pull/219471)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saarika Bhasi","email":"55930906+saarikabhasi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-29T15:24:07Z","message":"[Search] Fix content Indices documents error on paginate (#219471)\n\nInitially added fix in `8.17` branch in\n[PR](https://github.com/elastic/kibana/pull/219411), but need this\nchange in `main`, `8.18`, `8.19` & `9.0.0` and the file's paths are\ndifferent in all versions(main, 8.18/8.19, 8.17, 9.0.0).\n\nCreated this new PR, adding fix in `main` & will try to backport to\nother versions.\n\n## Summary\nWhen `track_total_hits` is not provided to `fetchSearchResults`, the\nvalue is set to `false`. As a result, the `search` api does not include\ntotal hit count in its response. Thus, the total count of hit is 0 and\nonPaginate results in error. This PR sets `track_total_hits` as an\noptional argument in `fetchSearchResults`\n\n**Note**\nOne other option would be to set `track_total_hits` to true but, based\non this\n[documentation](https://www.elastic.co/docs/solutions/search/the-search-api#track-total-hits)\nsetting `track_total_hits` to true would affect query performance.\n\n```\nSetting track_total_hits to true will cause Elasticsearch to return exact hit counts, which could hurt query performance because it disables the [Max WAND](https://www.elastic.co/blog/faster-retrieval-of-top-hits-in-elasticsearch-with-block-max-wand) optimization.\n\n````\n\n\n\nhttps://github.com/user-attachments/assets/4284e88f-2614-4fbe-a0eb-1980355f5bff\n\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"69d71244d67c7659590aa04f04cea5dd06e2d290","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","Team:Search","backport:version","v8.17.0","v8.18.0","v9.1.0","v8.19.0","v8.18.1","v9.0.1"],"title":"[Search] Fix content Indices documents error on paginate","number":219471,"url":"https://github.com/elastic/kibana/pull/219471","mergeCommit":{"message":"[Search] Fix content Indices documents error on paginate (#219471)\n\nInitially added fix in `8.17` branch in\n[PR](https://github.com/elastic/kibana/pull/219411), but need this\nchange in `main`, `8.18`, `8.19` & `9.0.0` and the file's paths are\ndifferent in all versions(main, 8.18/8.19, 8.17, 9.0.0).\n\nCreated this new PR, adding fix in `main` & will try to backport to\nother versions.\n\n## Summary\nWhen `track_total_hits` is not provided to `fetchSearchResults`, the\nvalue is set to `false`. As a result, the `search` api does not include\ntotal hit count in its response. Thus, the total count of hit is 0 and\nonPaginate results in error. This PR sets `track_total_hits` as an\noptional argument in `fetchSearchResults`\n\n**Note**\nOne other option would be to set `track_total_hits` to true but, based\non this\n[documentation](https://www.elastic.co/docs/solutions/search/the-search-api#track-total-hits)\nsetting `track_total_hits` to true would affect query performance.\n\n```\nSetting track_total_hits to true will cause Elasticsearch to return exact hit counts, which could hurt query performance because it disables the [Max WAND](https://www.elastic.co/blog/faster-retrieval-of-top-hits-in-elasticsearch-with-block-max-wand) optimization.\n\n````\n\n\n\nhttps://github.com/user-attachments/assets/4284e88f-2614-4fbe-a0eb-1980355f5bff\n\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"69d71244d67c7659590aa04f04cea5dd06e2d290"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/219579","number":219579,"state":"MERGED","mergeCommit":{"sha":"6bca376012094c252dae8e582893b46f1eda8fda","message":"[9.0] [Search] Fix content Indices documents error on paginate (#219471) (#219579)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Search] Fix content Indices documents error on paginate\n(#219471)](https://github.com/elastic/kibana/pull/219471)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Saarika Bhasi <55930906+saarikabhasi@users.noreply.github.com>"}},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/219577","number":219577,"state":"MERGED","mergeCommit":{"sha":"296b3c22d31c66dc46aec93051e371b30c286d8c","message":"[8.18] [Search] Fix content Indices documents error on paginate (#219471) (#219577)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.18`:\n- [[Search] Fix content Indices documents error on paginate\n(#219471)](https://github.com/elastic/kibana/pull/219471)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Saarika Bhasi <55930906+saarikabhasi@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219471","number":219471,"mergeCommit":{"message":"[Search] Fix content Indices documents error on paginate (#219471)\n\nInitially added fix in `8.17` branch in\n[PR](https://github.com/elastic/kibana/pull/219411), but need this\nchange in `main`, `8.18`, `8.19` & `9.0.0` and the file's paths are\ndifferent in all versions(main, 8.18/8.19, 8.17, 9.0.0).\n\nCreated this new PR, adding fix in `main` & will try to backport to\nother versions.\n\n## Summary\nWhen `track_total_hits` is not provided to `fetchSearchResults`, the\nvalue is set to `false`. As a result, the `search` api does not include\ntotal hit count in its response. Thus, the total count of hit is 0 and\nonPaginate results in error. This PR sets `track_total_hits` as an\noptional argument in `fetchSearchResults`\n\n**Note**\nOne other option would be to set `track_total_hits` to true but, based\non this\n[documentation](https://www.elastic.co/docs/solutions/search/the-search-api#track-total-hits)\nsetting `track_total_hits` to true would affect query performance.\n\n```\nSetting track_total_hits to true will cause Elasticsearch to return exact hit counts, which could hurt query performance because it disables the [Max WAND](https://www.elastic.co/blog/faster-retrieval-of-top-hits-in-elasticsearch-with-block-max-wand) optimization.\n\n````\n\n\n\nhttps://github.com/user-attachments/assets/4284e88f-2614-4fbe-a0eb-1980355f5bff\n\n\n\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"69d71244d67c7659590aa04f04cea5dd06e2d290"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/219578","number":219578,"state":"MERGED","mergeCommit":{"sha":"7790ebc7b5511c07aa057a085a349647381f5c31","message":"[8.19] [Search] Fix content Indices documents error on paginate (#219471) (#219578)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Search] Fix content Indices documents error on paginate\n(#219471)](https://github.com/elastic/kibana/pull/219471)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Saarika Bhasi <55930906+saarikabhasi@users.noreply.github.com>"}}]}] BACKPORT-->