### PR TITLE
[8.19] fixes sorting in profiler storage explorer (#212583)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/views/storage_explorer/host_breakdown/hosts_table.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/views/storage_explorer/host_breakdown/hosts_table.tsx
@@ -19,7 +19,6 @@ import { i18n } from '@kbn/i18n';
 import { asDynamicBytes, asAbsoluteDateTime } from '@kbn/observability-plugin/common';
 import React, { useMemo, useState } from 'react';
 import type { StorageExplorerHostDetails } from '../../../../common/storage_explorer';
-import { LabelWithHint } from '../../../components/label_with_hint';
 import { useProfilingParams } from '../../../hooks/use_profiling_params';
 import { useProfilingRouter } from '../../../hooks/use_profiling_router';
 
@@ -90,20 +89,15 @@ export function HostsTable({ data = [], hasDistinctProbabilisticValues }: Props)
       },
       {
         field: 'hostName',
-        name: (
-          <LabelWithHint
-            label={i18n.translate('xpack.profiling.storageExplorer.hostsTable.host', {
-              defaultMessage: 'Host',
-            })}
-            hint={i18n.translate('xpack.profiling.storageExplorer.hostsTable.host.hint', {
-              defaultMessage: 'host.name[host.id]',
-            })}
-            labelSize="xs"
-            labelStyle={{ fontWeight: 700 }}
-            iconSize="s"
-          />
-        ),
-        sortable: true,
+        name: i18n.translate('xpack.profiling.storageExplorer.hostsTable.host', {
+          defaultMessage: 'Host',
+        }),
+        nameTooltip: {
+          content: i18n.translate('xpack.profiling.storageExplorer.hostsTable.host.hint', {
+            defaultMessage: 'host.name[host.id]',
+          }),
+        },
+        sortable: (item) => `${item.hostName} [${item.hostId}]`,
         render: (_, item) => {
           return (
             <EuiLink
@@ -174,19 +168,14 @@ export function HostsTable({ data = [], hasDistinctProbabilisticValues }: Props)
       },
       {
         field: 'totalSize',
-        name: (
-          <LabelWithHint
-            label={i18n.translate('xpack.profiling.storageExplorer.hostsTable.totalData', {
-              defaultMessage: 'Total data',
-            })}
-            hint={i18n.translate('xpack.profiling.storageExplorer.hostsTable.totalData.hint', {
-              defaultMessage: 'The combined value of Universal Profiling metrics and samples.',
-            })}
-            labelSize="xs"
-            labelStyle={{ fontWeight: 700 }}
-            iconSize="s"
-          />
-        ),
+        name: i18n.translate('xpack.profiling.storageExplorer.hostsTable.totalData', {
+          defaultMessage: 'Total data',
+        }),
+        nameTooltip: {
+          content: i18n.translate('xpack.profiling.storageExplorer.hostsTable.totalData.hint', {
+            defaultMessage: 'The combined value of Universal Profiling metrics and samples.',
+          }),
+        },
         sortable: true,
         width: '200',
         render: (size: StorageExplorerHostDetails['totalSize']) => asDynamicBytes(size),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [fixes sorting in profiler storage explorer (#212583)](https://github.com/elastic/kibana/pull/212583)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bryce Buchanan","email":"75274611+bryce-b@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-27T15:53:44Z","message":"fixes sorting in profiler storage explorer (#212583)\n\n## Summary\nfixes #197448\nreplaces `LabelWithHint` with new built-in `nameTooltip` prop\nAlso updated sorting function for hostName column, as the default\nsorting doesn't take into account `host.id` when `host.name` is empty.\n\n\nhttps://github.com/user-attachments/assets/4e3632bf-61d0-4045-babd-2917fa7a204a\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6ce38c3c1b70124a2cded7b6c2ac7ef8aebb8435","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:skip","Team:obs-ux-infra_services","v9.1.0"],"title":"fixes sorting in profiler storage explorer","number":212583,"url":"https://github.com/elastic/kibana/pull/212583","mergeCommit":{"message":"fixes sorting in profiler storage explorer (#212583)\n\n## Summary\nfixes #197448\nreplaces `LabelWithHint` with new built-in `nameTooltip` prop\nAlso updated sorting function for hostName column, as the default\nsorting doesn't take into account `host.id` when `host.name` is empty.\n\n\nhttps://github.com/user-attachments/assets/4e3632bf-61d0-4045-babd-2917fa7a204a\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6ce38c3c1b70124a2cded7b6c2ac7ef8aebb8435"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/212583","number":212583,"mergeCommit":{"message":"fixes sorting in profiler storage explorer (#212583)\n\n## Summary\nfixes #197448\nreplaces `LabelWithHint` with new built-in `nameTooltip` prop\nAlso updated sorting function for hostName column, as the default\nsorting doesn't take into account `host.id` when `host.name` is empty.\n\n\nhttps://github.com/user-attachments/assets/4e3632bf-61d0-4045-babd-2917fa7a204a\n\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"6ce38c3c1b70124a2cded7b6c2ac7ef8aebb8435"}}]}] BACKPORT-->