### PR TITLE
[9.0] [Synthtrace] APM Otel v2 (#217019)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
@@ -11,14 +11,6 @@ export { observer } from './src/lib/agent_config';
 export type { AgentConfigFields } from './src/lib/agent_config/agent_config_fields';
 export { apm } from './src/lib/apm';
 export type { ApmFields } from './src/lib/apm/apm_fields';
-<<<<<<< HEAD
-=======
-export type {
-  ApmOtelFields,
-  ApmOtelAttributes,
-  SpanKind,
-} from './src/lib/apm/otel/apm_otel_fields';
->>>>>>> 9cc220ac52f ([Synthtrace] APM Otel v2 (#217019))
 export type { Instance } from './src/lib/apm/instance';
 export { MobileDevice } from './src/lib/apm/mobile_device';
 export type {

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
@@ -11,6 +11,14 @@ export { observer } from './src/lib/agent_config';
 export type { AgentConfigFields } from './src/lib/agent_config/agent_config_fields';
 export { apm } from './src/lib/apm';
 export type { ApmFields } from './src/lib/apm/apm_fields';
+<<<<<<< HEAD
+=======
+export type {
+  ApmOtelFields,
+  ApmOtelAttributes,
+  SpanKind,
+} from './src/lib/apm/otel/apm_otel_fields';
+>>>>>>> 9cc220ac52f ([Synthtrace] APM Otel v2 (#217019))
 export type { Instance } from './src/lib/apm/instance';
 export { MobileDevice } from './src/lib/apm/mobile_device';
 export type {

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
@@ -11,6 +11,11 @@ export { observer } from './src/lib/agent_config';
 export type { AgentConfigFields } from './src/lib/agent_config/agent_config_fields';
 export { apm } from './src/lib/apm';
 export type { ApmFields } from './src/lib/apm/apm_fields';
+export type {
+  ApmOtelFields,
+  ApmOtelAttributes,
+  SpanKind,
+} from './src/lib/apm/otel/apm_otel_fields';
 export type { Instance } from './src/lib/apm/instance';
 export { MobileDevice } from './src/lib/apm/mobile_device';
 export type {

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/abstract_span.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/abstract_span.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Fields } from '../entity';
+import { Serializable } from '../serializable';
+
+export abstract class AbstractSpan<
+  TFields extends Fields,
+  TChild extends AbstractSpan<TFields, any>
+> extends Serializable<TFields> {
+  protected _children: TChild[] = [];
+
+  constructor(fields: TFields) {
+    super(fields);
+  }
+
+  getChildren(): TChild[] {
+    return this._children;
+  }
+
+  children(...children: TChild[]): this {
+    for (const child of children) {
+      child.parent(this);
+    }
+    this._children.push(...children);
+    return this;
+  }
+
+  serialize(): TFields[] {
+    return [this.fields, ...this.getChildren().flatMap((child) => child.serialize())];
+  }
+
+  abstract parent(span: TChild): this;
+  abstract success(): this;
+  abstract failure(): this;
+  abstract outcome(outcome: 'success' | 'failure' | 'unknown'): this;
+  abstract isSpan(): boolean;
+  abstract isTransaction(): boolean;
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/index.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { service } from './service';
+import { service, otelService } from './service';
+
 import { mobileApp } from './mobile_app';
 import { browser } from './browser';
 import { serverlessFunction } from './serverless_function';
@@ -17,6 +18,7 @@ import type { ApmException } from './apm_fields';
 
 export const apm = {
   service,
+  otelService,
   mobileApp,
   browser,
   getChromeUserAgentDefaults,

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/apm_otel_error.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/apm_otel_error.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Serializable } from '../../serializable';
+import { generateLongId, generateLongIdWithSeed, generateShortId } from '../../utils/generate_id';
+import { ApmOtelFields } from './apm_otel_fields';
+
+export class ApmOtelError extends Serializable<ApmOtelFields> {
+  constructor(fields: ApmOtelFields) {
+    super({
+      ...fields,
+      'attributes.processor.event': 'error',
+      'attributes.error.id': generateShortId(),
+    });
+  }
+
+  serialize() {
+    const errorMessage =
+      this.fields['attributes.error.grouping_key'] || this.fields['attributes.exception.message'];
+
+    const [data] = super.serialize();
+
+    data['attributes.error.grouping_key'] =
+      this.fields['attributes.error.grouping_key'] ??
+      (errorMessage ? generateLongIdWithSeed(errorMessage) : generateLongId());
+
+    return [data];
+  }
+
+  timestamp(value: number) {
+    const ret = super.timestamp(value);
+    this.fields['attributes.timestamp.us'] = value * 1000;
+    return ret;
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/apm_otel_fields.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/apm_otel_fields.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Fields } from '../../entity';
+import type { ApmFields } from '../apm_fields';
+
+export type SpanKind = 'Internal' | 'Server' | 'Client' | 'Consumer' | 'Producer';
+
+interface ErrorAttributes {
+  'attributes.exception.message': string;
+  'attributes.exception.handled': boolean;
+  'attributes.exception.type': string;
+  'attributes.error.stack_trace': string;
+  'attributes.error.id': string;
+  'attributes.error.grouping_key': string;
+}
+
+type AttributesKeys = Pick<
+  ApmFields,
+  | 'timestamp.us'
+  | 'metricset.name'
+  | 'metricset.interval'
+  | 'transaction.id'
+  | 'transaction.type'
+  | 'transaction.name'
+  | 'transaction.duration.us'
+  | 'transaction.result'
+  | 'transaction.sampled'
+  | 'span.id'
+  | 'span.name'
+  | 'span.type'
+  | 'span.subtype'
+  | 'span.duration.us'
+  | 'span.destination.service.resource'
+  | 'service.name'
+  | 'service.target.name'
+  | 'service.target.type'
+  | 'processor.event'
+  | 'event.outcome'
+  | 'event.name'
+  | 'url.full'
+>;
+
+type MetricsKeys = Pick<
+  ApmFields,
+  | 'transaction.duration.histogram'
+  | 'span.destination.service.response_time.count'
+  | 'span.destination.service.response_time.sum.us'
+>;
+
+type ResourceAttributesKeys = Pick<
+  ApmFields,
+  | 'agent.name'
+  | 'agent.version'
+  | 'service.name'
+  | 'service.node.name'
+  | 'host.name'
+  | 'container.id'
+  | 'cloud.provider'
+  | 'cloud.region'
+  | 'cloud.availability_zone'
+  | 'cloud.service.name'
+  | 'cloud.account.id'
+  | 'cloud.account.name'
+  | 'cloud.project.id'
+  | 'cloud.project.name'
+  | 'cloud.machine.type'
+  | 'faas.coldstart'
+  | 'faas.id'
+  | 'faas.trigger.type'
+  | 'faas.name'
+  | 'faas.version'
+>;
+
+export type ApmOtelAttributes = {
+  [K in keyof AttributesKeys as `attributes.${K}`]: ApmFields[K];
+} & ErrorAttributes & {
+    'attributes.db.statement': string;
+    'attributes.db.system': string;
+    'attributes.network.peer.address': string;
+    'attributes.network.peer.port': number;
+    'attributes.network.type': string;
+    'attributes.rpc.grpc.status_code': number;
+    'attributes.rpc.method': string;
+    'attributes.rpc.service': string;
+    'attributes.rpc.system': string;
+    'attributes.server.address': string;
+    'attributes.server.port': number;
+    'attributes.session.id': string;
+    'attributes.thread.id': number;
+    'attributes.thread.name': string;
+    'attributes.service.namespace': string;
+    'attributes.http.request.method': string;
+    'attributes.http.response.status_code': number;
+    'attributes.http.url': string;
+    'attributes.span.kind': string;
+    'attributes.method': string;
+    'attributes.messaging.system': string;
+    'attributes.messaging.operation': string;
+    'attributes.messaging.destination.name': string;
+    'attributes.status.code': number;
+    'attributes.url.path': string;
+    'attributes.url.scheme': string;
+  };
+
+type MetricsAttributes = {
+  [K in keyof MetricsKeys as `metrics.${K}`]: ApmFields[K];
+} & {
+  'metrics.event.success_count': {
+    sum: number;
+    value_count: number;
+  };
+  'metrics.transaction.duration.summary': {
+    sum: number;
+    value_count: number;
+  };
+};
+
+type ResourceAttributes = {
+  [K in keyof ResourceAttributesKeys as `resource.attributes.${K}`]: ApmFields[K];
+} & {
+  'resource.attributes.deployment.environment': string;
+  'resource.attributes.service.namespace': string;
+  'resource.attributes.service.instance.id': string;
+  'resource.attributes.telemetry.sdk.language': string;
+  'resource.attributes.telemetry.sdk.name': string;
+  'resource.attributes.telemetry.sdk.version': string;
+  'resource.attributes.telemetry.distro.name': string;
+  'resource.attributes.telemetry.distro.version': string;
+  'resource.attributes.process.runtime.name': string;
+  'resource.attributes.process.runtime.version': string;
+  'resource.attributes.os.type': string;
+  'resource.attributes.os.description': string;
+  'resource.attributes.host.arch': string;
+  'resource.attributes.k8s.pod.name': string;
+};
+
+export type ApmOtelFields = Fields &
+  Partial<
+    {
+      'data_stream.dataset': string;
+      'data_stream.namespace': string;
+      'data_stream.type': string;
+      'resource.dropped_attributes_count': number;
+      'resource.schema_url': string;
+      'scope.attributes.service.framework.name': string;
+      'scope.attributes.service.framework.version': string;
+      'scope.dropped_attributes_count': number;
+      'scope.name': string;
+      name: string;
+      parent_span_id: string;
+      trace_id: string;
+      span_id: string;
+      kind: SpanKind;
+      dropped_attributes_count: number;
+      dropped_events_count: number;
+      dropped_links_count: number;
+      duration: number;
+      links: Array<{
+        span_id: string;
+        trace_id: string;
+      }>;
+    } & ApmOtelAttributes &
+      MetricsAttributes &
+      ResourceAttributes
+  >;

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export { OtelService, type OtelServiceParams } from './otel_service';

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_base_span.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_base_span.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { generateLongId } from '../../utils/generate_id';
+import { AbstractSpan } from '../abstract_span';
+import { ApmOtelFields } from './apm_otel_fields';
+import { OtelSpan } from './otel_span';
+
+export class OtelBaseSpan extends AbstractSpan<ApmOtelFields, OtelBaseSpan> {
+  constructor(fields: ApmOtelFields) {
+    super({
+      'attributes.event.outcome': 'unknown',
+      'data_stream.dataset': 'generic.otel',
+      'data_stream.namespace': 'default',
+      'data_stream.type': 'traces',
+      ...fields,
+      trace_id: generateLongId(),
+    });
+  }
+
+  parent(span: OtelBaseSpan): this {
+    this.fields.trace_id = span.fields.trace_id;
+    this.fields.parent_span_id = span.fields.span_id;
+
+    this._children.forEach((child) => {
+      child.parent(this);
+    });
+
+    return this;
+  }
+
+  success(): this {
+    this.fields['attributes.event.outcome'] = 'success';
+    return this;
+  }
+
+  failure(): this {
+    this.fields['attributes.event.outcome'] = 'failure';
+    return this;
+  }
+
+  outcome(outcome: 'success' | 'failure' | 'unknown'): this {
+    this.fields['attributes.event.outcome'] = outcome;
+    return this;
+  }
+
+  isSpan(): this is OtelSpan {
+    return this.fields.kind === 'Internal' || this.fields.kind === 'Client';
+  }
+
+  isTransaction(): this is OtelSpan {
+    return this.fields.kind === 'Server';
+  }
+
+  override timestamp(timestamp: number) {
+    const ret = super.timestamp(timestamp);
+    this.fields['attributes.timestamp.us'] = timestamp * 1000;
+    return ret;
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_instance.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_instance.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { OtelSpan } from './otel_span';
+import { ApmOtelFields, SpanKind } from './apm_otel_fields';
+import { ApmOtelError } from './apm_otel_error';
+import { Entity } from '../../entity';
+import { HttpMethod } from '../span';
+
+export class OtelInstance extends Entity<ApmOtelFields> {
+  span({
+    name,
+    kind = 'Server',
+    ...fields
+  }: ApmOtelFields & { kind: Extract<SpanKind, 'Internal' | 'Server'> }) {
+    return new OtelSpan({
+      ...this.fields,
+      ...(kind === 'Server'
+        ? {
+            'attributes.server.address': 'elastic.co',
+            'attributes.url.scheme': 'https',
+            'attributes.http.response.status_code': 200,
+            'attributes.http.request.method': 'GET',
+          }
+        : {}),
+      ...fields,
+      kind,
+      name,
+    });
+  }
+
+  httpExitSpan({
+    name,
+    destinationUrl,
+  }: {
+    name: string;
+    destinationUrl: string;
+    method?: HttpMethod;
+    statusCode?: number;
+  }) {
+    const destination = new URL(destinationUrl);
+
+    return new OtelSpan({
+      ...this.fields,
+      name,
+      kind: 'Client',
+
+      // http
+      'attributes.http.url': destinationUrl,
+
+      // destination
+      'attributes.service.target.name': destination.host,
+      'attributes.service.target.type': destination.hostname,
+      'attributes.span.destination.service.resource': destination.host,
+    });
+  }
+
+  dbExitSpan({ name, type, statement }: { name: string; type: string; statement?: string }) {
+    return new OtelSpan({
+      ...this.fields,
+      name,
+      kind: 'Client',
+      // db
+      ...(statement ? { 'attributes.db.statement': statement } : undefined),
+      'attributes.db.system': type,
+
+      // destination
+      'attributes.span.destination.service.resource': type,
+    });
+  }
+
+  messagingExitSpan({
+    name,
+    type,
+    operation,
+    destination,
+  }: {
+    name: string;
+    type: string;
+    destination: string;
+    operation: 'publish' | 'receive';
+  }) {
+    return new OtelSpan({
+      ...this.fields,
+      name,
+      kind: operation === 'publish' ? 'Producer' : 'Consumer',
+      // db
+      'attributes.messaging.system': type,
+      'attributes.messaging.operation': operation,
+      'attributes.messaging.destination.name': destination,
+
+      // destination
+      'attributes.span.destination.service.resource': `${type}/${operation}`,
+    });
+  }
+
+  rpcSpan({ name, method, service }: { name: string; method: string; service: string }) {
+    return new OtelSpan({
+      ...this.fields,
+      name,
+      kind: 'Server',
+      // rpc
+      'attributes.rpc.method': method,
+      'attributes.rpc.service': service,
+    });
+  }
+
+  error({
+    message,
+    type,
+    stackTrace,
+    groupingKey,
+  }: {
+    message: string;
+    type?: string;
+    stackTrace?: string;
+    groupingKey?: string;
+  }) {
+    return new ApmOtelError({
+      ...this.fields,
+      ...(groupingKey ? { 'attributes.error.grouping_key': groupingKey } : {}),
+      'attributes.exception.type': type,
+      'attributes.exception.message': message,
+      'attributes.error.stack_trace': stackTrace,
+    });
+  }
+
+  containerId(containerId: string) {
+    this.fields['resource.attributes.container.id'] = containerId;
+    return this;
+  }
+  podId(podId: string) {
+    this.fields['resource.attributes.k8s.pod.name'] = podId;
+    return this;
+  }
+
+  hostName(hostName: string) {
+    this.fields['resource.attributes.host.name'] = hostName;
+    return this;
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_service.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_service.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Entity } from '../../entity';
+import { ApmOtelFields } from './apm_otel_fields';
+import { OtelInstance } from './otel_instance';
+
+export interface OtelServiceParams {
+  name: string;
+  namespace?: string;
+  sdkName: 'opentelemetry' | 'otlp';
+  sdkLanguage: string;
+  distro?: 'elastic';
+}
+export class OtelService extends Entity<ApmOtelFields> {
+  constructor(params: OtelServiceParams) {
+    const { name, namespace, sdkName, sdkLanguage, distro } = params;
+
+    const fields: ApmOtelFields = {
+      'resource.attributes.service.name': name,
+      'resource.attributes.service.namespace': namespace,
+      'resource.attributes.telemetry.sdk.name': sdkName,
+      'resource.attributes.telemetry.sdk.language': sdkLanguage,
+      'resource.attributes.telemetry.distro.name': distro,
+    };
+    super(fields);
+  }
+
+  instance(instanceName: string) {
+    return new OtelInstance({
+      ...this.fields,
+      'resource.attributes.service.instance.id': instanceName,
+      'resource.attributes.host.name': instanceName,
+    });
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_span.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_span.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { generateShortId } from '../../utils/generate_id';
+import { ApmOtelError } from './apm_otel_error';
+import { ApmOtelFields } from './apm_otel_fields';
+import { OtelBaseSpan } from './otel_base_span';
+
+// In Otel we have only spans (https://opentelemetry.io/docs/concepts/signals/traces/#spans)
+export class OtelSpan extends OtelBaseSpan {
+  private readonly _errors: ApmOtelError[] = [];
+  private _sampled: boolean = true;
+  constructor(fields: ApmOtelFields) {
+    super({
+      kind: 'Internal',
+      ...fields,
+      span_id: generateShortId(),
+    });
+  }
+
+  duration(duration: number) {
+    this.fields.duration = duration * 1000;
+    return this;
+  }
+
+  parent(span: OtelBaseSpan) {
+    super.parent(span);
+
+    this._errors.forEach((error) => {
+      error.fields.trace_id = this.fields.trace_id;
+      error.fields.parent_span_id = this.fields.span_id;
+      error.fields.name = this.fields.name;
+      error.fields.kind = this.fields.kind;
+      error.fields.duration = this.fields.duration;
+    });
+
+    return this;
+  }
+
+  errors(...errors: ApmOtelError[]) {
+    errors.forEach((error) => {
+      error.fields.trace_id = this.fields.trace_id;
+      error.fields.span_id = this.fields.span_id;
+      error.fields.name = this.fields.name;
+      error.fields.kind = this.fields.kind;
+      error.fields.duration = this.fields.duration;
+    });
+
+    this._errors.push(...errors);
+
+    return this;
+  }
+
+  serialize() {
+    const [transaction, ...spans] = super.serialize();
+
+    const errors = this._errors.flatMap((error) => error.serialize());
+
+    const events = [transaction];
+    if (this._sampled) {
+      events.push(...spans);
+    }
+
+    return events.concat(errors);
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/span.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/span.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { generateShortId } from '../../utils/generate_id';
+import { ApmOtelFields } from './apm_otel_fields';
+import { OtelBaseSpan } from './otel_base_span';
+
+export class Span extends OtelBaseSpan {
+  constructor(fields: ApmOtelFields) {
+    super({
+      ...fields,
+      span_id: generateShortId(),
+      name: fields['attributes.span.name'],
+      'attributes.processor.event': 'span',
+      kind: 'Internal',
+    });
+  }
+
+  duration(duration: number) {
+    this.fields['attributes.span.duration.us'] = duration * 1000;
+    this.fields.duration = duration * 1000;
+    return this;
+  }
+
+  destination(resource: string) {
+    this.fields['attributes.span.destination.service.resource'] = resource;
+    this.fields.kind = 'Client';
+    return this;
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/service.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/service.ts
@@ -7,9 +7,11 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { OpenTelemetryAgentName } from '../../types/agent_names';
 import { Entity } from '../entity';
 import { ApmFields } from './apm_fields';
 import { Instance } from './instance';
+import { OtelService, OtelServiceParams } from './otel';
 
 export class Service extends Entity<ApmFields> {
   instance(instanceName: string) {
@@ -21,12 +23,23 @@ export class Service extends Entity<ApmFields> {
   }
 }
 
-export function service(name: string, environment: string, agentName: string): Service;
-
-export function service(options: { name: string; environment: string; agentName: string }): Service;
+export function service(
+  name: string,
+  environment: string,
+  agentName: string | OpenTelemetryAgentName
+): Service;
 
 export function service(
-  ...args: [{ name: string; environment: string; agentName: string }] | [string, string, string]
+  options: { name: string; environment: string } & (
+    | { agentName: string }
+    | { agentName: OpenTelemetryAgentName }
+  )
+): Service;
+
+export function service(
+  ...args:
+    | [{ name: string; environment: string; agentName: string | OpenTelemetryAgentName }]
+    | [string, string, string]
 ) {
   const [serviceName, environment, agentName] =
     args.length === 1 ? [args[0].name, args[0].environment, args[0].agentName] : args;
@@ -35,5 +48,16 @@ export function service(
     'service.name': serviceName,
     'service.environment': environment,
     'agent.name': agentName,
+  });
+}
+
+// otel native/edot
+export function otelService(options: OtelServiceParams) {
+  return new OtelService({
+    name: options.name,
+    sdkLanguage: options.sdkLanguage,
+    sdkName: options.sdkName,
+    distro: options.distro,
+    namespace: options.namespace,
   });
 }

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/types/agent_names.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/types/agent_names.ts
@@ -20,24 +20,47 @@ type ElasticAgentName =
   | 'php'
   | 'android/java';
 
-type OpenTelemetryAgentName =
-  | 'otlp'
-  | 'opentelemetry/cpp'
-  | 'opentelemetry/dotnet'
-  | 'opentelemetry/dotnet/opentelemetry-dotnet-instrumentation'
-  | 'opentelemetry/dotnet/elastic'
-  | 'opentelemetry/erlang'
-  | 'opentelemetry/go'
-  | 'opentelemetry/java'
-  | 'opentelemetry/java/opentelemetry-java-instrumentation'
-  | 'opentelemetry/java/elastic'
-  | 'opentelemetry/nodejs'
-  | 'opentelemetry/php'
-  | 'opentelemetry/python'
-  | 'opentelemetry/ruby'
-  | 'opentelemetry/swift'
-  | 'opentelemetry/android'
-  | 'opentelemetry/webjs';
+const OPEN_TELEMETRY_BASE_AGENT_NAMES = ['otlp', 'opentelemetry'] as const;
+export const EDOT_AGENT_NAMES = [
+  'opentelemetry/java/elastic',
+  'opentelemetry/dotnet/elastic',
+  'opentelemetry/nodejs/elastic',
+  'opentelemetry/php/elastic',
+  'opentelemetry/python/elastic',
+] as const;
+
+const OPEN_TELEMETRY_AGENT_NAMES = [
+  ...EDOT_AGENT_NAMES,
+  ...OPEN_TELEMETRY_BASE_AGENT_NAMES,
+  'opentelemetry/cpp',
+  'opentelemetry/dotnet',
+  'opentelemetry/erlang',
+  'opentelemetry/go',
+  'opentelemetry/java',
+  'opentelemetry/nodejs',
+  'opentelemetry/php',
+  'opentelemetry/python',
+  'opentelemetry/ruby',
+  'opentelemetry/rust',
+  'opentelemetry/swift',
+  'opentelemetry/android',
+  'opentelemetry/webjs',
+  'otlp/cpp',
+  'otlp/dotnet',
+  'otlp/erlang',
+  'otlp/go',
+  'otlp/java',
+  'otlp/nodejs',
+  'otlp/php',
+  'otlp/python',
+  'otlp/ruby',
+  'otlp/rust',
+  'otlp/swift',
+  'otlp/android',
+  'otlp/webjs',
+] as const;
+
+export type OpenTelemetryAgentName = (typeof OPEN_TELEMETRY_AGENT_NAMES)[number];
 
 // Unable to reference AgentName from '@kbn/apm-plugin/typings/es_schemas/ui/fields/agent' due to circular reference
 export type AgentName = ElasticAgentName | OpenTelemetryAgentName;

--- a/src/platform/packages/shared/kbn-apm-synthtrace/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/index.ts
@@ -9,7 +9,10 @@
 
 export { createLogger, LogLevel } from './src/lib/utils/create_logger';
 
-export { ApmSynthtraceEsClient } from './src/lib/apm/client/apm_synthtrace_es_client';
+export {
+  ApmSynthtraceEsClient,
+  type ApmSynthtracePipelines,
+} from './src/lib/apm/client/apm_synthtrace_es_client';
 export { ApmSynthtraceKibanaClient } from './src/lib/apm/client/apm_synthtrace_kibana_client';
 export { InfraSynthtraceEsClient } from './src/lib/infra/infra_synthtrace_es_client';
 export { InfraSynthtraceKibanaClient } from './src/lib/infra/infra_synthtrace_kibana_client';
@@ -18,7 +21,6 @@ export { LogsSynthtraceEsClient } from './src/lib/logs/logs_synthtrace_es_client
 export { EntitiesSynthtraceEsClient } from './src/lib/entities/entities_synthtrace_es_client';
 export { EntitiesSynthtraceKibanaClient } from './src/lib/entities/entities_synthtrace_kibana_client';
 export { SyntheticsSynthtraceEsClient } from './src/lib/synthetics/synthetics_synthtrace_es_client';
-export { OtelSynthtraceEsClient } from './src/lib/otel/otel_synthtrace_es_client';
 export {
   addObserverVersionTransform,
   deleteSummaryFieldTransform,

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_clients.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_clients.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Required } from 'utility-types';
+import { Client } from '@elastic/elasticsearch';
+import { ApmSynthtraceEsClient } from '../../lib/apm/client/apm_synthtrace_es_client';
+import { ApmSynthtraceKibanaClient } from '../../lib/apm/client/apm_synthtrace_kibana_client';
+import { EntitiesSynthtraceEsClient } from '../../lib/entities/entities_synthtrace_es_client';
+import { EntitiesSynthtraceKibanaClient } from '../../lib/entities/entities_synthtrace_kibana_client';
+import { InfraSynthtraceEsClient } from '../../lib/infra/infra_synthtrace_es_client';
+import { LogsSynthtraceEsClient } from '../../lib/logs/logs_synthtrace_es_client';
+import { SynthtraceEsClientOptions } from '../../lib/shared/base_client';
+import { SyntheticsSynthtraceEsClient } from '../../lib/synthetics/synthetics_synthtrace_es_client';
+import { Logger } from '../../lib/utils/create_logger';
+
+export interface SynthtraceClients {
+  apmEsClient: ApmSynthtraceEsClient;
+  entitiesEsClient: EntitiesSynthtraceEsClient;
+  infraEsClient: InfraSynthtraceEsClient;
+  logsEsClient: LogsSynthtraceEsClient;
+  syntheticsEsClient: SyntheticsSynthtraceEsClient;
+  entitiesKibanaClient: EntitiesSynthtraceKibanaClient;
+  esClient: Client;
+}
+
+export async function getClients({
+  logger,
+  options,
+  packageVersion,
+  skipBootstrap,
+}: {
+  logger: Logger;
+  options: Required<Omit<SynthtraceEsClientOptions, 'pipeline'>, 'kibana'>;
+  packageVersion?: string;
+  skipBootstrap?: boolean;
+}): Promise<SynthtraceClients> {
+  const apmKibanaClient = new ApmSynthtraceKibanaClient({
+    logger,
+    kibanaClient: options.kibana,
+  });
+
+  let version = packageVersion;
+
+  if (!version) {
+    version = await apmKibanaClient.fetchLatestApmPackageVersion();
+    if (!skipBootstrap) {
+      await apmKibanaClient.installApmPackage(version);
+    }
+  } else if (version === 'latest') {
+    version = await apmKibanaClient.fetchLatestApmPackageVersion();
+  }
+
+  logger.debug(`Using package version: ${version}`);
+
+  const apmEsClient = new ApmSynthtraceEsClient({
+    ...options,
+    version,
+  });
+
+  const logsEsClient = new LogsSynthtraceEsClient(options);
+  const infraEsClient = new InfraSynthtraceEsClient(options);
+  const entitiesEsClient = new EntitiesSynthtraceEsClient(options);
+
+  const entitiesKibanaClient = new EntitiesSynthtraceKibanaClient({
+    ...options,
+    kibanaClient: options.kibana,
+  });
+
+  const syntheticsEsClient = new SyntheticsSynthtraceEsClient(options);
+
+  return {
+    apmEsClient,
+    entitiesEsClient,
+    infraEsClient,
+    logsEsClient,
+    syntheticsEsClient,
+    entitiesKibanaClient,
+    esClient: options.client,
+  };
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_service_metrics_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_service_metrics_aggregator.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { pick } from 'lodash';
+import { hashKeysOf, ApmOtelFields } from '@kbn/apm-synthtrace-client';
+import { createLosslessHistogram } from '../../../utils/create_lossless_histogram';
+import { createOtelMetricAggregator } from '../create_apm_metric_aggregator';
+
+const KEY_FIELDS: Array<keyof ApmOtelFields> = [
+  'resource.attributes.agent.name',
+  'resource.attributes.deployment.environment',
+  'resource.attributes.service.name',
+  'attributes.transaction.type',
+  'resource.attributes.telemetry.sdk.name',
+  'resource.attributes.telemetry.sdk.language',
+  'scope.attributes.service.framework.name',
+];
+
+const METRICSET_NAME = 'service_transaction';
+export function createServiceMetricsAggregator(flushInterval: string) {
+  return createOtelMetricAggregator(
+    {
+      filter: (event) => event['attributes.processor.event'] === 'transaction',
+      getAggregateKey: (event) => {
+        return hashKeysOf(event, KEY_FIELDS);
+      },
+      flushInterval,
+      init: (event) => {
+        const set = pick(event, KEY_FIELDS);
+
+        return {
+          ...set,
+          'data_stream.dataset': `${METRICSET_NAME}.${flushInterval}.otel`,
+          'data_stream.namespace': 'default',
+          'data_stream.type': 'metrics',
+          'attributes.metricset.name': METRICSET_NAME,
+          'attributes.metricset.interval': flushInterval,
+          'attributes.processor.event': 'metric',
+          'metrics.transaction.duration.histogram': createLosslessHistogram(),
+          'metrics.transaction.duration.summary': {
+            value_count: 0,
+            sum: 0,
+          },
+          'metrics.event.success_count': {
+            sum: 0,
+            value_count: 0,
+          },
+        };
+      },
+    },
+    (metric, event) => {
+      const duration = event['attributes.transaction.duration.us']!;
+
+      metric['metrics.transaction.duration.histogram'].record(duration);
+
+      if (
+        event['attributes.event.outcome'] === 'success' ||
+        event['attributes.event.outcome'] === 'failure'
+      ) {
+        metric['metrics.event.success_count'].value_count += 1;
+      }
+
+      if (event['attributes.event.outcome'] === 'success') {
+        metric['metrics.event.success_count'].sum += 1;
+      }
+
+      const summary = metric['metrics.transaction.duration.summary'];
+
+      summary.sum += duration;
+      summary.value_count += 1;
+    },
+    (metric) => {
+      const serialized = metric['metrics.transaction.duration.histogram'].serialize();
+
+      metric['metrics.transaction.duration.histogram'] = {
+        // @ts-expect-error
+        values: serialized.values,
+        counts: serialized.counts,
+      };
+
+      // @ts-expect-error
+      metric._doc_count = serialized.total;
+
+      return metric;
+    }
+  );
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_service_summary_metrics_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_service_summary_metrics_aggregator.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ApmOtelFields, hashKeysOf } from '@kbn/apm-synthtrace-client';
+import { identity, noop, pick } from 'lodash';
+import { createOtelMetricAggregator } from '../create_apm_metric_aggregator';
+
+const KEY_FIELDS: Array<keyof ApmOtelFields> = [
+  'resource.attributes.agent.name',
+  'resource.attributes.deployment.environment',
+  'resource.attributes.service.name',
+  'resource.attributes.telemetry.sdk.name',
+  'resource.attributes.telemetry.sdk.language',
+  'scope.attributes.service.framework.name',
+];
+
+const METRICSET_NAME = 'service_summary';
+export function createServiceSummaryMetricsAggregator(flushInterval: string) {
+  return createOtelMetricAggregator(
+    {
+      filter: () => true,
+      getAggregateKey: (event) => {
+        return hashKeysOf(event, KEY_FIELDS);
+      },
+      flushInterval,
+      init: (event) => {
+        const set = pick(event, KEY_FIELDS);
+
+        return {
+          ...set,
+          'data_stream.dataset': `${METRICSET_NAME}.${flushInterval}.otel`,
+          'data_stream.namespace': 'default',
+          'data_stream.type': 'metrics',
+          'attributes.metricset.name': METRICSET_NAME,
+          'attributes.metricset.interval': flushInterval,
+          'attributes.processor.event': 'metric',
+        };
+      },
+    },
+    noop,
+    identity
+  );
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_span_metrics_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_span_metrics_aggregator.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { pick } from 'lodash';
+import { ApmOtelFields, hashKeysOf } from '@kbn/apm-synthtrace-client';
+import { createOtelMetricAggregator } from '../create_apm_metric_aggregator';
+
+const KEY_FIELDS: Array<keyof ApmOtelFields> = [
+  'resource.attributes.agent.name',
+  'resource.attributes.service.name',
+  'resource.attributes.deployment.environment',
+  'resource.attributes.service.instance.id',
+  'resource.attributes.telemetry.sdk.name',
+  'resource.attributes.telemetry.sdk.language',
+  'attributes.span.destination.service.resource',
+  'attributes.event.outcome',
+  'attributes.span.name',
+  'attributes.service.target.name',
+  'attributes.service.target.type',
+  'scope.attributes.service.framework.name',
+];
+
+const METRICSET_NAME = 'service_destination';
+export function createSpanMetricsAggregator(flushInterval: string) {
+  return createOtelMetricAggregator(
+    {
+      filter: (event) =>
+        event['attributes.processor.event'] === 'span' &&
+        !!event['attributes.span.destination.service.resource'],
+      getAggregateKey: (event) => {
+        const key = hashKeysOf(event, KEY_FIELDS);
+        return key;
+      },
+      flushInterval,
+      init: (event) => {
+        const set = pick(event, KEY_FIELDS);
+
+        return {
+          ...set,
+          'data_stream.dataset': `${METRICSET_NAME}.${flushInterval}.otel`,
+          'data_stream.namespace': 'default',
+          'data_stream.type': 'metrics',
+          'attributes.metricset.name': METRICSET_NAME,
+          'attributes.metricset.interval': flushInterval,
+          'attributes.processor.event': 'metric',
+          'processor.event': 'metric',
+          'metrics.span.destination.service.response_time.count': 0,
+          'metrics.span.destination.service.response_time.sum.us': 0,
+        };
+      },
+    },
+    (metric, event) => {
+      metric['metrics.span.destination.service.response_time.count'] += 1;
+      metric['metrics.span.destination.service.response_time.sum.us'] +=
+        event['attributes.span.duration.us']!;
+    },
+    (metric) => {
+      // @ts-expect-error
+      metric._doc_count = metric['span.destination.service.response_time.count'];
+
+      return metric;
+    }
+  );
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_transaction_metrics_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_transaction_metrics_aggregator.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ApmOtelFields, appendHash, hashKeysOf } from '@kbn/apm-synthtrace-client';
+import { pick } from 'lodash';
+import { createLosslessHistogram } from '../../../utils/create_lossless_histogram';
+
+import { createOtelMetricAggregator } from '../create_apm_metric_aggregator';
+
+const KEY_FIELDS: Array<keyof ApmOtelFields> = [
+  'attributes.transaction.name',
+  'attributes.transaction.result',
+  'attributes.transaction.type',
+  'attributes.event.outcome',
+
+  'resource.attributes.agent.name',
+  'resource.attributes.deployment.environment',
+  'resource.attributes.service.namespace',
+  'resource.attributes.service.name',
+  'resource.attributes.telemetry.sdk.name',
+  'resource.attributes.telemetry.sdk.language',
+  'resource.attributes.service.instance.id',
+  'resource.attributes.process.runtime.name',
+  'resource.attributes.process.runtime.version',
+
+  'resource.attributes.telemetry.sdk.language',
+  'resource.attributes.telemetry.sdk.version',
+
+  'resource.attributes.host.name',
+  'resource.attributes.os.type',
+  'resource.attributes.container.id',
+  'resource.attributes.k8s.pod.name',
+
+  'resource.attributes.cloud.provider',
+  'resource.attributes.cloud.region',
+  'resource.attributes.cloud.availability_zone',
+  'resource.attributes.cloud.service.name',
+  'resource.attributes.cloud.account.id',
+  'resource.attributes.cloud.account.name',
+  'resource.attributes.cloud.project.id',
+  'resource.attributes.cloud.project.name',
+  'resource.attributes.cloud.machine.type',
+
+  'resource.attributes.faas.coldstart',
+  'resource.attributes.faas.id',
+  'resource.attributes.faas.trigger.type',
+  'resource.attributes.faas.name',
+  'resource.attributes.faas.version',
+
+  'scope.attributes.service.framework.name',
+];
+
+const METRICSET_NAME = 'transaction';
+export function createTransactionMetricsAggregator(flushInterval: string) {
+  return createOtelMetricAggregator(
+    {
+      filter: (event) => event['attributes.processor.event'] === 'transaction',
+      getAggregateKey: (event) => {
+        let key = hashKeysOf(event, KEY_FIELDS);
+        key = appendHash(key, event.parent_span_id ? '1' : '0');
+        return key;
+      },
+      flushInterval,
+      init: (event) => {
+        const set = pick(event, KEY_FIELDS);
+
+        return {
+          ...set,
+          'data_stream.dataset': `${METRICSET_NAME}.${flushInterval}.otel`,
+          'data_stream.namespace': 'default',
+          'data_stream.type': 'metrics',
+          'attributes.metricset.name': METRICSET_NAME,
+          'attributes.metricset.interval': flushInterval,
+          'attributes.processor.event': 'metric',
+          'attributes.transaction.root': !event.parent_span_id,
+          'metrics.transaction.duration.histogram': createLosslessHistogram(),
+          'metrics.transaction.duration.summary': {
+            value_count: 0,
+            sum: 0,
+          },
+          'metrics.event.success_count': {
+            sum: 0,
+            value_count: 0,
+          },
+        };
+      },
+    },
+    (metric, event) => {
+      const duration = event['attributes.transaction.duration.us']!;
+      metric['metrics.transaction.duration.histogram'].record(duration);
+
+      if (
+        event['attributes.event.outcome'] === 'success' ||
+        event['attributes.event.outcome'] === 'failure'
+      ) {
+        metric['metrics.event.success_count'].value_count += 1;
+      }
+
+      if (event['attributes.event.outcome'] === 'success') {
+        metric['metrics.event.success_count'].sum += 1;
+      }
+
+      const summary = metric['metrics.transaction.duration.summary'];
+
+      summary.sum += duration;
+      summary.value_count += 1;
+    },
+    (metric) => {
+      const serialized = metric['metrics.transaction.duration.histogram'].serialize();
+
+      metric['metrics.transaction.duration.histogram'] = {
+        // @ts-expect-error
+        values: serialized.values,
+        counts: serialized.counts,
+      };
+
+      // @ts-expect-error
+      metric._doc_count = serialized.total;
+
+      return metric;
+    }
+  );
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/index.ts
@@ -8,11 +8,13 @@
  */
 
 import { Client, estypes } from '@elastic/elasticsearch';
-import { ApmFields } from '@kbn/apm-synthtrace-client';
+import { ApmFields, ApmOtelFields } from '@kbn/apm-synthtrace-client';
 import { ValuesType } from 'utility-types';
 import { SynthtraceEsClient, SynthtraceEsClientOptions } from '../../../shared/base_client';
 import { Logger } from '../../../utils/create_logger';
 import { apmPipeline } from './apm_pipeline';
+import { apmToOtelPipeline } from './otel/apm_to_otel_pipeline';
+import { otelToApmPipeline } from './otel/otel_to_apm_pipeline';
 
 export enum ComponentTemplateName {
   LogsApp = 'logs-apm.app@custom',
@@ -23,20 +25,28 @@ export enum ComponentTemplateName {
   TracesApmRum = 'traces-apm.rum@custom',
   TracesApmSampled = 'traces-apm.sampled@custom',
 }
+export type ApmSynthtracePipelines = 'default' | 'otelToApm' | 'apmToOtel';
 
 export interface ApmSynthtraceEsClientOptions extends Omit<SynthtraceEsClientOptions, 'pipeline'> {
   version: string;
 }
 
-export class ApmSynthtraceEsClient extends SynthtraceEsClient<ApmFields> {
-  private version: string;
+export class ApmSynthtraceEsClient extends SynthtraceEsClient<ApmFields | ApmOtelFields> {
+  public readonly version: string;
 
   constructor(options: { client: Client; logger: Logger } & ApmSynthtraceEsClientOptions) {
     super({
       ...options,
       pipeline: apmPipeline(options.logger, options.version),
     });
-    this.dataStreams = ['traces-apm*', 'metrics-apm*', 'logs-apm*'];
+    this.dataStreams = [
+      'traces-apm*',
+      'metrics-apm*',
+      'logs-apm*',
+      'metrics-*.otel*',
+      'traces-*.otel*',
+      'logs-*.otel*',
+    ];
     this.version = options.version;
   }
 
@@ -76,5 +86,29 @@ export class ApmSynthtraceEsClient extends SynthtraceEsClient<ApmFields> {
     } = { includeSerialization: true }
   ) {
     return apmPipeline(this.logger, versionOverride ?? this.version, includeSerialization);
+  }
+
+  getPipeline(
+    pipeline: ApmSynthtracePipelines,
+    options: {
+      includeSerialization?: boolean;
+      versionOverride?: string;
+    } = { includeSerialization: true }
+  ) {
+    switch (pipeline) {
+      case 'otelToApm': {
+        return otelToApmPipeline(this.logger, options.includeSerialization);
+      }
+      case 'apmToOtel': {
+        return apmToOtelPipeline(
+          this.logger,
+          options.versionOverride ?? this.version,
+          options.includeSerialization
+        );
+      }
+      default: {
+        return this.getDefaultPipeline(options);
+      }
+    }
   }
 }

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/apm_to_otel_pipeline.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/apm_to_otel_pipeline.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Readable, pipeline } from 'stream';
+import { Logger } from '../../../../utils/create_logger';
+import { getSerializeTransform } from '../../../../shared/get_serialize_transform';
+import { getIntakeDefaultsTransform } from '../get_intake_defaults_transform';
+import { getApmServerMetadataTransform } from '../get_apm_server_metadata_transform';
+import { getOtelToApmSpanTransform } from './get_apm_to_otel_span_transform';
+import { getOtelTransforms } from './otel_to_apm_pipeline';
+
+export function apmToOtelPipeline(
+  logger: Logger,
+  version: string,
+  includeSerialization: boolean = true
+) {
+  return (base: Readable) => {
+    const serializationTransform = includeSerialization ? [getSerializeTransform()] : [];
+
+    return pipeline(
+      // @ts-expect-error Some weird stuff here with the type definition for pipeline. We have tests!
+      base,
+      ...serializationTransform,
+      getIntakeDefaultsTransform(),
+      getApmServerMetadataTransform(version),
+      getOtelToApmSpanTransform(),
+      ...getOtelTransforms(),
+      (err) => {
+        if (err) {
+          logger.error(err);
+        }
+      }
+    );
+  };
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_apm_to_otel_span_transform.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_apm_to_otel_span_transform.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ApmFields, ApmOtelFields } from '@kbn/apm-synthtrace-client';
+import { Transform } from 'stream';
+
+function moveAttributes(
+  obj: Record<string, any>,
+  origin: string,
+  destination: string,
+  ignoreList: Array<keyof ApmFields> = []
+) {
+  return Object.entries(obj)
+    .filter(([key]) => key.startsWith(origin) && !ignoreList.some((item) => key.startsWith(item)))
+    .reduce((acc, [key, value]) => {
+      acc[`${destination}.${key}`] = value;
+      return acc;
+    }, {} as Record<string, any>);
+}
+
+export function getOtelToApmSpanTransform() {
+  return new Transform({
+    objectMode: true,
+    transform(document: ApmFields, encoding, callback) {
+      const links = document['span.links']?.map((p) => ({
+        span_id: p.span.id,
+        trace_id: p.trace.id,
+      }));
+
+      const spanId =
+        document['processor.event'] === 'transaction'
+          ? document['transaction.id']
+          : document['span.id'];
+
+      const spanName =
+        document['processor.event'] === 'transaction'
+          ? document['transaction.name']
+          : document['span.name'];
+
+      const [sdkName, language, distro] = document['agent.name']?.split('/') ?? [];
+      const serviceName = document['service.name'];
+      const serviceEnvironment = document['service.environment'];
+
+      const otelDoc: ApmOtelFields = {
+        ...(document['processor.event'] === 'span'
+          ? moveAttributes(document, 'span.', 'attributes', ['span.links'])
+          : moveAttributes(document, 'transaction.', 'attributes')),
+        ...moveAttributes(document, 'http.', 'attributes'),
+        ...moveAttributes(document, 'processor.', 'attributes'),
+        ...moveAttributes(document, 'url.', 'attributes'),
+        ...moveAttributes(document, 'event.', 'attributes'),
+        ...moveAttributes(document, 'timestamp.', 'attributes'),
+        ...moveAttributes(document, 'host.', 'resource.attributes'),
+        'attributes.error.id': document['error.id'],
+        'attributes.error.grouping_key': document['error.grouping_key'],
+        'attributes.exception.type': document['error.type'],
+        'attributes.exception.message': document['error.exception']
+          ?.map((p) => p.message)
+          .join(' '),
+        'attributes.error.stack_trace':
+          document['span.stacktrace']?.join(' ') ?? document['code.stacktrace'],
+        'attributes.service.name': serviceName,
+        'attributes.service.namespace': serviceEnvironment,
+        'resource.attributes.service.name': serviceName,
+        'resource.attributes.service.namespace': serviceEnvironment,
+        'resource.attributes.service.instance.id': document['service.node.name'],
+        'resource.attributes.deployment.environment': serviceEnvironment,
+        'resource.attributes.agent.name': document['agent.name'],
+        'resource.attributes.telemetry.sdk.name': sdkName,
+        'resource.attributes.telemetry.sdk.language': language,
+        'resource.attributes.telemetry.distro.name': distro,
+        'scope.attributes.service.framework.name': serviceName,
+        'scope.name': serviceName,
+        '@timestamp': document['@timestamp'],
+        kind: document['processor.event'] === 'transaction' ? 'Server' : 'Client',
+        parent_span_id: document['parent.id'],
+        links,
+        trace_id: document['trace.id'],
+        span_id: spanId,
+        name: spanName,
+      };
+
+      callback(null, otelDoc);
+    },
+  });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_otel_dedot_transform.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_otel_dedot_transform.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Transform } from 'stream';
+import { ApmOtelFields, dedot } from '@kbn/apm-synthtrace-client';
+
+function extractAttributes(obj: Record<string, any>, attribute: string) {
+  return Object.entries(obj)
+    .filter(([key]) => key.startsWith(attribute))
+    .reduce((acc, [key, value]) => {
+      acc[key.replace(`${attribute}`, '')] = value;
+      return acc;
+    }, {} as Record<string, any>);
+}
+
+function removeAttributes(obj: Record<string, any>, attributes: string[]): ApmOtelFields {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([key]) =>
+      attributes.every((attribute) => !key.startsWith(attribute))
+    )
+  );
+}
+export function getOtelDedotTransform(keepFlattenedFields: boolean = false) {
+  return new Transform({
+    objectMode: true,
+    transform(document: ApmOtelFields, encoding, callback) {
+      let target: Record<string, any>;
+
+      if (keepFlattenedFields) {
+        target =
+          document['attributes.processor.event'] === 'metric' ? document : dedot(document, {});
+      } else {
+        const attributes = extractAttributes(document, 'attributes.');
+        const resourceAttributes = extractAttributes(document, 'resource.attributes.');
+        const scopeAttributes = extractAttributes(document, 'scope.attributes.');
+
+        target = dedot(
+          removeAttributes(document, ['attributes.', 'resource.attributes.', 'scope.attributes.']),
+          {}
+        );
+
+        // these remain flattened
+        target.attributes = attributes;
+        target.resource = target.resource || {};
+        target.resource.attributes = resourceAttributes;
+        target.scope = target.scope || {};
+        target.scope.attributes = scopeAttributes;
+      }
+
+      delete target.meta;
+      if (target['@timestamp']) {
+        target['@timestamp'] = new Date(target['@timestamp']).toISOString();
+      }
+
+      callback(null, target);
+    },
+  });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_otel_dynamic_template_transform.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_otel_dynamic_template_transform.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Transform } from 'stream';
+import {
+  ApmOtelFields,
+  ESDocumentWithOperation,
+  SynthtraceDynamicTemplate,
+} from '@kbn/apm-synthtrace-client';
+
+export function getOtelDynamicTemplateTransform() {
+  return new Transform({
+    objectMode: true,
+    transform(document: ESDocumentWithOperation<ApmOtelFields>, encoding, callback) {
+      const dynamicTemplates: SynthtraceDynamicTemplate[] = [];
+
+      if (document['metrics.transaction.duration.histogram']) {
+        dynamicTemplates.push({
+          'metrics.transaction.duration.histogram': 'histogram',
+        });
+      }
+
+      if (document['metrics.event.success_count']) {
+        dynamicTemplates.push({
+          'metrics.event.success_count': 'summary',
+        });
+      }
+
+      if (document['metrics.transaction.duration.summary']) {
+        dynamicTemplates.push({
+          'metrics.transaction.duration.summary': 'summary',
+        });
+      }
+
+      if (dynamicTemplates.length > 0) {
+        document._dynamicTemplates = dynamicTemplates.reduce<SynthtraceDynamicTemplate>(
+          (acc, curr) => Object.assign(acc, curr),
+          {}
+        );
+      }
+      callback(null, document);
+    },
+  });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_otel_routing_transform.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_otel_routing_transform.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ESDocumentWithOperation, ApmOtelFields } from '@kbn/apm-synthtrace-client';
+import { Transform } from 'stream';
+
+export function getOtelRoutingTransform() {
+  return new Transform({
+    objectMode: true,
+    transform(document: ESDocumentWithOperation<ApmOtelFields>, encoding, callback) {
+      const namespace = 'default';
+      let index: string | undefined;
+
+      switch (document['attributes.processor.event']) {
+        case 'transaction':
+        case 'span':
+          index = `traces-generic.otel-${namespace}`;
+          break;
+
+        case 'error':
+          index = `logs-generic.otel-${namespace}`;
+          break;
+
+        case 'metric':
+          const metricsetName = document['attributes.metricset.name'];
+          const metricsetInterval = document['attributes.metricset.interval'];
+          if (
+            metricsetName === 'transaction' ||
+            metricsetName === 'service_transaction' ||
+            metricsetName === 'service_destination' ||
+            metricsetName === 'service_summary'
+          ) {
+            index = `metrics-${metricsetName}.${metricsetInterval}.otel-${namespace}`;
+          } else {
+            index = `metrics.otel-internal-${namespace}`;
+          }
+          break;
+        default:
+          break;
+      }
+
+      if (!index) {
+        const error = new Error('Cannot determine index for event');
+        Object.assign(error, { document });
+      }
+
+      document._index = index;
+
+      callback(null, document);
+    },
+  });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_otel_to_apm_span_transform.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/get_otel_to_apm_span_transform.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ApmOtelFields, SpanKind } from '@kbn/apm-synthtrace-client';
+import { Transform } from 'stream';
+
+const kindToProcessorEvent: Record<SpanKind, 'transaction' | 'span'> = {
+  Internal: 'span',
+  Client: 'span',
+  Server: 'transaction',
+  Consumer: 'transaction',
+  Producer: 'span',
+};
+
+export function getOtelToApmTransform() {
+  return new Transform({
+    objectMode: true,
+    transform(document: ApmOtelFields, encoding, callback) {
+      const { kind, name, duration, span_id: spanId } = document;
+
+      const sdkName = document['resource.attributes.telemetry.sdk.name'];
+      const sdkLanguage = document['resource.attributes.telemetry.sdk.language'];
+      const distro = document['resource.attributes.telemetry.distro.name'];
+
+      document['resource.attributes.agent.name'] = `${sdkName}/${sdkLanguage}${
+        distro ? `/${distro}` : ''
+      }`;
+      document['attributes.service.name'] = document['resource.attributes.service.name'];
+      document['attributes.service.namespace'] = document['resource.attributes.service.namespace'];
+      document['resource.attributes.deployment.environment'] =
+        document['resource.attributes.service.namespace'];
+
+      document['scope.attributes.service.framework.name'] =
+        document['resource.attributes.service.name'];
+      document['scope.name'] = document['resource.attributes.service.name'];
+
+      document['attributes.processor.event'] =
+        document['attributes.processor.event'] ?? (!!kind ? kindToProcessorEvent[kind] : undefined);
+
+      const event = document['attributes.processor.event'];
+
+      switch (event) {
+        case 'span': {
+          document['attributes.span.id'] = spanId;
+          document['attributes.span.name'] = name;
+          document['attributes.span.type'] =
+            kind === 'Internal'
+              ? 'app'
+              : document['attributes.http.url']
+              ? 'http'
+              : document['attributes.db.system']
+              ? 'db'
+              : document['attributes.messaging.system']
+              ? 'messaging'
+              : 'custom';
+          document['attributes.span.subtype'] =
+            kind === 'Internal'
+              ? 'internal'
+              : document['attributes.http.url']
+              ? 'http'
+              : document['attributes.db.system'] ??
+                document['attributes.messaging.system'] ??
+                'internal';
+
+          document['attributes.span.duration.us'] = duration;
+          break;
+        }
+        case 'transaction': {
+          document['attributes.transaction.id'] = spanId;
+          document['attributes.transaction.name'] = name;
+          document['attributes.transaction.duration.us'] = duration;
+          document['attributes.transaction.type'] = document['attributes.http.request.method']
+            ? 'request'
+            : document['attributes.messaging.system'] ?? 'unknown';
+          document['attributes.transaction.sampled'] = true;
+        }
+        default: {
+          const error = new Error('Cannot determine a processor.event for event');
+          Object.assign(error, { document });
+        }
+      }
+
+      callback(null, document);
+    },
+  });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/otel_to_apm_pipeline.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_es_client/otel/otel_to_apm_pipeline.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { PassThrough, Readable, pipeline } from 'stream';
+import { Logger } from '../../../../utils/create_logger';
+import { getSerializeTransform } from '../../../../shared/get_serialize_transform';
+import { getOtelDedotTransform } from './get_otel_dedot_transform';
+import { createTransactionMetricsAggregator } from '../../../aggregators/otel/create_transaction_metrics_aggregator';
+import { createServiceMetricsAggregator } from '../../../aggregators/otel/create_service_metrics_aggregator';
+import { createServiceSummaryMetricsAggregator } from '../../../aggregators/otel/create_service_summary_metrics_aggregator';
+import { createSpanMetricsAggregator } from '../../../aggregators/otel/create_span_metrics_aggregator';
+import { fork } from '../../../../utils/stream_utils';
+import { getOtelDynamicTemplateTransform } from './get_otel_dynamic_template_transform';
+import { getOtelRoutingTransform } from './get_otel_routing_transform';
+import { getOtelToApmTransform } from './get_otel_to_apm_span_transform';
+
+export function getOtelTransforms() {
+  const aggregators = [
+    createTransactionMetricsAggregator('1m'),
+    createSpanMetricsAggregator('1m'),
+    createTransactionMetricsAggregator('10m'),
+    createTransactionMetricsAggregator('60m'),
+    createServiceMetricsAggregator('1m'),
+    createServiceMetricsAggregator('10m'),
+    createServiceMetricsAggregator('60m'),
+    createServiceSummaryMetricsAggregator('1m'),
+    createServiceSummaryMetricsAggregator('10m'),
+    createServiceSummaryMetricsAggregator('60m'),
+    createSpanMetricsAggregator('10m'),
+    createSpanMetricsAggregator('60m'),
+  ];
+
+  return [
+    fork(new PassThrough({ objectMode: true }), ...aggregators),
+    getOtelRoutingTransform(),
+    getOtelDynamicTemplateTransform(),
+    getOtelDedotTransform(),
+  ];
+}
+export function otelToApmPipeline(logger: Logger, includeSerialization: boolean = true) {
+  return (base: Readable) => {
+    const serializationTransform = includeSerialization ? [getSerializeTransform()] : [];
+
+    return pipeline(
+      // @ts-expect-error Some weird stuff here with the type definition for pipeline. We have tests!
+      base,
+      ...serializationTransform,
+      getOtelToApmTransform(),
+      ...getOtelTransforms(),
+      (err) => {
+        if (err) {
+          logger.error(err);
+        }
+      }
+    );
+  };
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/helpers/apm_scenario_ops_parser.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/helpers/apm_scenario_ops_parser.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ApmSynthtracePipelines } from '../../lib/apm/client/apm_synthtrace_es_client';
+
+const validPipelines: ApmSynthtracePipelines[] = ['apmToOtel', 'otelToApm', 'default'];
+const parseApmPipeline = (value: ApmSynthtracePipelines): ApmSynthtracePipelines => {
+  if (!value) return 'default';
+
+  if (validPipelines.includes(value)) {
+    return value;
+  } else {
+    return 'default';
+  }
+};
+
+export interface ApmPipelineScenarioOpts {
+  pipeline: ApmSynthtracePipelines;
+  numServices?: number;
+}
+
+export const parseApmScenarioOpts = (
+  scenarioOpts: Record<string, any> | undefined
+): ApmPipelineScenarioOpts => {
+  const pipeline = parseApmPipeline(scenarioOpts?.pipeline);
+  const numServices = scenarioOpts?.numServices ? Number(scenarioOpts.numServices) : undefined;
+
+  return {
+    ...scenarioOpts,
+    pipeline,
+    numServices,
+  };
+};

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts
@@ -7,38 +7,101 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { otel, generateShortId, OtelDocument } from '@kbn/apm-synthtrace-client';
-import { times } from 'lodash';
+import { OtelInstance, ApmOtelFields } from '@kbn/apm-synthtrace-client';
+import { apm } from '@kbn/apm-synthtrace-client/src/lib/apm';
 import { Scenario } from '../cli/scenario';
 import { withClient } from '../lib/utils/with_client';
+import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
 
-const scenario: Scenario<OtelDocument> = async (runOptions) => {
+const ENVIRONMENT = getSynthtraceEnvironment(__filename);
+
+const scenario: Scenario<ApmOtelFields> = async (runOptions) => {
   return {
-    generate: ({ range, clients: { otelEsClient } }) => {
-      const { numOtelTraces = 5 } = runOptions.scenarioOpts || {};
+    bootstrap: async ({ apmEsClient }) => {
+      apmEsClient.pipeline(apmEsClient.getPipeline('otelToApm'));
+    },
+    generate: ({ range, clients: { apmEsClient } }) => {
+      const transactionName = 'oteldemo.AdServiceSynth/GetAds';
+
       const { logger } = runOptions;
-      const traceId = generateShortId();
-      const spanId = generateShortId();
 
-      const otelDocs = times(numOtelTraces / 2).map((index) => otel.create(traceId));
+      const edotInstance = apm
+        .otelService({
+          name: 'adservice-edot-synth',
+          namespace: ENVIRONMENT,
+          sdkLanguage: 'java',
+          sdkName: 'opentelemetry',
+          distro: 'elastic',
+        })
+        .instance('edot-instance');
 
-      const otelWithMetricsAndErrors = range
-        .interval('30s')
-        .rate(1)
-        .generator((timestamp) =>
-          otelDocs.flatMap((oteld) => {
-            return [
-              oteld.metric().timestamp(timestamp),
-              oteld.transaction(spanId).timestamp(timestamp),
-              oteld.error(spanId).timestamp(timestamp),
-            ];
-          })
+      const otelNativeInstance = apm
+        .otelService({
+          name: 'sendotlp-otel-native-synth',
+          namespace: ENVIRONMENT,
+          sdkName: 'otlp',
+          sdkLanguage: 'nodejs',
+        })
+        .instance('otel-native-instance');
+
+      const successfulTimestamps = range.interval('1m').rate(180);
+      const failedTimestamps = range.interval('1m').rate(40);
+
+      const instanceSpans = (instance: OtelInstance) => {
+        const successfulTraceEvents = successfulTimestamps.generator((timestamp) =>
+          instance
+            .span({
+              name: transactionName,
+              kind: 'Server',
+            })
+            .timestamp(timestamp)
+            .duration(1000)
+            .success()
+            .children(
+              instance
+                .dbExitSpan({
+                  name: 'GET apm-*/_search',
+                  type: 'elasticsearch',
+                })
+                .duration(1000)
+                .success()
+                .timestamp(timestamp),
+              instance
+                .span({
+                  name: 'custom_operation',
+                  kind: 'Internal',
+                })
+                .duration(100)
+                .success()
+                .timestamp(timestamp)
+            )
         );
+
+        const failedTraceEvents = failedTimestamps.generator((timestamp) =>
+          instance
+            .span({ name: transactionName, kind: 'Server' })
+            .timestamp(timestamp)
+            .duration(1000)
+            .failure()
+            .errors(
+              instance
+                .error({
+                  message: '[ResponseError] index_not_found_exception',
+                  type: 'ResponseError',
+                })
+                .timestamp(timestamp + 50)
+            )
+        );
+
+        return [successfulTraceEvents, failedTraceEvents];
+      };
 
       return [
         withClient(
-          otelEsClient,
-          logger.perf('generating_otel_trace', () => otelWithMetricsAndErrors)
+          apmEsClient,
+          logger.perf('generating_otel_trace', () =>
+            [otelNativeInstance, edotInstance].flatMap((instance) => instanceSpans(instance))
+          )
         ),
       ];
     },

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/service_summary_field_version_dependent.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/service_summary_field_version_dependent.ts
@@ -9,7 +9,6 @@
 
 import { ApmFields, apm } from '@kbn/apm-synthtrace-client';
 import { random } from 'lodash';
-import { Readable } from 'stream';
 import semver from 'semver';
 import { Scenario } from '../cli/scenario';
 import { withClient } from '../lib/utils/with_client';
@@ -25,11 +24,11 @@ const scenario: Scenario<ApmFields> = async ({
   return {
     bootstrap: async ({ apmEsClient }) => {
       if (isLegacy) {
-        apmEsClient.pipeline((base: Readable) => {
-          return apmEsClient.getDefaultPipeline({
+        apmEsClient.pipeline(
+          apmEsClient.getPipeline('default', {
             versionOverride: version,
-          })(base);
-        });
+          })
+        );
       }
     },
     generate: ({ range, clients: { apmEsClient } }) => {

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
@@ -12,13 +12,18 @@ import { Scenario } from '../cli/scenario';
 import { getSynthtraceEnvironment } from '../lib/utils/get_synthtrace_environment';
 import { withClient } from '../lib/utils/with_client';
 
+import { parseApmScenarioOpts } from './helpers/apm_scenario_ops_parser';
+
 const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
 const scenario: Scenario<ApmFields> = async (runOptions) => {
   const { logger } = runOptions;
-  const { numServices = 3 } = runOptions.scenarioOpts || {};
+  const { numServices = 3, pipeline = 'default' } = parseApmScenarioOpts(runOptions.scenarioOpts);
 
   return {
+    bootstrap: async ({ apmEsClient }) => {
+      apmEsClient.pipeline(apmEsClient.getPipeline(pipeline));
+    },
     generate: ({ range, clients: { apmEsClient } }) => {
       const transactionName = '240rpm/75% 1000ms';
 

--- a/src/platform/packages/shared/kbn-scout/src/common/services/synthtrace.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/synthtrace.ts
@@ -13,7 +13,6 @@ import {
   InfraSynthtraceEsClient,
   InfraSynthtraceKibanaClient,
   LogLevel,
-  OtelSynthtraceEsClient,
   createLogger,
 } from '@kbn/apm-synthtrace';
 import { ScoutLogger } from './logger';
@@ -21,7 +20,6 @@ import { EsClient } from '../../types';
 
 let apmSynthtraceEsClientInstance: ApmSynthtraceEsClient | undefined;
 let infraSynthtraceEsClientInstance: InfraSynthtraceEsClient | undefined;
-let otelSynthtraceEsClientInstance: OtelSynthtraceEsClient | undefined;
 const logger = createLogger(LogLevel.info);
 
 export async function getApmSynthtraceEsClient(
@@ -84,22 +82,4 @@ export async function getInfraSynthtraceEsClient(
   }
 
   return infraSynthtraceEsClientInstance;
-}
-
-export function getOtelSynthtraceEsClient(esClient: EsClient, log: ScoutLogger) {
-  if (!otelSynthtraceEsClientInstance) {
-    otelSynthtraceEsClientInstance = new OtelSynthtraceEsClient({
-      client: esClient,
-      logger,
-      refreshAfterIndex: true,
-    });
-
-    otelSynthtraceEsClientInstance.pipeline(
-      otelSynthtraceEsClientInstance.getDefaultPipeline({ includeSerialization: false })
-    );
-
-    log.serviceLoaded('otelSynthtraceClient');
-  }
-
-  return otelSynthtraceEsClientInstance;
 }

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/synthtrace.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/synthtrace.ts
@@ -20,7 +20,6 @@ import type { SynthtraceEsClient } from '@kbn/apm-synthtrace/src/lib/shared/base
 import {
   getApmSynthtraceEsClient,
   getInfraSynthtraceEsClient,
-  getOtelSynthtraceEsClient,
 } from '../../../common/services/synthtrace';
 import { coreWorkerFixtures } from './core_fixtures';
 
@@ -79,14 +78,6 @@ export const synthtraceFixture = coreWorkerFixtures.extend<{}, SynthtraceFixture
       );
 
       await useSynthtraceClient<InfraDocument>(infraSynthtraceEsClient, use);
-    },
-    { scope: 'worker' },
-  ],
-  otelSynthtraceEsClient: [
-    async ({ esClient, log }, use) => {
-      const otelSynthtraceEsClient = await getOtelSynthtraceEsClient(esClient, log);
-
-      await useSynthtraceClient<OtelDocument>(otelSynthtraceEsClient, use);
     },
     { scope: 'worker' },
   ],

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_overview/otel_edot_service_overview_and_transactions.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_overview/otel_edot_service_overview_and_transactions.cy.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import url from 'url';
+import { synthtrace } from '../../../synthtrace';
+import { adserviceEdot } from '../../fixtures/synthtrace/adservice_edot';
+import { checkA11y } from '../../support/commands';
+
+const start = '2021-10-10T00:00:00.000Z';
+const end = '2021-10-10T00:15:00.000Z';
+const serviceInstanceId = 'da7a8507-53be-421c-8d77-984f12397213';
+
+const serviceOverviewPath = '/app/apm/services/adservice-edot-synth/overview';
+const baseUrl = url.format({
+  pathname: serviceOverviewPath,
+  query: { rangeFrom: start, rangeTo: end },
+});
+
+const transactionTabPath = '/app/apm/services/adservice-edot-synth/transactions/view';
+const transactionUrl = url.format({
+  pathname: transactionTabPath,
+  query: { rangeFrom: start, rangeTo: end, transactionName: 'oteldemo.AdServiceEdotSynth/GetAds' },
+});
+
+describe('Service Overview', () => {
+  before(() => {
+    synthtrace.index(
+      adserviceEdot({
+        from: new Date(start).getTime(),
+        to: new Date(end).getTime(),
+      }),
+      'otelToApm'
+    );
+  });
+
+  after(() => {
+    synthtrace.clean();
+  });
+
+  describe('renders', () => {
+    beforeEach(() => {
+      cy.loginAsViewerUser();
+      cy.visitKibana(baseUrl);
+    });
+
+    it('renders all components on the page', () => {
+      cy.contains('adservice-edot-synth');
+      // set skipFailures to true to not fail the test when there are accessibility failures
+      checkA11y({ skipFailures: true });
+      cy.getByTestSubj('latencyChart');
+      cy.getByTestSubj('throughput');
+      cy.getByTestSubj('transactionsGroupTable');
+      cy.getByTestSubj('serviceOverviewErrorsTable');
+      cy.getByTestSubj('dependenciesTable');
+      cy.getByTestSubj('instancesLatencyDistribution');
+      cy.getByTestSubj('serviceOverviewInstancesTable');
+    });
+  });
+
+  describe('service icons', () => {
+    beforeEach(() => {
+      cy.loginAsViewerUser();
+    });
+
+    it('show information on click', () => {
+      cy.intercept('GET', '/internal/apm/services/adservice-edot-synth/metadata/details?*').as(
+        'metadataDetailsRequest'
+      );
+
+      cy.visitKibana(baseUrl);
+
+      cy.getByTestSubj('opentelemetry').click();
+      cy.wait('@metadataDetailsRequest');
+      cy.contains('dt', 'Language');
+      cy.contains('dd', 'java');
+    });
+  });
+
+  describe('instances table', () => {
+    beforeEach(() => {
+      cy.loginAsViewerUser();
+    });
+
+    it('has data in the table', () => {
+      cy.visitKibana(baseUrl);
+      cy.contains('adservice-edot-synth');
+      cy.getByTestSubj('serviceInstancesTableContainer');
+      cy.contains(serviceInstanceId);
+    });
+  });
+
+  describe('transactions', () => {
+    beforeEach(() => {
+      cy.loginAsViewerUser();
+    });
+
+    it('navigates to transaction detail page', () => {
+      cy.visitKibana(baseUrl);
+      cy.contains('Transactions').click();
+
+      cy.contains('a', 'oteldemo.AdServiceEdotSynth/GetAds').click();
+      cy.contains('h5', 'oteldemo.AdServiceEdotSynth/GetAds');
+    });
+    it('shows transaction summary', () => {
+      cy.visitKibana(transactionUrl);
+
+      cy.getByTestSubj('apmHttpInfoRequestMethod').should('exist');
+      cy.getByTestSubj('apmHttpInfoRequestMethod').contains('GET');
+      cy.getByTestSubj('apmHttpInfoUrl').should('exist');
+      cy.getByTestSubj('apmHttpInfoUrl').contains(
+        'https://otel-demo-blue-adservice-edot-synth:8080/some/path'
+      );
+      cy.getByTestSubj('apmHttpInfoRequestMethod').should('exist');
+      cy.getByTestSubj('apmHttpStatusBadge').should('exist');
+      cy.getByTestSubj('apmHttpStatusBadge').contains('OK');
+    });
+  });
+
+  describe('errors', () => {
+    beforeEach(() => {
+      cy.loginAsViewerUser();
+      cy.visitKibana(baseUrl);
+    });
+
+    it('navigates to the errors page', () => {
+      cy.contains('adservice-edot-synth');
+      cy.contains('a', 'View errors').click();
+      cy.url().should('include', '/adservice-edot-synth/errors');
+    });
+  });
+});

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_overview/otel_service_overview_and_transactions.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_overview/otel_service_overview_and_transactions.cy.ts
@@ -6,7 +6,7 @@
  */
 
 import url from 'url';
-import { synthtraceOtel } from '../../../synthtrace';
+import { synthtrace } from '../../../synthtrace';
 import { sendotlp } from '../../fixtures/synthtrace/sendotlp';
 import { checkA11y } from '../../support/commands';
 
@@ -28,16 +28,17 @@ const transactionUrl = url.format({
 
 describe('Service Overview', () => {
   before(() => {
-    synthtraceOtel.index(
+    synthtrace.index(
       sendotlp({
         from: new Date(start).getTime(),
         to: new Date(end).getTime(),
-      })
+      }),
+      'otelToApm'
     );
   });
 
   after(() => {
-    synthtraceOtel.clean();
+    synthtrace.clean();
   });
 
   describe('renders', () => {
@@ -110,9 +111,9 @@ describe('Service Overview', () => {
 
       cy.wait('@transactionTypesRequest');
 
-      cy.getByTestSubj('headerFilterTransactionType').should('have.value', 'unknown');
+      cy.getByTestSubj('headerFilterTransactionType').should('have.value', 'request');
       cy.contains('Transactions').click();
-      cy.getByTestSubj('headerFilterTransactionType').should('have.value', 'unknown');
+      cy.getByTestSubj('headerFilterTransactionType').should('have.value', 'request');
       cy.contains('parent-synth');
     });
 

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/adservice_edot.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/adservice_edot.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { apm, timerange } from '@kbn/apm-synthtrace-client';
+
+export function adserviceEdot({ from, to }: { from: number; to: number }) {
+  const range = timerange(from, to);
+  const transactionName = 'oteldemo.AdServiceEdotSynth/GetAds';
+
+  const edotInstance = apm
+    .otelService({
+      name: 'adservice-edot-synth',
+      namespace: 'opentelemetry-demo',
+      sdkLanguage: 'java',
+      sdkName: 'opentelemetry',
+      distro: 'elastic',
+    })
+    .instance('da7a8507-53be-421c-8d77-984f12397213');
+
+  return range
+    .interval('1s')
+    .rate(1)
+    .generator((timestamp) => [
+      edotInstance
+        .span({
+          name: transactionName,
+          kind: 'Server',
+        })
+        .overrides({
+          'attributes.server.address': 'otel-demo-blue-adservice-edot-synth',
+          'attributes.server.port': 8080,
+          'attributes.url.path': '/some/path',
+          'attributes.url.scheme': 'https',
+        })
+        .timestamp(timestamp)
+        .duration(551)
+        .success(),
+    ]);
+}

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/sendotlp.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/sendotlp.ts
@@ -4,26 +4,64 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { generateShortId, otel, timerange } from '@kbn/apm-synthtrace-client';
-import { times } from 'lodash';
+import { apm, timerange } from '@kbn/apm-synthtrace-client';
 
 export function sendotlp({ from, to }: { from: number; to: number }) {
   const range = timerange(from, to);
-  const traceId = generateShortId();
-  const spanId = generateShortId();
+  const transactionName = 'parent-synth';
 
-  const otelSendotlp = times(2).map((index) => otel.create(traceId));
+  const otelSendotlp = apm
+    .otelService({
+      name: 'sendotlp-otel-native-synth',
+      sdkName: 'otlp',
+      sdkLanguage: 'go',
+    })
+    .instance('89117ac1-0dbf-4488-9e17-4c2c3b76943a');
 
   return range
     .interval('1s')
     .rate(1)
-    .generator((timestamp) =>
-      otelSendotlp.flatMap((otelDoc) => {
-        return [
-          otelDoc.metric().timestamp(timestamp),
-          otelDoc.transaction(spanId).timestamp(timestamp),
-          otelDoc.error(spanId).timestamp(timestamp),
-        ];
-      })
-    );
+    .generator((timestamp) => [
+      otelSendotlp
+        .span({
+          name: transactionName,
+          kind: 'Server',
+        })
+        .defaults({
+          'attributes.transaction.result': 'HTTP 2xx',
+        })
+        .timestamp(timestamp)
+        .duration(15202)
+        .success()
+        .children(
+          otelSendotlp
+            .httpExitSpan({
+              destinationUrl: 'https://foo_service-otel-native-synth:8080',
+              method: 'GET',
+              name: 'child1',
+              statusCode: 200,
+            })
+            .duration(1000)
+            .success()
+            .timestamp(timestamp)
+        ),
+
+      otelSendotlp
+        .span({
+          name: transactionName,
+          kind: 'Server',
+        })
+        .timestamp(timestamp)
+        .duration(1000)
+        .failure()
+        .errors(
+          otelSendotlp
+            .error({
+              message: 'boom',
+              type: '*errors.errorString',
+              stackTrace: 'Error: INTERNAL: Boom',
+            })
+            .timestamp(timestamp + 50)
+        ),
+    ]);
 }

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/setup_cypress_node_events.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/setup_cypress_node_events.ts
@@ -4,12 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import {
-  ApmSynthtraceEsClient,
-  OtelSynthtraceEsClient,
-  createLogger,
-  LogLevel,
-} from '@kbn/apm-synthtrace';
+import type { ApmSynthtracePipelines } from '@kbn/apm-synthtrace';
+import { ApmSynthtraceEsClient, createLogger, LogLevel } from '@kbn/apm-synthtrace';
 import { createEsClientForTesting } from '@kbn/test';
 // eslint-disable-next-line @kbn/imports/no_unresolvable_imports
 import { initPlugin } from '@frsource/cypress-plugin-visual-regression-diff/plugins';
@@ -31,20 +27,6 @@ export function setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.Plugin
     version: config.env.APM_PACKAGE_VERSION,
   });
 
-  const synthtraceOtelEsClient = new OtelSynthtraceEsClient({
-    client,
-    logger,
-    refreshAfterIndex: true,
-  });
-
-  synthtraceEsClient.pipeline(
-    synthtraceEsClient.getDefaultPipeline({ includeSerialization: false })
-  );
-
-  synthtraceOtelEsClient.pipeline(
-    synthtraceOtelEsClient.getDefaultPipeline({ includeSerialization: false })
-  );
-
   initPlugin(on, config);
 
   on('task', {
@@ -55,20 +37,22 @@ export function setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.Plugin
       return null;
     },
 
-    async 'synthtrace:index'(events: Array<Record<string, any>>) {
+    async 'synthtrace:index'({
+      events,
+      pipeline,
+    }: {
+      events: Array<Record<string, any>>;
+      pipeline: ApmSynthtracePipelines;
+    }) {
+      synthtraceEsClient.pipeline(
+        synthtraceEsClient.getPipeline(pipeline, { includeSerialization: false })
+      );
+
       await synthtraceEsClient.index(Readable.from(events));
       return null;
     },
     async 'synthtrace:clean'() {
       await synthtraceEsClient.clean();
-      return null;
-    },
-    async 'synthtraceOtel:index'(events: Array<Record<string, any>>) {
-      await synthtraceOtelEsClient.index(Readable.from(events));
-      return null;
-    },
-    async 'synthtraceOtel:clean'() {
-      await synthtraceOtelEsClient.clean();
       return null;
     },
   });

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/synthtrace.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/synthtrace.ts
@@ -4,22 +4,22 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { Serializable, ApmFields, SynthtraceGenerator } from '@kbn/apm-synthtrace-client';
+import type { ApmSynthtracePipelines } from '@kbn/apm-synthtrace';
+import type {
+  Serializable,
+  ApmFields,
+  ApmOtelFields,
+  SynthtraceGenerator,
+} from '@kbn/apm-synthtrace-client';
 
 export const synthtrace = {
-  index: (events: SynthtraceGenerator<ApmFields> | Array<Serializable<ApmFields>>) =>
-    cy.task(
-      'synthtrace:index',
-      Array.from(events).flatMap((event) => event.serialize())
-    ),
+  index: <TFields extends ApmFields | ApmOtelFields>(
+    events: SynthtraceGenerator<TFields> | Array<Serializable<TFields>>,
+    pipeline: ApmSynthtracePipelines = 'default'
+  ) =>
+    cy.task('synthtrace:index', {
+      events: Array.from(events).flatMap((event) => event.serialize()),
+      pipeline,
+    }),
   clean: () => cy.task('synthtrace:clean'),
-};
-
-export const synthtraceOtel = {
-  index: (events: SynthtraceGenerator<ApmFields> | Array<Serializable<ApmFields>>) =>
-    cy.task(
-      'synthtraceOtel:index',
-      Array.from(events).flatMap((event) => event.serialize())
-    ),
-  clean: () => cy.task('synthtraceOtel:clean'),
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Synthtrace] APM Otel v2 (#217019)](https://github.com/elastic/kibana/pull/217019)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-08T07:16:19Z","message":"[Synthtrace] APM Otel v2 (#217019)\n\n## Summary\nThis PR enhances support for otel data in Synthtrace. It introduces the\nability to generate otel-sdk data and transforms APM Server data into\notel format.\n\nKey Changes\n- Added a pipeline for processing otel traces.\n\n- Add a pipeline to convert APM server traces into exported otel traces\n\n- Removed `OtelSynthtraceEsClient` in favor of `ApmSynthtraceEsClient`.\n\n### Examples\n\nReproduces the otlp traces -> APM Server/tracesexporter -> output case\n```ts\n // this needs to be set in the synthtrace scenario's `bootstrap` to run the correct pipeline\napmEsClient.pipeline(apmEsClient.getPipeline('otelToApm'));\n\n// scenario\napm.otelService({\n    name: 'sendotlp-otel-native-synth',\n    sdkName: 'otlp',\n    sdkLanguage: 'nodejs',\n  })\n  .instance('otel-native-instance')\n   // this interface doesn't provide a `transaction` function\n  .span({\n    name: transactionName,\n    kind: 'Server',\n  })\n  .timestamp(timestamp)\n  .duration(1000)\n  .success()\n  .children(\n    instance\n      .dbExitSpan({\n        name: 'GET /',\n        type: 'elasticsearch',\n      })\n      .duration(1000)\n      .success()\n      .timestamp(timestamp)\n  )\n```\n\nAPM Server -> otel output. This can be useful for reusing existing\nsynthtrace scenarios.\n\n```ts\n // this needs to be set in the synthtrace scenario's `bootstrap` to run the correct pipeline\n apmEsClient.pipeline(apmEsClient.getPipeline('apmToOtel'));\n\n // scenario\n apm.service({\n    name: 'apmserver-otel-synth',\n    environment: 'prod',\n    agentName: 'opentelemetry/java',\n  })\n  .instance('otel-apmserver-instance')\n  .transaction({ transactionName })\n  .timestamp(timestamp)\n  .defaults({\n    'url.domain': 'foo.bar',\n  })\n  .duration(1000)\n  .success()\n  .children(\n    otelApmServerInstace\n      .span({\n        spanName: 'GET apm-*/_search',\n        spanType: 'db',\n        spanSubtype: 'elasticsearch',\n      })\n      .duration(1000)\n      .success()\n      .destination('elasticsearch')\n      .timestamp(timestamp)\n  )\n```\n\n### How to test\n\n\notel -> APM Server/tracesexporter -> output\nRun `node scripts/synthtrace otel_simple_trace.ts --live --uniqueIds\n--clean`\n\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e237e506-1c0d-4851-9053-0f1e2fe554db\"\n/>\n\nAPM Server -> otel \n\nRun `node scripts/synthtrace simple_trace.ts --scenarioOpts\npipeline=apmToOtel --live --uniqueIds --clean`\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1bd577be-ded6-44ad-a54d-c5bb4e5ad59d\"\n/>\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9cc220ac52f6f5a64fbf53e03217121aec9056cf","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:obs-ux-infra_services","v9.1.0"],"title":"[Synthtrace] APM Otel v2","number":217019,"url":"https://github.com/elastic/kibana/pull/217019","mergeCommit":{"message":"[Synthtrace] APM Otel v2 (#217019)\n\n## Summary\nThis PR enhances support for otel data in Synthtrace. It introduces the\nability to generate otel-sdk data and transforms APM Server data into\notel format.\n\nKey Changes\n- Added a pipeline for processing otel traces.\n\n- Add a pipeline to convert APM server traces into exported otel traces\n\n- Removed `OtelSynthtraceEsClient` in favor of `ApmSynthtraceEsClient`.\n\n### Examples\n\nReproduces the otlp traces -> APM Server/tracesexporter -> output case\n```ts\n // this needs to be set in the synthtrace scenario's `bootstrap` to run the correct pipeline\napmEsClient.pipeline(apmEsClient.getPipeline('otelToApm'));\n\n// scenario\napm.otelService({\n    name: 'sendotlp-otel-native-synth',\n    sdkName: 'otlp',\n    sdkLanguage: 'nodejs',\n  })\n  .instance('otel-native-instance')\n   // this interface doesn't provide a `transaction` function\n  .span({\n    name: transactionName,\n    kind: 'Server',\n  })\n  .timestamp(timestamp)\n  .duration(1000)\n  .success()\n  .children(\n    instance\n      .dbExitSpan({\n        name: 'GET /',\n        type: 'elasticsearch',\n      })\n      .duration(1000)\n      .success()\n      .timestamp(timestamp)\n  )\n```\n\nAPM Server -> otel output. This can be useful for reusing existing\nsynthtrace scenarios.\n\n```ts\n // this needs to be set in the synthtrace scenario's `bootstrap` to run the correct pipeline\n apmEsClient.pipeline(apmEsClient.getPipeline('apmToOtel'));\n\n // scenario\n apm.service({\n    name: 'apmserver-otel-synth',\n    environment: 'prod',\n    agentName: 'opentelemetry/java',\n  })\n  .instance('otel-apmserver-instance')\n  .transaction({ transactionName })\n  .timestamp(timestamp)\n  .defaults({\n    'url.domain': 'foo.bar',\n  })\n  .duration(1000)\n  .success()\n  .children(\n    otelApmServerInstace\n      .span({\n        spanName: 'GET apm-*/_search',\n        spanType: 'db',\n        spanSubtype: 'elasticsearch',\n      })\n      .duration(1000)\n      .success()\n      .destination('elasticsearch')\n      .timestamp(timestamp)\n  )\n```\n\n### How to test\n\n\notel -> APM Server/tracesexporter -> output\nRun `node scripts/synthtrace otel_simple_trace.ts --live --uniqueIds\n--clean`\n\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e237e506-1c0d-4851-9053-0f1e2fe554db\"\n/>\n\nAPM Server -> otel \n\nRun `node scripts/synthtrace simple_trace.ts --scenarioOpts\npipeline=apmToOtel --live --uniqueIds --clean`\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1bd577be-ded6-44ad-a54d-c5bb4e5ad59d\"\n/>\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9cc220ac52f6f5a64fbf53e03217121aec9056cf"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217019","number":217019,"mergeCommit":{"message":"[Synthtrace] APM Otel v2 (#217019)\n\n## Summary\nThis PR enhances support for otel data in Synthtrace. It introduces the\nability to generate otel-sdk data and transforms APM Server data into\notel format.\n\nKey Changes\n- Added a pipeline for processing otel traces.\n\n- Add a pipeline to convert APM server traces into exported otel traces\n\n- Removed `OtelSynthtraceEsClient` in favor of `ApmSynthtraceEsClient`.\n\n### Examples\n\nReproduces the otlp traces -> APM Server/tracesexporter -> output case\n```ts\n // this needs to be set in the synthtrace scenario's `bootstrap` to run the correct pipeline\napmEsClient.pipeline(apmEsClient.getPipeline('otelToApm'));\n\n// scenario\napm.otelService({\n    name: 'sendotlp-otel-native-synth',\n    sdkName: 'otlp',\n    sdkLanguage: 'nodejs',\n  })\n  .instance('otel-native-instance')\n   // this interface doesn't provide a `transaction` function\n  .span({\n    name: transactionName,\n    kind: 'Server',\n  })\n  .timestamp(timestamp)\n  .duration(1000)\n  .success()\n  .children(\n    instance\n      .dbExitSpan({\n        name: 'GET /',\n        type: 'elasticsearch',\n      })\n      .duration(1000)\n      .success()\n      .timestamp(timestamp)\n  )\n```\n\nAPM Server -> otel output. This can be useful for reusing existing\nsynthtrace scenarios.\n\n```ts\n // this needs to be set in the synthtrace scenario's `bootstrap` to run the correct pipeline\n apmEsClient.pipeline(apmEsClient.getPipeline('apmToOtel'));\n\n // scenario\n apm.service({\n    name: 'apmserver-otel-synth',\n    environment: 'prod',\n    agentName: 'opentelemetry/java',\n  })\n  .instance('otel-apmserver-instance')\n  .transaction({ transactionName })\n  .timestamp(timestamp)\n  .defaults({\n    'url.domain': 'foo.bar',\n  })\n  .duration(1000)\n  .success()\n  .children(\n    otelApmServerInstace\n      .span({\n        spanName: 'GET apm-*/_search',\n        spanType: 'db',\n        spanSubtype: 'elasticsearch',\n      })\n      .duration(1000)\n      .success()\n      .destination('elasticsearch')\n      .timestamp(timestamp)\n  )\n```\n\n### How to test\n\n\notel -> APM Server/tracesexporter -> output\nRun `node scripts/synthtrace otel_simple_trace.ts --live --uniqueIds\n--clean`\n\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/e237e506-1c0d-4851-9053-0f1e2fe554db\"\n/>\n\nAPM Server -> otel \n\nRun `node scripts/synthtrace simple_trace.ts --scenarioOpts\npipeline=apmToOtel --live --uniqueIds --clean`\n\n<img width=\"800\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/1bd577be-ded6-44ad-a54d-c5bb4e5ad59d\"\n/>\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"9cc220ac52f6f5a64fbf53e03217121aec9056cf"}}]}] BACKPORT-->