### PR TITLE
[Maps] Remove icon from map tooltip

### DIFF
--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/__snapshots__/header.test.tsx.snap
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/__snapshots__/header.test.tsx.snap
@@ -7,15 +7,6 @@ exports[`isLocked 1`] = `
     gutterSize="s"
   >
     <EuiFlexItem
-      className="mapFeatureTooltip_layerIcon"
-      grow={false}
-      key="layerIcon"
-    >
-      <span>
-        mockIcon
-      </span>
-    </EuiFlexItem>
-    <EuiFlexItem
       className="eui-textTruncate"
       grow={true}
       key="layerName"
@@ -53,15 +44,6 @@ exports[`render 1`] = `
     alignItems="center"
     gutterSize="s"
   >
-    <EuiFlexItem
-      className="mapFeatureTooltip_layerIcon"
-      grow={false}
-      key="layerIcon"
-    >
-      <span>
-        mockIcon
-      </span>
-    </EuiFlexItem>
     <EuiFlexItem
       className="eui-textTruncate"
       grow={true}

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/header.test.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/header.test.tsx
@@ -14,11 +14,6 @@ const layerMock = {
   getDisplayName: async () => {
     return 'myLayerName';
   },
-  getLayerIcon: () => {
-    return {
-      icon: <span>mockIcon</span>,
-    };
-  },
 } as unknown as IVectorLayer;
 
 const defaultProps = {

--- a/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/header.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/connected_components/mb_map/tooltip_control/features_tooltip/header.tsx
@@ -24,14 +24,12 @@ interface Props {
 }
 
 interface State {
-  layerIcon: ReactNode;
   layerName: string | null;
 }
 
 export class Header extends Component<Props, State> {
   private _isMounted = false;
   state: State = {
-    layerIcon: null,
     layerName: null,
   };
 
@@ -50,21 +48,13 @@ export class Header extends Component<Props, State> {
       return;
     }
     const layerName = await layer.getDisplayName();
-    const { icon } = layer.getLayerIcon(false);
     if (this._isMounted) {
-      this.setState({ layerIcon: icon, layerName });
+      this.setState({ layerName });
     }
   }
 
   render() {
     const items: ReactNode[] = [];
-    if (this.state.layerIcon) {
-      items.push(
-        <EuiFlexItem grow={false} key="layerIcon" className="mapFeatureTooltip_layerIcon">
-          {this.state.layerIcon}
-        </EuiFlexItem>
-      );
-    }
 
     if (this.state.layerName) {
       items.push(


### PR DESCRIPTION
## Summary

Closes #217200

Removes the layer icon from map tooltip, ~~which would only match the first spot the user clicked on~~ which showed the layer icon and not the icon for the individual feature.

To test, load the Web Logs sample data set and examine the map panel on the included dashboard. Ensure there are no tooltip icons.

### Before
<img width="1110" alt="Screenshot 2025-05-05 at 12 55 54 PM" src="https://github.com/user-attachments/assets/a97a59a3-577a-437b-8c6a-132355f73787" />

### After
<img width="1064" alt="Screenshot 2025-05-05 at 12 55 23 PM" src="https://github.com/user-attachments/assets/642b99ed-d63b-4480-9498-8b10411b86f4" />


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->