### PR TITLE
[8.19] added performance telemetry to profiling pages (#208832)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/app.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/app.tsx
@@ -8,6 +8,7 @@
 import type { AppMountParameters, CoreSetup, CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
+import { PerformanceContextProvider } from '@kbn/ebt-tools';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
@@ -91,29 +92,31 @@ function App({
         <i18nCore.Context>
           <RedirectAppLinks coreStart={coreStart} currentAppId="profiling">
             <RouterProvider router={profilingRouter as any} history={history}>
-              <RouterErrorBoundary>
-                <TimeRangeContextProvider>
-                  <ProfilingDependenciesContextProvider value={profilingDependencies}>
-                    <ProfilingSetupStatusContextProvider>
-                      <LicenseProvider>
-                        <>
-                          <CheckSetup>
-                            <RedirectWithDefaultDateRange>
-                              <RouteBreadcrumbsContextProvider>
-                                <RouteRenderer />
-                              </RouteBreadcrumbsContextProvider>
-                            </RedirectWithDefaultDateRange>
-                          </CheckSetup>
-                          <MountProfilingActionMenu
-                            setHeaderActionMenu={setHeaderActionMenu}
-                            theme$={theme$}
-                          />
-                        </>
-                      </LicenseProvider>
-                    </ProfilingSetupStatusContextProvider>
-                  </ProfilingDependenciesContextProvider>
-                </TimeRangeContextProvider>
-              </RouterErrorBoundary>
+              <PerformanceContextProvider>
+                <RouterErrorBoundary>
+                  <TimeRangeContextProvider>
+                    <ProfilingDependenciesContextProvider value={profilingDependencies}>
+                      <ProfilingSetupStatusContextProvider>
+                        <LicenseProvider>
+                          <>
+                            <CheckSetup>
+                              <RedirectWithDefaultDateRange>
+                                <RouteBreadcrumbsContextProvider>
+                                  <RouteRenderer />
+                                </RouteBreadcrumbsContextProvider>
+                              </RedirectWithDefaultDateRange>
+                            </CheckSetup>
+                            <MountProfilingActionMenu
+                              setHeaderActionMenu={setHeaderActionMenu}
+                              theme$={theme$}
+                            />
+                          </>
+                        </LicenseProvider>
+                      </ProfilingSetupStatusContextProvider>
+                    </ProfilingDependenciesContextProvider>
+                  </TimeRangeContextProvider>
+                </RouterErrorBoundary>
+              </PerformanceContextProvider>
             </RouterProvider>
           </RedirectAppLinks>
         </i18nCore.Context>

--- a/x-pack/solutions/observability/plugins/profiling/public/views/flamegraphs/differential_flamegraphs/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/flamegraphs/differential_flamegraphs/index.tsx
@@ -5,7 +5,9 @@
  * 2.0.
  */
 import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer } from '@elastic/eui';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { usePerformanceContext } from '@kbn/ebt-tools';
+
 import { profilingShowErrorFrames } from '@kbn/observability-plugin/common';
 import { AsyncComponent } from '../../../components/async_component';
 import { useProfilingDependencies } from '../../../components/contexts/profiling_dependencies/use_profiling_dependencies';
@@ -118,6 +120,23 @@ export function DifferentialFlameGraphsView() {
     // @ts-expect-error Code gets too complicated to satisfy TS constraints
     profilingRouter.push(routePath, { query: { ...query, searchText: newSearchText } });
   }
+
+  const { onPageReady } = usePerformanceContext();
+
+  useEffect(() => {
+    if (state.status === AsyncStatus.Settled) {
+      onPageReady({
+        meta: {
+          rangeFrom,
+          rangeTo,
+        },
+        customMetrics: {
+          key1: 'totalSamples',
+          value1: state.data?.primaryFlamegraph.TotalSamples ?? 0,
+        },
+      });
+    }
+  }, [onPageReady, state, rangeFrom, rangeTo]);
 
   return (
     <EuiFlexGroup direction="column">

--- a/x-pack/solutions/observability/plugins/profiling/public/views/flamegraphs/flamegraph/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/flamegraphs/flamegraph/index.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { profilingShowErrorFrames } from '@kbn/observability-plugin/common';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { AsyncComponent } from '../../../components/async_component';
 import { useProfilingDependencies } from '../../../components/contexts/profiling_dependencies/use_profiling_dependencies';
 import { FlameGraph } from '../../../components/flamegraph';
@@ -15,6 +16,7 @@ import { useProfilingRoutePath } from '../../../hooks/use_profiling_route_path';
 import { useProfilingRouter } from '../../../hooks/use_profiling_router';
 import { useTimeRange } from '../../../hooks/use_time_range';
 import { useTimeRangeAsync } from '../../../hooks/use_time_range_async';
+import { AsyncStatus } from '../../../hooks/use_async';
 
 export function FlameGraphView() {
   const {
@@ -54,6 +56,22 @@ export function FlameGraphView() {
     // @ts-expect-error Code gets too complicated to satisfy TS constraints
     profilingRouter.push(routePath, { query: { ...query, searchText: newSearchText } });
   }
+
+  const { onPageReady } = usePerformanceContext();
+  useEffect(() => {
+    if (state.status === AsyncStatus.Settled) {
+      onPageReady({
+        meta: {
+          rangeFrom,
+          rangeTo,
+        },
+        customMetrics: {
+          key1: 'totalSamples',
+          value1: state.data?.TotalSamples ?? 0,
+        },
+      });
+    }
+  }, [onPageReady, state.status, state.data?.TotalSamples, rangeFrom, rangeTo]);
 
   return (
     <EuiFlexGroup direction="column">

--- a/x-pack/solutions/observability/plugins/profiling/public/views/functions/differential_topn/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/functions/differential_topn/index.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 import { EuiFlexGroup, EuiFlexItem, EuiHorizontalRule, EuiPanel, EuiSpacer } from '@elastic/eui';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { AsyncComponent } from '../../../components/async_component';
 import { useProfilingDependencies } from '../../../components/contexts/profiling_dependencies/use_profiling_dependencies';
 import { FramesSummary } from '../../../components/frames_summary';
@@ -22,6 +23,7 @@ import { useTimeRange } from '../../../hooks/use_time_range';
 import { useTimeRangeAsync } from '../../../hooks/use_time_range_async';
 
 export function DifferentialTopNFunctionsView() {
+  const { onPageReady } = usePerformanceContext();
   const { query } = useProfilingParams('/functions/differential');
   const {
     rangeFrom,
@@ -146,6 +148,28 @@ export function DifferentialTopNFunctionsView() {
       query: { ...query, ...sorting },
     });
   }
+
+  useEffect(() => {
+    if (state.status === AsyncStatus.Settled || comparisonState.status === AsyncStatus.Settled) {
+      onPageReady({
+        meta: {
+          rangeFrom,
+          rangeTo,
+        },
+        customMetrics: {
+          key1: 'totalCount',
+          value1: state.data?.TotalCount ?? 0,
+        },
+      });
+    }
+  }, [
+    state.status,
+    state.data?.TotalCount,
+    comparisonState.status,
+    onPageReady,
+    rangeTo,
+    rangeFrom,
+  ]);
 
   return (
     <>

--- a/x-pack/solutions/observability/plugins/profiling/public/views/functions/topn/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/functions/topn/index.tsx
@@ -6,7 +6,8 @@
  */
 import type { EuiDataGridSorting } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import type { TopNFunctionSortField } from '@kbn/profiling-utils';
 import { AsyncComponent } from '../../../components/async_component';
 import { useProfilingDependencies } from '../../../components/contexts/profiling_dependencies/use_profiling_dependencies';
@@ -15,8 +16,10 @@ import { useProfilingParams } from '../../../hooks/use_profiling_params';
 import { useProfilingRouter } from '../../../hooks/use_profiling_router';
 import { useTimeRange } from '../../../hooks/use_time_range';
 import { useTimeRangeAsync } from '../../../hooks/use_time_range_async';
+import { AsyncStatus } from '../../../hooks/use_async';
 
 export function TopNFunctionsView() {
+  const { onPageReady } = usePerformanceContext();
   const { query } = useProfilingParams('/functions/topn');
   const { rangeFrom, rangeTo, kuery, sortDirection, sortField, pageIndex = 0 } = query;
 
@@ -66,7 +69,20 @@ export function TopNFunctionsView() {
       },
     });
   }
-
+  useEffect(() => {
+    if (state.status === AsyncStatus.Settled) {
+      onPageReady({
+        meta: {
+          rangeFrom,
+          rangeTo,
+        },
+        customMetrics: {
+          key1: 'totalCount',
+          value1: state.data?.TotalCount ?? 0,
+        },
+      });
+    }
+  }, [state.status, state.data, onPageReady, rangeFrom, rangeTo]);
   return (
     <>
       <EuiFlexGroup direction="column">

--- a/x-pack/solutions/observability/plugins/profiling/public/views/stack_traces_view/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/stack_traces_view/index.tsx
@@ -4,7 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
+import { usePerformanceContext } from '@kbn/ebt-tools';
 import { groupSamplesByCategory } from '../../../common/topn';
 import { useProfilingDependencies } from '../../components/contexts/profiling_dependencies/use_profiling_dependencies';
 import { ProfilingAppPageTemplate } from '../../components/profiling_app_page_template';
@@ -17,6 +18,7 @@ import { useTimeRangeAsync } from '../../hooks/use_time_range_async';
 import { RouteBreadcrumb } from '../../routing/route_breadcrumb';
 import { getStackTracesTabs } from './get_stack_traces_tabs';
 import { getTracesViewRouteParams } from './utils';
+import { AsyncStatus } from '../../hooks/use_async';
 
 export function StackTracesView() {
   const routePath = useProfilingRoutePath();
@@ -71,6 +73,22 @@ export function StackTracesView() {
     );
   }
 
+  const { onPageReady } = usePerformanceContext();
+
+  useEffect(() => {
+    if (state.status === AsyncStatus.Settled) {
+      onPageReady({
+        meta: {
+          rangeFrom,
+          rangeTo,
+        },
+        customMetrics: {
+          key1: 'totalCount',
+          value1: state.data?.charts.length ?? 0,
+        },
+      });
+    }
+  }, [state.status, state.data?.charts.length, onPageReady, rangeFrom, rangeTo]);
   return (
     <RouteBreadcrumb title={selectedTab?.label || ''} href={selectedTab?.href || ''}>
       <ProfilingAppPageTemplate tabs={tabs}>

--- a/x-pack/solutions/observability/plugins/profiling/public/views/storage_explorer/host_breakdown/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/storage_explorer/host_breakdown/index.tsx
@@ -16,7 +16,8 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { AsyncStatus } from '../../../hooks/use_async';
 import { AsyncComponent } from '../../../components/async_component';
 import { useProfilingDependencies } from '../../../components/contexts/profiling_dependencies/use_profiling_dependencies';
 import { useProfilingParams } from '../../../hooks/use_profiling_params';
@@ -27,9 +28,10 @@ import { HostBreakdownChart } from './host_breakdown_chart';
 
 interface Props {
   hasDistinctProbabilisticValues: boolean;
+  onReady: () => void;
 }
 
-export function HostBreakdown({ hasDistinctProbabilisticValues }: Props) {
+export function HostBreakdown({ hasDistinctProbabilisticValues, onReady }: Props) {
   const { query } = useProfilingParams('/storage-explorer');
   const { rangeFrom, rangeTo, kuery, indexLifecyclePhase } = query;
   const timeRange = useTimeRange({ rangeFrom, rangeTo });
@@ -55,6 +57,12 @@ export function HostBreakdown({ hasDistinctProbabilisticValues }: Props) {
       indexLifecyclePhase,
     ]
   );
+
+  useEffect(() => {
+    if (storageExplorerHostDetailsState.status === AsyncStatus.Settled) {
+      onReady();
+    }
+  }, [storageExplorerHostDetailsState.status, onReady]);
 
   return (
     <>

--- a/x-pack/solutions/observability/plugins/profiling/public/views/storage_explorer/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/storage_explorer/index.tsx
@@ -14,7 +14,8 @@ import {
   EuiTabs,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import React, { useState } from 'react';
+import { usePerformanceContext } from '@kbn/ebt-tools';
+import React, { useState, useEffect } from 'react';
 import { useProfilingDependencies } from '../../components/contexts/profiling_dependencies/use_profiling_dependencies';
 import { ProfilingAppPageTemplate } from '../../components/profiling_app_page_template';
 import { PrimaryProfilingSearchBar } from '../../components/profiling_app_page_template/primary_profiling_search_bar';
@@ -36,6 +37,10 @@ export function StorageExplorerView() {
   const [selectedTab, setSelectedTab] = useState<'host_breakdown' | 'data_breakdown'>(
     'host_breakdown'
   );
+  const [loadedState, setLoadedState] = useState({
+    summary: false,
+    hostBreakdown: false,
+  });
 
   const {
     services: { fetchStorageExplorerSummary },
@@ -59,9 +64,33 @@ export function StorageExplorerView() {
     ]
   );
 
+  useEffect(() => {
+    if (!loadedState.summary && storageExplorerSummaryState.status === AsyncStatus.Settled) {
+      setLoadedState((prevState) => ({ ...prevState, summary: true }));
+    }
+  }, [loadedState.summary, storageExplorerSummaryState.status, setLoadedState]);
+
   const totalNumberOfDistinctProbabilisticValues =
     storageExplorerSummaryState.data?.totalNumberOfDistinctProbabilisticValues || 0;
   const hasDistinctProbabilisticValues = totalNumberOfDistinctProbabilisticValues > 1;
+
+  const handleOnReady = () => {
+    if (!loadedState.hostBreakdown) {
+      setLoadedState((prevState) => ({ ...prevState, hostBreakdown: true }));
+    }
+  };
+
+  const { onPageReady } = usePerformanceContext();
+  useEffect(() => {
+    if (loadedState.hostBreakdown && loadedState.summary) {
+      onPageReady({
+        meta: {
+          rangeFrom,
+          rangeTo,
+        },
+      });
+    }
+  }, [loadedState, onPageReady, rangeFrom, rangeTo]);
 
   return (
     <ProfilingAppPageTemplate
@@ -120,7 +149,10 @@ export function StorageExplorerView() {
         </EuiFlexItem>
         {selectedTab === 'host_breakdown' ? (
           <EuiFlexItem grow={false}>
-            <HostBreakdown hasDistinctProbabilisticValues={hasDistinctProbabilisticValues} />
+            <HostBreakdown
+              hasDistinctProbabilisticValues={hasDistinctProbabilisticValues}
+              onReady={handleOnReady}
+            />
           </EuiFlexItem>
         ) : null}
         {selectedTab === 'data_breakdown' ? (

--- a/x-pack/solutions/observability/plugins/profiling/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/profiling/tsconfig.json
@@ -56,7 +56,9 @@
     "@kbn/react-kibana-context-render",
     "@kbn/apm-data-access-plugin",
     "@kbn/core-security-server",
-    "@kbn/charts-theme"
+    "@kbn/charts-theme",
+    "@kbn/ebt-tools",
+    "@kbn/security-plugin-types-common"
     // add references to other TypeScript projects the plugin depends on
 
     // requiredPlugins from ./kibana.json

--- a/x-pack/solutions/observability/plugins/profiling/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/profiling/tsconfig.json
@@ -58,7 +58,6 @@
     "@kbn/core-security-server",
     "@kbn/charts-theme",
     "@kbn/ebt-tools",
-    "@kbn/security-plugin-types-common"
     // add references to other TypeScript projects the plugin depends on
 
     // requiredPlugins from ./kibana.json


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [added performance telemetry to profiling pages (#208832)](https://github.com/elastic/kibana/pull/208832)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bryce Buchanan","email":"75274611+bryce-b@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-10T18:38:43Z","message":"added performance telemetry to profiling pages (#208832)\n\n## Summary\r\n\r\nThis adds performance telemetry to the profiling pages listed in\r\n[#205393](https://github.com/elastic/kibana/issues/205393)\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>","sha":"f764e9985a14dbccb033b49ba63802b9d3f3c120","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","ci:build-cloud-image","ci:cloud-deploy","ci:cloud-redeploy","v9.1.0"],"title":"added performance telemetry to profiling pages","number":208832,"url":"https://github.com/elastic/kibana/pull/208832","mergeCommit":{"message":"added performance telemetry to profiling pages (#208832)\n\n## Summary\r\n\r\nThis adds performance telemetry to the profiling pages listed in\r\n[#205393](https://github.com/elastic/kibana/issues/205393)\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>","sha":"f764e9985a14dbccb033b49ba63802b9d3f3c120"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/208832","number":208832,"mergeCommit":{"message":"added performance telemetry to profiling pages (#208832)\n\n## Summary\r\n\r\nThis adds performance telemetry to the profiling pages listed in\r\n[#205393](https://github.com/elastic/kibana/issues/205393)\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Carlos Crespo <crespocarlos@users.noreply.github.com>","sha":"f764e9985a14dbccb033b49ba63802b9d3f3c120"}}]}] BACKPORT-->