### PR TITLE
[ci] fix docker pull retries

### DIFF
--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -398,6 +398,7 @@ const RETRYABLE_DOCKER_PULL_ERROR_MESSAGES = [
   'connection refused',
   'i/o timeout',
   'Client.Timeout',
+  'TLS handshake timeout',
 ];
 
 /**

--- a/src/platform/packages/shared/kbn-es/src/utils/docker.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker.ts
@@ -425,13 +425,15 @@ ${message}`;
       retries: 2,
       onFailedAttempt: (error) => {
         // Only retry if retryable error messages are found in the error message.
-        if (
-          RETRYABLE_DOCKER_PULL_ERROR_MESSAGES.every(
-            (msg) => !error?.message?.includes('connection refused')
-          )
-        ) {
-          throw error;
+        for (const msg of RETRYABLE_DOCKER_PULL_ERROR_MESSAGES) {
+          if (error?.message?.includes(msg)) {
+            log.info(`Retrying due to error: ${error.message}`);
+            return;
+          }
         }
+
+        log.warning('Docker pull failed, error not retriable. Exiting.');
+        throw error;
       },
     }
   );


### PR DESCRIPTION
## Summary
Due to a typo, some of the listed cases of retriable docker-pull errors weren't retried. This PR changes the code to respect the output error's message, changes it to be a bit more verbose for readability and logging, and adds another case for retries.

- Fixes an issue where the error message wasn't checked when verifying if the docker pull error is retriable.
- Adds more logging around docker pull retries
- Adds another case of retriable errors: "TLS handshake timeout" ( https://elastic.slack.com/archives/C5UDAFZQU/p1746441353412359 )

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->