### PR TITLE
[8.17] [Reporting] Use google headless binary for reporting (#216688)

### DIFF
--- a/packages/kbn-screenshotting-server/src/paths.ts
+++ b/packages/kbn-screenshotting-server/src/paths.ts
@@ -17,87 +17,87 @@ export interface PackageInfo {
   binaryChecksum: string;
   binaryRelativePath: string;
   isPreInstalled: boolean;
-  location: 'custom' | 'common';
-  revision: number;
+  location: 'custom' | 'chromeForTesting';
 }
 
 enum BaseUrl {
-  // see https://www.chromium.org/getting-involved/download-chromium
-  common = 'https://commondatastorage.googleapis.com/chromium-browser-snapshots',
   // A GCS bucket under the Kibana team
   custom = 'https://storage.googleapis.com/headless_shell',
+  // GCS bucket for headless chrome provided by the chrome team, see
+  // https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints
+  chromeForTesting = 'https://storage.googleapis.com/chrome-for-testing-public',
 }
 
 interface CustomPackageInfo extends PackageInfo {
   location: 'custom';
 }
-interface CommonPackageInfo extends PackageInfo {
-  location: 'common';
+
+interface ChromeForTestingPackageInfo extends PackageInfo {
+  version: string;
+  location: 'chromeForTesting';
   archivePath: string;
 }
 
-function isCommonPackage(p: PackageInfo): p is CommonPackageInfo {
-  return p.location === 'common';
+function isChromeForTestingPackage(p: PackageInfo): p is ChromeForTestingPackageInfo {
+  return p.location === 'chromeForTesting';
 }
 
 export class ChromiumArchivePaths {
-  public readonly packages: Array<CustomPackageInfo | CommonPackageInfo> = [
+  public readonly packages: Array<CustomPackageInfo | ChromeForTestingPackageInfo> = [
     {
       platform: 'darwin',
       architecture: 'x64',
-      archiveFilename: 'chrome-mac.zip',
-      archiveChecksum: '0dc11a5ecbe650077962f590f745aeacf655573dc1902181e2bddc82fb4dc067',
-      binaryChecksum: '4e2bb7b2cff0afea3ae1fc8a53474de807183a66b3c99b8f53e3869997232675',
-      binaryRelativePath: 'chrome-mac/Chromium.app/Contents/MacOS/Chromium',
-      revision: 1381526,
-      location: 'common',
-      archivePath: 'Mac',
+      archiveFilename: 'chrome-headless-shell-mac-x64.zip',
+      archiveChecksum: 'e09bd8cc7b381a20d7738c3026a359e5ddd6a587ecb33f8326c0818f243f50e2',
+      binaryChecksum: '7bef5a84fe90d2a243e1e9c45e86f53525b1a3adec598c0b6ce009792abd5f34',
+      binaryRelativePath: 'chrome-headless-shell-mac-x64/chrome-headless-shell',
+      version: '134.0.6998.35',
+      location: 'chromeForTesting',
+      archivePath: 'mac-x64',
       isPreInstalled: false,
     },
     {
       platform: 'darwin',
       architecture: 'arm64',
-      archiveFilename: 'chrome-mac.zip',
-      archiveChecksum: '48b51bceaf6d900748704c938c74e0ea581ee235f7cabe2a62ea09ce0f2d8361',
-      binaryChecksum: '8bd08f8e40f4edf7546adbe4b339a986b440f2737be84158e8bf8866992e59c7',
-      binaryRelativePath: 'chrome-mac/Chromium.app/Contents/MacOS/Chromium',
-      revision: 1381538,
-      location: 'common',
-      archivePath: 'Mac_Arm',
+      archiveFilename: 'chrome-headless-shell-mac-arm64.zip',
+      archiveChecksum: 'ead60a22ae13e93a74b88fe43df3aa547ca599d9f9b7fd4b060e5c595fd890cb',
+      binaryChecksum: '8f60afb3cabee80b3e7efa6898d589997d5f6e3669b1bdc1bca4b8685e500e7f',
+      binaryRelativePath: 'chrome-headless-shell-mac-arm64/chrome-headless-shell',
+      version: '134.0.6998.35',
+      location: 'chromeForTesting',
+      archivePath: 'mac-arm64',
       isPreInstalled: false,
     },
     {
       platform: 'linux',
       architecture: 'x64',
-      archiveFilename: 'chromium-df453a3-locales-linux_x64.zip',
-      archiveChecksum: '90c6adae9efdda89aeab9df58bce176e8fad137bb2e22bf6193fd6de766ff867',
-      binaryChecksum: '7dd357acbad7f7ee29b33949ef0a63ac5a51a26c6474ae8762d18a337a315b78',
+      archiveFilename: 'chromium-ea6ef4c-locales-linux_x64.zip',
+      archiveChecksum: '98db5f4ae704a0cf4d1612721334b0466908bf642ac547798aa303d17105e782',
+      binaryChecksum: '2ed0cbce8358e86b5c44719d1ccd50f711b879088946b6ffdeed22b4ce2e47ea',
       binaryRelativePath: 'headless_shell-linux_x64/headless_shell',
-      revision: 1381561,
       location: 'custom',
       isPreInstalled: true,
     },
     {
       platform: 'linux',
       architecture: 'arm64',
-      archiveFilename: 'chromium-df453a3-locales-linux_arm64.zip',
-      archiveChecksum: 'a13110193e746913c661ab6c07403b1aa5018cb1c8f0e7890da486a1fb2a413e',
-      binaryChecksum: 'c03865b5afc998107281547178440d49a56b2de32e6ecfaaa3b1db8697229fa3',
+      archiveFilename: 'chromium-ea6ef4c-locales-linux_arm64.zip',
+      archiveChecksum: '9b3bf295794f0d4fe5e52813aa31a5ed4ca4389384f7fff2a8465777709174ea',
+      binaryChecksum: '382c7f30a57b1096c7567d3a2cba0353aae80ec11790cd271601fb1b2ebb85cd',
       binaryRelativePath: 'headless_shell-linux_arm64/headless_shell',
-      revision: 1381561,
       location: 'custom',
       isPreInstalled: true,
     },
     {
       platform: 'win32',
       architecture: 'x64',
-      archiveFilename: 'chrome-win.zip',
-      archiveChecksum: '429e1a038124414e2908f026410e2f6bf8c81459fc5af8e03c9585237f391d01',
-      binaryChecksum: 'b49344c444fb0b543825dec26e4cadf9d5ffa648fdd9ec7f7d5d0961982dc758',
-      binaryRelativePath: path.join('chrome-win', 'chrome.exe'),
-      revision: 1381560,
-      location: 'common',
-      archivePath: 'Win',
+      archiveFilename: 'chrome-headless-shell-win64.zip',
+      archiveChecksum: '3bda1b7b1dc59fe4d79d68c5ca2384f8e7a743253e041eb731664b05a1e73343',
+      binaryChecksum: 'fffdc5e77fae67391e154d92f2084f84fec410632a48211ae0ab652dc64aeacf',
+      binaryRelativePath: path.join('chrome-headless-shell-win64', 'chrome-headless-shell.exe'),
+      version: '134.0.6998.35',
+      location: 'chromeForTesting',
+      archivePath: 'win64',
       isPreInstalled: true,
     },
   ];
@@ -119,11 +119,14 @@ export class ChromiumArchivePaths {
   }
 
   public getDownloadUrl(p: PackageInfo) {
-    if (isCommonPackage(p)) {
-      const { common } = BaseUrl;
-      const { archivePath, revision, archiveFilename } = p;
-      return `${common}/${archivePath}/${revision}/${archiveFilename}`;
+    if (isChromeForTestingPackage(p)) {
+      const { chromeForTesting } = BaseUrl;
+      const { archivePath, version, archiveFilename } = p;
+      // returned string matches download value found at the following endpoint;
+      // https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
+      return `${chromeForTesting}/${version}/${archivePath}/${archiveFilename}`;
     }
+
     return BaseUrl.custom + '/' + p.archiveFilename; // revision is not used for URL if package is a custom build
   }
 

--- a/x-pack/plugins/screenshotting/server/browsers/download/index.test.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/download/index.test.ts
@@ -86,14 +86,14 @@ describe('ensureDownloaded', () => {
       expect(fetch).not.toHaveBeenCalled();
       await expect(readdir(path.resolve(`${paths.archivesPath}/x64`))).resolves.toEqual(
         expect.arrayContaining([
-          'chrome-mac.zip',
-          'chrome-win.zip',
+          'chrome-headless-shell-mac-x64.zip',
+          'chrome-headless-shell-win64.zip',
           expect.stringMatching(/^chromium-[0-9a-f]{7}-locales-linux_x64\.zip$/),
         ])
       );
       await expect(readdir(path.resolve(`${paths.archivesPath}/arm64`))).resolves.toEqual(
         expect.arrayContaining([
-          'chrome-mac.zip',
+          'chrome-headless-shell-mac-arm64.zip',
           expect.stringMatching(/^chromium-[0-9a-f]{7}-locales-linux_arm64\.zip$/),
         ])
       );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Reporting] Use google headless binary for reporting (#216688)](https://github.com/elastic/kibana/pull/216688)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Eyo O. Eyo","email":"7893459+eokoneyo@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-20T14:41:36Z","message":"[Reporting] Use google headless binary for reporting (#216688)\n\n## Summary\n\nThis PR switches the chromium binary used for reporting to new\nheadless-shell binary provided by google, we only use said binaries for\nMac and Windows, and will keep the same our current approach for linux\nbecause there's no support for ARM linux.\n\nThe current installed version of puppeteer is `24.4.0`, with an\nexpectation for chromium of revision `1415337` and version\n`134.0.6998.35`, which has been selected.\n\n\n## How to verify this change;\n\n- Attempt generating exports of PDFs and PNG, with print option enabled\nand disabled\n- Verify that we are able to generate a report, and the reports match\nprevious ones.\n\n### Binary Verification\n\n- Mac Arm\n<img width=\"864\" alt=\"Screenshot 2025-04-04 at 12 15 31\"\nsrc=\"https://github.com/user-attachments/assets/00b22c69-6839-4056-ac67-c6001e16413d\"\n/>\n\n- Windows\n<img width=\"1395\" alt=\"Screenshot 2025-04-19 at 14 51 09\"\nsrc=\"https://github.com/user-attachments/assets/499b67ff-ab6a-41bb-ae4e-598c15e1bef4\"\n/>\n\nP.S. This PR is a prerequisite for\nhttps://github.com/elastic/kibana/pull/212674\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1c74e0fb959f325b193fc35aa7ef4754c8abf201","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:SharedUX","backport:prev-minor","backport:prev-major","v9.1.0","v8.19.0","v9.0.1"],"title":"[Reporting] Use google headless binary for reporting","number":216688,"url":"https://github.com/elastic/kibana/pull/216688","mergeCommit":{"message":"[Reporting] Use google headless binary for reporting (#216688)\n\n## Summary\n\nThis PR switches the chromium binary used for reporting to new\nheadless-shell binary provided by google, we only use said binaries for\nMac and Windows, and will keep the same our current approach for linux\nbecause there's no support for ARM linux.\n\nThe current installed version of puppeteer is `24.4.0`, with an\nexpectation for chromium of revision `1415337` and version\n`134.0.6998.35`, which has been selected.\n\n\n## How to verify this change;\n\n- Attempt generating exports of PDFs and PNG, with print option enabled\nand disabled\n- Verify that we are able to generate a report, and the reports match\nprevious ones.\n\n### Binary Verification\n\n- Mac Arm\n<img width=\"864\" alt=\"Screenshot 2025-04-04 at 12 15 31\"\nsrc=\"https://github.com/user-attachments/assets/00b22c69-6839-4056-ac67-c6001e16413d\"\n/>\n\n- Windows\n<img width=\"1395\" alt=\"Screenshot 2025-04-19 at 14 51 09\"\nsrc=\"https://github.com/user-attachments/assets/499b67ff-ab6a-41bb-ae4e-598c15e1bef4\"\n/>\n\nP.S. This PR is a prerequisite for\nhttps://github.com/elastic/kibana/pull/212674\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1c74e0fb959f325b193fc35aa7ef4754c8abf201"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216688","number":216688,"mergeCommit":{"message":"[Reporting] Use google headless binary for reporting (#216688)\n\n## Summary\n\nThis PR switches the chromium binary used for reporting to new\nheadless-shell binary provided by google, we only use said binaries for\nMac and Windows, and will keep the same our current approach for linux\nbecause there's no support for ARM linux.\n\nThe current installed version of puppeteer is `24.4.0`, with an\nexpectation for chromium of revision `1415337` and version\n`134.0.6998.35`, which has been selected.\n\n\n## How to verify this change;\n\n- Attempt generating exports of PDFs and PNG, with print option enabled\nand disabled\n- Verify that we are able to generate a report, and the reports match\nprevious ones.\n\n### Binary Verification\n\n- Mac Arm\n<img width=\"864\" alt=\"Screenshot 2025-04-04 at 12 15 31\"\nsrc=\"https://github.com/user-attachments/assets/00b22c69-6839-4056-ac67-c6001e16413d\"\n/>\n\n- Windows\n<img width=\"1395\" alt=\"Screenshot 2025-04-19 at 14 51 09\"\nsrc=\"https://github.com/user-attachments/assets/499b67ff-ab6a-41bb-ae4e-598c15e1bef4\"\n/>\n\nP.S. This PR is a prerequisite for\nhttps://github.com/elastic/kibana/pull/212674\n\n\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"1c74e0fb959f325b193fc35aa7ef4754c8abf201"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/218699","number":218699,"state":"MERGED","mergeCommit":{"sha":"d6b1c1f1617f7b028da6dc9d4fcacf3a7daa97ed","message":"[8.19] [Reporting] Use google headless binary for reporting (#216688) (#218699)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Reporting] Use google headless binary for reporting\n(#216688)](https://github.com/elastic/kibana/pull/216688)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Eyo O. Eyo <7893459+eokoneyo@users.noreply.github.com>"}},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/218700","number":218700,"state":"MERGED","mergeCommit":{"sha":"283e80f2b956ffbaa1cf2de8bb77bbef10123a3d","message":"[9.0] [Reporting] Use google headless binary for reporting (#216688) (#218700)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Reporting] Use google headless binary for reporting\n(#216688)](https://github.com/elastic/kibana/pull/216688)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Eyo O. Eyo <7893459+eokoneyo@users.noreply.github.com>"}},{"url":"https://github.com/elastic/kibana/pull/219631","number":219631,"branch":"8.18","state":"OPEN"}]}] BACKPORT-->