### PR TITLE
[Security Solution][AI4SOC] Rules navigation workaround

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/app/links/deep_links.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/app/links/deep_links.ts
@@ -94,7 +94,7 @@ const solutionNodesFormatter = (
     // Process security links
     const appLink = normalizedLinks[node.id as SecurityPageName];
     if (appLink) {
-      const deepLink = formatDeepLink(appLink);
+      const deepLink = formatDeepLink(appLink, node);
       if (node.children) {
         const childrenLinks = solutionNodesFormatter(node.children, normalizedLinks);
         if (childrenLinks.length > 0) {
@@ -114,9 +114,9 @@ const solutionNodesFormatter = (
   return deepLinks;
 };
 
-const formatDeepLink = (appLink: LinkItem): AppDeepLink => {
+const formatDeepLink = (appLink: LinkItem, node: NodeDefinition): AppDeepLink => {
   const visibleIn: Set<AppDeepLinkLocations> = new Set(appLink.visibleIn ?? []);
-  if (!appLink.globalSearchDisabled) {
+  if (!appLink.globalSearchDisabled && node.sideNavStatus !== 'hidden') {
     visibleIn.add('globalSearch');
   }
   if (!appLink.sideNavDisabled) {

--- a/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
+++ b/x-pack/solutions/security/plugins/security_solution_serverless/public/navigation/ai_navigation/ai_navigation_tree.ts
@@ -61,6 +61,14 @@ export const createAiNavigationTree = (): NavigationTreeDefinition => ({
                 {
                   id: SecurityPageName.configurationsBasicRules,
                   link: securityLink(SecurityPageName.configurationsBasicRules),
+                  children: [
+                    {
+                      id: SecurityPageName.rules,
+                      link: securityLink(SecurityPageName.rules),
+                      breadcrumbStatus: 'hidden',
+                      sideNavStatus: 'hidden',
+                    },
+                  ],
                 },
                 {
                   id: SecurityPageName.configurationsAiSettings,


### PR DESCRIPTION
## Summary

Adds the rules links hidden in the search AI lake tier.

### Issue

https://github.com/elastic/kibana/issues/219792

The problem is that the _Rule details_ page, which should be available, is a child of the main _Rules_ page, which is not available in this tier.

- Rules // not available
  - Rules create // not available
  - Rule details // available

The main _rules_ `deepLinkId` is passed to the component to navigate to the details page. However, this deepLink was not registered since it's not available in this tier:

https://github.com/elastic/kibana/blob/c5312e7d61daa44f96ffe75f4d6b767fca3acbba/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/use_columns.tsx#L132-L136

When the link is clicked, the Kibana navigation logic redirects to the landing page as a fallback because the deep link provided is not found.

### Workaround

Make the Rules page available but hidden, including:

- Navigation
- Breadcrumbs
- Global search


