### PR TITLE
[9.0] remove metrics and logs from get_service_stats api (#218346)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/apm_fields.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/apm_fields.ts
@@ -90,7 +90,6 @@ export type ApmFields = Fields<{
 }> &
   Partial<{
     'timestamp.us'?: number;
-
     'agent.name': string;
     'agent.version': string;
     'client.geo.city_name': string;

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/apm_otel_metrics.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/apm_otel_metrics.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Serializable } from '../../serializable';
-import { Fields } from '../../entity';
+import { Serializable } from '../serializable';
+import { Fields } from '../entity';
 
 export class OtelMetricset<TFields extends Fields> extends Serializable<TFields> {
   constructor(fields: TFields) {

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_logs_and_metrics_only.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_logs_and_metrics_only.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  OtelLogDocument,
+  generateLongId,
+  generateShortId,
+  otelLog,
+  apm,
+  ApmSynthtracePipelineSchema,
+} from '@kbn/apm-synthtrace-client';
+import { Scenario } from '../cli/scenario';
+import { withClient } from '../lib/utils/with_client';
+import { IndexTemplateName } from '../lib/logs/custom_logsdb_index_templates';
+
+const MESSAGE_LOG_LEVELS = [
+  {
+    message: 'A simple log with something random <random> in the middle',
+    level: 'info',
+    severityNumber: 9,
+  },
+  { message: 'Yet another debug log', level: 'debug', severityNumber: 5 },
+  {
+    message: 'Error with certificate: "ca_trusted_fingerprint"',
+    level: 'error',
+    severityNumber: 17,
+  },
+];
+
+const scenario: Scenario<OtelLogDocument> = async (runOptions) => {
+  const { logger } = runOptions;
+
+  const constructLogsCommonData = () => {
+    const index = Math.floor(Math.random() * 3);
+    const serviceName = 'otel-metrics-and-logs-only';
+    const logMessage = MESSAGE_LOG_LEVELS[index];
+
+    const commonLongEntryFields: OtelLogDocument = {
+      trace_id: generateLongId(),
+      resource: {
+        attributes: {
+          'service.name': serviceName,
+          'service.version': '1.0.0',
+          'service.environment': 'production',
+        },
+      },
+      attributes: {
+        'log.file.path': `/logs/${generateLongId()}/error.txt`,
+      },
+    };
+
+    return {
+      index,
+      serviceName,
+      logMessage,
+      commonLongEntryFields,
+    };
+  };
+
+  return {
+    bootstrap: async ({ logsEsClient, apmEsClient }) => {
+      await logsEsClient.createIndexTemplate(IndexTemplateName.LogsDb);
+      apmEsClient.pipeline(apmEsClient.getPipeline(ApmSynthtracePipelineSchema.Otel));
+    },
+    generate: ({ range, clients: { logsEsClient, apmEsClient } }) => {
+      const {
+        logMessage: { level, message },
+        commonLongEntryFields,
+        serviceName,
+      } = constructLogsCommonData();
+
+      const metricsets = range
+        .interval('30s')
+        .rate(1)
+        .generator((timestamp) =>
+          apm
+            .otelService({
+              name: serviceName,
+              sdkName: 'opentelemetry',
+              sdkLanguage: 'synthtrace',
+              namespace: 'production',
+            })
+            .instance('instance-1')
+            .appMetrics({
+              'system.memory.actual.free': 800,
+              'system.memory.total': 1000,
+              'system.cpu.total.norm.pct': 0.6,
+              'system.process.cpu.total.norm.pct': 0.7,
+            })
+            .timestamp(timestamp)
+        );
+
+      const apmAndLogsLogsEvents = range
+        .interval('1m')
+        .rate(1)
+        .generator((timestamp) => {
+          return Array(3)
+            .fill(0)
+            .map(() => {
+              return otelLog
+                .create()
+                .message(message.replace('<random>', generateShortId()))
+                .logLevel(level)
+                .defaults(commonLongEntryFields)
+                .timestamp(timestamp);
+            });
+        });
+      return [
+        withClient(
+          logsEsClient,
+          logger.perf('generating_otel_logs', () => apmAndLogsLogsEvents)
+        ),
+        withClient(
+          apmEsClient,
+          logger.perf('generating_apm_metrics', () => metricsets)
+        ),
+      ];
+    },
+  };
+};
+
+export default scenario;

--- a/src/platform/plugins/shared/dashboard/public/dashboard_container/component/settings/apm_otel_metrics.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_container/component/settings/apm_otel_metrics.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Serializable } from '../../serializable';
+import { Fields } from '../../entity';
+
+export class OtelMetricset<TFields extends Fields> extends Serializable<TFields> {
+  constructor(fields: TFields) {
+    super({
+      'data_stream.type': 'metrics',
+      'attributes.processor.event': 'metric',
+      'data_stream.dataset': 'otel.metrics',
+      ...fields,
+    });
+  }
+}

--- a/x-pack/solutions/observability/plugins/apm/server/routes/service_map/get_service_stats.ts
+++ b/x-pack/solutions/observability/plugins/apm/server/routes/service_map/get_service_stats.ts
@@ -6,7 +6,6 @@
  */
 
 import { kqlQuery, rangeQuery, termsQuery } from '@kbn/observability-plugin/server';
-import { ProcessorEvent } from '@kbn/observability-plugin/common';
 import { AGENT_NAME, SERVICE_ENVIRONMENT, SERVICE_NAME } from '../../../common/es_fields/apm';
 import { environmentQuery } from '../../../common/utils/environment_query';
 import { ENVIRONMENT_ALL } from '../../../common/environment_filter_values';
@@ -26,11 +25,7 @@ export async function getServiceStats({
 }: IEnvOptions & { maxNumberOfServices: number }) {
   const params = {
     apm: {
-      events: [
-        getProcessorEventForTransactions(searchAggregatedTransactions),
-        ProcessorEvent.metric as const,
-        ProcessorEvent.error as const,
-      ],
+      events: [getProcessorEventForTransactions(searchAggregatedTransactions)],
     },
     body: {
       track_total_hits: false,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [remove metrics and logs from get_service_stats api (#218346)](https://github.com/elastic/kibana/pull/218346)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bryce Buchanan","email":"75274611+bryce-b@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-24T18:20:46Z","message":"remove metrics and logs from get_service_stats api (#218346)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/214564\n\nThis change prevents services only transmitting logs and metrics from\nappearing in the service map.\n\nA point of discussion:\nWith this change the service's 'focused service map' will be empty.\nShould a placeholder node be added (no other nodes will be visible), or\nshould the service map for such services be hidden?\n\n### Testing \nI tested this by using a Otel-instrumented service with EDOT and\ndisabled all Trace exports. You'll see that without this change, that\nservice will appear in the service map, and with this change applied, it\nwill not.\n\nI've created a new synthtrace scenario that will generate the necessary\ndata to verify this change.\nrun the `otel_logs_and_metrics_only.ts` scenario for synthtrace, and a\nservice, named `otel-metrics-and-logs-only`, will be available in the\nservices inventory, but it will not appear in the service map, or the\nfocused service map for the service.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"94b58519363250299b20786ee352192c683db619","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport missing","v9.0.0","Team:obs-ux-infra_services","backport:version","v9.1.0","v8.19.0"],"title":"remove metrics and logs from get_service_stats api","number":218346,"url":"https://github.com/elastic/kibana/pull/218346","mergeCommit":{"message":"remove metrics and logs from get_service_stats api (#218346)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/214564\n\nThis change prevents services only transmitting logs and metrics from\nappearing in the service map.\n\nA point of discussion:\nWith this change the service's 'focused service map' will be empty.\nShould a placeholder node be added (no other nodes will be visible), or\nshould the service map for such services be hidden?\n\n### Testing \nI tested this by using a Otel-instrumented service with EDOT and\ndisabled all Trace exports. You'll see that without this change, that\nservice will appear in the service map, and with this change applied, it\nwill not.\n\nI've created a new synthtrace scenario that will generate the necessary\ndata to verify this change.\nrun the `otel_logs_and_metrics_only.ts` scenario for synthtrace, and a\nservice, named `otel-metrics-and-logs-only`, will be available in the\nservices inventory, but it will not appear in the service map, or the\nfocused service map for the service.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"94b58519363250299b20786ee352192c683db619"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218346","number":218346,"mergeCommit":{"message":"remove metrics and logs from get_service_stats api (#218346)\n\n## Summary\nFixes https://github.com/elastic/kibana/issues/214564\n\nThis change prevents services only transmitting logs and metrics from\nappearing in the service map.\n\nA point of discussion:\nWith this change the service's 'focused service map' will be empty.\nShould a placeholder node be added (no other nodes will be visible), or\nshould the service map for such services be hidden?\n\n### Testing \nI tested this by using a Otel-instrumented service with EDOT and\ndisabled all Trace exports. You'll see that without this change, that\nservice will appear in the service map, and with this change applied, it\nwill not.\n\nI've created a new synthtrace scenario that will generate the necessary\ndata to verify this change.\nrun the `otel_logs_and_metrics_only.ts` scenario for synthtrace, and a\nservice, named `otel-metrics-and-logs-only`, will be available in the\nservices inventory, but it will not appear in the service map, or the\nfocused service map for the service.\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [x] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [x] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"94b58519363250299b20786ee352192c683db619"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->