### PR TITLE
[8.19] [Synthtrace] Sanitize default value for error grouping key (#210010)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/instance.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/instance.ts
@@ -7,7 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { createHash } from 'crypto';
 import { ApmError } from './apm_error';
 import { Entity } from '../entity';
 import { Metricset } from './metricset';
@@ -113,8 +112,4 @@ export class Instance extends Entity<ApmFields> {
       ...metrics,
     });
   }
-}
-
-export function getErrorGroupingKey(content: string) {
-  return createHash('sha256').update(content).digest('hex');
 }

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/utils/generate_id.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/utils/generate_id.ts
@@ -24,7 +24,10 @@ function generateId(length: number = LONG_ID_LENGTH) {
 }
 
 function generateIdWithSeed(seed: string, length: number = LONG_ID_LENGTH) {
-  return seed?.padStart(length, '0');
+  // this is needed to sanitize errors like "No handler for /order/{id}",
+  // as encodeURIComponent is not enough and can cause errors in the client
+  const encodedSeed = seed.replace(/[/]/g, '_').replace(/[{}]/g, '');
+  return encodedSeed?.padStart(length, '0');
 }
 
 export function generateShortId() {

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/errors/error_details.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/errors/error_details.cy.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { getErrorGroupingKey } from '@kbn/apm-synthtrace-client/src/lib/apm/instance';
 import { generateLongIdWithSeed } from '@kbn/apm-synthtrace-client/src/lib/utils/generate_id';
 
 import url from 'url';
@@ -36,7 +35,7 @@ describe('Error details', () => {
     });
 
     it('has no detectable a11y violations on load', () => {
-      const errorGroupingKey = getErrorGroupingKey('Error 1');
+      const errorGroupingKey = generateLongIdWithSeed('Error 1');
       const errorGroupingKeyShort = errorGroupingKey.slice(0, 5);
       const errorDetailsPageHref = url.format({
         pathname: `/app/apm/services/opbeans-java/errors/${errorGroupingKey}`,
@@ -54,7 +53,7 @@ describe('Error details', () => {
 
     describe('when error has no occurrences', () => {
       it('shows zero occurrences', () => {
-        const errorGroupingKey = getErrorGroupingKey('Error foo bar');
+        const errorGroupingKey = generateLongIdWithSeed('Error foo bar');
 
         cy.visitKibana(
           url.format({


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthtrace] Sanitize default value for error grouping key (#210010)](https://github.com/elastic/kibana/pull/210010)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-02-07T17:13:11Z","message":"[Synthtrace] Sanitize default value for error grouping key (#210010)\n\n## Summary\n\nCloses #209096","sha":"ba5ae97569e59b83d6748bd0a8a5b52b573fda07","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","apm","backport:prev-minor","synthtrace","ci:project-deploy-observability","Team:obs-ux-infra_services","v9.1.0"],"title":"[Synthtrace] Sanitize default value for error grouping key","number":210010,"url":"https://github.com/elastic/kibana/pull/210010","mergeCommit":{"message":"[Synthtrace] Sanitize default value for error grouping key (#210010)\n\n## Summary\n\nCloses #209096","sha":"ba5ae97569e59b83d6748bd0a8a5b52b573fda07"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/210230","number":210230,"state":"MERGED","mergeCommit":{"sha":"177466455b7985d97f951b743fad101e677c8433","message":"[9.0] [Synthtrace] Sanitize default value for error grouping key (#210010) (#210230)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[Synthtrace] Sanitize default value for error grouping key\n(#210010)](https://github.com/elastic/kibana/pull/210010)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n\n\nCo-authored-by: Sergi Romeu <sergi.romeu@elastic.co>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/210010","number":210010,"mergeCommit":{"message":"[Synthtrace] Sanitize default value for error grouping key (#210010)\n\n## Summary\n\nCloses #209096","sha":"ba5ae97569e59b83d6748bd0a8a5b52b573fda07"}}]}] BACKPORT-->