### PR TITLE
log data stream stats

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/read_stream.ts
@@ -13,7 +13,7 @@ import {
   isGroupStreamDefinition,
   isUnwiredStreamDefinition,
 } from '@kbn/streams-schema';
-import { IScopedClusterClient } from '@kbn/core/server';
+import { IScopedClusterClient, Logger } from '@kbn/core/server';
 import { partition } from 'lodash';
 import { AssetClient } from '../../../lib/streams/assets/asset_client';
 import { StreamsClient } from '../../../lib/streams/client';
@@ -29,11 +29,13 @@ export async function readStream({
   assetClient,
   streamsClient,
   scopedClusterClient,
+  logger,
 }: {
   name: string;
   assetClient: AssetClient;
   streamsClient: StreamsClient;
   scopedClusterClient: IScopedClusterClient;
+  logger: Logger;
 }): Promise<StreamGetResponse> {
   const [streamDefinition, dashboardsAndQueries] = await Promise.all([
     streamsClient.getStream(name),
@@ -71,6 +73,7 @@ export async function readStream({
   ]);
 
   if (isUnwiredStreamDefinition(streamDefinition)) {
+    logger.info(`Unwired stream data stream stats\n${JSON.stringify(dataStream, null, 2)}`);
     return {
       stream: streamDefinition,
       privileges,

--- a/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/streams/crud/route.ts
@@ -36,7 +36,7 @@ export const readStreamRoute = createServerRoute({
   params: z.object({
     path: z.object({ name: z.string() }),
   }),
-  handler: async ({ params, request, getScopedClients }): Promise<StreamGetResponse> => {
+  handler: async ({ logger, params, request, getScopedClients }): Promise<StreamGetResponse> => {
     const { assetClient, streamsClient, scopedClusterClient } = await getScopedClients({
       request,
     });
@@ -46,6 +46,7 @@ export const readStreamRoute = createServerRoute({
       assetClient,
       scopedClusterClient,
       streamsClient,
+      logger,
     });
 
     return body;

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/classic.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/classic.ts
@@ -25,7 +25,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
   let apiClient: StreamsSupertestRepositoryClient;
 
-  describe.only('Classic streams', () => {
+  describe('Classic streams', () => {
     before(async () => {
       apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
     });

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/classic.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/classic.ts
@@ -25,7 +25,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
   let apiClient: StreamsSupertestRepositoryClient;
 
-  describe('Classic streams', () => {
+  describe.only('Classic streams', () => {
     before(async () => {
       apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
     });


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



