### PR TITLE
[Discover ] Increase test jest timeout

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/sidebar/discover_sidebar_responsive.test.tsx
@@ -688,7 +688,7 @@ describe('discover responsive sidebar', function () {
     expect(createDataViewButton.length).toBe(1);
     createDataViewButton.simulate('click');
     expect(services.dataViewEditor.openEditor).toHaveBeenCalled();
-  });
+  }, 10000);
 
   it('should not render buttons in data view picker when in viewer mode', async () => {
     const services = createMockServices();
@@ -720,7 +720,7 @@ describe('discover responsive sidebar', function () {
     expect(addFieldButtonInDataViewPicker.length).toBe(0);
     const createDataViewButton = findTestSubject(compWithPickerInViewerMode, 'dataview-create-new');
     expect(createDataViewButton.length).toBe(0);
-  });
+  }, 10000);
 
   describe('search bar customization', () => {
     it('should not render CustomDataViewPicker', async () => {


### PR DESCRIPTION
## Summary

resolves #217005

This test occasionally times out. Not a great solution, but we increase the timeout to reduce the noise of this flaky one (5s seem to be not sufficient)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->