### PR TITLE
Upgrade EUI to v102.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@elastic/ecs": "^8.11.5",
     "@elastic/elasticsearch": "9.0.0-alpha.4",
     "@elastic/ems-client": "8.6.3",
-    "@elastic/eui": "102.0.0",
+    "@elastic/eui": "102.1.0",
     "@elastic/eui-theme-borealis": "1.0.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/monaco-esql": "^3.1.0",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -88,7 +88,7 @@ export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
   '@elastic/ems-client@8.6.3': ['Elastic License 2.0'],
-  '@elastic/eui@102.0.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
+  '@elastic/eui@102.1.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   '@elastic/eui-theme-borealis@1.0.0': ['Elastic License 2.0 OR AGPL-3.0-only OR SSPL-1.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
   'buffers@0.1.1': ['MIT'], // license in importing module https://www.npmjs.com/package/binary

--- a/src/platform/plugins/shared/data/public/utils/table_inspector_view/components/__snapshots__/data_view.test.tsx.snap
+++ b/src/platform/plugins/shared/data/public/utils/table_inspector_view/components/__snapshots__/data_view.test.tsx.snap
@@ -227,26 +227,30 @@ Array [
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
                 >
-                  column1
-                </span>
-                <span
-                  class="euiTableSortIcon euiTableSortIcon--sortable"
-                  color="subdued"
-                  data-euiicon-type="sortable"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                  >
+                    column1
+                  </span>
+                  <span
+                    class="euiTableSortIcon euiTableSortIcon--sortable"
+                    color="subdued"
+                    data-euiicon-type="sortable"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
         </tr>
       </thead>
@@ -507,27 +511,31 @@ Array [
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="column1"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
                 >
-                  column1
-                </span>
-                <span
-                  class="euiTableSortIcon euiTableSortIcon--sortable"
-                  color="subdued"
-                  data-euiicon-type="sortable"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="column1"
+                  >
+                    column1
+                  </span>
+                  <span
+                    class="euiTableSortIcon euiTableSortIcon--sortable"
+                    color="subdued"
+                    data-euiicon-type="sortable"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
         </tr>
       </thead>

--- a/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/processes/__snapshots__/processes_table.test.tsx.snap
+++ b/x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/processes/__snapshots__/processes_table.test.tsx.snap
@@ -68,27 +68,31 @@ Object {
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Time"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Time
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Time"
+                    >
+                      Time
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="descending"
@@ -97,26 +101,30 @@ Object {
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="CPU"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
                   >
-                    CPU
-                  </span>
-                  <span
-                    class="euiTableSortIcon"
-                    data-euiicon-type="sortDown"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="CPU"
+                    >
+                      CPU
+                    </span>
+                    <span
+                      class="euiTableSortIcon"
+                      data-euiicon-type="sortDown"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="none"
@@ -125,27 +133,31 @@ Object {
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Mem."
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
                   >
-                    Mem.
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Mem."
+                    >
+                      Mem.
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
           </tr>
         </thead>
@@ -334,27 +346,31 @@ Object {
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="Time"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                 >
-                  Time
-                </span>
-                <span
-                  class="euiTableSortIcon euiTableSortIcon--sortable"
-                  color="subdued"
-                  data-euiicon-type="sortable"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="Time"
+                  >
+                    Time
+                  </span>
+                  <span
+                    class="euiTableSortIcon euiTableSortIcon--sortable"
+                    color="subdued"
+                    data-euiicon-type="sortable"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
           <th
             aria-sort="descending"
@@ -363,26 +379,30 @@ Object {
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="CPU"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
                 >
-                  CPU
-                </span>
-                <span
-                  class="euiTableSortIcon"
-                  data-euiicon-type="sortDown"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="CPU"
+                  >
+                    CPU
+                  </span>
+                  <span
+                    class="euiTableSortIcon"
+                    data-euiicon-type="sortDown"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
           <th
             aria-sort="none"
@@ -391,27 +411,31 @@ Object {
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="Mem."
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
                 >
-                  Mem.
-                </span>
-                <span
-                  class="euiTableSortIcon euiTableSortIcon--sortable"
-                  color="subdued"
-                  data-euiicon-type="sortable"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="Mem."
+                  >
+                    Mem.
+                  </span>
+                  <span
+                    class="euiTableSortIcon euiTableSortIcon--sortable"
+                    color="subdued"
+                    data-euiicon-type="sortable"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
         </tr>
       </thead>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_dns_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_dns_table/__snapshots__/index.test.tsx.snap
@@ -235,27 +235,31 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="Registered domain"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
                 >
-                  Registered domain
-                </span>
-                <span
-                  class="euiTableSortIcon euiTableSortIcon--sortable"
-                  color="subdued"
-                  data-euiicon-type="sortable"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="Registered domain"
+                  >
+                    Registered domain
+                  </span>
+                  <span
+                    class="euiTableSortIcon euiTableSortIcon--sortable"
+                    color="subdued"
+                    data-euiicon-type="sortable"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
           <th
             aria-sort="descending"
@@ -264,26 +268,30 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="Total queries"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                 >
-                  Total queries
-                </span>
-                <span
-                  class="euiTableSortIcon"
-                  data-euiicon-type="sortDown"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="Total queries"
+                  >
+                    Total queries
+                  </span>
+                  <span
+                    class="euiTableSortIcon"
+                    data-euiicon-type="sortDown"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
           <th
             aria-sort="none"
@@ -292,27 +300,31 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="Unique domains"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                 >
-                  Unique domains
-                </span>
-                <span
-                  class="euiTableSortIcon euiTableSortIcon--sortable"
-                  color="subdued"
-                  data-euiicon-type="sortable"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="Unique domains"
+                  >
+                    Unique domains
+                  </span>
+                  <span
+                    class="euiTableSortIcon euiTableSortIcon--sortable"
+                    color="subdued"
+                    data-euiicon-type="sortable"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
           <th
             aria-sort="none"
@@ -321,27 +333,31 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="DNS bytes in"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                 >
-                  DNS bytes in
-                </span>
-                <span
-                  class="euiTableSortIcon euiTableSortIcon--sortable"
-                  color="subdued"
-                  data-euiicon-type="sortable"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="DNS bytes in"
+                  >
+                    DNS bytes in
+                  </span>
+                  <span
+                    class="euiTableSortIcon euiTableSortIcon--sortable"
+                    color="subdued"
+                    data-euiicon-type="sortable"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
           <th
             aria-sort="none"
@@ -350,27 +366,31 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="DNS bytes out"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                 >
-                  DNS bytes out
-                </span>
-                <span
-                  class="euiTableSortIcon euiTableSortIcon--sortable"
-                  color="subdued"
-                  data-euiicon-type="sortable"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="DNS bytes out"
+                  >
+                    DNS bytes out
+                  </span>
+                  <span
+                    class="euiTableSortIcon euiTableSortIcon--sortable"
+                    color="subdued"
+                    data-euiicon-type="sortable"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
         </tr>
       </thead>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_http_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_http_table/__snapshots__/index.test.tsx.snap
@@ -304,26 +304,30 @@ exports[`NetworkHttp Table Component rendering it renders the default NetworkHtt
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Requests"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Requests
-                  </span>
-                  <span
-                    class="euiTableSortIcon"
-                    data-euiicon-type="sortDown"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Requests"
+                    >
+                      Requests
+                    </span>
+                    <span
+                      class="euiTableSortIcon"
+                      data-euiicon-type="sortDown"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
           </tr>
         </thead>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_countries_table/__snapshots__/index.test.tsx.snap
@@ -236,27 +236,31 @@ exports[`NetworkTopCountries Table Component rendering it renders the IP Details
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Bytes in"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Bytes in
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Bytes in"
+                    >
+                      Bytes in
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="descending"
@@ -265,26 +269,30 @@ exports[`NetworkTopCountries Table Component rendering it renders the IP Details
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Bytes out"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Bytes out
-                  </span>
-                  <span
-                    class="euiTableSortIcon"
-                    data-euiicon-type="sortDown"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Bytes out"
+                    >
+                      Bytes out
+                    </span>
+                    <span
+                      class="euiTableSortIcon"
+                      data-euiicon-type="sortDown"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="none"
@@ -293,27 +301,31 @@ exports[`NetworkTopCountries Table Component rendering it renders the IP Details
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Flows"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Flows
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Flows"
+                    >
+                      Flows
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="none"
@@ -322,27 +334,31 @@ exports[`NetworkTopCountries Table Component rendering it renders the IP Details
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Source IPs"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Source IPs
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Source IPs"
+                    >
+                      Source IPs
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
           </tr>
         </thead>
@@ -887,27 +903,31 @@ exports[`NetworkTopCountries Table Component rendering it renders the default Ne
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Bytes in"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Bytes in
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Bytes in"
+                    >
+                      Bytes in
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="descending"
@@ -916,26 +936,30 @@ exports[`NetworkTopCountries Table Component rendering it renders the default Ne
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Bytes out"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Bytes out
-                  </span>
-                  <span
-                    class="euiTableSortIcon"
-                    data-euiicon-type="sortDown"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Bytes out"
+                    >
+                      Bytes out
+                    </span>
+                    <span
+                      class="euiTableSortIcon"
+                      data-euiicon-type="sortDown"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="none"
@@ -944,27 +968,31 @@ exports[`NetworkTopCountries Table Component rendering it renders the default Ne
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Flows"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Flows
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Flows"
+                    >
+                      Flows
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="none"
@@ -973,27 +1001,31 @@ exports[`NetworkTopCountries Table Component rendering it renders the default Ne
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Source IPs"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Source IPs
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Source IPs"
+                    >
+                      Source IPs
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="none"
@@ -1002,27 +1034,31 @@ exports[`NetworkTopCountries Table Component rendering it renders the default Ne
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Destination IPs"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Destination IPs
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Destination IPs"
+                    >
+                      Destination IPs
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
           </tr>
         </thead>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/network_top_n_flow_table/__snapshots__/index.test.tsx.snap
@@ -272,27 +272,31 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Bytes in"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Bytes in
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Bytes in"
+                    >
+                      Bytes in
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="descending"
@@ -301,26 +305,30 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Bytes out"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Bytes out
-                  </span>
-                  <span
-                    class="euiTableSortIcon"
-                    data-euiicon-type="sortDown"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Bytes out"
+                    >
+                      Bytes out
+                    </span>
+                    <span
+                      class="euiTableSortIcon"
+                      data-euiicon-type="sortDown"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="none"
@@ -329,27 +337,31 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Flows"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Flows
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Flows"
+                    >
+                      Flows
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
           </tr>
         </thead>
@@ -1020,27 +1032,31 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Bytes in"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Bytes in
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Bytes in"
+                    >
+                      Bytes in
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="descending"
@@ -1049,26 +1065,30 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Bytes out"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Bytes out
-                  </span>
-                  <span
-                    class="euiTableSortIcon"
-                    data-euiicon-type="sortDown"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Bytes out"
+                    >
+                      Bytes out
+                    </span>
+                    <span
+                      class="euiTableSortIcon"
+                      data-euiicon-type="sortDown"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="none"
@@ -1077,27 +1097,31 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Flows"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Flows
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Flows"
+                    >
+                      Flows
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               aria-sort="none"
@@ -1106,27 +1130,31 @@ exports[`NetworkTopNFlow Table Component rendering it renders the default Networ
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="Destination IPs"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                   >
-                    Destination IPs
-                  </span>
-                  <span
-                    class="euiTableSortIcon euiTableSortIcon--sortable"
-                    color="subdued"
-                    data-euiicon-type="sortable"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="Destination IPs"
+                    >
+                      Destination IPs
+                    </span>
+                    <span
+                      class="euiTableSortIcon euiTableSortIcon--sortable"
+                      color="subdued"
+                      data-euiicon-type="sortable"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
           </tr>
         </thead>

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/tls_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/tls_table/__snapshots__/index.test.tsx.snap
@@ -252,26 +252,30 @@ exports[`Tls Table Component Rendering it renders the default Domains table 1`] 
               role="columnheader"
               scope="col"
             >
-              <button
-                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
               >
-                <div
-                  class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+                <button
+                  class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
-                  <span
-                    class="eui-textTruncate"
-                    title="SHA1 fingerprint"
+                  <div
+                    class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
                   >
-                    SHA1 fingerprint
-                  </span>
-                  <span
-                    class="euiTableSortIcon"
-                    data-euiicon-type="sortDown"
-                  />
-                </div>
-              </button>
+                    <span
+                      class="eui-textTruncate"
+                      title="SHA1 fingerprint"
+                    >
+                      SHA1 fingerprint
+                    </span>
+                    <span
+                      class="euiTableSortIcon"
+                      data-euiicon-type="sortDown"
+                    />
+                  </div>
+                </button>
+              </span>
             </th>
             <th
               class="euiTableHeaderCell emotion-euiTableHeaderCell"

--- a/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/users_table/__snapshots__/index.test.tsx.snap
+++ b/x-pack/solutions/security/plugins/security_solution/public/explore/network/components/users_table/__snapshots__/index.test.tsx.snap
@@ -185,26 +185,30 @@ exports[`Users Table Component Rendering it renders the default Users table 1`] 
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="User"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
                 >
-                  User
-                </span>
-                <span
-                  class="euiTableSortIcon"
-                  data-euiicon-type="sortUp"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="User"
+                  >
+                    User
+                  </span>
+                  <span
+                    class="euiTableSortIcon"
+                    data-euiicon-type="sortUp"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
           <th
             class="euiTableHeaderCell emotion-euiTableHeaderCell"
@@ -264,27 +268,31 @@ exports[`Users Table Component Rendering it renders the default Users table 1`] 
             role="columnheader"
             scope="col"
           >
-            <button
-              class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
             >
-              <div
-                class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
+              <button
+                class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
+                data-test-subj="tableHeaderSortButton"
+                type="button"
               >
-                <span
-                  class="eui-textTruncate"
-                  title="Document count"
+                <div
+                  class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
                 >
-                  Document count
-                </span>
-                <span
-                  class="euiTableSortIcon euiTableSortIcon--sortable"
-                  color="subdued"
-                  data-euiicon-type="sortable"
-                />
-              </div>
-            </button>
+                  <span
+                    class="eui-textTruncate"
+                    title="Document count"
+                  >
+                    Document count
+                  </span>
+                  <span
+                    class="euiTableSortIcon euiTableSortIcon--sortable"
+                    color="subdued"
+                    data-euiicon-type="sortable"
+                  />
+                </div>
+              </button>
+            </span>
           </th>
         </tr>
       </thead>

--- a/x-pack/test/functional/services/monitoring/elasticsearch_nodes.js
+++ b/x-pack/test/functional/services/monitoring/elasticsearch_nodes.js
@@ -65,36 +65,50 @@ export function MonitoringElasticsearchNodesProvider({ getService, getPageObject
     }
 
     async clickNameCol() {
-      await find.clickByCssSelector(`[data-test-subj="${SUBJ_TABLE_SORT_NAME_COL}"] > button`);
+      await find.clickByCssSelector(
+        `[data-test-subj="${SUBJ_TABLE_SORT_NAME_COL}"] [data-test-subj="tableHeaderSortButton"]`
+      );
       await this.waitForTableToFinishLoading();
     }
 
     async clickStatusCol() {
-      await find.clickByCssSelector(`[data-test-subj="${SUBJ_TABLE_SORT_STATUS_COL}"] > button`);
+      await find.clickByCssSelector(
+        `[data-test-subj="${SUBJ_TABLE_SORT_STATUS_COL}"] [data-test-subj="tableHeaderSortButton"]`
+      );
       await this.waitForTableToFinishLoading();
     }
 
     async clickCpuCol() {
-      await find.clickByCssSelector(`[data-test-subj="${SUBJ_TABLE_SORT_CPU_COL}"] > button`);
+      await find.clickByCssSelector(
+        `[data-test-subj="${SUBJ_TABLE_SORT_CPU_COL}"] [data-test-subj="tableHeaderSortButton"]`
+      );
       await this.waitForTableToFinishLoading();
     }
 
     async clickLoadCol() {
-      await find.clickByCssSelector(`[data-test-subj="${SUBJ_TABLE_SORT_LOAD_COL}"] > button`);
+      await find.clickByCssSelector(
+        `[data-test-subj="${SUBJ_TABLE_SORT_LOAD_COL}"] [data-test-subj="tableHeaderSortButton"]`
+      );
       await this.waitForTableToFinishLoading();
     }
 
     async clickMemoryCol() {
-      await find.clickByCssSelector(`[data-test-subj="${SUBJ_TABLE_SORT_MEM_COL}"] > button`);
+      await find.clickByCssSelector(
+        `[data-test-subj="${SUBJ_TABLE_SORT_MEM_COL}"] [data-test-subj="tableHeaderSortButton"]`
+      );
       await this.waitForTableToFinishLoading();
     }
     async clickDiskCol() {
-      await find.clickByCssSelector(`[data-test-subj="${SUBJ_TABLE_SORT_DISK_COL}"] > button`);
+      await find.clickByCssSelector(
+        `[data-test-subj="${SUBJ_TABLE_SORT_DISK_COL}"] [data-test-subj="tableHeaderSortButton"]`
+      );
       await this.waitForTableToFinishLoading();
     }
 
     async clickShardsCol() {
-      await find.clickByCssSelector(`[data-test-subj="${SUBJ_TABLE_SORT_SHARDS_COL}"] > button`);
+      await find.clickByCssSelector(
+        `[data-test-subj="${SUBJ_TABLE_SORT_SHARDS_COL}"] [data-test-subj="tableHeaderSortButton"]`
+      );
       await this.waitForTableToFinishLoading();
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,10 +2180,10 @@
     chroma-js "^2.4.2"
     lodash "^4.17.21"
 
-"@elastic/eui@102.0.0":
-  version "102.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-102.0.0.tgz#dda965d92eb46bf061aac8d0219218779aea28bb"
-  integrity sha512-o4BuXdyGLTAJOBMIUVovDaDmmW+RJgKG6XdIDds7aJyQFlcqIOHgM59yCorzEHhpPAuaYparShJE/vug2dJAIQ==
+"@elastic/eui@102.1.0":
+  version "102.1.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-102.1.0.tgz#ca3ba0389779822c6081d016ebaae06e52baff9f"
+  integrity sha512-h8w4r8OKMWYAGMzz3tDyNDeayW6q+EBMwyXTw5+kQlmkenOxFyHgX7SwsOQTUf2+83aMsrdlMAvSaIfYYljgXA==
   dependencies:
     "@elastic/eui-theme-common" "1.0.0"
     "@elastic/prismjs-esql" "^1.1.0"


### PR DESCRIPTION
`102.0.0` ⏩ `102.1.0`

[Questions? Please see our Kibana upgrade FAQ.](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/upgrading-kibana.md#faq-for-kibana-teams)

>[!NOTE]
There is also the sibling PR for `8.19` with old Amsterdam theme ready for review [here](https://github.com/elastic/kibana/pull/220049). It contains the same changes.

## Changes

- Updated test selector (due to changed tooltip placement in [#8644](https://github.com/elastic/eui/pull/8644))
- snapshot updates

## Package updates

### `@elastic/eui`

#### [`v102.1.0`](https://github.com/elastic/eui/releases/v102.1.0)

- Update `EuiDataGrid` to use `expand` glyph ([#8646](https://github.com/elastic/eui/pull/8646))

**Accessibility**

- Updated `EuiTableHeaderCell` to output `nameTooltip` directly on sortable cell elements, ensuring tooltips appear on focus ([#8644](https://github.com/elastic/eui/pull/8644))
- Improved the accessibility of `EuiColorPicker` by: ([#8639](https://github.com/elastic/eui/pull/8639))
  - preventing duplicate color output for screen readers
  - adding tooltips with visual color labels for the selected colors on the saturation and hue sliders
  - updated accessible labels and announcements to be more descriptive

**Dependency updates**

- Updated `typescript` to v5.8.3 ([#8626](https://github.com/elastic/eui/pull/8626))

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->