### PR TITLE
Add Core Rendering Service to SharedUX Dev Docs sidenav

### DIFF
--- a/dev_docs/nav-kibana-dev.docnav.json
+++ b/dev_docs/nav-kibana-dev.docnav.json
@@ -283,8 +283,8 @@
           "label": "Kibana Page Template"
         },
         {
-          "id": "kibDevReactKibanaContext",
-          "label": "Kibana React Contexts"
+          "id": "kibDevRenderingService",
+          "label": "Core Rendering Service"
         },
         {
           "id": "kibDevDocsChromeRecentlyAccessed",

--- a/dev_docs/shared_ux/shared_ux_landing.mdx
+++ b/dev_docs/shared_ux/shared_ux_landing.mdx
@@ -62,11 +62,6 @@ layout: landing
       description: 'Learn how to provide the Kibana global context in your React apps',
     },
     {
-      pageId: 'kibDevReactKibanaContext',
-      title: 'Kibana React Contexts',
-      description: 'Learn how to use common React contexts in Kibana',
-    },
-    {
       pageId: 'kibDevDocsChromeRecentlyAccessed',
       title: 'Chrome Recently Viewed',
       description: 'Learn how to add recently viewed items to the side navigation',


### PR DESCRIPTION
A documentation structure update was unintentionally missed in https://github.com/elastic/kibana/pull/218630

This update promotes the Core Rendering Service and offsets the prior documentation of Kibana React Contexts.

## Summary

<img width="1800" alt="image" src="https://github.com/user-attachments/assets/9c7634c9-2a1e-43d8-8bb7-850bbf96fc53" />
