### PR TITLE
fix image embeddable reset

### DIFF
--- a/src/platform/plugins/private/image_embeddable/public/image_embeddable/get_image_embeddable_factory.tsx
+++ b/src/platform/plugins/private/image_embeddable/public/image_embeddable/get_image_embeddable_factory.tsx
@@ -76,6 +76,7 @@ export const getImageEmbeddableFactory = ({
         },
         onReset: (lastSaved) => {
           titleManager.reinitializeState(lastSaved?.rawState);
+          if (lastSaved) imageConfig$.next(lastSaved.rawState.imageConfig);
         },
       });
 

--- a/src/platform/plugins/private/image_embeddable/public/image_embeddable/get_image_embeddable_factory.tsx
+++ b/src/platform/plugins/private/image_embeddable/public/image_embeddable/get_image_embeddable_factory.tsx
@@ -76,6 +76,7 @@ export const getImageEmbeddableFactory = ({
         },
         onReset: (lastSaved) => {
           titleManager.reinitializeState(lastSaved?.rawState);
+          dynamicActionsManager?.reinitializeState(lastSaved?.rawState ?? {});
           if (lastSaved) imageConfig$.next(lastSaved.rawState.imageConfig);
         },
       });


### PR DESCRIPTION
This PR does not need to be reviewed by external teams. This PR merges into a feature branch that Kibana presentation team is working on to convert the embeddable framework to only expose serialized state. Your team will be pinged for review once the work is complete and the final PR opens that merges the feature branch into main