### PR TITLE
[Cloud Security] add handling of non existing fields in the grouping query builder logic

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/helpers.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { MAX_RUNTIME_FIELD_SIZE } from '.';
 import { createGroupFilter } from './helpers';
 
 const selectedGroup = 'host.name';
@@ -39,7 +40,12 @@ describe('createGroupFilter', () => {
     const selectedGroupMock = 'vulnerability.id';
     const cveMockData = ['CVE-2021-12345', 'CVE-2021-56789'];
     const result = createGroupFilter(selectedGroupMock, cveMockData, multiValueFields);
-    expect(result[0].query.script).toBeUndefined();
+    const mockResponse = {
+      source: `doc[params['field']].size() <  ${MAX_RUNTIME_FIELD_SIZE}`,
+      params: { field: 'vulnerability.id', size: 2 },
+    };
+
+    expect(result[0].query.script.script).toEqual(mockResponse);
   });
 
   it('returns filter with script key when selectedGroup is not included in multiValueFields', () => {

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { getGroupingQuery, parseGroupingQuery } from '.';
+import { getGroupingQuery, MAX_RUNTIME_FIELD_SIZE, parseGroupingQuery } from '.';
 import { getEmptyValue } from './helpers';
 import type { GroupingAggregation } from '../../..';
 import { groupingBucket, mocktestProps1, mockTestProps2 } from '../../mocks';
@@ -93,8 +93,13 @@ describe('group selector', () => {
 
     it('groupByField script should contain logic which gets all values of groupByField', () => {
       const scriptResponse = {
-        source:
-          "def groupValues = doc[params['selectedGroup']]; int count = groupValues.size(); if (count == 0 || count > 100 ) { emit(params['uniqueValue']); } else { emit(groupValues.join(params['uniqueValue']))}",
+        source: `def groupValues = [];
+if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
+  groupValues = doc[params['selectedGroup']];
+}  
+int count = groupValues.size();
+if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
+else { emit(groupValues.join(params['uniqueValue']))}`,
         params: {
           selectedGroup: 'resource.name',
           uniqueValue: 'whatAGreatAndUniqueValue',
@@ -104,6 +109,7 @@ describe('group selector', () => {
       const result = getGroupingQuery(mockTestProps2);
 
       expect(result.runtime_mappings.groupByField.script).toEqual(scriptResponse);
+      expect(result.runtime_mappings.groupByField.script.params).toEqual(scriptResponse.params);
       expect(result.aggs.unitsCount).toEqual({ value_count: { field: 'groupByField' } });
     });
 
@@ -112,8 +118,13 @@ describe('group selector', () => {
       const countByKeyForMultiValueFields = 'event.id';
 
       const scriptResponse = {
-        source:
-          "def groupValues = doc[params['selectedGroup']]; int count = groupValues.size(); if (count == 0 || count > 100 ) { emit(params['uniqueValue']); } else { for (int i = 0; i < count && i < 100; i++) { emit(groupValues[i]); } }",
+        source: `def groupValues = [];
+if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
+  groupValues = doc[params['selectedGroup']];
+}  
+int count = groupValues.size();
+if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
+else { for (int i = 0; i < count && i < ${MAX_RUNTIME_FIELD_SIZE}; i++) { emit(groupValues[i]); } }`,
         params: {
           selectedGroup: groupByField,
           uniqueValue: 'whatAGreatAndUniqueValue',

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import dedent from 'dedent';
 import { getGroupingQuery, MAX_RUNTIME_FIELD_SIZE, parseGroupingQuery } from '.';
 import { getEmptyValue } from './helpers';
 import type { GroupingAggregation } from '../../..';
@@ -93,13 +94,16 @@ describe('group selector', () => {
 
     it('groupByField script should contain logic which gets all values of groupByField', () => {
       const scriptResponse = {
-        source: `def groupValues = [];
-if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
-  groupValues = doc[params['selectedGroup']];
-}  
-int count = groupValues.size();
-if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
-else { emit(groupValues.join(params['uniqueValue']))}`,
+        source: dedent(`
+          def groupValues = [];
+          if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
+            groupValues = doc[params['selectedGroup']];
+          }  
+          int count = groupValues.size();
+          if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
+          else {
+            emit(groupValues.join(params['uniqueValue']));
+          }`),
         params: {
           selectedGroup: 'resource.name',
           uniqueValue: 'whatAGreatAndUniqueValue',
@@ -118,13 +122,16 @@ else { emit(groupValues.join(params['uniqueValue']))}`,
       const countByKeyForMultiValueFields = 'event.id';
 
       const scriptResponse = {
-        source: `def groupValues = [];
-if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
-  groupValues = doc[params['selectedGroup']];
-}  
-int count = groupValues.size();
-if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
-else { for (int i = 0; i < count && i < ${MAX_RUNTIME_FIELD_SIZE}; i++) { emit(groupValues[i]); } }`,
+        source: dedent(`
+          def groupValues = [];
+          if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
+            groupValues = doc[params['selectedGroup']];
+          }  
+          int count = groupValues.size();
+          if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
+          else {
+            for (int i = 0; i < count && i < ${MAX_RUNTIME_FIELD_SIZE}; i++) { emit(groupValues[i]); }
+          }`),
         params: {
           selectedGroup: groupByField,
           uniqueValue: 'whatAGreatAndUniqueValue',

--- a/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
+++ b/src/platform/packages/shared/kbn-grouping/src/containers/query/index.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import dedent from 'dedent';
 import { checkIsFlattenResults, getEmptyValue } from './helpers';
 import type { GroupingAggregation, ParsedGroupingAggregation } from '../..';
 import type { GroupingQueryArgs, GroupingQuery } from './types';
@@ -66,16 +67,9 @@ export const getGroupingQuery = ({
         type: 'keyword',
         script: {
           source:
-            // when size()==0 or size() > MAX_RUNTIME_FIELD_SIZE, emits a uniqueValue as the value to represent this group
-            `def groupValues = [];
-if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
-  groupValues = doc[params['selectedGroup']];
-}  
-int count = groupValues.size();
-if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
-` +
             /*
-             * condition to decide between joining values or flattening based on shouldFlattenMultiValueField and groupByField parameters
+             * when size()==0 or size() > MAX_RUNTIME_FIELD_SIZE, emits a uniqueValue as the value to represent this group
+             * else - condition to decide between joining values or flattening based on shouldFlattenMultiValueField and groupByField parameters
              * if shouldFlattenMultiValueField is true, and the selectedGroup field is an array, then emit each value in the array
              * this is usefull when we would like to group documents based on each uniqueValue
              * Else, join the values with uniqueValue. We cannot simply emit the value like doc[params['selectedGroup']].value,
@@ -86,9 +80,20 @@ if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue
              * Instead of joining with a "," we should join with a unique value to avoid splitting a value that happens to contain a ",".
              * We will format into a proper array in parseGroupingQuery
              */
-            (shouldFlattenMultiValueField
-              ? `else { for (int i = 0; i < count && i < ${MAX_RUNTIME_FIELD_SIZE}; i++) { emit(groupValues[i]); } }`
-              : "else { emit(groupValues.join(params['uniqueValue']))}"),
+            dedent(`
+              def groupValues = [];
+              if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
+                groupValues = doc[params['selectedGroup']];
+              }  
+              int count = groupValues.size();
+              if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
+              else {
+                ${
+                  shouldFlattenMultiValueField
+                    ? `for (int i = 0; i < count && i < ${MAX_RUNTIME_FIELD_SIZE}; i++) { emit(groupValues[i]); }`
+                    : `emit(groupValues.join(params['uniqueValue']));`
+                }
+              }`),
           params: {
             selectedGroup: groupByField,
             uniqueValue,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { MAX_RUNTIME_FIELD_SIZE } from '@kbn/grouping/src';
 import { mockAlertSearchResponse } from '../../alerts_kpis/alerts_treemap_panel/alerts_treemap/lib/mocks/mock_alert_search_response';
 
 export const getQuery = (
@@ -96,8 +97,13 @@ export const getQuery = (
     groupByField: {
       type: 'keyword',
       script: {
-        source:
-          "def groupValues = doc[params['selectedGroup']]; int count = groupValues.size(); if (count == 0 || count > 100 ) { emit(params['uniqueValue']); } else { emit(groupValues.join(params['uniqueValue']))}",
+        source: `def groupValues = [];
+if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
+  groupValues = doc[params['selectedGroup']];
+}  
+int count = groupValues.size();
+if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
+else { emit(groupValues.join(params['uniqueValue']))}`,
         params: {
           selectedGroup,
           uniqueValue,

--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alerts_table/grouping_settings/mock.ts
@@ -6,6 +6,7 @@
  */
 
 import { MAX_RUNTIME_FIELD_SIZE } from '@kbn/grouping/src';
+import dedent from 'dedent';
 import { mockAlertSearchResponse } from '../../alerts_kpis/alerts_treemap_panel/alerts_treemap/lib/mocks/mock_alert_search_response';
 
 export const getQuery = (
@@ -97,13 +98,16 @@ export const getQuery = (
     groupByField: {
       type: 'keyword',
       script: {
-        source: `def groupValues = [];
-if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
-  groupValues = doc[params['selectedGroup']];
-}  
-int count = groupValues.size();
-if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
-else { emit(groupValues.join(params['uniqueValue']))}`,
+        source: dedent(`
+          def groupValues = [];
+          if (doc.containsKey(params['selectedGroup']) && !doc[params['selectedGroup']].empty) {
+            groupValues = doc[params['selectedGroup']];
+          }  
+          int count = groupValues.size();
+          if (count == 0 || count > ${MAX_RUNTIME_FIELD_SIZE} ) { emit(params['uniqueValue']); }
+          else {
+            emit(groupValues.join(params['uniqueValue']));
+          }`),
         params: {
           selectedGroup,
           uniqueValue,


### PR DESCRIPTION
## Summary
This PR should fix the following issue: https://github.com/elastic/kibana/issues/220022
The issue opened contains two bugs:
1. an issue when trying to group by field which is missing in one or more of the fetched documents - causing the query to fail.
2. duplication of documents with more than 100 values in a specific field - they are part of the none-group which is correct and also part of any other group containing one or more of the values which they shouldn't be.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Recordings
**Before fix**

https://github.com/user-attachments/assets/0109ddba-ef0d-456b-865e-5c52883dc04a

**After fix**

https://github.com/user-attachments/assets/f8b4e1d7-2be4-4b28-8e43-cd1398eed136
