### PR TITLE
[8.19] chore(codeql): ignore more dev-only packages (#219681)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -38,30 +38,42 @@ paths-ignore:
   - oas_docs
   - packages/kbn-babel-*
   - packages/kbn-bazel-*
+  - packages/kbn-capture-oas-snapshot-cli
+  - packages/kbn-check-mappings-update-cli
+  - packages/kbn-check-prod-native-modules-cli
   - packages/kbn-ci-*
   - packages/kbn-cli-dev-mode
+  - packages/kbn-dependency-*
   - packages/kbn-docs-utils
   - packages/kbn-eslint-*
   - packages/kbn-failed-test-reporter-cli
   - packages/kbn-find-used-node-modules
   - packages/kbn-ftr-*
+  - packages/kbn-import-locator
   - packages/kbn-generate
+  - packages/kbn-generate-console-definitions
+  - packages/kbn-json-ast
   - packages/kbn-kibana-manifest-schema
-  - packages/kbn-managed-vscode-config
-  - packages/kbn-managed-vscode-config-cli
+  - packages/kbn-lint-*
+  - packages/kbn-managed-vscode-*
+  - packages/kbn-manifest
+  - packages/kbn-mock-idp-plugin
   - packages/kbn-optimizer
   - packages/kbn-peggy-loader
   - packages/kbn-performance-testing-dataset-extractor
-  - packages/kbn-plugin-generator
-  - packages/kbn-plugin-helpers
+  - packages/kbn-picomatcher
+  - packages/kbn-plugin-*
   - packages/kbn-relocate
-  - packages/kbn-repo-source-classifier
-  - packages/kbn-repo-source-classifier-cli
+  - packages/kbn-repo-*
+  - packages/kbn-set-map
   - packages/kbn-sort-package-json
   - packages/kbn-spec-to-console
+  - packages/kbn-styled-components-mapping-cli
   - packages/kbn-test-*
   - packages/kbn-ts-*
+  - packages/kbn-validate-next-docs-cli
   - packages/kbn-web-worker-stub
+  - packages/kbn-whereis-pkg-cli
   - packages/kbn-yarn-lock-validator
   - scripts
   - src/platform/packages/*/kbn-ambient-*-types
@@ -72,10 +84,15 @@ paths-ignore:
   - src/platform/packages/*/kbn-jest-*
   - src/platform/packages/*/kbn-optimizer-*
   - src/platform/packages/*/kbn-test-*
+  - src/platform/packages/private/kbn-code-owners
   - src/platform/packages/private/kbn-gen-ai-functional-testing
   - src/platform/packages/private/kbn-get-repo-files
   - src/platform/packages/private/kbn-import-resolver
   - src/platform/packages/private/kbn-journeys
+  - src/platform/packages/private/kbn-mock-idp-utils
+  - src/platform/packages/private/kbn-node-libs-browser-webpack-plugin
+  - src/platform/packages/private/kbn-optimizer-webpack-helpers
+  - src/platform/packages/private/kbn-reporting/mocks_server
   - src/platform/packages/private/kbn-peggy
   - src/platform/packages/private/kbn-repo-path
   - src/platform/packages/private/kbn-some-dev-log
@@ -90,16 +107,22 @@ paths-ignore:
   - src/platform/packages/shared/kbn-es
   - src/platform/packages/shared/kbn-es-archiver
   - src/platform/packages/shared/kbn-expect
+  - src/platform/packages/shared/kbn-openapi-*
   - src/platform/packages/shared/kbn-scout
   - src/platform/packages/shared/kbn-storybook
   - src/platform/packages/shared/kbn-test
   - src/platform/packages/shared/kbn-tooling-log
   - src/platform/test
+  - test
   - typings
   - x-pack/examples
   - x-pack/packages/ai-infra/product-doc-artifact-builder
+  - x-pack/packages/kbn-synthetics-private-location
   - x-pack/platform/packages/shared/kbn-inference-cli
+  - x-pack/platform/packages/shared/kbn-sample-parser
+  - x-pack/platform/test
   - x-pack/performance
   - x-pack/scripts
+  - x-pack/solutions/observability/packages/kbn-genai-cli
   - x-pack/test
   - x-pack/test_serverless


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore(codeql): ignore more dev-only packages (#219681)](https://github.com/elastic/kibana/pull/219681)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Aleh Zasypkin","email":"aleh.zasypkin@elastic.co"},"sourceCommit":{"committedDate":"2025-04-30T10:01:47Z","message":"chore(codeql): ignore more dev-only packages (#219681)\n\n## Summary\n\nIgnore more dev-only packages.","sha":"4b798e791edf28fd29cbd5d5ee1d7f6cb5b15eab","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:version","v9.1.0","v8.19.0","v9.0.1"],"title":"chore(codeql): ignore more dev-only packages","number":219681,"url":"https://github.com/elastic/kibana/pull/219681","mergeCommit":{"message":"chore(codeql): ignore more dev-only packages (#219681)\n\n## Summary\n\nIgnore more dev-only packages.","sha":"4b798e791edf28fd29cbd5d5ee1d7f6cb5b15eab"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219681","number":219681,"mergeCommit":{"message":"chore(codeql): ignore more dev-only packages (#219681)\n\n## Summary\n\nIgnore more dev-only packages.","sha":"4b798e791edf28fd29cbd5d5ee1d7f6cb5b15eab"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->