### PR TITLE
[APM] Optional chaining to prevent undefined error in `custom_link_flyout.tsx`

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/transaction_action_menu/custom_link_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/transaction_action_menu/custom_link_flyout.tsx
@@ -25,10 +25,10 @@ export function CustomLinkFlyout({
   const filters = useMemo(
     () =>
       [
-        { key: 'service.name', value: transaction?.service.name },
-        { key: 'service.environment', value: transaction?.service.environment },
-        { key: 'transaction.name', value: transaction?.transaction.name },
-        { key: 'transaction.type', value: transaction?.transaction.type },
+        { key: 'service.name', value: transaction?.service?.name },
+        { key: 'service.environment', value: transaction?.service?.environment },
+        { key: 'transaction.name', value: transaction?.transaction?.name },
+        { key: 'transaction.type', value: transaction?.transaction?.type },
       ].filter((filter): filter is Filter => typeof filter.value === 'string'),
     [transaction]
   );


### PR DESCRIPTION
## Summary

Prevent `TypeError: Cannot read properties of undefined (reading 'name')` in `custom_link_flyout.tsx`.

Before:

https://github.com/user-attachments/assets/385228fe-1421-46fb-bfee-da1efe829fcb

After:

https://github.com/user-attachments/assets/76da5646-962f-4a6f-9eb5-f7632444e795

### How to test:
1. Mock empty `transaction.name` property in `CustomLinkFlyout` component
2. Visit Service -> Transaction -> Check for `Investigate` dropdown in trace waterfall 


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->