### PR TITLE
[Search] Fix Pagination when number of documents is changed

### DIFF
--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/documents.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/documents.tsx
@@ -126,7 +126,7 @@ export const SearchIndexDocuments: React.FC = () => {
               mappings={mappingData ? { [indexName]: mappingData } : undefined}
               meta={data?.meta ?? DEFAULT_PAGINATION}
               onPaginate={(pageIndex) => setPagination({ ...pagination, pageIndex })}
-              setDocsPerPage={(pageSize) => setPagination({ ...pagination, pageSize })}
+              setDocsPerPage={(pageSize) => setPagination({ ...DEFAULT_PAGINATION, pageSize })}
             />
           )}
         </>

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -125,7 +125,7 @@ export const SearchIndexDocuments: React.FC = () => {
               mappings={mappingData ? { [indexName]: mappingData } : undefined}
               meta={data?.meta ?? DEFAULT_PAGINATION}
               onPaginate={(pageIndex) => setPagination({ ...pagination, pageIndex })}
-              setDocsPerPage={(pageSize) => setPagination({ ...pagination, pageSize })}
+              setDocsPerPage={(pageSize) => setPagination({ ...DEFAULT_PAGINATION, pageSize })}
             />
           )}
         </>

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_documents/documents.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_documents/documents.tsx
@@ -66,7 +66,7 @@ export const IndexDocuments: React.FC<IndexDocumentsProps> = ({ indexName }) => 
               mappings={mappingData ? { [indexName]: mappingData } : undefined}
               meta={documentsMeta ?? DEFAULT_PAGINATION}
               onPaginate={(pageIndex) => setPagination({ ...pagination, pageIndex })}
-              setDocsPerPage={(pageSize) => setPagination({ ...pagination, pageSize })}
+              setDocsPerPage={(pageSize) => setPagination({ ...DEFAULT_PAGINATION, pageSize })}
             />
           )}
         </>


### PR DESCRIPTION
## Summary
**Problem** 
When number of documents is changed, the total number of pages are recalculated but  current page is not changed. This works fine, but when on last page and changing to larger number of documents makes the page to show zero documents 

**Fix**
Changed to reset pagination to first page when number of documents is changed. 

https://github.com/user-attachments/assets/02eab354-b4bd-40cf-af47-1a692951f08e







<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->