### PR TITLE
[8.19] [ObsUX][Profiling] Remove float numbers on samples (#211489)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/public/components/frames_summary/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/frames_summary/index.tsx
@@ -19,7 +19,7 @@ import { isEmpty } from 'lodash';
 import React, { useMemo } from 'react';
 import { asCost } from '../../utils/formatters/as_cost';
 import { asWeight } from '../../utils/formatters/as_weight';
-import { calculateBaseComparisonDiff } from '../topn_functions/utils';
+import { calculateBaseComparisonDiff, scaleAndRoundValue } from '../topn_functions/utils';
 import { SummaryItem } from './summary_item';
 
 interface FrameValue {
@@ -41,10 +41,6 @@ const ESTIMATED_VALUE_LABEL = i18n.translate('xpack.profiling.diffTopNFunctions.
   defaultMessage: 'Estimated value',
 }) as string;
 
-function getScaleFactor(scaleFactor: number = 1) {
-  return scaleFactor;
-}
-
 export function FramesSummary({
   baseValue,
   comparisonValue,
@@ -53,11 +49,14 @@ export function FramesSummary({
   compressed = false,
 }: Props) {
   const baselineScaledTotalSamples = baseValue
-    ? baseValue.totalCount * getScaleFactor(baseValue.scaleFactor)
+    ? scaleAndRoundValue({ value: baseValue.totalCount, scaleFactor: baseValue.scaleFactor })
     : 0;
 
   const comparisonScaledTotalSamples = comparisonValue
-    ? comparisonValue.totalCount * getScaleFactor(comparisonValue.scaleFactor)
+    ? scaleAndRoundValue({
+        value: comparisonValue.totalCount,
+        scaleFactor: comparisonValue.scaleFactor,
+      })
     : 0;
 
   const { co2EmissionDiff, costImpactDiff, totalSamplesDiff } = useMemo(() => {

--- a/x-pack/solutions/observability/plugins/profiling/public/components/normalization_menu/index.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/normalization_menu/index.tsx
@@ -113,7 +113,7 @@ export function NormalizationMenu(props: Props) {
             style={{
               height: '100%',
               justifyContent: 'center',
-              backgroundColor: theme.euiTheme.colors.ghost,
+              backgroundColor: theme.euiTheme.colors.backgroundBasePlain,
               padding: '0 16px',
             }}
           >

--- a/x-pack/solutions/observability/plugins/profiling/public/components/topn_functions/total_samples_stat.tsx
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/topn_functions/total_samples_stat.tsx
@@ -9,7 +9,7 @@ import { EuiStat, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 import { Label } from './label';
-import { scaleValue } from './utils';
+import { scaleAndRoundValue } from './utils';
 
 interface Props {
   baselineTotalSamples: number;
@@ -24,7 +24,7 @@ export function TotalSamplesStat({
   comparisonTotalSamples,
   comparisonScaleFactor,
 }: Props) {
-  const scaledBaselineTotalSamples = scaleValue({
+  const scaledBaselineTotalSamples = scaleAndRoundValue({
     value: baselineTotalSamples,
     scaleFactor: baselineScaleFactor,
   });
@@ -44,7 +44,7 @@ export function TotalSamplesStat({
     );
   }
 
-  const scaledComparisonTotalSamples = scaleValue({
+  const scaledComparisonTotalSamples = scaleAndRoundValue({
     value: comparisonTotalSamples,
     scaleFactor: comparisonScaleFactor,
   });

--- a/x-pack/solutions/observability/plugins/profiling/public/components/topn_functions/utils.ts
+++ b/x-pack/solutions/observability/plugins/profiling/public/components/topn_functions/utils.ts
@@ -28,8 +28,18 @@ export function getColorLabel(percent: number) {
   return { color: 'text', label: undefined, icon: undefined };
 }
 
-export function scaleValue({ value, scaleFactor = 1 }: { value: number; scaleFactor?: number }) {
+function scaleValue({ value, scaleFactor = 1 }: { value: number; scaleFactor?: number }) {
   return value * scaleFactor;
+}
+
+export function scaleAndRoundValue({
+  value,
+  scaleFactor = 1,
+}: {
+  value: number;
+  scaleFactor?: number;
+}) {
+  return Math.round(scaleValue({ value, scaleFactor }));
 }
 
 export const getTotalCount = (topNFunctions?: TopNFunctions) => topNFunctions?.selfCPU ?? 0;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ObsUX][Profiling] Remove float numbers on samples (#211489)](https://github.com/elastic/kibana/pull/211489)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Miriam","email":"31922082+MiriamAparicio@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-02-19T08:39:03Z","message":"[ObsUX][Profiling] Remove float numbers on samples (#211489)\n\nCloses https://github.com/elastic/kibana/issues/181295\n\n#### Summary\n\nThere should be no decimal / fraction in the number of samples (those\nare integer values).\n\n#### What was done\n\nWhen the scale factor was a number with decimals, was changing the value\nof the samples to a float number\nAlso, the background color for the `Normalized By` dropdown was fixed in\ndark mode\n\nBefore\n\n<img width=\"1335\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/93b6c301-5b7f-41b6-857b-3551cf88b095\"\n/>\n\nAfter\n\n<img width=\"1335\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ebbe78ed-d8cb-4308-acf4-0d15221f986b\"\n/>","sha":"5b96461ee74eaafe5903d80609732cfd6f868679","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:prev-minor","Team:obs-ux-infra_services","v9.1.0"],"title":"[ObsUX][Profiling] Remove float numbers on samples","number":211489,"url":"https://github.com/elastic/kibana/pull/211489","mergeCommit":{"message":"[ObsUX][Profiling] Remove float numbers on samples (#211489)\n\nCloses https://github.com/elastic/kibana/issues/181295\n\n#### Summary\n\nThere should be no decimal / fraction in the number of samples (those\nare integer values).\n\n#### What was done\n\nWhen the scale factor was a number with decimals, was changing the value\nof the samples to a float number\nAlso, the background color for the `Normalized By` dropdown was fixed in\ndark mode\n\nBefore\n\n<img width=\"1335\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/93b6c301-5b7f-41b6-857b-3551cf88b095\"\n/>\n\nAfter\n\n<img width=\"1335\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ebbe78ed-d8cb-4308-acf4-0d15221f986b\"\n/>","sha":"5b96461ee74eaafe5903d80609732cfd6f868679"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/211687","number":211687,"state":"MERGED","mergeCommit":{"sha":"9bb1c79f3d4dc52433048e2f8e0ebb6980fefb84","message":"[9.0] [ObsUX][Profiling] Remove float numbers on samples (#211489) (#211687)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[ObsUX][Profiling] Remove float numbers on samples\n(#211489)](https://github.com/elastic/kibana/pull/211489)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Miriam <31922082+MiriamAparicio@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/211489","number":211489,"mergeCommit":{"message":"[ObsUX][Profiling] Remove float numbers on samples (#211489)\n\nCloses https://github.com/elastic/kibana/issues/181295\n\n#### Summary\n\nThere should be no decimal / fraction in the number of samples (those\nare integer values).\n\n#### What was done\n\nWhen the scale factor was a number with decimals, was changing the value\nof the samples to a float number\nAlso, the background color for the `Normalized By` dropdown was fixed in\ndark mode\n\nBefore\n\n<img width=\"1335\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/93b6c301-5b7f-41b6-857b-3551cf88b095\"\n/>\n\nAfter\n\n<img width=\"1335\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/ebbe78ed-d8cb-4308-acf4-0d15221f986b\"\n/>","sha":"5b96461ee74eaafe5903d80609732cfd6f868679"}}]}] BACKPORT-->