### PR TITLE
Upgrade `chromedriver` to 136

### DIFF
--- a/package.json
+++ b/package.json
@@ -1754,7 +1754,7 @@
     "buildkite-test-collector": "^1.7.0",
     "callsites": "^3.1.0",
     "chance": "1.0.18",
-    "chromedriver": "^134.0.0",
+    "chromedriver": "^136.0.0",
     "clarify": "^2.2.0",
     "clean-webpack-plugin": "^4.0.0",
     "cli-progress": "^3.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14721,10 +14721,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^134.0.0:
-  version "134.0.2"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-134.0.2.tgz#a9ccfbb4e1f3398c3289e755ddec657ed8158ccf"
-  integrity sha512-r1yIHP0Lo61CdFGjZXITSY2ZGYBS5B/qwOs8NMm0r31qnyS4MAuSmMiIiZKhu+ThxfcT8zPrGPGT6RmM0LWljQ==
+chromedriver@^136.0.0:
+  version "136.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-136.0.0.tgz#b777a33ea50b8c775b522317175379d8c79e84ab"
+  integrity sha512-21LxtGIqRLkafi0aOLKxIyQ3uRklgdmhuihzAkoL3Er5QtC74UDuu2OeTDdh58LM7WDbiuTXjdoIQARUekL8DA==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
     axios "^1.7.4"


### PR DESCRIPTION
## Summary

This isn't being triggered by Renovate, updating to unblock while investigating




<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->