### PR TITLE
[8.19] [FTR] Skipped basic license tests for FIPS (#208916)

### DIFF
--- a/x-pack/test/spaces_api_integration/security_and_spaces/apis/copy_to_space/copy_to_space.ts
+++ b/x-pack/test/spaces_api_integration/security_and_spaces/apis/copy_to_space/copy_to_space.ts
@@ -25,7 +25,7 @@ export default function copyToSpaceSpacesAndSecuritySuite(context: FtrProviderCo
     createMultiNamespaceTestCases,
   } = copyToSpaceTestSuiteFactory(context);
 
-  describe('copy to spaces', () => {
+  describe('copy to spaces', function () {
     [
       {
         spaceId: SPACES.DEFAULT.spaceId,

--- a/x-pack/test/spaces_api_integration/security_and_spaces/copy_to_space_config_basic.ts
+++ b/x-pack/test/spaces_api_integration/security_and_spaces/copy_to_space_config_basic.ts
@@ -10,5 +10,5 @@ import { createTestConfig } from '../common/config';
 // eslint-disable-next-line import/no-default-export
 export default createTestConfig('security_and_spaces', {
   license: 'basic',
-  testFiles: [require.resolve('./apis/copy_to_space')],
+  testFiles: [require.resolve('./apis/copy_to_space/index_basic')],
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[FTR] Skipped basic license tests for FIPS (#208916)](https://github.com/elastic/kibana/pull/208916)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Elena Shostak","email":"165678770+elena-shostak@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-01-31T12:56:29Z","message":"[FTR] Skipped basic license tests for FIPS (#208916)\n\n## Summary\r\nAll tests in\r\n`deployment_agnostic/security_and_spaces/stateful.config_basic.ts` and\r\n`deployment_agnostic/security_and_spaces/stateful.copy_to_space.config_basic.ts`\r\nare intended to be run only with `basic` license, since FIPS overrides\r\nit we need to skip that test for FIPS.\r\n\r\nSeparated index entries for `basic` and `trial` license, so tests with\r\ntrial config would still run.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9120c36e165a40e26b08c07a892a3bd70f0a05f5","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","FTR","backport:version","v9.1.0","v8.19.0"],"title":"[FTR] Skipped basic license tests for FIPS","number":208916,"url":"https://github.com/elastic/kibana/pull/208916","mergeCommit":{"message":"[FTR] Skipped basic license tests for FIPS (#208916)\n\n## Summary\r\nAll tests in\r\n`deployment_agnostic/security_and_spaces/stateful.config_basic.ts` and\r\n`deployment_agnostic/security_and_spaces/stateful.copy_to_space.config_basic.ts`\r\nare intended to be run only with `basic` license, since FIPS overrides\r\nit we need to skip that test for FIPS.\r\n\r\nSeparated index entries for `basic` and `trial` license, so tests with\r\ntrial config would still run.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9120c36e165a40e26b08c07a892a3bd70f0a05f5"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208916","number":208916,"mergeCommit":{"message":"[FTR] Skipped basic license tests for FIPS (#208916)\n\n## Summary\r\nAll tests in\r\n`deployment_agnostic/security_and_spaces/stateful.config_basic.ts` and\r\n`deployment_agnostic/security_and_spaces/stateful.copy_to_space.config_basic.ts`\r\nare intended to be run only with `basic` license, since FIPS overrides\r\nit we need to skip that test for FIPS.\r\n\r\nSeparated index entries for `basic` and `trial` license, so tests with\r\ntrial config would still run.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9120c36e165a40e26b08c07a892a3bd70f0a05f5"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->