### PR TITLE
[Discover] Make icon only presentational (#217519)

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/solutions_view_badge.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/solutions_view_badge.tsx
@@ -53,8 +53,6 @@ export const SolutionsViewBadge: FunctionComponent<{ badgeText: string }> = ({ b
           iconSide="right"
           onClick={() => setIsPopoverOpen((value) => !value)}
           onClickAriaLabel={onClickAriaLabel}
-          iconOnClick={() => setIsPopoverOpen((value) => !value)}
-          iconOnClickAriaLabel={onClickAriaLabel}
         >
           {badgeText}
         </EuiBadge>


### PR DESCRIPTION
## Summary

Removed the aria-label and onClick from the icon, this makes the icon only presentational, the onClick still applies through the whole badge and the screen reader only detects it once.

![image](https://github.com/user-attachments/assets/850c26f6-d6dc-45a6-ba7a-76b81a299e4c)

Solves https://github.com/elastic/kibana/issues/217519

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->