### PR TITLE
[WIP] Spec out EmbeddableContentManagementDefinitions and developer example

### DIFF
--- a/examples/embeddable_examples/common/book/content_management/cm_services.ts
+++ b/examples/embeddable_examples/common/book/content_management/cm_services.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EmbeddableContentManagementDefinition } from '@kbn/embeddable-plugin/common';
+import { bookAttributesDefinition as bookAttributesDefinitionV1 } from './schema/v1';
+import { bookAttributesDefinition as bookAttributesDefinitionV2 } from './schema/v2';
+import { bookAttributesDefinition as bookAttributesDefinitionV3 } from './schema/v3';
+
+export const bookCmDefinitions: EmbeddableContentManagementDefinition = {
+  id: 'book',
+  versions: {
+    1: bookAttributesDefinitionV1,
+    2: bookAttributesDefinitionV2,
+    3: bookAttributesDefinitionV3,
+  },
+  latestVersion: 1,
+};

--- a/examples/embeddable_examples/common/book/content_management/schema/v1/index.ts
+++ b/examples/embeddable_examples/common/book/content_management/schema/v1/index.ts
@@ -7,11 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+export { bookAttributesDefinition } from './v1';

--- a/examples/embeddable_examples/common/book/content_management/schema/v1/v1.ts
+++ b/examples/embeddable_examples/common/book/content_management/schema/v1/v1.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { VersionableEmbeddableObject } from '@kbn/embeddable-plugin/common';
+import type { SavedBookAttributes } from '../../../../../server/types';
+import type { BookAttributes } from '../../../../../server/book/content_management/schema/v1';
+
+export const bookAttributesDefinition: VersionableEmbeddableObject<
+  SavedBookAttributes,
+  BookAttributes
+> = {
+  // TODO up or down?
+  itemToSavedObject: (item) => item,
+  savedObjectToItem: (savedObject) => savedObject,
+};

--- a/examples/embeddable_examples/common/book/content_management/schema/v2/index.ts
+++ b/examples/embeddable_examples/common/book/content_management/schema/v2/index.ts
@@ -7,11 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+export { bookAttributesDefinition } from './v2';

--- a/examples/embeddable_examples/common/book/content_management/schema/v2/v2.ts
+++ b/examples/embeddable_examples/common/book/content_management/schema/v2/v2.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { VersionableEmbeddableObject } from '@kbn/embeddable-plugin/common';
+import type { SavedBookAttributes } from '../../../../../server/types';
+import type { BookAttributes } from '../../../../../server/book/content_management/schema/v2';
+import type { BookAttributes as BookV1Attributes } from '../../../../../server/book/content_management/schema/v1';
+
+function transformV1ToV2(v1Item: BookV1Attributes): BookAttributes {
+  return {
+    title: v1Item.bookTitle,
+    author: v1Item.authorName,
+    numberOfPages: v1Item.numberOfPages,
+    synopsis: v1Item.bookSynopsis,
+  };
+}
+
+function transformV2ToV1(v2Item: BookAttributes): BookV1Attributes {
+  return {
+    bookTitle: v2Item.title,
+    authorName: v2Item.author,
+    numberOfPages: v2Item.numberOfPages,
+    bookSynopsis: v2Item.synopsis,
+  };
+}
+
+export const bookAttributesDefinition: VersionableEmbeddableObject<
+  SavedBookAttributes,
+  BookAttributes,
+  BookV1Attributes
+> = {
+  up: transformV1ToV2,
+  down: transformV2ToV1,
+  itemToSavedObject: transformV2ToV1,
+  savedObjectToItem: transformV1ToV2,
+};

--- a/examples/embeddable_examples/common/book/content_management/schema/v2/v2.ts
+++ b/examples/embeddable_examples/common/book/content_management/schema/v2/v2.ts
@@ -8,25 +8,38 @@
  */
 
 import type { VersionableEmbeddableObject } from '@kbn/embeddable-plugin/common';
+import type { ItemAttributesWithReferences } from '@kbn/embeddable-plugin/common/types';
 import type { SavedBookAttributes } from '../../../../../server/types';
 import type { BookAttributes } from '../../../../../server/book/content_management/schema/v2';
 import type { BookAttributes as BookV1Attributes } from '../../../../../server/book/content_management/schema/v1';
 
