### PR TITLE
fix(slo): alert deletion

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/services/tasks/bulk_delete/run_bulk_delete.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/tasks/bulk_delete/run_bulk_delete.ts
@@ -103,7 +103,7 @@ export async function runBulkDelete(
 
   try {
     await rulesClient.bulkDeleteRules({
-      filter: `alert.attributes.params.sloId:${itemsDeletedSuccessfully.join(' or ')}`,
+      filter: `alert.attributes.params.sloId:(${itemsDeletedSuccessfully.join(' or ')})`,
     });
   } catch (err) {
     logger.debug(`Error deleting rules: ${err}`);


### PR DESCRIPTION
## Summary

Properly delete the rules when bulk deleting SLOs.



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->