### PR TITLE
[ES|QL] Renames the ESQLRealField type to ESQLFieldWithMetadata

### DIFF
--- a/examples/esql_validation_example/public/app.tsx
+++ b/examples/esql_validation_example/public/app.tsx
@@ -24,7 +24,7 @@ import {
 
 import type { CoreStart } from '@kbn/core/public';
 
-import { ESQLCallbacks, ESQLRealField, validateQuery } from '@kbn/esql-validation-autocomplete';
+import { ESQLCallbacks, ESQLFieldWithMetadata, validateQuery } from '@kbn/esql-validation-autocomplete';
 import type { StartDependencies } from './plugin';
 import { CodeSnippet } from './code_snippet';
 
@@ -56,7 +56,7 @@ export const App = (props: { core: CoreStart; plugins: StartDependencies }) => {
             [
               { name: 'doubleField', type: 'double' },
               { name: 'keywordField', type: 'keyword' },
-            ] as ESQLRealField[]
+            ] as ESQLFieldWithMetadata[]
         : undefined,
       getPolicies: callbacksEnabled.policies
         ? async () => [

--- a/examples/esql_validation_example/public/app.tsx
+++ b/examples/esql_validation_example/public/app.tsx
@@ -24,7 +24,11 @@ import {
 
 import type { CoreStart } from '@kbn/core/public';
 
-import { ESQLCallbacks, ESQLFieldWithMetadata, validateQuery } from '@kbn/esql-validation-autocomplete';
+import {
+  ESQLCallbacks,
+  ESQLFieldWithMetadata,
+  validateQuery,
+} from '@kbn/esql-validation-autocomplete';
 import type { StartDependencies } from './plugin';
 import { CodeSnippet } from './code_snippet';
 

--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -34,7 +34,7 @@ import { fixESQLQueryWithVariables } from '@kbn/esql-utils';
 import { createPortal } from 'react-dom';
 import { css } from '@emotion/react';
 import { ESQLVariableType, type ESQLControlVariable } from '@kbn/esql-types';
-import { type ESQLRealField } from '@kbn/esql-validation-autocomplete';
+import { type ESQLFieldWithMetadata } from '@kbn/esql-validation-autocomplete';
 import { FieldType } from '@kbn/esql-validation-autocomplete/src/definitions/types';
 import { EditorFooter } from './editor_footer';
 import { fetchFieldsFromESQL } from './fetch_fields_from_esql';
@@ -472,7 +472,7 @@ export const ESQLEditor = memo(function ESQLEditor({
               undefined,
               variablesService?.esqlVariables
             ).result;
-            const columns: ESQLRealField[] =
+            const columns: ESQLFieldWithMetadata[] =
               table?.columns.map((c) => {
                 return {
                   name: c.name,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/index.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/index.ts
@@ -26,7 +26,7 @@ export { suggest } from './src/autocomplete/autocomplete';
 export type {
   ValidationErrors,
   ESQLUserDefinedColumn,
-  ESQLRealField,
+  ESQLFieldWithMetadata,
   ESQLPolicy,
   ErrorTypes as ESQLValidationErrorTypes,
 } from './src/validation/types';

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/__tests__/helpers.ts
@@ -8,24 +8,24 @@
  */
 
 import { camelCase } from 'lodash';
-import { ESQLRealField, JoinIndexAutocompleteItem } from '../validation/types';
+import { ESQLFieldWithMetadata, JoinIndexAutocompleteItem } from '../validation/types';
 import { fieldTypes } from '../definitions/types';
 import { ESQLCallbacks } from '../shared/types';
 
-export const fields: ESQLRealField[] = [
+export const fields: ESQLFieldWithMetadata[] = [
   ...fieldTypes.map((type) => ({ name: `${camelCase(type)}Field`, type })),
   { name: 'any#Char$Field', type: 'double' },
   { name: 'kubernetes.something.something', type: 'double' },
   { name: '@timestamp', type: 'date' },
 ];
 
-export const enrichFields: ESQLRealField[] = [
+export const enrichFields: ESQLFieldWithMetadata[] = [
   { name: 'otherField', type: 'text' },
   { name: 'yetAnotherField', type: 'double' },
 ];
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const unsupported_field: ESQLRealField[] = [
+export const unsupported_field: ESQLFieldWithMetadata[] = [
   { name: 'unsupported_field', type: 'unsupported' },
 ];
 
@@ -81,7 +81,7 @@ export function getCallbackMocks(): ESQLCallbacks {
         return unsupported_field;
       }
       if (/join_index/.test(query)) {
-        const field: ESQLRealField = {
+        const field: ESQLFieldWithMetadata = {
           name: 'keywordField',
           type: 'unsupported',
           hasConflict: true,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/__tests__/helpers.ts
@@ -23,7 +23,7 @@ import * as autocomplete from '../autocomplete';
 import type { ESQLCallbacks } from '../../shared/types';
 import type { EditorContext, SuggestionRawDefinition } from '../types';
 import { TIME_SYSTEM_PARAMS, TRIGGER_SUGGESTION_COMMAND, getSafeInsertText } from '../factories';
-import { ESQLRealField } from '../../validation/types';
+import { ESQLFieldWithMetadata } from '../../validation/types';
 import {
   FieldType,
   fieldTypes,
@@ -52,7 +52,7 @@ export const TIME_PICKER_SUGGESTION: PartialSuggestionWithText = {
 
 export const triggerCharacters = [',', '(', '=', ' '];
 
-export type TestField = ESQLRealField & { suggestedAs?: string };
+export type TestField = ESQLFieldWithMetadata & { suggestedAs?: string };
 
 export const fields: TestField[] = [
   ...fieldTypes.map((type) => ({
@@ -278,7 +278,7 @@ export function createCustomCallbackMocks(
    * `FROM index | EVAL foo = 1 | LIMIT 0` will be used to fetch columns. The response
    * will include "foo" as a column.
    */
-  customColumnsSinceLastCommand?: ESQLRealField[],
+  customColumnsSinceLastCommand?: ESQLFieldWithMetadata[],
   customSources?: Array<{ name: string; hidden: boolean }>,
   customPolicies?: Array<{
     name: string;

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/autocomplete.ts
@@ -40,7 +40,7 @@ import {
   collectUserDefinedColumns,
   excludeUserDefinedColumnsFromCurrentCommand,
 } from '../shared/user_defined_columns';
-import type { ESQLRealField, ESQLUserDefinedColumn } from '../validation/types';
+import type { ESQLFieldWithMetadata, ESQLUserDefinedColumn } from '../validation/types';
 import {
   allStarConstant,
   commaCompleteItem,
@@ -84,7 +84,7 @@ import {
 import { comparisonFunctions } from '../definitions/all_operators';
 import { getRecommendedQueriesSuggestions } from './recommended_queries/suggestions';
 
-type GetFieldsMapFn = () => Promise<Map<string, ESQLRealField>>;
+type GetFieldsMapFn = () => Promise<Map<string, ESQLFieldWithMetadata>>;
 type GetPoliciesFn = () => Promise<SuggestionRawDefinition[]>;
 
 export async function suggest(
@@ -279,7 +279,7 @@ async function getSuggestionsWithinCommandExpression(
   const commandDef = getCommandDefinition(astContext.command.name);
 
   // collect all fields + userDefinedColumns to suggest
-  const fieldsMap: Map<string, ESQLRealField> = await getFieldsMap();
+  const fieldsMap: Map<string, ESQLFieldWithMetadata> = await getFieldsMap();
   const anyUserDefinedColumns = collectUserDefinedColumns(commands, fieldsMap, innerText);
 
   const references = { fields: fieldsMap, userDefinedColumns: anyUserDefinedColumns };
@@ -366,7 +366,7 @@ async function getFunctionArgsSuggestions(
   if (!fnDefinition) {
     return [];
   }
-  const fieldsMap: Map<string, ESQLRealField> = await getFieldsMap();
+  const fieldsMap: Map<string, ESQLFieldWithMetadata> = await getFieldsMap();
   const anyUserDefinedColumns = collectUserDefinedColumns(commands, fieldsMap, innerText);
 
   const references = {
@@ -604,7 +604,7 @@ async function getListArgsSuggestions(
   // node is supposed to be the function who support a list argument (like the "in" operator)
   // so extract the type of the first argument and suggest fields of that type
   if (node && isFunctionItem(node)) {
-    const fieldsMap: Map<string, ESQLRealField> = await getFieldsMaps();
+    const fieldsMap: Map<string, ESQLFieldWithMetadata> = await getFieldsMaps();
     const anyUserDefinedColumns = collectUserDefinedColumns(commands, fieldsMap, innerText);
     // extract the current node from the userDefinedColumns inferred
     anyUserDefinedColumns.forEach((values, key) => {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/change_point/fields_suggestions_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/change_point/fields_suggestions_after.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { synth } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { fieldsSuggestionsAfter } from './fields_suggestions_after';
 
 describe('CHANGE_POINT', () => {
@@ -15,9 +15,9 @@ describe('CHANGE_POINT', () => {
     const previousCommandFields = [
       { name: 'field1', type: 'keyword' },
       { name: 'count', type: 'double' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
-    const userDefinedColumns = [] as ESQLRealField[];
+    const userDefinedColumns = [] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`CHANGE_POINT count ON field1`,
@@ -37,9 +37,9 @@ describe('CHANGE_POINT', () => {
     const previousCommandFields = [
       { name: 'field1', type: 'keyword' },
       { name: 'count', type: 'double' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
-    const userDefinedColumns = [] as ESQLRealField[];
+    const userDefinedColumns = [] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`CHANGE_POINT count ON field1 AS changePointType, pValue`,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/change_point/fields_suggestions_after.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/change_point/fields_suggestions_after.ts
@@ -7,12 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { type ESQLAstCommand, type ESQLAstChangePointCommand, LeafPrinter } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 
 export const fieldsSuggestionsAfter = (
   command: ESQLAstCommand,
-  previousCommandFields: ESQLRealField[],
-  userDefinedColumns: ESQLRealField[]
+  previousCommandFields: ESQLFieldWithMetadata[],
+  userDefinedColumns: ESQLFieldWithMetadata[]
 ) => {
   const { target } = command as ESQLAstChangePointCommand;
   previousCommandFields.push(

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/dissect/fields_suggestions_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/dissect/fields_suggestions_after.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { synth } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { extractDissectColumnNames, fieldsSuggestionsAfter } from './fields_suggestions_after';
 
 describe('DISSECT', () => {
@@ -73,9 +73,9 @@ describe('DISSECT', () => {
       const previousCommandFields = [
         { name: 'field1', type: 'keyword' },
         { name: 'field2', type: 'double' },
-      ] as ESQLRealField[];
+      ] as ESQLFieldWithMetadata[];
 
-      const userDefinedColumns = [] as ESQLRealField[];
+      const userDefinedColumns = [] as ESQLFieldWithMetadata[];
 
       const result = fieldsSuggestionsAfter(
         synth.cmd`DISSECT agent "%{firstWord}"`,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/dissect/fields_suggestions_after.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/dissect/fields_suggestions_after.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { type ESQLAstCommand, walk } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 
 function unquoteTemplate(inputString: string): string {
   if (inputString.startsWith('"') && inputString.endsWith('"') && inputString.length >= 2) {
@@ -33,8 +33,8 @@ export function extractDissectColumnNames(pattern: string): string[] {
 
 export const fieldsSuggestionsAfter = (
   command: ESQLAstCommand,
-  previousCommandFields: ESQLRealField[],
-  userDefinedColumns: ESQLRealField[]
+  previousCommandFields: ESQLFieldWithMetadata[],
+  userDefinedColumns: ESQLFieldWithMetadata[]
 ) => {
   const columns: string[] = [];
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/drop/fields_suggestions_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/drop/fields_suggestions_after.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { synth } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { fieldsSuggestionsAfter } from './fields_suggestions_after';
 
 describe('DROP', () => {
@@ -15,9 +15,9 @@ describe('DROP', () => {
     const previousCommandFields = [
       { name: 'field1', type: 'keyword' },
       { name: 'field2', type: 'double' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
-    const userDefinedColumns = [] as ESQLRealField[];
+    const userDefinedColumns = [] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`DROP field1`,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/drop/fields_suggestions_after.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/drop/fields_suggestions_after.ts
@@ -7,12 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { type ESQLAstCommand, walk } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 
 export const fieldsSuggestionsAfter = (
   command: ESQLAstCommand,
-  previousCommandFields: ESQLRealField[],
-  userDefinedColumns: ESQLRealField[]
+  previousCommandFields: ESQLFieldWithMetadata[],
+  userDefinedColumns: ESQLFieldWithMetadata[]
 ) => {
   const columnsToDrop: string[] = [];
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/fork/fields_suggestions_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/fork/fields_suggestions_after.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { synth } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { fieldsSuggestionsAfter } from './fields_suggestions_after';
 
 describe('FORK', () => {
@@ -15,9 +15,9 @@ describe('FORK', () => {
     const previousCommandFields = [
       { name: 'field1', type: 'keyword' },
       { name: 'field2', type: 'double' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
-    const userDefinedColumns = [] as ESQLRealField[];
+    const userDefinedColumns = [] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`FORK (LIMIT 10 ) (LIMIT 1000 ) `,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/fork/fields_suggestions_after.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/fork/fields_suggestions_after.ts
@@ -7,12 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { type ESQLAstCommand } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 
 export const fieldsSuggestionsAfter = (
   command: ESQLAstCommand,
-  previousCommandFields: ESQLRealField[],
-  userDefinedColumns: ESQLRealField[]
+  previousCommandFields: ESQLFieldWithMetadata[],
+  userDefinedColumns: ESQLFieldWithMetadata[]
 ) => {
   return [
     ...previousCommandFields,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/grok/fields_suggestions_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/grok/fields_suggestions_after.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { synth } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { extractSemanticsFromGrok, fieldsSuggestionsAfter } from './fields_suggestions_after';
 
 describe('GROK', () => {
@@ -32,9 +32,9 @@ describe('GROK', () => {
       const previousCommandFields = [
         { name: 'field1', type: 'keyword' },
         { name: 'field2', type: 'double' },
-      ] as ESQLRealField[];
+      ] as ESQLFieldWithMetadata[];
 
-      const userDefinedColumns = [] as ESQLRealField[];
+      const userDefinedColumns = [] as ESQLFieldWithMetadata[];
 
       const result = fieldsSuggestionsAfter(
         synth.cmd`GROK agent "%{WORD:firstWord}"`,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/grok/fields_suggestions_after.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/grok/fields_suggestions_after.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { type ESQLAstCommand, walk } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 
 function unquoteTemplate(inputString: string): string {
   if (inputString.startsWith('"') && inputString.endsWith('"') && inputString.length >= 2) {
@@ -30,8 +30,8 @@ export function extractSemanticsFromGrok(pattern: string): string[] {
 
 export const fieldsSuggestionsAfter = (
   command: ESQLAstCommand,
-  previousCommandFields: ESQLRealField[],
-  userDefinedColumns: ESQLRealField[]
+  previousCommandFields: ESQLFieldWithMetadata[],
+  userDefinedColumns: ESQLFieldWithMetadata[]
 ) => {
   const columns: string[] = [];
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/keep/fields_suggestions_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/keep/fields_suggestions_after.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { synth } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { fieldsSuggestionsAfter } from './fields_suggestions_after';
 
 describe('fieldsSuggestionsAfterKeep', () => {
@@ -15,9 +15,9 @@ describe('fieldsSuggestionsAfterKeep', () => {
     const previousCommandFields = [
       { name: 'field1', type: 'keyword' },
       { name: 'field2', type: 'double' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
-    const userDefinedColumns = [] as ESQLRealField[];
+    const userDefinedColumns = [] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`KEEP field1`,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/keep/fields_suggestions_after.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/keep/fields_suggestions_after.ts
@@ -7,12 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { type ESQLAstCommand, walk } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 
 export const fieldsSuggestionsAfter = (
   command: ESQLAstCommand,
-  previousCommandFields: ESQLRealField[],
-  userDefinedColumns: ESQLRealField[]
+  previousCommandFields: ESQLFieldWithMetadata[],
+  userDefinedColumns: ESQLFieldWithMetadata[]
 ) => {
   const columnsToKeep: string[] = [];
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/rename/fields_suggestions_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/rename/fields_suggestions_after.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { synth } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { fieldsSuggestionsAfter } from './fields_suggestions_after';
 
 describe('RENAME', () => {
@@ -15,9 +15,9 @@ describe('RENAME', () => {
     const previousCommandFields = [
       { name: 'field1', type: 'keyword' },
       { name: 'field2', type: 'double' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
-    const userDefinedColumns = [] as ESQLRealField[];
+    const userDefinedColumns = [] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`RENAME field1 as meow`,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/rename/fields_suggestions_after.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/rename/fields_suggestions_after.ts
@@ -12,13 +12,13 @@ import {
   type ESQLAstRenameExpression,
   type ESQLAstBaseItem,
 } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { isOptionItem } from '../../../shared/helpers';
 
 export const fieldsSuggestionsAfter = (
   command: ESQLAstCommand,
-  previousCommandFields: ESQLRealField[],
-  userDefinedColumns: ESQLRealField[]
+  previousCommandFields: ESQLFieldWithMetadata[],
+  userDefinedColumns: ESQLFieldWithMetadata[]
 ) => {
   const currentColumns: string[] = [];
   const renamePairs: ESQLAstRenameExpression[] = [];

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/fields_suggestions_after.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/fields_suggestions_after.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import { synth } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { fieldsSuggestionsAfter } from './fields_suggestions_after';
 
 describe('STATS', () => {
@@ -15,9 +15,9 @@ describe('STATS', () => {
     const previousCommandFields = [
       { name: 'field1', type: 'keyword' },
       { name: 'field2', type: 'double' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
-    const userDefinedColumns = [{ name: 'var0', type: 'double' }] as ESQLRealField[];
+    const userDefinedColumns = [{ name: 'var0', type: 'double' }] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`STATS var0=AVG(field2)`,
@@ -32,9 +32,9 @@ describe('STATS', () => {
     const previousCommandFields = [
       { name: 'field1', type: 'keyword' },
       { name: 'field2', type: 'double' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
-    const userDefinedColumns = [{ name: 'AVG(field2)', type: 'double' }] as ESQLRealField[];
+    const userDefinedColumns = [{ name: 'AVG(field2)', type: 'double' }] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`STATS AVG(field2)`,
@@ -49,9 +49,9 @@ describe('STATS', () => {
     const previousCommandFields = [
       { name: 'field1', type: 'keyword' },
       { name: 'field2', type: 'double' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
-    const userDefinedColumns = [{ name: 'AVG(field2)', type: 'double' }] as ESQLRealField[];
+    const userDefinedColumns = [{ name: 'AVG(field2)', type: 'double' }] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`STATS AVG(field2) BY field1`,
@@ -70,12 +70,12 @@ describe('STATS', () => {
       { name: 'field1', type: 'keyword' },
       { name: 'field2', type: 'double' },
       { name: '@timestamp', type: 'date' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
     const userDefinedColumns = [
       { name: 'AVG(field2)', type: 'double' },
       { name: 'buckets', type: 'unknown' },
-    ] as ESQLRealField[];
+    ] as ESQLFieldWithMetadata[];
 
     const result = fieldsSuggestionsAfter(
       synth.cmd`STATS AVG(field2) BY buckets=BUCKET(@timestamp,50,?_tstart,?_tend)`,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/fields_suggestions_after.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/commands/stats/fields_suggestions_after.ts
@@ -8,13 +8,13 @@
  */
 import { uniqBy } from 'lodash';
 import { type ESQLAstCommand, walk } from '@kbn/esql-ast';
-import type { ESQLRealField } from '../../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../../validation/types';
 import { isColumnItem } from '../../../shared/helpers';
 
 export const fieldsSuggestionsAfter = (
   command: ESQLAstCommand,
-  previousCommandFields: ESQLRealField[],
-  userDefinedColumns: ESQLRealField[]
+  previousCommandFields: ESQLFieldWithMetadata[],
+  userDefinedColumns: ESQLFieldWithMetadata[]
 ) => {
   const columns: string[] = [];
 

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/factories.ts
@@ -25,7 +25,7 @@ import {
 import { shouldBeQuotedSource, shouldBeQuotedText } from '../shared/helpers';
 import { buildFunctionDocumentation } from './documentation_util';
 import { DOUBLE_BACKTICK, SINGLE_TICK_REGEX } from '../shared/constants';
-import { ESQLRealField } from '../validation/types';
+import { ESQLFieldWithMetadata } from '../validation/types';
 import { getTestFunctions } from '../shared/test_functions';
 import { operatorsDefinitions } from '../definitions/all_operators';
 
@@ -199,7 +199,7 @@ export const getSuggestionsAfterNot = (): SuggestionRawDefinition[] => {
 };
 
 export const buildFieldsDefinitionsWithMetadata = (
-  fields: ESQLRealField[],
+  fields: ESQLFieldWithMetadata[],
   options?: {
     advanceCursor?: boolean;
     openSuggestions?: boolean;

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/helper.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/helper.ts
@@ -47,7 +47,7 @@ import {
   isLiteralItem,
   isTimeIntervalItem,
 } from '../shared/helpers';
-import { ESQLRealField, ESQLUserDefinedColumn, ReferenceMaps } from '../validation/types';
+import { ESQLFieldWithMetadata, ESQLUserDefinedColumn, ReferenceMaps } from '../validation/types';
 import { listCompleteItem } from './complete_items';
 import {
   TIME_SYSTEM_PARAMS,
@@ -267,7 +267,7 @@ export function isLiteralDateItem(nodeArg: ESQLAstItem): boolean {
 export function getValidSignaturesAndTypesToSuggestNext(
   node: ESQLFunction,
   references: {
-    fields: Map<string, ESQLRealField>;
+    fields: Map<string, ESQLFieldWithMetadata>;
     userDefinedColumns: Map<string, ESQLUserDefinedColumn[]>;
   },
   fnDefinition: FunctionDefinition,

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/utils/ecs_metadata_helper.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/utils/ecs_metadata_helper.test.ts
@@ -7,12 +7,12 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ESQLRealField } from '../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../validation/types';
 import { type ECSMetadata, enrichFieldsWithECSInfo } from './ecs_metadata_helper';
 
 describe('enrichFieldsWithECSInfo', () => {
   it('should return original columns if fieldsMetadata is not provided', async () => {
-    const columns: ESQLRealField[] = [
+    const columns: ESQLFieldWithMetadata[] = [
       { name: 'ecs.version', type: 'keyword' },
       { name: 'field1', type: 'text' },
       { name: 'field2', type: 'double' },
@@ -23,7 +23,7 @@ describe('enrichFieldsWithECSInfo', () => {
   });
 
   it('should return columns with metadata if both name and type match with ECS fields', async () => {
-    const columns: ESQLRealField[] = [
+    const columns: ESQLFieldWithMetadata[] = [
       { name: 'ecs.field', type: 'text' },
       { name: 'ecs.fakeBooleanField', type: 'boolean' },
       { name: 'field2', type: 'double' },
@@ -65,7 +65,7 @@ describe('enrichFieldsWithECSInfo', () => {
   });
 
   it('should handle keyword suffix correctly', async () => {
-    const columns: ESQLRealField[] = [
+    const columns: ESQLFieldWithMetadata[] = [
       { name: 'ecs.version', type: 'keyword' },
       { name: 'ecs.version.keyword', type: 'keyword' },
       { name: 'field2', type: 'double' },

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/utils/ecs_metadata_helper.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/autocomplete/utils/ecs_metadata_helper.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { ESQLRealField } from '../../validation/types';
+import type { ESQLFieldWithMetadata } from '../../validation/types';
 
 const removeKeywordSuffix = (name: string) => {
   return name.endsWith('.keyword') ? name.slice(0, -8) : name;
@@ -29,9 +29,9 @@ export interface ECSMetadata {
  * @returns
  */
 export function enrichFieldsWithECSInfo(
-  columns: Array<Omit<ESQLRealField, 'metadata'>>,
+  columns: Array<Omit<ESQLFieldWithMetadata, 'metadata'>>,
   ecsMetadataCache?: ECSMetadata
-): ESQLRealField[] {
+): ESQLFieldWithMetadata[] {
   if (!ecsMetadataCache) return columns;
 
   try {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands_helpers.ts
@@ -24,7 +24,7 @@ import {
 } from '../shared/helpers';
 import { FieldType, FunctionDefinitionTypes } from './types';
 import { getMessageFromId } from '../validation/errors';
-import { ESQLRealField } from '../validation/types';
+import { ESQLFieldWithMetadata } from '../validation/types';
 
 function isAggregation(arg: ESQLAstItem): arg is ESQLFunction {
   return (
@@ -112,7 +112,7 @@ export const ENRICH_MODES = [
 
 export const validateColumnForGrokDissect = (
   command: ESQLCommand,
-  { fields }: { fields: Map<string, ESQLRealField> }
+  { fields }: { fields: Map<string, ESQLFieldWithMetadata> }
 ) => {
   const acceptedColumnTypes: FieldType[] = ['keyword', 'text'];
   const astCol = command.args[0] as ESQLColumn;

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/types.ts
@@ -16,7 +16,7 @@ import type {
 } from '@kbn/esql-ast';
 import { ESQLControlVariable } from '@kbn/esql-types';
 import { GetColumnsByTypeFn, SuggestionRawDefinition } from '../autocomplete/types';
-import type { ESQLPolicy, ReferenceMaps, ESQLRealField } from '../validation/types';
+import type { ESQLPolicy, ReferenceMaps, ESQLFieldWithMetadata } from '../validation/types';
 import { ESQLCallbacks, ESQLSourceResult } from '../shared/types';
 
 /**
@@ -427,9 +427,9 @@ export interface CommandDefinition<CommandName extends string> {
    */
   fieldsSuggestionsAfter?: (
     lastCommand: ESQLAstCommand,
-    previousCommandFields: ESQLRealField[],
-    userDefinedColumns: ESQLRealField[]
-  ) => ESQLRealField[];
+    previousCommandFields: ESQLFieldWithMetadata[],
+    userDefinedColumns: ESQLFieldWithMetadata[]
+  ) => ESQLFieldWithMetadata[];
 }
 
 export interface CommandTypeDefinition {

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/helpers.ts
@@ -48,7 +48,11 @@ import {
   FunctionDefinitionTypes,
   getLocationFromCommandOrOptionName,
 } from '../definitions/types';
-import type { ESQLRealField, ESQLUserDefinedColumn, ReferenceMaps } from '../validation/types';
+import type {
+  ESQLFieldWithMetadata,
+  ESQLUserDefinedColumn,
+  ReferenceMaps,
+} from '../validation/types';
 import { removeMarkerArgFromArgsList } from './context';
 import type { ReasonTypes, ESQLCallbacks } from './types';
 import { DOUBLE_TICKS_REGEX, EDITOR_MARKER, SINGLE_BACKTICK } from './constants';
@@ -259,7 +263,7 @@ function doesLiteralMatchParameterType(argType: FunctionParameterType, item: ESQ
 export function getColumnForASTNode(
   node: ESQLColumn | ESQLIdentifier,
   { fields, userDefinedColumns }: Pick<ReferenceMaps, 'fields' | 'userDefinedColumns'>
-): ESQLRealField | ESQLUserDefinedColumn | undefined {
+): ESQLFieldWithMetadata | ESQLUserDefinedColumn | undefined {
   const formatted = node.type === 'identifier' ? node.name : node.parts.join('.');
   return getColumnByName(formatted, { fields, userDefinedColumns });
 }
@@ -282,7 +286,7 @@ export function unescapeColumnName(columnName: string) {
 export function getColumnByName(
   columnName: string,
   { fields, userDefinedColumns }: Pick<ReferenceMaps, 'fields' | 'userDefinedColumns'>
-): ESQLRealField | ESQLUserDefinedColumn | undefined {
+): ESQLFieldWithMetadata | ESQLUserDefinedColumn | undefined {
   const unescaped = unescapeColumnName(columnName);
   return fields.get(unescaped) || userDefinedColumns.get(unescaped)?.[0];
 }
@@ -549,7 +553,7 @@ export function hasWildcard(name: string) {
   return /\*/.test(name);
 }
 export function isUserDefinedColumn(
-  column: ESQLRealField | ESQLUserDefinedColumn | undefined
+  column: ESQLFieldWithMetadata | ESQLUserDefinedColumn | undefined
 ): column is ESQLUserDefinedColumn {
   return Boolean(column && 'location' in column);
 }
@@ -813,7 +817,7 @@ export function getParamAtPosition(
  */
 export function getExpressionType(
   root: ESQLAstItem | undefined,
-  fields?: Map<string, ESQLRealField>,
+  fields?: Map<string, ESQLFieldWithMetadata>,
   userDefinedColumns?: Map<string, ESQLUserDefinedColumn[]>
 ): SupportedDataType | 'unknown' {
   if (!root) {
@@ -933,16 +937,16 @@ export function getExpressionType(
   return 'unknown';
 }
 
-export function transformMapToRealFields(
+export function transformMapToESQLFields(
   inputMap: Map<string, ESQLUserDefinedColumn[]>
-): ESQLRealField[] {
-  const realFields: ESQLRealField[] = [];
+): ESQLFieldWithMetadata[] {
+  const esqlFields: ESQLFieldWithMetadata[] = [];
 
   for (const [, userDefinedColumns] of inputMap) {
     for (const userDefinedColumn of userDefinedColumns) {
       // Only include userDefinedColumns that have a known type
       if (userDefinedColumn.type) {
-        realFields.push({
+        esqlFields.push({
           name: userDefinedColumn.name,
           type: userDefinedColumn.type as FieldType,
         });
@@ -950,7 +954,7 @@ export function transformMapToRealFields(
     }
   }
 
-  return realFields;
+  return esqlFields;
 }
 
 async function getEcsMetadata(resourceRetriever?: ESQLCallbacks) {
@@ -982,9 +986,9 @@ export async function getFieldsFromES(query: string, resourceRetriever?: ESQLCal
 export async function getCurrentQueryAvailableFields(
   query: string,
   commands: ESQLAstCommand[],
-  previousPipeFields: ESQLRealField[]
+  previousPipeFields: ESQLFieldWithMetadata[]
 ) {
-  const cacheCopy = new Map<string, ESQLRealField>();
+  const cacheCopy = new Map<string, ESQLFieldWithMetadata>();
   previousPipeFields?.forEach((field) => cacheCopy.set(field.name, field));
   const lastCommand = commands[commands.length - 1];
   const commandDef = getCommandDefinition(lastCommand.name);
@@ -992,7 +996,7 @@ export async function getCurrentQueryAvailableFields(
   // If the command has a fieldsSuggestionsAfter function, use it to get the fields
   if (commandDef.fieldsSuggestionsAfter) {
     const userDefinedColumns = collectUserDefinedColumns([lastCommand], cacheCopy, query);
-    const arrayOfUserDefinedColumns: ESQLRealField[] = transformMapToRealFields(
+    const arrayOfUserDefinedColumns: ESQLFieldWithMetadata[] = transformMapToESQLFields(
       userDefinedColumns ?? new Map<string, ESQLUserDefinedColumn[]>()
     );
 
@@ -1004,7 +1008,7 @@ export async function getCurrentQueryAvailableFields(
   } else {
     // If the command doesn't have a fieldsSuggestionsAfter function, use the default behavior
     const userDefinedColumns = collectUserDefinedColumns(commands, cacheCopy, query);
-    const arrayOfUserDefinedColumns: ESQLRealField[] = transformMapToRealFields(
+    const arrayOfUserDefinedColumns: ESQLFieldWithMetadata[] = transformMapToESQLFields(
       userDefinedColumns ?? new Map<string, ESQLUserDefinedColumn[]>()
     );
     const allFields = uniqBy([...(previousPipeFields ?? []), ...arrayOfUserDefinedColumns], 'name');

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/resources_helpers.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/resources_helpers.ts
@@ -8,7 +8,7 @@
  */
 import { type ESQLAst, parse } from '@kbn/esql-ast';
 import type { ESQLCallbacks } from './types';
-import type { ESQLRealField } from '../validation/types';
+import type { ESQLFieldWithMetadata } from '../validation/types';
 import { getFieldsFromES, getCurrentQueryAvailableFields } from './helpers';
 import {
   removeLastPipe,
@@ -24,7 +24,7 @@ export function buildQueryUntilPreviousCommand(ast: ESQLAst, queryString: string
   return prevCommand ? queryString.substring(0, prevCommand.location.max + 1) : queryString;
 }
 
-const cache = new Map<string, ESQLRealField[]>();
+const cache = new Map<string, ESQLFieldWithMetadata[]>();
 
 // Function to check if a key exists in the cache, ignoring case
 function checkCacheInsensitive(keyToCheck: string) {
@@ -96,7 +96,7 @@ export function getFieldsByTypeHelper(queryText: string, resourceRetriever?: ESQ
     getFieldsByType: async (
       expectedType: Readonly<string> | Readonly<string[]> = 'any',
       ignored: string[] = []
-    ): Promise<ESQLRealField[]> => {
+    ): Promise<ESQLFieldWithMetadata[]> => {
       const types = Array.isArray(expectedType) ? expectedType : [expectedType];
       await getFields();
       const queryTextForCacheSearch = toSingleLine(queryText);
@@ -116,7 +116,7 @@ export function getFieldsByTypeHelper(queryText: string, resourceRetriever?: ESQ
       await getFields();
       const queryTextForCacheSearch = toSingleLine(queryText);
       const cachedFields = getValueInsensitive(queryTextForCacheSearch);
-      const cacheCopy = new Map<string, ESQLRealField>();
+      const cacheCopy = new Map<string, ESQLFieldWithMetadata>();
       cachedFields?.forEach((field) => cacheCopy.set(field.name, field));
       return cacheCopy;
     },

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/types.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import type { ESQLControlVariable } from '@kbn/esql-types';
-import type { ESQLRealField, JoinIndexAutocompleteItem } from '../validation/types';
+import type { ESQLFieldWithMetadata, JoinIndexAutocompleteItem } from '../validation/types';
 
 /** @internal **/
 type CallbackFn<Options = {}, Result = string> = (ctx?: Options) => Result[] | Promise<Result[]>;
@@ -39,7 +39,7 @@ export interface ESQLSourceResult {
 
 export interface ESQLCallbacks {
   getSources?: CallbackFn<{}, ESQLSourceResult>;
-  getColumnsFor?: CallbackFn<{ query: string }, ESQLRealField>;
+  getColumnsFor?: CallbackFn<{ query: string }, ESQLFieldWithMetadata>;
   getPolicies?: CallbackFn<
     {},
     { name: string; sourceIndices: string[]; matchField: string; enrichFields: string[] }

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/user_defined_columns.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/user_defined_columns.ts
@@ -9,7 +9,7 @@
 
 import type { ESQLAst, ESQLAstItem, ESQLCommand, ESQLFunction } from '@kbn/esql-ast';
 import { Visitor } from '@kbn/esql-ast/src/visitor';
-import type { ESQLUserDefinedColumn, ESQLRealField } from '../validation/types';
+import type { ESQLUserDefinedColumn, ESQLFieldWithMetadata } from '../validation/types';
 import { EDITOR_MARKER } from './constants';
 import { isColumnItem, isFunctionItem, getExpressionType } from './helpers';
 
@@ -27,7 +27,7 @@ function addToUserDefinedColumnOccurrences(
 function addToUserDefinedColumns(
   oldArg: ESQLAstItem,
   newArg: ESQLAstItem,
-  fields: Map<string, ESQLRealField>,
+  fields: Map<string, ESQLFieldWithMetadata>,
   userDefinedColumns: Map<string, ESQLUserDefinedColumn[]>
 ) {
   if (isColumnItem(oldArg) && isColumnItem(newArg)) {
@@ -50,7 +50,7 @@ function addToUserDefinedColumns(
 export function excludeUserDefinedColumnsFromCurrentCommand(
   commands: ESQLCommand[],
   currentCommand: ESQLCommand,
-  fieldsMap: Map<string, ESQLRealField>,
+  fieldsMap: Map<string, ESQLFieldWithMetadata>,
   queryString: string
 ) {
   const anyUserDefinedColumns = collectUserDefinedColumns(commands, fieldsMap, queryString);
@@ -71,7 +71,7 @@ export function excludeUserDefinedColumnsFromCurrentCommand(
 function addUserDefinedColumnFromAssignment(
   assignOperation: ESQLFunction,
   userDefinedColumns: Map<string, ESQLUserDefinedColumn[]>,
-  fields: Map<string, ESQLRealField>
+  fields: Map<string, ESQLFieldWithMetadata>
 ) {
   if (isColumnItem(assignOperation.args[0])) {
     const rightHandSideArgType = getExpressionType(
@@ -91,7 +91,7 @@ function addUserDefinedColumnFromExpression(
   expressionOperation: ESQLFunction,
   queryString: string,
   userDefinedColumns: Map<string, ESQLUserDefinedColumn[]>,
-  fields: Map<string, ESQLRealField>
+  fields: Map<string, ESQLFieldWithMetadata>
 ) {
   if (!expressionOperation.text.includes(EDITOR_MARKER)) {
     const expressionText = queryString.substring(
@@ -109,7 +109,7 @@ function addUserDefinedColumnFromExpression(
 
 export function collectUserDefinedColumns(
   ast: ESQLAst,
-  fields: Map<string, ESQLRealField>,
+  fields: Map<string, ESQLFieldWithMetadata>,
   queryString: string
 ): Map<string, ESQLUserDefinedColumn[]> {
   const userDefinedColumns = new Map<string, ESQLUserDefinedColumn[]>();

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/resources.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/resources.ts
@@ -20,13 +20,13 @@ import {
   buildQueryForFieldsFromSource,
   buildQueryForFieldsInPolicies,
 } from './helpers';
-import type { ESQLRealField, ESQLPolicy } from './types';
+import type { ESQLFieldWithMetadata, ESQLPolicy } from './types';
 
 export async function retrieveFields(
   queryString: string,
   commands: ESQLCommand[],
   callbacks?: ESQLCallbacks
-): Promise<Map<string, ESQLRealField>> {
+): Promise<Map<string, ESQLFieldWithMetadata>> {
   if (!callbacks || commands.length < 1) {
     return new Map();
   }
@@ -78,7 +78,7 @@ export async function retrievePoliciesFields(
   commands: ESQLCommand[],
   policies: Map<string, ESQLPolicy>,
   callbacks?: ESQLCallbacks
-): Promise<Map<string, ESQLRealField>> {
+): Promise<Map<string, ESQLFieldWithMetadata>> {
   if (!callbacks) {
     return new Map();
   }
@@ -103,7 +103,7 @@ export async function retrieveFieldsFromStringSources(
   queryString: string,
   commands: ESQLCommand[],
   callbacks?: ESQLCallbacks
-): Promise<Map<string, ESQLRealField>> {
+): Promise<Map<string, ESQLFieldWithMetadata>> {
   if (!callbacks) {
     return new Map();
   }

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/types.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/types.ts
@@ -20,7 +20,7 @@ export interface ESQLUserDefinedColumn {
   location: ESQLLocation;
 }
 
-export interface ESQLRealField {
+export interface ESQLFieldWithMetadata {
   name: string;
   type: FieldType;
   isEcs?: boolean;
@@ -40,7 +40,7 @@ export interface ESQLPolicy {
 export interface ReferenceMaps {
   sources: Set<string>;
   userDefinedColumns: Map<string, ESQLUserDefinedColumn[]>;
-  fields: Map<string, ESQLRealField>;
+  fields: Map<string, ESQLFieldWithMetadata>;
   policies: Map<string, ESQLPolicy>;
   query: string;
   joinIndices: JoinIndexAutocompleteItem[];

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/validation/validation.ts
@@ -46,7 +46,7 @@ import {
   retrieveSources,
 } from './resources';
 import type {
-  ESQLRealField,
+  ESQLFieldWithMetadata,
   ESQLUserDefinedColumn,
   ErrorTypes,
   ReferenceMaps,
@@ -335,7 +335,7 @@ function validateOption(
 }
 
 function validateFieldsShadowing(
-  fields: Map<string, ESQLRealField>,
+  fields: Map<string, ESQLFieldWithMetadata>,
   userDefinedColumns: Map<string, ESQLUserDefinedColumn[]>
 ) {
   const messages: ESQLMessage[] = [];
@@ -370,7 +370,7 @@ function validateFieldsShadowing(
   return messages;
 }
 
-function validateUnsupportedTypeFields(fields: Map<string, ESQLRealField>, ast: ESQLAst) {
+function validateUnsupportedTypeFields(fields: Map<string, ESQLFieldWithMetadata>, ast: ESQLAst) {
   const usedColumnsInQuery: string[] = [];
 
   walk(ast, {

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/hover/hover.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/hover/hover.test.ts
@@ -8,7 +8,7 @@
  */
 
 import {
-  ESQLRealField,
+  ESQLFieldWithMetadata,
   getFunctionDefinition,
   getFunctionSignatures,
 } from '@kbn/esql-validation-autocomplete';
@@ -20,7 +20,7 @@ import { getHoverItem } from './hover';
 
 const types: FieldType[] = ['keyword', 'double', 'date', 'boolean', 'ip'];
 
-const fields: Array<ESQLRealField & { suggestedAs?: string }> = [
+const fields: Array<ESQLFieldWithMetadata & { suggestedAs?: string }> = [
   ...types.map((type) => ({
     name: `${type}Field`,
     type,
@@ -61,7 +61,7 @@ const policies = [
 ];
 
 function createCustomCallbackMocks(
-  customFields: ESQLRealField[] | undefined,
+  customFields: ESQLFieldWithMetadata[] | undefined,
   customSources: Array<{ name: string; hidden: boolean }> | undefined,
   customPolicies:
     | Array<{

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/hover/hover.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/lib/hover/hover.ts
@@ -15,7 +15,7 @@ import {
   isESQLNamedParamLiteral,
 } from '@kbn/esql-ast/src/types';
 import {
-  ESQLRealField,
+  ESQLFieldWithMetadata,
   collectUserDefinedColumns,
   getFunctionDefinition,
   getFunctionSignatures,
@@ -179,7 +179,7 @@ async function getHintForFunctionArg(
   if (!fnDefinition) {
     return [];
   }
-  const fieldsMap: Map<string, ESQLRealField> = await getFieldsMap();
+  const fieldsMap: Map<string, ESQLFieldWithMetadata> = await getFieldsMap();
   const anyUserDefinedColumns = collectUserDefinedColumns(root.commands, fieldsMap, query);
 
   const references = {


### PR DESCRIPTION
## Summary

Improves the naming of the `ESQLRealField` type






<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->