### PR TITLE
[8.19] [Discover] Add 'Copy value' button to field value cells (#217457) (#218817)

### DIFF
--- a/src/platform/packages/shared/kbn-discover-utils/index.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/index.ts
@@ -33,6 +33,7 @@ export {
   IgnoredReason,
   buildDataTableRecord,
   buildDataTableRecordList,
+  convertValueToString,
   createLogsContextService,
   createDegradedDocsControl,
   createStacktraceControl,

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.test.tsx
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
+import { convertValueToString } from './convert_value_to_string';
+import { formatFieldValue } from './format_value';
+import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
+import { buildDataViewMock } from '../__mocks__';
+
+export const mockSourceField = {
+  name: '_source',
+  type: '_source',
+  esTypes: ['_source'],
+  scripted: false,
+  searchable: false,
+  aggregatable: false,
+  readFromDocValues: false,
+} as DataViewField;
+
+export const mockStringField = {
+  count: 0,
+  name: 'array_objects.description.keyword',
+  type: 'string',
+  esTypes: ['keyword'],
+  scripted: false,
+  searchable: true,
+  aggregatable: true,
+  readFromDocValues: true,
+  subType: {
+    multi: {
+      parent: 'array_objects.description',
+    },
+  },
+} as DataViewField;
+
+export const dataViewComplexMock = buildDataViewMock({
+  name: 'data-view-with-various-field-types',
+  fields: [mockSourceField, mockStringField] as DataView['fields'],
+  timeFieldName: 'data',
+});
+
+// The format_value file has its own test suite, so we can mock it here to avoid duplication.
+jest.mock('./format_value');
+const mockFormatFieldValue = jest.mocked(formatFieldValue);
+
+describe('convertValueToString', () => {
+  describe('when the data view field type is _source', () => {
+    it('should stringify the flattened value', () => {
+      const result = convertValueToString({
+        dataView: dataViewComplexMock,
+        dataViewField: mockSourceField,
+        flattenedValue: 'test',
+        dataTableRecord: {
+          id: '1',
+          raw: {},
+          flattened: { testKey: 'testValue' },
+        },
+        fieldFormats: fieldFormatsMock,
+        options: { compatibleWithCSV: true },
+      });
+
+      expect(result).toEqual({
+        formattedString: `{\"testKey\":\"testValue\"}`,
+        withFormula: false,
+      });
+    });
+  });
+
+  describe('when the data view field type is not _source', () => {
+    describe('when the flattened value is an array', () => {
+      it('should format the values and join them with a comma', () => {
+        mockFormatFieldValue.mockReturnValueOnce('value1').mockReturnValueOnce('value2');
+
+        const result = convertValueToString({
+          dataView: dataViewComplexMock,
+          dataViewField: mockStringField,
+          flattenedValue: ['value1', 'value2'],
+          dataTableRecord: {
+            id: '1',
+            raw: {},
+            flattened: { testKey: 'testValue' },
+          },
+          fieldFormats: fieldFormatsMock,
+          options: { compatibleWithCSV: true },
+        });
+
+        expect(result).toEqual({
+          formattedString: `value1, value2`,
+          withFormula: false,
+        });
+      });
+    });
+
+    describe('when the flattened value is not an array', () => {
+      it('should format the value', () => {
+        mockFormatFieldValue.mockReturnValue('formattedValue');
+
+        const result = convertValueToString({
+          dataView: dataViewComplexMock,
+          dataViewField: mockStringField,
+          flattenedValue: 'value',
+          dataTableRecord: {
+            id: '1',
+            raw: {},
+            flattened: { testKey: 'testValue' },
+          },
+          fieldFormats: fieldFormatsMock,
+          options: { compatibleWithCSV: true },
+        });
+
+        expect(result).toEqual({
+          formattedString: `formattedValue`,
+          withFormula: false,
+        });
+      });
+    });
+  });
+});

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/convert_value_to_string.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
+import { cellHasFormulas, createEscapeValue } from '@kbn/data-plugin/common';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+import type { DataTableRecord } from '../../types';
+import { formatFieldValue } from './format_value';
+
+interface ConvertedResult {
+  formattedString: string;
+  withFormula: boolean;
+}
+
+const separator = ',';
+
+export const convertValueToString = ({
+  dataView,
+  dataViewField,
+  flattenedValue,
+  dataTableRecord,
+  fieldFormats,
+  options,
+}: {
+  dataView: DataView;
+  dataViewField?: DataViewField;
+  flattenedValue: unknown;
+  dataTableRecord: DataTableRecord;
+  fieldFormats: FieldFormatsStart;
+  options?: {
+    compatibleWithCSV?: boolean; // values as one-liner + escaping formulas + adding wrapping quotes
+  };
+}): ConvertedResult => {
+  const disableMultiline = options?.compatibleWithCSV ?? false;
+
+  if (dataViewField?.type === '_source') {
+    return {
+      formattedString: stringify(dataTableRecord.flattened, disableMultiline),
+      withFormula: false,
+    };
+  }
+
+  const valuesArray = Array.isArray(flattenedValue) ? flattenedValue : [flattenedValue];
+  const enableEscapingForValue = options?.compatibleWithCSV ?? false;
+  let withFormula = false;
+
+  const formatted = valuesArray
+    .map((subValue) => {
+      const formattedValue = formatFieldValue(
+        subValue,
+        dataTableRecord.raw,
+        fieldFormats,
+        dataView,
+        dataViewField,
+        'text',
+        {
+          skipFormattingInStringifiedJSON: disableMultiline,
+        }
+      );
+
+      if (typeof formattedValue === 'string') {
+        withFormula = withFormula || cellHasFormulas(formattedValue);
+        return enableEscapingForValue ? escapeFormattedValue(formattedValue) : formattedValue;
+      }
+
+      return stringify(formattedValue, disableMultiline) || '';
+    })
+    .join(`${separator} `);
+
+  return {
+    formattedString: formatted,
+    withFormula,
+  };
+};
+
+const stringify = (val: object | string, disableMultiline: boolean) => {
+  // it can wrap "strings" with quotes
+  return disableMultiline ? JSON.stringify(val) : JSON.stringify(val, null, 2);
+};
+
+const escapeValueFn = createEscapeValue({
+  separator,
+  quoteValues: true,
+  escapeFormulaValues: true,
+});
+
+const escapeFormattedValue = (formattedValue: string): string => {
+  return escapeValueFn(formattedValue);
+};

--- a/src/platform/packages/shared/kbn-discover-utils/src/utils/index.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/utils/index.ts
@@ -21,5 +21,6 @@ export * from './nested_fields';
 export * from './get_field_value';
 export * from './calc_field_counts';
 export * from './get_visible_columns';
+export * from './convert_value_to_string';
 export { isLegacyTableEnabled } from './is_legacy_table_enabled';
 export { DiscoverFlyouts, dismissAllFlyoutsExceptFor, dismissFlyouts } from './dismiss_flyouts';

--- a/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
@@ -25,7 +25,6 @@
     "@kbn/logs-data-access-plugin",
     "@kbn/i18n-react",
     "@kbn/navigation-plugin",
-    "@kbn/apm-sources-access-plugin",
     "@kbn/data-plugin",
   ]
 }

