### PR TITLE
[8.19] [AI4DSOC][Security Solution] Extract takeActions logic outside the detections grouping alerts table (#219878)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -39,6 +39,7 @@ import {
   TableId,
 } from '@kbn/securitysolution-data-table';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { useGroupTakeActionsItems } from '../../../../detections/hooks/alerts_table/use_group_take_action_items';
 import {
   defaultGroupStatsAggregations,
   defaultGroupStatsRenderer,
@@ -559,6 +560,11 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
     confirmManualRuleRun,
   } = useManualRuleRunConfirmation();
 
+  const groupTakeActionItems = useGroupTakeActionsItems({
+    currentStatus: currentAlertStatusFilterValue,
+    showAlertStatusActions: Boolean(hasIndexWrite) && Boolean(hasIndexMaintenance),
+  });
+
   const accordionExtraActionGroupStats = useMemo(
     () => ({
       aggregations: defaultGroupStatsAggregations,
@@ -796,14 +802,12 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
                       <GroupedAlertsTable
                         accordionButtonContent={defaultGroupTitleRenderers}
                         accordionExtraActionGroupStats={accordionExtraActionGroupStats}
-                        currentAlertStatusFilterValue={currentAlertStatusFilterValue}
                         defaultFilters={alertMergedFilters}
                         defaultGroupingOptions={defaultGroupingOptions}
                         from={from}
                         globalFilters={filters}
                         globalQuery={query}
-                        hasIndexMaintenance={hasIndexMaintenance ?? false}
-                        hasIndexWrite={hasIndexWrite ?? false}
+                        groupTakeActionItems={groupTakeActionItems}
                         loading={loading}
                         renderChildComponent={renderGroupedAlertTable}
                         runtimeMappings={sourcererDataView?.runtimeFieldMap as RunTimeMappings}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.test.tsx
@@ -131,8 +131,6 @@ const testProps: AlertsTableComponentProps = {
     query: 'query',
     language: 'language',
   },
-  hasIndexMaintenance: true,
-  hasIndexWrite: true,
   loading: false,
   renderChildComponent,
   runtimeMappings: {},

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_grouping.tsx
@@ -20,11 +20,11 @@ import { isEmpty, isEqual } from 'lodash/fp';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { TableIdLiteral } from '@kbn/securitysolution-data-table';
 import type { GetGroupStats, GroupingArgs, GroupPanelRenderer } from '@kbn/grouping/src';
+import type { GroupTakeActionItems } from './types';
 import type { AlertsGroupingAggregation } from './grouping_settings/types';
 import { groupIdSelector } from '../../../common/store/grouping/selectors';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import { updateGroups } from '../../../common/store/grouping/actions';
-import type { Status } from '../../../../common/api/detection_engine';
 import { defaultUnit } from '../../../common/components/toolbar/unit';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import type { RunTimeMappings } from '../../../sourcerer/store/model';
@@ -56,7 +56,6 @@ export interface AlertsTableComponentProps {
      */
     renderer: GetGroupStats<AlertsGroupingAggregation>;
   };
-  currentAlertStatusFilterValue?: Status[];
   defaultFilters?: Filter[];
   /**
    * Default values to display in the group selection dropdown.
@@ -66,8 +65,11 @@ export interface AlertsTableComponentProps {
   from: string;
   globalFilters: Filter[];
   globalQuery: Query;
-  hasIndexMaintenance: boolean;
-  hasIndexWrite: boolean;
+  /**
+   * Allows to customize the content of the Take actions button rendered at the group level.
+   * If no value is provided, the Take actins button is not displayed.
+   */
+  groupTakeActionItems?: GroupTakeActionItems;
   loading: boolean;
   renderChildComponent: (groupingFilters: Filter[]) => React.ReactElement;
   runtimeMappings: RunTimeMappings;
@@ -326,6 +328,7 @@ const GroupedAlertsTableComponent: React.FC<AlertsTableComponentProps> = (props)
           getGrouping={getGrouping}
           groupingLevel={level}
           groupStatsAggregations={groupStatusAggregations}
+          groupTakeActionItems={props.groupTakeActionItems}
           onGroupClose={() => resetGroupChildrenPagination(level)}
           pageIndex={pageIndex[level] ?? DEFAULT_PAGE_INDEX}
           pageSize={pageSize[level] ?? DEFAULT_PAGE_SIZE}

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/alerts_sub_grouping.tsx
@@ -15,11 +15,11 @@ import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { DynamicGroupingProps } from '@kbn/grouping/src';
 import { parseGroupingQuery } from '@kbn/grouping/src';
 import type { TableIdLiteral } from '@kbn/securitysolution-data-table';
+import type { GroupTakeActionItems } from './types';
 import type { RunTimeMappings } from '../../../sourcerer/store/model';
 import { SourcererScopeName } from '../../../sourcerer/store/model';
 import { combineQueries } from '../../../common/lib/kuery';
 import type { AlertsGroupingAggregation } from './grouping_settings/types';
-import type { Status } from '../../../../common/api/detection_engine';
 import { InspectButton } from '../../../common/components/inspect';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import { useKibana } from '../../../common/lib/kibana';
@@ -31,13 +31,12 @@ import { buildTimeRangeFilter } from './helpers';
 import * as i18n from './translations';
 import { useQueryAlerts } from '../../containers/detection_engine/alerts/use_query';
 import { ALERTS_QUERY_NAMES } from '../../containers/detection_engine/alerts/constants';
-import { getAlertsGroupingQuery, useGroupTakeActionsItems } from './grouping_settings';
+import { getAlertsGroupingQuery } from './grouping_settings';
 
 const ALERTS_GROUPING_ID = 'alerts-grouping';
 const DEFAULT_FILTERS: Filter[] = [];
 
 interface OwnProps {
-  currentAlertStatusFilterValue?: Status[];
   defaultFilters?: Filter[];
   from: string;
   getGrouping: (
@@ -51,8 +50,11 @@ interface OwnProps {
    * This is then used to render values in the EuiAccordion `extraAction` section.
    */
   groupStatsAggregations: (field: string) => NamedAggregation[];
-  hasIndexMaintenance: boolean;
-  hasIndexWrite: boolean;
+  /**
+   * Allows to customize the content of the Take actions button rendered at the group level.
+   * If no value is provided, the Take actins button is not displayed.
+   */
+  groupTakeActionItems?: GroupTakeActionItems;
   loading: boolean;
   onGroupClose: () => void;
   pageIndex: number;
@@ -71,7 +73,6 @@ interface OwnProps {
 export type AlertsTableComponentProps = OwnProps;
 
 export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
-  currentAlertStatusFilterValue,
   defaultFilters = DEFAULT_FILTERS,
   from,
   getGrouping,
@@ -79,8 +80,7 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
   globalQuery,
   groupingLevel,
   groupStatsAggregations,
-  hasIndexMaintenance,
-  hasIndexWrite,
+  groupTakeActionItems,
   loading,
   onGroupClose,
   pageIndex,
@@ -109,7 +109,7 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
           indexPattern,
           browserFields,
           filters: [
-            ...(defaultFilters ?? []),
+            ...defaultFilters,
             ...globalFilters,
             ...customFilters,
             ...(parentGroupingFilter ? JSON.parse(parentGroupingFilter) : []),
@@ -243,20 +243,18 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
     [uniqueQueryId]
   );
 
-  const takeActionItems = useGroupTakeActionsItems({
-    currentStatus: currentAlertStatusFilterValue,
-    showAlertStatusActions: hasIndexWrite && hasIndexMaintenance,
-  });
-
   const getTakeActionItems = useCallback(
-    (groupFilters: Filter[], groupNumber: number) =>
-      takeActionItems({
+    (groupFilters: Filter[], groupNumber: number) => {
+      const takeActionParams = {
         groupNumber,
         query: getGlobalQuery([...(defaultFilters ?? []), ...groupFilters])?.filterQuery,
         selectedGroup,
         tableId,
-      }),
-    [defaultFilters, getGlobalQuery, selectedGroup, tableId, takeActionItems]
+      };
+
+      return groupTakeActionItems?.(takeActionParams) ?? [];
+    },
+    [defaultFilters, getGlobalQuery, groupTakeActionItems, selectedGroup, tableId]
   );
 
   const onChangeGroupsItemsPerPage = useCallback(
@@ -280,13 +278,14 @@ export const GroupedSubLevelComponent: React.FC<AlertsTableComponentProps> = ({
         onGroupClose,
         renderChildComponent,
         selectedGroup,
-        takeActionItems: getTakeActionItems,
+        ...(groupTakeActionItems && { takeActionItems: getTakeActionItems }),
       }),
     [
       aggs,
       getGrouping,
       getTakeActionItems,
       groupingLevel,
+      groupTakeActionItems,
       inspect,
       isLoadingGroups,
       loading,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/index.tsx
@@ -9,5 +9,4 @@ export * from './default_grouping_options';
 export * from './default_group_stats_aggregations';
 export * from './default_group_stats_renderers';
 export * from './default_group_title_renderers';
-export * from './group_take_action_items';
 export * from './query_builder';

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/types.ts
@@ -17,7 +17,6 @@ import type { Status } from '../../../../common/api/detection_engine';
 import type { Note } from '../../../../common/api/timeline';
 import type { DataProvider } from '../../../timelines/components/timeline/data_providers/data_provider';
 import type { TimelineModel } from '../../../timelines/store/model';
-import type { inputsModel } from '../../../common/store';
 import type { ControlColumnProps, RowRenderer } from '../../../../common/types';
 
 export interface SetEventsLoadingProps {
@@ -29,23 +28,6 @@ export interface SetEventsDeletedProps {
   eventIds: string[];
   isDeleted: boolean;
 }
-
-export interface UpdateAlertsStatusProps {
-  alertIds: string[];
-  status: Status;
-  selectedStatus: Status;
-}
-
-export type UpdateAlertsStatusCallback = (
-  refetchQuery: inputsModel.Refetch,
-  { alertIds, status, selectedStatus }: UpdateAlertsStatusProps
-) => void;
-
-export type UpdateAlertsStatus = ({
-  alertIds,
-  status,
-  selectedStatus,
-}: UpdateAlertsStatusProps) => void;
 
 export interface UpdateAlertStatusActionProps {
   query?: string;
@@ -99,3 +81,22 @@ export type SecurityAlertsTableProps = AlertsTablePropsWithRef<SecurityAlertsTab
 export type GetSecurityAlertsTableProp<PropKey extends keyof SecurityAlertsTableProps> =
   NonNullable<SecurityAlertsTableProps[PropKey]>;
 export type { AlertWithLegacyFormats } from '@kbn/response-ops-alerts-table/types';
+
+export type GroupTakeActionItems = (props: {
+  /**
+   * Query to run when an item is clicked (meaning when an alert status is updated)
+   */
+  query?: string;
+  /**
+   * Id of the table (used for telemetry)
+   */
+  tableId: string;
+  /**
+   * Group number to know which group to apply the logic to. This value is coming from the callback in the kbn-grouping package.
+   */
+  groupNumber: number;
+  /**
+   * Selected group to know which group is extended/visible. This is coming from the getLevel function in the detections alert grouping code.
+   */
+  selectedGroup: string;
+}) => JSX.Element[];

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alerts_table/use_group_take_action_items.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/hooks/alerts_table/use_group_take_action_items.test.tsx
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { waitFor, renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
-import { TestProviders } from '../../../../common/mock';
-import { useGroupTakeActionsItems } from '.';
+import { TestProviders } from '../../../common/mock';
+import { useGroupTakeActionsItems } from './use_group_take_action_items';
 
 describe('useGroupTakeActionsItems', () => {
   const wrapperContainer: React.FC<{ children?: React.ReactNode }> = ({ children }) => (

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.test.tsx
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { useParams } from 'react-router-dom';
-import { mockGlobalState, TestProviders, createMockStore } from '../../../common/mock';
+import { createMockStore, mockGlobalState, TestProviders } from '../../../common/mock';
 import { useUserData } from '../../components/user_info';
 import { useSourcererDataView } from '../../../sourcerer/containers';
 import type { State } from '../../../common/store';
@@ -22,10 +22,8 @@ import { createStubDataView } from '@kbn/data-views-plugin/common/data_view.stub
 import { useListsConfig } from '../../containers/detection_engine/lists/use_lists_config';
 import * as alertFilterControlsPackage from '@kbn/alerts-ui-shared/src/alert_filter_controls/alert_filter_controls';
 import { DetectionEnginePage } from './detection_engine';
-import type { AlertsTableComponentProps } from '../../components/alerts_table/alerts_grouping';
 import { TableId } from '@kbn/securitysolution-data-table';
 import { useUpsellingMessage } from '../../../common/hooks/use_upselling';
-import { mockAlertFilterControls } from '@kbn/alerts-ui-shared/src/alert_filter_controls/mocks';
 
 // Test will fail because we will to need to mock some core services to make the test work
 // For now let's forget about SiemSearchBar and QueryBar
@@ -39,23 +37,9 @@ jest.mock('../../../common/hooks/use_space_id', () => ({
   useSpaceId: () => 'default',
 }));
 jest.mock('@kbn/alerts-ui-shared/src/alert_filter_controls/alert_filter_controls');
-
-const mockStatusCapture = jest.fn();
-const GroupedAlertsTable: React.FC<AlertsTableComponentProps> = ({
-  currentAlertStatusFilterValue,
-}) => {
-  useEffect(() => {
-    if (currentAlertStatusFilterValue) {
-      mockStatusCapture(currentAlertStatusFilterValue);
-    }
-  }, [currentAlertStatusFilterValue]);
-  return <span />;
-};
-
 jest.mock('../../components/alerts_table/alerts_grouping', () => ({
-  GroupedAlertsTable,
+  GroupedAlertsTable: () => <span />,
 }));
-
 jest.mock('../../containers/detection_engine/lists/use_lists_config');
 jest.mock('../../components/user_info');
 jest.mock('../../../sourcerer/containers');
@@ -220,9 +204,11 @@ describe('DetectionEnginePageComponent', () => {
       .mockImplementation(() => <span data-test-subj="filter-group__loading" />);
     (useUpsellingMessage as jest.Mock).mockReturnValue('Go for Platinum!');
   });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   it('renders correctly', async () => {
     const { getByTestId } = render(
       <TestProviders>
@@ -318,102 +304,5 @@ describe('DetectionEnginePageComponent', () => {
       }),
       expect.anything()
     );
-  });
-
-  it('the pageFiltersUpdateHandler updates status when a multi status filter is passed', async () => {
-    jest.spyOn(alertFilterControlsPackage, 'AlertFilterControls').mockImplementationOnce(
-      mockAlertFilterControls([
-        {
-          meta: {
-            index: 'security-solution-default',
-            key: 'kibana.alert.workflow_status',
-            params: ['open', 'acknowledged'],
-          },
-        },
-      ])
-    );
-
-    render(
-      <TestProviders>
-        <Router history={mockHistory}>
-          <DetectionEnginePage />
-        </Router>
-      </TestProviders>
-    );
-    // when statusFilter updates, we call mockStatusCapture in test mocks
-    expect(mockStatusCapture).toHaveBeenNthCalledWith(1, []);
-    expect(mockStatusCapture).toHaveBeenNthCalledWith(2, ['open', 'acknowledged']);
-  });
-
-  it('the pageFiltersUpdateHandler updates status when a single status filter is passed', async () => {
-    jest.spyOn(alertFilterControlsPackage, 'AlertFilterControls').mockImplementation(
-      mockAlertFilterControls([
-        {
-          meta: {
-            index: 'security-solution-default',
-            key: 'kibana.alert.workflow_status',
-            disabled: false,
-          },
-          query: {
-            match_phrase: {
-              'kibana.alert.workflow_status': 'open',
-            },
-          },
-        },
-        {
-          meta: {
-            index: 'security-solution-default',
-            key: 'kibana.alert.severity',
-            disabled: false,
-          },
-          query: {
-            match_phrase: {
-              'kibana.alert.severity': 'low',
-            },
-          },
-        },
-      ])
-    );
-
-    render(
-      <TestProviders>
-        <Router history={mockHistory}>
-          <DetectionEnginePage />
-        </Router>
-      </TestProviders>
-    );
-    // when statusFilter updates, we call mockStatusCapture in test mocks
-    expect(mockStatusCapture).toHaveBeenNthCalledWith(1, []);
-    expect(mockStatusCapture).toHaveBeenNthCalledWith(2, ['open']);
-  });
-
-  it('the pageFiltersUpdateHandler clears status when no status filter is passed', async () => {
-    jest.spyOn(alertFilterControlsPackage, 'AlertFilterControls').mockImplementation(
-      mockAlertFilterControls([
-        {
-          meta: {
-            index: 'security-solution-default',
-            key: 'kibana.alert.severity',
-            disabled: false,
-          },
-          query: {
-            match_phrase: {
-              'kibana.alert.severity': 'low',
-            },
-          },
-        },
-      ])
-    );
-
-    render(
-      <TestProviders>
-        <Router history={mockHistory}>
-          <DetectionEnginePage />
-        </Router>
-      </TestProviders>
-    );
-    // when statusFilter updates, we call mockStatusCapture in test mocks
-    expect(mockStatusCapture).toHaveBeenNthCalledWith(1, []);
-    expect(mockStatusCapture).toHaveBeenNthCalledWith(2, []);
   });
 });

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/pages/alerts/detection_engine.tsx
@@ -34,6 +34,7 @@ import {
 import { isEqual } from 'lodash';
 import type { FilterGroupHandler } from '@kbn/alerts-ui-shared';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { useGroupTakeActionsItems } from '../../hooks/alerts_table/use_group_take_action_items';
 import {
   defaultGroupingOptions,
   defaultGroupStatsAggregations,
@@ -329,6 +330,11 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
     [alertsTableDefaultFilters, isAlertTableLoading]
   );
 
+  const groupTakeActionItems = useGroupTakeActionsItems({
+    currentStatus: statusFilter,
+    showAlertStatusActions: Boolean(hasIndexWrite) && Boolean(hasIndexMaintenance),
+  });
+
   const accordionExtraActionGroupStats = useMemo(
     () => ({
       aggregations: defaultGroupStatsAggregations,
@@ -438,14 +444,12 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ()
             <GroupedAlertsTable
               accordionButtonContent={defaultGroupTitleRenderers}
               accordionExtraActionGroupStats={accordionExtraActionGroupStats}
-              currentAlertStatusFilterValue={statusFilter}
               defaultFilters={alertsTableDefaultFilters}
               defaultGroupingOptions={defaultGroupingOptions}
               from={from}
               globalFilters={filters}
               globalQuery={query}
-              hasIndexMaintenance={hasIndexMaintenance ?? false}
-              hasIndexWrite={hasIndexWrite ?? false}
+              groupTakeActionItems={groupTakeActionItems}
               loading={isAlertTableLoading}
               renderChildComponent={renderAlertTable}
               runtimeMappings={sourcererDataView?.runtimeFieldMap as RunTimeMappings}

--- a/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/top_risk_score_contributors_alerts/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/entity_analytics/components/top_risk_score_contributors_alerts/index.tsx
@@ -10,6 +10,7 @@ import { TableId } from '@kbn/securitysolution-data-table';
 import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
 import type { RunTimeMappings } from '@kbn/timelines-plugin/common/search_strategy';
+import { useGroupTakeActionsItems } from '../../../detections/hooks/alerts_table/use_group_take_action_items';
 import {
   defaultGroupingOptions,
   defaultGroupStatsAggregations,
@@ -101,6 +102,10 @@ export const TopRiskScoreContributorsAlerts = <T extends EntityType>({
 
   const defaultFilters = useMemo(() => [...inputFilters, ...filters], [filters, inputFilters]);
 
+  const groupTakeActionItems = useGroupTakeActionsItems({
+    showAlertStatusActions: Boolean(hasIndexWrite) && Boolean(hasIndexMaintenance),
+  });
+
   const accordionExtraActionGroupStats = useMemo(
     () => ({
       aggregations: defaultGroupStatsAggregations,
@@ -138,8 +143,7 @@ export const TopRiskScoreContributorsAlerts = <T extends EntityType>({
               from={from}
               globalFilters={filters}
               globalQuery={query}
-              hasIndexMaintenance={hasIndexMaintenance ?? false}
-              hasIndexWrite={hasIndexWrite ?? false}
+              groupTakeActionItems={groupTakeActionItems}
               loading={userInfoLoading || loading}
               renderChildComponent={renderGroupedAlertTable}
               runtimeMappings={sourcererDataView?.runtimeFieldMap as RunTimeMappings}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[AI4DSOC][Security Solution] Extract takeActions logic outside the detections grouping alerts table (#219878)](https://github.com/elastic/kibana/pull/219878)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2025-05-02T19:57:41Z","message":"[AI4DSOC][Security Solution] Extract takeActions logic outside the detections grouping alerts table (#219878)\n\n## Summary\n\nThis PR continues the effort started in [this previous\nPR](https://github.com/elastic/kibana/pull/216572). The AI4DSOC effort\nrevealed a limitation with the current GroupedAlertsTable: it currently\nalways displays the `Take actions` button at each group level, and the\navailable actions are\n- Mark as opened\n- Mark as acknowledged\n- Marck as closed\n\nIn AI4DSOC though those actions are not available.\n\nWhile it would have been easy and simple to just disable the actions\nsomehow internally to the GroupedAlertsTable, this is not the correct\napproach. Like done in the prior PR mentioned above, the approach here\nconsists of making this an opt-in prop to the component. This means that\nwe now have a new `groupTakeActionItems` prop that developers have to\nprovide if they want the `Take actions` button to be displayed. This\n`groupTakeActionItems` will return n array of `EuiContextMenuItem`\ncomponents that will be rendered in the menu\n\n**_The 3 places where this `Take actions` exist today have been updated\naccordingly, to ensure to change in the logic or UI:_**\n- alerts table\n- rule details page\n- entity analytis risk score\n\n\nhttps://github.com/user-attachments/assets/24ff489d-ca66-457d-bd03-f09a04f67d2a\n\n\nhttps://github.com/user-attachments/assets/9324029d-f653-42bd-bca1-73a25d46c476\n\n**_The Alert summary page visible in AI4DSOC (`searchAiLake` tier) no\nlonger displays the `Take actions` button._**\n\n![Screenshot 2025-05-01 at 3 14\n28 PM](https://github.com/user-attachments/assets/c8b74731-8685-483d-aff3-237df8c66823)\n\n### Notes\n\nSome code documentation and very minor cleanup was also performed.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\nRelates to https://github.com/elastic/security-team/issues/11973","sha":"22fbe0087da0e7aaf7284e413db3aa9bee387aea","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","backport:version","v9.1.0","v8.19.0"],"title":"[AI4DSOC][Security Solution] Extract takeActions logic outside the detections grouping alerts table","number":219878,"url":"https://github.com/elastic/kibana/pull/219878","mergeCommit":{"message":"[AI4DSOC][Security Solution] Extract takeActions logic outside the detections grouping alerts table (#219878)\n\n## Summary\n\nThis PR continues the effort started in [this previous\nPR](https://github.com/elastic/kibana/pull/216572). The AI4DSOC effort\nrevealed a limitation with the current GroupedAlertsTable: it currently\nalways displays the `Take actions` button at each group level, and the\navailable actions are\n- Mark as opened\n- Mark as acknowledged\n- Marck as closed\n\nIn AI4DSOC though those actions are not available.\n\nWhile it would have been easy and simple to just disable the actions\nsomehow internally to the GroupedAlertsTable, this is not the correct\napproach. Like done in the prior PR mentioned above, the approach here\nconsists of making this an opt-in prop to the component. This means that\nwe now have a new `groupTakeActionItems` prop that developers have to\nprovide if they want the `Take actions` button to be displayed. This\n`groupTakeActionItems` will return n array of `EuiContextMenuItem`\ncomponents that will be rendered in the menu\n\n**_The 3 places where this `Take actions` exist today have been updated\naccordingly, to ensure to change in the logic or UI:_**\n- alerts table\n- rule details page\n- entity analytis risk score\n\n\nhttps://github.com/user-attachments/assets/24ff489d-ca66-457d-bd03-f09a04f67d2a\n\n\nhttps://github.com/user-attachments/assets/9324029d-f653-42bd-bca1-73a25d46c476\n\n**_The Alert summary page visible in AI4DSOC (`searchAiLake` tier) no\nlonger displays the `Take actions` button._**\n\n![Screenshot 2025-05-01 at 3 14\n28 PM](https://github.com/user-attachments/assets/c8b74731-8685-483d-aff3-237df8c66823)\n\n### Notes\n\nSome code documentation and very minor cleanup was also performed.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\nRelates to https://github.com/elastic/security-team/issues/11973","sha":"22fbe0087da0e7aaf7284e413db3aa9bee387aea"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219878","number":219878,"mergeCommit":{"message":"[AI4DSOC][Security Solution] Extract takeActions logic outside the detections grouping alerts table (#219878)\n\n## Summary\n\nThis PR continues the effort started in [this previous\nPR](https://github.com/elastic/kibana/pull/216572). The AI4DSOC effort\nrevealed a limitation with the current GroupedAlertsTable: it currently\nalways displays the `Take actions` button at each group level, and the\navailable actions are\n- Mark as opened\n- Mark as acknowledged\n- Marck as closed\n\nIn AI4DSOC though those actions are not available.\n\nWhile it would have been easy and simple to just disable the actions\nsomehow internally to the GroupedAlertsTable, this is not the correct\napproach. Like done in the prior PR mentioned above, the approach here\nconsists of making this an opt-in prop to the component. This means that\nwe now have a new `groupTakeActionItems` prop that developers have to\nprovide if they want the `Take actions` button to be displayed. This\n`groupTakeActionItems` will return n array of `EuiContextMenuItem`\ncomponents that will be rendered in the menu\n\n**_The 3 places where this `Take actions` exist today have been updated\naccordingly, to ensure to change in the logic or UI:_**\n- alerts table\n- rule details page\n- entity analytis risk score\n\n\nhttps://github.com/user-attachments/assets/24ff489d-ca66-457d-bd03-f09a04f67d2a\n\n\nhttps://github.com/user-attachments/assets/9324029d-f653-42bd-bca1-73a25d46c476\n\n**_The Alert summary page visible in AI4DSOC (`searchAiLake` tier) no\nlonger displays the `Take actions` button._**\n\n![Screenshot 2025-05-01 at 3 14\n28 PM](https://github.com/user-attachments/assets/c8b74731-8685-483d-aff3-237df8c66823)\n\n### Notes\n\nSome code documentation and very minor cleanup was also performed.\n\n### Checklist\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n\nRelates to https://github.com/elastic/security-team/issues/11973","sha":"22fbe0087da0e7aaf7284e413db3aa9bee387aea"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->