### PR TITLE
[9.0] Update publish_oas_docs.sh for 9.0, 8.19, and 8.18 (#219864)

### DIFF
--- a/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
+++ b/.buildkite/scripts/steps/openapi_publishing/publish_oas_docs.sh
@@ -46,10 +46,24 @@ if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
   exit 0;
 fi
 
-if [[ "$BUILDKITE_BRANCH" == "8.x" ]]; then
+if [[ "$BUILDKITE_BRANCH" == "9.0" ]]; then
+  BUMP_KIBANA_DOC_NAME="$(vault_get kibana-bump-sh kibana-doc-name)"
+  BUMP_KIBANA_DOC_TOKEN="$(vault_get kibana-bump-sh kibana-token)"
+  deploy_to_bump "$(pwd)/oas_docs/output/kibana.yaml" $BUMP_KIBANA_DOC_NAME $BUMP_KIBANA_DOC_TOKEN v9;
+  exit 0;
+fi
+
+if [[ "$BUILDKITE_BRANCH" == "8.19" ]]; then
   BUMP_KIBANA_DOC_NAME="$(vault_get kibana-bump-sh kibana-doc-name)"
   BUMP_KIBANA_DOC_TOKEN="$(vault_get kibana-bump-sh kibana-token)"
   deploy_to_bump "$(pwd)/oas_docs/output/kibana.yaml" $BUMP_KIBANA_DOC_NAME $BUMP_KIBANA_DOC_TOKEN 8x-unreleased;
+  exit 0;
+fi
+
+if [[ "$BUILDKITE_BRANCH" == "8.18" ]]; then
+  BUMP_KIBANA_DOC_NAME="$(vault_get kibana-bump-sh kibana-doc-name)"
+  BUMP_KIBANA_DOC_TOKEN="$(vault_get kibana-bump-sh kibana-token)"
+  deploy_to_bump "$(pwd)/oas_docs/output/kibana.yaml" $BUMP_KIBANA_DOC_NAME $BUMP_KIBANA_DOC_TOKEN v8;
   exit 0;
 fi
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Update publish_oas_docs.sh for 9.0, 8.19, and 8.18 (#219864)](https://github.com/elastic/kibana/pull/219864)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2025-05-05T18:54:51Z","message":"Update publish_oas_docs.sh for 9.0, 8.19, and 8.18 (#219864)","sha":"3a2866bb93dc864cef81212493fdcc2eefe3addc","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","backport:all-open","v9.1.0"],"title":"Update publish_oas_docs.sh for 9.0, 8.19, and 8.18","number":219864,"url":"https://github.com/elastic/kibana/pull/219864","mergeCommit":{"message":"Update publish_oas_docs.sh for 9.0, 8.19, and 8.18 (#219864)","sha":"3a2866bb93dc864cef81212493fdcc2eefe3addc"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219864","number":219864,"mergeCommit":{"message":"Update publish_oas_docs.sh for 9.0, 8.19, and 8.18 (#219864)","sha":"3a2866bb93dc864cef81212493fdcc2eefe3addc"}},{"url":"https://github.com/elastic/kibana/pull/220140","number":220140,"branch":"8.19","state":"OPEN"}]}] BACKPORT-->