### PR TITLE
[ES|QL] Fixes the code alert problem in query-utils

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/query_string_utils.test.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/query_string_utils.test.ts
@@ -15,8 +15,7 @@ describe('query_string_utils', () => {
         FROM users // This is a comment
         | WHERE age > 18
       `;
-      const expected = `FROM users 
-        | WHERE age > 18`;
+      const expected = `FROM users         | WHERE age > 18`;
       expect(removeComments(text)).toBe(expected);
     });
 
@@ -39,8 +38,7 @@ describe('query_string_utils', () => {
         product */
         | KEEP name, price
       `;
-      const expected = `FROM items 
-        
+      const expected = `FROM items         
         | KEEP name, price`;
       expect(removeComments(text)).toBe(expected);
     });

--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/query_string_utils.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/shared/query_string_utils.ts
@@ -8,7 +8,7 @@
  */
 export function removeComments(text: string): string {
   // Remove single-line comments
-  const withoutSingleLineComments = text.replace(/\/\/.*$/gm, '');
+  const withoutSingleLineComments = text.replace(/\/\/.*?(?:\r\n|\r|\n|$)/gm, '');
   // Remove multi-line comments
   const withoutMultiLineComments = withoutSingleLineComments.replace(/\/\*[\s\S]*?\*\//g, '');
   return withoutMultiLineComments.trim();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana-team/issues/1642

I run the `bash ./scripts/codeql/quick_check.sh -s src/platform/packages/shared/kbn-esql-validation-autocomplete` to confirm the fix.

The regex is a safer now and it has the same result. Small changes in the tests but the comments are being removed which is the desired result here

### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->