--- a/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
+++ b/src/platform/packages/shared/kbn-discover-utils/tsconfig.json
@@ -24,6 +24,8 @@
     "@kbn/expressions-plugin",
     "@kbn/logs-data-access-plugin",
     "@kbn/i18n-react",
-    "@kbn/navigation-plugin"
+    "@kbn/navigation-plugin",
+    "@kbn/apm-sources-access-plugin",
+    "@kbn/data-plugin",
   ]
 }

--- a/src/platform/plugins/shared/unified_doc_viewer/public/__mocks__/services.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/__mocks__/services.ts
@@ -17,6 +17,7 @@ import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
 import type { UnifiedDocViewerServices, UnifiedDocViewerStart } from '../types';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
+import { notificationServiceMock } from '@kbn/core/public/mocks';
 
 export const mockUnifiedDocViewer: jest.Mocked<UnifiedDocViewerStart> = {
   registry: new DocViewsRegistry(),
@@ -27,6 +28,7 @@ export const mockUnifiedDocViewerServices: jest.Mocked<UnifiedDocViewerServices>
   data: dataPluginMock.createStartContract(),
   fieldFormats: fieldFormatsMock,
   fieldsMetadata: fieldsMetadataPluginPublicMock.createStartContract(),
+  toasts: notificationServiceMock.createStartContract().toasts,
   storage: new Storage(localStorage),
   uiSettings: uiSettingsServiceMock.createStartContract(),
   unifiedDocViewer: mockUnifiedDocViewer,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/__snapshots__/table_cell_actions.test.tsx.snap
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/__snapshots__/table_cell_actions.test.tsx.snap
@@ -75,7 +75,41 @@ Array [
 ]
 `;
 
-exports[`TableActions getFieldValueCellActions should render correctly for undefined functions 1`] = `Array []`;
+exports[`TableActions getFieldValueCellActions should render correctly for undefined functions 1`] = `
+Array [
+  <Copy
+    Component={[Function]}
+    row={
+      FieldRow {
+        "columnsMeta": undefined,
+        "dataViewField": Object {
+          "aggregatable": false,
+          "displayName": "message",
+          "filterable": false,
+          "name": "message",
+          "scripted": false,
+          "type": "string",
+        },
+        "flattenedValue": "test",
+        "isPinned": false,
+        "name": "message",
+      }
+    }
+    toasts={
+      Object {
+        "add": [MockFunction],
+        "addDanger": [MockFunction],
+        "addError": [MockFunction],
+        "addInfo": [MockFunction],
+        "addSuccess": [MockFunction],
+        "addWarning": [MockFunction],
+        "get$": [MockFunction],
+        "remove": [MockFunction],
+      }
+    }
+  />,
+]
+`;
 
 exports[`TableActions getFieldValueCellActions should render the panels correctly for defined onFilter function 1`] = `
 Array [
@@ -118,6 +152,37 @@ Array [
         "flattenedValue": "test",
         "isPinned": false,
         "name": "message",
+      }
+    }
+  />,
+  <Copy
+    Component={[Function]}
+    row={
+      FieldRow {
+        "columnsMeta": undefined,
+        "dataViewField": Object {
+          "aggregatable": false,
+          "displayName": "message",
+          "filterable": false,
+          "name": "message",
+          "scripted": false,
+          "type": "string",
+        },
+        "flattenedValue": "test",
+        "isPinned": false,
+        "name": "message",
+      }
+    }
+    toasts={
+      Object {
+        "add": [MockFunction],
+        "addDanger": [MockFunction],
+        "addError": [MockFunction],
+        "addInfo": [MockFunction],
+        "addSuccess": [MockFunction],
+        "addWarning": [MockFunction],
+        "get$": [MockFunction],
+        "remove": [MockFunction],
       }
     }
   />,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/field_row.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/field_row.ts
@@ -10,6 +10,7 @@
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/common';
 import type { DataTableColumnsMeta, DataTableRecord } from '@kbn/discover-utils/types';
 import {
+  convertValueToString,
   formatFieldValue,
   getIgnoredReason,
   IgnoredReason,
@@ -92,16 +93,16 @@ export class FieldRow {
   // format as text in a lazy way
   public get formattedAsText(): string | undefined {
     if (!this.#isFormattedAsText) {
-      this.#formattedAsText = String(
-        formatFieldValue(
-          this.flattenedValue,
-          this.#hit.raw,
-          this.#fieldFormats,
-          this.#dataView,
-          this.dataViewField,
-          'text'
-        )
-      );
+      this.#formattedAsText = convertValueToString({
+        dataView: this.#dataView,
+        dataViewField: this.dataViewField,
+        flattenedValue: this.flattenedValue,
+        dataTableRecord: this.#hit,
+        fieldFormats: this.#fieldFormats,
+        options: {
+          compatibleWithCSV: true,
+        },
+      }).formattedString;
       this.#isFormattedAsText = true;
     }
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
@@ -131,7 +131,7 @@ export const DocViewerTable = ({
 }: DocViewRenderProps) => {
   const isEsqlMode = Array.isArray(textBasedHits);
   const [containerRef, setContainerRef] = useState<HTMLDivElement | null>(null);
-  const { fieldFormats, storage, uiSettings } = getUnifiedDocViewerServices();
+  const { fieldFormats, storage, uiSettings, toasts } = getUnifiedDocViewerServices();
   const showMultiFields = uiSettings.get(SHOW_MULTIFIELDS);
   const currentDataViewId = dataView.id!;
 
@@ -328,8 +328,8 @@ export const DocViewerTable = ({
     [rows, isEsqlMode, filter, onToggleColumn]
   );
   const fieldValueCellActions = useMemo(
-    () => getFieldValueCellActions({ rows, isEsqlMode, onFilter: filter }),
-    [rows, isEsqlMode, filter]
+    () => getFieldValueCellActions({ rows, isEsqlMode, toasts, onFilter: filter }),
+    [rows, isEsqlMode, toasts, filter]
   );
 
   useWindowSize(); // trigger re-render on window resize to recalculate the grid container height
@@ -356,7 +356,7 @@ export const DocViewerTable = ({
           defaultMessage: 'Value',
         }),
         actions: false,
-        visibleCellActions: 2,
+        visibleCellActions: 3,
         cellActions: fieldValueCellActions,
       },
     ],

--- a/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
@@ -108,7 +108,11 @@ export class UnifiedDocViewerPublicPlugin
   }
 
   public start(core: CoreStart, deps: UnifiedDocViewerStartDeps) {
-    const { analytics, uiSettings } = core;
+    const {
+      analytics,
+      uiSettings,
+      notifications: { toasts },
+    } = core;
     const { data, fieldFormats, fieldsMetadata, share } = deps;
     const storage = new Storage(localStorage);
     const unifiedDocViewer = {
@@ -119,6 +123,7 @@ export class UnifiedDocViewerPublicPlugin
       data,
       fieldFormats,
       fieldsMetadata,
+      toasts,
       storage,
       uiSettings,
       unifiedDocViewer,

--- a/src/platform/plugins/shared/unified_doc_viewer/public/types.ts
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/types.ts
@@ -19,6 +19,7 @@ import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/publ
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
+import type { IToasts } from '@kbn/core/public';
 import type { UnifiedDocViewerStart } from './plugin';
 
 export interface UnifiedDocViewerServices {
@@ -26,6 +27,7 @@ export interface UnifiedDocViewerServices {
   data: DataPublicPluginStart;
   fieldFormats: FieldFormatsStart;
   fieldsMetadata: FieldsMetadataPublicStart;
+  toasts: IToasts;
   storage: Storage;
   uiSettings: IUiSettingsClient;
   unifiedDocViewer: UnifiedDocViewerStart;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Discover] Add 'Copy value' button to field value cells (#217457) (#218817)](https://github.com/elastic/kibana/pull/218817)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alejandro García Parrondo","email":"31973472+AlexGPlay@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-05T11:38:43Z","message":"[Discover] Add 'Copy value' button to field value cells (#217457) (#218817)\n\n## Summary\n\nAdded a \"Copy value\" button to the field value cells.\n\n\n![chrome-capture-2025-4-23](https://github.com/user-attachments/assets/fb8d4815-9acd-47ab-b266-22008c9d22ac)\n\nSolves https://github.com/elastic/kibana/issues/217457\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d1a7c7bd52335f855f83d7e55453c86c960b5481","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Team:DataDiscovery","Feature:UnifiedDocViewer","backport:version","v9.1.0","v8.19.0"],"title":"[Discover] Add 'Copy value' button to field value cells (#217457)","number":218817,"url":"https://github.com/elastic/kibana/pull/218817","mergeCommit":{"message":"[Discover] Add 'Copy value' button to field value cells (#217457) (#218817)\n\n## Summary\n\nAdded a \"Copy value\" button to the field value cells.\n\n\n![chrome-capture-2025-4-23](https://github.com/user-attachments/assets/fb8d4815-9acd-47ab-b266-22008c9d22ac)\n\nSolves https://github.com/elastic/kibana/issues/217457\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d1a7c7bd52335f855f83d7e55453c86c960b5481"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218817","number":218817,"mergeCommit":{"message":"[Discover] Add 'Copy value' button to field value cells (#217457) (#218817)\n\n## Summary\n\nAdded a \"Copy value\" button to the field value cells.\n\n\n![chrome-capture-2025-4-23](https://github.com/user-attachments/assets/fb8d4815-9acd-47ab-b266-22008c9d22ac)\n\nSolves https://github.com/elastic/kibana/issues/217457\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [ ]\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\n- [ ] This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n### Identify risks\n\nDoes this PR introduce any risks? For example, consider risks like hard\nto test bugs, performance regression, potential of data loss.\n\nDescribe the risk, its severity, and mitigation for each identified\nrisk. Invite stakeholders and evaluate how to proceed before merging.\n\n- [ ] [See some risk\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)\n- [ ] ...\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"d1a7c7bd52335f855f83d7e55453c86c960b5481"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->