### PR TITLE
[8.19] [Infra UI][OTel] Use fields instead of _source in the metadata endpoint (#218869)

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/common/http_api/metadata_api.ts
+++ b/x-pack/solutions/observability/plugins/infra/common/http_api/metadata_api.ts
@@ -95,6 +95,10 @@ export const InfraMetadataInfoRT = rt.partial({
   '@timestamp': rt.string,
 });
 
+export const InfraMetadataFieldsRT = rt.partial({
+  fields: rt.record(rt.string, rt.union([rt.string, rt.array(rt.string), rt.null, rt.undefined])),
+});
+
 export const InfraMetadataInfoResponseRT = rt.partial({
   cloud: InfraMetadataCloudRT,
   host: InfraMetadataHostRT,
@@ -117,6 +121,8 @@ const InfraMetadataOptionalRT = rt.partial({
 export const InfraMetadataRT = rt.intersection([InfraMetadataRequiredRT, InfraMetadataOptionalRT]);
 
 export type InfraMetadata = rt.TypeOf<typeof InfraMetadataRT>;
+
+export type InfraMetadataFields = rt.TypeOf<typeof InfraMetadataFieldsRT>;
 
 export type InfraMetadataRequest = rt.TypeOf<typeof InfraMetadataRequestRT>;
 

--- a/x-pack/solutions/observability/plugins/infra/server/routes/metadata/lib/unflatten_metadata_info_fileds.test.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/metadata/lib/unflatten_metadata_info_fileds.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { unflattenMetadataInfoFields } from './unflatten_metadata_info_fileds';
+
+describe('unflattenMetadataInfoFields', () => {
+  it('should map fields with single values correctly', () => {
+    const fields = {
+      'host.name': ['host-1'],
+      'host.os.name': ['Linux'],
+      'agent.name': ['agent-1'],
+      'agent.version': ['8.0.0'],
+      'container.runtime': ['docker'],
+      'host.os.type': ['linux'],
+    };
+
+    const result: Record<string, any> = {};
+    unflattenMetadataInfoFields(result, { fields });
+
+    expect(result).toEqual({
+      host: {
+        name: 'host-1',
+        os: {
+          name: 'Linux',
+          type: 'linux',
+        },
+      },
+      agent: {
+        name: 'agent-1',
+        version: '8.0.0',
+      },
+      container: {
+        runtime: 'docker',
+      },
+    });
+  });
+
+  it('should map fields with multiple values as arrays', () => {
+    const fields = {
+      'host.name': ['host-1'],
+      'host.mac': ['36-5D-68-05-71-00', '16-40-2D-D3-28-73', '3E-DD-4B-37-4C-C2'],
+    };
+
+    const result: Record<string, any> = {};
+    unflattenMetadataInfoFields(result, { fields });
+
+    expect(result).toEqual({
+      host: {
+        name: 'host-1',
+        mac: ['36-5D-68-05-71-00', '16-40-2D-D3-28-73', '3E-DD-4B-37-4C-C2'],
+      },
+    });
+  });
+
+  it('should ignore null or undefined values', () => {
+    const fields = {
+      'host.name': ['host-1'],
+      'host.os.name': null,
+      'host.os.version': undefined,
+    };
+
+    const result: Record<string, any> = {};
+    unflattenMetadataInfoFields(result, { fields });
+
+    expect(result).toEqual({
+      host: {
+        name: 'host-1',
+      },
+    });
+  });
+
+  it('should handle empty fields object', () => {
+    const fields = {};
+
+    const result: Record<string, any> = {};
+    unflattenMetadataInfoFields(result, { fields });
+
+    expect(result).toEqual({});
+  });
+
+  it('should handle fields with arrays of length 1 as single values', () => {
+    const fields = {
+      'host.name': ['host-1'],
+      'host.os.name': ['Linux'],
+    };
+
+    const result: Record<string, any> = {};
+    unflattenMetadataInfoFields(result, { fields });
+
+    expect(result).toEqual({
+      host: {
+        name: 'host-1',
+        os: {
+          name: 'Linux',
+        },
+      },
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/infra/server/routes/metadata/lib/unflatten_metadata_info_fileds.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/metadata/lib/unflatten_metadata_info_fileds.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { castArray, isArray } from 'lodash';
+import { set } from '@kbn/safer-lodash-set';
+import type { InfraMetadataFields } from '../../../../common/http_api/metadata_api';
+
+export const unflattenMetadataInfoFields = (result = {}, hit: InfraMetadataFields) => {
+  for (const [field, value] of Object.entries(hit?.fields ?? {})) {
+    if (value !== null && value !== undefined) {
+      if (isArray(value) && value.length > 1) {
+        set(result, field, value);
+      } else {
+        set(result, field, castArray(value)[0]);
+      }
+    }
+  }
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Infra UI][OTel] Use fields instead of _source in the metadata endpoint (#218869)](https://github.com/elastic/kibana/pull/218869)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-04-24T17:06:35Z","message":"[Infra UI][OTel] Use fields instead of _source in the metadata endpoint (#218869)\n\nCloses \n## Summary\n\nThis PR adds metadata support for OTel in the asset details view. While\ndebugging the problem, I saw that inside the metadata endpoint query, we\nwere using `_source` instead of `fields`, so I changed the query. The\ndifference with the APM queries is that hare we request all `'host.*',\n'cloud.*', 'agent.*', 'container.*'` fields and not predefined ones\n(depending on the setup the fields may vary) That's why the logic I\nadded is slightly different from what we have in APM and we don't have\nthe predefined required/optional fields\n- Hosts\n\n![image](https://github.com/user-attachments/assets/21064423-4cf7-4d68-9664-f93e79f2f6e3)\n\n- Containers\n\n![image](https://github.com/user-attachments/assets/5906bd93-9cd8-4985-bb6a-8891cf9e478a)\n\n## Testing\n- Using the setup from the issue: \n- As a prerequisite, we need to have any Kubernetes setup locally. I\nwill add the steps I followed, as IMO it is easier to setup (especially\nafter adding this summary and not figuring it out):\n- I used mini kube: First, follow the guide to install\n[minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download)\nand then [helm](https://helm.sh/) - I used ` brew install helm` (also\nthe [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) utility\nto interact with the cluster)\n      - Then run: `minikube start`\n  - Create a serverless deployment \n- ⚠️ I couldn't make it work locally as the serverless auth is hard to\nsetup in serverless - for some reason the onboarding showed empty\n`elastic_otlp_endpoint ` :\n  \n<img width=\"1704\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/424b23cf-18dc-4076-8f0e-a3cbf14f00d0\"\n/>\n\nI also tried with adding a certificate from dev utils as\n`--certificate-authority=` and using `https://localhost:9200` but no\nluck :/ )\n  So I will use the PR project deployment\n\n✅ Tested on serverless\n<img width=\"1693\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0a90b1b4-ecf1-43cf-9f96-78c1ee4f0d23\"\n/>\n\n\n  - Go to the onboarding page and select:\n\n![image](https://github.com/user-attachments/assets/da10b40f-44e1-4a32-87ab-fb00fe2a9f3a)\n   - Follow the steps shown there \n- Go to Infra > inventory and open a host > go to metadata - clicking\none of:\n<img width=\"1452\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/65c3820e-4329-4195-9736-a9fc8bdb4d99\"\n/>\n\n- Using metricbeat for regressions (as the fields change affect it) \n   - run metricbeat (containers as well)\n   - go to Infra > inventory and open a host > go to metadata\n- go to Infra > inventory, select \"Container\" and open a container > go\nto metadata","sha":"6a8827bf758cc5856080998509a89f9d396598f0","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","ci:project-deploy-observability","Team:obs-ux-infra_services","ci:project-redeploy","v9.1.0","v8.19.0","v9.0.1"],"title":"[Infra UI][OTel] Use fields instead of _source in the metadata endpoint","number":218869,"url":"https://github.com/elastic/kibana/pull/218869","mergeCommit":{"message":"[Infra UI][OTel] Use fields instead of _source in the metadata endpoint (#218869)\n\nCloses \n## Summary\n\nThis PR adds metadata support for OTel in the asset details view. While\ndebugging the problem, I saw that inside the metadata endpoint query, we\nwere using `_source` instead of `fields`, so I changed the query. The\ndifference with the APM queries is that hare we request all `'host.*',\n'cloud.*', 'agent.*', 'container.*'` fields and not predefined ones\n(depending on the setup the fields may vary) That's why the logic I\nadded is slightly different from what we have in APM and we don't have\nthe predefined required/optional fields\n- Hosts\n\n![image](https://github.com/user-attachments/assets/21064423-4cf7-4d68-9664-f93e79f2f6e3)\n\n- Containers\n\n![image](https://github.com/user-attachments/assets/5906bd93-9cd8-4985-bb6a-8891cf9e478a)\n\n## Testing\n- Using the setup from the issue: \n- As a prerequisite, we need to have any Kubernetes setup locally. I\nwill add the steps I followed, as IMO it is easier to setup (especially\nafter adding this summary and not figuring it out):\n- I used mini kube: First, follow the guide to install\n[minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download)\nand then [helm](https://helm.sh/) - I used ` brew install helm` (also\nthe [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) utility\nto interact with the cluster)\n      - Then run: `minikube start`\n  - Create a serverless deployment \n- ⚠️ I couldn't make it work locally as the serverless auth is hard to\nsetup in serverless - for some reason the onboarding showed empty\n`elastic_otlp_endpoint ` :\n  \n<img width=\"1704\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/424b23cf-18dc-4076-8f0e-a3cbf14f00d0\"\n/>\n\nI also tried with adding a certificate from dev utils as\n`--certificate-authority=` and using `https://localhost:9200` but no\nluck :/ )\n  So I will use the PR project deployment\n\n✅ Tested on serverless\n<img width=\"1693\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0a90b1b4-ecf1-43cf-9f96-78c1ee4f0d23\"\n/>\n\n\n  - Go to the onboarding page and select:\n\n![image](https://github.com/user-attachments/assets/da10b40f-44e1-4a32-87ab-fb00fe2a9f3a)\n   - Follow the steps shown there \n- Go to Infra > inventory and open a host > go to metadata - clicking\none of:\n<img width=\"1452\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/65c3820e-4329-4195-9736-a9fc8bdb4d99\"\n/>\n\n- Using metricbeat for regressions (as the fields change affect it) \n   - run metricbeat (containers as well)\n   - go to Infra > inventory and open a host > go to metadata\n- go to Infra > inventory, select \"Container\" and open a container > go\nto metadata","sha":"6a8827bf758cc5856080998509a89f9d396598f0"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218869","number":218869,"mergeCommit":{"message":"[Infra UI][OTel] Use fields instead of _source in the metadata endpoint (#218869)\n\nCloses \n## Summary\n\nThis PR adds metadata support for OTel in the asset details view. While\ndebugging the problem, I saw that inside the metadata endpoint query, we\nwere using `_source` instead of `fields`, so I changed the query. The\ndifference with the APM queries is that hare we request all `'host.*',\n'cloud.*', 'agent.*', 'container.*'` fields and not predefined ones\n(depending on the setup the fields may vary) That's why the logic I\nadded is slightly different from what we have in APM and we don't have\nthe predefined required/optional fields\n- Hosts\n\n![image](https://github.com/user-attachments/assets/21064423-4cf7-4d68-9664-f93e79f2f6e3)\n\n- Containers\n\n![image](https://github.com/user-attachments/assets/5906bd93-9cd8-4985-bb6a-8891cf9e478a)\n\n## Testing\n- Using the setup from the issue: \n- As a prerequisite, we need to have any Kubernetes setup locally. I\nwill add the steps I followed, as IMO it is easier to setup (especially\nafter adding this summary and not figuring it out):\n- I used mini kube: First, follow the guide to install\n[minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download)\nand then [helm](https://helm.sh/) - I used ` brew install helm` (also\nthe [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) utility\nto interact with the cluster)\n      - Then run: `minikube start`\n  - Create a serverless deployment \n- ⚠️ I couldn't make it work locally as the serverless auth is hard to\nsetup in serverless - for some reason the onboarding showed empty\n`elastic_otlp_endpoint ` :\n  \n<img width=\"1704\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/424b23cf-18dc-4076-8f0e-a3cbf14f00d0\"\n/>\n\nI also tried with adding a certificate from dev utils as\n`--certificate-authority=` and using `https://localhost:9200` but no\nluck :/ )\n  So I will use the PR project deployment\n\n✅ Tested on serverless\n<img width=\"1693\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/0a90b1b4-ecf1-43cf-9f96-78c1ee4f0d23\"\n/>\n\n\n  - Go to the onboarding page and select:\n\n![image](https://github.com/user-attachments/assets/da10b40f-44e1-4a32-87ab-fb00fe2a9f3a)\n   - Follow the steps shown there \n- Go to Infra > inventory and open a host > go to metadata - clicking\none of:\n<img width=\"1452\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/65c3820e-4329-4195-9736-a9fc8bdb4d99\"\n/>\n\n- Using metricbeat for regressions (as the fields change affect it) \n   - run metricbeat (containers as well)\n   - go to Infra > inventory and open a host > go to metadata\n- go to Infra > inventory, select \"Container\" and open a container > go\nto metadata","sha":"6a8827bf758cc5856080998509a89f9d396598f0"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.1","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/219133","number":219133,"state":"MERGED","mergeCommit":{"sha":"ed0968df75a3348bd0d68d4612bc1e215e129c31","message":"[9.0] [Infra UI][OTel] Use fields instead of _source in the metadata endpoint (#218869) (#219133)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Infra UI][OTel] Use fields instead of _source in the metadata\nendpoint (#218869)](https://github.com/elastic/kibana/pull/218869)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: jennypavlova <dzheni.pavlova@elastic.co>"}}]}] BACKPORT-->