### PR TITLE
Add flow id to copy button

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/auto_detect_panel.tsx
@@ -109,7 +109,11 @@ export const AutoDetectPanel: FunctionComponent = () => {
                   {command}
                 </EuiCodeBlock>
                 <EuiSpacer />
-                <CopyToClipboardButton textToCopy={command} fill={status === 'notStarted'} />
+                <CopyToClipboardButton
+                  textToCopy={command}
+                  fill={status === 'notStarted'}
+                  data-onboarding-id={data?.onboardingFlow.id}
+                />
               </>
             ) : (
               <EuiSkeletonText lines={6} />


### PR DESCRIPTION
This change adds onboarding ID to the "Copy To Clipboard" button in Auto Detect flow. This ID is needed to correctly connect BI events during the flow.

**Note about backports**
I'm going to add backport labels for 8.18 and 9.0 after 8.18.1 and 9.0.1 have been released (May 6th).

![CleanShot 2025-05-05 at 16 05 24@2x](https://github.com/user-attachments/assets/49c0f4a9-29e1-47f8-89ef-2d03016d747c)


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->