### PR TITLE
[8.19] [Synthetics] Added compact view in monitors overview page (#219060)

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/synthetics_overview_status.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/common/runtime_types/monitor_management/synthetics_overview_status.ts
@@ -53,6 +53,7 @@ export const OverviewStatusMetaDataCodec = t.intersection([
     updated_at: t.string,
     timestamp: t.string,
     spaceId: t.string,
+    urls: t.string,
   }),
 ]);
 

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/index.ts
@@ -28,3 +28,4 @@ export * from './step_details.journey';
 export * from './project_monitor_read_only.journey';
 export * from './overview_save_lens_visualization.journey';
 export * from './filter_monitors.journey';
+export * from './overview_compact_view.journey';

--- a/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/overview_compact_view.journey.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/e2e/synthetics/journeys/overview_compact_view.journey.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { before, expect, journey, step, after } from '@elastic/synthetics';
+import { syntheticsAppPageProvider } from '../page_objects/synthetics_app';
+import { SyntheticsServices } from './services/synthetics_services';
+
+journey('OverviewCompactView', async ({ page, params }) => {
+  const syntheticsApp = syntheticsAppPageProvider({ page, kibanaUrl: params.kibanaUrl, params });
+  const syntheticsService = new SyntheticsServices(params);
+
+  before(async () => {
+    await syntheticsService.cleanUp();
+  });
+
+  after(async () => {
+    await syntheticsService.cleanUp();
+  });
+
+  step('Go to Monitors overview page', async () => {
+    await syntheticsApp.navigateToOverview(true, 15);
+  });
+
+  step('Create test monitor', async () => {
+    await syntheticsService.addTestMonitor('Test Overview Compact View Monitor', {
+      type: 'http',
+      urls: 'https://www.google.com',
+      locations: ['us_central'],
+    });
+    await page.getByTestId('syntheticsRefreshButtonButton').click();
+  });
+
+  step('Change to compact view', async () => {
+    await expect(page.getByTestId('compactView')).toBeEnabled();
+    await page.getByTestId('compactView').click();
+    await expect(page.getByTestId('syntheticsCompactViewTable')).toBeVisible();
+  });
+
+  step('The selected view for the overview page is saved in local storage', async () => {
+    await syntheticsApp.navigateToOverview();
+    await expect(page.getByTestId('syntheticsCompactViewTable')).toBeVisible();
+  });
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/common/monitors_open_configuration.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/common/monitors_open_configuration.tsx
@@ -5,36 +5,55 @@
  * 2.0.
  */
 
-import React, { Suspense, lazy } from 'react';
+import React from 'react';
 import type { CoreStart } from '@kbn/core/public';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
-import { EuiSkeletonText } from '@elastic/eui';
-import { MonitorFilters } from '../monitors_overview/types';
 import { ClientPluginsStart } from '../../../plugin';
+import { MonitorConfiguration } from './monitor_configuration';
+import { SYNTHETICS_MONITORS_EMBEDDABLE, SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE } from '../constants';
+import { OverviewMonitorsEmbeddableCustomState } from '../monitors_overview/monitors_embeddable_factory';
+import { OverviewStatsEmbeddableCustomState } from '../stats_overview/stats_overview_embeddable_factory';
 
+interface CommonParams {
+  title: string;
+  coreStart: CoreStart;
+  pluginStart: ClientPluginsStart;
+}
+
+type OverviewMonitorsInput = Required<OverviewMonitorsEmbeddableCustomState>;
+type OverviewStatsInput = Required<OverviewStatsEmbeddableCustomState>;
+
+// Function overloads to provide type safety without casting
+export async function openMonitorConfiguration(
+  params: CommonParams & {
+    initialState?: OverviewMonitorsInput;
+    type: typeof SYNTHETICS_MONITORS_EMBEDDABLE;
+  }
+): Promise<OverviewMonitorsInput>;
+export async function openMonitorConfiguration(
+  params: CommonParams & {
+    initialState?: OverviewStatsInput;
+    type: typeof SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE;
+  }
+): Promise<OverviewStatsInput>;
+
+// Implementation
 export async function openMonitorConfiguration({
   coreStart,
   pluginStart,
   initialState,
   title,
-}: {
-  title: string;
-  coreStart: CoreStart;
-  pluginStart: ClientPluginsStart;
-  initialState?: { filters: MonitorFilters };
-}): Promise<{ filters: MonitorFilters }> {
+  type,
+}: CommonParams & {
+  initialState?: OverviewMonitorsInput | OverviewStatsInput;
+  type: typeof SYNTHETICS_MONITORS_EMBEDDABLE | typeof SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE;
+}): Promise<OverviewMonitorsInput | OverviewStatsInput> {
   const { overlays } = coreStart;
   const queryClient = new QueryClient();
   return new Promise(async (resolve, reject) => {
     try {
-      const LazyMonitorConfiguration = lazy(async () => {
-        const { MonitorConfiguration } = await import('./monitor_configuration');
-        return {
-          default: MonitorConfiguration,
-        };
-      });
       const flyoutSession = overlays.openFlyout(
         toMountPoint(
           <KibanaContextProvider
@@ -44,20 +63,22 @@ export async function openMonitorConfiguration({
             }}
           >
             <QueryClientProvider client={queryClient}>
-              <Suspense fallback={<EuiSkeletonText />}>
-                <LazyMonitorConfiguration
-                  title={title}
-                  initialInput={initialState}
-                  onCreate={(update: { filters: MonitorFilters }) => {
-                    flyoutSession.close();
-                    resolve(update);
-                  }}
-                  onCancel={() => {
-                    flyoutSession.close();
-                    reject();
-                  }}
-                />
-              </Suspense>
+              <MonitorConfiguration
+                title={title}
+                initialInput={initialState}
+                onCreate={(update) => {
+                  flyoutSession.close();
+                  resolve(update);
+                }}
+                onCancel={() => {
+                  flyoutSession.close();
+                  reject();
+                }}
+              >
+                {type === SYNTHETICS_MONITORS_EMBEDDABLE ? (
+                  <MonitorConfiguration.ViewSwitch />
+                ) : null}
+              </MonitorConfiguration>
             </QueryClientProvider>
           </KibanaContextProvider>,
           coreStart

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_embeddable_factory.tsx
@@ -24,17 +24,30 @@ import { StatusGridComponent } from './monitors_grid_component';
 import { SYNTHETICS_MONITORS_EMBEDDABLE } from '../constants';
 import { ClientPluginsStart } from '../../../plugin';
 import { openMonitorConfiguration } from '../common/monitors_open_configuration';
+import { OverviewView } from '../../synthetics/state';
 
 export const getOverviewPanelTitle = () =>
   i18n.translate('xpack.synthetics.monitors.displayName', {
     defaultMessage: 'Synthetics Monitors',
   });
 
-export type OverviewEmbeddableState = SerializedTitles & {
-  filters: MonitorFilters;
+const DEFAULT_FILTERS: MonitorFilters = {
+  projects: [],
+  tags: [],
+  locations: [],
+  monitorIds: [],
+  monitorTypes: [],
 };
 
-export type StatusOverviewApi = DefaultEmbeddableApi<OverviewEmbeddableState> &
+export interface OverviewMonitorsEmbeddableCustomState {
+  filters?: MonitorFilters;
+  view: OverviewView;
+}
+
+export type OverviewMonitorsEmbeddableState = SerializedTitles &
+  OverviewMonitorsEmbeddableCustomState;
+
+export type StatusOverviewApi = DefaultEmbeddableApi<OverviewMonitorsEmbeddableState> &
   PublishesWritableTitle &
   PublishesTitle &
   HasEditCapabilities;
@@ -43,13 +56,13 @@ export const getMonitorsEmbeddableFactory = (
   getStartServices: StartServicesAccessor<ClientPluginsStart>
 ) => {
   const factory: ReactEmbeddableFactory<
-    OverviewEmbeddableState,
-    OverviewEmbeddableState,
+    OverviewMonitorsEmbeddableState,
+    OverviewMonitorsEmbeddableState,
     StatusOverviewApi
   > = {
     type: SYNTHETICS_MONITORS_EMBEDDABLE,
     deserializeState: (state) => {
-      return state.rawState as OverviewEmbeddableState;
+      return state.rawState as OverviewMonitorsEmbeddableState;
     },
     buildEmbeddable: async (state, buildApi) => {
       const [coreStart, pluginStart] = await getStartServices();
@@ -58,6 +71,7 @@ export const getMonitorsEmbeddableFactory = (
       const defaultTitle$ = new BehaviorSubject<string | undefined>(getOverviewPanelTitle());
       const reload$ = new Subject<boolean>();
       const filters$ = new BehaviorSubject(state.filters);
+      const view$ = new BehaviorSubject(state.view);
 
       const api = buildApi(
         {
@@ -73,6 +87,7 @@ export const getMonitorsEmbeddableFactory = (
               rawState: {
                 ...titleManager.serialize(),
                 filters: filters$.getValue(),
+                view: view$.getValue(),
               },
             };
           },
@@ -82,7 +97,8 @@ export const getMonitorsEmbeddableFactory = (
                 coreStart,
                 pluginStart,
                 initialState: {
-                  filters: filters$.getValue(),
+                  filters: filters$.getValue() || DEFAULT_FILTERS,
+                  view: view$.getValue(),
                 },
                 title: i18n.translate(
                   'xpack.synthetics.editSyntheticsOverviewEmbeddableTitle.overview.title',
@@ -90,8 +106,10 @@ export const getMonitorsEmbeddableFactory = (
                     defaultMessage: 'Create monitors overview',
                   }
                 ),
+                type: SYNTHETICS_MONITORS_EMBEDDABLE,
               });
               filters$.next(result.filters);
+              view$.next(result.view);
             } catch (e) {
               return Promise.reject();
             }
@@ -100,6 +118,7 @@ export const getMonitorsEmbeddableFactory = (
         {
           ...titleManager.comparators,
           filters: [filters$, (value) => filters$.next(value)],
+          view: [view$, (value) => view$.next(value)],
         }
       );
 
@@ -113,6 +132,7 @@ export const getMonitorsEmbeddableFactory = (
         api,
         Component: () => {
           const [filters] = useBatchedPublishingSubjects(filters$);
+          const [view] = useBatchedPublishingSubjects(view$);
 
           useEffect(() => {
             return () => {
@@ -128,7 +148,11 @@ export const getMonitorsEmbeddableFactory = (
               }}
               data-shared-item="" // TODO: Remove data-shared-item and data-rendering-count as part of https://github.com/elastic/kibana/issues/179376
             >
-              <StatusGridComponent reload$={reload$} filters={filters} />
+              <StatusGridComponent
+                reload$={reload$}
+                filters={filters || DEFAULT_FILTERS}
+                view={view}
+              />
             </div>
           );
         },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_grid_component.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/monitors_overview/monitors_grid_component.tsx
@@ -12,6 +12,7 @@ import { areFiltersEmpty } from '../common/utils';
 import { getOverviewStore } from './redux_store';
 import { ShowSelectedFilters } from '../common/show_selected_filters';
 import {
+  OverviewView,
   selectOverviewTrends,
   setFlyoutConfig,
   setOverviewPageStateAction,
@@ -31,9 +32,11 @@ import { OverviewLoader } from '../../synthetics/components/monitors_page/overvi
 export const StatusGridComponent = ({
   reload$,
   filters,
+  view,
 }: {
   reload$: Subject<boolean>;
   filters: MonitorFilters;
+  view: OverviewView;
 }) => {
   const overviewStore = useRef(getOverviewStore());
 
@@ -43,7 +46,7 @@ export const StatusGridComponent = ({
 
   const monitorOverviewListComponent = (
     <SyntheticsEmbeddableContext reload$={reload$} reduxStore={overviewStore.current}>
-      <MonitorsOverviewList filters={filters} singleMonitor={singleMonitor} />
+      <MonitorsOverviewList filters={filters} singleMonitor={singleMonitor} view={view} />
     </SyntheticsEmbeddableContext>
   );
 
@@ -111,9 +114,11 @@ const SingleMonitorView = () => {
 const MonitorsOverviewList = ({
   filters,
   singleMonitor,
+  view,
 }: {
   filters: MonitorFilters;
   singleMonitor?: boolean;
+  view: OverviewView;
 }) => {
   const dispatch = useDispatch();
   useEffect(() => {
@@ -129,9 +134,9 @@ const MonitorsOverviewList = ({
     );
   }, [dispatch, filters]);
 
-  if (singleMonitor) {
+  if (singleMonitor && view === 'cardView') {
     return <SingleMonitorView />;
   }
 
-  return <OverviewGrid />;
+  return <OverviewGrid view={view} isEmbeddable />;
 };

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/stats_overview/stats_overview_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/stats_overview/stats_overview_embeddable_factory.tsx
@@ -38,12 +38,23 @@ export const getOverviewPanelTitle = () =>
     defaultMessage: 'Synthetics Stats Overview',
   });
 
-export type OverviewEmbeddableState = SerializedTitles &
-  DynamicActionsSerializedState & {
-    filters: MonitorFilters;
-  };
+const DEFAULT_FILTERS: MonitorFilters = {
+  projects: [],
+  tags: [],
+  locations: [],
+  monitorIds: [],
+  monitorTypes: [],
+};
 
-export type StatsOverviewApi = DefaultEmbeddableApi<OverviewEmbeddableState> &
+export interface OverviewStatsEmbeddableCustomState {
+  filters?: MonitorFilters;
+}
+
+export type OverviewStatsEmbeddableState = SerializedTitles &
+  DynamicActionsSerializedState &
+  OverviewStatsEmbeddableCustomState;
+
+export type StatsOverviewApi = DefaultEmbeddableApi<OverviewStatsEmbeddableState> &
   PublishesWritableTitle &
   PublishesTitle &
   HasEditCapabilities &
@@ -87,13 +98,13 @@ export const getStatsOverviewEmbeddableFactory = (
   getStartServices: StartServicesAccessor<ClientPluginsStart>
 ) => {
   const factory: ReactEmbeddableFactory<
-    OverviewEmbeddableState,
-    OverviewEmbeddableState,
+    OverviewStatsEmbeddableState,
+    OverviewStatsEmbeddableState,
     StatsOverviewApi
   > = {
     type: SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE,
     deserializeState: (state) => {
-      return state.rawState as OverviewEmbeddableState;
+      return state.rawState as OverviewStatsEmbeddableState;
     },
     buildEmbeddable: async (state, buildApi, uuid) => {
       const [coreStart, pluginStart] = await getStartServices();
@@ -138,11 +149,12 @@ export const getStatsOverviewEmbeddableFactory = (
                 coreStart,
                 pluginStart,
                 initialState: {
-                  filters: filters$.getValue(),
+                  filters: filters$.getValue() || DEFAULT_FILTERS,
                 },
                 title: i18n.translate('xpack.synthetics.editSloOverviewEmbeddableTitle.title', {
                   defaultMessage: 'Create monitor stats',
                 }),
+                type: SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE,
               });
               filters$.next(result.filters);
             } catch (e) {
@@ -190,7 +202,7 @@ export const getStatsOverviewEmbeddableFactory = (
               }}
               data-shared-item="" // TODO: Remove data-shared-item and data-rendering-count as part of https://github.com/elastic/kibana/issues/179376
             >
-              <StatsOverviewComponent reload$={reload$} filters={filters} />
+              <StatsOverviewComponent reload$={reload$} filters={filters || DEFAULT_FILTERS} />
             </div>
           );
         },

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/ui_actions/create_monitors_overview_panel_action.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/ui_actions/create_monitors_overview_panel_action.tsx
@@ -41,6 +41,7 @@ export function createMonitorsOverviewPanelAction(
             defaultMessage: 'Create monitors overview',
           }
         ),
+        type: SYNTHETICS_MONITORS_EMBEDDABLE,
       });
       try {
         embeddable.addNewPanel({

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/ui_actions/create_stats_overview_panel_action.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/embeddables/ui_actions/create_stats_overview_panel_action.tsx
@@ -39,6 +39,7 @@ export function createStatusOverviewPanelAction(
           title: i18n.translate('xpack.synthetics.editSyntheticsOverviewEmbeddableTitle.title', {
             defaultMessage: 'Create monitor stats',
           }),
+          type: SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE,
         });
         embeddable.addNewPanel({
           panelType: SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE,

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/add_to_dashboard.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/add_to_dashboard.tsx
@@ -20,11 +20,15 @@ import {
   withSuspense,
 } from '@kbn/presentation-util-plugin/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { useSelector } from 'react-redux';
+import { OverviewStatsEmbeddableCustomState } from '../../../../embeddables/stats_overview/stats_overview_embeddable_factory';
 import { ClientPluginsStart } from '../../../../../plugin';
 import {
   SYNTHETICS_MONITORS_EMBEDDABLE,
   SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE,
 } from '../../../../embeddables/constants';
+import { selectOverviewState } from '../../../state';
+import { OverviewMonitorsEmbeddableCustomState } from '../../../../embeddables/monitors_overview/monitors_embeddable_factory';
 
 const SavedObjectSaveModalDashboard = withSuspense(LazySavedObjectSaveModalDashboard);
 
@@ -38,11 +42,18 @@ export const useAddToDashboard = ({
     defaultMessage: 'Status Overview',
   }),
 }: {
-  type: typeof SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE | typeof SYNTHETICS_MONITORS_EMBEDDABLE;
-  embeddableInput?: Record<string, unknown>;
   objectType?: string;
   documentTitle?: string;
-}) => {
+} & (
+  | {
+      type: typeof SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE;
+      embeddableInput?: OverviewStatsEmbeddableCustomState;
+    }
+  | {
+      type: typeof SYNTHETICS_MONITORS_EMBEDDABLE;
+      embeddableInput?: OverviewMonitorsEmbeddableCustomState;
+    }
+)) => {
   const [isDashboardAttachmentReady, setDashboardAttachmentReady] = React.useState(false);
 
   const { embeddable } = useKibana<ClientPluginsStart>().services;
@@ -90,9 +101,11 @@ export const AddToDashboard = ({
   type: typeof SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE | typeof SYNTHETICS_MONITORS_EMBEDDABLE;
   asButton?: boolean;
 }) => {
-  const { setDashboardAttachmentReady, MaybeSavedObjectSaveModalDashboard } = useAddToDashboard({
-    type,
-  });
+  const { view } = useSelector(selectOverviewState);
+
+  const { setDashboardAttachmentReady, MaybeSavedObjectSaveModalDashboard } = useAddToDashboard(
+    type === SYNTHETICS_STATS_OVERVIEW_EMBEDDABLE ? { type } : { type, embeddableInput: { view } }
+  );
 
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
   const closePopover = () => {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_status.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_status.tsx
@@ -12,21 +12,25 @@ import { EncryptedSyntheticsMonitor } from '../../../../../../common/runtime_typ
 export const BadgeStatus = ({
   status,
   isBrowserType,
+  onClickBadge,
 }: {
   status?: string;
   isBrowserType: boolean;
+  onClickBadge?: () => void;
 }) => {
-  return !status || status === 'unknown' ? (
-    <EuiBadge color="default" data-test-subj="monitorLatestStatusPending">
-      {PENDING_LABEL}
-    </EuiBadge>
-  ) : status === 'up' ? (
-    <EuiBadge color="success" data-test-subj="monitorLatestStatusUp">
-      {isBrowserType ? SUCCESS_LABEL : UP_LABEL}
-    </EuiBadge>
-  ) : (
-    <EuiBadge color="danger" data-test-subj="monitorLatestStatusDown">
-      {isBrowserType ? FAILED_LABEL : DOWN_LABEL}
+  const { color, dataTestSubj, labels } = badgeMapping[status || 'unknown'];
+  const label = isBrowserType && labels.browser ? labels.browser : labels.default;
+
+  return (
+    <EuiBadge
+      color={color}
+      data-test-subj={dataTestSubj}
+      onClick={() => {
+        if (onClickBadge) onClickBadge();
+      }}
+      onClickAriaLabel={CLICK_BADGE_ARIA_LABEL}
+    >
+      {label}
     </EuiBadge>
   );
 };
@@ -86,3 +90,43 @@ const UP_LABEL = i18n.translate('xpack.synthetics.monitorStatus.upLabel', {
 const DOWN_LABEL = i18n.translate('xpack.synthetics.monitorStatus.downLabel', {
   defaultMessage: 'Down',
 });
+
+const DISABLED_LABEL = i18n.translate('xpack.synthetics.monitorStatus.disabledLabel', {
+  defaultMessage: 'Disabled',
+});
+
+const CLICK_BADGE_ARIA_LABEL = i18n.translate(
+  'xpack.synthetics.monitorStatus.clickBadgeAriaLabel',
+  {
+    defaultMessage: 'Click to trigger the related action',
+  }
+);
+
+interface BadgeData {
+  color: string;
+  dataTestSubj: string;
+  labels: { default: string; browser?: string };
+}
+
+const badgeMapping: Record<string, BadgeData> = {
+  unknown: {
+    color: 'default',
+    dataTestSubj: 'monitorLatestStatusPending',
+    labels: { default: PENDING_LABEL },
+  },
+  up: {
+    color: 'success',
+    dataTestSubj: 'monitorLatestStatusUp',
+    labels: { default: UP_LABEL, browser: SUCCESS_LABEL },
+  },
+  down: {
+    color: 'danger',
+    dataTestSubj: 'monitorLatestStatusDown',
+    labels: { default: DOWN_LABEL, browser: FAILED_LABEL },
+  },
+  disabled: {
+    color: 'default',
+    dataTestSubj: 'monitorLatestStatusDisabled',
+    labels: { default: DISABLED_LABEL },
+  },
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/get_histogram_interval.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/common/get_histogram_interval.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import DateMath from '@kbn/datemath';
+
+export const parseRelativeDate = (dateStr: string, options = {}) => {
+  // We need this this parsing because if user selects This week or this date
+  // That represents end date in future, if week or day is still in the middle
+  // Uptime data can never be collected in future, so we will reset date to now
+  // in That case. Example case we select this week range will be to='now/w' and from = 'now/w';
+
+  const parsedDate = DateMath.parse(dateStr, options);
+  const dateTimestamp = parsedDate?.valueOf() ?? 0;
+  if (dateTimestamp > Date.now()) {
+    return DateMath.parse('now');
+  }
+  return parsedDate;
+};
+
+export const getHistogramInterval = (
+  dateRangeStart: string,
+  dateRangeEnd: string,
+  bucketCount?: number
+): number => {
+  const from = parseRelativeDate(dateRangeStart);
+
+  // roundUp is required for relative date like now/w to get the end of the week
+  const to = parseRelativeDate(dateRangeEnd, { roundUp: true });
+  if (from === undefined) {
+    throw Error('Invalid dateRangeStart value');
+  }
+  if (to === undefined) {
+    throw Error('Invalid dateRangeEnd value');
+  }
+  const interval = Math.round((to.valueOf() - from.valueOf()) / (bucketCount || 25));
+
+  // Interval can never be zero, if it's 0 we return at least 1ms interval
+  return interval > 0 ? interval : 1;
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_histogram.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_monitor_histogram.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { estypes } from '@elastic/elasticsearch';
+import { useEsSearch } from '@kbn/observability-shared-plugin/public';
+
+import { getHistogramInterval } from '../common/get_histogram_interval';
+import {
+  Histogram,
+  HistogramPoint,
+  OverviewStatusMetaData,
+  Ping,
+} from '../../../../../../common/runtime_types';
+import { SYNTHETICS_INDEX_PATTERN } from '../../../../../../common/constants';
+import { useGetUrlParams } from '../../../hooks';
+import { useSyntheticsRefreshContext } from '../../../contexts';
+
+export const useMonitorHistogram = ({ items }: { items: OverviewStatusMetaData[] }) => {
+  const { dateRangeStart, dateRangeEnd } = useGetUrlParams();
+
+  const { lastRefresh } = useSyntheticsRefreshContext();
+
+  const monitorIds = (items ?? []).map(({ configId }) => configId);
+
+  const { queryParams, minInterval } = getQueryParams(
+    dateRangeStart,
+    dateRangeEnd,
+    monitorIds,
+    SYNTHETICS_INDEX_PATTERN
+  );
+
+  const { data, loading } = useEsSearch<Ping, typeof queryParams>(
+    queryParams,
+    [JSON.stringify(monitorIds), lastRefresh],
+    {
+      name: 'getMonitorDownHistory',
+    }
+  );
+
+  const byIdsBuckets = data?.aggregations?.byIds.buckets ?? [];
+  const histogramsById: { [key: string]: Histogram } = {};
+
+  byIdsBuckets.forEach((idBucket) => {
+    idBucket.perLocation.buckets.forEach((locationBucket) => {
+      const uniqId = `${idBucket.key}-${locationBucket.key}`;
+      const points: HistogramPoint[] = [];
+      locationBucket.histogram.buckets.forEach((histogramBucket) => {
+        const timestamp = histogramBucket.key;
+        const down = histogramBucket.totalDown.value ?? 0;
+        points.push({
+          timestamp,
+          up: undefined,
+          down,
+        });
+      });
+      histogramsById[uniqId] = { points };
+    });
+  });
+
+  return { histogramsById, loading, minInterval };
+};
+
+const getQueryParams = (
+  dateRangeStart: string,
+  dateRangeEnd: string,
+  configIds: string[],
+  index: string
+) => {
+  const minInterval = getHistogramInterval(dateRangeStart, dateRangeEnd, 30);
+
+  const queryParams = {
+    index,
+    size: 0,
+    query: {
+      bool: {
+        filter: [
+          {
+            range: {
+              'summary.down': { gt: 0 },
+            },
+          },
+          {
+            terms: {
+              config_id: configIds,
+            },
+          },
+          {
+            range: {
+              '@timestamp': {
+                gte: dateRangeStart,
+                lte: dateRangeEnd,
+              },
+            },
+          },
+        ] as estypes.QueryDslQueryContainer,
+      },
+    },
+    aggs: {
+      byIds: {
+        terms: {
+          field: 'monitor.id',
+          size: Math.max(configIds.length, 1),
+        },
+        aggs: {
+          perLocation: {
+            terms: {
+              field: 'observer.name',
+            },
+            aggs: {
+              histogram: {
+                date_histogram: {
+                  field: '@timestamp',
+                  fixed_interval: minInterval + 'ms',
+                },
+                aggs: {
+                  totalDown: {
+                    sum: { field: 'summary.down' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  return { queryParams, minInterval };
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/hooks/use_overview_status.ts
@@ -58,7 +58,7 @@ export function useOverviewStatus({ scopeStatusByLocation }: { scopeStatusByLoca
         isInitialMount.current = false;
         return;
       }
-      dispatch(fetchOverviewStatusAction.get({ pageState, scopeStatusByLocation }));
+      dispatch(quietFetchOverviewStatusAction.get({ pageState, scopeStatusByLocation }));
     },
     100,
     [pageState, scopeStatusByLocation]

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -38,6 +38,7 @@ import { useEditMonitorLocator } from '../../../../hooks/use_edit_monitor_locato
 import { useMonitorDetailLocator } from '../../../../hooks/use_monitor_detail_locator';
 import { NoPermissionsTooltip } from '../../../common/components/permissions';
 import { useAddToDashboard } from '../../../common/components/add_to_dashboard';
+import { selectOverviewState } from '../../../../state';
 
 type PopoverPosition = 'relative' | 'default';
 
@@ -152,6 +153,8 @@ export function ActionsPopover({
 
   const testInProgress = useSelector(manualTestRunInProgressSelector(monitor.configId));
 
+  const { view } = useSelector(selectOverviewState);
+
   useEffect(() => {
     if (status === FETCH_STATUS.LOADING) {
       setEnableLabel(loadingLabel(monitor.isEnabled));
@@ -190,6 +193,7 @@ export function ActionsPopover({
         monitorTypes: [],
         projects: [],
       },
+      view,
     },
     documentTitle: `${monitor.name} - ${monitor.locationLabel}`,
     objectType: i18n.translate('xpack.synthetics.overview.actions.addToDashboard.objectTypeLabel', {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitor_bar_series.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitor_bar_series.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Axis, BarSeries, Chart, ScaleType, Settings, Position } from '@elastic/charts';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import moment from 'moment';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { EuiText, EuiToolTip, useEuiTheme } from '@elastic/eui';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { HistogramPoint } from '../../../../../../../../../common/runtime_types/monitor';
+import { ClientPluginsStart } from '../../../../../../../../plugin';
+const seriesHasDownValues = (series: HistogramPoint[] | null): boolean => {
+  return series ? series.some((point) => !!point.down) : false;
+};
+export interface MonitorBarSeriesProps {
+  histogramSeries: HistogramPoint[] | null;
+  minInterval: number;
+}
+
+/**
+ * There is a specific focus on the monitor's down count, the up series is not shown,
+ * so we will only render the series component if there are down counts for the selected monitor.
+ * @param props - the values for the monitor this chart visualizes
+ */
+export const MonitorBarSeries = ({ histogramSeries, minInterval }: MonitorBarSeriesProps) => {
+  const {
+    services: { charts },
+  } = useKibana<ClientPluginsStart>();
+  const baseTheme = charts.theme.useChartsBaseTheme();
+
+  const theme = useEuiTheme();
+  const danger = theme.euiTheme.colors.danger;
+
+  const id = 'downSeries';
+
+  return seriesHasDownValues(histogramSeries) ? (
+    <div style={{ height: 50, width: '100%', maxWidth: '1200px', marginRight: 15 }}>
+      <Chart>
+        <Settings
+          xDomain={{
+            minInterval,
+            min: moment().subtract(24, 'hours').valueOf(),
+            max: moment().valueOf(),
+          }}
+          locale={i18n.getLocale()}
+          baseTheme={baseTheme}
+        />
+        <Axis
+          hide
+          id="bottom"
+          position={Position.Bottom}
+          tickFormat={(d) => moment(d).format('YYYY-MM-DD HH:mm:ss')}
+        />
+        <BarSeries
+          id={id}
+          color={danger}
+          data={(histogramSeries || []).map(({ timestamp, down }) => [timestamp, down])}
+          name={i18n.translate('xpack.synthetics.monitorList.downLineSeries.downLabel', {
+            defaultMessage: 'Down checks',
+          })}
+          timeZone="local"
+          xAccessor={0}
+          xScaleType={ScaleType.Time}
+          yAccessors={[1]}
+          yScaleType={ScaleType.Linear}
+        />
+      </Chart>
+    </div>
+  ) : (
+    <EuiToolTip
+      position="top"
+      content={
+        <FormattedMessage
+          id="xpack.synthetics.monitorList.noDownHistory"
+          defaultMessage="This monitor has never been {emphasizedText} during the last 24 hours"
+          values={{
+            emphasizedText: (
+              <strong>
+                {i18n.translate('xpack.synthetics.monitorBarSeries.strong.downLabel', {
+                  defaultMessage: 'down',
+                })}
+              </strong>
+            ),
+          }}
+        />
+      }
+    >
+      <EuiText color="success">
+        {i18n.translate('xpack.synthetics.monitorBarSeries.TextLabel', { defaultMessage: '--' })}
+      </EuiText>
+    </EuiToolTip>
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitors_actions.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitors_actions.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { OverviewStatusMetaData } from '../../../../../../../../../common/runtime_types';
+import { ActionsPopover } from '../../actions_popover';
+
+export const MonitorsActions = ({ monitor }: { monitor: OverviewStatusMetaData }) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  return (
+    <ActionsPopover
+      isPopoverOpen={isPopoverOpen}
+      locationId={monitor.locationId}
+      monitor={monitor}
+      position="default"
+      setIsPopoverOpen={setIsPopoverOpen}
+    />
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitors_duration.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitors_duration.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { EuiText } from '@elastic/eui';
+import { formatDuration } from '../../../../../../utils/formatting';
+import { selectOverviewTrends } from '../../../../../../state';
+import { OverviewStatusMetaData } from '../../../../../../../../../common/runtime_types';
+
+export const MonitorsDuration = ({
+  monitor,
+  onClickDuration,
+}: {
+  monitor: OverviewStatusMetaData;
+  onClickDuration: () => void;
+}) => {
+  const trendData = useSelector(selectOverviewTrends)[monitor.configId + monitor.locationId];
+  const duration = trendData === 'loading' || !trendData?.median ? 0 : trendData.median;
+  return (
+    <EuiText size="s" onClick={onClickDuration}>
+      {formatDuration(duration)}
+    </EuiText>
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitors_table.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/components/monitors_table.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React, { useCallback } from 'react';
+import { EuiBasicTable, EuiTableRowProps } from '@elastic/eui';
+import { useDispatch } from 'react-redux';
+import { OverviewStatusMetaData } from '../../../../../../../../../common/runtime_types';
+import { useOverviewStatus } from '../../../../hooks/use_overview_status';
+import { FlyoutParamProps } from '../../types';
+import { useMonitorsTableColumns } from '../hooks/use_monitors_table_columns';
+import { useMonitorsTablePagination } from '../hooks/use_monitors_table_pagination';
+
+export const MonitorsTable = ({
+  items,
+  setFlyoutConfigCallback,
+}: {
+  items: OverviewStatusMetaData[];
+  setFlyoutConfigCallback: (params: FlyoutParamProps) => void;
+}) => {
+  const { loaded, status, loading } = useOverviewStatus({
+    scopeStatusByLocation: true,
+  });
+  const { pageOfItems, pagination, onTableChange } = useMonitorsTablePagination({
+    totalItems: items,
+  });
+
+  const { columns } = useMonitorsTableColumns({ setFlyoutConfigCallback, items: pageOfItems });
+
+  const dispatch = useDispatch();
+
+  const getRowProps = useCallback(
+    (monitor: OverviewStatusMetaData): EuiTableRowProps => {
+      const { configId, locationLabel, locationId, spaceId } = monitor;
+      return {
+        onClick: (e) => {
+          // This is a workaround to prevent the flyout from opening when clicking on the action buttons
+          if (
+            Array.from((e.target as HTMLElement).classList).some(
+              (className) =>
+                className.includes('euiTableCellContent') || className.includes('clickCellContent')
+            )
+          ) {
+            dispatch(
+              setFlyoutConfigCallback({
+                configId,
+                id: configId,
+                location: locationLabel,
+                locationId,
+                spaceId,
+              })
+            );
+          }
+        },
+      };
+    },
+    [dispatch, setFlyoutConfigCallback]
+  );
+
+  return (
+    <EuiBasicTable
+      compressed
+      items={pageOfItems}
+      columns={columns}
+      loading={!status || !loaded || loading}
+      pagination={pagination}
+      onChange={onTableChange}
+      rowProps={getRowProps}
+      data-test-subj="syntheticsCompactViewTable"
+      tableLayout="auto"
+    />
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/hooks/use_monitors_table_columns.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/hooks/use_monitors_table_columns.tsx
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useCallback, useMemo } from 'react';
+import { EuiBasicTableColumn, EuiLink, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+import { useHistory } from 'react-router-dom';
+import { TagsList } from '@kbn/observability-shared-plugin/public';
+import { useDispatch } from 'react-redux';
+import { MonitorBarSeries } from '../components/monitor_bar_series';
+import { useMonitorHistogram } from '../../../../hooks/use_monitor_histogram';
+import {
+  MonitorTypeEnum,
+  OverviewStatusMetaData,
+} from '../../../../../../../../../common/runtime_types';
+import { MonitorTypeBadge } from '../../../../../common/components/monitor_type_badge';
+import { getFilterForTypeMessage } from '../../../../management/monitor_list_table/labels';
+import { BadgeStatus } from '../../../../../common/components/monitor_status';
+import { FlyoutParamProps } from '../../types';
+import { MonitorsActions } from '../components/monitors_actions';
+import {
+  STATUS,
+  ACTIONS,
+  LOCATIONS,
+  NAME,
+  TAGS,
+  DURATION,
+  URL,
+  NO_URL,
+  MONITOR_HISTORY,
+} from '../labels';
+import { MonitorsDuration } from '../components/monitors_duration';
+
+export const useMonitorsTableColumns = ({
+  setFlyoutConfigCallback,
+  items,
+}: {
+  items: OverviewStatusMetaData[];
+  setFlyoutConfigCallback: (params: FlyoutParamProps) => void;
+}) => {
+  const history = useHistory();
+  const { histogramsById, minInterval } = useMonitorHistogram({ items });
+
+  const onClickMonitorFilter = useCallback(
+    (filterName: string, filterValue: string) => {
+      const searchParams = new URLSearchParams(history.location.search); // Get existing query params
+      searchParams.set(filterName, JSON.stringify([filterValue])); // Add or update the query param
+
+      history.push({
+        search: searchParams.toString(), // Convert back to a query string
+      });
+    },
+    [history]
+  );
+
+  const dispatch = useDispatch();
+
+  const openFlyout = useCallback(
+    (monitor: OverviewStatusMetaData) => {
+      const { configId, locationLabel, locationId, spaceId } = monitor;
+      dispatch(
+        setFlyoutConfigCallback({
+          configId,
+          id: configId,
+          location: locationLabel,
+          locationId,
+          spaceId,
+        })
+      );
+    },
+    [dispatch, setFlyoutConfigCallback]
+  );
+
+  const columns: Array<EuiBasicTableColumn<OverviewStatusMetaData>> = useMemo(
+    () => [
+      {
+        field: 'status',
+        name: STATUS,
+        render: (status: OverviewStatusMetaData['status'], monitor) => (
+          <BadgeStatus
+            status={status}
+            isBrowserType={monitor.type === MonitorTypeEnum.BROWSER}
+            onClickBadge={() => openFlyout(monitor)}
+          />
+        ),
+      },
+      {
+        field: 'name',
+        name: NAME,
+        render: (name: OverviewStatusMetaData['name'], monitor) => (
+          <EuiFlexGroup
+            direction="column"
+            alignItems="flexStart"
+            gutterSize="s"
+            className="clickCellContent"
+          >
+            <EuiFlexItem>
+              <EuiText size="s" onClick={() => openFlyout(monitor)}>
+                {name}
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <MonitorTypeBadge
+                monitorType={monitor.type}
+                ariaLabel={getFilterForTypeMessage(monitor.type)}
+                onClick={() => onClickMonitorFilter('monitorTypes', monitor.type)}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
+      },
+      {
+        field: 'urls',
+        name: URL,
+        render: (url: OverviewStatusMetaData['urls']) =>
+          url ? (
+            <EuiLink
+              data-test-subj="syntheticsCompactViewUrl"
+              href={url}
+              target="_blank"
+              color="text"
+              external
+            >
+              {url}
+            </EuiLink>
+          ) : (
+            <EuiText>{NO_URL}</EuiText>
+          ),
+      },
+      {
+        field: 'locationLabel',
+        name: LOCATIONS,
+        render: (locationLabel: OverviewStatusMetaData['locationLabel']) => (
+          <EuiLink
+            data-test-subj="syntheticsCompactViewLocation"
+            onClick={() => onClickMonitorFilter('locations', locationLabel)}
+          >
+            {locationLabel}
+          </EuiLink>
+        ),
+      },
+      {
+        field: 'tags',
+        name: TAGS,
+        render: (tags: OverviewStatusMetaData['tags']) => (
+          <TagsList tags={tags} onClick={(tag) => onClickMonitorFilter('tags', tag)} />
+        ),
+      },
+      {
+        name: DURATION,
+        render: (monitor: OverviewStatusMetaData) => (
+          <MonitorsDuration monitor={monitor} onClickDuration={() => openFlyout(monitor)} />
+        ),
+        width: '100px',
+      },
+      {
+        align: 'left' as const,
+        field: 'configId',
+        name: MONITOR_HISTORY,
+        mobileOptions: {
+          show: false,
+        },
+        width: '220px',
+        render: (configId: string, monitor: OverviewStatusMetaData) => {
+          const uniqId = `${configId}-${monitor.locationId}`;
+          return (
+            <MonitorBarSeries
+              histogramSeries={histogramsById?.[uniqId]?.points}
+              minInterval={minInterval!}
+            />
+          );
+        },
+      },
+      {
+        name: ACTIONS,
+        render: (monitor: OverviewStatusMetaData) => <MonitorsActions monitor={monitor} />,
+        align: 'right',
+        width: '40px',
+      },
+    ],
+    [histogramsById, minInterval, onClickMonitorFilter, openFlyout]
+  );
+
+  return {
+    columns,
+  };
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/hooks/use_monitors_table_pagination.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/hooks/use_monitors_table_pagination.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Criteria } from '@elastic/eui';
+import { useState } from 'react';
+import { OverviewStatusMetaData } from '../../../../../../../../../common/runtime_types';
+
+const findMonitors = (monitors: OverviewStatusMetaData[], pageIndex: number, pageSize: number) => {
+  let pageOfItems;
+
+  if (!pageIndex && !pageSize) {
+    pageOfItems = monitors;
+  } else {
+    const startIndex = pageIndex * pageSize;
+    pageOfItems = monitors.slice(startIndex, Math.min(startIndex + pageSize, monitors.length));
+  }
+
+  return {
+    pageOfItems,
+    totalItemCount: monitors.length,
+  };
+};
+
+export const useMonitorsTablePagination = ({
+  totalItems,
+}: {
+  totalItems: OverviewStatusMetaData[];
+}) => {
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+
+  const onTableChange = ({ page }: Criteria<OverviewStatusMetaData>) => {
+    if (page) {
+      setPageIndex(page.index);
+      setPageSize(page.size);
+    }
+  };
+
+  const { pageOfItems, totalItemCount } = findMonitors(totalItems, pageIndex, pageSize);
+
+  const pagination = {
+    pageIndex,
+    pageSize,
+    totalItemCount,
+    pageSizeOptions: [5, 10, 25, 50, 100],
+  };
+
+  return { onTableChange, pageOfItems, pagination };
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/labels.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/labels.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const STATUS = i18n.translate('xpack.synthetics.overview.compactView.monitorStatus', {
+  defaultMessage: 'Status',
+});
+
+export const NAME = i18n.translate('xpack.synthetics.overview.compactView.monitorName', {
+  defaultMessage: 'Name',
+});
+
+export const URL = i18n.translate('xpack.synthetics.overview.compactView.monitorUrl', {
+  defaultMessage: 'Url',
+});
+
+export const NO_URL = i18n.translate('xpack.synthetics.overview.compactView.noUrl', {
+  defaultMessage: '--',
+});
+
+export const LOCATIONS = i18n.translate('xpack.synthetics.overview.compactView.monitorLocations', {
+  defaultMessage: 'Locations',
+});
+
+export const TAGS = i18n.translate('xpack.synthetics.overview.compactView.monitorTags', {
+  defaultMessage: 'Tags',
+});
+
+export const ACTIONS = i18n.translate('xpack.synthetics.overview.compactView.monitorActions', {
+  defaultMessage: 'Actions',
+});
+
+export const DURATION = i18n.translate('xpack.synthetics.overview.compactView.monitorDuration', {
+  defaultMessage: 'Median duration',
+});
+
+export const MONITOR_HISTORY = i18n.translate(
+  'xpack.synthetics.monitorList.monitorHistoryColumnLabel',
+  {
+    defaultMessage: 'Downtime history',
+  }
+);

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/overview_grid_compact_view.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/overview_grid_compact_view.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useMonitorsSortedByStatus } from '../../../../../hooks/use_monitors_sorted_by_status';
+import { selectOverviewState } from '../../../../../state';
+import { GridItemsByGroup } from '../grid_by_group/grid_items_by_group';
+import { FlyoutParamProps } from '../types';
+import { MonitorsTable } from './components/monitors_table';
+
+export const OverviewGridCompactView = ({
+  setFlyoutConfigCallback,
+}: {
+  setFlyoutConfigCallback: (params: FlyoutParamProps) => void;
+}) => {
+  const {
+    groupBy: { field: groupField },
+  } = useSelector(selectOverviewState);
+  const monitorsSortedByStatus = useMonitorsSortedByStatus();
+
+  return groupField === 'none' ? (
+    <MonitorsTable
+      items={monitorsSortedByStatus}
+      setFlyoutConfigCallback={setFlyoutConfigCallback}
+    />
+  ) : (
+    <GridItemsByGroup setFlyoutConfigCallback={setFlyoutConfigCallback} view="compactView" />
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/grid_by_group/grid_items_by_group.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/grid_by_group/grid_items_by_group.tsx
@@ -19,14 +19,20 @@ import {
 import { useFilters } from '../../../common/monitor_filters/use_filters';
 import { GroupGridItem } from './grid_group_item';
 import { ConfigKey } from '../../../../../../../../common/runtime_types';
-import { selectOverviewState, selectServiceLocationsState } from '../../../../../state';
+import {
+  OverviewView,
+  selectOverviewState,
+  selectServiceLocationsState,
+} from '../../../../../state';
 import { FlyoutParamProps } from '../types';
 import { selectOverviewStatus } from '../../../../../state/overview_status';
 
 export const GridItemsByGroup = ({
   setFlyoutConfigCallback,
+  view,
 }: {
   setFlyoutConfigCallback: (params: FlyoutParamProps) => void;
+  view: OverviewView;
 }) => {
   const [fullScreenGroup, setFullScreenGroup] = useState('');
   const {
@@ -149,6 +155,7 @@ export const GridItemsByGroup = ({
                 setFlyoutConfigCallback={setFlyoutConfigCallback}
                 setFullScreenGroup={setFullScreenGroup}
                 fullScreenGroup={fullScreenGroup}
+                view={view}
               />
             </WrappedPanel>
             <EuiSpacer size="m" />
@@ -164,6 +171,7 @@ export const GridItemsByGroup = ({
             setFlyoutConfigCallback={setFlyoutConfigCallback}
             setFullScreenGroup={setFullScreenGroup}
             fullScreenGroup={fullScreenGroup}
+            view={view}
           />
         </WrappedPanel>
       )}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_grid.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/overview_grid.tsx
@@ -27,7 +27,7 @@ import { AddToDashboard } from '../../../common/components/add_to_dashboard';
 import { useOverviewStatus } from '../../hooks/use_overview_status';
 import { GridItemsByGroup } from './grid_by_group/grid_items_by_group';
 import { GroupFields } from './grid_by_group/group_fields';
-import { selectOverviewState, setFlyoutConfig } from '../../../../state/overview';
+import { OverviewView, selectOverviewState, setFlyoutConfig } from '../../../../state/overview';
 import { useMonitorsSortedByStatus } from '../../../../hooks/use_monitors_sorted_by_status';
 import {
   refreshOverviewTrends,
@@ -41,6 +41,8 @@ import { NoMonitorsFound } from '../../common/no_monitors_found';
 import { useSyntheticsRefreshContext } from '../../../../contexts';
 import { FlyoutParamProps } from './types';
 import { MaybeMonitorDetailsFlyout } from './monitor_detail_flyout';
+import { OverviewGridCompactView } from './compact_view/overview_grid_compact_view';
+import { ViewButtons } from './view_buttons/view_buttons';
 
 const ITEM_HEIGHT = 172;
 const ROW_COUNT = 4;
@@ -53,202 +55,216 @@ interface ListItem {
   locationId: string;
 }
 
-export const OverviewGrid = memo(() => {
-  const { status, allConfigs, loaded } = useOverviewStatus({
-    scopeStatusByLocation: true,
-  });
-  const monitorsSortedByStatus: OverviewStatusMetaData[] = useMonitorsSortedByStatus();
+export const OverviewGrid = memo(
+  ({ view, isEmbeddable }: { view: OverviewView; isEmbeddable?: boolean }) => {
+    const { status, allConfigs, loaded } = useOverviewStatus({
+      scopeStatusByLocation: true,
+    });
+    const monitorsSortedByStatus: OverviewStatusMetaData[] = useMonitorsSortedByStatus();
 
-  const {
-    pageState,
-    groupBy: { field: groupField },
-  } = useSelector(selectOverviewState);
-  const trendData = useSelector(selectOverviewTrends);
-  const { perPage } = pageState;
+    const {
+      pageState,
+      groupBy: { field: groupField },
+    } = useSelector(selectOverviewState);
 
-  const [maxItem, setMaxItem] = useState(0);
-  const [currentIndex, setCurrentIndex] = useState(0);
+    const trendData = useSelector(selectOverviewTrends);
+    const { perPage } = pageState;
 
-  const dispatch = useDispatch();
+    const [maxItem, setMaxItem] = useState(0);
+    const [currentIndex, setCurrentIndex] = useState(0);
 
-  const setFlyoutConfigCallback = useCallback(
-    (params: FlyoutParamProps) => dispatch(setFlyoutConfig(params)),
-    [dispatch]
-  );
-  const { lastRefresh } = useSyntheticsRefreshContext();
+    const dispatch = useDispatch();
 
-  useEffect(() => {
-    if (monitorsSortedByStatus.length) {
-      const batch: TrendRequest[] = [];
-      const chunk = monitorsSortedByStatus.slice(0, (maxItem + 1) * ROW_COUNT);
-      for (const item of chunk) {
+    const setFlyoutConfigCallback = useCallback(
+      (params: FlyoutParamProps) => dispatch(setFlyoutConfig(params)),
+      [dispatch]
+    );
+    const { lastRefresh } = useSyntheticsRefreshContext();
+
+    useEffect(() => {
+      const trendRequests = monitorsSortedByStatus.reduce((acc, item) => {
         if (trendData[item.configId + item.locationId] === undefined) {
-          batch.push({
+          acc.push({
             configId: item.configId,
             locationId: item.locationId,
             schedule: item.schedule,
           });
         }
+        return acc;
+      }, [] as TrendRequest[]);
+      if (trendRequests.length) dispatch(trendStatsBatch.get(trendRequests));
+    }, [dispatch, maxItem, monitorsSortedByStatus, trendData]);
+
+    const listHeight = Math.min(
+      ITEM_HEIGHT * Math.ceil(monitorsSortedByStatus.length / ROW_COUNT),
+      MAX_LIST_HEIGHT
+    );
+
+    const listItems: ListItem[][] = useMemo(() => {
+      const acc: ListItem[][] = [];
+      for (let i = 0; i < monitorsSortedByStatus.length; i += ROW_COUNT) {
+        acc.push(monitorsSortedByStatus.slice(i, i + ROW_COUNT));
       }
-      if (batch.length) dispatch(trendStatsBatch.get(batch));
+      return acc;
+    }, [monitorsSortedByStatus]);
+
+    const listRef: React.LegacyRef<FixedSizeList<ListItem[][]>> | undefined = React.createRef();
+    useEffect(() => {
+      dispatch(refreshOverviewTrends.get());
+    }, [dispatch, lastRefresh]);
+
+    // Display no monitors found when down, up, or disabled filter produces no results
+    if (status && !monitorsSortedByStatus.length && loaded) {
+      return <NoMonitorsFound />;
     }
-  }, [dispatch, maxItem, monitorsSortedByStatus, trendData]);
 
-  const listHeight = Math.min(
-    ITEM_HEIGHT * Math.ceil(monitorsSortedByStatus.length / ROW_COUNT),
-    MAX_LIST_HEIGHT
-  );
+    return (
+      <>
+        <EuiFlexGroup
+          justifyContent="spaceBetween"
+          alignItems="center"
+          responsive={false}
+          wrap={true}
+        >
+          <EuiFlexItem grow={true}>
+            <OverviewPaginationInfo total={status ? monitorsSortedByStatus.length : undefined} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <ShowAllSpaces />
+          </EuiFlexItem>
 
-  const listItems: ListItem[][] = useMemo(() => {
-    const acc: ListItem[][] = [];
-    for (let i = 0; i < monitorsSortedByStatus.length; i += ROW_COUNT) {
-      acc.push(monitorsSortedByStatus.slice(i, i + ROW_COUNT));
-    }
-    return acc;
-  }, [monitorsSortedByStatus]);
+          <EuiFlexItem grow={false}>
+            <AddToDashboard type={SYNTHETICS_MONITORS_EMBEDDABLE} asButton />
+          </EuiFlexItem>
 
-  const listRef: React.LegacyRef<FixedSizeList<ListItem[][]>> | undefined = React.createRef();
-  useEffect(() => {
-    dispatch(refreshOverviewTrends.get());
-  }, [dispatch, lastRefresh]);
-
-  // Display no monitors found when down, up, or disabled filter produces no results
-  if (status && !monitorsSortedByStatus.length && loaded) {
-    return <NoMonitorsFound />;
-  }
-
-  return (
-    <>
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
-        alignItems="center"
-        responsive={false}
-        wrap={true}
-      >
-        <EuiFlexItem grow={true}>
-          <OverviewPaginationInfo total={status ? monitorsSortedByStatus.length : undefined} />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <ShowAllSpaces />
-        </EuiFlexItem>
-
-        <EuiFlexItem grow={false}>
-          <AddToDashboard type={SYNTHETICS_MONITORS_EMBEDDABLE} asButton />
-        </EuiFlexItem>
-
-        <EuiFlexItem grow={false}>
-          <SortFields />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <GroupFields />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="m" />
-      <div style={groupField === 'none' ? { height: listHeight } : undefined}>
-        {groupField === 'none' ? (
-          loaded && monitorsSortedByStatus.length ? (
-            <EuiAutoSizer>
-              {({ width }: EuiAutoSize) => (
-                <InfiniteLoader
-                  isItemLoaded={(idx: number) =>
-                    listItems[idx].every((m) => !!trendData[m.configId + m.locationId])
-                  }
-                  itemCount={listItems.length}
-                  loadMoreItems={(_, stop: number) => setMaxItem(Math.max(maxItem, stop))}
-                  minimumBatchSize={MIN_BATCH_SIZE}
-                  threshold={LIST_THRESHOLD}
-                >
-                  {({ onItemsRendered }) => (
-                    <FixedSizeList
-                      // pad computed height to avoid clipping last row's drop shadow
-                      height={listHeight + 16}
-                      width={width}
-                      onItemsRendered={onItemsRendered}
-                      itemSize={ITEM_HEIGHT}
-                      itemCount={listItems.length}
-                      itemData={listItems}
-                      ref={listRef}
-                    >
-                      {({
-                        index: listIndex,
-                        style,
-                        data: listData,
-                      }: React.PropsWithChildren<ListChildComponentProps<ListItem[][]>>) => {
-                        setCurrentIndex(listIndex);
-                        return (
-                          <EuiFlexGroup
-                            data-test-subj={`overview-grid-row-${listIndex}`}
-                            gutterSize="m"
-                            style={{ ...style }}
-                          >
-                            {listData[listIndex].map((_, idx) => (
-                              <EuiFlexItem
-                                data-test-subj="syntheticsOverviewGridItem"
-                                key={listIndex * ROW_COUNT + idx}
-                              >
-                                <MetricItem
-                                  monitor={monitorsSortedByStatus[listIndex * ROW_COUNT + idx]}
-                                  onClick={setFlyoutConfigCallback}
-                                />
-                              </EuiFlexItem>
-                            ))}
-                            {listData[listIndex].length % ROW_COUNT !== 0 &&
-                              // Adds empty items to fill out row
-                              Array.from({
-                                length: ROW_COUNT - listData[listIndex].length,
-                              }).map((_, idx) => <EuiFlexItem key={idx} />)}
-                          </EuiFlexGroup>
-                        );
-                      }}
-                    </FixedSizeList>
-                  )}
-                </InfiniteLoader>
-              )}
-            </EuiAutoSizer>
-          ) : (
-            <OverviewLoader />
-          )
-        ) : (
-          <GridItemsByGroup setFlyoutConfigCallback={setFlyoutConfigCallback} />
-        )}
+          <EuiFlexItem grow={false}>
+            <SortFields />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <GroupFields />
+          </EuiFlexItem>
+          {!isEmbeddable ? (
+            <EuiFlexItem grow={false}>
+              <ViewButtons />
+            </EuiFlexItem>
+          ) : null}
+        </EuiFlexGroup>
         <EuiSpacer size="m" />
-      </div>
-      {groupField === 'none' &&
-        loaded &&
-        // display this footer when user scrolls to end of list
-        currentIndex * ROW_COUNT + ROW_COUNT >= monitorsSortedByStatus.length && (
+        {view === 'cardView' ? (
           <>
-            <EuiSpacer />
-            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-              {monitorsSortedByStatus.length === allConfigs.length && (
-                <EuiFlexItem grow={false}>
-                  <EuiText size="xs">{SHOWING_ALL_MONITORS_LABEL}</EuiText>
-                </EuiFlexItem>
+            <div style={groupField === 'none' ? { height: listHeight } : undefined}>
+              {groupField === 'none' ? (
+                loaded && monitorsSortedByStatus.length ? (
+                  <EuiAutoSizer>
+                    {({ width }: EuiAutoSize) => (
+                      <InfiniteLoader
+                        isItemLoaded={(idx: number) =>
+                          listItems[idx].every((m) => !!trendData[m.configId + m.locationId])
+                        }
+                        itemCount={listItems.length}
+                        loadMoreItems={(_, stop: number) => setMaxItem(Math.max(maxItem, stop))}
+                        minimumBatchSize={MIN_BATCH_SIZE}
+                        threshold={LIST_THRESHOLD}
+                      >
+                        {({ onItemsRendered }) => (
+                          <FixedSizeList
+                            // pad computed height to avoid clipping last row's drop shadow
+                            height={listHeight + 16}
+                            width={width}
+                            onItemsRendered={onItemsRendered}
+                            itemSize={ITEM_HEIGHT}
+                            itemCount={listItems.length}
+                            itemData={listItems}
+                            ref={listRef}
+                          >
+                            {({
+                              index: listIndex,
+                              style,
+                              data: listData,
+                            }: React.PropsWithChildren<ListChildComponentProps<ListItem[][]>>) => {
+                              setCurrentIndex(listIndex);
+                              return (
+                                <EuiFlexGroup
+                                  data-test-subj={`overview-grid-row-${listIndex}`}
+                                  gutterSize="m"
+                                  style={{ ...style }}
+                                >
+                                  {listData[listIndex].map((_, idx) => (
+                                    <EuiFlexItem
+                                      data-test-subj="syntheticsOverviewGridItem"
+                                      key={listIndex * ROW_COUNT + idx}
+                                    >
+                                      <MetricItem
+                                        monitor={
+                                          monitorsSortedByStatus[listIndex * ROW_COUNT + idx]
+                                        }
+                                        onClick={setFlyoutConfigCallback}
+                                      />
+                                    </EuiFlexItem>
+                                  ))}
+                                  {listData[listIndex].length % ROW_COUNT !== 0 &&
+                                    // Adds empty items to fill out row
+                                    Array.from({
+                                      length: ROW_COUNT - listData[listIndex].length,
+                                    }).map((_, idx) => <EuiFlexItem key={idx} />)}
+                                </EuiFlexGroup>
+                              );
+                            }}
+                          </FixedSizeList>
+                        )}
+                      </InfiniteLoader>
+                    )}
+                  </EuiAutoSizer>
+                ) : (
+                  <OverviewLoader />
+                )
+              ) : (
+                <GridItemsByGroup setFlyoutConfigCallback={setFlyoutConfigCallback} view={view} />
               )}
-              {monitorsSortedByStatus.length === allConfigs.length &&
-                monitorsSortedByStatus.length > perPage && (
-                  <EuiFlexItem grow={false}>
-                    <EuiButtonEmpty
-                      data-test-subj="syntheticsOverviewGridButton"
-                      onClick={() => {
-                        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-                        listRef.current?.scrollToItem(0);
-                      }}
-                      iconType="sortUp"
-                      iconSide="right"
-                      size="xs"
-                    >
-                      {SCROLL_TO_TOP_LABEL}
-                    </EuiButtonEmpty>
-                  </EuiFlexItem>
-                )}
-            </EuiFlexGroup>
+              <EuiSpacer size="m" />
+            </div>
+            {groupField === 'none' &&
+              loaded &&
+              // display this footer when user scrolls to end of list
+              currentIndex * ROW_COUNT + ROW_COUNT >= monitorsSortedByStatus.length && (
+                <>
+                  <EuiSpacer />
+                  <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+                    {monitorsSortedByStatus.length === allConfigs.length && (
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="xs">{SHOWING_ALL_MONITORS_LABEL}</EuiText>
+                      </EuiFlexItem>
+                    )}
+                    {monitorsSortedByStatus.length === allConfigs.length &&
+                      monitorsSortedByStatus.length > perPage && (
+                        <EuiFlexItem grow={false}>
+                          <EuiButtonEmpty
+                            data-test-subj="syntheticsOverviewGridButton"
+                            onClick={() => {
+                              window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+                              listRef.current?.scrollToItem(0);
+                            }}
+                            iconType="sortUp"
+                            iconSide="right"
+                            size="xs"
+                          >
+                            {SCROLL_TO_TOP_LABEL}
+                          </EuiButtonEmpty>
+                        </EuiFlexItem>
+                      )}
+                  </EuiFlexGroup>
+                </>
+              )}
           </>
-        )}
-      <MaybeMonitorDetailsFlyout setFlyoutConfigCallback={setFlyoutConfigCallback} />
-    </>
-  );
-});
+        ) : null}
+        {view === 'compactView' ? (
+          <OverviewGridCompactView setFlyoutConfigCallback={setFlyoutConfigCallback} />
+        ) : null}
+        <MaybeMonitorDetailsFlyout setFlyoutConfigCallback={setFlyoutConfigCallback} />
+      </>
+    );
+  }
+);
 
 const SHOWING_ALL_MONITORS_LABEL = i18n.translate(
   'xpack.synthetics.overview.grid.showingAllMonitors.label',

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/view_buttons/hooks/use_view_buttons.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/view_buttons/hooks/use_view_buttons.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+import {
+  DEFAULT_OVERVIEW_VIEW,
+  OverviewView,
+  isOverviewView,
+  selectOverviewState,
+  setOverviewViewAction,
+} from '../../../../../../state';
+import { useUrlParams } from '../../../../../../hooks';
+
+export const useViewButtons = () => {
+  const isInitialMount = useRef(true);
+
+  const { view } = useSelector(selectOverviewState);
+  const [urlParams, updateUrlParams] = useUrlParams();
+
+  const { view: urlView } = urlParams();
+
+  const [localStorageView, setLocalStorageView] = useLocalStorage<OverviewView>(
+    'synthetics.overviewView',
+    urlView || view
+  );
+  const dispatch = useDispatch();
+
+  if (isInitialMount.current) {
+    // When the component mounts, check if there is a view in the URL first
+    if (urlView) {
+      dispatch(setOverviewViewAction(urlView));
+    } // If there is no view in the URL, check if there is a view in local storage that is not the default view
+    else if (localStorageView && localStorageView !== DEFAULT_OVERVIEW_VIEW) {
+      dispatch(setOverviewViewAction(localStorageView));
+      updateUrlParams({ view: localStorageView });
+    }
+    isInitialMount.current = false;
+  }
+
+  const onChangeView = (id: string) => {
+    if (!isOverviewView(id)) {
+      throw new Error(`Invalid view: ${id}, this should never happen`);
+    }
+    dispatch(setOverviewViewAction(id));
+    updateUrlParams({ view: id === DEFAULT_OVERVIEW_VIEW ? undefined : id });
+    setLocalStorageView(id);
+  };
+
+  return { view, onChangeView };
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/view_buttons/labels.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/view_buttons/labels.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const CARD_VIEW_LABEL = i18n.translate('xpack.synthetics.overview.grid.cardView.label', {
+  defaultMessage: 'Card view',
+});
+
+export const COMPACT_VIEW_LABEL = i18n.translate(
+  'xpack.synthetics.overview.grid.compactView.label',
+  {
+    defaultMessage: 'Compact view',
+  }
+);
+
+export const VIEW_LEGEND = i18n.translate('xpack.synthetics.overview.grid.view.legend', {
+  defaultMessage: 'Monitors view',
+});

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/view_buttons/view_buttons.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/view_buttons/view_buttons.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiButtonGroup, IconType } from '@elastic/eui';
+import { OverviewView } from '../../../../../state';
+import { useViewButtons } from './hooks/use_view_buttons';
+import { CARD_VIEW_LABEL, COMPACT_VIEW_LABEL, VIEW_LEGEND } from './labels';
+import { useOverviewStatus } from '../../../hooks/use_overview_status';
+
+const toggleButtonsIcons: Array<{ id: OverviewView; iconType: IconType; label: string }> = [
+  {
+    id: `cardView`,
+    iconType: 'apps',
+    label: CARD_VIEW_LABEL,
+  },
+  {
+    id: 'compactView',
+    iconType: 'tableDensityCompact',
+    label: COMPACT_VIEW_LABEL,
+  },
+];
+
+export const ViewButtons = () => {
+  const { status, loaded } = useOverviewStatus({
+    scopeStatusByLocation: true,
+  });
+
+  const { onChangeView, view } = useViewButtons();
+
+  return (
+    <EuiButtonGroup
+      buttonSize="compressed"
+      options={toggleButtonsIcons}
+      idSelected={view}
+      onChange={onChangeView}
+      isIconOnly
+      isDisabled={!status || !loaded}
+      legend={VIEW_LEGEND}
+    />
+  );
+};

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview_page.tsx
@@ -15,7 +15,7 @@ import { DisabledCallout } from '../management/disabled_callout';
 import { FilterGroup } from '../common/monitor_filters/filter_group';
 import { OverviewAlerts } from './overview/overview_alerts';
 import { useEnablement } from '../../../hooks';
-import { selectServiceLocationsState } from '../../../state';
+import { selectOverviewState, selectServiceLocationsState } from '../../../state';
 import { getServiceLocations } from '../../../state/service_locations';
 import { GETTING_STARTED_ROUTE, MONITORS_ROUTE } from '../../../../../../common/constants';
 
@@ -33,6 +33,8 @@ export const OverviewPage: React.FC = () => {
   useTrackPageview({ app: 'synthetics', path: 'overview' });
   useTrackPageview({ app: 'synthetics', path: 'overview', delay: 15000 });
   useOverviewBreadcrumbs();
+
+  const { view } = useSelector(selectOverviewState);
 
   const dispatch = useDispatch();
 
@@ -94,15 +96,15 @@ export const OverviewPage: React.FC = () => {
             <EuiFlexItem grow={false}>
               <OverviewStatus />
             </EuiFlexItem>
-            <EuiFlexItem grow={3} style={{ minWidth: 300 }}>
+            <EuiFlexItem grow={3} css={{ minWidth: 300 }}>
               <OverviewErrors />
             </EuiFlexItem>
-            <EuiFlexItem grow={3} style={{ minWidth: 300 }}>
+            <EuiFlexItem grow={3} css={{ minWidth: 300 }}>
               <OverviewAlerts />
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer />
-          <OverviewGrid />
+          <OverviewGrid view={view} />
         </>
       ) : (
         <NoMonitorsFound />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/contexts/synthetics_shared_context.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/contexts/synthetics_shared_context.tsx
@@ -41,6 +41,7 @@ export const SyntheticsSharedContext: React.FC<
         embeddable: startPlugins.embeddable,
         slo: startPlugins.slo,
         serverless: startPlugins.serverless,
+        charts: startPlugins.charts,
       }}
     >
       <EuiThemeProvider darkMode={darkMode}>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/actions.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/actions.ts
@@ -31,3 +31,5 @@ export const refreshOverviewTrends = createAsyncAction<void, TrendTable, any>(
 export const trendStatsBatch = createAsyncAction<TrendRequest[], GetTrendPayload, TrendRequest[]>(
   'batchTrendStats'
 );
+export const setOverviewViewAction =
+  createAction<MonitorOverviewState['view']>('setOverviewViewAction');

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/index.ts
@@ -6,15 +6,18 @@
  */
 
 import { createReducer } from '@reduxjs/toolkit';
-import { MonitorOverviewState } from './models';
+import { MonitorOverviewState, overviewViews } from './models';
 
 import {
   setFlyoutConfig,
   setOverviewGroupByAction,
   setOverviewPageStateAction,
+  setOverviewViewAction,
   toggleErrorPopoverOpen,
   trendStatsBatch,
 } from './actions';
+
+export const DEFAULT_OVERVIEW_VIEW = overviewViews[0];
 
 const initialState: MonitorOverviewState = {
   pageState: {
@@ -26,6 +29,7 @@ const initialState: MonitorOverviewState = {
   groupBy: { field: 'none', order: 'asc' },
   flyoutConfig: null,
   isErrorPopoverOpen: null,
+  view: DEFAULT_OVERVIEW_VIEW,
 };
 
 export const monitorOverviewReducer = createReducer(initialState, (builder) => {
@@ -72,6 +76,9 @@ export const monitorOverviewReducer = createReducer(initialState, (builder) => {
           state.trendStats[configId + locationId] = null;
         }
       }
+    })
+    .addCase(setOverviewViewAction, (state, action) => {
+      state.view = action.payload;
     });
 });
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/models.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/state/overview/models.ts
@@ -20,12 +20,22 @@ export interface MonitorOverviewPageState extends MonitorFilterState {
 
 export type MonitorOverviewFlyoutConfig = FlyoutParamProps | null;
 
+// The first view in the list is the default view
+export const overviewViews = ['cardView', 'compactView'] as const;
+
+export type OverviewView = (typeof overviewViews)[number];
+
+export const isOverviewView = (view: string): view is OverviewView => {
+  return Object.values<string>(overviewViews).includes(view);
+};
+
 export interface MonitorOverviewState {
   flyoutConfig: MonitorOverviewFlyoutConfig;
   pageState: MonitorOverviewPageState;
   isErrorPopoverOpen?: string | null;
   groupBy: GroupByState;
   trendStats: TrendTable;
+  view: OverviewView;
 }
 
 export interface GroupByState {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/testing/__mocks__/synthetics_store.mock.ts
@@ -104,6 +104,7 @@ export const mockState: SyntheticsAppState = {
       field: 'none',
       order: 'asc',
     },
+    view: 'cardView',
   },
   syntheticsEnablement: { loading: false, error: null, enablement: null },
   monitorDetails: getMonitorDetailsMockSlice(),

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/url_params/get_supported_url_params.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/url_params/get_supported_url_params.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { MonitorOverviewState } from '../../state';
+import {
+  DEFAULT_OVERVIEW_VIEW,
+  MonitorOverviewState,
+  OverviewView,
+  isOverviewView,
+} from '../../state';
 import { CLIENT_DEFAULTS_SYNTHETICS } from '../../../../../common/constants/synthetics/client_defaults';
 import { CLIENT_DEFAULTS, UseLogicalAndField } from '../../../../../common/constants';
 import { parseAbsoluteDate } from './parse_absolute_date';
@@ -36,6 +41,7 @@ export interface SyntheticsUrlParams {
   cloneId?: string;
   spaceId?: string;
   useLogicalAndFor?: UseLogicalAndField[];
+  view?: Exclude<OverviewView, typeof DEFAULT_OVERVIEW_VIEW>;
 }
 
 const { ABSOLUTE_DATE_RANGE_START, ABSOLUTE_DATE_RANGE_END, SEARCH, FILTERS, STATUS_FILTER } =
@@ -93,6 +99,7 @@ export const getSupportedUrlParams = (params: {
     packagePolicyId,
     spaceId,
     useLogicalAndFor,
+    view,
   } = filteredParams;
 
   return {
@@ -126,6 +133,7 @@ export const getSupportedUrlParams = (params: {
     cloneId: filteredParams.cloneId,
     spaceId: spaceId || undefined,
     useLogicalAndFor: parseFilters(useLogicalAndFor),
+    view: view && isOverviewView(view) && view !== DEFAULT_OVERVIEW_VIEW ? view : undefined,
   };
 };
 

--- a/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/routes/overview_status/overview_status_service.test.ts
@@ -196,6 +196,7 @@ describe('current status route', () => {
               "timestamp": "2022-09-15T16:19:16.724Z",
               "type": "browser",
               "updated_at": undefined,
+              "urls": undefined,
             },
           },
           "enabledMonitorQueryIds": Array [
@@ -226,6 +227,7 @@ describe('current status route', () => {
               "timestamp": "2022-09-15T16:19:16.724Z",
               "type": "browser",
               "updated_at": undefined,
+              "urls": undefined,
             },
             "id2-asia_japan": Object {
               "configId": "id2",
@@ -246,6 +248,7 @@ describe('current status route', () => {
               "timestamp": "2022-09-15T16:19:16.724Z",
               "type": "browser",
               "updated_at": undefined,
+              "urls": undefined,
             },
           },
         }
@@ -355,6 +358,7 @@ describe('current status route', () => {
               "timestamp": "2022-09-15T16:19:16.724Z",
               "type": "browser",
               "updated_at": undefined,
+              "urls": undefined,
             },
           },
           "enabledMonitorQueryIds": Array [
@@ -385,6 +389,7 @@ describe('current status route', () => {
               "timestamp": "2022-09-15T16:19:16.724Z",
               "type": "browser",
               "updated_at": undefined,
+              "urls": undefined,
             },
             "id2-asia_japan": Object {
               "configId": "id2",
@@ -405,6 +410,7 @@ describe('current status route', () => {
               "timestamp": "2022-09-15T16:19:16.724Z",
               "type": "browser",
               "updated_at": undefined,
+              "urls": undefined,
             },
           },
         }
@@ -464,6 +470,7 @@ describe('current status route', () => {
               "timestamp": undefined,
               "type": "browser",
               "updated_at": undefined,
+              "urls": undefined,
             },
             "id2-asia_japan": Object {
               "configId": "id2",
@@ -484,6 +491,7 @@ describe('current status route', () => {
               "timestamp": undefined,
               "type": "browser",
               "updated_at": undefined,
+              "urls": undefined,
             },
             "id2-europe_germany": Object {
               "configId": "id2",
@@ -504,6 +512,7 @@ describe('current status route', () => {
               "timestamp": undefined,
               "type": "browser",
               "updated_at": undefined,
+              "urls": undefined,
             },
           },
           "projectMonitorsCount": 0,

--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.ts
@@ -20,7 +20,9 @@ import {
   SourceType,
 } from '../../../common/runtime_types';
 
-export const getAllMonitors = async ({
+export const getAllMonitors = async <
+  T extends EncryptedSyntheticsMonitorAttributes = EncryptedSyntheticsMonitorAttributes
+>({
   soClient,
   search,
   fields,
@@ -36,7 +38,7 @@ export const getAllMonitors = async ({
   showFromAllSpaces?: boolean;
 } & Pick<SavedObjectsFindOptions, 'sortField' | 'sortOrder' | 'fields' | 'searchFields'>) => {
   return withApmSpan('get_all_monitors', async () => {
-    const finder = soClient.createPointInTimeFinder<EncryptedSyntheticsMonitorAttributes>({
+    const finder = soClient.createPointInTimeFinder<T>({
       type: syntheticsMonitorType,
       perPage: 5000,
       search,
@@ -48,7 +50,7 @@ export const getAllMonitors = async ({
       ...(showFromAllSpaces && { namespaces: ['*'] }),
     });
 
-    const hits: Array<SavedObjectsFindResult<EncryptedSyntheticsMonitorAttributes>> = [];
+    const hits: Array<SavedObjectsFindResult<T>> = [];
     for await (const result of finder.find()) {
       hits.push(...result.saved_objects);
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthetics] Added compact view in monitors overview page (#219060)](https://github.com/elastic/kibana/pull/219060)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Francesco Fagnani","email":"fagnani.francesco@gmail.com"},"sourceCommit":{"committedDate":"2025-04-30T10:36:46Z","message":"[Synthetics] Added compact view in monitors overview page (#219060)\n\nThis PR contains the first version of the new compact view for monitors\noverview in Synthetics, see issue #217579.\n\n\n\nhttps://github.com/user-attachments/assets/b096d5c3-c8c2-4e27-a889-8dee6ef52481\n\nAdditional points:\n- When selecting a different view the value is saved in local storage.\n- All the actions available in the card view are available in the\ncompact view.\n- When adding an embeddable to a dashboard the current view is saved in\nthe dashboard state.\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"543503761693f087156518a81e103422db1bd7a7","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Synthetics] Added compact view in monitors overview page","number":219060,"url":"https://github.com/elastic/kibana/pull/219060","mergeCommit":{"message":"[Synthetics] Added compact view in monitors overview page (#219060)\n\nThis PR contains the first version of the new compact view for monitors\noverview in Synthetics, see issue #217579.\n\n\n\nhttps://github.com/user-attachments/assets/b096d5c3-c8c2-4e27-a889-8dee6ef52481\n\nAdditional points:\n- When selecting a different view the value is saved in local storage.\n- All the actions available in the card view are available in the\ncompact view.\n- When adding an embeddable to a dashboard the current view is saved in\nthe dashboard state.\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"543503761693f087156518a81e103422db1bd7a7"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219060","number":219060,"mergeCommit":{"message":"[Synthetics] Added compact view in monitors overview page (#219060)\n\nThis PR contains the first version of the new compact view for monitors\noverview in Synthetics, see issue #217579.\n\n\n\nhttps://github.com/user-attachments/assets/b096d5c3-c8c2-4e27-a889-8dee6ef52481\n\nAdditional points:\n- When selecting a different view the value is saved in local storage.\n- All the actions available in the card view are available in the\ncompact view.\n- When adding an embeddable to a dashboard the current view is saved in\nthe dashboard state.\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"543503761693f087156518a81e103422db1bd7a7"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->