### PR TITLE
[8.19] Lens performance metrics (#216330)

### DIFF
--- a/src/platform/packages/shared/kbn-ebt-tools/index.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/index.ts
@@ -10,3 +10,5 @@
 export * from './src/performance_metrics';
 
 export * from './src/performance_metric_events';
+
+export * from './src/performance_tracker';

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_tracker.test.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_tracker.test.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  PERFORMANCE_TRACKER_TYPES,
+  PERFORMANCE_TRACKER_MARKS,
+  createPerformanceTracker,
+  getPerformanceTrackersByType,
+  getPerformanceTrackersGroupedById,
+  clearPerformanceTrackersByType,
+  getMeanFromPerformanceMeasures,
+  findMarkerByNamePostfix,
+} from './performance_tracker';
+
+// Mock the performance API
+const mockMark = jest.fn();
+const mockGetEntriesByType = jest.fn();
+const mockClearMarks = jest.fn();
+const mockMeasure = jest.fn();
+
+// Mock uuid to return predictable values
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'test-uuid'),
+}));
+
+describe('Performance Tracker', () => {
+  beforeAll(() => {
+    // Setup performance API mocks
+    Object.defineProperty(window, 'performance', {
+      value: {
+        mark: mockMark,
+        getEntriesByType: mockGetEntriesByType,
+        clearMarks: mockClearMarks,
+        measure: mockMeasure,
+      },
+      writable: true,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createPerformanceTracker', () => {
+    it('creates a tracker with the correct mark method', () => {
+      const tracker = createPerformanceTracker({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        subType: 'testSubType',
+      });
+
+      expect(tracker).toHaveProperty('mark');
+      expect(typeof tracker.mark).toBe('function');
+      expect(uuidv4).toHaveBeenCalledTimes(1);
+    });
+
+    it('generates mark names with the correct format', () => {
+      const tracker = createPerformanceTracker({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        subType: 'testSubType',
+      });
+
+      tracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+
+      expect(mockMark).toHaveBeenCalledWith('Panel:testSubType:preRender', {
+        detail: { id: 'test-uuid' },
+      });
+    });
+  });
+
+  describe('getPerformanceTrackersByType', () => {
+    it('filters marks by type prefix', () => {
+      const mockMarks = [
+        { name: 'Panel:test1:preRender', startTime: 100, detail: { id: 'id1' } },
+        { name: 'Panel:test2:renderStart', startTime: 200, detail: { id: 'id2' } },
+        { name: 'Other:test:preRender', startTime: 300, detail: { id: 'id3' } },
+      ];
+
+      mockGetEntriesByType.mockReturnValue(mockMarks);
+
+      const result = getPerformanceTrackersByType('Panel');
+
+      expect(mockGetEntriesByType).toHaveBeenCalledWith('mark');
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('Panel:test1:preRender');
+      expect(result[1].name).toBe('Panel:test2:renderStart');
+    });
+
+    it('returns an empty array when no marks match', () => {
+      mockGetEntriesByType.mockReturnValue([
+        { name: 'Other:test:preRender', startTime: 300, detail: { id: 'id3' } },
+      ]);
+
+      const result = getPerformanceTrackersByType('Panel');
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('getPerformanceTrackersGroupedById', () => {
+    it('groups performance marks by id', () => {
+      const mockMarks = [
+        { name: 'Panel:test1:preRender', startTime: 100, detail: { id: 'id1' } },
+        { name: 'Panel:test1:renderStart', startTime: 200, detail: { id: 'id1' } },
+        { name: 'Panel:test2:preRender', startTime: 300, detail: { id: 'id2' } },
+      ];
+
+      mockGetEntriesByType.mockReturnValue(mockMarks);
+
+      const result = getPerformanceTrackersGroupedById('Panel');
+
+      // Check the structure of the result - should be grouped by id
+      expect(Object.keys(result).length).toBe(2);
+      expect(result.id1).toBeDefined();
+      expect(result.id1.length).toBe(2);
+      expect(result.id2).toBeDefined();
+      expect(result.id2.length).toBe(1);
+
+      // Verify the correct marks are in each group
+      expect(result.id1[0].name).toBe('Panel:test1:preRender');
+      expect(result.id1[1].name).toBe('Panel:test1:renderStart');
+      expect(result.id2[0].name).toBe('Panel:test2:preRender');
+    });
+
+    it('returns empty object when no marks match', () => {
+      mockGetEntriesByType.mockReturnValue([]);
+      const result = getPerformanceTrackersGroupedById('Panel');
+      expect(Object.keys(result).length).toBe(0);
+    });
+  });
+
+  describe('clearPerformanceTrackersByType', () => {
+    it('clears all marks of a given type', () => {
+      const mockMarks = [
+        { name: 'Panel:test1:preRender', startTime: 100, detail: { id: 'id1' } },
+        { name: 'Panel:test2:renderStart', startTime: 200, detail: { id: 'id2' } },
+      ];
+
+      mockGetEntriesByType.mockReturnValue(mockMarks);
+
+      clearPerformanceTrackersByType('Panel');
+
+      expect(mockClearMarks).toHaveBeenCalledTimes(2);
+      expect(mockClearMarks).toHaveBeenCalledWith('Panel:test1:preRender');
+      expect(mockClearMarks).toHaveBeenCalledWith('Panel:test2:renderStart');
+    });
+
+    it('does nothing when no marks match', () => {
+      mockGetEntriesByType.mockReturnValue([]);
+
+      clearPerformanceTrackersByType('Panel');
+
+      expect(mockClearMarks).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findMarkerByNamePostfix', () => {
+    it('finds a marker by name postfix', () => {
+      const markers = [
+        { name: 'Panel:test1:preRender', startTime: 100 },
+        { name: 'Panel:test1:renderStart', startTime: 200 },
+        { name: 'Panel:test1:renderComplete', startTime: 300 },
+      ] as PerformanceMark[];
+
+      const result = findMarkerByNamePostfix(markers, PERFORMANCE_TRACKER_MARKS.RENDER_START);
+
+      expect(result).toBeDefined();
+      expect(result!.name).toBe('Panel:test1:renderStart');
+      expect(result!.startTime).toBe(200);
+    });
+
+    it('returns undefined when no marker matches', () => {
+      const markers = [
+        { name: 'Panel:test1:preRender', startTime: 100 },
+        { name: 'Panel:test1:renderComplete', startTime: 300 },
+      ] as PerformanceMark[];
+
+      const result = findMarkerByNamePostfix(markers, PERFORMANCE_TRACKER_MARKS.RENDER_START);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getMeanFromPerformanceMeasures', () => {
+    it('calculates the mean duration between start and end marks', () => {
+      const mockMarks = [
+        { name: 'Panel:test1:preRender', startTime: 100, detail: { id: 'id1' } },
+        { name: 'Panel:test1:renderStart', startTime: 200, detail: { id: 'id1' } },
+        { name: 'Panel:test2:preRender', startTime: 300, detail: { id: 'id2' } },
+        { name: 'Panel:test2:renderStart', startTime: 450, detail: { id: 'id2' } },
+      ];
+
+      mockGetEntriesByType.mockReturnValue(mockMarks);
+
+      const result = getMeanFromPerformanceMeasures({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        startMark: PERFORMANCE_TRACKER_MARKS.PRE_RENDER,
+        endMark: PERFORMANCE_TRACKER_MARKS.RENDER_START,
+      });
+
+      // Mean of (200-100) and (450-300) = (100+150)/2 = 125
+      expect(result).toBe(125);
+
+      // Verify performance measures were created
+      expect(mockMeasure).toHaveBeenCalledTimes(2);
+      expect(mockMeasure).toHaveBeenCalledWith('Panel:test1:preRenderDuration', {
+        start: 100,
+        end: 200,
+      });
+      expect(mockMeasure).toHaveBeenCalledWith('Panel:test2:preRenderDuration', {
+        start: 300,
+        end: 450,
+      });
+    });
+
+    it('skips creating performance measures when createPerformanceMeasures is false', () => {
+      const mockMarks = [
+        { name: 'Panel:test1:preRender', startTime: 100, detail: { id: 'id1' } },
+        { name: 'Panel:test1:renderStart', startTime: 200, detail: { id: 'id1' } },
+      ];
+
+      mockGetEntriesByType.mockReturnValue(mockMarks);
+
+      const result = getMeanFromPerformanceMeasures({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        startMark: PERFORMANCE_TRACKER_MARKS.PRE_RENDER,
+        endMark: PERFORMANCE_TRACKER_MARKS.RENDER_START,
+        createPerformanceMeasures: false,
+      });
+
+      expect(result).toBe(100);
+      expect(mockMeasure).not.toHaveBeenCalled();
+    });
+
+    it('handles missing markers correctly', () => {
+      const mockMarks = [
+        { name: 'Panel:test1:preRender', startTime: 100, detail: { id: 'id1' } },
+        // Missing renderStart for id1
+        { name: 'Panel:test2:preRender', startTime: 300, detail: { id: 'id2' } },
+        { name: 'Panel:test2:renderStart', startTime: 450, detail: { id: 'id2' } },
+      ];
+
+      mockGetEntriesByType.mockReturnValue(mockMarks);
+
+      const result = getMeanFromPerformanceMeasures({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        startMark: PERFORMANCE_TRACKER_MARKS.PRE_RENDER,
+        endMark: PERFORMANCE_TRACKER_MARKS.RENDER_START,
+      });
+
+      // Only one valid measurement (450-300 = 150)
+      expect(result).toBe(75);
+
+      // Only one performance measure should be created
+      expect(mockMeasure).toHaveBeenCalledTimes(1);
+      expect(mockMeasure).toHaveBeenCalledWith('Panel:test2:preRenderDuration', {
+        start: 300,
+        end: 450,
+      });
+    });
+
+    it('returns 0 when no valid measurements are found', () => {
+      mockGetEntriesByType.mockReturnValue([]);
+
+      const result = getMeanFromPerformanceMeasures({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        startMark: PERFORMANCE_TRACKER_MARKS.PRE_RENDER,
+        endMark: PERFORMANCE_TRACKER_MARKS.RENDER_START,
+      });
+
+      expect(result).toBe(0);
+      expect(mockMeasure).not.toHaveBeenCalled();
+    });
+
+    it('extracts the marker name correctly to create the measure name', () => {
+      const mockMarks = [
+        { name: 'Panel:test1:preRender', startTime: 100, detail: { id: 'id1' } },
+        { name: 'Panel:test1:renderStart', startTime: 200, detail: { id: 'id1' } },
+      ];
+
+      mockGetEntriesByType.mockReturnValue(mockMarks);
+
+      getMeanFromPerformanceMeasures({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        startMark: PERFORMANCE_TRACKER_MARKS.PRE_RENDER,
+        endMark: PERFORMANCE_TRACKER_MARKS.RENDER_START,
+      });
+
+      expect(mockMeasure).toHaveBeenCalledWith('Panel:test1:preRenderDuration', {
+        start: 100,
+        end: 200,
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-ebt-tools/src/performance_tracker.ts
+++ b/src/platform/packages/shared/kbn-ebt-tools/src/performance_tracker.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { groupBy, mean, round } from 'lodash';
+
+import type { Logger } from '@kbn/logging';
+
+/**
+ * PERFORMANCE_TRACKER_TYPES defines top-level categories to be used as
+ * the mark name. They are used to group marks and measures by type.
+ */
+export const PERFORMANCE_TRACKER_TYPES = {
+  PANEL: 'Panel',
+} as const;
+export type PerformanceTrackerTypes =
+  (typeof PERFORMANCE_TRACKER_TYPES)[keyof typeof PERFORMANCE_TRACKER_TYPES];
+
+/**
+ * PerformanceTrackerMarks are the marks that can be used to track performance
+ * of lens charts. They are used to mark specific points in time during
+ * the chart's lifecycle.
+ */
+export const PERFORMANCE_TRACKER_MARKS = {
+  /**
+   * Mark that indicates the start of everything before the rendering process.
+   */
+  PRE_RENDER: 'preRender',
+  /**
+   * Mark that indicates the start of the rendering process.
+   * Should be used right before returning the chart's JSX.
+   */
+  RENDER_START: 'renderStart',
+  /**
+   * Mark that indicates the end of the rendering process.
+   * Should be used at the beginning of the `renderComplete` callback.
+   */
+  RENDER_COMPLETE: 'renderComplete',
+} as const;
+export type PerformanceTrackerMarks =
+  (typeof PERFORMANCE_TRACKER_MARKS)[keyof typeof PERFORMANCE_TRACKER_MARKS];
+
+export const PERFORMANCE_TRACKER_MEASURES = {
+  PRE_RENDER_DURATION: 'preRenderDuration',
+  RENDER_DURATION: 'renderDuration',
+} as const;
+export type PerformanceTrackerMeasures =
+  (typeof PERFORMANCE_TRACKER_MEASURES)[keyof typeof PERFORMANCE_TRACKER_MEASURES];
+
+/**
+ * Options to create a performance tracker.
+ */
+interface PerformanceTrackerOptions {
+  /**
+   * High-level type of the performance tracker, for example "Panel".
+   */
+  type: PerformanceTrackerTypes;
+  /**
+   * Lower-level type of the performance tracker type, for example "xyVis".
+   * This is used to group marks and measures by sub type.
+   */
+  subType: string;
+  /**
+   * Optional logger.
+   */
+  logger?: Logger;
+}
+
+/**
+ * Creates a performance tracker to mark and measure performance events.
+ * @param options.type - High-level type of the performance tracker, for example "Panel".
+ * @param options.subType - Lower-level type of the performance tracker type, for example "xyVis".
+ * @returns A performance tracker object with a mark method.
+ */
+export const createPerformanceTracker = ({ type, subType, logger }: PerformanceTrackerOptions) => {
+  const id = uuidv4();
+  const createMarkName = (name: string) => `${type}:${subType}:${name}`;
+
+  return {
+    /**
+     * Creates a performance mark with the given name.
+     * @param name - The name of the mark to create, will be postfixed.
+     * @returns The created performance mark
+     */
+    mark: (name: PerformanceTrackerMarks) => {
+      try {
+        performance.mark(createMarkName(name), { detail: { id } });
+      } catch (error) {
+        logger?.error('Error creating performance mark:', error);
+      }
+    },
+  };
+};
+
+/**
+ * Finds a performance marker by its name postfix.
+ * @param markers
+ * @param namePostfix
+ * @returns The found performance marker or undefined if not found.
+ */
+export const findMarkerByNamePostfix = (
+  markers: PerformanceMark[],
+  namePostfix: PerformanceTrackerMarks
+) => markers.find((marker) => marker.name.endsWith(`:${namePostfix}`));
+
+/**
+ * Get all performance trackers by type.
+ * @param type - High-level type of the performance tracker, for example "Panel".
+ * @returns An array of performance trackers.
+ */
+export const getPerformanceTrackersByType = (type: PerformanceTrackerTypes) => {
+  try {
+    return performance
+      .getEntriesByType('mark')
+      .filter((marker) => marker.name.startsWith(`${type}:`)) as PerformanceMark[];
+  } catch (e) {
+    // Fail silently if performance API is not supported.
+    return [];
+  }
+};
+
+/**
+ * Get all performance trackers grouped by id.
+ * @param type - High-level type of the performance tracker, for example "Panel".
+ * @returns A map of performance trackers grouped by id.
+ */
+export const getPerformanceTrackersGroupedById = (type: PerformanceTrackerTypes) => {
+  try {
+    return groupBy(getPerformanceTrackersByType(type), (marker) => marker.detail?.id);
+  } catch (e) {
+    // Fail silently if performance API is not supported.
+    return {};
+  }
+};
+
+/**
+ * Clear all performance trackers by type.
+ * @param type - High-level type of the performance tracker, for example "Panel".
+ */
+export const clearPerformanceTrackersByType = (type: PerformanceTrackerTypes) => {
+  try {
+    getPerformanceTrackersByType(type).forEach((marker) => performance.clearMarks(marker.name));
+  } catch (e) {
+    // Fail silently if performance API is not supported.
+  }
+};
+
+interface GetMeanFromMeasuresOptions {
+  type: PerformanceTrackerTypes;
+  startMark: PerformanceTrackerMarks;
+  endMark: PerformanceTrackerMarks;
+  createPerformanceMeasures?: boolean;
+}
+
+/**
+ * Get the mean duration of performance measures between two marks.
+ * @param type
+ * @param startMark
+ * @param endMark
+ * @param createPerformanceMeasures - Whether to create performance measures.
+ * @returns The mean duration of the performance measures between the two marks.
+ */
+export const getMeanFromPerformanceMeasures = ({
+  type,
+  startMark,
+  endMark,
+  createPerformanceMeasures = true,
+}: GetMeanFromMeasuresOptions) => {
+  const groupedMarkers = getPerformanceTrackersGroupedById(type);
+
+  if (Object.keys(groupedMarkers).length === 0) {
+    return 0;
+  }
+
+  // `groupedMarkers` is a map of performance markers grouped by id.
+  // Each group contains the performance markers for a single panel.
+  // We need to extract the start and end times of the preRender, renderStart
+  // and renderComplete markers and calculate the duration of each phase.
+  const measurements = Object.values(groupedMarkers).map((markers) => {
+    const markerName =
+      Array.isArray(markers) && markers.length > 0
+        ? markers[0].name.split(':').slice(0, -1).join(':')
+        : undefined;
+
+    const startTime = findMarkerByNamePostfix(markers, startMark)?.startTime;
+    const endTime = findMarkerByNamePostfix(markers, endMark)?.startTime;
+
+    if (createPerformanceMeasures && markerName && startTime && endTime) {
+      performance.measure(`${markerName}:${PERFORMANCE_TRACKER_MEASURES.PRE_RENDER_DURATION}`, {
+        start: startTime,
+        end: endTime,
+      });
+    }
+
+    return startTime && endTime ? endTime - startTime : 0;
+  });
+
+  return round(mean(measurements), 2);
+};

--- a/src/platform/packages/shared/kbn-ebt-tools/tsconfig.json
+++ b/src/platform/packages/shared/kbn-ebt-tools/tsconfig.json
@@ -5,6 +5,10 @@
     "types": ["jest", "node"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "kbn_references": ["@kbn/logging-mocks", "@kbn/timerange"],
+  "kbn_references": [
+    "@kbn/logging-mocks",
+    "@kbn/timerange",
+    "@kbn/logging",
+  ],
   "exclude": ["target/**/*"]
 }

--- a/src/platform/plugins/shared/chart_expressions/expression_gauge/public/expression_renderers/gauge_renderer.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_gauge/public/expression_renderers/gauge_renderer.tsx
@@ -17,6 +17,11 @@ import { ExpressionRenderDefinition } from '@kbn/expressions-plugin/common/expre
 import { StartServicesGetter } from '@kbn/kibana-utils-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
 import {
+  createPerformanceTracker,
+  PERFORMANCE_TRACKER_MARKS,
+  PERFORMANCE_TRACKER_TYPES,
+} from '@kbn/ebt-tools';
+import {
   ChartSizeEvent,
   extractContainerType,
   extractVisualizationType,
@@ -38,6 +43,13 @@ export const gaugeRenderer: (
   }),
   reuseDomNode: true,
   render: async (domNode, config, handlers) => {
+    const performanceTracker = createPerformanceTracker({
+      type: PERFORMANCE_TRACKER_TYPES.PANEL,
+      subType: EXPRESSION_GAUGE_NAME,
+    });
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+
     const { core, plugins } = getStartDeps();
 
     handlers.onDestroy(() => {
@@ -45,6 +57,8 @@ export const gaugeRenderer: (
     });
 
     const renderComplete = () => {
+      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE);
+
       let type: string;
 
       switch (config.args.shape) {
@@ -92,6 +106,9 @@ export const gaugeRenderer: (
     };
 
     const { GaugeComponent } = await import('../components/gauge_component');
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_START);
+
     render(
       <KibanaRenderContextProvider {...core}>
         <div

--- a/src/platform/plugins/shared/chart_expressions/expression_gauge/tsconfig.json
+++ b/src/platform/plugins/shared/chart_expressions/expression_gauge/tsconfig.json
@@ -27,6 +27,7 @@
     "@kbn/chart-icons",
     "@kbn/chart-expressions-common",
     "@kbn/react-kibana-context-render",
+    "@kbn/ebt-tools",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/plugins/shared/chart_expressions/expression_heatmap/public/expression_renderers/heatmap_renderer.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_heatmap/public/expression_renderers/heatmap_renderer.tsx
@@ -17,6 +17,11 @@ import { ExpressionRenderDefinition } from '@kbn/expressions-plugin/common/expre
 import { StartServicesGetter } from '@kbn/kibana-utils-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
 import {
+  createPerformanceTracker,
+  PERFORMANCE_TRACKER_MARKS,
+  PERFORMANCE_TRACKER_TYPES,
+} from '@kbn/ebt-tools';
+import {
   ChartSizeEvent,
   extractContainerType,
   extractVisualizationType,
@@ -49,6 +54,13 @@ export const heatmapRenderer: (
   }),
   reuseDomNode: true,
   render: async (domNode, config, handlers) => {
+    const performanceTracker = createPerformanceTracker({
+      type: PERFORMANCE_TRACKER_TYPES.PANEL,
+      subType: EXPRESSION_HEATMAP_NAME,
+    });
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+
     const { core, plugins } = getStartDeps();
 
     handlers.onDestroy(() => {
@@ -65,6 +77,8 @@ export const heatmapRenderer: (
     };
 
     const renderComplete = () => {
+      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE);
+
       const executionContext = handlers.getExecutionContext();
       const containerType = extractContainerType(executionContext);
       const visualizationType = extractVisualizationType(executionContext);
@@ -98,6 +112,8 @@ export const heatmapRenderer: (
     const timeZone = getTimeZone(getUISettings());
     const { HeatmapComponent } = await import('../components/heatmap_component');
     const { isInteractive } = handlers;
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_START);
 
     render(
       <KibanaRenderContextProvider {...core}>

--- a/src/platform/plugins/shared/chart_expressions/expression_heatmap/tsconfig.json
+++ b/src/platform/plugins/shared/chart_expressions/expression_heatmap/tsconfig.json
@@ -29,6 +29,7 @@
     "@kbn/visualization-utils",
     "@kbn/react-kibana-context-render",
     "@kbn/transpose-utils",
+    "@kbn/ebt-tools",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/plugins/shared/chart_expressions/expression_metric/public/expression_renderers/metric_vis_renderer.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_metric/public/expression_renderers/metric_vis_renderer.tsx
@@ -15,6 +15,11 @@ import { ExpressionRenderDefinition } from '@kbn/expressions-plugin/common/expre
 import { css } from '@emotion/react';
 import { StartServicesGetter } from '@kbn/kibana-utils-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
+import {
+  createPerformanceTracker,
+  PERFORMANCE_TRACKER_MARKS,
+  PERFORMANCE_TRACKER_TYPES,
+} from '@kbn/ebt-tools';
 import type { IInterpreterRenderHandlers, Datatable } from '@kbn/expressions-plugin/common';
 import { getColumnByAccessor } from '@kbn/visualizations-plugin/common/utils';
 import { extractContainerType, extractVisualizationType } from '@kbn/chart-expressions-common';
@@ -57,6 +62,13 @@ export const getMetricVisRenderer = (
     displayName: 'metric visualization',
     reuseDomNode: true,
     render: async (domNode, { visData, visConfig, overrides }, handlers) => {
+      const performanceTracker = createPerformanceTracker({
+        type: PERFORMANCE_TRACKER_TYPES.PANEL,
+        subType: EXPRESSION_METRIC_NAME,
+      });
+
+      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+
       const { core, plugins } = deps.getStartDeps();
 
       handlers.onDestroy(() => {
@@ -71,6 +83,8 @@ export const getMetricVisRenderer = (
           )
         : false;
       const renderComplete = () => {
+        performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE);
+
         const executionContext = handlers.getExecutionContext();
         const containerType = extractContainerType(executionContext);
         const visualizationType = extractVisualizationType(executionContext);
@@ -85,6 +99,9 @@ export const getMetricVisRenderer = (
       };
 
       const { MetricVis } = await import('../components/metric_vis');
+
+      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_START);
+
       render(
         <KibanaRenderContextProvider {...core}>
           <div

--- a/src/platform/plugins/shared/chart_expressions/expression_metric/tsconfig.json
+++ b/src/platform/plugins/shared/chart_expressions/expression_metric/tsconfig.json
@@ -26,6 +26,7 @@
     "@kbn/analytics",
     "@kbn/chart-expressions-common",
     "@kbn/react-kibana-context-render",
+    "@kbn/ebt-tools",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/plugins/shared/chart_expressions/expression_partition_vis/public/expression_renderers/partition_vis_renderer.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_partition_vis/public/expression_renderers/partition_vis_renderer.tsx
@@ -20,6 +20,11 @@ import type { PersistedState } from '@kbn/visualizations-plugin/public';
 import { withSuspense } from '@kbn/presentation-util-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { METRIC_TYPE } from '@kbn/analytics';
+import {
+  createPerformanceTracker,
+  PERFORMANCE_TRACKER_MARKS,
+  PERFORMANCE_TRACKER_TYPES,
+} from '@kbn/ebt-tools';
 import { getColumnByAccessor } from '@kbn/visualizations-plugin/common/utils';
 import {
   type ChartSizeEvent,
@@ -88,6 +93,13 @@ export const getPartitionVisRenderer: (
     { visConfig, visData, visType, syncColors, canNavigateToLens, overrides },
     handlers
   ) => {
+    const performanceTracker = createPerformanceTracker({
+      type: PERFORMANCE_TRACKER_TYPES.PANEL,
+      subType: PARTITION_VIS_RENDERER_NAME,
+    });
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+
     const { core, plugins } = getStartDeps();
 
     handlers.onDestroy(() => {
@@ -95,6 +107,8 @@ export const getPartitionVisRenderer: (
     });
 
     const renderComplete = () => {
+      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE);
+
       const executionContext = handlers.getExecutionContext();
       const containerType = extractContainerType(executionContext);
       const visualizationType = extractVisualizationType(executionContext);
@@ -128,6 +142,8 @@ export const getPartitionVisRenderer: (
     };
 
     handlers.event(chartSizeEvent);
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_START);
 
     render(
       <KibanaRenderContextProvider {...core}>

--- a/src/platform/plugins/shared/chart_expressions/expression_partition_vis/tsconfig.json
+++ b/src/platform/plugins/shared/chart_expressions/expression_partition_vis/tsconfig.json
@@ -31,6 +31,7 @@
     "@kbn/cell-actions",
     "@kbn/react-kibana-context-render",
     "@kbn/core-rendering-browser",
+    "@kbn/ebt-tools",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/plugins/shared/chart_expressions/expression_tagcloud/public/expression_renderers/tagcloud_renderer.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_tagcloud/public/expression_renderers/tagcloud_renderer.tsx
@@ -16,6 +16,12 @@ import { VisualizationContainer } from '@kbn/visualizations-plugin/public';
 import { ExpressionRenderDefinition } from '@kbn/expressions-plugin/common/expression_renderers';
 import { METRIC_TYPE } from '@kbn/analytics';
 import {
+  createPerformanceTracker,
+  PERFORMANCE_TRACKER_MARKS,
+  PERFORMANCE_TRACKER_TYPES,
+} from '@kbn/ebt-tools';
+
+import {
   type ChartSizeEvent,
   extractContainerType,
   extractVisualizationType,
@@ -50,6 +56,13 @@ export const tagcloudRenderer: (
   help: strings.getHelpDescription(),
   reuseDomNode: true,
   render: async (domNode, config, handlers) => {
+    const performanceTracker = createPerformanceTracker({
+      type: PERFORMANCE_TRACKER_TYPES.PANEL,
+      subType: EXPRESSION_NAME,
+    });
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+
     const { core, plugins } = getStartDeps();
 
     handlers.onDestroy(() => {
@@ -57,6 +70,8 @@ export const tagcloudRenderer: (
     });
 
     const renderComplete = () => {
+      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE);
+
       const executionContext = handlers.getExecutionContext();
       const containerType = extractContainerType(executionContext);
       const visualizationType = extractVisualizationType(executionContext);
@@ -89,6 +104,8 @@ export const tagcloudRenderer: (
         isDarkMode = val.darkMode;
       })
       .unsubscribe();
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_START);
 
     render(
       <KibanaRenderContextProvider {...core}>

--- a/src/platform/plugins/shared/chart_expressions/expression_tagcloud/tsconfig.json
+++ b/src/platform/plugins/shared/chart_expressions/expression_tagcloud/tsconfig.json
@@ -29,6 +29,7 @@
     "@kbn/data-plugin",
     "@kbn/react-kibana-context-render",
     "@kbn/charts-theme",
+    "@kbn/ebt-tools",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
@@ -12,6 +12,11 @@ import { css } from '@emotion/react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { METRIC_TYPE } from '@kbn/analytics';
+import {
+  createPerformanceTracker,
+  PERFORMANCE_TRACKER_MARKS,
+  PERFORMANCE_TRACKER_TYPES,
+} from '@kbn/ebt-tools';
 import type { PaletteRegistry } from '@kbn/coloring';
 import { PersistedState } from '@kbn/visualizations-plugin/public';
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
@@ -202,6 +207,13 @@ export const getXyChartRenderer = ({
   validate: () => undefined,
   reuseDomNode: true,
   render: async (domNode: Element, config: XYChartProps, handlers) => {
+    const performanceTracker = createPerformanceTracker({
+      type: PERFORMANCE_TRACKER_TYPES.PANEL,
+      subType: 'xyVis',
+    });
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+
     const deps = await getStartDeps();
 
     // Lazy loaded parts
@@ -231,6 +243,8 @@ export const getXyChartRenderer = ({
     );
 
     const renderComplete = () => {
+      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE);
+
       const executionContext = handlers.getExecutionContext();
       const containerType = extractContainerType(executionContext);
       const visualizationType = extractVisualizationType(executionContext);
@@ -258,6 +272,8 @@ export const getXyChartRenderer = ({
       width: '100%',
       height: '100%',
     });
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_START);
 
     ReactDOM.render(
       <KibanaRenderContextProvider {...deps.startServices}>

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/tsconfig.json
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/tsconfig.json
@@ -37,6 +37,7 @@
     "@kbn/cell-actions",
     "@kbn/react-kibana-context-render",
     "@kbn/core-rendering-browser",
+    "@kbn/ebt-tools",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/performance/query_performance_tracking.test.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/performance/query_performance_tracking.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CoreStart } from '@kbn/core/public';
-import { PerformanceMetricEvent } from '@kbn/ebt-tools';
+import type { PerformanceMetricEvent } from '@kbn/ebt-tools';
 import { PresentationContainer } from '@kbn/presentation-containers';
 import { getMockPresentationContainer } from '@kbn/presentation-containers/mocks';
 import { PhaseEvent, PhaseEventType, apiPublishesPhaseEvents } from '@kbn/presentation-publishing';
@@ -18,6 +18,7 @@ import { PerformanceState, startQueryPerformanceTracking } from './query_perform
 
 const mockMetricEvent = jest.fn();
 jest.mock('@kbn/ebt-tools', () => ({
+  ...jest.requireActual('@kbn/ebt-tools'),
   reportPerformanceMetricEvent: (_: CoreStart['analytics'], args: PerformanceMetricEvent) => {
     mockMetricEvent(args);
   },

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/performance/query_performance_tracking.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/performance/query_performance_tracking.ts
@@ -12,6 +12,12 @@ import { combineLatest, map, pairwise, startWith, switchMap, skipWhile, of } fro
 import { reportPerformanceMetricEvent } from '@kbn/ebt-tools';
 import { PresentationContainer } from '@kbn/presentation-containers';
 import { PublishesPhaseEvents, apiPublishesPhaseEvents } from '@kbn/presentation-publishing';
+import {
+  clearPerformanceTrackersByType,
+  getMeanFromPerformanceMeasures,
+  PERFORMANCE_TRACKER_MARKS,
+  PERFORMANCE_TRACKER_TYPES,
+} from '@kbn/ebt-tools';
 
 import { coreServices } from '../../services/kibana_services';
 import { DASHBOARD_LOADED_EVENT } from '../../utils/telemetry_constants';
@@ -124,7 +130,19 @@ function reportPerformanceMetrics({
   const duration =
     loadType === 'dashboardSubsequentLoad' ? timeToData : Math.max(timeToData, totalLoadTime);
 
-  const e = {
+  const meanPanelPrerender = getMeanFromPerformanceMeasures({
+    type: PERFORMANCE_TRACKER_TYPES.PANEL,
+    startMark: PERFORMANCE_TRACKER_MARKS.PRE_RENDER,
+    endMark: PERFORMANCE_TRACKER_MARKS.RENDER_START,
+  });
+
+  const meanPanelRenderComplete = getMeanFromPerformanceMeasures({
+    type: PERFORMANCE_TRACKER_TYPES.PANEL,
+    startMark: PERFORMANCE_TRACKER_MARKS.RENDER_START,
+    endMark: PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE,
+  });
+
+  const performanceMetricEvent = {
     eventName: DASHBOARD_LOADED_EVENT,
     duration,
     key1: 'time_to_data',
@@ -133,6 +151,12 @@ function reportPerformanceMetrics({
     value2: panelCount,
     key4: 'load_type',
     value4: loadTypesMapping[loadType],
+    key8: 'mean_panel_prerender',
+    value8: meanPanelPrerender,
+    key9: 'mean_panel_rendering',
+    value9: meanPanelRenderComplete,
   };
-  reportPerformanceMetricEvent(coreServices.analytics, e);
+
+  reportPerformanceMetricEvent(coreServices.analytics, performanceMetricEvent);
+  clearPerformanceTrackersByType(PERFORMANCE_TRACKER_TYPES.PANEL);
 }

--- a/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/expression.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/visualizations/datatable/expression.tsx
@@ -19,6 +19,11 @@ import type {
 } from '@kbn/expressions-plugin/common';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { ChartSizeEvent } from '@kbn/chart-expressions-common';
+import {
+  createPerformanceTracker,
+  PERFORMANCE_TRACKER_MARKS,
+  PERFORMANCE_TRACKER_TYPES,
+} from '@kbn/ebt-tools';
 import { trackUiCounterEvents } from '../../lens_ui_telemetry';
 import { DatatableComponent } from './components/table_basic';
 
@@ -100,6 +105,13 @@ export const getDatatableRenderer = (dependencies: {
     config: DatatableProps,
     handlers: ILensInterpreterRenderHandlers
   ) => {
+    const performanceTracker = createPerformanceTracker({
+      type: PERFORMANCE_TRACKER_TYPES.PANEL,
+      subType: 'lens_datatable_renderer',
+    });
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.PRE_RENDER);
+
     handlers.onDestroy(() => ReactDOM.unmountComponentAtNode(domNode));
 
     const resolvedGetType = await dependencies.getType;
@@ -111,6 +123,7 @@ export const getDatatableRenderer = (dependencies: {
     const { hasCompatibleActions, isInteractive, getCompatibleCellValueActions } = handlers;
 
     const renderComplete = () => {
+      performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_COMPLETE);
       trackUiCounterEvents('table', handlers.getExecutionContext());
       handlers.done();
     };
@@ -158,6 +171,8 @@ export const getDatatableRenderer = (dependencies: {
       getColumnCellValueActions(config, getCompatibleCellValueActions),
       getColumnsFilterable(config.data, handlers),
     ]);
+
+    performanceTracker.mark(PERFORMANCE_TRACKER_MARKS.RENDER_START);
 
     ReactDOM.render(
       <KibanaRenderContextProvider {...startServices}>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Lens performance metrics (#216330)](https://github.com/elastic/kibana/pull/216330)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Walter Rafelsberger","email":"walter.rafelsberger@elastic.co"},"sourceCommit":{"committedDate":"2025-05-05T11:45:25Z","message":"Lens performance metrics (#216330)\n\n## Summary\n\nPart of #203438.\n\nThis adds performance tracking to lens charts in dashboards. For each\nchart, we set three performance marks `preRender`, `renderStart` and\n`renderComplete`. We then collect two measures `preRenderDuration` and\n`renderDuration`. The measures are collected for each lens panel on a\ndashboard, the mean durations are then used for the `dashboard_loaded`\nevent.\n\nThe performance measures can be investigated via developer tools:\n\n\n![image](https://github.com/user-attachments/assets/b83decae-0c65-455e-90a7-b3ab108e2efe)\n\nThe measures can be visualized like this for example:\n\n![CleanShot 2025-04-15 at 15 36\n09@2x](https://github.com/user-attachments/assets/8cb77bee-8082-470b-a255-fd409554abdb)\n\nThe performance metrics are stored as part of the `dashboard_loaded`\nevent like this:\n\n```\n    key8: 'mean_panel_prerender',\n    value8: <rounded mean of all pre-render measurements>,\n    key9: 'mean_panel_rendering',\n    value9: <rounded mean of all render-duration meaurements>,\n ```\n\nIn Dev Tools query the latest docs ingested by the local shipper:\n\n```\nGET ebt-kibana-browser/_search\n{\n  \"query\": {\n    \"term\": {\n      \"eventName.keyword\": \"dashboard_loaded\"\n    }\n  },\n  \"sort\": [\n    {\n      \"timestamp\": {\n        \"order\": \"desc\"\n      }\n    }\n  ]\n}\n```\n\n### added to these charts\n\n- [x] gauge\n- [x] heatmap\n- [x] metric\n- [x] partition\n- [x] table\n- [x] tag_cloud\n- [x] xy\n\n### Misc\n\n- [x] check the trackers are only run in dashboards, not full screen lens.\n- [x] check if we can store arrays of values for performance metrics: this doesn't work ootb with the current schema, something we could investigate in a follow up.\n\n### Checklist\n\n- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials\n- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.\n\n### Risk notes\n\n- Includes try/catch blocks to prevent failures when Performance API is unavailable","sha":"7b9ce3cd927c21626b980c482c64436463e4841f","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.1.0","v8.19.0"],"title":"Lens performance metrics","number":216330,"url":"https://github.com/elastic/kibana/pull/216330","mergeCommit":{"message":"Lens performance metrics (#216330)\n\n## Summary\n\nPart of #203438.\n\nThis adds performance tracking to lens charts in dashboards. For each\nchart, we set three performance marks `preRender`, `renderStart` and\n`renderComplete`. We then collect two measures `preRenderDuration` and\n`renderDuration`. The measures are collected for each lens panel on a\ndashboard, the mean durations are then used for the `dashboard_loaded`\nevent.\n\nThe performance measures can be investigated via developer tools:\n\n\n![image](https://github.com/user-attachments/assets/b83decae-0c65-455e-90a7-b3ab108e2efe)\n\nThe measures can be visualized like this for example:\n\n![CleanShot 2025-04-15 at 15 36\n09@2x](https://github.com/user-attachments/assets/8cb77bee-8082-470b-a255-fd409554abdb)\n\nThe performance metrics are stored as part of the `dashboard_loaded`\nevent like this:\n\n```\n    key8: 'mean_panel_prerender',\n    value8: <rounded mean of all pre-render measurements>,\n    key9: 'mean_panel_rendering',\n    value9: <rounded mean of all render-duration meaurements>,\n ```\n\nIn Dev Tools query the latest docs ingested by the local shipper:\n\n```\nGET ebt-kibana-browser/_search\n{\n  \"query\": {\n    \"term\": {\n      \"eventName.keyword\": \"dashboard_loaded\"\n    }\n  },\n  \"sort\": [\n    {\n      \"timestamp\": {\n        \"order\": \"desc\"\n      }\n    }\n  ]\n}\n```\n\n### added to these charts\n\n- [x] gauge\n- [x] heatmap\n- [x] metric\n- [x] partition\n- [x] table\n- [x] tag_cloud\n- [x] xy\n\n### Misc\n\n- [x] check the trackers are only run in dashboards, not full screen lens.\n- [x] check if we can store arrays of values for performance metrics: this doesn't work ootb with the current schema, something we could investigate in a follow up.\n\n### Checklist\n\n- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials\n- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.\n\n### Risk notes\n\n- Includes try/catch blocks to prevent failures when Performance API is unavailable","sha":"7b9ce3cd927c21626b980c482c64436463e4841f"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216330","number":216330,"mergeCommit":{"message":"Lens performance metrics (#216330)\n\n## Summary\n\nPart of #203438.\n\nThis adds performance tracking to lens charts in dashboards. For each\nchart, we set three performance marks `preRender`, `renderStart` and\n`renderComplete`. We then collect two measures `preRenderDuration` and\n`renderDuration`. The measures are collected for each lens panel on a\ndashboard, the mean durations are then used for the `dashboard_loaded`\nevent.\n\nThe performance measures can be investigated via developer tools:\n\n\n![image](https://github.com/user-attachments/assets/b83decae-0c65-455e-90a7-b3ab108e2efe)\n\nThe measures can be visualized like this for example:\n\n![CleanShot 2025-04-15 at 15 36\n09@2x](https://github.com/user-attachments/assets/8cb77bee-8082-470b-a255-fd409554abdb)\n\nThe performance metrics are stored as part of the `dashboard_loaded`\nevent like this:\n\n```\n    key8: 'mean_panel_prerender',\n    value8: <rounded mean of all pre-render measurements>,\n    key9: 'mean_panel_rendering',\n    value9: <rounded mean of all render-duration meaurements>,\n ```\n\nIn Dev Tools query the latest docs ingested by the local shipper:\n\n```\nGET ebt-kibana-browser/_search\n{\n  \"query\": {\n    \"term\": {\n      \"eventName.keyword\": \"dashboard_loaded\"\n    }\n  },\n  \"sort\": [\n    {\n      \"timestamp\": {\n        \"order\": \"desc\"\n      }\n    }\n  ]\n}\n```\n\n### added to these charts\n\n- [x] gauge\n- [x] heatmap\n- [x] metric\n- [x] partition\n- [x] table\n- [x] tag_cloud\n- [x] xy\n\n### Misc\n\n- [x] check the trackers are only run in dashboards, not full screen lens.\n- [x] check if we can store arrays of values for performance metrics: this doesn't work ootb with the current schema, something we could investigate in a follow up.\n\n### Checklist\n\n- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials\n- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios\n- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.\n\n### Risk notes\n\n- Includes try/catch blocks to prevent failures when Performance API is unavailable","sha":"7b9ce3cd927c21626b980c482c64436463e4841f"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->