### PR TITLE
[8.19] [FIPS] Skips new alerting artifacts spaces-only test (#218983)

### DIFF
--- a/.buildkite/scripts/steps/checks/verify_fips_enabled.sh
+++ b/.buildkite/scripts/steps/checks/verify_fips_enabled.sh
@@ -8,7 +8,7 @@ source .buildkite/scripts/common/util.sh
 function build_ready() {
   build_state=$(buildkite-agent step get "state" --step "build")
 
-  if [[ "$build_state" == "finished" || "$build_state" == "ready" ]]; then
+  if [[ "$build_state" == "finished" || "$build_state" == "ready" || "$build_state" == "ignored" ]]; then
     echo "Build is ready, continuing..."
   else
     echo "Build is not ready, current state: $build_state"

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/create.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group1/create.ts
@@ -856,7 +856,9 @@ export default function createAlertTests({ getService }: FtrProviderContext) {
       });
     });
     describe('artifacts', () => {
-      describe('create rule with dashboards artifacts correctly', () => {
+      describe('create rule with dashboards artifacts correctly', function () {
+        this.tags('skipFIPS');
+
         it('should not return dashboards artifacts in the rule response', async () => {
           const response = await supertest
             .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[FIPS] Skips new alerting artifacts spaces-only test (#218983)](https://github.com/elastic/kibana/pull/218983)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2025-04-25T22:13:34Z","message":"[FIPS] Skips new alerting artifacts spaces-only test (#218983)\n\n## Summary\n\nThis test runs as part of the \"spaces-only\" test group, and contains\nexplicit security-related checks (e.g. created-by user) that assume\nsecurity is disabled. Like other tests in this file, it will need to be\nskipped when running in a FIPS configuration because FIPS requires\nsecurity.","sha":"0efbd19044b9ae653add1e45375b17f24d96f483","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","ci:enable-fips-agent","backport:version","v9.1.0","v8.19.0"],"title":"[FIPS] Skips new alerting artifacts spaces-only test","number":218983,"url":"https://github.com/elastic/kibana/pull/218983","mergeCommit":{"message":"[FIPS] Skips new alerting artifacts spaces-only test (#218983)\n\n## Summary\n\nThis test runs as part of the \"spaces-only\" test group, and contains\nexplicit security-related checks (e.g. created-by user) that assume\nsecurity is disabled. Like other tests in this file, it will need to be\nskipped when running in a FIPS configuration because FIPS requires\nsecurity.","sha":"0efbd19044b9ae653add1e45375b17f24d96f483"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218983","number":218983,"mergeCommit":{"message":"[FIPS] Skips new alerting artifacts spaces-only test (#218983)\n\n## Summary\n\nThis test runs as part of the \"spaces-only\" test group, and contains\nexplicit security-related checks (e.g. created-by user) that assume\nsecurity is disabled. Like other tests in this file, it will need to be\nskipped when running in a FIPS configuration because FIPS requires\nsecurity.","sha":"0efbd19044b9ae653add1e45375b17f24d96f483"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->