### PR TITLE
Expose frozen indices information on the rule health endpoint

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/health_endpoints.md
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/health_endpoints.md
@@ -205,7 +205,8 @@ Response:
         "total_filled_duration_ms": 0,
         "total_in_progress_duration_ms": 0,
         "total_unfilled_duration_ms": 0,
-      }
+      },
+      "frozen_indices_queried_max_count": 0
     },
     "history_over_interval": {
       "buckets": [
@@ -277,7 +278,8 @@ Response:
                 "95.0": 0,
                 "99.0": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         },
         {
@@ -348,7 +350,8 @@ Response:
                 "95.0": 0,
                 "99.0": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         }
       ]
@@ -569,7 +572,8 @@ Response:
           "count": 2129,
           "message": "This rule is attempting to query data from Elasticsearch indices listed in the Index pattern section of the rule definition however no index matching was found This warning will continue to appear until matching index is created or this rule is disabled"
         }
-      ]
+      ],
+      "frozen_indices_queried_max_count": 0
     },
     "history_over_interval": {
       "buckets": [
@@ -641,7 +645,8 @@ Response:
                 "95.0": 0,
                 "99.0": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         },
         {
@@ -712,7 +717,8 @@ Response:
                 "95.0": 0,
                 "99.0": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         }
       ]
@@ -893,7 +899,8 @@ Response:
           "count": 240,
           "message": "This rule is attempting to query data from Elasticsearch indices listed in the Index pattern section of the rule definition however no index matching filebeat logs-aws was found This warning will continue to appear until matching index is created or this rule is disabled"
         }
-      ]
+      ],
+      "frozen_indices_queried_max_count": 0
     },
     "history_over_interval": {
       "buckets": [
@@ -953,7 +960,8 @@ Response:
                 "99.0": 0,
                 "99.9": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         },
         {
@@ -1012,7 +1020,8 @@ Response:
                 "99.0": 0,
                 "99.9": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         }
       ]

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/model/health_stats.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/model/health_stats.mock.ts
@@ -64,6 +64,7 @@ const getEmptyHealthOverviewStats = (): HealthOverviewStats => {
     indexing_duration_ms: getZeroAggregatedMetric(),
     top_errors: [],
     top_warnings: [],
+    frozen_indices_queried_max_count: 0,
   };
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/model/health_stats.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/model/health_stats.ts
@@ -160,6 +160,11 @@ export interface HealthOverviewStats {
    * N most frequent warning messages logged by rule(s) to Event Log.
    */
   top_warnings?: TopMessages;
+
+  /**
+   * Max count of frozen indices queried during rule execution
+   */
+  frozen_indices_queried_max_count: number;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/detection_engine_health/event_log/aggregations/rule_execution_stats.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/detection_engine_health/event_log/aggregations/rule_execution_stats.ts
@@ -120,6 +120,20 @@ export const getRuleExecutionStatsAggregation = (
             },
           },
         },
