### PR TITLE
[8.19] Added minHeight to profiler flamegraphs (#210443)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/components/flamegraph/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/flamegraph/index.tsx
@@ -140,7 +140,7 @@ export function FlameGraph({
         <EuiFlexItem>
           <EuiFlexGroup direction="row">
             {columnarData.viewModel.label.length > 0 && (
-              <EuiFlexItem grow>
+              <EuiFlexItem grow style={{ minHeight: '400px' }}>
                 <Chart key={columnarData.key}>
                   <Settings
                     theme={chartTheme}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Added minHeight to profiler flamegraphs (#210443)](https://github.com/elastic/kibana/pull/210443)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bryce Buchanan","email":"75274611+bryce-b@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-20T21:08:13Z","message":"Added minHeight to profiler flamegraphs (#210443)\n\n## Summary\r\nSolves https://github.com/elastic/prodfiler/issues/4896\r\n\r\nThis PR set a minimum height of 400px to flamegraph charts in universal\r\nprofiling.\r\n\r\nbelow shows the flamegraphs at their minimum heights.\r\n\r\n<img width=\"860\" alt=\"Screenshot 2025-02-10 at 10 24 02\"\r\nsrc=\"https://github.com/user-attachments/assets/ad121d44-da47-46a5-a719-08b59fee74c4\"\r\n/>\r\n<img width=\"1040\" alt=\"Screenshot 2025-02-10 at 10 24 22\"\r\nsrc=\"https://github.com/user-attachments/assets/feb07704-74a1-4eab-ab29-0bac59944296\"\r\n/>\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"ad9baa68afa1aa16605e5a344fc18cb7eeaa4a44","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:skip","Team:obs-ux-infra_services","v9.1.0"],"title":"Added minHeight to profiler flamegraphs","number":210443,"url":"https://github.com/elastic/kibana/pull/210443","mergeCommit":{"message":"Added minHeight to profiler flamegraphs (#210443)\n\n## Summary\r\nSolves https://github.com/elastic/prodfiler/issues/4896\r\n\r\nThis PR set a minimum height of 400px to flamegraph charts in universal\r\nprofiling.\r\n\r\nbelow shows the flamegraphs at their minimum heights.\r\n\r\n<img width=\"860\" alt=\"Screenshot 2025-02-10 at 10 24 02\"\r\nsrc=\"https://github.com/user-attachments/assets/ad121d44-da47-46a5-a719-08b59fee74c4\"\r\n/>\r\n<img width=\"1040\" alt=\"Screenshot 2025-02-10 at 10 24 22\"\r\nsrc=\"https://github.com/user-attachments/assets/feb07704-74a1-4eab-ab29-0bac59944296\"\r\n/>\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"ad9baa68afa1aa16605e5a344fc18cb7eeaa4a44"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210443","number":210443,"mergeCommit":{"message":"Added minHeight to profiler flamegraphs (#210443)\n\n## Summary\r\nSolves https://github.com/elastic/prodfiler/issues/4896\r\n\r\nThis PR set a minimum height of 400px to flamegraph charts in universal\r\nprofiling.\r\n\r\nbelow shows the flamegraphs at their minimum heights.\r\n\r\n<img width=\"860\" alt=\"Screenshot 2025-02-10 at 10 24 02\"\r\nsrc=\"https://github.com/user-attachments/assets/ad121d44-da47-46a5-a719-08b59fee74c4\"\r\n/>\r\n<img width=\"1040\" alt=\"Screenshot 2025-02-10 at 10 24 22\"\r\nsrc=\"https://github.com/user-attachments/assets/feb07704-74a1-4eab-ab29-0bac59944296\"\r\n/>\r\n\r\n### Checklist\r\n\r\nCheck the PR satisfies following conditions. \r\n\r\nReviewers should verify this PR satisfies this list as well.\r\n\r\n- [x] The PR description includes the appropriate Release Notes section,\r\nand the correct `release_note:*` label is applied per the\r\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"ad9baa68afa1aa16605e5a344fc18cb7eeaa4a44"}}]}] BACKPORT-->