### PR TITLE
[Docs] Replace remaining occurrences of ESS

### DIFF
--- a/docs/reference/cloud/elastic-cloud-kibana-settings.md
+++ b/docs/reference/cloud/elastic-cloud-kibana-settings.md
@@ -9,7 +9,7 @@ mapped_pages:
 
 ### OpenID Connect [ec_openid_connect]
 
-If you are using OpenID Connect to secure your clusters, these settings are supported in Elasticsearch Service.
+If you are using OpenID Connect to secure your clusters, these settings are supported on {{ech}}.
 
 `xpack.security.authc.providers.oidc.<provider-name>.order`
 :   Specifies order of the OpenID Connect authentication provider in the authentication chain.
@@ -28,7 +28,7 @@ To learn more, check [configuring Kibana to use OpenID Connect](docs-content://d
 
 ### Anonymous authentication [ec_anonymous_authentication]
 
-If you want to allow anonymous authentication in Kibana, these settings are supported in Elasticsearch Service. To learn more on how to enable anonymous access, check [Enabling anonymous access](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access.md) and [Configuring Kibana to use anonymous authentication](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-authentication.md#anonymous-authentication).
+If you want to allow anonymous authentication in Kibana, these settings are supported on {{ech}}. To learn more on how to enable anonymous access, check [Enabling anonymous access](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access.md) and [Configuring Kibana to use anonymous authentication](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/kibana-authentication.md#anonymous-authentication).
 
 #### Supported versions before 8.0.0 [ec_supported_versions_before_8_0_0]
 

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -6,7 +6,7 @@ navigation_title: "Configuration"
 Configuration settings enable you to customize the behavior of Kibana apps and features.
 This reference provides details about each setting, such as its purpose, default behavior, and availability in Elastic Cloud environments.
 
-For information about how to update these settings, refer to the appropriate instructions for your environment. For example, [{{ecloud}} Hosted](docs-content://deploy-manage/deploy/elastic-cloud/edit-stack-settings.md), [{{ece}}](docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-kibana.md), or [self-managed clusters](docs-content://deploy-manage/deploy/self-managed/configure-kibana.md).
+For information about how to update these settings, refer to the appropriate instructions for your environment. For example, [{{ech}}](docs-content://deploy-manage/deploy/elastic-cloud/edit-stack-settings.md), [{{ece}}](docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-kibana.md), or [self-managed clusters](docs-content://deploy-manage/deploy/self-managed/configure-kibana.md).
 
 The settings are grouped by feature or purpose, for example:
 

--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -18,7 +18,7 @@ Alerting and actions are enabled by default in {{kib}}, but require you to confi
 3. If you are using an **on-premises** Elastic Stack deployment, [specify a value for `xpack.encryptedSavedObjects.encryptionKey`](#general-alert-action-settings).
 
 :::{note}
-If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
+If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :::
 
 ## General settings [general-alert-action-settings]

--- a/docs/reference/configuration-reference/alerting-settings.md
+++ b/docs/reference/configuration-reference/alerting-settings.md
@@ -37,14 +37,14 @@ If a setting is applicable to {{ecloud}} Hosted environments, its name is follow
 
 ## Action settings [action-settings]
 
-`xpack.actions.allowedHosts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.allowedHosts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :    A list of hostnames that Kibana is allowed to connect to when built-in actions are triggered. It defaults to `["*"]`, allowing any host, but keep in mind the potential for SSRF attacks when hosts are not explicitly added to the allowed hosts. An empty list `[]` can be used to block built-in actions from making any external connections.
 
     Note that hosts associated with built-in actions, such as Slack and PagerDuty, are not automatically added to allowed hosts. If you are not using the default `["*"]` setting, you must ensure that the corresponding endpoints are added to the allowed hosts as well.
 
     Data type: `string`
 
-`xpack.actions.customHostSettings` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.customHostSettings` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :    A list of custom host settings to override existing global settings.
 
     Each entry in the list must have a `url` property, to associate a connection type (mail or https), hostname and port with the remaining options in the entry.
@@ -75,7 +75,7 @@ If a setting is applicable to {{ecloud}} Hosted environments, its name is follow
           verificationMode: 'none'
     ```
 
-`xpack.actions.customHostSettings[n].url` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.customHostSettings[n].url` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :    A URL associated with this custom host setting.  Should be in the form of `protocol://hostname:port`, where `protocol` is `https` or `smtp`.  If the port is not provided, 443 is used for `https` and 25 is used for `smtp`.  The `smtp` URLs are used for the Email actions that use this server, and the `https` URLs are used for actions which use `https` to connect to services.
 
     Entries with `https` URLs can use the `ssl` options, and entries with `smtp` URLs can use both the `ssl` and `smtp` options.
@@ -85,14 +85,14 @@ If a setting is applicable to {{ecloud}} Hosted environments, its name is follow
     Data type: `string`
 
 
-`xpack.actions.customHostSettings[n].smtp.ignoreTLS` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.customHostSettings[n].smtp.ignoreTLS` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :    A boolean value indicating that TLS must not be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true.
 
     Data type: `bool`
     Default: `false`
 
 
-`xpack.actions.customHostSettings[n].smtp.requireTLS` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.customHostSettings[n].smtp.requireTLS` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :    A boolean value indicating that TLS must be used for this connection. The options `smtp.ignoreTLS` and `smtp.requireTLS` can not both be set to true.
 
     Data type: `bool`
@@ -100,7 +100,7 @@ If a setting is applicable to {{ecloud}} Hosted environments, its name is follow
 
 $$$action-config-custom-host-verification-mode$$$
 
-`xpack.actions.customHostSettings[n].ssl.verificationMode` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.customHostSettings[n].ssl.verificationMode` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :    Controls the verification of the server certificate that Kibana receives when making an outbound SSL/TLS connection to the host server. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification. Default: `full`. [Equivalent Kibana setting](/reference/configuration-reference/general-settings.md#elasticsearch-ssl-verificationMode). Overrides the general `xpack.actions.ssl.verificationMode` configuration for requests made for this hostname/port.
 
     Data type: `enum`
@@ -118,14 +118,14 @@ $$$action-config-custom-host-verification-mode$$$
 
     Data type: `string`
 
-`xpack.actions.customHostSettings[n].ssl.certificateAuthoritiesData` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.customHostSettings[n].ssl.certificateAuthoritiesData` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The contents of one or more PEM-encoded certificate files in multiline format. This configuration can be used for environments where the files cannot be made available.
 
     Data type: `string`
 
 $$$action-config-email-domain-allowlist$$$
 
-`xpack.actions.email.domain_allowlist` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.email.domain_allowlist` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :    A list of allowed email domains which can be used with the email connector. When this setting is not used, all email domains are allowed. When this setting is used, if any email is attempted to be sent that (a) includes an addressee with an email domain that is not in the allowlist, or (b) includes a from address domain that is not in the allowlist, it will fail with a message indicating the email is not allowed.
 
     ::::{warning}
@@ -134,13 +134,13 @@ $$$action-config-email-domain-allowlist$$$
 
     Data type: `string`
 
-`xpack.actions.enableFooterInEmail` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.enableFooterInEmail` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   A boolean value indicating that a footer with a relevant link should be added to emails sent as alerting actions.
 
     Data type: `bool`
     Default: `true`
 
-`xpack.actions.enabledActionTypes` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.enabledActionTypes` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :    A list of action types that are enabled. It defaults to `["*"]`, enabling all types. The names for built-in Kibana action types are prefixed with a `.` and include: `.email`, `.index`, `.jira`, `.opsgenie`, `.pagerduty`, `.resilient`, `.server-log`, `.servicenow`, .`servicenow-itom`, `.servicenow-sir`, `.slack`, `.swimlane`, `.teams`, `.tines`, `.torq`, `.xmatters`,  `.gen-ai`,  `.bedrock`, `.gemini`,  `.d3security`, and `.webhook`. An empty list `[]` will disable all action types.
 
     Disabled action types will not appear as an option when creating new connectors, but existing connectors and actions of that type will remain in Kibana and will not function.
@@ -170,7 +170,7 @@ $$$action-config-email-domain-allowlist$$$
     Data type: `string`
     Default: `https://graph.microsoft.com/.default`
 
-`xpack.actions.proxyUrl` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.proxyUrl` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the proxy URL to use, if using a proxy for actions. By default, no proxy is used.
 
     Proxies may be used to proxy http or https requests through a proxy using the http or https protocol.  Kibana only uses proxies in "CONNECT" mode (sometimes referred to as "tunneling" TCP mode, compared to HTTP mode).  That is, Kibana will always make requests through a proxy using the HTTP `CONNECT` method.
@@ -187,7 +187,7 @@ $$$action-config-email-domain-allowlist$$$
     curl --verbose --proxytunnel --proxy http://localhost:8080 http://example.com
     ```
 
-`xpack.actions.proxyBypassHosts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.proxyBypassHosts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies hostnames which should not use the proxy, if using a proxy for actions. The value is an array of hostnames as strings.
 
     By default, all hosts will use the proxy, but if an action’s hostname is in this list, the proxy will not be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time.
@@ -202,7 +202,7 @@ $$$action-config-email-domain-allowlist$$$
 
     If applicable, include the subdomain in the hostname
 
-`xpack.actions.proxyOnlyHosts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.proxyOnlyHosts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies hostnames which should only use the proxy, if using a proxy for actions. The value is an array of hostnames as strings.
 
     By default, no hosts will use the proxy, but if an action’s hostname is in this list, the proxy will be used.  The settings `xpack.actions.proxyBypassHosts` and `xpack.actions.proxyOnlyHosts` cannot be used at the same time.
@@ -218,7 +218,7 @@ $$$action-config-email-domain-allowlist$$$
     If applicable, include the subdomain in the hostname
 
 
-`xpack.actions.proxyHeaders` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.proxyHeaders` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies HTTP headers for the proxy, if using a proxy for actions.
 
     Data type: `string`
@@ -226,7 +226,7 @@ $$$action-config-email-domain-allowlist$$$
 
 $$$action-config-proxy-verification-mode$$$
 
-`xpack.actions.ssl.proxyVerificationMode` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.ssl.proxyVerificationMode` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :    Controls the verification for the proxy server certificate that Kibana receives when making an outbound SSL/TLS connection to the proxy server.
 
     Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification.
@@ -245,7 +245,7 @@ $$$action-config-proxy-verification-mode$$$
 
 $$$action-config-verification-mode$$$
 
-`xpack.actions.ssl.verificationMode` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.ssl.verificationMode` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Controls the verification for the server certificate that Elastic Maps Server receives when making an outbound SSL/TLS connection for actions. Valid values are `full`, `certificate`, and `none`. Use `full` to perform hostname verification, `certificate` to skip hostname verification, and `none` to skip verification.
 
     [Equivalent Kibana setting](/reference/configuration-reference/general-settings.md#elasticsearch-ssl-verificationMode)
@@ -262,18 +262,18 @@ $$$action-config-verification-mode$$$
 
     Default: `full`
 
-`xpack.actions.maxResponseContentLength` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.maxResponseContentLength` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the max number of bytes of the http response for requests to external resources.
 
     Data type: `int`
     Default: `1000000 (1MB)`
 
-`xpack.actions.responseTimeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.responseTimeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the time allowed for requests to external resources. Requests that take longer are canceled. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `60s`.
 
     Data type: `string`
 
-`xpack.actions.run.maxAttempts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.run.maxAttempts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the maximum number of times an action can be attempted to run.
 
     Data type: `int`
@@ -282,7 +282,7 @@ $$$action-config-verification-mode$$$
 
     * `minimum 1 and maximum 10`
 
-`xpack.actions.run.connectorTypeOverrides` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.run.connectorTypeOverrides` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Overrides the configs under `xpack.actions.run` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects.
 
     Data type: `string`
@@ -297,7 +297,7 @@ $$$action-config-verification-mode$$$
               maxAttempts: 5
     ```
 
-`xpack.actions.queued.max` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.queued.max` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the maximum number of actions that can be queued.
     It is available in {{ecloud}} 8.11.0 and later versions.
 
@@ -319,7 +319,7 @@ xpack.actions.preconfigured:
 
 For more examples, go to [Preconfigured connectors](/reference/connectors-kibana/pre-configured-connectors.md).
 
-`xpack.actions.preconfiguredAlertHistoryEsIndex` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.actions.preconfiguredAlertHistoryEsIndex` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Enables a preconfigured alert history Elasticsearch [Index](/reference/connectors-kibana/index-action-type.md) connector.
 
     Data type: `bool`
@@ -824,7 +824,7 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
 
 ## Alerting settings [alert-settings]
 
-`xpack.alerting.cancelAlertsOnRuleTimeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.alerting.cancelAlertsOnRuleTimeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies whether to skip writing alerts and scheduling actions if rule processing was cancelled due to a timeout. This setting can be overridden by individual rule types.
 
     Data type: `bool`
@@ -836,24 +836,24 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
     Data type: `int`
     Default: `10000`
 
-`xpack.alerting.rules.minimumScheduleInterval.value` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.alerting.rules.minimumScheduleInterval.value` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the minimum schedule interval for rules. This minimum is applied to all rules created or updated after you set this value. The time is formatted as a number and a time unit (`s`, `m`, `h`, or `d`). For example, `20m`, `24h`, `7d`. This duration cannot exceed `1d`.
 
     Data type: `string`
     Default: `1m`
 
-`xpack.alerting.rules.minimumScheduleInterval.enforce` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.alerting.rules.minimumScheduleInterval.enforce` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the behavior when a new or changed rule has a schedule interval less than the value defined in `xpack.alerting.rules.minimumScheduleInterval.value`. If `false`, rules with schedules less than the interval will be created but warnings will be logged. If `true`, rules with schedules less than the interval cannot be created.
 
     Data type: `bool`
     Default: `false`
 
-`xpack.alerting.rules.run.actions.max` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.alerting.rules.run.actions.max` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the maximum number of actions that a rule can generate each time detection checks run.
 
     Data type: `int`
 
-`xpack.alerting.rules.run.alerts.max` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.alerting.rules.run.alerts.max` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the maximum number of alerts that a rule can generate each time detection checks run.
 
     ::::{warning}
@@ -863,12 +863,12 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
     Data type: `int`
     Default: `1000`
 
-`xpack.alerting.rules.run.timeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.alerting.rules.run.timeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the default timeout for tasks associated with all types of rules. The time is formatted as a number and a time unit (`ms`, `s`, `m`, `h`, `d`, `w`, `M`, or `Y`). For example, `20m`, `24h`, `7d`, `1w`. Default: `5m`.
 
     Data type: `string`
 
-`xpack.alerting.rules.run.ruleTypeOverrides` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.alerting.rules.run.ruleTypeOverrides` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Overrides the configs under `xpack.alerting.rules.run` for the rule type with the given ID. List the rule identifier and its settings in an array of objects.
 
     Data type: `string`
@@ -883,7 +883,7 @@ For more examples, go to [Preconfigured connectors](/reference/connectors-kibana
               timeout: '15m'
     ```
 
-`xpack.alerting.rules.run.actions.connectorTypeOverrides` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.alerting.rules.run.actions.connectorTypeOverrides` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Overrides the configs under `xpack.alerting.rules.run.actions` for the connector type with the given ID. List the connector type identifier and its settings in an array of objects.
 
     Data type: `string`

--- a/docs/reference/configuration-reference/apm-settings.md
+++ b/docs/reference/configuration-reference/apm-settings.md
@@ -31,64 +31,64 @@ More settings are available in the [Observability advanced settings](/reference/
 ::::
 
 
-`xpack.apm.maxSuggestions` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.maxSuggestions` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Maximum number of suggestions fetched in autocomplete selection boxes. Defaults to `100`.
 
-`xpack.apm.serviceMapFingerprintBucketSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.serviceMapFingerprintBucketSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Maximum number of unique transaction combinations sampled for generating service map focused on a specific service. Defaults to `100`.
 
-`xpack.apm.serviceMapFingerprintGlobalBucketSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.serviceMapFingerprintGlobalBucketSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Maximum number of unique transaction combinations sampled for generating the global service map. Defaults to `100`.
 
-`xpack.apm.serviceMapEnabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.serviceMapEnabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `false` to disable service maps. Defaults to `true`.
 
-`xpack.apm.serviceMapTraceIdBucketSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.serviceMapTraceIdBucketSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Maximum number of trace IDs sampled for generating service map focused on a specific service. Defaults to `65`.
 
-`xpack.apm.serviceMapTraceIdGlobalBucketSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.serviceMapTraceIdGlobalBucketSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Maximum number of trace IDs sampled for generating the global service map. Defaults to `6`.
 
-`xpack.apm.serviceMapMaxTracesPerRequest` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.serviceMapMaxTracesPerRequest` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Maximum number of traces per request for generating the global service map. Defaults to `50`.
 
-`xpack.apm.ui.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.ui.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `false` to hide the APM app from the main menu. Defaults to `true`.
 
-`xpack.apm.ui.maxTraceItems` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.ui.maxTraceItems` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Maximum number of child items displayed when viewing trace details. Defaults to `5000`.
 
-`xpack.observability.annotations.index` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.observability.annotations.index` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Index name where Observability annotations are stored. Defaults to `observability-annotations`.
 
-`xpack.apm.metricsInterval` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.metricsInterval` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Sets a `fixed_interval` for date histograms in metrics aggregations. Defaults to `30`.
 
-`xpack.apm.agent.migrations.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.agent.migrations.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `false` to disable cloud APM migrations. Defaults to `true`.
 
-`xpack.apm.indices.error` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.indices.error` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Matcher for all error indices. Defaults to `logs-apm*,apm-*,traces-*.otel-*`.
 
-`xpack.apm.indices.onboarding` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.indices.onboarding` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Matcher for all onboarding indices. Defaults to `apm-*`.
 
-`xpack.apm.indices.span` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.indices.span` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Matcher for all span indices. Defaults to `traces-apm*,apm-*,traces-*.otel-*`.
 
-`xpack.apm.indices.transaction` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.indices.transaction` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Matcher for all transaction indices. Defaults to `traces-apm*,apm-*,traces-*.otel-*`.
 
-`xpack.apm.indices.metric` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.indices.metric` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Matcher for all metrics indices. Defaults to `metrics-apm*,apm-*,metrics-*.otel-*`.
 
-`xpack.apm.indices.sourcemap` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.indices.sourcemap` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Matcher for all source map indices. Defaults to `apm-*`.
 
-`xpack.apm.autoCreateApmDataView` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.autoCreateApmDataView` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `false` to disable the automatic creation of the APM data view when the APM app is opened. Defaults to `true`.
 
-`xpack.apm.latestAgentVersionsUrl` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.apm.latestAgentVersionsUrl` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the URL of a self hosted file that contains latest agent versions. Defaults to `https://apm-agent-versions.elastic.co/versions.json`. Set to `''` to disable requesting latest agent versions.
 
 ## Logging settings [logging-settings]

--- a/docs/reference/configuration-reference/apm-settings.md
+++ b/docs/reference/configuration-reference/apm-settings.md
@@ -13,7 +13,7 @@ applies_to:
 These settings allow the APM app to function, and specify the data that it surfaces. Unless you’ve customized your setup, you do not need to configure any settings to use the APM app. It is enabled by default.
 
 :::{note}
-If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
+If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :::
 
 ## APM indices [apm-indices-settings-kb]

--- a/docs/reference/configuration-reference/fleet-settings.md
+++ b/docs/reference/configuration-reference/fleet-settings.md
@@ -13,7 +13,7 @@ applies_to:
 
 ::::{note}
 In {{ecloud}}, {{fleet}} flags are already configured.
-If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
+If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 ::::
 
 By default, {{fleet}} is enabled. To use {{fleet}}, you also need to configure {{kib}} and {{es}} hosts.

--- a/docs/reference/configuration-reference/fleet-settings.md
+++ b/docs/reference/configuration-reference/fleet-settings.md
@@ -24,13 +24,13 @@ Go to the [{{fleet}}](docs-content://reference/fleet/index.md) docs for more inf
 
 ## General {{fleet}} settings [general-fleet-settings-kb]
 
-`xpack.fleet.agents.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.fleet.agents.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `true` (default) to enable {{fleet}}.
 
 `xpack.fleet.isAirGapped`
 :   Set to `true` to indicate {{fleet}} is running in an air-gapped environment. Refer to [Air-gapped environments](docs-content://reference/fleet/air-gapped.md) for details. Enabling this flag helps Fleet skip needless requests and improve the user experience for air-gapped environments.
 
-`xpack.fleet.createArtifactsBulkBatchSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.fleet.createArtifactsBulkBatchSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Allow to configure batch size for creating and updating Fleet user artifacts.  Examples include creation of Trusted Applications and Endpoint Exceptions in Security. It is available in {{ecloud}} 8.9.0 and later versions.
 % TBD: Supported only in Elastic Cloud?
 
@@ -348,7 +348,7 @@ These settings are not supported to pre-configure the Endpoint and Cloud Securit
     :::::
 
 
-`xpack.fleet.enableExperimental` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.fleet.enableExperimental` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   List of experimental feature flag to enable in Fleet.
     It is available in {{ecloud}} 8.6.0 and later versions.
 

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -70,15 +70,15 @@ $$$csp-strict$$$ `csp.strict`
 `csp.warnLegacyBrowsers`
 :   Shows a warning message after loading {{kib}} to any browser that does not enforce even rudimentary CSP rules, though {{kib}} is still accessible. This configuration is effectively ignored when [`csp.strict`](#csp-strict) is enabled. **Default: `true`**
 
-`data.autocomplete.valueSuggestions.terminateAfter` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`data.autocomplete.valueSuggestions.terminateAfter` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the max number of documents loaded by each shard to generate autocomplete suggestions. The default is 100000. Allowed values are between 1 and 10000000.
 % TBD: Applicable only to Elastic Cloud?
 
-`data.autocomplete.valueSuggestions.timeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`data.autocomplete.valueSuggestions.timeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the time in milliseconds to wait for autocomplete suggestions from Elasticsearch. The default is 1000. Allowed values are between 1 and 1200000.
 % TBD: Applicable only to Elastic Cloud?
 
-$$$elasticsearch-maxSockets$$$ `elasticsearch.maxSockets` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$elasticsearch-maxSockets$$$ `elasticsearch.maxSockets` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The maximum number of sockets that can be used for communications with {{es}}. **Default: `Infinity`**
     It is available in {{ecloud}} 8.2.0 and later versions.
 
@@ -115,7 +115,7 @@ $$$elasticsearch-requestTimeout$$$ `elasticsearch.requestTimeout`
 `elasticsearch.shardTimeout`
 :   Time in milliseconds for {{es}} to wait for responses from shards. Set to 0 to disable. **Default: `30000`**
 
-`elasticsearch.compression` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`elasticsearch.compression` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies whether {{kib}} should use compression for communications with {{es}}.
     **Default: `false`**
     It is available in {{ecloud}} 8.3.0 and later versions.
@@ -184,7 +184,7 @@ $$$elasticsearch-user-passwd$$$ `elasticsearch.username` and `elasticsearch.pass
 $$$elasticsearch-service-account-token$$$ `elasticsearch.serviceAccountToken`
 :   If your {{es}} is protected with basic authentication, this token provides the credentials that the {{kib}} server uses to perform maintenance on the {{kib}} index at startup. This setting is an alternative to `elasticsearch.username` and `elasticsearch.password`.
 
-`execution_context.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`execution_context.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Propagate request-specific metadata to Elasticsearch server by way of the `x-opaque-id` header.
     It is available in {{ecloud}} 8.1.0 and later versions.
 % TBD: Available only in Elastic Cloud?
@@ -195,7 +195,7 @@ $$$logging-root$$$ `logging.root`
 $$$logging-root-appenders$$$ `logging.root.appenders`
 :   A list of logging appenders to forward the root level logger instance to.  By default `root` is configured with the `default` appender that logs to stdout with a `pattern` layout. This is the configuration that all custom loggers will use unless they’re re-configured explicitly. You can override the default behavior by configuring a different [appender](docs-content://deploy-manage/monitor/logging-configuration/kibana-logging.md#logging-appenders) to apply to `root`.
 
-$$$logging-root-level$$$ `logging.root.level` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$logging-root-level$$$ `logging.root.level` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Level at which a log record should be logged. Supported levels are: *all*, *fatal*, *error*, *warn*, *info*, *debug*, *trace*, *off*. Levels are ordered from *all* (highest) to *off* and a log record will be logged it its level is higher than or equal to the level of its logger, otherwise the log record is ignored. Use this value to [change the overall log level](docs-content://deploy-manage/monitor/logging-configuration/kibana-log-settings-examples.md#change-overall-log-level). **Default: `info`**.
 
     ::::{tip}
@@ -225,36 +225,36 @@ $$$logging-loggers$$$ `logging.loggers[]`
 `logging.appenders[]`
 :   [Appenders](docs-content://deploy-manage/monitor/logging-configuration/kibana-logging.md#logging-appenders) define how and where log messages are displayed (eg. **stdout** or console) and stored (eg. file on the disk).
 
-`map.includeElasticMapsService` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`map.includeElasticMapsService` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `false` to disable connections to Elastic Maps Service. When `includeElasticMapsService` is turned off, only tile layer configured by [`map.tilemap.url`](#tilemap-url) is available in [Maps](docs-content://explore-analyze/visualize/maps.md). **Default: `true`**
 
 `map.emsUrl`
 :   Specifies the URL of a self hosted [{{hosted-ems}}](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md#elastic-maps-server)
 
-$$$tilemap-settings$$$ `map.tilemap.options.attribution` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$tilemap-settings$$$ `map.tilemap.options.attribution` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The map attribution string. Provide attributions in markdown and use `\|` to delimit attributions, for example: `"[attribution 1](https://www.attribution1)\|[attribution 2](https://www.attribution2)"`. **Default: `"© [Elastic Maps Service](https://www.elastic.co/elastic-maps-service)"`**
 
-$$$tilemap-max-zoom$$$ `map.tilemap.options.maxZoom` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$tilemap-max-zoom$$$ `map.tilemap.options.maxZoom` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The maximum zoom level. **Default: `10`**
 
-$$$tilemap-min-zoom$$$ `map.tilemap.options.minZoom` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$tilemap-min-zoom$$$ `map.tilemap.options.minZoom` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The minimum zoom level. **Default: `1`**
 
-$$$tilemap-subdomains$$$ `map.tilemap.options.subdomains` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$tilemap-subdomains$$$ `map.tilemap.options.subdomains` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   An array of subdomains used by the tile service. Specify the position of the subdomain the URL with the token `{{s}}`.
 
-$$$tilemap-url$$$ `map.tilemap.url` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$tilemap-url$$$ `map.tilemap.url` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The URL to the service that {{kib}} uses as the default basemap in [maps](docs-content://explore-analyze/visualize/maps.md) and [vega maps](docs-content://explore-analyze/visualize/custom-visualizations-with-vega.md#vega-with-a-map). By default, {{kib}} sets a basemap from the [Elastic Maps Service](docs-content://explore-analyze/visualize/maps/maps-connect-to-ems.md), but users can point to their own Tile Map Service. For example: `"https://tiles.elastic.co/v2/default/{{z}}/{x}/{{y}}.png?elastic_tile_service_tos=agree&my_app_name=kibana"`
 
-`migrations.batchSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`migrations.batchSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Defines the number of documents migrated at a time. The higher the value, the faster the Saved Objects migration process performs at the cost of higher memory consumption. If upgrade migrations results in {{kib}} crashing with an out of memory exception or fails due to an Elasticsearch `circuit_breaking_exception`, use a smaller `batchSize` value to reduce the memory pressure. **Default: `1000`**
 
-`migrations.discardUnknownObjects` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`migrations.discardUnknownObjects` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Discard saved objects with unknown types during a migration. Must be set to the target version, for example: `8.4.0`. Default: undefined.
     It is available in {{ecloud}} 8.4.0 and later versions.
 % TBD: Supported only in Elastic Cloud?
 
-`migrations.discardCorruptObjects` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`migrations.discardCorruptObjects` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Discard corrupt saved objects, as well as those that cause transform errors during a migration. Must be set to the target version, for example: `8.4.0`. Default: undefined.
     It is available in {{ecloud}} 8.4.0 and later versions.
 % TBD: Supported only in Elastic Cloud?
@@ -302,7 +302,7 @@ $$$savedObjects-maxImportPayloadBytes$$$ `savedObjects.maxImportPayloadBytes`
 $$$server-basePath$$$ `server.basePath`
 :   Enables you to specify a path to mount {{kib}} at if you are running behind a proxy. Use the [`server.rewriteBasePath`](#server-rewriteBasePath) setting to tell {{kib}} if it should remove the basePath from requests it receives, and to prevent a deprecation warning at startup. This setting cannot end in a slash (`/`).
 
-`server.defaultRoute` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`server.defaultRoute` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the default route when opening Kibana. You can use this setting to modify the landing page when opening Kibana.
 % TBD: Applicable only to Elastic Cloud?
 
@@ -324,33 +324,33 @@ $$$server-compression$$$ `server.compression.enabled`
 `server.compression.referrerWhitelist`
 :   Specifies an array of trusted hostnames, such as the {{kib}} host, or a reverse proxy sitting in front of it. This determines whether HTTP compression may be used for responses, based on the request `Referer` header. This setting may not be used when [`server.compression.enabled`](#server-compression) is set to `false`. **Default: `none`**
 
-`server.compression.brotli.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`server.compression.brotli.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `true` to enable brotli (br) compression format. NOTE: Browsers not supporting brotli compression will fallback to using gzip instead. This setting may not be used when [`server.compression.enabled`](#server-compression) is set to `false`. **Default: `false`**
     It is available in {{ecloud}} 8.6.0 and later versions.
 
-$$$server-securityResponseHeaders-strictTransportSecurity$$$ `server.securityResponseHeaders.strictTransportSecurity` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$server-securityResponseHeaders-strictTransportSecurity$$$ `server.securityResponseHeaders.strictTransportSecurity` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Controls whether the [`Strict-Transport-Security`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header is used in all responses to the client from the {{kib}} server, and specifies what value is used. Allowed values are any text value or `null`. To disable, set to `null`. **Default:** `null`
 
-$$$server-securityResponseHeaders-xContentTypeOptions$$$ `server.securityResponseHeaders.xContentTypeOptions` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$server-securityResponseHeaders-xContentTypeOptions$$$ `server.securityResponseHeaders.xContentTypeOptions` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Controls whether the [`X-Content-Type-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options) header is used in all responses to the client from the {{kib}} server, and specifies what value is used. Allowed values are `nosniff` or `null`. To disable, set to `null`. **Default:** `"nosniff"`
 
-$$$server-securityResponseHeaders-referrerPolicy$$$ `server.securityResponseHeaders.referrerPolicy` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$server-securityResponseHeaders-referrerPolicy$$$ `server.securityResponseHeaders.referrerPolicy` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Controls whether the [`Referrer-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) header is used in all responses to the client from the {{kib}} server, and specifies what value is used. Allowed values are `no-referrer`, `no-referrer-when-downgrade`, `origin`, `origin-when-cross-origin`, `same-origin`, `strict-origin`, `strict-origin-when-cross-origin`, `unsafe-url`, or `null`. To disable, set to `null`. **Default:** `"strict-origin-when-cross-origin"`
 
-$$$server-securityResponseHeaders-permissionsPolicy$$$ `server.securityResponseHeaders.permissionsPolicy` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$server-securityResponseHeaders-permissionsPolicy$$$ `server.securityResponseHeaders.permissionsPolicy` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Controls whether the [`Permissions-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy) header is used in all responses to the client from the {{kib}} server, and specifies what value is used. Allowed values are any text value or `null`. Refer to the [`Permissions-Policy` documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy) for defined directives, values, and text format. To disable, set to `null`. **Default:** `camera=(), display-capture=(), fullscreen=(self), geolocation=(), microphone=(), web-share=()`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 
-$$$server-securityResponseHeaders-permissionsPolicyReportOnly$$$ `server.securityResponseHeaders.permissionsPolicyReportOnly` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$server-securityResponseHeaders-permissionsPolicyReportOnly$$$ `server.securityResponseHeaders.permissionsPolicyReportOnly` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Controls whether the [`Permissions-Policy-Report-Only`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy) header is used in all responses to the client from the {{kib}} server, and specifies what value is used. Allowed values are any text value or `null`. Refer to the [`Permissions-Policy` documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy) for defined directives, values, and text format. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 
-$$$server-securityResponseHeaders-disableEmbedding$$$`server.securityResponseHeaders.disableEmbedding` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$server-securityResponseHeaders-disableEmbedding$$$`server.securityResponseHeaders.disableEmbedding` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Controls whether the [`Content-Security-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) and [`X-Frame-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) headers are configured to disable embedding {{kib}} in other webpages using iframes. When set to `true`, secure headers are used to disable embedding, which adds the `frame-ancestors: 'self'` directive to the `Content-Security-Policy` response header and adds the `X-Frame-Options: SAMEORIGIN` response header. **Default:** `false`
 
-$$$server-securityResponseHeaders-crossOriginOpenerPolicy$$$ `server.securityResponseHeaders.crossOriginOpenerPolicy` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$server-securityResponseHeaders-crossOriginOpenerPolicy$$$ `server.securityResponseHeaders.crossOriginOpenerPolicy` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Controls whether the [`Cross-Origin-Opener-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy) header is used in all responses to the client from the {{kib}} server, and specifies what value is used. Allowed values are `unsafe-none`, `same-origin-allow-popups`, `same-origin`, or `null`. To disable, set to `null`. **Default:** `"same-origin"`
     It is available in {{ecloud}} 8.7.0 and later versions.
 
-`server.customResponseHeaders` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`server.customResponseHeaders` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Header names and values to send on all responses to the client from the {{kib}} server. **Default: `{}`**
 
 $$$server-shutdownTimeout$$$ `server.shutdownTimeout`
@@ -362,7 +362,7 @@ $$$server-host$$$ `server.host`
 `server.keepaliveTimeout`
 :   The number of milliseconds to wait for additional data before restarting the [`server.socketTimeout`](#server-socketTimeout) counter. **Default: `"120000"`**
 
-$$$server-maxPayload$$$ `server.maxPayload` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$server-maxPayload$$$ `server.maxPayload` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The maximum payload size in bytes for incoming server requests. **Default: `1048576`**
 
 `server.name`
@@ -477,7 +477,7 @@ $$$server-ssl-supportedProtocols$$$ `server.ssl.supportedProtocols`
 $$$server-uuid$$$ `server.uuid`
 :   The unique identifier for this {{kib}} instance. It must be a valid UUIDv4. It gets automatically generated on the first startup if not specified and persisted in the `data` path.
 
-$$$settings-xsrf-allowlist$$$ `server.xsrf.allowlist` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$settings-xsrf-allowlist$$$ `server.xsrf.allowlist` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   It is not recommended to disable protections for arbitrary API endpoints. Instead, supply the `kbn-xsrf` header. The [`server.xsrf.allowlist`](#settings-xsrf-allowlist) setting requires the following format:
 
     ```text
@@ -500,23 +500,23 @@ $$$settings-telemetry-optIn$$$ `telemetry.optIn`
 
     This setting can be changed at any time in [Advanced Settings](/reference/advanced-settings.md). To prevent users from changing it, set [`telemetry.allowChangingOptInStatus`](#telemetry-allowChangingOptInStatus) to `false`. **Default: `true`**
 
-`unifiedSearch.autocomplete.valueSuggestions.timeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`unifiedSearch.autocomplete.valueSuggestions.timeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Time in milliseconds to wait for autocomplete suggestions from {{es}}. This value must be a whole number greater than zero. **Default: `"1000"`**
 
-`unifiedSearch.autocomplete.valueSuggestions.terminateAfter` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`unifiedSearch.autocomplete.valueSuggestions.terminateAfter` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Maximum number of documents loaded by each shard to generate autocomplete suggestions. This value must be a whole number greater than zero. **Default: `"100000"`**
 
     ::::{note}
     To reload the logging settings, send a SIGHUP signal to {{kib}}. For more logging configuration options, see the [Configure Logging in {{kib}}](docs-content://deploy-manage/monitor/logging-configuration/kibana-logging.md) guide.
     ::::
 
-`vega.enableExternalUrls` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`vega.enableExternalUrls` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `true` to allow Vega vizualizations to use data from sources other than the linked Elasticsearch cluster. In version 8.0 and later, the `vega.enableExternalUrls` is not supported. Use `vis_type_vega.enableExternalUrls` instead.
 
-`vis_type_table.legacyVisEnabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`vis_type_table.legacyVisEnabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   For 7.x versions version 7.11 and later, a new version of the datatable visualization is used. Set to `true` to enable the legacy version. In version 8.0 and later, the old implementation is removed and this setting is no longer supported.
 
-`vis_type_vega.enableExternalUrls` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`vis_type_vega.enableExternalUrls` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set this value to true to allow Vega to use any URL to access external data sources and images. When false, Vega can only get data from {{es}}. **Default: `false`**
 
 `xpack.ccr.ui.enabled`
@@ -551,7 +551,7 @@ $$$settings-explore-data-in-chart$$$ `xpack.discoverEnhanced.actions.exploreData
     Rollups are deprecated and will be removed in a future version. Use [downsampling](docs-content://manage-data/data-store/data-streams/downsampling-time-series-data-stream.md) instead.
     ::::
 
-`xpack.securitySolution.maxUploadResponseActionFileBytes` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.securitySolution.maxUploadResponseActionFileBytes` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Allow to configure the max file upload size for use with the Upload File Repsonse action available with the Defend Integration.  To learn more, check [Endpoint Response actions](docs-content://solutions/security/endpoint-response-actions.md).
     It is available in {{ecloud}} 8.9.0 and later versions.
 % TBD: Available only in Elastic Cloud?

--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -9,7 +9,7 @@ applies_to:
 # General settings in {{kib}}
 
 :::{note}
-If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
+If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :::
 
 `console.ui.enabled`

--- a/docs/reference/configuration-reference/internationalization-settings.md
+++ b/docs/reference/configuration-reference/internationalization-settings.md
@@ -12,7 +12,7 @@ applies_to:
 
 You do not need to configure any settings to run Kibana in English.
 
-`i18n.locale` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`i18n.locale` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set the {{kib}} interface language:
 
     * English - `en`

--- a/docs/reference/configuration-reference/map-settings.md
+++ b/docs/reference/configuration-reference/map-settings.md
@@ -9,7 +9,7 @@ applies_to:
 
 # Map settings in {{kib}}
 
-`map.regionmap` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`map.regionmap` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies additional vector layers for use in [Region Map](docs-content://explore-analyze/visualize/maps/maps-getting-started.md) visualizations. Each layer object points to an external vector file that contains a geojson FeatureCollection. The file must use the [WGS84 coordinate reference system](https://en.wikipedia.org/wiki/World_Geodetic_System) and only include polygons. If the file is hosted on a separate domain from Kibana, the server needs to be CORS-enabled so Kibana can download the file. The following example shows a valid regionmap configuration.
 
     ```yaml
@@ -27,38 +27,38 @@ applies_to:
     ```
 
 
-`map.regionmap.includeElasticMapsService` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`map.regionmap.includeElasticMapsService` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Turns on or off whether layers from the Elastic Maps Service should be included in the vector layer option list. Supported on Elastic Cloud Enterprise. By turning this off, only the layers that are configured here will be included. The default is `true`.
 
-`map.regionmap.layers[].attribution` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`map.regionmap.layers[].attribution` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Optional. References the originating source of the geojson file.
 
-`map.regionmap.layers[].fields[]` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`map.regionmap.layers[].fields[]` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Mandatory. Each layer can contain multiple fields to indicate what properties from the geojson features you wish to expose. The previous example shows how to define multiple properties.
 
-`map.regionmap.layers[].fields[].description` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`map.regionmap.layers[].fields[].description` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Mandatory. The human readable text that is shown under the Options tab when building the Region Map visualization.
 
-`map.regionmap.layers[].fields[].name` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`map.regionmap.layers[].fields[].name` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Mandatory. This value is used to do an inner-join between the document stored in Elasticsearch and the geojson file. For example, if the field in the geojson is called `Location` and has city names, there must be a field in Elasticsearch that holds the same values that Kibana can then use to lookup for the geoshape data.
 
-`map.regionmap.layers[].name` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`map.regionmap.layers[].name` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Mandatory. A description of the map being provided.
 
-`map.regionmap.layers[].url` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`map.regionmap.layers[].url` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Mandatory. The location of the geojson file as provided by a webserver.
 
-`tilemap.options.attribution` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`tilemap.options.attribution` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Adds the map attribution string.
 
-`tilemap.options.maxZoom` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`tilemap.options.maxZoom` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Sets the maximum zoom level.
 
-`tilemap.options.minZoom` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`tilemap.options.minZoom` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Sets the minimum zoom level.
 
-`tilemap.options.subdomains` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`tilemap.options.subdomains` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Provides an array of subdomains used by the tile service. Specify the position of the subdomain the URL with the token `{{s}}`.
 
-`tilemap.url` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`tilemap.url` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Lists the URL to the tileservice that Kibana uses to display map tiles in tilemap visualizations.

--- a/docs/reference/configuration-reference/monitoring-settings.md
+++ b/docs/reference/configuration-reference/monitoring-settings.md
@@ -19,7 +19,7 @@ To control how data is collected from your {{es}} nodes, you configure [`xpack.m
 For more information, check out [Monitor a cluster](docs-content://deploy-manage/monitor.md).
 
 :::{note}
-If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
+If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :::
 
 ## General monitoring settings [monitoring-general-settings]

--- a/docs/reference/configuration-reference/monitoring-settings.md
+++ b/docs/reference/configuration-reference/monitoring-settings.md
@@ -27,7 +27,7 @@ If a setting is applicable to {{ecloud}} Hosted environments, its name is follow
 `monitoring.cluster_alerts.email_notifications.enabled`
 :   Deprecated in 7.11. When enabled, sends email notifications for Watcher alerts to the specified email address. The default is `true`.
 
-`monitoring.cluster_alerts.email_notifications.email_address` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`monitoring.cluster_alerts.email_notifications.email_address` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Deprecated in 7.11. When enabled, specifies the email address where you want to receive cluster alert notifications.
 
 `monitoring.ui.ccs.enabled`
@@ -72,7 +72,7 @@ These settings control how data is collected from {{kib}}.
 `monitoring.kibana.collection.enabled`
 :   Set to `true` (default) to enable data collection from the {{kib}} NodeJS server for {{kib}} dashboards to be featured in **{{stack-monitor-app}}**.
 
-`monitoring.kibana.collection.interval` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`monitoring.kibana.collection.interval` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the number of milliseconds to wait in between data sampling on the {{kib}} NodeJS server for the metrics that are displayed in the {{kib}} dashboards. Defaults to `10000` (10 seconds).
 
 
@@ -95,7 +95,7 @@ $$$monitoring-ui-enabled$$$ `monitoring.ui.enabled`
 `monitoring.ui.max_bucket_size`
 :   Specifies the number of term buckets to return out of the overall terms list when performing terms aggregations to retrieve index and node metrics. For more information about the `size` parameter, see [Terms Aggregation](elasticsearch://reference/aggregations/search-aggregations-bucket-terms-aggregation.md#search-aggregations-bucket-terms-aggregation-size). Defaults to `10000`.
 
-`monitoring.ui.min_interval_seconds` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`monitoring.ui.min_interval_seconds` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the minimum number of seconds that a time bucket in a chart can represent. Defaults to 10. If you modify the `monitoring.ui.collection.interval` in `elasticsearch.yml`, use the same value in this setting.
 
 `monitoring.ui.kibana.reporting.stale_status_threshold_seconds`
@@ -106,7 +106,7 @@ $$$monitoring-ui-enabled$$$ `monitoring.ui.enabled`
 
 **{{stack-monitor-app}}** exposes the Cgroup statistics that we collect for you to make better decisions about your container performance, rather than guessing based on the overall machine performance. If you are not running your applications in a container, then Cgroup statistics are not useful.
 
-`monitoring.ui.container.elasticsearch.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`monitoring.ui.container.elasticsearch.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   For {{es}} clusters that are running in containers, this setting changes the **Node Listing** to display the CPU utilization based on the reported Cgroup statistics. It also adds the calculated Cgroup CPU utilization to the **Node Overview** page instead of the overall operating system’s CPU utilization. Defaults to `false`.
 
 `monitoring.ui.container.logstash.enabled`

--- a/docs/reference/configuration-reference/reporting-settings.md
+++ b/docs/reference/configuration-reference/reporting-settings.md
@@ -21,7 +21,7 @@ You can configure `xpack.reporting` settings to:
 * [Control the limits and capabilities of CSV reports](#reporting-csv-settings)
 
 :::{note}
-If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
+If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :::
 
 ## Enable reporting [general-reporting-settings]

--- a/docs/reference/configuration-reference/reporting-settings.md
+++ b/docs/reference/configuration-reference/reporting-settings.md
@@ -26,7 +26,7 @@ If a setting is applicable to {{ecloud}} Hosted environments, its name is follow
 
 ## Enable reporting [general-reporting-settings]
 
-$$$xpack-enable-reporting$$$`xpack.reporting.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$xpack-enable-reporting$$$`xpack.reporting.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   When `true`, enables the {{report-features}}. Set this to `false` to disable {{report-features}} entirely. The default is `true`.
 
 ::::{note}
@@ -44,7 +44,7 @@ By default, an encryption key is generated for the {{report-features}} each time
 
 If you are load balancing across multiple {{kib}} instances, each instance needs to have the same reporting encryption key. Otherwise, report generation fails if a report is queued through one instance, and another instance picks up the job from the report queue. The instance that picks up the job is unable to decrypt the reporting job metadata.
 
-$$$xpack-reporting-encryptionKey$$$ `xpack.reporting.encryptionKey` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$xpack-reporting-encryptionKey$$$ `xpack.reporting.encryptionKey` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The static encryption key for reporting. Use an alphanumeric text string that is at least 32 characters. By default, {{kib}} generates a random key when it starts, which causes pending reports to fail after restart. Configure `xpack.reporting.encryptionKey` to preserve the same key across multiple restarts and multiple {{kib}} instances.
 
 ```yaml
@@ -61,7 +61,7 @@ Reporting privileges are configured with [{{kib}} application privileges](docs-c
 
 Reporting generates reports on the {{kib}} server as background tasks, and jobs are coordinated using documents in {{es}}. Depending on how often you generate reports and the overall number of reports, you might need to change the following settings.
 
-`xpack.reporting.capture.maxAttempts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.reporting.capture.maxAttempts` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   If capturing a report fails for any reason, {{kib}} will re-queue the report job for retry, as many times as this setting. Defaults to `3`.
 
 `xpack.reporting.queue.indexInterval`
@@ -78,7 +78,7 @@ Running multiple instances of {{kib}} in a cluster for load balancing of reporti
 `xpack.reporting.queue.pollInterval`
 :   Specifies the [time](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#time-units) that the reporting poller waits between polling the index for any pending Reporting jobs. Can be specified as a number of milliseconds. Defaults to `3s`.
 
-$$$xpack-reporting-q-timeout$$$ `xpack.reporting.queue.timeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$xpack-reporting-q-timeout$$$ `xpack.reporting.queue.timeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   [How long](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#time-units) each worker has to produce a report. If your machine is slow or under heavy load, you might need to increase this timeout. If a Reporting job execution goes over this time limit, the job is marked as a failure and no download will be available. Can be specified as a number of milliseconds. Defaults to `4m`.
 
 
@@ -96,13 +96,13 @@ To generate PDF and PNG files, Reporting uses an internal "screenshotting" plugi
 
 The following settings control the capturing process.
 
-`xpack.screenshotting.capture.timeouts.openUrl` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.screenshotting.capture.timeouts.openUrl` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specify the [time](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#time-units) to allow the Reporting browser to wait for the "Loading…​" screen to dismiss and find the initial data for the page. If the time is exceeded, a screenshot is captured showing the current page, and the download link shows a warning message. Can be specified as number of milliseconds. Defaults to `1m`.
 
-`xpack.screenshotting.capture.timeouts.waitForElements` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.screenshotting.capture.timeouts.waitForElements` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specify the [time](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#time-units) to allow the Reporting browser to wait for all visualization panels to load on the page. If the time is exceeded, a screenshot is captured showing the current page, and the download link shows a warning message. Can be specified as number of milliseconds. Defaults to `1m`.
 
-`xpack.screenshotting.capture.timeouts.renderComplete` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.screenshotting.capture.timeouts.renderComplete` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specify the [time](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#time-units) to allow the Reporting browser to wait for all visualizations to fetch and render the data. If the time is exceeded, a screenshot is captured showing the current page, and the download link shows a warning message. Can be specified as number of milliseconds. Defaults to `2m`.
 
 ::::{note}
@@ -231,11 +231,11 @@ Reporting parameters can be adjusted to overcome some of these limiting scenario
 
 ::::
 
-`xpack.reporting.csv.maxConcurrentShardRequests` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.reporting.csv.maxConcurrentShardRequests` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Sets the maximum number of concurrent shard requests that each sub-search request executes per node during Kibana CSV export. Defaults to `5`. This setting is available in 8.12.0 and later versions in {{ecloud}}.
 % TBD: Is this setting applicable only to Elastic Cloud?
 
-$$$xpack-reporting-csv$$$ `xpack.reporting.csv.maxSizeBytes` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$xpack-reporting-csv$$$ `xpack.reporting.csv.maxSizeBytes` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The maximum [byte size](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#byte-units) of a CSV file before being truncated. This setting exists to prevent large exports from causing performance and storage issues. Can be specified as a number of bytes. Defaults to `250mb`.
 
 `xpack.reporting.csv.scroll.size`

--- a/docs/reference/configuration-reference/search-sessions-settings.md
+++ b/docs/reference/configuration-reference/search-sessions-settings.md
@@ -12,7 +12,7 @@ applies_to:
 # Search sessions settings in {{kib}} [search-session-settings-kb]
 
 :::{note}
-If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
+If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :::
 
 `data.search.sessions.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")

--- a/docs/reference/configuration-reference/search-sessions-settings.md
+++ b/docs/reference/configuration-reference/search-sessions-settings.md
@@ -15,15 +15,15 @@ applies_to:
 If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :::
 
-`data.search.sessions.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`data.search.sessions.enabled` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Deprecated in 8.15.0. `false` by default. Set to `true` to enable search sessions.
 
-`data.search.sessions.notTouchedTimeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`data.search.sessions.notTouchedTimeout` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Deprecated in 8.15.0. How long {{kib}} stores search results from unsaved sessions, after the last search in the session completes. The default is `5m`.
 
-`data.search.sessions.maxUpdateRetries` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`data.search.sessions.maxUpdateRetries` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Deprecated in 8.15.0. How many retries {{kib}} can perform while attempting to save a search session. The default is `10`.
 
-`data.search.sessions.defaultExpiration` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`data.search.sessions.defaultExpiration` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Deprecated in 8.15.0. How long search session results are stored before they are deleted. Extending a search session resets the expiration by the same value. The default is `7d`.
 

--- a/docs/reference/configuration-reference/security-settings.md
+++ b/docs/reference/configuration-reference/security-settings.md
@@ -59,32 +59,32 @@ xpack.security.authc:
 
 The valid settings in the `xpack.security.authc.providers` namespace vary depending on the authentication provider type. For more information, refer to [Authentication](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/user-authentication.md).
 
-xpack.security.authc.providers.<provider-type>.<provider-name>.enabled ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.<provider-type>.<provider-name>.enabled ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Determines if the authentication provider should be enabled. By default, {{kib}} enables the provider as soon as you configure any of its properties.
 
-xpack.security.authc.providers.<provider-type>.<provider-name>.order ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.<provider-type>.<provider-name>.order ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Order of the provider in the authentication chain and on the Login Selector UI.
 
-xpack.security.authc.providers.<provider-type>.<provider-name>.description ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.<provider-type>.<provider-name>.description ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Custom description of the provider entry displayed on the Login Selector UI.
 
-xpack.security.authc.providers.<provider-type>.<provider-name>.hint ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.<provider-type>.<provider-name>.hint ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Custom hint for the provider entry displayed on the Login Selector UI.
 
-xpack.security.authc.providers.<provider-type>.<provider-name>.icon ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.<provider-type>.<provider-name>.icon ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Custom icon for the provider entry displayed on the Login Selector UI.
 
-xpack.security.authc.providers.<provider-type>.<provider-name>.showInSelector ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.<provider-type>.<provider-name>.showInSelector ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Flag that indicates if the provider should have an entry on the Login Selector UI. Setting this to `false` doesn’t remove the provider from the authentication chain.
 
     ::::{note}
     You are unable to set this setting to `false` for `basic` and `token` authentication providers.
     ::::
 
-xpack.security.authc.providers.<provider-type>.<provider-name>.accessAgreement.message ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.<provider-type>.<provider-name>.accessAgreement.message ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Access agreement text in Markdown format. For more information, refer to [Access agreement](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/access-agreement.md).
 
-$$$xpack-security-provider-session-idleTimeout$$$ xpack.security.authc.providers.<provider-type>.<provider-name>.session.idleTimeout ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$xpack-security-provider-session-idleTimeout$$$ xpack.security.authc.providers.<provider-type>.<provider-name>.session.idleTimeout ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Ensures that user sessions will expire after a period of inactivity. Setting this to `0` will prevent sessions from expiring because of inactivity. By default, this setting is equal to [`xpack.security.session.idleTimeout`](#xpack-session-idleTimeout).
 
     ::::{note}
@@ -92,7 +92,7 @@ $$$xpack-security-provider-session-idleTimeout$$$ xpack.security.authc.providers
     ::::
 
 
-$$$xpack-security-provider-session-lifespan$$$ `xpack.security.authc.providers.<provider-type>.<provider-name>.session.lifespan` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$xpack-security-provider-session-lifespan$$$ `xpack.security.authc.providers.<provider-type>.<provider-name>.session.lifespan` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Ensures that user sessions will expire after the defined time period. This behavior is also known as an "absolute timeout". If this is set to `0`, user sessions could stay active indefinitely. By default, this setting is equal to [`xpack.security.session.lifespan`](#xpack-session-lifespan).
 
     ::::{note}
@@ -105,17 +105,17 @@ $$$xpack-security-provider-session-lifespan$$$ `xpack.security.authc.providers.<
 
 In addition to [the settings that are valid for all providers](#authentication-provider-settings), you can specify the following settings:
 
-`xpack.security.authc.providers.saml.<provider-name>.realm` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.security.authc.providers.saml.<provider-name>.realm` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   SAML realm in {{es}} that provider should use.
 
-`xpack.security.authc.providers.saml.<provider-name>.maxRedirectURLSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.security.authc.providers.saml.<provider-name>.maxRedirectURLSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the maximum size of the URL that Kibana is allowed to store during the SAML handshake.
 % TBD: Available only on Elastic Cloud?
 
-xpack.security.authc.providers.saml.<provider-name>.useRelayStateDeepLink ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.saml.<provider-name>.useRelayStateDeepLink ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Determines if the provider should treat the `RelayState` parameter as a deep link in {{kib}} during Identity Provider initiated log in. By default, this setting is set to `false`. The link specified in `RelayState` should be a relative, URL-encoded {{kib}} URL. For example, the `/app/dashboards#/list` link in `RelayState` parameter would look like this: `RelayState=%2Fapp%2Fdashboards%23%2Flist`.
 
-`xpack.security.authc.saml.maxRedirectURLSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.security.authc.saml.maxRedirectURLSize` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies the maximum size of the URL that Kibana is allowed to store during the SAML handshake.
 % TBD: Available only on Elastic Cloud?
 
@@ -125,27 +125,27 @@ ess: discontinued 8.0
 ```
 The following settings are available in {{ecloud}} for all supported versions before 8.0:
 
-`xpack.security.authProviders` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.security.authProviders` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `saml` to instruct Kibana to use SAML SSO as the authentication method.
 % TBD: Available only on Elastic Cloud?
 
-`xpack.security.public.protocol` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.security.public.protocol` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to HTTP or HTTPS. To access Kibana, HTTPS protocol is recommended.
 % TBD: Available only on Elastic Cloud?
 
-`xpack.security.public.hostname` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.security.public.hostname` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to a fully qualified hostname to connect your users to the proxy server.
 % TBD: Available only on Elastic Cloud?
 
-`xpack.security.public.port` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.security.public.port` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The port number that connects your users to the proxy server (for example, 80 for HTTP or 443 for HTTPS).
 % TBD: Available only on Elastic Cloud?
 
-`xpack.security.authc.saml.useRelayStateDeepLink` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`xpack.security.authc.saml.useRelayStateDeepLink` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Specifies if Kibana should treat the `RelayState` parameter as a deep link when Identity Provider Initiated login flow is used.
 % TBD: Available only on Elastic Cloud?
 
-`server.xsrf.whitelist` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+`server.xsrf.whitelist` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Explicitly allows the SAML authentication URL within Kibana, so that the Kibana server doesn't reject external authentication messages that originate from your Identity Provider. This setting is renamed to `server.xsrf.allowlist` in version 8.0.0.
 % TBD: Available only on Elastic Cloud?
 
@@ -153,7 +153,7 @@ The following settings are available in {{ecloud}} for all supported versions be
 
 In addition to [the settings that are valid for all providers](#authentication-provider-settings), you can specify the following settings:
 
-xpack.security.authc.providers.oidc.<provider-name>.realm ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.oidc.<provider-name>.realm ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   OpenID Connect realm in {{es}} that the provider should use.
 
 
@@ -166,7 +166,7 @@ You can configure only one anonymous provider per {{kib}} instance.
 ::::
 
 
-xpack.security.authc.providers.anonymous.<provider-name>.credentials ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.providers.anonymous.<provider-name>.credentials ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Credentials that {{kib}} should use internally to authenticate anonymous requests to {{es}}.
 
     For example:
@@ -198,19 +198,19 @@ xpack.security.authc.http.schemes[]
 
 ### Login user interface settings [login-ui-settings]
 
-xpack.security.loginAssistanceMessage ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.loginAssistanceMessage ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Adds a message to the login UI. Useful for displaying information about maintenance windows, links to corporate sign up pages, and so on.
 
-xpack.security.loginHelp ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.loginHelp ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Adds a message accessible at the login UI with additional help information for the login process.
 
-xpack.security.authc.selector.enabled ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.authc.selector.enabled ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Determines if the login selector UI should be enabled. By default, this setting is set to `true` if more than one authentication provider is configured.
 
 
 ### Configure a default access agreement [authentication-access-agreement-settings]
 
-xpack.security.accessAgreement.message ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.accessAgreement.message ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   This setting specifies the access agreement text in Markdown format that will be used as the default access agreement for all providers that do not specify a value for `xpack.security.authc.providers.<provider-type>.<provider-name>.accessAgreement.message`. For more information, refer to [Access agreement](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/access-agreement.md).
 
 
@@ -225,10 +225,10 @@ $$$xpack-security-encryptionKey$$$ xpack.security.encryptionKey
 $$$xpack-security-secureCookies$$$ xpack.security.secureCookies
 :   Sets the `secure` flag of the session cookie. The default value is `false`. It is automatically set to `true` if [`server.ssl.enabled`](/reference/configuration-reference/general-settings.md#server-ssl-enabled) is set to `true`. Set this to `true` if SSL is configured outside of {{kib}} (for example, you are routing requests through a load balancer or proxy).
 
-$$$xpack-security-sameSiteCookies$$$ xpack.security.sameSiteCookies ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$xpack-security-sameSiteCookies$$$ xpack.security.sameSiteCookies ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Sets the `SameSite` attribute of the session cookie. This allows you to declare whether your cookie should be restricted to a first-party or same-site context. Valid values are `Strict`, `Lax`, `None`. This is **not set** by default, which modern browsers will treat as `Lax`. If you use Kibana embedded in an iframe in modern browsers, you might need to set it to `None`. Setting this value to `None` requires cookies to be sent over a secure connection by setting [`xpack.security.secureCookies`](#xpack-security-secureCookies): `true`.
 
-$$$xpack-session-idleTimeout$$$ xpack.security.session.idleTimeout ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$xpack-session-idleTimeout$$$ xpack.security.session.idleTimeout ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Ensures that user sessions will expire after a period of inactivity. This and [`xpack.security.session.lifespan`](#xpack-session-lifespan) are both highly recommended. You can also specify this setting for [every provider separately](#xpack-security-provider-session-idleTimeout). If this is set to `0`, then sessions will never expire due to inactivity. By default, this value is 3 days.
 
     ::::{note}
@@ -236,7 +236,7 @@ $$$xpack-session-idleTimeout$$$ xpack.security.session.idleTimeout ![logo cloud]
     ::::
 
 
-$$$xpack-session-lifespan$$$ xpack.security.session.lifespan ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+$$$xpack-session-lifespan$$$ xpack.security.session.lifespan ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Ensures that user sessions will expire after the defined time period. This behavior is also known as an "absolute timeout". If this is set to `0`, user sessions could stay active indefinitely. This and [`xpack.security.session.idleTimeout`](#xpack-session-idleTimeout) are both highly recommended. You can also specify this setting for [every provider separately](#xpack-security-provider-session-lifespan). By default, this value is 30 days for on-prem installations, and 24 hours for Elastic Cloud installations.
 
     ::::{tip}
@@ -244,7 +244,7 @@ $$$xpack-session-lifespan$$$ xpack.security.session.lifespan ![logo cloud](https
     ::::
 
 
-xpack.security.session.cleanupInterval ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.session.cleanupInterval ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Sets the interval at which {{kib}} tries to remove expired and invalid sessions from the session index. By default, this value is 1 hour. The minimum value is 10 seconds.
 
     ::::{tip}
@@ -252,7 +252,7 @@ xpack.security.session.cleanupInterval ![logo cloud](https://doc-icons.s3.us-eas
     ::::
 
 
-xpack.security.session.concurrentSessions.maxSessions ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.session.concurrentSessions.maxSessions ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set the maximum number of sessions each user is allowed to have active at any given time. By default, no limit is applied. If set, the value of this option should be an integer between `1` and `1000`. When the limit is exceeded, the oldest session is automatically invalidated.
     It is available in {{ecloud}} 8.7.0 and later versions.
 
@@ -277,7 +277,7 @@ You can enable audit logging to support compliance, accountability, and security
 
 For more details and a reference of audit events, refer to [Audit logs](/reference/kibana-audit-events.md).
 
-xpack.security.audit.enabled ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.audit.enabled ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   Set to `true` to enable audit logging`. **Default:** `false`
 
     For example:
@@ -393,7 +393,7 @@ xpack.security.audit.appender.layout.highlight
 
 ### Ignore filters [audit-logging-ignore-filters]
 
-xpack.security.audit.ignore_filters[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.audit.ignore_filters[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   List of filters that determine which events should be excluded from the audit log. An event will get filtered out if at least one of the provided filters matches.
 
     For example:
@@ -413,20 +413,20 @@ xpack.security.audit.ignore_filters[] ![logo cloud](https://doc-icons.s3.us-east
     4. Filters out events from the `elastic` and `kibana_system` users
 
 
-xpack.security.audit.ignore_filters[].actions[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.audit.ignore_filters[].actions[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   List of values matched against the `event.action` field of an audit event. Refer to [Audit logs](/reference/kibana-audit-events.md) for a list of available events.
 
-xpack.security.audit.ignore_filters[].categories[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.audit.ignore_filters[].categories[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   List of values matched against the `event.category` field of an audit event. Refer to [ECS categorization field](ecs://reference/ecs-allowed-values-event-category.md) for allowed values.
 
-xpack.security.audit.ignore_filters[].outcomes[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.audit.ignore_filters[].outcomes[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   List of values matched against the `event.outcome` field of an audit event. Refer to [ECS outcome field](ecs://reference/ecs-allowed-values-event-outcome.md) for allowed values.
 
-xpack.security.audit.ignore_filters[].spaces[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.audit.ignore_filters[].spaces[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   List of values matched against the `kibana.space_id` field of an audit event. This represents the space id in which the event took place.
 
-xpack.security.audit.ignore_filters[].types[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.audit.ignore_filters[].types[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   List of values matched against the `event.type` field of an audit event. Refer to [ECS type field](ecs://reference/ecs-allowed-values-event-type.md) for allowed values.
 
-xpack.security.audit.ignore_filters[].users[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ess}}")
+xpack.security.audit.ignore_filters[].users[] ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   List of values matched against the `user.name` field of an audit event. This represents the `username` associated with the audit event.

--- a/docs/reference/configuration-reference/security-settings.md
+++ b/docs/reference/configuration-reference/security-settings.md
@@ -18,7 +18,7 @@ In high-availability deployments, make sure you use the same security settings f
 ::::
 
 :::{note}
-If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
+If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
 :::
 
 ### Authentication security settings [authentication-security-settings]

--- a/docs/reference/connectors-kibana/pre-configured-connectors.md
+++ b/docs/reference/connectors-kibana/pre-configured-connectors.md
@@ -8,7 +8,7 @@ mapped_pages:
 If you are running {{kib}} on-prem, you can preconfigure a connector to have all the information it needs prior to startup by adding it to the `kibana.yml` file.
 
 ::::{note}
-{{ess}} provides a preconfigured email connector but you cannot create additional preconfigured connectors.
+{{ech}} provides a preconfigured email connector but you cannot create additional preconfigured connectors.
 ::::
 
 

--- a/docs/settings-gen/source/kibana-alert-action-settings.yml
+++ b/docs/settings-gen/source/kibana-alert-action-settings.yml
@@ -10,7 +10,7 @@ page_description: |
   2. [Set up TLS encryption between {{kib}} and {{es}}](docs-content://deploy-manage/security/set-up-basic-security-plus-https.  md#encrypt-kibana-http).
   3. If you are using an **on-premises** Elastic Stack deployment, [specify a value for `xpack.encryptedSavedObjects.encryptionKey`](#general-alert-action-settings).
   
-note: 'If a setting is applicable to {{ecloud}} Hosted environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")'
+note: 'If a setting is applicable to {{ech}} environments, its name is followed by this icon: ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")'
 
 groups:
   - group: General settings


### PR DESCRIPTION
This PR updates some remaining obsolete variables and mentions of ESS/Elasticsearch Service that should now refer to Elastic Cloud Hosted.

Note: There are still a few valid references to the Elasticsearch service, not to be mixed with the cloud offering bearing the same name.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->