### PR TITLE
[8.19] [Observability] Make create annotations form keyboard navigable (#217918)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/components/annotations/annotation_form.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/annotations/annotation_form.tsx
@@ -18,7 +18,7 @@ import { AnnotationRange } from './components/annotation_range';
 import { AnnotationAppearance } from './annotation_apearance';
 
 export function AnnotationForm({ editAnnotation }: { editAnnotation?: Annotation | null }) {
-  const { control, formState, watch, trigger, unregister, setValue } =
+  const { control, formState, watch, unregister, setValue } =
     useFormContext<CreateAnnotationForm>();
 
   const timestampStart = watch('@timestamp');
@@ -77,11 +77,6 @@ export function AnnotationForm({ editAnnotation }: { editAnnotation?: Annotation
               isInvalid={fieldState.invalid}
               compressed
               data-test-subj="annotationTitle"
-              onBlur={() => {
-                field.onBlur();
-                // this is done to avoid too many re-renders, watch on name is expensive
-                trigger();
-              }}
             />
           )}
         />
@@ -106,11 +101,6 @@ export function AnnotationForm({ editAnnotation }: { editAnnotation?: Annotation
               isInvalid={fieldState.invalid}
               compressed
               data-test-subj="annotationMessage"
-              onBlur={() => {
-                field.onBlur();
-                // this is done to avoid too many re-renders, watch on name is expensive
-                trigger();
-              }}
             />
           )}
         />


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Observability] Make create annotations form keyboard navigable (#217918)](https://github.com/elastic/kibana/pull/217918)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Justin Kambic","email":"jk@elastic.co"},"sourceCommit":{"committedDate":"2025-04-22T12:45:10Z","message":"[Observability] Make create annotations form keyboard navigable (#217918)\n\n## Summary\n\nPartially addresses #210531.\n\nThis doesn't fully fix the ticket linked, as elements that control the\nannotation look in the second half of the form still trigger re-renders.\nThis means the focus will still be lost when those elements are\nmodified.\n\nThis is going to require significant refactoring of this form, but this\npatch will at least make the elements reachable via tabbing.\n\nThe custom `onBlur` removed here doesn't seem to impact the form and the\nrendering issues are prominent in any case.\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>","sha":"cc18709d015b016cb68ab450d25f0f0d2bbb1960","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","Team:obs-ux-management","v9.1.0","v9.0.1"],"title":"[Observability] Make create annotations form keyboard navigable","number":217918,"url":"https://github.com/elastic/kibana/pull/217918","mergeCommit":{"message":"[Observability] Make create annotations form keyboard navigable (#217918)\n\n## Summary\n\nPartially addresses #210531.\n\nThis doesn't fully fix the ticket linked, as elements that control the\nannotation look in the second half of the form still trigger re-renders.\nThis means the focus will still be lost when those elements are\nmodified.\n\nThis is going to require significant refactoring of this form, but this\npatch will at least make the elements reachable via tabbing.\n\nThe custom `onBlur` removed here doesn't seem to impact the form and the\nrendering issues are prominent in any case.\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>","sha":"cc18709d015b016cb68ab450d25f0f0d2bbb1960"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217918","number":217918,"mergeCommit":{"message":"[Observability] Make create annotations form keyboard navigable (#217918)\n\n## Summary\n\nPartially addresses #210531.\n\nThis doesn't fully fix the ticket linked, as elements that control the\nannotation look in the second half of the form still trigger re-renders.\nThis means the focus will still be lost when those elements are\nmodified.\n\nThis is going to require significant refactoring of this form, but this\npatch will at least make the elements reachable via tabbing.\n\nThe custom `onBlur` removed here doesn't seem to impact the form and the\nrendering issues are prominent in any case.\n\nCo-authored-by: Dominique Clarke <dominique.clarke@elastic.co>","sha":"cc18709d015b016cb68ab450d25f0f0d2bbb1960"}},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/218813","number":218813,"state":"MERGED","mergeCommit":{"sha":"9893145a6730e89eeb3afb1b19b83e1d61d2ee97","message":"[9.0] [Observability] Make create annotations form keyboard navigable (#217918) (#218813)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Observability] Make create annotations form keyboard navigable\n(#217918)](https://github.com/elastic/kibana/pull/217918)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Justin Kambic <jk@elastic.co>"}}]}] BACKPORT-->