-function transformV1ToV2(v1Item: BookV1Attributes): BookAttributes {
+function savedObjectToItem({
+  attributes,
+  references,
+}: ItemAttributesWithReferences<BookV1Attributes>): ItemAttributesWithReferences<BookAttributes> {
   return {
-    title: v1Item.bookTitle,
-    author: v1Item.authorName,
-    numberOfPages: v1Item.numberOfPages,
-    synopsis: v1Item.bookSynopsis,
+    attributes: {
+      title: attributes.bookTitle,
+      author: attributes.authorName,
+      numberOfPages: attributes.numberOfPages,
+      synopsis: attributes.bookSynopsis,
+    },
+    references,
   };
 }
 
-function transformV2ToV1(v2Item: BookAttributes): BookV1Attributes {
+function itemToSavedObject({
+  attributes,
+  references,
+}: ItemAttributesWithReferences<BookAttributes>): ItemAttributesWithReferences<BookV1Attributes> {
   return {
-    bookTitle: v2Item.title,
-    authorName: v2Item.author,
-    numberOfPages: v2Item.numberOfPages,
-    bookSynopsis: v2Item.synopsis,
+    attributes: {
+      bookTitle: attributes.title,
+      authorName: attributes.author,
+      numberOfPages: attributes.numberOfPages,
+      bookSynopsis: attributes.synopsis,
+    },
+    references,
   };
 }
 
@@ -35,8 +48,8 @@ export const bookAttributesDefinition: VersionableEmbeddableObject<
   BookAttributes,
   BookV1Attributes
 > = {
-  up: transformV1ToV2,
-  down: transformV2ToV1,
-  itemToSavedObject: transformV2ToV1,
-  savedObjectToItem: transformV1ToV2,
+  // up: transformV1ToV2,
+  // down: transformV2ToV1,
+  itemToSavedObject,
+  savedObjectToItem,
 };

--- a/examples/embeddable_examples/common/book/content_management/schema/v3/index.ts
+++ b/examples/embeddable_examples/common/book/content_management/schema/v3/index.ts
@@ -7,11 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+export { bookAttributesDefinition } from './v3';

--- a/examples/embeddable_examples/common/book/content_management/schema/v3/v3.ts
+++ b/examples/embeddable_examples/common/book/content_management/schema/v3/v3.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { VersionableEmbeddableObject } from '@kbn/embeddable-plugin/common';
+import type { SavedBookAttributes } from '../../../../../server/types';
+import type { BookAttributes } from '../../../../../server/book/content_management/schema/v3';
+import type { BookAttributes as BookV2Attributes } from '../../../../../server/book/content_management/schema/v2';
+
+export const bookAttributesDefinition: VersionableEmbeddableObject<
+  SavedBookAttributes,
+  BookAttributes,
+  BookV2Attributes
+> = {
+  up: (item) => ({
+    ...item,
+    pages: item.numberOfPages,
+  }),
+  down: (item) => ({
+    ...item,
+    numberOfPages: item.pages,
+  }),
+  itemToSavedObject: (item) => ({
+    bookTitle: item.title,
+    authorName: item.author,
+    numberOfPages: item.pages,
+    bookSynopsis: item.synopsis,
+  }),
+  savedObjectToItem: (savedObject) => ({
+    title: savedObject.bookTitle,
+    author: savedObject.authorName,
+    pages: savedObject.numberOfPages,
+    synopsis: savedObject.bookSynopsis,
+  }),
+};

--- a/examples/embeddable_examples/kibana.jsonc
+++ b/examples/embeddable_examples/kibana.jsonc
@@ -5,7 +5,7 @@
   "description": "Example app that shows how to register custom embeddables",
   "plugin": {
     "id": "embeddableExamples",
-    "server": false,
+    "server": true,
     "browser": true,
     "requiredPlugins": [
       "dataViews",

--- a/examples/embeddable_examples/public/app/app.tsx
+++ b/examples/embeddable_examples/public/app/app.tsx
@@ -56,10 +56,12 @@ const App = ({
       {
         id: 'presentationContainer',
         title: 'Create a dashboard like experience with embeddables',
-        component: <PresentationContainerExample uiActions={deps.uiActions} />,
+        component: (
+          <PresentationContainerExample uiActions={deps.uiActions} embeddable={deps.embeddable} />
+        ),
       },
     ];
-  }, [deps.uiActions]);
+  }, [deps.uiActions, deps.embeddable]);
 
   const routes = useMemo(() => {
     return pages.map((page) => (

--- a/examples/embeddable_examples/public/app/presentation_container_example/components/presentation_container_example.tsx
+++ b/examples/embeddable_examples/public/app/presentation_container_example/components/presentation_container_example.tsx
@@ -17,7 +17,7 @@ import {
   EuiSuperDatePicker,
 } from '@elastic/eui';
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
-import { EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
+import { EmbeddableStart, EmbeddableRenderer } from '@kbn/embeddable-plugin/public';
 import { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import { getPageApi } from '../page_api';
 import { AddButton } from './add_button';
@@ -25,10 +25,16 @@ import { TopNav } from './top_nav';
 import { lastSavedStateSessionStorage } from '../session_storage/last_saved_state';
 import { unsavedChangesSessionStorage } from '../session_storage/unsaved_changes';
 
-export const PresentationContainerExample = ({ uiActions }: { uiActions: UiActionsStart }) => {
+export const PresentationContainerExample = ({
+  embeddable,
+  uiActions,
+}: {
+  embeddable: EmbeddableStart;
+  uiActions: UiActionsStart;
+}) => {
   const { cleanUp, componentApi, pageApi } = useMemo(() => {
-    return getPageApi();
-  }, []);
+    return getPageApi(embeddable);
+  }, [embeddable]);
 
   useEffect(() => {
     return () => {

--- a/examples/embeddable_examples/public/app/presentation_container_example/page_api.ts
+++ b/examples/embeddable_examples/public/app/presentation_container_example/page_api.ts
@@ -25,6 +25,7 @@ import {
   apiPublishesDataLoading,
   apiPublishesUnsavedChanges,
 } from '@kbn/presentation-publishing';
+import { EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import { lastSavedStateSessionStorage } from './session_storage/last_saved_state';
 import { unsavedChangesSessionStorage } from './session_storage/unsaved_changes';
 import { PageApi, PageState } from './types';
@@ -39,9 +40,9 @@ function deserializePanels(panels: PageState['panels']) {
   return { layout, childState };
 }
 
-export function getPageApi() {
+export function getPageApi(embeddable: EmbeddableStart) {
   const initialUnsavedState = unsavedChangesSessionStorage.load();
-  const initialState = lastSavedStateSessionStorage.load();
+  const initialState = lastSavedStateSessionStorage.load(embeddable);
   const lastSavedState$ = new BehaviorSubject<PageState>(initialState);
   const children$ = new BehaviorSubject<{ [key: string]: unknown }>({});
   const { layout: initialLayout, childState: initialChildState } = deserializePanels(
@@ -174,7 +175,7 @@ export function getPageApi() {
         // simulate save await
         await new Promise((resolve) => setTimeout(resolve, 1000));
         lastSavedState$.next(serializedPage);
-        lastSavedStateSessionStorage.save(serializedPage);
+        lastSavedStateSessionStorage.save(serializedPage, embeddable);
         unsavedChangesSessionStorage.clear();
       },
       layout$,

--- a/examples/embeddable_examples/public/app/presentation_container_example/session_storage/last_saved_state.ts
+++ b/examples/embeddable_examples/public/app/presentation_container_example/session_storage/last_saved_state.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { PageState } from '../types';
 import { EmbeddableStart } from '@kbn/embeddable-plugin/public';
+import { PageState } from '../types';
 
 const SAVED_STATE_SESSION_STORAGE_KEY =
   'kibana.examples.embeddables.presentationContainerExample.savedState';
@@ -38,7 +38,10 @@ export const lastSavedStateSessionStorage = {
       const { savedObjectToItem } =
         embeddableCmDefinitions?.versions[embeddableCmDefinitions.latestVersion] ?? {};
       if (!savedObjectToItem) return panel;
-      const newState = savedObjectToItem(panel.serializedState?.rawState);
+      const newState = savedObjectToItem({
+        attributes: panel.serializedState?.rawState,
+        references: panel.serializedState?.references,
+      });
       return {
         ...panel,
         serializedState: {
@@ -57,7 +60,10 @@ export const lastSavedStateSessionStorage = {
       const { itemToSavedObject } =
         embeddableCmDefinitions?.versions[embeddableCmDefinitions.latestVersion] ?? {};
       if (!itemToSavedObject) return panel;
-      const savedState = itemToSavedObject(panel.serializedState?.rawState);
+      const savedState = itemToSavedObject({
+        attributes: panel.serializedState?.rawState,
+        references: panel.serializedState?.references,
+      });
       return {
         ...panel,
         serializedState: {

--- a/examples/embeddable_examples/public/plugin.ts
+++ b/examples/embeddable_examples/public/plugin.ts
@@ -29,6 +29,7 @@ import { SAVED_BOOK_ID } from './react_embeddables/saved_book/constants';
 import { registerCreateSavedBookAction } from './react_embeddables/saved_book/create_saved_book_action';
 import { registerAddSearchPanelAction } from './react_embeddables/search/register_add_search_panel_action';
 import { registerSearchEmbeddable } from './react_embeddables/search/register_search_embeddable';
+import { bookCmDefinitions } from '../common/book/content_management/cm_services';
 
 export interface SetupDeps {
   developerExamples: DeveloperExamplesSetup;
@@ -88,6 +89,8 @@ export class EmbeddableExamplesPlugin implements Plugin<void, void, SetupDeps, S
       embeddable,
       new Promise((resolve) => startServicesPromise.then(([_, startDeps]) => resolve(startDeps)))
     );
+
+    embeddable.registerEmbeddableContentManagementDefinition(bookCmDefinitions);
   }
 
   public start(core: CoreStart, deps: StartDeps) {

--- a/examples/embeddable_examples/server/book/content_management/schema/v1/index.ts
+++ b/examples/embeddable_examples/server/book/content_management/schema/v1/index.ts
@@ -7,11 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+export type { BookAttributes } from './types';
+export { bookAttributesSchema } from './v1';

--- a/examples/embeddable_examples/server/book/content_management/schema/v1/types.ts
+++ b/examples/embeddable_examples/server/book/content_management/schema/v1/types.ts
@@ -7,11 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import { TypeOf } from '@kbn/config-schema';
+import { bookAttributesSchema } from './v1';
+
+export type BookAttributes = TypeOf<typeof bookAttributesSchema>;

--- a/examples/embeddable_examples/server/book/content_management/schema/v1/v1.ts
+++ b/examples/embeddable_examples/server/book/content_management/schema/v1/v1.ts
@@ -7,11 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import { savedBookAttributesSchema } from '../../../saved_object/schema/v1';
+
+export const bookAttributesSchema = savedBookAttributesSchema;

--- a/examples/embeddable_examples/server/book/content_management/schema/v2/index.ts
+++ b/examples/embeddable_examples/server/book/content_management/schema/v2/index.ts
@@ -7,11 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+export type { BookAttributes } from './types';
+export { bookAttributesSchema } from './v2';

--- a/examples/embeddable_examples/server/book/content_management/schema/v2/types.ts
+++ b/examples/embeddable_examples/server/book/content_management/schema/v2/types.ts
@@ -7,11 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import { TypeOf } from '@kbn/config-schema';
+import { bookAttributesSchema } from './v2';
+
+export type BookAttributes = TypeOf<typeof bookAttributesSchema>;

--- a/examples/embeddable_examples/server/book/content_management/schema/v2/v2.ts
+++ b/examples/embeddable_examples/server/book/content_management/schema/v2/v2.ts
@@ -7,11 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import { schema } from '@kbn/config-schema';
+
+export const bookAttributesSchema = schema.object({
+  title: schema.string(),
+  author: schema.string(),
+  numberOfPages: schema.number(),
+  synopsis: schema.maybe(schema.string()),
+});

--- a/examples/embeddable_examples/server/book/content_management/schema/v3/index.ts
+++ b/examples/embeddable_examples/server/book/content_management/schema/v3/index.ts
@@ -7,11 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+export type { BookAttributes } from './types';
+export { bookAttributesSchema } from './v3';

--- a/examples/embeddable_examples/server/book/content_management/schema/v3/types.ts
+++ b/examples/embeddable_examples/server/book/content_management/schema/v3/types.ts
@@ -7,11 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import { TypeOf } from '@kbn/config-schema';
+import { bookAttributesSchema } from './v3';
+
+export type BookAttributes = TypeOf<typeof bookAttributesSchema>;

--- a/examples/embeddable_examples/server/book/content_management/schema/v3/v3.ts
+++ b/examples/embeddable_examples/server/book/content_management/schema/v3/v3.ts
@@ -7,11 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import { schema } from '@kbn/config-schema';
+
+export const bookAttributesSchema = schema.object({
+  title: schema.string(),
+  author: schema.string(),
+  pages: schema.number(),
+  synopsis: schema.maybe(schema.string()),
+});

--- a/examples/embeddable_examples/server/book/saved_object/schema/v1/index.ts
+++ b/examples/embeddable_examples/server/book/saved_object/schema/v1/index.ts
@@ -7,11 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+export type { SavedBookAttributes } from './types';
+export { savedBookAttributesSchema } from './v1';

--- a/examples/embeddable_examples/server/book/saved_object/schema/v1/types.ts
+++ b/examples/embeddable_examples/server/book/saved_object/schema/v1/types.ts
@@ -7,11 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import { TypeOf } from '@kbn/config-schema';
+import { savedBookAttributesSchema } from './v1';
+
+export type SavedBookAttributes = TypeOf<typeof savedBookAttributesSchema>;

--- a/examples/embeddable_examples/server/book/saved_object/schema/v1/v1.ts
+++ b/examples/embeddable_examples/server/book/saved_object/schema/v1/v1.ts
@@ -7,11 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import { schema } from '@kbn/config-schema';
+
+export const savedBookAttributesSchema = schema.object({
+  bookTitle: schema.string(),
+  authorName: schema.string(),
+  numberOfPages: schema.number(),
+  bookSynopsis: schema.maybe(schema.string()),
+});

--- a/examples/embeddable_examples/server/index.ts
+++ b/examples/embeddable_examples/server/index.ts
@@ -7,11 +7,9 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import { PluginInitializerContext } from '@kbn/core/server';
+
+export async function plugin(initializerContext: PluginInitializerContext) {
+  const { EmbeddableExamplesPlugin } = await import('./plugin');
+  return new EmbeddableExamplesPlugin(initializerContext);
+}

--- a/examples/embeddable_examples/server/plugin.ts
+++ b/examples/embeddable_examples/server/plugin.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { CoreSetup, CoreStart, Plugin, PluginInitializerContext } from '@kbn/core/server';
+import type { EmbeddableContentManagementDefinition } from '@kbn/embeddable-plugin/common';
+import type { SetupDeps, StartDeps } from './types';
+import { bookCmDefinitions } from '../common/book/content_management/cm_services';
+import { bookAttributesSchema as bookAttributesSchemaV1 } from './book/content_management/schema/v1';
+import { bookAttributesSchema as bookAttributesSchemaV2 } from './book/content_management/schema/v2';
+import { bookAttributesSchema as bookAttributesSchemaV3 } from './book/content_management/schema/v3';
+
+export class EmbeddableExamplesPlugin implements Plugin<void, void, SetupDeps, StartDeps> {
+  constructor(initializerContext: PluginInitializerContext) {}
+
+  public setup(core: CoreSetup, { embeddable }: SetupDeps) {
+    const bookCmDefinitionsWithSchemas: EmbeddableContentManagementDefinition = {
+      id: 'book',
+      versions: {
+        1: { ...bookCmDefinitions.versions[1], itemSchema: bookAttributesSchemaV1 },
+        2: { ...bookCmDefinitions.versions[2], itemSchema: bookAttributesSchemaV2 },
+        3: { ...bookCmDefinitions.versions[3], itemSchema: bookAttributesSchemaV3 },
+      },
+      latestVersion: 3,
+    };
+
+    embeddable.registerEmbeddableContentManagementDefinition(bookCmDefinitionsWithSchemas);
+
+    return {};
+  }
+
+  public start(core: CoreStart, { embeddable }: StartDeps) {
+    return {};
+  }
+
+  public stop() {}
+}

--- a/examples/embeddable_examples/server/types.ts
+++ b/examples/embeddable_examples/server/types.ts
@@ -7,11 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export type {
-  CommonEmbeddableStartContract,
-  EmbeddableStateWithType,
-  EmbeddablePersistableStateService,
-  EmbeddableRegistryDefinition,
-  EmbeddableContentManagementDefinition,
-  VersionableEmbeddableObject,
-} from './types';
+import type { EmbeddableSetup, EmbeddableStart } from '@kbn/embeddable-plugin/server';
+
+export type { SavedBookAttributes } from './book/saved_object/schema/v1';
+
+export interface SetupDeps {
+  embeddable: EmbeddableSetup;
+}
+
+export interface StartDeps {
+  embeddable: EmbeddableStart;
+}

--- a/src/platform/plugins/shared/embeddable/common/embeddable_content_management/registry.ts
+++ b/src/platform/plugins/shared/embeddable/common/embeddable_content_management/registry.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EmbeddableContentManagementDefinition } from '..';
+
+export class EmbeddableContentManagementRegistry {
+  private registry: Map<string, EmbeddableContentManagementDefinition> = new Map();
+
+  public registerContentManagementDefinition = (
+    definition: EmbeddableContentManagementDefinition
+  ) => {
+    if (this.registry.has(definition.id)) {
+      throw new Error(
+        `Content management definition for type "${definition.id}" is already registered.`
+      );
+    }
+
+    if (!(definition.latestVersion in definition.versions)) {
+      throw new Error(
+        `Content management definition for type "${definition.id}" does not include the current version "${definition.latestVersion}".`
+      );
+    }
+    this.registry.set(definition.id, definition);
+  };
+
+  public getContentManagementDefinition = (id: string) => {
+    return this.registry.get(id);
+  };
+}

--- a/src/platform/plugins/shared/embeddable/common/types.ts
+++ b/src/platform/plugins/shared/embeddable/common/types.ts
@@ -16,6 +16,7 @@ import type {
 import type { ObjectTransform } from '@kbn/object-versioning';
 import type { MaybePromise } from '@kbn/utility-types';
 import type { Type } from '@kbn/config-schema';
+import type { SavedObject, SavedObjectReference } from '@kbn/core/server';
 
 export type EmbeddableStateWithType = {
   enhancements?: SerializableRecord;
@@ -30,16 +31,37 @@ export interface EmbeddableRegistryDefinition<
 
 export type EmbeddablePersistableStateService = PersistableStateService<EmbeddableStateWithType>;
 
+export type SavedObjectAttributesWithReferences<SavedObjectAttributes> = Pick<
+  SavedObject<SavedObjectAttributes>,
+  'attributes' | 'references'
+>;
+
+export type ItemAttributesWithReferences<ItemAttributes> = {
+  attributes: ItemAttributes;
+  references: SavedObjectReference[];
+};
+
 export type VersionableEmbeddableObject<
   SOAttributes = unknown,
-  Item = unknown,
-  PrevItem = unknown
+  ItemAttributes = unknown,
+  PrevItemAttributes = void,
+  NextItemAttributes = void
 > = {
-  up?: ObjectTransform<PrevItem, Item>;
-  down?: ObjectTransform<Item, PrevItem>;
-  itemSchema?: Type<Item>;
-  savedObjectToItem?: (savedObject: SOAttributes) => MaybePromise<Item>;
-  itemToSavedObject?: (item: Item) => MaybePromise<SOAttributes>;
+  up?: ObjectTransform<
+    ItemAttributesWithReferences<ItemAttributes>,
+    ItemAttributesWithReferences<NextItemAttributes>
+  >;
+  down?: ObjectTransform<
+    ItemAttributesWithReferences<ItemAttributes>,
+    ItemAttributesWithReferences<PrevItemAttributes>
+  >;
+  itemSchema?: Type<ItemAttributes>;
+  savedObjectToItem?: (
+    savedObject: SavedObjectAttributesWithReferences<SOAttributes>
+  ) => MaybePromise<ItemAttributesWithReferences<ItemAttributes>>;
+  itemToSavedObject?: (
+    item: ItemAttributesWithReferences<ItemAttributes>
+  ) => MaybePromise<SavedObjectAttributesWithReferences<SOAttributes>>;
 };
 
 export type EmbeddableContentManagementDefinition = {

--- a/src/platform/plugins/shared/embeddable/common/types.ts
+++ b/src/platform/plugins/shared/embeddable/common/types.ts
@@ -13,6 +13,9 @@ import type {
   PersistableState,
   PersistableStateDefinition,
 } from '@kbn/kibana-utils-plugin/common';
+import type { ObjectTransform } from '@kbn/object-versioning';
+import type { MaybePromise } from '@kbn/utility-types';
+import type { Type } from '@kbn/config-schema';
 
 export type EmbeddableStateWithType = {
   enhancements?: SerializableRecord;
@@ -26,6 +29,28 @@ export interface EmbeddableRegistryDefinition<
 }
 
 export type EmbeddablePersistableStateService = PersistableStateService<EmbeddableStateWithType>;
+
+export type VersionableEmbeddableObject<
+  SOAttributes = unknown,
+  Item = unknown,
+  PrevItem = unknown
+> = {
+  up?: ObjectTransform<PrevItem, Item>;
+  down?: ObjectTransform<Item, PrevItem>;
+  itemSchema?: Type<Item>;
+  savedObjectToItem?: (savedObject: SOAttributes) => MaybePromise<Item>;
+  itemToSavedObject?: (item: Item) => MaybePromise<SOAttributes>;
+};
+
+export type EmbeddableContentManagementDefinition = {
+  id: string;
+  versions: Record<number, VersionableEmbeddableObject<any, any, any>>;
+  latestVersion: number;
+};
+
+export type EmbeddableContentManagementService = {
+  getEmbeddableMigrationDefinition: (id: string) => EmbeddableContentManagementDefinition;
+};
 
 export interface CommonEmbeddableStartContract {
   getEmbeddableFactory?: (

--- a/src/platform/plugins/shared/embeddable/common/types.ts
+++ b/src/platform/plugins/shared/embeddable/common/types.ts
@@ -16,7 +16,7 @@ import type {
 import type { ObjectTransform } from '@kbn/object-versioning';
 import type { MaybePromise } from '@kbn/utility-types';
 import type { Type } from '@kbn/config-schema';
-import type { SavedObject, SavedObjectReference } from '@kbn/core/server';
+import type { SavedObjectReference } from '@kbn/core/server';
 
 export type EmbeddableStateWithType = {
   enhancements?: SerializableRecord;
@@ -31,14 +31,14 @@ export interface EmbeddableRegistryDefinition<
 
 export type EmbeddablePersistableStateService = PersistableStateService<EmbeddableStateWithType>;
 
-export type SavedObjectAttributesWithReferences<SavedObjectAttributes> = Pick<
-  SavedObject<SavedObjectAttributes>,
-  'attributes' | 'references'
->;
+export type SavedObjectAttributesWithReferences<SavedObjectAttributes> = {
+  attributes: SavedObjectAttributes;
+  references?: SavedObjectReference[];
+};
 
 export type ItemAttributesWithReferences<ItemAttributes> = {
   attributes: ItemAttributes;
-  references: SavedObjectReference[];
+  references?: SavedObjectReference[];
 };
 
 export type VersionableEmbeddableObject<

--- a/src/platform/plugins/shared/embeddable/public/plugin.tsx
+++ b/src/platform/plugins/shared/embeddable/public/plugin.tsx
@@ -30,6 +30,7 @@ import { getAllMigrations } from '../common/lib/get_all_migrations';
 import { setKibanaServices } from './kibana_services';
 import { registerReactEmbeddableFactory } from './react_embeddable_system';
 import { registerAddFromLibraryType } from './add_from_library/registry';
+import { EmbeddableContentManagementRegistry } from '../common/embeddable_content_management/registry';
 import { EnhancementsRegistry } from './enhancements/registry';
 import {
   EmbeddableSetup,
@@ -43,6 +44,7 @@ export class EmbeddablePublicPlugin implements Plugin<EmbeddableSetup, Embeddabl
   private appList?: ReadonlyMap<string, PublicAppInfo>;
   private appListSubscription?: Subscription;
   private enhancementsRegistry = new EnhancementsRegistry();
+  private embeddableContentManagementRegistry = new EmbeddableContentManagementRegistry();
 
   constructor(initializerContext: PluginInitializerContext) {}
 
@@ -53,6 +55,8 @@ export class EmbeddablePublicPlugin implements Plugin<EmbeddableSetup, Embeddabl
       registerReactEmbeddableFactory,
       registerAddFromLibraryType,
       registerEnhancement: this.enhancementsRegistry.registerEnhancement,
+      registerEmbeddableContentManagementDefinition:
+        this.embeddableContentManagementRegistry.registerContentManagementDefinition,
     };
   }
 
@@ -91,6 +95,8 @@ export class EmbeddablePublicPlugin implements Plugin<EmbeddableSetup, Embeddabl
       telemetry: getTelemetryFunction(commonContract),
       extract: getExtractFunction(commonContract),
       inject: getInjectFunction(commonContract),
+      getEmbeddableContentManagementDefinition:
+        this.embeddableContentManagementRegistry.getContentManagementDefinition,
       getAllMigrations: getAllMigrationsFn,
       migrateToLatest: (state) => {
         return migrateToLatest(getAllMigrationsFn(), state) as EmbeddableStateWithType;

--- a/src/platform/plugins/shared/embeddable/public/types.ts
+++ b/src/platform/plugins/shared/embeddable/public/types.ts
@@ -18,7 +18,7 @@ import type { PersistableStateService } from '@kbn/kibana-utils-plugin/common';
 import type { registerAddFromLibraryType } from './add_from_library/registry';
 import type { registerReactEmbeddableFactory } from './react_embeddable_system';
 import type { EmbeddableStateTransfer } from './state_transfer';
-import type { EmbeddableStateWithType } from '../common';
+import type { EmbeddableContentManagementDefinition, EmbeddableStateWithType } from '../common';
 import { EnhancementRegistryDefinition } from './enhancements/types';
 
 export interface EmbeddableSetupDependencies {
@@ -60,6 +60,10 @@ export interface EmbeddableSetup {
    */
   registerReactEmbeddableFactory: typeof registerReactEmbeddableFactory;
 
+  registerEmbeddableContentManagementDefinition: (
+    definition: EmbeddableContentManagementDefinition
+  ) => void;
+
   /**
    * @deprecated
    */
@@ -68,4 +72,7 @@ export interface EmbeddableSetup {
 
 export interface EmbeddableStart extends PersistableStateService<EmbeddableStateWithType> {
   getStateTransfer: (storage?: Storage) => EmbeddableStateTransfer;
+  getEmbeddableContentManagementDefinition: (
+    id: string
+  ) => EmbeddableContentManagementDefinition | undefined;
 }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/192622

Adds a `EmbeddableContentManagementDefinition` (naming is hard) registry for embeddables to register versioned validation schemas (server-side only) and transform functions (public and server-side) for transforming saved state (such as by-value embeddables in a dashboard) into state that the embeddable supports.

See the implementation in the saved book embeddable developer example:
1.  Start kibana with `yarn start --run-examples` 
2. Go to the  http://localhost:5601/app/embeddablesApp/presentationContainer example
3. Add a Book embeddable. 
4. The `latestVersion` of the `book` content definition determines which transforms are run.
5. The Storage Context layer is mimiced in session storage in `examples/embeddable_examples/public/app/presentation_container_example/session_storage/last_saved_state.ts` 