+        frozenIndices: {
+          filter: {
+            exists: {
+              field: f.RULE_EXECUTION_FROZEN_INDICES_QUERIED_COUNT,
+            },
+          },
+          aggs: {
+            frozenIndicesQueriedCount: {
+              max: {
+                field: f.RULE_EXECUTION_FROZEN_INDICES_QUERIED_COUNT,
+              },
+            },
+          },
+        },
         searchDurationMs: {
           percentiles: {
             field: f.RULE_EXECUTION_SEARCH_DURATION_MS,
@@ -211,6 +225,7 @@ export const normalizeRuleExecutionStatsAggregationResult = (
   const gaps = executionMetricsEvents.gaps || {};
   const searchDurationMs = executionMetricsEvents.searchDurationMs || {};
   const indexingDurationMs = executionMetricsEvents.indexingDurationMs || {};
+  const frozenIndices = executionMetricsEvents.frozenIndices || {};
 
   return {
     number_of_executions: normalizeNumberOfExecutions(totalExecutions, executionsByStatus),
@@ -228,6 +243,7 @@ export const normalizeRuleExecutionStatsAggregationResult = (
       aggregationLevel === 'whole-interval'
         ? normalizeTopWarnings(messageContainingEvents)
         : undefined,
+    frozen_indices_queried_max_count: normalizeFrozenQueriedIndices(frozenIndices),
   };
 };
 
@@ -277,6 +293,10 @@ const normalizeNumberOfDetectedGaps = (gaps: RawData): NumberOfDetectedGaps => {
     total: Number(gaps.doc_count || 0),
     total_duration_s: Number(gaps.totalGapDurationS?.value || 0),
   };
+};
+
+const normalizeFrozenQueriedIndices = (frozenQueriedIndices: RawData): number => {
+  return Number(frozenQueriedIndices?.frozenIndicesQueriedCount?.value || 0);
 };
 
 const normalizeAggregatedMetric = (

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/detection_engine_health/event_log/aggregations/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/detection_engine_health/event_log/aggregations/types.ts
@@ -163,6 +163,11 @@ export interface HealthOverviewStats {
    * N most frequent warning messages logged by rule(s) to Event Log.
    */
   top_warnings?: TopMessages;
+
+  /**
+   * Max count of frozen indices queried during rule execution
+   */
+  frozen_indices_queried_max_count: number;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/event_log/event_log_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/event_log/event_log_fields.ts
@@ -42,6 +42,9 @@ export const RULE_EXECUTION_INDEXING_DURATION_MS =
 export const RULE_EXECUTION_GAP_DURATION_S =
   `${RULE_EXECUTION_METRICS}.execution_gap_duration_s` as const;
 
+export const RULE_EXECUTION_FROZEN_INDICES_QUERIED_COUNT =
+  `${RULE_EXECUTION_METRICS}.frozen_indices_queried_count` as const;
+
 export const RULE_EXECUTION_SCHEDULE_DELAY_NS = 'kibana.task.schedule_delay' as const;
 
 export const NUMBER_OF_ALERTS_GENERATED = `${RULE_EXECUTION_METRICS}.alert_counts.new` as const;


### PR DESCRIPTION
## Summary
This is a follow up PR to expose the metric `frozen_indices_queried_max_count` on the rule healthcheck endpoint. 
This metric is an aggregation of the metric `frozen_indices_queried_count` which is calculated upon rule execution. Refer to [this PR](https://github.com/elastic/kibana/pull/218435) to see more details about it.

## How to test this?
- Run Elastic locally with these additional parameters in order to enable the frozen data tier: -E path.repo="/tmp" -E xpack.searchable.snapshot.shared_cache.size=20GB.
- Use [this tutorial](https://docs.elastic.dev/security-soution/analyst-experience-team/eng-prod/how-to/configure-local-frozen-tier) to create the snapshot repository and an ILM policy. You can disable rollover for the ILM policy and configure indices to be moved to frozen after 0 days.
- Create an index manually and populate it with a couple of documents.
- Assign the ILM policy to the index you created in the previous step and wait for it to be rolled to frozen. You can run this command to speed up the process:
```
PUT /_cluster/settings
{
  "persistent": {
    "indices.lifecycle.poll_interval": "10s"
  }
}
```
You can confirm that the index is indeed in frozen by calling
```
GET <YOUR_IDX_HERE>/_ilm/explain
```
`phase` should be `frozen` and `step` should be `complete`.
- Create a rule querying the frozen index.
- Call the rule health endpoint with:
```
curl -X POST --user elastic:changeme "http://localhost:5601/internal/detection_engine/health/_rule?date_start=2025-04-29T09:07:39.489Z&date_end=2025-05-01T09:08:39.489Z" \
  -H "Content-Type: application/json" \
  -H "elastic-api-version: 1" \
  -H 'kbn-xsrf: 123' \
  -H "x-elastic-internal-origin: Kibana" \
  --data '{"rule_id":"2f9780b5-7819-4685-ab8e-d817d3701d10"}'
```
You should see `frozen_indices_queried_max_count` populated with `1`.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->