### PR TITLE
[8.19] chore: remove react-syntax-highlighter leftovers (#213076)

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,13 +9,5 @@
 
 declare module 'axios/lib/adapters/xhr';
 
-// Storybook references this module. It's @ts-ignored in the codebase but when
-// built into its dist it strips that out. Add it here to avoid a type checking
-// error.
-//
-// See https://github.com/storybookjs/storybook/issues/11684
-declare module 'react-syntax-highlighter/dist/cjs/create-element';
-declare module 'react-syntax-highlighter/dist/cjs/prism-light';
-
 declare module 'find-cypress-specs';
 declare module '@cypress/grep/src/plugin';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [chore: remove react-syntax-highlighter leftovers (#213076)](https://github.com/elastic/kibana/pull/213076)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Sergi Romeu","email":"sergi.romeu@elastic.co"},"sourceCommit":{"committedDate":"2025-03-04T14:35:34Z","message":"chore: remove react-syntax-highlighter leftovers (#213076)\n\n## Summary\n\nRemoves leftovers of react-syntax-highlighter removed in [this\nPR](https://github.com/elastic/kibana/pull/204902)","sha":"b2dd88ec55278396e2b950a1c92c4cca18abad51","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-ux-infra_services","v9.1.0"],"title":"chore: remove react-syntax-highlighter leftovers","number":213076,"url":"https://github.com/elastic/kibana/pull/213076","mergeCommit":{"message":"chore: remove react-syntax-highlighter leftovers (#213076)\n\n## Summary\n\nRemoves leftovers of react-syntax-highlighter removed in [this\nPR](https://github.com/elastic/kibana/pull/204902)","sha":"b2dd88ec55278396e2b950a1c92c4cca18abad51"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/213076","number":213076,"mergeCommit":{"message":"chore: remove react-syntax-highlighter leftovers (#213076)\n\n## Summary\n\nRemoves leftovers of react-syntax-highlighter removed in [this\nPR](https://github.com/elastic/kibana/pull/204902)","sha":"b2dd88ec55278396e2b950a1c92c4cca18abad51"}}]}] BACKPORT-->