### PR TITLE
fix: [Security:Intelligence:AddIntegrations] Change defaults option on add integrations page is announced incorrectly

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
@@ -9,6 +9,7 @@ import React, { useState, Fragment, memo, useMemo, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styled from 'styled-components';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,7 +19,6 @@ import {
   EuiHorizontalRule,
   EuiSpacer,
   EuiButtonEmpty,
-  htmlIdGenerator,
 } from '@elastic/eui';
 
 import type {
@@ -158,8 +158,6 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
       [packageInputStreamShouldBeVisible, packageInputStreams, packagePolicyInput.streams]
     );
 
-    const titleElementId = useMemo(() => htmlIdGenerator()(), []);
-
     return (
       <>
         {/* Header / input-level toggle */}
@@ -171,10 +169,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
                 <EuiFlexGroup alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
                     <EuiTitle size="xs">
-                      <h3
-                        data-test-subj="PackagePolicy.InputStreamConfig.title"
-                        id={titleElementId}
-                      >
+                      <h3 data-test-subj="PackagePolicy.InputStreamConfig.title">
                         {packageInput.title || packageInput.type}
                       </h3>
                     </EuiTitle>
@@ -228,7 +223,15 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
                   iconType={isShowingStreams ? 'arrowUp' : 'arrowDown'}
                   iconSide="right"
                   aria-expanded={isShowingStreams}
-                  aria-labelledby={titleElementId}
+                  aria-label={i18n.translate(
+                    'xpack.fleet.createPackagePolicy.stepConfigure.expandAriaLabel',
+                    {
+                      defaultMessage: 'Change default settings for {title}',
+                      values: {
+                        title: packageInput.title || packageInput.type,
+                      },
+                    }
+                  )}
                 >
                   {
                     <FormattedMessage


### PR DESCRIPTION
Closes: #209785

## Description
The change defaults option on add integrations page is announced as "Collect abuseCH logs via API using Elastic Agent, collapsed, button' instead of change defaults

## Screen

<img width="1093" alt="image" src="https://github.com/user-attachments/assets/20455a4f-2549-4c08-82ca-258e1abb9b1b" />

## Changes made: 

1. `aria-label` was set to `Change default settings for {title}`


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19"]} ONMERGE-->