### PR TITLE
Update FIPS Test Failure Debugging docs to mention backport branch

### DIFF
--- a/dev_docs/tutorials/debugging_fips_test_failures.mdx
+++ b/dev_docs/tutorials/debugging_fips_test_failures.mdx
@@ -49,6 +49,8 @@ It is imperative to skip only the tests that are affected by FIPS overrides. If 
 
 This will still allow the test to run as part of regular CI, but will skip the test in the FIPS pipeline.
 
+PRs for these test skips on `main` should be backported to the `8.19` branch as well.
+
 ### Failed tests due to FIPS/OpenSSL errors
 
 Errors that are related to FIPS/OpenSSL are more serious and should be addressed immediately. These will require code changes to switch to FIPS compliant crypto functionality.


### PR DESCRIPTION
## Summary

Update FIPS docs to call out new backport requirements

