### PR TITLE
[8.18] Upgrade `chromedriver` to 136 (#220178)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1716,7 +1716,7 @@
     "buildkite-test-collector": "^1.7.0",
     "callsites": "^3.1.0",
     "chance": "1.0.18",
-    "chromedriver": "^134.0.0",
+    "chromedriver": "^136.0.0",
     "clean-webpack-plugin": "^4.0.0",
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15496,10 +15496,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^134.0.0:
-  version "134.0.2"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-134.0.2.tgz#a9ccfbb4e1f3398c3289e755ddec657ed8158ccf"
-  integrity sha512-r1yIHP0Lo61CdFGjZXITSY2ZGYBS5B/qwOs8NMm0r31qnyS4MAuSmMiIiZKhu+ThxfcT8zPrGPGT6RmM0LWljQ==
+chromedriver@^136.0.0:
+  version "136.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-136.0.0.tgz#b777a33ea50b8c775b522317175379d8c79e84ab"
+  integrity sha512-21LxtGIqRLkafi0aOLKxIyQ3uRklgdmhuihzAkoL3Er5QtC74UDuu2OeTDdh58LM7WDbiuTXjdoIQARUekL8DA==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
     axios "^1.7.4"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Upgrade `chromedriver` to 136 (#220178)](https://github.com/elastic/kibana/pull/220178)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-06T01:19:14Z","message":"Upgrade `chromedriver` to 136 (#220178)\n\n## Summary\n\nThis isn't being triggered by Renovate, updating to unblock while\ninvestigating","sha":"b8b16f30042008bca3c343a241cc269a6e08228c","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:prev-minor","backport:prev-major","v9.1.0"],"title":"Upgrade `chromedriver` to 136","number":220178,"url":"https://github.com/elastic/kibana/pull/220178","mergeCommit":{"message":"Upgrade `chromedriver` to 136 (#220178)\n\n## Summary\n\nThis isn't being triggered by Renovate, updating to unblock while\ninvestigating","sha":"b8b16f30042008bca3c343a241cc269a6e08228c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220178","number":220178,"mergeCommit":{"message":"Upgrade `chromedriver` to 136 (#220178)\n\n## Summary\n\nThis isn't being triggered by Renovate, updating to unblock while\ninvestigating","sha":"b8b16f30042008bca3c343a241cc269a6e08228c"}},{"url":"https://github.com/elastic/kibana/pull/220184","number":220184,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->