### PR TITLE
Remove failsOnMKI tag from knowledge base status API tests

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_status.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/knowledge_base/knowledge_base_status.spec.ts
@@ -22,9 +22,6 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
 
   describe('/internal/observability_ai_assistant/kb/status', function () {
-    // see details: https://github.com/elastic/kibana/issues/219217
-    this.tags(['failsOnMKI']);
-
     it('returns correct status before knowledge base is setup', async () => {
       const res = await observabilityAIAssistantAPIClient.editor({
         endpoint: 'GET /internal/observability_ai_assistant/kb/status',


### PR DESCRIPTION
Closes [#219217](https://github.com/elastic/kibana/issues/219217)