### PR TITLE
[LockManager] Add `isLockAcquisitionError` helper

### DIFF
--- a/packages/kbn-lock-manager/index.ts
+++ b/packages/kbn-lock-manager/index.ts
@@ -7,5 +7,5 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { LockAcquisitionError } from './src/lock_manager_client';
+export { LockAcquisitionError, isLockAcquisitionError } from './src/lock_manager_client';
 export { LockManagerService } from './src/lock_manager_service';

--- a/packages/kbn-lock-manager/src/lock_manager_client.ts
+++ b/packages/kbn-lock-manager/src/lock_manager_client.ts
@@ -269,6 +269,10 @@ export async function getLock({
   return lockManager.get();
 }
 
+export function isLockAcquisitionError(error: unknown): error is LockAcquisitionError {
+  return error instanceof LockAcquisitionError;
+}
+
 export async function withLock<T>(
   {
     esClient,

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -31,8 +31,7 @@ import { v4 } from 'uuid';
 import type { AssistantScope } from '@kbn/ai-assistant-common';
 import type { InferenceClient } from '@kbn/inference-plugin/server';
 import { ChatCompleteResponse, FunctionCallingMode, ToolChoiceType } from '@kbn/inference-common';
-
-import { LockAcquisitionError } from '@kbn/lock-manager';
+import { isLockAcquisitionError } from '@kbn/lock-manager';
 import { resourceNames } from '..';
 import {
   ChatCompletionChunkEvent,
@@ -730,8 +729,7 @@ export class ObservabilityAIAssistantClient {
         });
       })
       .catch((e) => {
-        const isLockAcquisitionError = e instanceof LockAcquisitionError;
-        if (isLockAcquisitionError) {
+        if (isLockAcquisitionError(e)) {
           logger.info(e.message);
         } else {
           logger.error(

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/index.ts
@@ -10,7 +10,7 @@ import type { CoreSetup, ElasticsearchClient, IUiSettingsClient } from '@kbn/cor
 import type { Logger } from '@kbn/logging';
 import { orderBy } from 'lodash';
 import { encode } from 'gpt-tokenizer';
-import { LockAcquisitionError } from '@kbn/lock-manager';
+import { isLockAcquisitionError } from '@kbn/lock-manager';
 import { resourceNames } from '..';
 import {
   Instruction,
@@ -449,7 +449,7 @@ export class KnowledgeBaseService {
           esClient: this.dependencies.esClient,
           inferenceId,
         }).catch((e) => {
-          if (error instanceof LockAcquisitionError) {
+          if (isLockAcquisitionError(e)) {
             this.dependencies.logger.info(`Re-indexing operation is already in progress`);
             return;
           }


### PR DESCRIPTION
- Adds a small helper method for handling errors of type `LockAcquisitionError`.
- Flips retry logic for `populateMissingSemanticTextFieldWithLock ` so we retry all errors except `LockAcquisitionError`


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->