### PR TITLE
[9.0] [APM][OTel] Change the alerts query to include environment not defined value (#219228)

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/common/environment_filter_values.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/environment_filter_values.ts
@@ -41,12 +41,8 @@ export const ENVIRONMENT_NOT_DEFINED = {
   label: getEnvironmentLabel(ENVIRONMENT_NOT_DEFINED_VALUE),
 };
 
-function isEnvironmentDefined(environment: string) {
-  return (
-    environment &&
-    environment !== ENVIRONMENT_NOT_DEFINED_VALUE &&
-    environment !== ENVIRONMENT_ALL_VALUE
-  );
+export function isEnvironmentDefined(environment: string) {
+  return environment && environment !== ENVIRONMENT_ALL_VALUE;
 }
 
 export function getEnvironmentEsField(environment: string) {

--- a/x-pack/solutions/observability/plugins/apm/common/utils/environment_query.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/utils/environment_query.test.ts
@@ -6,13 +6,17 @@
  */
 
 import { SERVICE_ENVIRONMENT } from '../es_fields/apm';
-import { ENVIRONMENT_NOT_DEFINED } from '../environment_filter_values';
+import { ENVIRONMENT_ALL, ENVIRONMENT_NOT_DEFINED } from '../environment_filter_values';
 import { environmentQuery } from './environment_query';
 
 describe('environmentQuery', () => {
   describe('when environment is an empty string', () => {
-    it('returns an empty query', () => {
-      expect(environmentQuery('')).toEqual([]);
+    it('returns ENVIRONMENT_NOT_DEFINED', () => {
+      expect(environmentQuery('')).toEqual([
+        {
+          term: { [SERVICE_ENVIRONMENT]: ENVIRONMENT_NOT_DEFINED.value },
+        },
+      ]);
     });
   });
 
@@ -24,10 +28,15 @@ describe('environmentQuery', () => {
     ]);
   });
 
+  it('creates a query for all environments', () => {
+    expect(environmentQuery(ENVIRONMENT_ALL.value)).toEqual([]);
+  });
+
   it('creates a query for missing service environments', () => {
-    expect(environmentQuery(ENVIRONMENT_NOT_DEFINED.value)[0]).toHaveProperty(
-      ['bool', 'must_not', 'exists', 'field'],
-      SERVICE_ENVIRONMENT
-    );
+    expect(environmentQuery(ENVIRONMENT_NOT_DEFINED.value)).toEqual([
+      {
+        term: { [SERVICE_ENVIRONMENT]: ENVIRONMENT_NOT_DEFINED.value },
+      },
+    ]);
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/common/utils/environment_query.ts
+++ b/x-pack/solutions/observability/plugins/apm/common/utils/environment_query.ts
@@ -14,6 +14,21 @@ export function environmentQuery(
   environment: string | undefined,
   field: string = SERVICE_ENVIRONMENT
 ): QueryDslQueryContainer[] {
+  if (environment === ENVIRONMENT_ALL.value) {
+    return [];
+  }
+
+  if (!environment || environment === ENVIRONMENT_NOT_DEFINED.value) {
+    return [{ term: { [field]: ENVIRONMENT_NOT_DEFINED.value } }];
+  }
+
+  return [{ term: { [field]: environment } }];
+}
+
+export function environmentQueryAnnotations(
+  environment: string | undefined,
+  field: string = SERVICE_ENVIRONMENT
+): QueryDslQueryContainer[] {
   if (!environment || environment === ENVIRONMENT_ALL.value) {
     return [];
   }

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts
@@ -724,7 +724,7 @@ describe('Error count alert', () => {
         threshold: 2,
         triggerValue: 5,
         viewInAppUrl:
-          'http://localhost:5601/eyr/app/apm/services/foo/errors?environment=ENVIRONMENT_ALL',
+          'http://localhost:5601/eyr/app/apm/services/foo/errors?environment=ENVIRONMENT_NOT_DEFINED',
       },
       id: 'foo_ENVIRONMENT_NOT_DEFINED',
       payload: {
@@ -750,7 +750,7 @@ describe('Error count alert', () => {
         threshold: 2,
         triggerValue: 4,
         viewInAppUrl:
-          'http://localhost:5601/eyr/app/apm/services/foo/errors?environment=ENVIRONMENT_ALL',
+          'http://localhost:5601/eyr/app/apm/services/foo/errors?environment=ENVIRONMENT_NOT_DEFINED',
       },
       id: 'foo_ENVIRONMENT_NOT_DEFINED',
       payload: {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
@@ -378,16 +378,6 @@ describe('registerTransactionDurationRuleType', () => {
           'http://localhost:5601/eyr/app/observability/alerts/'
         ),
         environment: 'All',
-        grouping: {
-          service: {
-            environment: 'ENVIRONMENT_ALL',
-            name: 'opbeans-java',
-          },
-          transaction: {
-            type: 'request',
-            name: 'tx-java',
-          },
-        },
         interval: '5 mins',
         reason:
           'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: All, type: request, name: tx-java. Alert when > 3.0 s.',

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
@@ -309,7 +309,7 @@ describe('registerTransactionDurationRuleType', () => {
         transactionType: 'request',
         triggerValue: '5,500 ms',
         viewInAppUrl:
-          'http://localhost:5601/eyr/app/apm/services/opbeans-java?transactionType=request&environment=ENVIRONMENT_ALL',
+          'http://localhost:5601/eyr/app/apm/services/opbeans-java?transactionType=request&environment=ENVIRONMENT_NOT_DEFINED',
       },
       id: 'opbeans-java_ENVIRONMENT_NOT_DEFINED_request_tx-java',
       payload: {
@@ -319,6 +319,94 @@ describe('registerTransactionDurationRuleType', () => {
           'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: Not defined, type: request, name: tx-java. Alert when > 3.0 s.',
         'processor.event': 'transaction',
         'service.environment': 'ENVIRONMENT_NOT_DEFINED',
+        'service.name': 'opbeans-java',
+        'transaction.name': 'tx-java',
+        'transaction.type': 'request',
+      },
+    });
+  });
+  it('sends alert when service.environment is ENVIRONMENT_ALL', async () => {
+    const { services, dependencies, executor } = createRuleTypeMocks();
+
+    registerTransactionDurationRuleType(dependencies);
+
+    services.scopedClusterClient.asCurrentUser.search.mockResponse({
+      hits: {
+        hits: [],
+        total: {
+          relation: 'eq',
+          value: 2,
+        },
+      },
+      aggregations: {
+        series: {
+          buckets: [
+            {
+              key: ['opbeans-java', 'ENVIRONMENT_ALL', 'request', 'tx-java'],
+              avgLatency: {
+                value: 5500000,
+              },
+            },
+          ],
+        },
+      },
+      took: 0,
+      timed_out: false,
+      _shards: {
+        failed: 0,
+        skipped: 0,
+        successful: 1,
+        total: 1,
+      },
+    });
+    services.alertsClient.report.mockReturnValue({ uuid: 'test-uuid' });
+
+    const params = {
+      threshold: 3000,
+      windowSize: 5,
+      windowUnit: 'm',
+      transactionType: 'request',
+      serviceName: 'opbeans-java',
+      aggregationType: 'avg',
+      groupBy: ['service.name', 'service.environment', 'transaction.type', 'transaction.name'],
+    };
+    await executor({ params });
+    expect(services.alertsClient.setAlertData).toHaveBeenCalledTimes(1);
+    expect(services.alertsClient.setAlertData).toHaveBeenCalledWith({
+      context: {
+        alertDetailsUrl: expect.stringContaining(
+          'http://localhost:5601/eyr/app/observability/alerts/'
+        ),
+        environment: 'All',
+        grouping: {
+          service: {
+            environment: 'ENVIRONMENT_ALL',
+            name: 'opbeans-java',
+          },
+          transaction: {
+            type: 'request',
+            name: 'tx-java',
+          },
+        },
+        interval: '5 mins',
+        reason:
+          'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: All, type: request, name: tx-java. Alert when > 3.0 s.',
+        serviceName: 'opbeans-java',
+        threshold: 3000,
+        transactionName: 'tx-java',
+        transactionType: 'request',
+        triggerValue: '5,500 ms',
+        viewInAppUrl:
+          'http://localhost:5601/eyr/app/apm/services/opbeans-java?transactionType=request&environment=ENVIRONMENT_ALL',
+      },
+      id: 'opbeans-java_ENVIRONMENT_ALL_request_tx-java',
+      payload: {
+        'kibana.alert.evaluation.threshold': 3000000,
+        'kibana.alert.evaluation.value': 5500000,
+        'kibana.alert.reason':
+          'Avg. latency is 5.5 s in the last 5 mins for service: opbeans-java, env: All, type: request, name: tx-java. Alert when > 3.0 s.',
+        'processor.event': 'transaction',
+        'service.environment': 'ENVIRONMENT_ALL',
         'service.name': 'opbeans-java',
         'transaction.name': 'tx-java',
         'transaction.type': 'request',

--- a/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.test.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.test.ts
@@ -479,7 +479,7 @@ describe('Transaction error rate alert', () => {
         transactionType: 'type-foo',
         triggerValue: '10',
         viewInAppUrl:
-          'http://localhost:5601/eyr/app/apm/services/foo?transactionType=type-foo&environment=ENVIRONMENT_ALL',
+          'http://localhost:5601/eyr/app/apm/services/foo?transactionType=type-foo&environment=ENVIRONMENT_NOT_DEFINED',
       },
       id: 'foo_ENVIRONMENT_NOT_DEFINED_type-foo',
       payload: {

--- a/x-pack/solutions/observability/plugins/apm/server/routes/services/annotations/get_derived_service_annotations.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/services/annotations/get_derived_service_annotations.ts
@@ -14,7 +14,7 @@ import { isFiniteNumber } from '../../../../common/utils/is_finite_number';
 import type { Annotation } from '../../../../common/annotations';
 import { AnnotationType } from '../../../../common/annotations';
 import { AT_TIMESTAMP, SERVICE_NAME, SERVICE_VERSION } from '../../../../common/es_fields/apm';
-import { environmentQuery } from '../../../../common/utils/environment_query';
+import { environmentQueryAnnotations } from '../../../../common/utils/environment_query';
 import {
   getBackwardCompatibleDocumentTypeFilter,
   getProcessorEventForTransactions,
@@ -39,7 +39,7 @@ export async function getDerivedServiceAnnotations({
   const filter: ESFilter[] = [
     { term: { [SERVICE_NAME]: serviceName } },
     ...getBackwardCompatibleDocumentTypeFilter(searchAggregatedTransactions),
-    ...environmentQuery(environment),
+    ...environmentQueryAnnotations(environment),
   ];
 
   const versions =

--- a/x-pack/solutions/observability/plugins/apm/server/routes/services/annotations/get_stored_annotations.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/services/annotations/get_stored_annotations.ts
@@ -15,7 +15,7 @@ import {
 import type { ESSearchResponse } from '@kbn/es-types';
 import type { Annotation as ESAnnotation } from '@kbn/observability-plugin/common/annotations';
 import type { ScopedAnnotationsClient } from '@kbn/observability-plugin/server';
-import { environmentQuery } from '../../../../common/utils/environment_query';
+import { environmentQueryAnnotations } from '../../../../common/utils/environment_query';
 import type { Annotation } from '../../../../common/annotations';
 import { AnnotationType } from '../../../../common/annotations';
 import { SERVICE_NAME } from '../../../../common/es_fields/apm';
@@ -48,7 +48,7 @@ export function getStoredAnnotations({
             { term: { tags: 'apm' } },
             { term: { [SERVICE_NAME]: serviceName } },
             ...rangeQuery(start, end),
-            ...environmentQuery(environment),
+            ...environmentQueryAnnotations(environment),
           ],
         },
       },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[APM][OTel] Change the alerts query to include environment not defined value (#219228)](https://github.com/elastic/kibana/pull/219228)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-04-29T10:16:58Z","message":"[APM][OTel] Change the alerts query to include environment not defined value (#219228)\n\nCloses #217914 \n\n## Summary\n\nThis PR fixes the issue with the alerts filtering when the service\nenvironment is not defined.\n\n\n![output](https://github.com/user-attachments/assets/05ef791a-1de4-4d06-bb2d-3b99b5f8afc4)\n\n## Testing\n- Using synthtrace (any scenario) inject some data: for example: \n```\n node scripts/synthtrace simple_trace --scenarioOpts pipeline=apmToOtel --live --uniqueIds\n```\n- Change the scenario - the same one, so the same services have one\nsynthrace env and one `undefined` (set the environment to `undefined`)\n- Run the scenario again in a different terminal (also using `live`\nwithout closing the previous one)\n- Configure some alert rules (that will generate alerts for both), for\nexample, latency > 1ms or error count > 0\n- Check the environment drop-down and the alerts tab (should behave the\nsame as in the description example here - the env filter should be\napplied to the table results and the alert count badge - similar on the\nservice inventory page - there we should retest with the\nhttps://github.com/elastic/kibana/pull/217899 changes when merged )\n \n\n![output1](https://github.com/user-attachments/assets/f77e6da1-8e60-4c8e-a1ee-c0e0e4a632e7)","sha":"bb025a82c94ef46105e914bf33a79cc7e13c3acc","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport missing","v9.0.0","Team:obs-ux-infra_services","backport:version","v9.1.0","v8.19.0","v9.0.1"],"title":"[APM][OTel] Change the alerts query to include environment not defined value","number":219228,"url":"https://github.com/elastic/kibana/pull/219228","mergeCommit":{"message":"[APM][OTel] Change the alerts query to include environment not defined value (#219228)\n\nCloses #217914 \n\n## Summary\n\nThis PR fixes the issue with the alerts filtering when the service\nenvironment is not defined.\n\n\n![output](https://github.com/user-attachments/assets/05ef791a-1de4-4d06-bb2d-3b99b5f8afc4)\n\n## Testing\n- Using synthtrace (any scenario) inject some data: for example: \n```\n node scripts/synthtrace simple_trace --scenarioOpts pipeline=apmToOtel --live --uniqueIds\n```\n- Change the scenario - the same one, so the same services have one\nsynthrace env and one `undefined` (set the environment to `undefined`)\n- Run the scenario again in a different terminal (also using `live`\nwithout closing the previous one)\n- Configure some alert rules (that will generate alerts for both), for\nexample, latency > 1ms or error count > 0\n- Check the environment drop-down and the alerts tab (should behave the\nsame as in the description example here - the env filter should be\napplied to the table results and the alert count badge - similar on the\nservice inventory page - there we should retest with the\nhttps://github.com/elastic/kibana/pull/217899 changes when merged )\n \n\n![output1](https://github.com/user-attachments/assets/f77e6da1-8e60-4c8e-a1ee-c0e0e4a632e7)","sha":"bb025a82c94ef46105e914bf33a79cc7e13c3acc"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219228","number":219228,"mergeCommit":{"message":"[APM][OTel] Change the alerts query to include environment not defined value (#219228)\n\nCloses #217914 \n\n## Summary\n\nThis PR fixes the issue with the alerts filtering when the service\nenvironment is not defined.\n\n\n![output](https://github.com/user-attachments/assets/05ef791a-1de4-4d06-bb2d-3b99b5f8afc4)\n\n## Testing\n- Using synthtrace (any scenario) inject some data: for example: \n```\n node scripts/synthtrace simple_trace --scenarioOpts pipeline=apmToOtel --live --uniqueIds\n```\n- Change the scenario - the same one, so the same services have one\nsynthrace env and one `undefined` (set the environment to `undefined`)\n- Run the scenario again in a different terminal (also using `live`\nwithout closing the previous one)\n- Configure some alert rules (that will generate alerts for both), for\nexample, latency > 1ms or error count > 0\n- Check the environment drop-down and the alerts tab (should behave the\nsame as in the description example here - the env filter should be\napplied to the table results and the alert count badge - similar on the\nservice inventory page - there we should retest with the\nhttps://github.com/elastic/kibana/pull/217899 changes when merged )\n \n\n![output1](https://github.com/user-attachments/assets/f77e6da1-8e60-4c8e-a1ee-c0e0e4a632e7)","sha":"bb025a82c94ef46105e914bf33a79cc7e13c3acc"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->