### PR TITLE
[Fleet] Fix dataset validation to show errors on upgrade

### DIFF
--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -40700,7 +40700,7 @@
                               "type": "object"
                             },
                             {
-                              "additionalProperties": false,
+                              "additionalProperties": true,
                               "properties": {
                                 "additional_datastreams_permissions": {
                                   "description": "Additional datastream permissions, that will be added to the agent policy.",
@@ -40710,9 +40710,33 @@
                                   "nullable": true,
                                   "type": "array"
                                 },
+                                "created_at": {
+                                  "type": "string"
+                                },
+                                "created_by": {
+                                  "type": "string"
+                                },
                                 "description": {
                                   "description": "Package policy description",
                                   "type": "string"
+                                },
+                                "elasticsearch": {
+                                  "additionalProperties": true,
+                                  "properties": {
+                                    "privileges": {
+                                      "additionalProperties": true,
+                                      "properties": {
+                                        "cluster": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
                                 },
                                 "enabled": {
                                   "type": "boolean"
@@ -40745,6 +40769,7 @@
                                   "items": {
                                     "additionalProperties": false,
                                     "properties": {
+                                      "compiled_input": {},
                                       "config": {
                                         "additionalProperties": {
                                           "additionalProperties": false,
@@ -40916,7 +40941,8 @@
                                     "required": [
                                       "type",
                                       "enabled",
-                                      "streams"
+                                      "streams",
+                                      "compiled_input"
                                     ],
                                     "type": "object"
                                   },
@@ -41026,11 +41052,35 @@
                                   },
                                   "type": "array"
                                 },
+                                "revision": {
+                                  "type": "number"
+                                },
+                                "secret_references": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "id"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
                                 "supports_agentless": {
                                   "default": false,
                                   "description": "Indicates whether the package policy belongs to an agentless agent policy.",
                                   "nullable": true,
                                   "type": "boolean"
+                                },
+                                "updated_at": {
+                                  "type": "string"
+                                },
+                                "updated_by": {
+                                  "type": "string"
                                 },
                                 "vars": {
                                   "additionalProperties": {
@@ -41051,12 +41101,20 @@
                                   },
                                   "description": "Package variable (see integration documentation for more information)",
                                   "type": "object"
+                                },
+                                "version": {
+                                  "type": "string"
                                 }
                               },
                               "required": [
                                 "name",
                                 "enabled",
-                                "inputs"
+                                "inputs",
+                                "revision",
+                                "updated_at",
+                                "updated_by",
+                                "created_at",
+                                "created_by"
                               ],
                               "type": "object"
                             }

--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -41109,11 +41109,7 @@
                               "required": [
                                 "name",
                                 "enabled",
-                                "inputs",
-                                "updated_at",
-                                "updated_by",
-                                "created_at",
-                                "created_by"
+                                "inputs"
                               ],
                               "type": "object"
                             }

--- a/oas_docs/bundle.json
+++ b/oas_docs/bundle.json
@@ -41110,7 +41110,6 @@
                                 "name",
                                 "enabled",
                                 "inputs",
-                                "revision",
                                 "updated_at",
                                 "updated_by",
                                 "created_at",

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -40700,7 +40700,7 @@
                               "type": "object"
                             },
                             {
-                              "additionalProperties": false,
+                              "additionalProperties": true,
                               "properties": {
                                 "additional_datastreams_permissions": {
                                   "description": "Additional datastream permissions, that will be added to the agent policy.",
@@ -40710,9 +40710,33 @@
                                   "nullable": true,
                                   "type": "array"
                                 },
+                                "created_at": {
+                                  "type": "string"
+                                },
+                                "created_by": {
+                                  "type": "string"
+                                },
                                 "description": {
                                   "description": "Package policy description",
                                   "type": "string"
+                                },
+                                "elasticsearch": {
+                                  "additionalProperties": true,
+                                  "properties": {
+                                    "privileges": {
+                                      "additionalProperties": true,
+                                      "properties": {
+                                        "cluster": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
                                 },
                                 "enabled": {
                                   "type": "boolean"
@@ -40745,6 +40769,7 @@
                                   "items": {
                                     "additionalProperties": false,
                                     "properties": {
+                                      "compiled_input": {},
                                       "config": {
                                         "additionalProperties": {
                                           "additionalProperties": false,
@@ -40916,7 +40941,8 @@
                                     "required": [
                                       "type",
                                       "enabled",
-                                      "streams"
+                                      "streams",
+                                      "compiled_input"
                                     ],
                                     "type": "object"
                                   },
@@ -41026,11 +41052,35 @@
                                   },
                                   "type": "array"
                                 },
+                                "revision": {
+                                  "type": "number"
+                                },
+                                "secret_references": {
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "id"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
                                 "supports_agentless": {
                                   "default": false,
                                   "description": "Indicates whether the package policy belongs to an agentless agent policy.",
                                   "nullable": true,
                                   "type": "boolean"
+                                },
+                                "updated_at": {
+                                  "type": "string"
+                                },
+                                "updated_by": {
+                                  "type": "string"
                                 },
                                 "vars": {
                                   "additionalProperties": {
@@ -41051,12 +41101,20 @@
                                   },
                                   "description": "Package variable (see integration documentation for more information)",
                                   "type": "object"
+                                },
+                                "version": {
+                                  "type": "string"
                                 }
                               },
                               "required": [
                                 "name",
                                 "enabled",
-                                "inputs"
+                                "inputs",
+                                "revision",
+                                "updated_at",
+                                "updated_by",
+                                "created_at",
+                                "created_by"
                               ],
                               "type": "object"
                             }

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -41109,11 +41109,7 @@
                               "required": [
                                 "name",
                                 "enabled",
-                                "inputs",
-                                "updated_at",
-                                "updated_by",
-                                "created_at",
-                                "created_by"
+                                "inputs"
                               ],
                               "type": "object"
                             }

--- a/oas_docs/bundle.serverless.json
+++ b/oas_docs/bundle.serverless.json
@@ -41110,7 +41110,6 @@
                                 "name",
                                 "enabled",
                                 "inputs",
-                                "revision",
                                 "updated_at",
                                 "updated_by",
                                 "created_at",

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -37885,7 +37885,7 @@ paths:
                               - updated_by
                               - created_at
                               - created_by
-                          - additionalProperties: false
+                          - additionalProperties: true
                             type: object
                             properties:
                               additional_datastreams_permissions:
@@ -37894,9 +37894,25 @@ paths:
                                   type: string
                                 nullable: true
                                 type: array
+                              created_at:
+                                type: string
+                              created_by:
+                                type: string
                               description:
                                 description: Package policy description
                                 type: string
+                              elasticsearch:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  privileges:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      cluster:
+                                        items:
+                                          type: string
+                                        type: array
                               enabled:
                                 type: boolean
                               errors:
@@ -37920,6 +37936,7 @@ paths:
                                   additionalProperties: false
                                   type: object
                                   properties:
+                                    compiled_input: {}
                                     config:
                                       additionalProperties:
                                         additionalProperties: false
@@ -38040,6 +38057,7 @@ paths:
                                     - type
                                     - enabled
                                     - streams
+                                    - compiled_input
                                 type: array
                               is_managed:
                                 type: boolean
@@ -38115,11 +38133,27 @@ paths:
                                   description: Agent policy IDs where that package policy will be added
                                   type: string
                                 type: array
+                              revision:
+                                type: number
+                              secret_references:
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    id:
+                                      type: string
+                                  required:
+                                    - id
+                                type: array
                               supports_agentless:
                                 default: false
                                 description: Indicates whether the package policy belongs to an agentless agent policy.
                                 nullable: true
                                 type: boolean
+                              updated_at:
+                                type: string
+                              updated_by:
+                                type: string
                               vars:
                                 additionalProperties:
                                   additionalProperties: false
@@ -38134,10 +38168,17 @@ paths:
                                     - value
                                 description: Package variable (see integration documentation for more information)
                                 type: object
+                              version:
+                                type: string
                             required:
                               - name
                               - enabled
                               - inputs
+                              - revision
+                              - updated_at
+                              - updated_by
+                              - created_at
+                              - created_by
                       type: array
                     hasErrors:
                       type: boolean

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -38174,7 +38174,6 @@ paths:
                               - name
                               - enabled
                               - inputs
-                              - revision
                               - updated_at
                               - updated_by
                               - created_at

--- a/oas_docs/output/kibana.serverless.yaml
+++ b/oas_docs/output/kibana.serverless.yaml
@@ -38174,10 +38174,6 @@ paths:
                               - name
                               - enabled
                               - inputs
-                              - updated_at
-                              - updated_by
-                              - created_at
-                              - created_by
                       type: array
                     hasErrors:
                       type: boolean

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -40127,7 +40127,7 @@ paths:
                               - updated_by
                               - created_at
                               - created_by
-                          - additionalProperties: false
+                          - additionalProperties: true
                             type: object
                             properties:
                               additional_datastreams_permissions:
@@ -40136,9 +40136,25 @@ paths:
                                   type: string
                                 nullable: true
                                 type: array
+                              created_at:
+                                type: string
+                              created_by:
+                                type: string
                               description:
                                 description: Package policy description
                                 type: string
+                              elasticsearch:
+                                additionalProperties: true
+                                type: object
+                                properties:
+                                  privileges:
+                                    additionalProperties: true
+                                    type: object
+                                    properties:
+                                      cluster:
+                                        items:
+                                          type: string
+                                        type: array
                               enabled:
                                 type: boolean
                               errors:
@@ -40162,6 +40178,7 @@ paths:
                                   additionalProperties: false
                                   type: object
                                   properties:
+                                    compiled_input: {}
                                     config:
                                       additionalProperties:
                                         additionalProperties: false
@@ -40282,6 +40299,7 @@ paths:
                                     - type
                                     - enabled
                                     - streams
+                                    - compiled_input
                                 type: array
                               is_managed:
                                 type: boolean
@@ -40357,11 +40375,27 @@ paths:
                                   description: Agent policy IDs where that package policy will be added
                                   type: string
                                 type: array
+                              revision:
+                                type: number
+                              secret_references:
+                                items:
+                                  additionalProperties: false
+                                  type: object
+                                  properties:
+                                    id:
+                                      type: string
+                                  required:
+                                    - id
+                                type: array
                               supports_agentless:
                                 default: false
                                 description: Indicates whether the package policy belongs to an agentless agent policy.
                                 nullable: true
                                 type: boolean
+                              updated_at:
+                                type: string
+                              updated_by:
+                                type: string
                               vars:
                                 additionalProperties:
                                   additionalProperties: false
@@ -40376,10 +40410,17 @@ paths:
                                     - value
                                 description: Package variable (see integration documentation for more information)
                                 type: object
+                              version:
+                                type: string
                             required:
                               - name
                               - enabled
                               - inputs
+                              - revision
+                              - updated_at
+                              - updated_by
+                              - created_at
+                              - created_by
                       type: array
                     hasErrors:
                       type: boolean

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -40416,7 +40416,6 @@ paths:
                               - name
                               - enabled
                               - inputs
-                              - revision
                               - updated_at
                               - updated_by
                               - created_at

--- a/oas_docs/output/kibana.yaml
+++ b/oas_docs/output/kibana.yaml
@@ -40416,10 +40416,6 @@ paths:
                               - name
                               - enabled
                               - inputs
-                              - updated_at
-                              - updated_by
-                              - created_at
-                              - created_by
                       type: array
                     hasErrors:
                       type: boolean

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_component.test.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_component.test.tsx
@@ -13,7 +13,7 @@ import { createFleetTestRendererMock } from '../../../../../../../../mock';
 import { DatasetComponent } from './dataset_component';
 
 describe('DatasetComponent', () => {
-  function render(value = 'generic', datastreams: any = []) {
+  function render(value = 'generic', datastreams: any = [], props?: any) {
     const renderer = createFleetTestRendererMock();
     const mockOnChange = jest.fn();
     const fieldLabel = 'Dataset name';
@@ -29,6 +29,7 @@ describe('DatasetComponent', () => {
         onChange={mockOnChange}
         isDisabled={false}
         fieldLabel={fieldLabel}
+        {...props}
       />
     );
 
@@ -36,21 +37,22 @@ describe('DatasetComponent', () => {
   }
 
   it('should show validation error if dataset is invalid', () => {
-    const { utils } = render();
-
-    const inputEl = utils.getByTestId('comboBoxSearchInput');
-    fireEvent.change(inputEl, { target: { value: 'generic*' } });
-    fireEvent.keyDown(inputEl, { key: 'Enter', code: 'Enter' });
+    const { utils } = render('generic', [], {
+      errors: ['Dataset contains invalid characters'],
+      isInvalid: true,
+    });
 
     utils.getByText('Dataset contains invalid characters');
   });
 
   it('should not show validation error if dataset is valid', () => {
-    const { utils } = render();
+    const { utils, mockOnChange } = render();
 
     const inputEl = utils.getByTestId('comboBoxSearchInput');
     fireEvent.change(inputEl, { target: { value: 'test' } });
     fireEvent.keyDown(inputEl, { key: 'Enter', code: 'Enter' });
+
+    expect(mockOnChange).toBeCalled();
 
     expect(utils.queryByText('Dataset contains invalid characters')).toBeNull();
   });

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_component.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/dataset_component.tsx
@@ -23,7 +23,6 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 import type { DataStream } from '../../../../../../../../../common/types';
 import { GENERIC_DATASET_NAME } from '../../../../../../../../../common/constants';
-import { isValidDataset } from '../../../../../../../../../common';
 
 const FormRow = styled(EuiFormRow)`
   .euiFormRow__label {
@@ -48,7 +47,19 @@ export const DatasetComponent: React.FC<{
   isDisabled?: boolean;
   fieldLabel: string;
   description?: string;
-}> = ({ value, onChange, datastreams, isDisabled, pkgName = '', fieldLabel, description }) => {
+  errors?: string[] | null;
+  isInvalid?: boolean;
+}> = ({
+  value,
+  errors,
+  onChange,
+  datastreams,
+  isDisabled,
+  isInvalid,
+  pkgName = '',
+  fieldLabel,
+  description,
+}) => {
   const datasetOptions =
     datastreams.map((datastream: DataStream) => ({
       label: datastream.dataset,
@@ -67,8 +78,8 @@ export const DatasetComponent: React.FC<{
     };
 
   const [selectedOptions, setSelectedOptions] = useState<Array<{ label: string }>>([defaultOption]);
-  const [isInvalid, setIsInvalid] = useState<boolean>(false);
-  const [error, setError] = useState<string | undefined>(undefined);
+
+  const error = errors ? errors.join(', ') : undefined;
 
   useEffect(() => {
     if (!value || typeof value === 'string') onChange(defaultOption.value as SelectedDataset);
@@ -77,9 +88,7 @@ export const DatasetComponent: React.FC<{
   const onDatasetChange = (newSelectedOptions: Array<{ label: string; value?: DataStream }>) => {
     setSelectedOptions(newSelectedOptions);
     const dataStream = newSelectedOptions[0].value;
-    const { valid, error: dsError } = isValidDataset(newSelectedOptions[0].label, false);
-    setIsInvalid(!valid);
-    setError(dsError);
+
     onChange({
       dataset: newSelectedOptions[0].label,
       package: !dataStream || typeof dataStream === 'string' ? pkgName : dataStream.package,
@@ -96,9 +105,6 @@ export const DatasetComponent: React.FC<{
       value: { dataset: searchValue, package: pkgName },
     };
     setSelectedOptions([newOption]);
-    const { valid, error: dsError } = isValidDataset(searchValue, false);
-    setIsInvalid(!valid);
-    setError(dsError);
     onChange({
       dataset: searchValue,
       package: pkgName,

--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -108,6 +108,8 @@ export const PackagePolicyInputVarField: React.FunctionComponent<InputFieldProps
           datastreams={datastreams}
           value={value}
           onChange={onChange}
+          errors={errors}
+          isInvalid={isInvalid}
           isDisabled={isEditPage}
           fieldLabel={fieldLabel}
           description={description}

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/package_policy.ts
@@ -439,6 +439,7 @@ export const DryRunPackagePolicySchema = PackagePolicySchema.extends(
   {
     id: schema.maybe(schema.string()),
     force: schema.maybe(schema.boolean()),
+    revision: schema.maybe(schema.number()),
     errors: schema.maybe(
       schema.arrayOf(
         schema.object({

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/package_policy.ts
@@ -435,20 +435,24 @@ export const OrphanedPackagePoliciesResponseSchema = schema.object({
   total: schema.number(),
 });
 
-export const DryRunPackagePolicySchema = schema.object({
-  ...PackagePolicyBaseSchema,
-  id: schema.maybe(schema.string()),
-  force: schema.maybe(schema.boolean()),
-  errors: schema.maybe(
-    schema.arrayOf(
-      schema.object({
-        message: schema.string(),
-        key: schema.maybe(schema.string()),
-      })
-    )
-  ),
-  missingVars: schema.maybe(schema.arrayOf(schema.string())),
-});
+export const DryRunPackagePolicySchema = PackagePolicySchema.extends(
+  {
+    id: schema.maybe(schema.string()),
+    force: schema.maybe(schema.boolean()),
+    errors: schema.maybe(
+      schema.arrayOf(
+        schema.object({
+          message: schema.string(),
+          key: schema.maybe(schema.string()),
+        })
+      )
+    ),
+    missingVars: schema.maybe(schema.arrayOf(schema.string())),
+  },
+  {
+    unknowns: 'allow',
+  }
+);
 
 export const PackagePolicyStatusResponseSchema = schema.object({
   id: schema.string(),

--- a/x-pack/platform/plugins/shared/fleet/server/types/models/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/types/models/package_policy.ts
@@ -440,6 +440,10 @@ export const DryRunPackagePolicySchema = PackagePolicySchema.extends(
     id: schema.maybe(schema.string()),
     force: schema.maybe(schema.boolean()),
     revision: schema.maybe(schema.number()),
+    updated_at: schema.maybe(schema.string()),
+    updated_by: schema.maybe(schema.string()),
+    created_at: schema.maybe(schema.string()),
+    created_by: schema.maybe(schema.string()),
     errors: schema.maybe(
       schema.arrayOf(
         schema.object({


### PR DESCRIPTION
## Summary

Resolve #219200

Fix dataset validation so invalid dataset errors (that were not validated in 7.17, only shown in the help text) are properly shown.

To fix that I removed the specific validation in that component and use the validation done at the package policy level.

## UI Change

With a custom log with dataset containing a `-` created in 7.17

Upgrade look like this:

<img width="1163" alt="Screenshot 2025-04-30 at 9 55 34 AM" src="https://github.com/user-attachments/assets/7a28b2b9-9b1d-4d4c-8132-8ca2194cb30f" />

Validation on create still work


<img width="973" alt="Screenshot 2025-04-30 at 9 55 26 AM" src="https://github.com/user-attachments/assets/9eeb5f51-267e-49a5-8d04-db3ab0561088" />


## Tests

You can manually test this by creating an old package policy and try to upgrade it 

<details>

```
PUT .kibana_ingest/_doc/ingest-package-policies:dc564214-1eff-455f-b820-b64a4805563b
{
          "ingest-package-policies" : {
            "name" : "log-1",
            "description" : "",
            "namespace" : "default",
            "policy_ids" : ["<POLICY_ID>"],
            "enabled" : true,
            "output_id" : "",
            "inputs" : [
              {
                "type" : "logfile",
                "policy_template" : "logs",
                "enabled" : true,
                "streams" : [
                  {
                    "enabled" : true,
                    "data_stream" : {
                      "type" : "logs",
                      "dataset" : "log.log"
                    },
                    "vars" : {
                      "paths" : {
                        "type" : "text",
                        "value" : [
                          "/test.log"
                        ]
                      },
                      "data_stream.dataset" : {
                        "value" : "linux-generic",
                        "type" : "text"
                      },
                      "tags" : {
                        "value" : [ ],
                        "type" : "text"
                      },
                      "processors" : {
                        "type" : "yaml"
                      },
                      "custom" : {
                        "value" : "",
                        "type" : "yaml"
                      }
                    },
                    "id" : "logfile-log.log-dc564214-1eff-455f-b820-b64a4805563b",
                    "compiled_stream" : {
                      "paths" : [
                        "/test.log"
                      ],
                      "data_stream" : {
                        "dataset" : "linux.generic"
                      }
                    }
                  }
                ]
              }
            ],
            "package" : {
              "name" : "log",
              "title" : "Custom Logs",
              "version" : "1.1.2"
            },
            "revision" : 1,
            "created_at" : "2025-04-29T15:37:31.981Z",
            "created_by" : "2292991986",
            "updated_at" : "2025-04-29T15:37:31.981Z",
            "updated_by" : "2292991986"
          },
          "type" : "ingest-package-policies",
          "references" : [ ],
          "coreMigrationVersion" : "7.17.28",
          "updated_at" : "2025-04-29T15:37:31.993Z"
        }
```


</details>


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->