### PR TITLE
[Docs] Add 8.18.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -10,6 +10,7 @@
 
 Review important information about the {kib} 8.x releases.
 
+* <<release-notes-8.18.1>>
 * <<release-notes-8.18.0>>
 * <<release-notes-8.17.5>>
 * <<release-notes-8.17.4>>
@@ -93,6 +94,43 @@ Review important information about the {kib} 8.x releases.
 
 include::upgrade-notes.asciidoc[]
 
+[[release-notes-8.18.1]]
+== {kib} 8.18.1
+
+The 8.18.1 release includes the following fixes.
+
+[float]
+[[enhancement-v8.18.1]]
+=== Enhancements
+Elastic Security solution::
+For the Elastic Security 8.18.1 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+
+[float]
+[[fixes-v8.18.1]]
+=== Fixes
+Dashboards and Visualizations::
+* Syncs the dashboard ES|QL query and filters with the ones in the corresponding *Lens* visualization ({kibana-pull}218997[#218997]).
+* Correctly formats keywords in metric visualizations ({kibana-pull}218233[#218233]).
+Discover::
+* Fixes the result of the *Generate CSV report* action for ES|QL panels ({kibana-pull}216325[#216325]).
+Elastic Observability Solution::
+* Prevents unnecessary suggestion requests when interacting with inputs on the APM *Custom Links* page ({kibana-pull}218927[#218927]).
+* Filters out null values from `sourceDataStreams` ({kibana-pull}218772[#218772]).
+* Fixes a bug with navigating to the *Search Connectors* tab in the AI Assistant Settings ({kibana-pull}217749[#217749]).
+* Improves `aria-label` attributes for correlations ({kibana-pull}217512[#217512]).
+Elastic Security solution::
+For the Elastic Security 8.18.1 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+Kibana platform::
+* Fixes broken icons in integrations coming from the Home plugin ({kibana-pull}219206[#219206]).
+Kibana security::
+* Removes check for unused connector role ({kibana-pull}219358[#219358]).
+Machine Learning::
+* Fixes error when switching Service providers in the *Inference Endpoint* flyout ({kibana-pull}219020[#219020]).
+* Corrects quotes in ES|QL queries for function arguments ({kibana-pull}217680[#217680]).
+Management::
+* Fixes missing `allow_hidden` usage for data views in the request for fields ({kibana-pull}217628[#217628]).
+Platform::
+* Shows the correct request and response for any successful scenario in Inspector ({kibana-pull}216519[#216519]).
 
 [[release-notes-8.18.0]]
 == {kib} 8.18.0

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -113,7 +113,7 @@ Dashboards and Visualizations::
 * Correctly formats keywords in metric visualizations ({kibana-pull}218233[#218233]).
 * When exploring a dashboard, the request inspector now shows the correct request and response in any successful scenario ({kibana-pull}216519[#216519]).
 Discover::
-* Fixes incorrect behavior for requests on fields where the Allow hidden and system indices (`allow_hidden`) option of the data view could be ignored
+* Fixes incorrect behavior for requests on fields where the Allow hidden and system indices (`allow_hidden`) option of the data view could be ignored ({kibana-pull}217628[#217628]).
 * Fixes the result of the *Generate CSV report* action for ES|QL panels ({kibana-pull}216325[#216325]).
 Elastic Observability Solution::
 * Prevents unnecessary suggestion requests when interacting with inputs on the APM *Custom Links* page ({kibana-pull}218927[#218927]).

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -113,7 +113,7 @@ Dashboards and Visualizations::
 * Correctly formats keywords in metric visualizations ({kibana-pull}218233[#218233]).
 * When exploring a dashboard, the request inspector now shows the correct request and response in any successful scenario ({kibana-pull}216519[#216519]).
 Discover::
-* Fixes incorrect behavior for requests on fields where the Allow hidden and system indices (`allow_hidden`) option of the data view could be ignored ({kibana-pull}217628[#217628]).
+* Fixes incorrect behavior for requests on fields where the *Allow hidden and system indices* (`allow_hidden`) option of the data view could be ignored ({kibana-pull}217628[#217628]).
 * Fixes the result of the *Generate CSV report* action for ES|QL panels ({kibana-pull}216325[#216325]).
 Elastic Observability Solution::
 * Prevents unnecessary suggestion requests when interacting with inputs on the APM *Custom Links* page ({kibana-pull}218927[#218927]).

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -97,7 +97,7 @@ include::upgrade-notes.asciidoc[]
 [[release-notes-8.18.1]]
 == {kib} 8.18.1
 
-The 8.18.1 release includes the following fixes.
+The 8.18.1 release includes the following enhancements and fixes.
 
 [float]
 [[enhancement-v8.18.1]]

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -109,9 +109,11 @@ For the Elastic Security 8.18.1 release information, refer to {security-guide}/r
 [[fixes-v8.18.1]]
 === Fixes
 Dashboards and Visualizations::
-* Syncs the dashboard ES|QL query and filters with the ones in the corresponding *Lens* visualization ({kibana-pull}218997[#218997]).
+* Syncs the dashboard ES|QL query and filters with the corresponding visualization query in *Lens* ({kibana-pull}218997[#218997]).
 * Correctly formats keywords in metric visualizations ({kibana-pull}218233[#218233]).
+* When exploring a dashboard, the request inspector now shows the correct request and response in any successful scenario ({kibana-pull}216519[#216519]).
 Discover::
+* Fixes incorrect behavior for requests on fields where the Allow hidden and system indices (`allow_hidden`) option of the data view could be ignored
 * Fixes the result of the *Generate CSV report* action for ES|QL panels ({kibana-pull}216325[#216325]).
 Elastic Observability Solution::
 * Prevents unnecessary suggestion requests when interacting with inputs on the APM *Custom Links* page ({kibana-pull}218927[#218927]).
@@ -127,10 +129,6 @@ Kibana security::
 Machine Learning::
 * Fixes error when switching Service providers in the *Inference Endpoint* flyout ({kibana-pull}219020[#219020]).
 * Corrects quotes in ES|QL queries for function arguments ({kibana-pull}217680[#217680]).
-Management::
-* Fixes missing `allow_hidden` usage for data views in the request for fields ({kibana-pull}217628[#217628]).
-Platform::
-* Shows the correct request and response for any successful scenario in Inspector ({kibana-pull}216519[#216519]).
 
 [[release-notes-8.18.0]]
 == {kib} 8.18.0


### PR DESCRIPTION
## Summary

Adds 8.18.1 release notes.

Closes: [#670](https://github.com/elastic/platform-docs-team/issues/670)
[Preview](https://kibana_bk_219768.docs-preview.app.elstc.co/guide/en/kibana/8.18/release-notes-8.18.1.html)
