### PR TITLE
[8.19] [ObsUX] [Profiling] Add date/time to main bar chart tooltip (#210367)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/components/stacked_bar_chart/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/stacked_bar_chart/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { XYChartElementEvent } from '@elastic/charts';
+import type { CustomTooltip, SeriesIdentifier, XYChartElementEvent } from '@elastic/charts';
 import {
   Axis,
   BrushAxis,
@@ -17,6 +17,7 @@ import {
   timeFormatter,
   Tooltip,
   TooltipContainer,
+  TooltipHeader,
 } from '@elastic/charts';
 import { EuiPanel } from '@elastic/eui';
 import { keyBy } from 'lodash';
@@ -57,7 +58,7 @@ export function StackedBarChart({
 
   const { chartsBaseTheme, chartsTheme } = useProfilingChartsTheme();
 
-  function CustomTooltipWithSubChart() {
+  const CustomTooltipWithSubChart: CustomTooltip<{}, SeriesIdentifier> = ({ header }) => {
     if (!highlightedSample) {
       return null;
     }
@@ -69,6 +70,7 @@ export function StackedBarChart({
 
     return (
       <TooltipContainer>
+        <TooltipHeader header={header} />
         <EuiPanel>
           <SubChart
             index={highlightedSubchart.Index}
@@ -88,7 +90,7 @@ export function StackedBarChart({
         </EuiPanel>
       </TooltipContainer>
     );
-  }
+  };
 
   return (
     <Chart size={{ height }}>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ObsUX] [Profiling] Add date/time to main bar chart tooltip (#210367)](https://github.com/elastic/kibana/pull/210367)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miriam","email":"31922082+MiriamAparicio@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-11T08:52:21Z","message":"[ObsUX] [Profiling] Add date/time to main bar chart tooltip (#210367)\n\nCloses https://github.com/elastic/prodfiler/issues/4605\r\n\r\nBEFORE\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/d1315071-9168-4348-94aa-88fc23297a57)\r\n\r\nAFTER\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/21555db6-3337-4a09-bcfe-8e1f8561f0f5)","sha":"782c82be2984108f13b31dc4e920bfe93734f174","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-ux-infra_services","v9.1.0"],"title":"[ObsUX] [Profiling] Add date/time to main bar chart tooltip","number":210367,"url":"https://github.com/elastic/kibana/pull/210367","mergeCommit":{"message":"[ObsUX] [Profiling] Add date/time to main bar chart tooltip (#210367)\n\nCloses https://github.com/elastic/prodfiler/issues/4605\r\n\r\nBEFORE\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/d1315071-9168-4348-94aa-88fc23297a57)\r\n\r\nAFTER\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/21555db6-3337-4a09-bcfe-8e1f8561f0f5)","sha":"782c82be2984108f13b31dc4e920bfe93734f174"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210367","number":210367,"mergeCommit":{"message":"[ObsUX] [Profiling] Add date/time to main bar chart tooltip (#210367)\n\nCloses https://github.com/elastic/prodfiler/issues/4605\r\n\r\nBEFORE\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/d1315071-9168-4348-94aa-88fc23297a57)\r\n\r\nAFTER\r\n\r\n\r\n![image](https://github.com/user-attachments/assets/21555db6-3337-4a09-bcfe-8e1f8561f0f5)","sha":"782c82be2984108f13b31dc4e920bfe93734f174"}}]}] BACKPORT-->