### PR TITLE
[8.19] [Obs AI Assistant] Query alerts using the `alert.start` field and update alerts function API test to check alert information (#219651)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/alerts.ts
+++ b/x-pack/solutions/observability/plugins/observability_ai_assistant_app/server/functions/alerts.ts
@@ -195,7 +195,9 @@ export function registerAlertsFunction({
               filter: [
                 {
                   range: {
-                    '@timestamp': {
+                    // Note: The @timestamp field is the value for when the alert was last updated
+                    // and not when the alert was created
+                    'kibana.alert.start': {
                       gte: start,
                       lte: end,
                     },

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/alerts.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/complete/functions/alerts.spec.ts
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
-import { MessageRole, MessageAddEvent } from '@kbn/observability-ai-assistant-plugin/common';
 import expect from '@kbn/expect';
+import { MessageRole, MessageAddEvent } from '@kbn/observability-ai-assistant-plugin/common';
+import { InternalRequestHeader, RoleCredentials } from '@kbn/ftr-common-functional-services';
+import { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
+import { ApmRuleType } from '@kbn/rule-data-utils';
+import { SearchAlertsResult } from '@kbn/alerts-ui-shared/src/common/apis/search_alerts/search_alerts';
 import {
   LlmProxy,
   createLlmProxy,
@@ -15,10 +19,31 @@ import {
   getMessageAddedEvents,
   invokeChatCompleteWithFunctionRequest,
 } from '../../utils/conversation';
+import { createRule, deleteRules } from '../../utils/alerts';
 import type { DeploymentAgnosticFtrProviderContext } from '../../../../../ftr_provider_context';
+import { createSyntheticApmData } from '../../synthtrace_scenarios/create_synthetic_apm_data';
+import { APM_ALERTS_INDEX as APM_ALERTS_INDEX_PATTERN } from '../../../apm/alerts/helpers/alerting_helper';
+
+const RECENT_ALERT_RULE_NAME = 'Recent Alert';
+const OLD_ALERT_DOC_RULE_NAME = 'Manually Indexed Old Alert';
+const APM_ALERTS_INDEX = '.internal.alerts-observability.apm.alerts-default-000001';
+
+const alertRuleData = {
+  ruleTypeId: ApmRuleType.TransactionErrorRate,
+  indexName: APM_ALERTS_INDEX_PATTERN,
+  consumer: 'apm',
+  environment: 'production',
+  threshold: 1,
+  windowSize: 1,
+  windowUnit: 'h',
+  ruleName: RECENT_ALERT_RULE_NAME,
+};
 
 export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const es = getService('es');
   const log = getService('log');
+  const samlAuth = getService('samlAuth');
+  const alertingApi = getService('alertingApi');
   const observabilityAIAssistantAPIClient = getService('observabilityAIAssistantApi');
 
   describe('alerts', function () {
@@ -27,14 +52,53 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
     let proxy: LlmProxy;
     let connectorId: string;
     let alertsEvents: MessageAddEvent[];
+    let internalReqHeader: InternalRequestHeader;
+    let roleAuthc: RoleCredentials;
+    let apmSynthtraceEsClient: ApmSynthtraceEsClient;
+    let createdRuleId: string;
+    let parsedAlertsResponse: SearchAlertsResult;
 
     const start = 'now-100h';
     const end = 'now';
 
     before(async () => {
+      internalReqHeader = samlAuth.getInternalRequestHeader();
+      roleAuthc = await samlAuth.createM2mApiKeyWithRoleScope('editor');
+
+      ({ apmSynthtraceEsClient } = await createSyntheticApmData({ getService }));
+
       proxy = await createLlmProxy(log);
       connectorId = await observabilityAIAssistantAPIClient.createProxyActionConnector({
         port: proxy.getPort(),
+      });
+
+      // Create alerting rule
+      createdRuleId = await createRule({
+        getService,
+        roleAuthc,
+        internalReqHeader,
+        data: alertRuleData,
+      });
+
+      // Manually index old alert
+      const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+      await es.index({
+        index: APM_ALERTS_INDEX,
+        refresh: 'wait_for',
+        document: {
+          '@timestamp': new Date().toISOString(),
+          'kibana.alert.start': eightDaysAgo,
+          'kibana.alert.status': 'active',
+          'kibana.alert.rule.name': OLD_ALERT_DOC_RULE_NAME,
+          'kibana.alert.rule.consumer': 'apm',
+          'kibana.alert.rule.rule_type_id': 'apm.transaction_error_rate',
+          'kibana.alert.evaluation.threshold': 1,
+          'service.environment': 'production',
+          'kibana.space_ids': ['default'],
+          'event.kind': 'signal',
+          'event.action': 'open',
+          'kibana.alert.workflow_status': 'open',
+        },
       });
 
       void proxy.interceptConversation('Hello from LLM Proxy');
@@ -52,6 +116,8 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       await proxy.waitForAllInterceptorsToHaveBeenCalled();
 
       alertsEvents = getMessageAddedEvents(alertsResponseBody);
+      const alertsFunctionResponse = alertsEvents[0];
+      parsedAlertsResponse = JSON.parse(alertsFunctionResponse.message.message.content!);
     });
 
     after(async () => {
@@ -59,21 +125,53 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       await observabilityAIAssistantAPIClient.deleteActionConnector({
         actionId: connectorId,
       });
+
+      await apmSynthtraceEsClient.clean();
+      await alertingApi.cleanUpAlerts({
+        roleAuthc,
+        ruleId: createdRuleId,
+        alertIndexName: APM_ALERTS_INDEX_PATTERN,
+        consumer: 'apm',
+      });
+      await deleteRules({ getService, roleAuthc, internalReqHeader });
+
+      await samlAuth.invalidateM2mApiKeyWithRoleScope(roleAuthc);
     });
 
-    // This test ensures that invoking the alerts function does not result in an error.
     it('should execute the function without any errors', async () => {
-      const alertsFunctionResponse = alertsEvents[0];
-      expect(alertsFunctionResponse.message.message.name).to.be('alerts');
-
-      const parsedAlertsResponse = JSON.parse(alertsFunctionResponse.message.message.content!);
+      expect(alertsEvents[0].message.message.name).to.be('alerts');
 
       expect(parsedAlertsResponse).not.to.have.property('error');
       expect(parsedAlertsResponse).to.have.property('total');
       expect(parsedAlertsResponse).to.have.property('alerts');
       expect(parsedAlertsResponse.alerts).to.be.an('array');
-      expect(parsedAlertsResponse.total).to.be(0);
-      expect(parsedAlertsResponse.alerts.length).to.be(0);
+    });
+
+    it('should retrieve 1 active alert', async () => {
+      expect(parsedAlertsResponse.total).to.be(1);
+      expect(parsedAlertsResponse.alerts.length).to.be(1);
+      expect(parsedAlertsResponse.alerts[0]['kibana.alert.status']).to.eql('active');
+    });
+
+    it('should retrieve correct alert information', async () => {
+      const alert = parsedAlertsResponse.alerts[0];
+
+      expect(alert['service.environment']).to.eql(alertRuleData.environment);
+      expect(alert['kibana.alert.rule.consumer']).to.eql(alertRuleData.consumer);
+      expect(alert['kibana.alert.evaluation.threshold']).to.eql(alertRuleData.threshold);
+      expect(alert['kibana.alert.rule.rule_type_id']).to.eql(alertRuleData.ruleTypeId);
+      expect(alert['kibana.alert.rule.name']).to.eql(alertRuleData.ruleName);
+    });
+
+    it('should only return alerts that started within the requested range', async () => {
+      const returnedAlert = parsedAlertsResponse.alerts[0];
+      expect(returnedAlert['kibana.alert.rule.name']).to.be(RECENT_ALERT_RULE_NAME);
+
+      const alertStartTime = new Date(returnedAlert['kibana.alert.start'] as unknown as string);
+      const from = new Date(Date.now() - 100 * 60 * 60 * 1000); // now-100h
+      const to = new Date();
+
+      expect(alertStartTime >= from && alertStartTime <= to).to.be(true);
     });
   });
 }

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/synthtrace_scenarios/create_synthetic_apm_data.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/synthtrace_scenarios/create_synthetic_apm_data.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+import { apm, timerange } from '@kbn/apm-synthtrace-client';
+import { DeploymentAgnosticFtrProviderContext } from '../../../../ftr_provider_context';
+
+export const createSyntheticApmData = async ({
+  getService,
+  serviceName = 'my-service',
+  environment = 'production',
+  language = 'go',
+}: {
+  getService: DeploymentAgnosticFtrProviderContext['getService'];
+  serviceName?: string;
+  environment?: string;
+  language?: string;
+}) => {
+  const synthtrace = getService('synthtrace');
+  const apmSynthtraceEsClient = await synthtrace.createApmSynthtraceEsClient();
+
+  await apmSynthtraceEsClient.clean();
+
+  const instance = apm
+    .service({ name: serviceName, environment, agentName: language })
+    .instance('my-instance');
+
+  await apmSynthtraceEsClient.index(
+    timerange(moment().subtract(15, 'minutes'), moment())
+      .interval('1m')
+      .rate(10)
+      .generator((timestamp) => [
+        instance
+          .transaction('GET /api')
+          .timestamp(timestamp)
+          .duration(50)
+          .failure()
+          .errors(
+            instance.error({ message: 'error message', type: 'Sample Type' }).timestamp(timestamp)
+          ),
+      ])
+  );
+
+  return { apmSynthtraceEsClient };
+};

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/alerts.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/alerts.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { InternalRequestHeader, RoleCredentials } from '@kbn/ftr-common-functional-services';
+import { ApmRuleType } from '@kbn/rule-data-utils';
+import { DeploymentAgnosticFtrProviderContext } from '../../../../ftr_provider_context';
+import { APM_ALERTS_INDEX, ApmAlertFields } from '../../apm/alerts/helpers/alerting_helper';
+
+export const createRule = async ({
+  getService,
+  roleAuthc,
+  data,
+}: {
+  getService: DeploymentAgnosticFtrProviderContext['getService'];
+  roleAuthc: RoleCredentials;
+  internalReqHeader: InternalRequestHeader;
+  data?: any;
+}) => {
+  const alertingApi = getService('alertingApi');
+  const logger = getService('log');
+
+  try {
+    const createdRule = await alertingApi.createRule({
+      ruleTypeId: data?.ruleTypeId || ApmRuleType.TransactionErrorRate,
+      name: data?.ruleName || 'APM transaction error rate',
+      consumer: data?.consumer || 'apm',
+      schedule: { interval: data?.interval || '1m' },
+      tags: data?.tags || ['apm'],
+      params: {
+        environment: data?.environment || 'production',
+        threshold: data?.threshold || 1,
+        windowSize: data?.windowSize || 1,
+        windowUnit: data?.windowUnit || 'h',
+      },
+      roleAuthc,
+    });
+
+    const ruleId = createdRule.id as string;
+
+    await alertingApi.waitForDocumentInIndex<ApmAlertFields>({
+      indexName: data?.indexName || APM_ALERTS_INDEX,
+      ruleId,
+      docCountTarget: data?.docCountTarget || 1,
+    });
+
+    return ruleId;
+  } catch (e) {
+    logger.error(`Failed to create alerting rule: ${e}`);
+    throw e;
+  }
+};
+
+export const runRule = async ({
+  getService,
+  roleAuthc,
+  ruleId,
+}: {
+  getService: DeploymentAgnosticFtrProviderContext['getService'];
+  roleAuthc: RoleCredentials;
+  internalReqHeader: InternalRequestHeader;
+  ruleId: string;
+}) => {
+  const alertingApi = getService('alertingApi');
+  return alertingApi.runRule(roleAuthc, ruleId);
+};
+
+export const deleteRules = async ({
+  getService,
+  roleAuthc,
+}: {
+  getService: DeploymentAgnosticFtrProviderContext['getService'];
+  roleAuthc: RoleCredentials;
+  internalReqHeader: InternalRequestHeader;
+}) => {
+  const alertingApi = getService('alertingApi');
+  return alertingApi.deleteRules({ roleAuthc });
+};

--- a/x-pack/test/tsconfig.json
+++ b/x-pack/test/tsconfig.json
@@ -199,5 +199,6 @@
     "@kbn/aiops-change-point-detection",
     "@kbn/es-errors",
     "@kbn/content-packs-schema",
+    "@kbn/alerts-ui-shared",
   ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Obs AI Assistant] Query alerts using the `alert.start` field and update alerts function API test to check alert information (#219651)](https://github.com/elastic/kibana/pull/219651)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Viduni Wickramarachchi","email":"viduni.wickramarachchi@elastic.co"},"sourceCommit":{"committedDate":"2025-04-30T20:59:38Z","message":"[Obs AI Assistant] Query alerts using the `alert.start` field and update alerts function API test to check alert information (#219651)\n\nCloses https://github.com/elastic/kibana/issues/219558\nCloses https://github.com/elastic/kibana/issues/219781\n\n## Summary\n\nThis PR extends the current alerts API test to check for retrieved\nalerts and their content.\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1b75e9b092f45fca789bacc49570e84f050efd52","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Obs AI Assistant","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0"],"title":"[Obs AI Assistant] Query alerts using the `alert.start` field and update alerts function API test to check alert information","number":219651,"url":"https://github.com/elastic/kibana/pull/219651","mergeCommit":{"message":"[Obs AI Assistant] Query alerts using the `alert.start` field and update alerts function API test to check alert information (#219651)\n\nCloses https://github.com/elastic/kibana/issues/219558\nCloses https://github.com/elastic/kibana/issues/219781\n\n## Summary\n\nThis PR extends the current alerts API test to check for retrieved\nalerts and their content.\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1b75e9b092f45fca789bacc49570e84f050efd52"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219651","number":219651,"mergeCommit":{"message":"[Obs AI Assistant] Query alerts using the `alert.start` field and update alerts function API test to check alert information (#219651)\n\nCloses https://github.com/elastic/kibana/issues/219558\nCloses https://github.com/elastic/kibana/issues/219781\n\n## Summary\n\nThis PR extends the current alerts API test to check for retrieved\nalerts and their content.\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"1b75e9b092f45fca789bacc49570e84f050efd52"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->