### PR TITLE
partial revert of PR 209025

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_summarized_alerts_query.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/get_summarized_alerts_query.ts
@@ -341,7 +341,7 @@ export const getQueryByScopedQueries = ({
       aggs: {
         alertId: {
           top_hits: {
-            size: maxAlertLimit,
+            size: 100,
             _source: {
               includes: [ALERT_UUID],
             },


### PR DESCRIPTION
work-around for https://github.com/elastic/response-ops-team/issues/320

In that issue, maintenance windows with filters will cause the following errors when rules generate alerts:

![image](https://github.com/user-attachments/assets/19b023c2-ea81-4806-b60e-34bd83aa2dba)

## Summary

Partially revert PR https://github.com/elastic/kibana/pull/209025 .  In that PR, we ended up passing a value of `size` in a `top_hits` aggregation, which can easily be larger than what ES allows, resulting in the search failing.  In this PR, we change that `size` parameter back it's original `100` value, but leave the other changes alone.




<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->