### PR TITLE
[9.0] [APM][OTel] Add EDOT support in the Synthtrace OTel client (#214141)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
@@ -36,5 +36,6 @@ export { appendHash, hashKeysOf } from './src/lib/utils/hash';
 export type { ESDocumentWithOperation, SynthtraceESAction, SynthtraceGenerator } from './src/types';
 export { log, type LogDocument, LONG_FIELD_NAME } from './src/lib/logs';
 export { syntheticsMonitor, type SyntheticsMonitorDocument } from './src/lib/synthetics';
-export { otel, type OtelDocument } from './src/lib/otel';
+export { otel, type OtelDocument } from './src/lib/otel/otel_native';
+export { otelEdot, type OtelEdotDocument } from './src/lib/otel/otel_edot';
 export { type EntityFields, entities } from './src/lib/entities';

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_edot/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_edot/index.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Fields } from '../../entity';
+import { Serializable } from '../../serializable';
+import { OtelEdotMetric } from './metric';
+import { OtelEdotTransaction } from './transaction';
+
+interface OtelEdotSharedResourceAttributes {
+  'service.name'?: string;
+  'agent.name'?: string;
+  'agent.version'?: string;
+  'metricset.interval'?: string;
+  'service.instance.id'?: string;
+  'telemetry.sdk.language'?: string;
+  'telemetry.sdk.name'?: string;
+  'telemetry.sdk.version'?: string;
+}
+
+export interface OtelEdotDocument extends Fields {
+  data_stream?: {
+    dataset: string;
+    namespace: string;
+    type: string;
+  };
+  attributes?: {
+    'timestamp.us'?: number;
+    'metricset.name'?: string;
+    [key: string]: any;
+  };
+  resource?: {
+    attributes?: OtelEdotSharedResourceAttributes;
+    dropped_attributes_count?: number;
+    schema_url?: string;
+  };
+  scope?: {
+    attributes?: {
+      'service.framework.name'?: string;
+      'service.framework.version'?: string;
+    };
+    dropped_attributes_count?: number;
+    name?: string;
+  };
+  name?: string;
+  trace_id?: string;
+  trace?: { id: string };
+  span_id?: string;
+  span?: { id: string };
+  dropped_attributes_count?: number;
+  dropped_events_count?: number;
+  dropped_links_count?: number;
+  timestamp_us?: number;
+}
+
+class OtelEdot extends Serializable<OtelEdotDocument> {
+  constructor(fields: OtelEdotDocument) {
+    super({
+      ...fields,
+    });
+  }
+
+  metric() {
+    return new OtelEdotMetric({
+      ...this.fields,
+      attributes: {
+        'service.name': 'adservice-edot-synth',
+        'span.kind': 'SPAN_KIND_INTERNAL',
+        'span.name': 'SynchronizationContext#drain',
+        'status.code': 'STATUS_CODE_UNSET',
+        'metricset.name': 'service_summary',
+        'processor.event': 'metric',
+      },
+      data_stream: {
+        dataset: 'generic.otel',
+        namespace: 'default',
+        type: 'metrics',
+      },
+      metrics: {
+        'traces.span.metrics.calls': 1,
+      },
+      resource: {
+        attributes: {
+          'agent.name': 'opentelemetry/java/elastic',
+          'agent.version': '1.0.1-SNAPSHOT',
+          'app.label.name': 'otel-demo-blue-adservice-edot-synth',
+          'cloud.account.id': 'elastic-product',
+          'cloud.availability_zone': 'us-central1-a',
+          'cloud.platform': 'gcp_kubernetes_engine',
+          'cloud.provider': 'gcp',
+          'container.id': 'e4f5dd426472aacd6124e85a0cd8a1ef55c263374c16179d1bf75292224c2dc0',
+          'deployment.environment': 'opentelemetry-demo',
+          'host.arch': 'amd64',
+          'host.id': '8645892066193866279',
+          'host.name': 'gke-demo-elastic-co-pool-5-29a9d3db-t79s',
+          'k8s.cluster.name': 'demo-elastic-co',
+          'k8s.deployment.name': 'otel-demo-blue-adservice-edot-synth',
+          'k8s.namespace.name': 'otel-blue',
+          'k8s.node.name': 'gke-demo-elastic-co-pool-5-29a9d3db-t79s',
+          'k8s.pod.ip': '10.12.3.63',
+          'k8s.pod.name': 'otel-demo-blue-adservice-edot-synth-7c68c8f968-tvf54',
+          'k8s.pod.start_time': '2025-01-15T12:51:39Z',
+          'k8s.pod.uid': 'da7a8507-53be-421c-8d77-984f12397213',
+          'k8s.replicaset.name': 'otel-demo-blue-adservice-edot-synth-7c68c8f968',
+          'os.description': 'Linux 5.15.109+',
+          'os.type': 'linux',
+          'process.command_line':
+            '/opt/java/openjdk/bin/java -javaagent:/usr/src/app/opentelemetry-javaagent.jar oteldemo.AdServiceEdotSynth',
+          'process.executable.path': '/opt/java/openjdk/bin/java',
+          'process.pid': 1,
+          'process.runtime.description': 'Eclipse Adoptium OpenJDK 64-Bit Server VM 21.0.5+11-LTS',
+          'process.runtime.name': 'OpenJDK Runtime Environment',
+          'process.runtime.version': '21.0.5+11-LTS',
+          'service.instance.id': 'da7a8507-53be-421c-8d77-984f12397213',
+          'service.name': 'adservice-edot-synth',
+          'service.namespace': 'opentelemetry-demo',
+          'telemetry.distro.name': 'elastic',
+          'telemetry.distro.version': '1.0.1-SNAPSHOT',
+          'telemetry.sdk.language': 'java',
+          'telemetry.sdk.name': 'opentelemetry',
+          'telemetry.sdk.version': '1.43.0',
+        },
+      },
+      scope: {
+        dropped_attributes_count: 0,
+        name: 'spanmetricsconnector',
+      },
+    });
+  }
+
+  transaction(id: string) {
+    return new OtelEdotTransaction({
+      ...this.fields,
+      attributes: {
+        'app.ads.ad_request_type': 'TARGETED',
+        'app.ads.ad_response_type': 'TARGETED',
+        'app.ads.contextKeys': '[travel]',
+        'app.ads.contextKeys.count': 1,
+        'app.ads.count': 1,
+        'event.outcome': 'success',
+        'event.success_count': 1,
+        'network.peer.address': '10.12.9.56',
+        'network.peer.port': 41208,
+        'network.type': 'ipv4',
+        'processor.event': 'transaction',
+        'rpc.grpc.status_code': 0,
+        'rpc.method': 'GetAds',
+        'rpc.service': 'oteldemo.AdServiceEdotSynth',
+        'rpc.system': 'grpc',
+        'server.address': 'otel-demo-blue-adservice-edot-synth',
+        'server.port': 8080,
+        'session.id': 'ce3ed7c7-47d7-42a5-baae-86d0a716752d',
+        'thread.id': 9412,
+        'thread.name': 'grpc-default-executor-23',
+        'timestamp.us': 1740679709260508,
+        'transaction.duration.us': 551,
+        'transaction.id': id,
+        'transaction.name': 'oteldemo.AdServiceEdotSynth/GetAds',
+        'transaction.representative_count': 1,
+        'transaction.result': 'OK',
+        'transaction.root': false,
+        'transaction.sampled': true,
+        'transaction.type': 'request',
+      },
+      data_stream: {
+        dataset: 'generic.otel',
+        namespace: 'default',
+        type: 'traces',
+      },
+      duration: 551551,
+      kind: 'Server',
+      name: 'oteldemo.AdServiceEdotSynth/GetAds',
+      // parent_span_id: 'b8fc0a55e4ae6b53',
+      resource: {
+        attributes: {
+          'agent.name': 'opentelemetry/java/elastic',
+          'agent.version': '1.0.1-SNAPSHOT',
+          'app.label.name': 'otel-demo-blue-adservice-edot-synth',
+          'cloud.account.id': 'elastic-product',
+          'cloud.availability_zone': 'us-central1-a',
+          'cloud.platform': 'gcp_kubernetes_engine',
+          'cloud.provider': 'gcp',
+          'container.id': 'e4f5dd426472aacd6124e85a0cd8a1ef55c263374c16179d1bf75292224c2dc0',
+          'deployment.environment': 'opentelemetry-demo',
+          'host.arch': 'amd64',
+          'host.id': '8645892066193866279',
+          'host.name': 'gke-demo-elastic-co-pool-5-29a9d3db-t79s',
+          'k8s.cluster.name': 'demo-elastic-co',
+          'k8s.deployment.name': 'otel-demo-blue-adservice-edot-synth',
+          'k8s.namespace.name': 'otel-blue',
+          'k8s.node.name': 'gke-demo-elastic-co-pool-5-29a9d3db-t79s',
+          'k8s.pod.ip': '10.12.3.63',
+          'k8s.pod.name': 'otel-demo-blue-adservice-edot-synth-7c68c8f968-tvf54',
+          'k8s.pod.start_time': '2025-01-15T12:51:39Z',
+          'k8s.pod.uid': 'da7a8507-53be-421c-8d77-984f12397213',
+          'k8s.replicaset.name': 'otel-demo-blue-adservice-edot-synth-7c68c8f968',
+          'os.description': 'Linux 5.15.109+',
+          'os.type': 'linux',
+          'process.command_line':
+            '/opt/java/openjdk/bin/java -javaagent:/usr/src/app/opentelemetry-javaagent.jar oteldemo.AdServiceEdotSynth',
+          'process.executable.path': '/opt/java/openjdk/bin/java',
+          'process.pid': 1,
+          'process.runtime.description': 'Eclipse Adoptium OpenJDK 64-Bit Server VM 21.0.5+11-LTS',
+          'process.runtime.name': 'OpenJDK Runtime Environment',
+          'process.runtime.version': '21.0.5+11-LTS',
+          'service.instance.id': 'da7a8507-53be-421c-8d77-984f12397213',
+          'service.name': 'adservice-edot-synth',
+          'service.namespace': 'opentelemetry-demo',
+          'telemetry.distro.name': 'elastic',
+          'telemetry.distro.version': '1.0.1-SNAPSHOT',
+          'telemetry.sdk.language': 'java',
+          'telemetry.sdk.name': 'opentelemetry',
+          'telemetry.sdk.version': '1.43.0',
+        },
+        // schema_url: 'https://opentelemetry.io/schemas/1.24.0',
+      },
+      scope: {
+        attributes: {
+          'service.framework.name': 'io.opentelemetry.grpc-1.6',
+          'service.framework.version': '2.9.0-alpha',
+        },
+        dropped_attributes_count: 0,
+        name: 'io.opentelemetry.grpc-1.6',
+        // version: '2.9.0-alpha',
+      },
+      span_id: '8884909eca61b9d5',
+      status: {
+        code: 'Unset',
+      },
+      trace_id: '70219abfdc4f0e17ca0975a339c2c135',
+    });
+  }
+}
+
+export function create(id: string): OtelEdot {
+  return new OtelEdot({
+    trace_id: id,
+    dropped_attributes_count: 0,
+    dropped_events_count: 0,
+    dropped_links_count: 0,
+  });
+}
+
+export const otelEdot = {
+  create,
+};

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_edot/metric.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_edot/metric.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { OtelEdotDocument } from '.';
+import { Serializable } from '../../serializable';
+
+export interface OtelEdotMetricDocument extends OtelEdotDocument {
+  attributes?: {
+    'metricset.name'?: string;
+    'processor.event'?: string;
+    'event.outcome'?: string;
+    'service.name'?: string;
+    'span.name'?: string;
+    'span.kind'?: string;
+    'status.code'?: string;
+    'span.destination.service.resource'?: string;
+  };
+  metrics?: {
+    service_summary?: number;
+    'traces.span.metrics.calls'?: number;
+  };
+  resource?: {
+    attributes?: {
+      'agent.name'?: string;
+      'agent.version'?: string;
+      'app.label.name'?: string;
+      'cloud.account.id'?: string;
+      'cloud.availability_zone'?: string;
+      'cloud.platform'?: string;
+      'cloud.provider'?: string;
+      'container.id'?: string;
+      'deployment.environment'?: string;
+      'host.arch'?: string;
+      'host.id'?: string;
+      'host.name'?: string;
+      'k8s.cluster.name'?: string;
+      'k8s.deployment.name'?: string;
+      'k8s.namespace.name'?: string;
+      'k8s.node.name'?: string;
+      'k8s.pod.ip'?: string;
+      'k8s.pod.name'?: string;
+      'k8s.pod.uid'?: string;
+      'k8s.replicaset.name'?: string;
+      'k8s.pod.start_time'?: string;
+      'os.description'?: string;
+      'os.type'?: string;
+      'process.command_args'?: string;
+      'process.command_line'?: string;
+      'process.executable.path'?: string;
+      'process.pid'?: number;
+      'process.runtime.description'?: string;
+      'process.runtime.name'?: string;
+      'process.runtime.version'?: string;
+      'service.instance.id'?: string;
+      'service.name'?: string;
+      'service.namespace'?: string;
+      'telemetry.distro.name'?: string;
+      'telemetry.distro.version'?: string;
+      'telemetry.sdk.language'?: string;
+      'telemetry.sdk.name'?: string;
+      'telemetry.sdk.version'?: string;
+    };
+  };
+}
+export class OtelEdotMetric extends Serializable<OtelEdotMetricDocument> {
+  constructor(fields: OtelEdotMetricDocument) {
+    super({
+      ...fields,
+    });
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_edot/transaction.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_edot/transaction.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { OtelEdotDocument } from '.';
+import { Serializable } from '../../serializable';
+
+export interface OtelEdotTransactionDocument extends OtelEdotDocument {
+  attributes?: {
+    'event.outcome'?: string;
+    'event.success_count'?: number;
+    'processor.event'?: string;
+    'timestamp.us'?: number;
+    'transaction.duration.us'?: number;
+    'transaction.id'?: string;
+    'transaction.name'?: string;
+    'transaction.representative_count'?: number;
+    'transaction.result'?: string;
+    'transaction.root'?: boolean;
+    'transaction.sampled'?: boolean;
+    'transaction.type'?: string;
+    'http.response.status_code'?: number;
+    'http.request.method'?: string;
+    'url.full'?: string;
+    'service.name'?: string;
+    'service.namespace'?: string;
+    'service.instance.id'?: string;
+    'service.target.name'?: string;
+    'service.target.type'?: string;
+    'span.name'?: string;
+    'span.destination.service.resource'?: string;
+    'app.ads.ad_request_type'?: string;
+    'app.ads.ad_response_type'?: string;
+    'app.ads.contextKeys'?: string;
+    'app.ads.contextKeys.count'?: number;
+    'app.ads.count'?: number;
+    'network.peer.address'?: string;
+    'network.peer.port'?: number;
+    'network.type'?: string;
+    'rpc.grpc.status_code'?: number;
+    'rpc.method'?: string;
+    'rpc.service'?: string;
+    'rpc.system'?: string;
+    'server.address'?: string;
+    'server.port'?: number;
+    'session.id'?: string;
+    'thread.id'?: number;
+    'thread.name'?: string;
+  };
+  status?: {
+    code?: string;
+  };
+  dropped_events_count?: number;
+  dropped_links_count?: number;
+  duration?: number;
+  kind?: string;
+  name?: string;
+  resource?: {
+    attributes?: {
+      'agent.name'?: string;
+      'agent.version'?: string;
+      'app.label.name'?: string;
+      'cloud.account.id'?: string;
+      'cloud.availability_zone'?: string;
+      'cloud.platform'?: string;
+      'cloud.provider'?: string;
+      'container.id'?: string;
+      'deployment.environment'?: string;
+      'host.arch'?: string;
+      'host.id'?: string;
+      'host.name'?: string;
+      'k8s.cluster.name'?: string;
+      'k8s.deployment.name'?: string;
+      'k8s.namespace.name'?: string;
+      'k8s.node.name'?: string;
+      'k8s.pod.ip'?: string;
+      'k8s.pod.name'?: string;
+      'k8s.pod.uid'?: string;
+      'k8s.pod.start_time'?: string;
+      'k8s.replicaset.name'?: string;
+      'os.description'?: string;
+      'os.type'?: string;
+      'process.command_args'?: string;
+      'process.command_line'?: string;
+      'process.executable.path'?: string;
+      'process.pid'?: number;
+      'process.runtime.description'?: string;
+      'process.runtime.name'?: string;
+      'process.runtime.version'?: string;
+      'service.instance.id'?: string;
+      'service.name'?: string;
+      'service.namespace'?: string;
+      'telemetry.distro.name'?: string;
+      'telemetry.distro.version'?: string;
+      'telemetry.sdk.language'?: string;
+      'telemetry.sdk.name'?: string;
+      'telemetry.sdk.version'?: string;
+    };
+  };
+}
+
+export class OtelEdotTransaction extends Serializable<OtelEdotTransactionDocument> {
+  constructor(fields: OtelEdotTransactionDocument) {
+    super({
+      ...fields,
+    });
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_native/error.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_native/error.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type { OtelDocument } from '../../..';
-import { Serializable } from '../serializable';
+import type { OtelDocument } from '../../../..';
+import { Serializable } from '../../serializable';
 
 export interface OtelErrorDocument extends OtelDocument {
   'event.name'?: string;

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_native/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_native/index.ts
@@ -7,8 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Fields } from '../entity';
-import { Serializable } from '../serializable';
+import type { Fields } from '../../entity';
+import { Serializable } from '../../serializable';
 import { OtelError } from './error';
 import { OtelMetric } from './metric';
 import { OtelTransaction } from './transaction';
@@ -91,7 +91,7 @@ class Otel extends Serializable<OtelDocument> {
         attributes: {
           'agent.name': 'opentelemetry/go',
           'agent.version': '1.28.0',
-          'service.name': 'sendotlp-synth',
+          'service.name': 'sendotlp-otel-native-synth',
           'service.instance.id': '89117ac1-0dbf-4488-9e17-4c2c3b76943a',
         },
         dropped_attributes_count: 0,
@@ -99,11 +99,11 @@ class Otel extends Serializable<OtelDocument> {
       },
       scope: {
         attributes: {
-          'service.framework.name': 'sendotlp-synth',
+          'service.framework.name': 'sendotlp-otel-native-synth',
           'service.framework.version': '',
         },
         dropped_attributes_count: 0,
-        name: 'sendotlp-synth',
+        name: 'sendotlp-otel-native-synth',
       },
       span_id: spanId,
     });
@@ -116,10 +116,10 @@ class Otel extends Serializable<OtelDocument> {
         'metricset.name': 'service_destination',
         'processor.event': 'metric',
         'event.outcome': 'success',
-        'service.target.name': 'foo_service',
+        'service.target.name': 'foo_service-otel-native-synth',
         'service.target.type': 'http',
         'span.name': 'child1',
-        'span.destination.service.resource': 'foo_service:8080',
+        'span.destination.service.resource': 'foo_service-otel-native-synth:8080',
       },
       data_stream: {
         dataset: 'service_destination.10m.otel',
@@ -134,7 +134,7 @@ class Otel extends Serializable<OtelDocument> {
           'agent.name': 'opentelemetry/nodejs',
           'agent.version': '1.28.0',
           'service.instance.id': '89117ac1-0dbf-4488-9e17-4c2c3b76943a',
-          'service.name': 'sendotlp-synth',
+          'service.name': 'sendotlp-otel-native-synth',
           'metricset.interval': '10m',
           'telemetry.sdk.name': 'opentelemetry',
           'telemetry.sdk.language': 'nodejs',
@@ -183,18 +183,18 @@ class Otel extends Serializable<OtelDocument> {
           'agent.name': 'otlp',
           'agent.version': '1.28.0',
           'service.instance.id': '89117ac1-0dbf-4488-9e17-4c2c3b76943a',
-          'service.name': 'sendotlp-synth',
+          'service.name': 'sendotlp-otel-native-synth',
         },
         dropped_attributes_count: 0,
         schema_url: 'https://opentelemetry.io/schemas/1.26.0',
       },
       scope: {
         attributes: {
-          'service.framework.name': 'sendotlp-synth',
+          'service.framework.name': 'sendotlp-otel-native-synth',
           'service.framework.version': '',
         },
         dropped_attributes_count: 0,
-        name: 'sendotlp-synth',
+        name: 'sendotlp-otel-native-synth',
       },
       span_id: id,
       status: {

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_native/metric.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_native/metric.ts
@@ -8,7 +8,7 @@
  */
 
 import { OtelDocument } from '.';
-import { Serializable } from '../serializable';
+import { Serializable } from '../../serializable';
 
 export interface OtelMetricDocument extends OtelDocument {
   attributes?: {

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_native/transaction.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/otel/otel_native/transaction.ts
@@ -8,7 +8,7 @@
  */
 
 import { OtelDocument } from '.';
-import { Serializable } from '../serializable';
+import { Serializable } from '../../serializable';
 
 export interface OtelTransactionDocument extends OtelDocument {
   attributes?: {

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_edot_simple_trace.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_edot_simple_trace.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { generateShortId, OtelEdotDocument, otelEdot } from '@kbn/apm-synthtrace-client';
+import { times } from 'lodash';
+import { Scenario } from '../cli/scenario';
+import { withClient } from '../lib/utils/with_client';
+
+const scenario: Scenario<OtelEdotDocument> = async (runOptions) => {
+  return {
+    generate: ({ range, clients: { otelEsClient } }) => {
+      const { numOtelTraces = 5 } = runOptions.scenarioOpts || {};
+      const { logger } = runOptions;
+      const traceId = generateShortId();
+      const spanId = generateShortId();
+
+      const otelEdotDocs = times(numOtelTraces / 2).map((index) => otelEdot.create(traceId));
+
+      const otelWithMetricsAndErrors = range
+        .interval('30s')
+        .rate(1)
+        .generator((timestamp) =>
+          otelEdotDocs.flatMap((otelEdotd) => {
+            return [
+              otelEdotd.metric().timestamp(timestamp),
+              otelEdotd.transaction(spanId).timestamp(timestamp),
+            ];
+          })
+        );
+
+      return [
+        withClient(
+          otelEsClient,
+          logger.perf('generating_otel_trace', () => otelWithMetricsAndErrors)
+        ),
+      ];
+    },
+  };
+};
+
+export default scenario;

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_overview/otel_edot_service_overview_and_transactions.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_overview/otel_edot_service_overview_and_transactions.cy.ts
@@ -7,29 +7,23 @@
 
 import url from 'url';
 import { synthtraceOtel } from '../../../synthtrace';
-import { sendotlp } from '../../fixtures/synthtrace/sendotlp';
+import { adserviceEdot } from '../../fixtures/synthtrace/adservice_edot';
 import { checkA11y } from '../../support/commands';
 
 const start = '2021-10-10T00:00:00.000Z';
 const end = '2021-10-10T00:15:00.000Z';
-const serviceInstanceId = '89117ac1-0dbf-4488-9e17-4c2c3b76943a';
+const serviceInstanceId = 'da7a8507-53be-421c-8d77-984f12397213';
 
-const serviceOverviewPath = '/app/apm/services/sendotlp-otel-native-synth/overview';
+const serviceOverviewPath = '/app/apm/services/adservice-edot-synth/overview';
 const baseUrl = url.format({
   pathname: serviceOverviewPath,
   query: { rangeFrom: start, rangeTo: end },
 });
 
-const transactionTabPath = '/app/apm/services/sendotlp-otel-native-synth/transactions/view';
-const transactionUrl = url.format({
-  pathname: transactionTabPath,
-  query: { rangeFrom: start, rangeTo: end, transactionName: 'parent-synth' },
-});
-
 describe('Service Overview', () => {
   before(() => {
     synthtraceOtel.index(
-      sendotlp({
+      adserviceEdot({
         from: new Date(start).getTime(),
         to: new Date(end).getTime(),
       })
@@ -47,7 +41,7 @@ describe('Service Overview', () => {
     });
 
     it('renders all components on the page', () => {
-      cy.contains('sendotlp-otel-native-synth');
+      cy.contains('adservice-edot-synth');
       // set skipFailures to true to not fail the test when there are accessibility failures
       checkA11y({ skipFailures: true });
       cy.getByTestSubj('latencyChart');
@@ -66,21 +60,16 @@ describe('Service Overview', () => {
     });
 
     it('show information on click', () => {
-      cy.intercept(
-        'GET',
-        '/internal/apm/services/sendotlp-otel-native-synth/metadata/details?*'
-      ).as('metadataDetailsRequest');
+      cy.intercept('GET', '/internal/apm/services/adservice-edot-synth/metadata/details?*').as(
+        'metadataDetailsRequest'
+      );
 
       cy.visitKibana(baseUrl);
 
-      cy.getByTestSubj('service').click();
-      cy.wait('@metadataDetailsRequest');
-      cy.contains('dt', 'Framework name');
-      cy.contains('dd', 'sendotlp-otel-native-synth');
-
       cy.getByTestSubj('opentelemetry').click();
+      cy.wait('@metadataDetailsRequest');
       cy.contains('dt', 'Language');
-      cy.contains('dd', 'go');
+      cy.contains('dd', 'java');
     });
   });
 
@@ -91,7 +80,7 @@ describe('Service Overview', () => {
 
     it('has data in the table', () => {
       cy.visitKibana(baseUrl);
-      cy.contains('sendotlp-otel-native-synth');
+      cy.contains('adservice-edot-synth');
       cy.getByTestSubj('serviceInstancesTableContainer');
       cy.contains(serviceInstanceId);
     });
@@ -102,35 +91,12 @@ describe('Service Overview', () => {
       cy.loginAsViewerUser();
     });
 
-    it('persists transaction type selected when clicking on Transactions tab', () => {
-      cy.intercept(
-        'GET',
-        '/internal/apm/services/sendotlp-otel-native-synth/transaction_types?*'
-      ).as('transactionTypesRequest');
-
-      cy.visitKibana(baseUrl);
-
-      cy.wait('@transactionTypesRequest');
-
-      cy.getByTestSubj('headerFilterTransactionType').should('have.value', 'unknown');
-      cy.contains('Transactions').click();
-      cy.getByTestSubj('headerFilterTransactionType').should('have.value', 'unknown');
-      cy.contains('parent-synth');
-    });
-
     it('navigates to transaction detail page', () => {
       cy.visitKibana(baseUrl);
       cy.contains('Transactions').click();
 
-      cy.contains('a', 'parent-synth').click();
-      cy.contains('h5', 'parent-synth');
-    });
-    it('shows transaction summary', () => {
-      cy.visitKibana(transactionUrl);
-
-      cy.getByTestSubj('apmHttpInfoRequestMethod').should('exist');
-      cy.getByTestSubj('apmHttpInfoUrl').should('exist');
-      cy.getByTestSubj('apmHttpStatusBadge').should('exist');
+      cy.contains('a', 'oteldemo.AdServiceEdotSynth/GetAds').click();
+      cy.contains('h5', 'oteldemo.AdServiceEdotSynth/GetAds');
     });
   });
 
@@ -139,20 +105,11 @@ describe('Service Overview', () => {
       cy.loginAsViewerUser();
       cy.visitKibana(baseUrl);
     });
-    it('errors table is populated', () => {
-      cy.contains('sendotlp-otel-native-synth');
-      cy.contains('*errors.errorString');
-    });
 
     it('navigates to the errors page', () => {
-      cy.contains('sendotlp-otel-native-synth');
+      cy.contains('adservice-edot-synth');
       cy.contains('a', 'View errors').click();
-      cy.url().should('include', '/sendotlp-otel-native-synth/errors');
-    });
-
-    it('navigates to error detail page', () => {
-      cy.contains('a', '*errors.errorString').click();
-      cy.contains('div', 'boom');
+      cy.url().should('include', '/adservice-edot-synth/errors');
     });
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/adservice_edot.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/adservice_edot.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { generateShortId, otelEdot, timerange } from '@kbn/apm-synthtrace-client';
+import { times } from 'lodash';
+
+export function adserviceEdot({ from, to }: { from: number; to: number }) {
+  const range = timerange(from, to);
+  const traceId = generateShortId();
+  const spanId = generateShortId();
+
+  const otelAdserviceEdot = times(2).map((index) => otelEdot.create(traceId));
+
+  return range
+    .interval('1s')
+    .rate(1)
+    .generator((timestamp) =>
+      otelAdserviceEdot.flatMap((otelDoc) => {
+        return [
+          otelDoc.metric().timestamp(timestamp),
+          otelDoc.transaction(spanId).timestamp(timestamp),
+        ];
+      })
+    );
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[APM][OTel] Add EDOT support in the Synthtrace OTel client (#214141)](https://github.com/elastic/kibana/pull/214141)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-03-12T15:50:51Z","message":"[APM][OTel] Add EDOT support in the Synthtrace OTel client (#214141)\n\nCloses #212564 \n\n## Summary\n\nThis PR adds EDOT data and scenarios to the OTel synthtrace client. The\nprevious OTel class now lives in `otel_native` folder and the EDOT one\nin `otel_edot`. It updates the otel native service name and the old\ntests and adds a simple test for EDOT.\n⚠️ Currently the edot service doesn't have an error document (on the\n[otel demo env](https://otel.demo.elastic.co) I couldn't find any) so\nthere won't be any errors for the `adservice-edot-synth` - same as in\n[the\ndemo](https://otel.demo.elastic.co/app/apm/services/adservice/errors?comparisonEnabled=true&environment=ENVIRONMENT_ALL&kuery=&latencyAggregationType=avg&offset=1d&rangeFrom=2025-03-12T12:49:15.506Z&rangeTo=2025-03-12T13:04:19.779Z&serviceGroup=&transactionType=request)\n\n## Testing\nRun: \n- ```node scripts/synthtrace otel_edot_simple_trace.ts ```\n- and ```node scripts/synthtrace otel_simple_trace.ts```\n\nGo to APM service inventory\n- Both services should be visible\n  \n\n![image](https://github.com/user-attachments/assets/b698cc14-d40a-4925-861f-4da0d9707f48)\n\n- Service overview and other tabs should be visible \n  - Otel native case: \n  \n\n![image](https://github.com/user-attachments/assets/4c423ff0-2dee-4eb4-b69b-057bad3a4747)\n\n![image](https://github.com/user-attachments/assets/407907bd-212e-486e-bc2a-0e2370f21be5)\n\n  - EDOT case\n \n\n![image](https://github.com/user-attachments/assets/3766e1e2-a8d7-45d4-887d-b67533a1b3eb)\n\n![image](https://github.com/user-attachments/assets/aff544fa-72b5-4826-963f-2b4c44d517bb)","sha":"ded1b15b87ec8f4f933596baf2fd96cfda1977d5","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","Team:obs-ux-infra_services","v9.1.0","v8.19.0"],"title":"[APM][OTel] Add EDOT support in the Synthtrace OTel client","number":214141,"url":"https://github.com/elastic/kibana/pull/214141","mergeCommit":{"message":"[APM][OTel] Add EDOT support in the Synthtrace OTel client (#214141)\n\nCloses #212564 \n\n## Summary\n\nThis PR adds EDOT data and scenarios to the OTel synthtrace client. The\nprevious OTel class now lives in `otel_native` folder and the EDOT one\nin `otel_edot`. It updates the otel native service name and the old\ntests and adds a simple test for EDOT.\n⚠️ Currently the edot service doesn't have an error document (on the\n[otel demo env](https://otel.demo.elastic.co) I couldn't find any) so\nthere won't be any errors for the `adservice-edot-synth` - same as in\n[the\ndemo](https://otel.demo.elastic.co/app/apm/services/adservice/errors?comparisonEnabled=true&environment=ENVIRONMENT_ALL&kuery=&latencyAggregationType=avg&offset=1d&rangeFrom=2025-03-12T12:49:15.506Z&rangeTo=2025-03-12T13:04:19.779Z&serviceGroup=&transactionType=request)\n\n## Testing\nRun: \n- ```node scripts/synthtrace otel_edot_simple_trace.ts ```\n- and ```node scripts/synthtrace otel_simple_trace.ts```\n\nGo to APM service inventory\n- Both services should be visible\n  \n\n![image](https://github.com/user-attachments/assets/b698cc14-d40a-4925-861f-4da0d9707f48)\n\n- Service overview and other tabs should be visible \n  - Otel native case: \n  \n\n![image](https://github.com/user-attachments/assets/4c423ff0-2dee-4eb4-b69b-057bad3a4747)\n\n![image](https://github.com/user-attachments/assets/407907bd-212e-486e-bc2a-0e2370f21be5)\n\n  - EDOT case\n \n\n![image](https://github.com/user-attachments/assets/3766e1e2-a8d7-45d4-887d-b67533a1b3eb)\n\n![image](https://github.com/user-attachments/assets/aff544fa-72b5-4826-963f-2b4c44d517bb)","sha":"ded1b15b87ec8f4f933596baf2fd96cfda1977d5"}},"sourceBranch":"main","suggestedTargetBranches":["9.0"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214141","number":214141,"mergeCommit":{"message":"[APM][OTel] Add EDOT support in the Synthtrace OTel client (#214141)\n\nCloses #212564 \n\n## Summary\n\nThis PR adds EDOT data and scenarios to the OTel synthtrace client. The\nprevious OTel class now lives in `otel_native` folder and the EDOT one\nin `otel_edot`. It updates the otel native service name and the old\ntests and adds a simple test for EDOT.\n⚠️ Currently the edot service doesn't have an error document (on the\n[otel demo env](https://otel.demo.elastic.co) I couldn't find any) so\nthere won't be any errors for the `adservice-edot-synth` - same as in\n[the\ndemo](https://otel.demo.elastic.co/app/apm/services/adservice/errors?comparisonEnabled=true&environment=ENVIRONMENT_ALL&kuery=&latencyAggregationType=avg&offset=1d&rangeFrom=2025-03-12T12:49:15.506Z&rangeTo=2025-03-12T13:04:19.779Z&serviceGroup=&transactionType=request)\n\n## Testing\nRun: \n- ```node scripts/synthtrace otel_edot_simple_trace.ts ```\n- and ```node scripts/synthtrace otel_simple_trace.ts```\n\nGo to APM service inventory\n- Both services should be visible\n  \n\n![image](https://github.com/user-attachments/assets/b698cc14-d40a-4925-861f-4da0d9707f48)\n\n- Service overview and other tabs should be visible \n  - Otel native case: \n  \n\n![image](https://github.com/user-attachments/assets/4c423ff0-2dee-4eb4-b69b-057bad3a4747)\n\n![image](https://github.com/user-attachments/assets/407907bd-212e-486e-bc2a-0e2370f21be5)\n\n  - EDOT case\n \n\n![image](https://github.com/user-attachments/assets/3766e1e2-a8d7-45d4-887d-b67533a1b3eb)\n\n![image](https://github.com/user-attachments/assets/aff544fa-72b5-4826-963f-2b4c44d517bb)","sha":"ded1b15b87ec8f4f933596baf2fd96cfda1977d5"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"url":"https://github.com/elastic/kibana/pull/219941","number":219941,"branch":"8.19","state":"MERGED","mergeCommit":{"sha":"ede610b9e0d17bd6cdcc11804397a043d07d97ba","message":"[8.19] [APM][OTel] Add EDOT support in the Synthtrace OTel client (#214141) (#219941)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[APM][OTel] Add EDOT support in the Synthtrace OTel client\n(#214141)](https://github.com/elastic/kibana/pull/214141)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: jennypavlova <dzheni.pavlova@elastic.co>"}}]}] BACKPORT-->