### PR TITLE
[8.18] [Synthtrace] Fluent API for APM otel (#216099)

### DIFF
--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/index.ts
@@ -9,9 +9,11 @@
 
 export { observer } from './src/lib/agent_config';
 export type { AgentConfigFields } from './src/lib/agent_config/agent_config_fields';
-export { apm } from './src/lib/apm';
+export { apm, apmOtel } from './src/lib/apm';
 export type { ApmFields } from './src/lib/apm/apm_fields';
+export type { ApmOtelFields } from './src/lib/apm/otel/apm_otel_fields';
 export type { Instance } from './src/lib/apm/instance';
+export type { OtelInstance } from './src/lib/apm/otel/otel_instance';
 export { MobileDevice } from './src/lib/apm/mobile_device';
 export type {
   DeviceInfo,
@@ -33,7 +35,12 @@ export type { Timerange } from './src/lib/timerange';
 export { dedot } from './src/lib/utils/dedot';
 export { generateLongId, generateShortId } from './src/lib/utils/generate_id';
 export { appendHash, hashKeysOf } from './src/lib/utils/hash';
-export type { ESDocumentWithOperation, SynthtraceESAction, SynthtraceGenerator } from './src/types';
+export type {
+  ESDocumentWithOperation,
+  SynthtraceESAction,
+  SynthtraceGenerator,
+  SynthtraceDynamicTemplate,
+} from './src/types';
 export { log, type LogDocument, LONG_FIELD_NAME } from './src/lib/logs';
 export { syntheticsMonitor, type SyntheticsMonitorDocument } from './src/lib/synthetics';
 export { type EntityFields, entities } from './src/lib/entities';

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/abstract_span.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/abstract_span.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Fields } from '../entity';
+import { Serializable } from '../serializable';
+
+export abstract class AbstractSpan<
+  TFields extends Fields,
+  TChild extends AbstractSpan<TFields, any>
+> extends Serializable<TFields> {
+  protected _children: TChild[] = [];
+
+  constructor(fields: TFields) {
+    super(fields);
+  }
+
+  getChildren(): TChild[] {
+    return this._children;
+  }
+
+  children(...children: TChild[]): this {
+    for (const child of children) {
+      child.parent(this);
+    }
+    this._children.push(...children);
+    return this;
+  }
+
+  serialize(): TFields[] {
+    return [this.fields, ...this.getChildren().flatMap((child) => child.serialize())];
+  }
+
+  abstract parent(span: TChild): this;
+  abstract success(): this;
+  abstract failure(): this;
+  abstract outcome(outcome: 'success' | 'failure' | 'unknown'): this;
+  abstract isSpan(): boolean;
+  abstract isTransaction(): boolean;
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/base_span.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/base_span.ts
@@ -7,15 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Serializable } from '../serializable';
 import { Span } from './span';
 import { Transaction } from './transaction';
 import { generateLongId } from '../utils/generate_id';
 import { ApmFields } from './apm_fields';
+import { AbstractSpan } from './abstract_span';
 
-export class BaseSpan extends Serializable<ApmFields> {
-  private readonly _children: BaseSpan[] = [];
-
+export class BaseSpan extends AbstractSpan<ApmFields, BaseSpan> {
   constructor(fields: ApmFields) {
     super({
       ...fields,
@@ -41,20 +39,6 @@ export class BaseSpan extends Serializable<ApmFields> {
     return this;
   }
 
-  getChildren() {
-    return this._children;
-  }
-
-  children(...children: BaseSpan[]): this {
-    children.forEach((child) => {
-      child.parent(this);
-    });
-
-    this._children.push(...children);
-
-    return this;
-  }
-
   success(): this {
     this.fields['event.outcome'] = 'success';
     return this;
@@ -73,10 +57,6 @@ export class BaseSpan extends Serializable<ApmFields> {
   crash(): this {
     this.fields['event.name'] = 'crash';
     return this;
-  }
-
-  serialize(): ApmFields[] {
-    return [this.fields, ...this._children.flatMap((child) => child.serialize())];
   }
 
   isSpan(): this is Span {

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { service } from './service';
+import { service as otelService } from './otel/service';
 import { mobileApp } from './mobile_app';
 import { browser } from './browser';
 import { serverlessFunction } from './serverless_function';
@@ -21,6 +22,10 @@ export const apm = {
   browser,
   getChromeUserAgentDefaults,
   serverlessFunction,
+};
+
+export const apmOtel = {
+  service: otelService,
 };
 
 export type { ApmException };

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/apm_otel_error.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/apm_otel_error.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Serializable } from '../../serializable';
+import { generateLongId, generateLongIdWithSeed, generateShortId } from '../../utils/generate_id';
+import { ApmOtelFields } from './apm_otel_fields';
+
+export class ApmOtelError extends Serializable<ApmOtelFields> {
+  constructor(fields: ApmOtelFields) {
+    super({
+      ...fields,
+      'attributes.processor.event': 'error',
+      'attributes.error.id': generateShortId(),
+    });
+  }
+
+  serialize() {
+    const errorMessage =
+      this.fields['attributes.error.grouping_key'] || this.fields['attributes.exception.message'];
+
+    const [data] = super.serialize();
+
+    data['attributes.error.grouping_key'] =
+      this.fields['attributes.error.grouping_key'] ??
+      (errorMessage ? generateLongIdWithSeed(errorMessage) : generateLongId());
+
+    return [data];
+  }
+
+  timestamp(value: number) {
+    const ret = super.timestamp(value);
+    this.fields['attributes.timestamp.us'] = value * 1000;
+    return ret;
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/apm_otel_fields.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/apm_otel_fields.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Fields } from '../../entity';
+import type { ApmFields } from '../apm_fields';
+
+interface ErrorAttributes {
+  'attributes.exception.message': string;
+  'attributes.exception.handled': boolean;
+  'attributes.exception.type': string;
+  'attributes.error.stack_trace': string;
+  'attributes.error.id': string;
+  'attributes.error.grouping_key': string;
+}
+
+type AttributesKeys = Pick<
+  ApmFields,
+  | 'timestamp.us'
+  | 'metricset.name'
+  | 'metricset.interval'
+  | 'transaction.id'
+  | 'transaction.type'
+  | 'transaction.name'
+  | 'transaction.duration.us'
+  | 'transaction.result'
+  | 'transaction.sampled'
+  | 'span.name'
+  | 'span.type'
+  | 'span.subtype'
+  | 'span.duration.us'
+  | 'span.destination.service.resource'
+  | 'service.name'
+  | 'service.target.name'
+  | 'service.target.type'
+  | 'processor.event'
+  | 'event.outcome'
+  | 'event.name'
+  | 'url.full'
+>;
+
+type MetricsKeys = Pick<
+  ApmFields,
+  | 'transaction.duration.histogram'
+  | 'span.destination.service.response_time.count'
+  | 'span.destination.service.response_time.sum.us'
+>;
+
+type ResourceAttributesKeys = Pick<
+  ApmFields,
+  | 'agent.name'
+  | 'agent.version'
+  | 'service.name'
+  | 'host.name'
+  | 'container.id'
+  | 'kubernetes.pod.name'
+  | 'cloud.provider'
+  | 'cloud.region'
+  | 'cloud.availability_zone'
+  | 'cloud.service.name'
+  | 'cloud.account.id'
+  | 'cloud.account.name'
+  | 'cloud.project.id'
+  | 'cloud.project.name'
+  | 'cloud.machine.type'
+  | 'faas.coldstart'
+  | 'faas.id'
+  | 'faas.trigger.type'
+  | 'faas.name'
+  | 'faas.version'
+>;
+
+type Attributes = {
+  [K in keyof AttributesKeys as `attributes.${K}`]: ApmFields[K];
+} & ErrorAttributes & {
+    'attributes.network.peer.address': string;
+    'attributes.network.peer.port': number;
+    'attributes.network.type': string;
+    'attributes.rpc.grpc.status_code': number;
+    'attributes.rpc.method': string;
+    'attributes.rpc.service': string;
+    'attributes.rpc.system': string;
+    'attributes.server.address': string;
+    'attributes.server.port': number;
+    'attributes.session.id': string;
+    'attributes.thread.id': number;
+    'attributes.thread.name': string;
+    'attributes.service.namespace': string;
+    'attributes.http.request.method': string;
+    'attributes.http.response.status_code': number;
+    'attributes.http.url': string;
+    'attributes.span.kind': string;
+    'attributes.method': string;
+    'attributes.status.code': number;
+    'attributes.url.path': string;
+    'attributes.url.scheme': string;
+  };
+
+type MetricsAttributes = {
+  [K in keyof MetricsKeys as `metrics.${K}`]: ApmFields[K];
+} & {
+  'metrics.event.success_count': {
+    sum: number;
+    value_count: number;
+  };
+  'metrics.transaction.duration.summary': {
+    sum: number;
+    value_count: number;
+  };
+};
+
+type ResourceAttributes = {
+  [K in keyof ResourceAttributesKeys as `resource.attributes.${K}`]: ApmFields[K];
+} & {
+  'resource.attributes.deployment.environment': string;
+  'resource.attributes.service.namespace': string;
+  'resource.attributes.service.instance.id': string;
+  'resource.attributes.telemetry.sdk.language': string;
+  'resource.attributes.telemetry.sdk.name': string;
+  'resource.attributes.telemetry.sdk.version': string;
+  'resource.attributes.telemetry.distro.name': string;
+  'resource.attributes.telemetry.distro.version': string;
+  'resource.attributes.process.runtime.name': string;
+  'resource.attributes.process.runtime.version': string;
+  'resource.attributes.os.type': string;
+  'resource.attributes.os.description': string;
+  'resource.attributes.host.arch': string;
+};
+
+export type ApmOtelFields = Fields &
+  Partial<
+    {
+      'data_stream.dataset': string;
+      'data_stream.namespace': string;
+      'data_stream.type': string;
+      'resource.dropped_attributes_count': number;
+      'resource.schema_url': string;
+      'scope.attributes.service.framework.name': string;
+      'scope.attributes.service.framework.version': string;
+      'scope.dropped_attributes_count': number;
+      'scope.name': string;
+      name: string;
+      parent_span_id: string;
+      trace_id: string;
+      span_id: string;
+      kind: 'Internal' | 'Server' | 'Client' | 'Consumer' | 'Producer';
+      dropped_attributes_count: number;
+      dropped_events_count: number;
+      dropped_links_count: number;
+      duration: number;
+      links: [
+        {
+          span_id: string;
+          trace_id: string;
+        }
+      ];
+    } & Attributes &
+      MetricsAttributes &
+      ResourceAttributes
+  >;
+
+export type OtelSpanParams = {
+  spanName: string;
+  spanType: string;
+  spanSubtype?: string;
+} & ApmOtelFields;

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_base_span.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_base_span.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { generateLongId } from '../../utils/generate_id';
+import { AbstractSpan } from '../abstract_span';
+import { ApmOtelFields } from './apm_otel_fields';
+import { Span } from './span';
+import { Transaction } from './transaction';
+
+export class OtelBaseSpan extends AbstractSpan<ApmOtelFields, OtelBaseSpan> {
+  constructor(fields: ApmOtelFields) {
+    super({
+      'attributes.processor.event': 'span',
+      'attributes.event.outcome': 'unknown',
+      'data_stream.dataset': 'generic.otel',
+      'data_stream.namespace': 'default',
+      'data_stream.type': 'traces',
+      'resource.attributes.os.type': 'Linux',
+      ...fields,
+      trace_id: generateLongId(),
+    });
+  }
+
+  parent(span: OtelBaseSpan): this {
+    this.fields.trace_id = span.fields.trace_id;
+    this.fields.parent_span_id = span.fields.span_id;
+
+    if (this.isSpan()) {
+      this.fields['attributes.transaction.id'] = span.fields['attributes.transaction.id'];
+    }
+    this._children.forEach((child) => {
+      child.parent(this);
+    });
+
+    return this;
+  }
+
+  success(): this {
+    this.fields['attributes.event.outcome'] = 'success';
+    return this;
+  }
+
+  failure(): this {
+    this.fields['attributes.event.outcome'] = 'failure';
+    return this;
+  }
+
+  outcome(outcome: 'success' | 'failure' | 'unknown'): this {
+    this.fields['attributes.event.outcome'] = outcome;
+    return this;
+  }
+
+  isSpan(): this is Span {
+    return this.fields['attributes.processor.event'] === 'span';
+  }
+
+  isTransaction(): this is Transaction {
+    return this.fields['attributes.processor.event'] === 'transaction';
+  }
+
+  override timestamp(timestamp: number) {
+    const ret = super.timestamp(timestamp);
+    this.fields['attributes.timestamp.us'] = timestamp * 1000;
+    return ret;
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_instance.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/otel_instance.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Span } from './span';
+import { Transaction } from './transaction';
+import { ApmOtelFields, OtelSpanParams } from './apm_otel_fields';
+import { ApmOtelError } from './apm_otel_error';
+import { Entity } from '../../entity';
+
+export class OtelInstance extends Entity<ApmOtelFields> {
+  transaction(
+    ...options:
+      | [{ transactionName: string; transactionType?: string }]
+      | [string]
+      | [string, string]
+  ) {
+    let transactionName: string;
+    let transactionType: string | undefined;
+    if (options.length === 2) {
+      transactionName = options[0];
+      transactionType = options[1];
+    } else if (typeof options[0] === 'string') {
+      transactionName = options[0];
+    } else {
+      transactionName = options[0].transactionName;
+      transactionType = options[0].transactionType;
+    }
+
+    return new Transaction({
+      ...this.fields,
+      'attributes.transaction.name': transactionName,
+      'attributes.transaction.type': transactionType || 'request',
+    });
+  }
+
+  span(...options: [string, string] | [string, string, string] | [OtelSpanParams]) {
+    let spanName: string;
+    let spanType: string | undefined;
+    let spanSubtype: string | undefined;
+    let spanKind: string | undefined;
+    let fields: ApmOtelFields;
+
+    if (options.length === 3 || options.length === 2) {
+      // When two or three arguments are passed
+      spanName = options[0];
+      spanType = options[1];
+      spanSubtype = options[2] || 'unknown'; // Default to 'unknown' if no third argument
+      fields = {};
+    } else {
+      ({ spanName, spanType, spanSubtype = 'unknown', ...fields } = options[0]);
+    }
+
+    return new Span({
+      ...this.fields,
+      ...fields,
+      'attributes.span.name': spanName,
+      'attributes.span.type': spanType,
+      'attributes.span.kind': spanKind,
+      'attributes.span.subtype': spanSubtype,
+    });
+  }
+  error({
+    message,
+    type,
+    stackTrace,
+    groupingKey,
+  }: {
+    message: string;
+    type?: string;
+    stackTrace?: string;
+    groupingKey?: string;
+  }) {
+    return new ApmOtelError({
+      ...this.fields,
+      ...(groupingKey ? { 'attributes.error.grouping_key': groupingKey } : {}),
+      'attributes.exception.type': type,
+      'attributes.exception.message': message,
+      'attributes.error.stack_trace': stackTrace,
+    });
+  }
+
+  hostName(hostName: string) {
+    this.fields['resource.attributes.host.name'] = hostName;
+    return this;
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/service.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/service.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Entity } from '../../entity';
+import { ApmOtelFields } from './apm_otel_fields';
+import { OtelInstance } from './otel_instance';
+
+interface ServiceParams {
+  name: string;
+  namespace?: string;
+  sdkName: 'opentelemetry' | 'otlp';
+  sdkLanguage: string;
+  distro?: 'elastic';
+}
+export class Service extends Entity<ApmOtelFields> {
+  constructor({ name, namespace, sdkName, sdkLanguage, distro }: ServiceParams) {
+    const agentName = `${sdkName}/${sdkLanguage}${distro ? `/${distro}` : ''}`;
+
+    const fields: ApmOtelFields = {
+      'attributes.service.name': name,
+      'attributes.service.namespace': namespace,
+      'resource.attributes.service.name': name,
+      'resource.attributes.agent.name': agentName,
+      'resource.attributes.service.namespace': namespace,
+      'resource.attributes.deployment.environment': namespace,
+      'resource.attributes.telemetry.sdk.name': sdkName,
+      'resource.attributes.telemetry.sdk.language': sdkLanguage,
+      'resource.attributes.telemetry.distro.name': distro,
+      'scope.attributes.service.framework.name': name,
+      'scope.name': name,
+    };
+    super(fields);
+  }
+  instance(instanceName: string) {
+    return new OtelInstance({
+      ...this.fields,
+      'resource.attributes.service.instance.id': instanceName,
+      'resource.attributes.host.name': instanceName,
+    });
+  }
+}
+
+export function service({ name, namespace, sdkName, sdkLanguage, distro }: ServiceParams): Service {
+  return new Service({ name, namespace, sdkName, sdkLanguage, distro });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/span.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/span.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { generateShortId } from '../../utils/generate_id';
+import { ApmOtelFields } from './apm_otel_fields';
+import { OtelBaseSpan } from './otel_base_span';
+
+export class Span extends OtelBaseSpan {
+  constructor(fields: ApmOtelFields) {
+    super({
+      ...fields,
+      span_id: generateShortId(),
+      name: fields['attributes.span.name'],
+      'attributes.processor.event': 'span',
+      kind: 'Internal',
+    });
+  }
+
+  duration(duration: number) {
+    this.fields['attributes.span.duration.us'] = duration * 1000;
+    this.fields.duration = duration * 1000;
+    return this;
+  }
+
+  destination(resource: string) {
+    this.fields['attributes.span.destination.service.resource'] = resource;
+    this.fields.kind = 'Client';
+    return this;
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/transaction.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/lib/apm/otel/transaction.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { generateShortId } from '../../utils/generate_id';
+import { ApmOtelError } from './apm_otel_error';
+import { ApmOtelFields } from './apm_otel_fields';
+import { OtelBaseSpan } from './otel_base_span';
+
+export class Transaction extends OtelBaseSpan {
+  private _sampled: boolean = true;
+  private readonly _errors: ApmOtelError[] = [];
+  constructor(fields: ApmOtelFields) {
+    const spanId = generateShortId();
+    super({
+      ...fields,
+      'attributes.transaction.sampled': true,
+      'attributes.transaction.id': spanId,
+      'attributes.processor.event': 'transaction',
+      'attributes.http.response.status_code': 200,
+      'attributes.http.request.method': 'GET',
+      'attributes.url.full': 'elastic.co',
+      name: fields['attributes.transaction.name'],
+      // In Otel we have only spans (https://opentelemetry.io/docs/concepts/signals/traces/#spans)
+      span_id: spanId,
+      kind: 'Server',
+    });
+  }
+
+  parent(span: OtelBaseSpan) {
+    super.parent(span);
+
+    this._errors.forEach((error) => {
+      error.fields.trace_id = this.fields.trace_id;
+      error.fields['attributes.transaction.id'] = this.fields['attributes.transaction.id'];
+      error.fields['attributes.transaction.name'] = this.fields['attributes.transaction.name'];
+      error.fields['attributes.transaction.type'] = this.fields['attributes.transaction.type'];
+      error.fields['attributes.transaction.sampled'] =
+        this.fields['attributes.transaction.sampled'];
+    });
+
+    return this;
+  }
+
+  errors(...errors: ApmOtelError[]) {
+    errors.forEach((error) => {
+      error.fields.trace_id = this.fields.trace_id;
+      error.fields['attributes.transaction.id'] = this.fields['attributes.transaction.id'];
+      error.fields['attributes.transaction.name'] = this.fields['attributes.transaction.name'];
+      error.fields['attributes.transaction.type'] = this.fields['attributes.transaction.type'];
+      error.fields['attributes.transaction.sampled'] =
+        this.fields['attributes.transaction.sampled'];
+    });
+
+    this._errors.push(...errors);
+
+    return this;
+  }
+
+  duration(duration: number) {
+    this.fields['attributes.transaction.duration.us'] = duration * 1000;
+    this.fields.duration = duration * 1000;
+    return this;
+  }
+
+  serialize() {
+    const [transaction, ...spans] = super.serialize();
+
+    const errors = this._errors.flatMap((error) => error.serialize());
+
+    const events = [transaction];
+    if (this._sampled) {
+      events.push(...spans);
+    }
+
+    return events.concat(errors);
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace-client/src/types/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace-client/src/types/index.ts
@@ -12,10 +12,12 @@ import { Fields } from '../lib/entity';
 import { Serializable } from '../lib/serializable';
 
 export type SynthtraceESAction = { create: BulkCreateOperation } | { index: BulkIndexOperation };
+export type SynthtraceDynamicTemplate = Record<string, string>;
 
 export type ESDocumentWithOperation<TFields extends Fields> = {
   _index?: string;
   _action?: SynthtraceESAction;
+  _dynamicTemplates?: SynthtraceDynamicTemplate;
 } & TFields;
 
 export type SynthtraceGenerator<TFields extends Fields> = Generator<Serializable<TFields>>;

--- a/src/platform/packages/shared/kbn-apm-synthtrace/index.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/index.ts
@@ -18,6 +18,7 @@ export { LogsSynthtraceEsClient } from './src/lib/logs/logs_synthtrace_es_client
 export { EntitiesSynthtraceEsClient } from './src/lib/entities/entities_synthtrace_es_client';
 export { EntitiesSynthtraceKibanaClient } from './src/lib/entities/entities_synthtrace_kibana_client';
 export { SyntheticsSynthtraceEsClient } from './src/lib/synthetics/synthetics_synthtrace_es_client';
+export { OtelSynthtraceEsClient } from './src/lib/apm/client/apm_otel_synthtrace_es_client/otel_synthtrace_es_client';
 export {
   addObserverVersionTransform,
   deleteSummaryFieldTransform,

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_clients.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/get_clients.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Required } from 'utility-types';
+import { Client } from '@elastic/elasticsearch';
+import { ApmSynthtraceEsClient } from '../../lib/apm/client/apm_synthtrace_es_client';
+import { ApmSynthtraceKibanaClient } from '../../lib/apm/client/apm_synthtrace_kibana_client';
+import { EntitiesSynthtraceEsClient } from '../../lib/entities/entities_synthtrace_es_client';
+import { EntitiesSynthtraceKibanaClient } from '../../lib/entities/entities_synthtrace_kibana_client';
+import { InfraSynthtraceEsClient } from '../../lib/infra/infra_synthtrace_es_client';
+import { LogsSynthtraceEsClient } from '../../lib/logs/logs_synthtrace_es_client';
+import { OtelSynthtraceEsClient } from '../../lib/apm/client/apm_otel_synthtrace_es_client/otel_synthtrace_es_client';
+import { SynthtraceEsClientOptions } from '../../lib/shared/base_client';
+import { StreamsSynthtraceClient } from '../../lib/streams/streams_synthtrace_client';
+import { SyntheticsSynthtraceEsClient } from '../../lib/synthetics/synthetics_synthtrace_es_client';
+import { Logger } from '../../lib/utils/create_logger';
+
+export interface SynthtraceClients {
+  apmEsClient: ApmSynthtraceEsClient;
+  entitiesEsClient: EntitiesSynthtraceEsClient;
+  infraEsClient: InfraSynthtraceEsClient;
+  logsEsClient: LogsSynthtraceEsClient;
+  otelEsClient: OtelSynthtraceEsClient;
+  streamsClient: StreamsSynthtraceClient;
+  syntheticsEsClient: SyntheticsSynthtraceEsClient;
+  entitiesKibanaClient: EntitiesSynthtraceKibanaClient;
+  esClient: Client;
+}
+
+export async function getClients({
+  logger,
+  options,
+  packageVersion,
+  skipBootstrap,
+}: {
+  logger: Logger;
+  options: Required<Omit<SynthtraceEsClientOptions, 'pipeline'>, 'kibana'>;
+  packageVersion?: string;
+  skipBootstrap?: boolean;
+}): Promise<SynthtraceClients> {
+  const apmKibanaClient = new ApmSynthtraceKibanaClient({
+    logger,
+    kibanaClient: options.kibana,
+  });
+
+  let version = packageVersion;
+
+  if (!version) {
+    version = await apmKibanaClient.fetchLatestApmPackageVersion();
+    if (!skipBootstrap) {
+      await apmKibanaClient.installApmPackage(version);
+    }
+  } else if (version === 'latest') {
+    version = await apmKibanaClient.fetchLatestApmPackageVersion();
+  }
+
+  logger.debug(`Using package version: ${version}`);
+
+  const apmEsClient = new ApmSynthtraceEsClient({
+    ...options,
+    version,
+  });
+
+  const logsEsClient = new LogsSynthtraceEsClient(options);
+  const infraEsClient = new InfraSynthtraceEsClient(options);
+  const entitiesEsClient = new EntitiesSynthtraceEsClient(options);
+
+  const entitiesKibanaClient = new EntitiesSynthtraceKibanaClient({
+    ...options,
+    kibanaClient: options.kibana,
+  });
+
+  const syntheticsEsClient = new SyntheticsSynthtraceEsClient(options);
+  const otelEsClient = new OtelSynthtraceEsClient(options);
+
+  const streamsClient = new StreamsSynthtraceClient(options);
+
+  return {
+    apmEsClient,
+    entitiesEsClient,
+    infraEsClient,
+    logsEsClient,
+    otelEsClient,
+    streamsClient,
+    syntheticsEsClient,
+    entitiesKibanaClient,
+    esClient: options.client,
+  };
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/create_apm_metric_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/create_apm_metric_aggregator.ts
@@ -7,7 +7,8 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { ApmFields } from '@kbn/apm-synthtrace-client';
+import { ApmFields, ApmOtelFields } from '@kbn/apm-synthtrace-client';
 import { createMetricAggregatorFactory } from '../../utils/create_metric_aggregator_factory';
 
 export const createApmMetricAggregator = createMetricAggregatorFactory<ApmFields>();
+export const createOtelMetricAggregator = createMetricAggregatorFactory<ApmOtelFields>();

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_service_metrics_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_service_metrics_aggregator.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { pick } from 'lodash';
+import { hashKeysOf, ApmOtelFields } from '@kbn/apm-synthtrace-client';
+import { createLosslessHistogram } from '../../../utils/create_lossless_histogram';
+import { createOtelMetricAggregator } from '../create_apm_metric_aggregator';
+
+const KEY_FIELDS: Array<keyof ApmOtelFields> = [
+  'resource.attributes.agent.name',
+  'resource.attributes.deployment.environment',
+  'resource.attributes.service.name',
+  'attributes.transaction.type',
+  'resource.attributes.telemetry.sdk.language',
+];
+
+const METRICSET_NAME = 'service_transaction';
+export function createServiceMetricsAggregator(flushInterval: string) {
+  return createOtelMetricAggregator(
+    {
+      filter: (event) => event['attributes.processor.event'] === 'transaction',
+      getAggregateKey: (event) => {
+        return hashKeysOf(event, KEY_FIELDS);
+      },
+      flushInterval,
+      init: (event) => {
+        const set = pick(event, KEY_FIELDS);
+
+        return {
+          ...set,
+          'data_stream.dataset': `${METRICSET_NAME}.${flushInterval}.otel`,
+          'data_stream.namespace': 'default',
+          'data_stream.type': 'metrics',
+          'attributes.metricset.name': METRICSET_NAME,
+          'attributes.metricset.interval': flushInterval,
+          'attributes.processor.event': 'metric',
+          'metrics.transaction.duration.histogram': createLosslessHistogram(),
+          'metrics.transaction.duration.summary': {
+            value_count: 0,
+            sum: 0,
+          },
+          'metrics.event.success_count': {
+            sum: 0,
+            value_count: 0,
+          },
+        };
+      },
+    },
+    (metric, event) => {
+      const duration = event['attributes.transaction.duration.us']!;
+
+      metric['metrics.transaction.duration.histogram'].record(duration);
+
+      if (
+        event['attributes.event.outcome'] === 'success' ||
+        event['attributes.event.outcome'] === 'failure'
+      ) {
+        metric['metrics.event.success_count'].value_count += 1;
+      }
+
+      if (event['attributes.event.outcome'] === 'success') {
+        metric['metrics.event.success_count'].sum += 1;
+      }
+
+      const summary = metric['metrics.transaction.duration.summary'];
+
+      summary.sum += duration;
+      summary.value_count += 1;
+    },
+    (metric) => {
+      const serialized = metric['metrics.transaction.duration.histogram'].serialize();
+
+      metric['metrics.transaction.duration.histogram'] = {
+        // @ts-expect-error
+        values: serialized.values,
+        counts: serialized.counts,
+      };
+
+      // @ts-expect-error
+      metric._doc_count = serialized.total;
+
+      return metric;
+    }
+  );
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_service_summary_metrics_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_service_summary_metrics_aggregator.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ApmOtelFields, hashKeysOf } from '@kbn/apm-synthtrace-client';
+import { identity, noop, pick } from 'lodash';
+import { createOtelMetricAggregator } from '../create_apm_metric_aggregator';
+
+const KEY_FIELDS: Array<keyof ApmOtelFields> = [
+  'resource.attributes.agent.name',
+  'resource.attributes.deployment.environment',
+  'resource.attributes.service.name',
+  'resource.attributes.telemetry.sdk.language',
+];
+
+const METRICSET_NAME = 'service_summary';
+export function createServiceSummaryMetricsAggregator(flushInterval: string) {
+  return createOtelMetricAggregator(
+    {
+      filter: () => true,
+      getAggregateKey: (event) => {
+        return hashKeysOf(event, KEY_FIELDS);
+      },
+      flushInterval,
+      init: (event) => {
+        const set = pick(event, KEY_FIELDS);
+
+        return {
+          ...set,
+          'data_stream.dataset': `${METRICSET_NAME}.${flushInterval}.otel`,
+          'data_stream.namespace': 'default',
+          'data_stream.type': 'metrics',
+          'attributes.metricset.name': METRICSET_NAME,
+          'attributes.metricset.interval': flushInterval,
+          'attributes.processor.event': 'metric',
+        };
+      },
+    },
+    noop,
+    identity
+  );
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_span_metrics_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_span_metrics_aggregator.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { pick } from 'lodash';
+import { ApmOtelFields, hashKeysOf } from '@kbn/apm-synthtrace-client';
+import { createOtelMetricAggregator } from '../create_apm_metric_aggregator';
+
+const KEY_FIELDS: Array<keyof ApmOtelFields> = [
+  'resource.attributes.agent.name',
+  'resource.attributes.service.name',
+  'resource.attributes.deployment.environment',
+  'attributes.span.destination.service.resource',
+  'attributes.service.target.type',
+  'attributes.event.outcome',
+  'attributes.span.name',
+  'attributes.service.target.name',
+  'attributes.service.target.type',
+];
+
+const METRICSET_NAME = 'service_destination';
+export function createSpanMetricsAggregator(flushInterval: string) {
+  return createOtelMetricAggregator(
+    {
+      filter: (event) =>
+        event['attributes.processor.event'] === 'span' &&
+        !!event['attributes.span.destination.service.resource'],
+      getAggregateKey: (event) => {
+        const key = hashKeysOf(event, KEY_FIELDS);
+        return key;
+      },
+      flushInterval,
+      init: (event) => {
+        const set = pick(event, KEY_FIELDS);
+
+        return {
+          ...set,
+          'data_stream.dataset': `${METRICSET_NAME}.${flushInterval}.otel`,
+          'data_stream.namespace': 'default',
+          'data_stream.type': 'metrics',
+          'attributes.metricset.name': METRICSET_NAME,
+          'attributes.metricset.interval': flushInterval,
+          'attributes.processor.event': 'metric',
+          'processor.event': 'metric',
+          'metrics.span.destination.service.response_time.count': 0,
+          'metrics.span.destination.service.response_time.sum.us': 0,
+        };
+      },
+    },
+    (metric, event) => {
+      metric['metrics.span.destination.service.response_time.count'] += 1;
+      metric['metrics.span.destination.service.response_time.sum.us'] +=
+        event['attributes.span.duration.us']!;
+    },
+    (metric) => {
+      // @ts-expect-error
+      metric._doc_count = metric['span.destination.service.response_time.count'];
+
+      return metric;
+    }
+  );
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_transaction_metrics_aggregator.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/aggregators/otel/create_transaction_metrics_aggregator.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ApmOtelFields, appendHash, hashKeysOf } from '@kbn/apm-synthtrace-client';
+import { pick } from 'lodash';
+import { createLosslessHistogram } from '../../../utils/create_lossless_histogram';
+
+import { createOtelMetricAggregator } from '../create_apm_metric_aggregator';
+
+const KEY_FIELDS: Array<keyof ApmOtelFields> = [
+  'attributes.transaction.name',
+  'attributes.transaction.result',
+  'attributes.transaction.type',
+  'attributes.event.outcome',
+
+  'resource.attributes.agent.name',
+  'resource.attributes.deployment.environment',
+  'attributes.service.namespace',
+  'attributes.service.name',
+  'resource.attributes.service.instance.id',
+  'resource.attributes.process.runtime.name',
+  'resource.attributes.process.runtime.version',
+
+  'resource.attributes.telemetry.sdk.language',
+  'resource.attributes.telemetry.sdk.version',
+
+  'resource.attributes.host.name',
+  'resource.attributes.container.id',
+  'resource.attributes.kubernetes.pod.name',
+
+  'resource.attributes.host.name',
+  'resource.attributes.os.type',
+  'resource.attributes.container.id',
+  'resource.attributes.kubernetes.pod.name',
+
+  'resource.attributes.cloud.provider',
+  'resource.attributes.cloud.region',
+  'resource.attributes.cloud.availability_zone',
+  'resource.attributes.cloud.service.name',
+  'resource.attributes.cloud.account.id',
+  'resource.attributes.cloud.account.name',
+  'resource.attributes.cloud.project.id',
+  'resource.attributes.cloud.project.name',
+  'resource.attributes.cloud.machine.type',
+
+  'resource.attributes.faas.coldstart',
+  'resource.attributes.faas.id',
+  'resource.attributes.faas.trigger.type',
+  'resource.attributes.faas.name',
+  'resource.attributes.faas.version',
+];
+
+const METRICSET_NAME = 'transaction';
+export function createTransactionMetricsAggregator(flushInterval: string) {
+  return createOtelMetricAggregator(
+    {
+      filter: (event) => event['attributes.processor.event'] === 'transaction',
+      getAggregateKey: (event) => {
+        let key = hashKeysOf(event, KEY_FIELDS);
+        key = appendHash(key, event.parent_span_id ? '1' : '0');
+        return key;
+      },
+      flushInterval,
+      init: (event) => {
+        const set = pick(event, KEY_FIELDS);
+
+        return {
+          ...set,
+          'data_stream.dataset': `${METRICSET_NAME}.${flushInterval}.otel`,
+          'data_stream.namespace': 'default',
+          'data_stream.type': 'metrics',
+          'attributes.metricset.name': METRICSET_NAME,
+          'attributes.metricset.interval': flushInterval,
+          'attributes.processor.event': 'metric',
+          'attributes.transaction.root': !event.parent_span_id,
+          'metrics.transaction.duration.histogram': createLosslessHistogram(),
+          'metrics.transaction.duration.summary': {
+            value_count: 0,
+            sum: 0,
+          },
+          'metrics.event.success_count': {
+            sum: 0,
+            value_count: 0,
+          },
+        };
+      },
+    },
+    (metric, event) => {
+      const duration = event['attributes.transaction.duration.us']!;
+      metric['metrics.transaction.duration.histogram'].record(duration);
+
+      if (
+        event['attributes.event.outcome'] === 'success' ||
+        event['attributes.event.outcome'] === 'failure'
+      ) {
+        metric['metrics.event.success_count'].value_count += 1;
+      }
+
+      if (event['attributes.event.outcome'] === 'success') {
+        metric['metrics.event.success_count'].sum += 1;
+      }
+
+      const summary = metric['metrics.transaction.duration.summary'];
+
+      summary.sum += duration;
+      summary.value_count += 1;
+    },
+    (metric) => {
+      const serialized = metric['metrics.transaction.duration.histogram'].serialize();
+
+      metric['metrics.transaction.duration.histogram'] = {
+        // @ts-expect-error
+        values: serialized.values,
+        counts: serialized.counts,
+      };
+
+      // @ts-expect-error
+      metric._doc_count = serialized.total;
+
+      return metric;
+    }
+  );
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/apm_otel_pipeline.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/apm_otel_pipeline.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { PassThrough, pipeline, Readable } from 'stream';
+import { getDedotTransform } from './get_dedot_transform';
+import { getSerializeTransform } from '../../../shared/get_serialize_transform';
+import { createTransactionMetricsAggregator } from '../../aggregators/otel/create_transaction_metrics_aggregator';
+import { createServiceMetricsAggregator } from '../../aggregators/otel/create_service_metrics_aggregator';
+import { createServiceSummaryMetricsAggregator } from '../../aggregators/otel/create_service_summary_metrics_aggregator';
+import { createSpanMetricsAggregator } from '../../aggregators/otel/create_span_metrics_aggregator';
+import { fork } from '../../../utils/stream_utils';
+import { getDynamicTemplateTransform } from './get_dynamic_template_transform';
+import { getRoutingTransform } from './get_routing_transform';
+
+export function otelPipeline(includeSerialization: boolean = true) {
+  const aggregators = [
+    createTransactionMetricsAggregator('1m'),
+    createSpanMetricsAggregator('1m'),
+    createTransactionMetricsAggregator('10m'),
+    createTransactionMetricsAggregator('60m'),
+    createServiceMetricsAggregator('1m'),
+    createServiceMetricsAggregator('10m'),
+    createServiceMetricsAggregator('60m'),
+    createServiceSummaryMetricsAggregator('1m'),
+    createServiceSummaryMetricsAggregator('10m'),
+    createServiceSummaryMetricsAggregator('60m'),
+    createSpanMetricsAggregator('10m'),
+    createSpanMetricsAggregator('60m'),
+  ];
+
+  const serializationTransform = includeSerialization ? [getSerializeTransform()] : [];
+  return (base: Readable) => {
+    return pipeline(
+      // @ts-expect-error see apm_pipeline.ts
+      base,
+      ...serializationTransform,
+      fork(new PassThrough({ objectMode: true }), ...aggregators),
+      getRoutingTransform(),
+      getDynamicTemplateTransform(),
+      getDedotTransform(),
+      (err: unknown) => {
+        if (err) {
+          throw err;
+        }
+      }
+    );
+  };
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/get_dedot_transform.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/get_dedot_transform.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Transform } from 'stream';
+import { ApmOtelFields, dedot } from '@kbn/apm-synthtrace-client';
+
+function extractAttributes(obj: Record<string, any>, attribute: string) {
+  return Object.entries(obj)
+    .filter(([key]) => key.startsWith(attribute))
+    .reduce((acc, [key, value]) => {
+      acc[key.replace(`${attribute}`, '')] = value;
+      return acc;
+    }, {} as Record<string, any>);
+}
+
+function removeAttributes(obj: Record<string, any>, attributes: string[]): ApmOtelFields {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([key]) =>
+      attributes.every((attribute) => !key.startsWith(attribute))
+    )
+  );
+}
+export function getDedotTransform(keepFlattenedFields: boolean = false) {
+  return new Transform({
+    objectMode: true,
+    transform(document: ApmOtelFields, encoding, callback) {
+      let target: Record<string, any>;
+
+      if (keepFlattenedFields) {
+        target =
+          document['attributes.processor.event'] === 'metric' ? document : dedot(document, {});
+      } else {
+        const attributes = extractAttributes(document, 'attributes.');
+        const resourceAttributes = extractAttributes(document, 'resource.attributes.');
+        const scopeAttributes = extractAttributes(document, 'scope.attributes.');
+
+        target = dedot(
+          removeAttributes(document, ['attributes.', 'resource.attributes.', 'scope.attributes.']),
+          {}
+        );
+
+        // these remain flattened
+        target.attributes = attributes;
+        target.resource = target.resource || {};
+        target.resource.attributes = resourceAttributes;
+        target.scope = target.scope || {};
+        target.scope.attributes = scopeAttributes;
+      }
+
+      delete target.meta;
+      if (target['@timestamp']) {
+        target['@timestamp'] = new Date(target['@timestamp']).toISOString();
+      }
+
+      callback(null, target);
+    },
+  });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/get_dynamic_template_transform.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/get_dynamic_template_transform.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Transform } from 'stream';
+import {
+  ApmOtelFields,
+  ESDocumentWithOperation,
+  SynthtraceDynamicTemplate,
+} from '@kbn/apm-synthtrace-client';
+
+export function getDynamicTemplateTransform() {
+  return new Transform({
+    objectMode: true,
+    transform(document: ESDocumentWithOperation<ApmOtelFields>, encoding, callback) {
+      const dynamicTemplates: SynthtraceDynamicTemplate[] = [];
+
+      if (document['metrics.transaction.duration.histogram']) {
+        dynamicTemplates.push({
+          'metrics.transaction.duration.histogram': 'histogram',
+        });
+      }
+
+      if (document['metrics.event.success_count']) {
+        dynamicTemplates.push({
+          'metrics.event.success_count': 'summary',
+        });
+      }
+
+      if (document['metrics.transaction.duration.summary']) {
+        dynamicTemplates.push({
+          'metrics.transaction.duration.summary': 'summary',
+        });
+      }
+
+      if (dynamicTemplates.length > 0) {
+        document._dynamicTemplates = dynamicTemplates.reduce<SynthtraceDynamicTemplate>(
+          (acc, curr) => Object.assign(acc, curr),
+          {}
+        );
+      }
+      callback(null, document);
+    },
+  });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/get_routing_transform.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/get_routing_transform.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { ESDocumentWithOperation, ApmOtelFields } from '@kbn/apm-synthtrace-client';
+import { Transform } from 'stream';
+
+export function getRoutingTransform() {
+  return new Transform({
+    objectMode: true,
+    transform(document: ESDocumentWithOperation<ApmOtelFields>, encoding, callback) {
+      const namespace = 'default';
+      let index: string | undefined;
+
+      switch (document['attributes.processor.event']) {
+        case 'transaction':
+        case 'span':
+          index = `traces-generic.otel-${namespace}`;
+          break;
+
+        case 'error':
+          index = `logs-generic.otel-${namespace}`;
+          break;
+
+        case 'metric':
+          const metricsetName = document['attributes.metricset.name'];
+          const metricsetInterval = document['attributes.metricset.interval'];
+          if (
+            metricsetName === 'transaction' ||
+            metricsetName === 'service_transaction' ||
+            metricsetName === 'service_destination' ||
+            metricsetName === 'service_summary'
+          ) {
+            index = `metrics-${metricsetName}.${metricsetInterval}.otel-${namespace}`;
+          } else {
+            index = `metrics.otel-internal-${namespace}`;
+          }
+          break;
+        default:
+          break;
+      }
+
+      if (!index) {
+        const error = new Error('Cannot determine index for event');
+        Object.assign(error, { document });
+      }
+
+      document._index = index;
+
+      callback(null, document);
+    },
+  });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/otel_synthtrace_es_client.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/apm/client/apm_otel_synthtrace_es_client/otel_synthtrace_es_client.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Client } from '@elastic/elasticsearch';
+import { ApmOtelFields } from '@kbn/apm-synthtrace-client';
+import { SynthtraceEsClient, SynthtraceEsClientOptions } from '../../../shared/base_client';
+import { Logger } from '../../../utils/create_logger';
+import { otelPipeline } from './apm_otel_pipeline';
+
+export type OtelSynthtraceEsClientOptions = Omit<SynthtraceEsClientOptions, 'pipeline'>;
+
+export class OtelSynthtraceEsClient extends SynthtraceEsClient<ApmOtelFields> {
+  constructor(options: { client: Client; logger: Logger } & OtelSynthtraceEsClientOptions) {
+    super({
+      ...options,
+      pipeline: otelPipeline(),
+    });
+    this.dataStreams = ['metrics-*.otel*', 'traces-*.otel*', 'logs-*.otel*'];
+  }
+
+  getDefaultPipeline(
+    {
+      includeSerialization,
+    }: {
+      includeSerialization?: boolean;
+    } = { includeSerialization: true }
+  ) {
+    return otelPipeline(includeSerialization);
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/shared/base_client.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/shared/base_client.ts
@@ -144,8 +144,11 @@ export class SynthtraceEsClient<TFields extends Fields> {
           action = doc._action!;
           delete doc._action;
         } else if (doc._index) {
-          action = { create: { _index: doc._index } };
+          action = { create: { _index: doc._index, dynamic_templates: doc._dynamicTemplates } };
           delete doc._index;
+          if (doc._dynamicTemplates) {
+            delete doc._dynamicTemplates;
+          }
         } else {
           this.logger.debug(doc);
           throw new Error(

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/shared/get_serialize_transform.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/shared/get_serialize_transform.ts
@@ -7,10 +7,10 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { ApmFields, Serializable } from '@kbn/apm-synthtrace-client';
+import { ApmFields, ApmOtelFields, Serializable } from '@kbn/apm-synthtrace-client';
 import { Transform } from 'stream';
 
-export function getSerializeTransform<TFields = ApmFields>() {
+export function getSerializeTransform<TFields = ApmFields | ApmOtelFields>() {
   const buffer: TFields[] = [];
 
   let cb: (() => void) | undefined;

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { OtelInstance, ApmOtelFields } from '@kbn/apm-synthtrace-client';
+import { apmOtel } from '@kbn/apm-synthtrace-client/src/lib/apm';
+import { Scenario } from '../cli/scenario';
+import { withClient } from '../lib/utils/with_client';
+
+const scenario: Scenario<ApmOtelFields> = async (runOptions) => {
+  return {
+    generate: ({ range, clients: { otelEsClient } }) => {
+      const transactionName = 'oteldemo.AdServiceEdotSynth/GetAds';
+
+      const { logger } = runOptions;
+
+      const edotInstance = apmOtel
+        .service({
+          name: 'adservice-edot-synth',
+          namespace: 'opentelemetry-demo',
+          sdkLanguage: 'java',
+          sdkName: 'opentelemetry',
+          distro: 'elastic',
+        })
+        .instance('edot-instance');
+
+      const otelNativeInstance = apmOtel
+        .service({
+          name: 'sendotlp-otel-native-synth',
+          sdkName: 'otlp',
+          sdkLanguage: 'nodejs',
+        })
+        .instance('otel-native-instance');
+
+      const successfulTimestamps = range.interval('1m').rate(180);
+      const failedTimestamps = range.interval('1m').rate(40);
+
+      const instanceSpans = (instance: OtelInstance) => {
+        const successfulTraceEvents = successfulTimestamps.generator((timestamp) =>
+          instance
+            .transaction({
+              transactionName,
+            })
+            .timestamp(timestamp)
+            .duration(1000)
+            .success()
+            .children(
+              instance
+                .span({
+                  spanName: 'GET /',
+                  spanType: 'db',
+                  spanSubtype: 'elasticsearch',
+                })
+                .duration(1000)
+                .success()
+                .destination('elasticsearch')
+                .timestamp(timestamp)
+            )
+        );
+
+        const failedTraceEvents = failedTimestamps.generator((timestamp) =>
+          instance
+            .transaction({ transactionName })
+            .timestamp(timestamp)
+            .duration(1000)
+            .failure()
+            .errors(
+              instance
+                .error({
+                  message: '[ResponseError] index_not_found_exception',
+                  type: 'ResponseError',
+                })
+                .timestamp(timestamp + 50)
+            )
+        );
+
+        return [successfulTraceEvents, failedTraceEvents];
+      };
+
+      return [
+        withClient(
+          otelEsClient,
+          logger.perf('generating_otel_trace', () =>
+            [otelNativeInstance, edotInstance].flatMap((instance) => instanceSpans(instance))
+          )
+        ),
+      ];
+    },
+  };
+};
+
+export default scenario;

--- a/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/synthtrace.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/fixtures/worker/synthtrace.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Readable } from 'stream';
+import type {
+  ApmFields,
+  Fields,
+  InfraDocument,
+  ApmOtelFields,
+  SynthtraceGenerator,
+} from '@kbn/apm-synthtrace-client';
+import Url from 'url';
+import type { SynthtraceEsClient } from '@kbn/apm-synthtrace/src/lib/shared/base_client';
+import {
+  getApmSynthtraceEsClient,
+  getInfraSynthtraceEsClient,
+  getOtelSynthtraceEsClient,
+} from '../../../common/services/synthtrace';
+import { coreWorkerFixtures } from './core_fixtures';
+
+interface SynthtraceFixtureEsClient<TFields extends Fields> {
+  index: (events: SynthtraceGenerator<TFields>) => Promise<void>;
+  clean: SynthtraceEsClient<TFields>['clean'];
+}
+
+export interface SynthtraceFixture {
+  apmSynthtraceEsClient: SynthtraceFixtureEsClient<ApmFields>;
+  infraSynthtraceEsClient: SynthtraceFixtureEsClient<InfraDocument>;
+  otelSynthtraceEsClient: SynthtraceFixtureEsClient<ApmOtelFields>;
+}
+
+const useSynthtraceClient = async <TFields extends Fields>(
+  client: SynthtraceEsClient<TFields>,
+  use: (client: SynthtraceFixtureEsClient<TFields>) => Promise<void>
+) => {
+  const index = async (events: SynthtraceGenerator<TFields>) =>
+    await client.index(Readable.from(Array.from(events).flatMap((event) => event.serialize())));
+
+  const clean = async () => await client.clean();
+
+  await use({ index, clean });
+};
+
+export const synthtraceFixture = coreWorkerFixtures.extend<{}, SynthtraceFixture>({
+  apmSynthtraceEsClient: [
+    async ({ esClient, config, kbnUrl, log }, use) => {
+      const { username, password } = config.auth;
+      const kibanaUrl = new URL(kbnUrl.get());
+      const kibanaUrlWithAuth = Url.format({
+        protocol: kibanaUrl.protocol,
+        hostname: kibanaUrl.hostname,
+        port: kibanaUrl.port,
+        auth: `${username}:${password}`,
+      });
+
+      const apmSynthtraceEsClient = await getApmSynthtraceEsClient(
+        esClient,
+        kibanaUrlWithAuth,
+        log
+      );
+
+      await useSynthtraceClient<ApmFields>(apmSynthtraceEsClient, use);
+    },
+    { scope: 'worker' },
+  ],
+  infraSynthtraceEsClient: [
+    async ({ esClient, config, kbnUrl, log }, use) => {
+      const infraSynthtraceEsClient = await getInfraSynthtraceEsClient(
+        esClient,
+        kbnUrl.get(),
+        config.auth,
+        log
+      );
+
+      await useSynthtraceClient<InfraDocument>(infraSynthtraceEsClient, use);
+    },
+    { scope: 'worker' },
+  ],
+  otelSynthtraceEsClient: [
+    async ({ esClient, log }, use) => {
+      const otelSynthtraceEsClient = await getOtelSynthtraceEsClient(esClient, log);
+
+      await useSynthtraceClient<ApmOtelFields>(otelSynthtraceEsClient, use);
+    },
+    { scope: 'worker' },
+  ],
+});

--- a/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/synthtrace_ingestion.ts
+++ b/src/platform/packages/shared/kbn-scout/src/playwright/global_hooks/synthtrace_ingestion.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { FullConfig } from 'playwright/test';
+import Url from 'url';
+import { Readable } from 'node:stream';
+import type {
+  ApmFields,
+  Fields,
+  InfraDocument,
+  ApmOtelFields,
+  Serializable,
+  SynthtraceGenerator,
+} from '@kbn/apm-synthtrace-client';
+import {
+  getLogger,
+  createScoutConfig,
+  measurePerformanceAsync,
+  getEsClient,
+  ScoutLogger,
+  EsClient,
+} from '../../common';
+import { ScoutTestOptions } from '../types';
+import {
+  getApmSynthtraceEsClient,
+  getInfraSynthtraceEsClient,
+  getOtelSynthtraceEsClient,
+} from '../../common/services/synthtrace';
+
+export type SynthtraceEvents<T extends Fields> = SynthtraceGenerator<T> | Array<Serializable<T>>;
+
+interface SynthtraceIngestionData {
+  apm: Array<SynthtraceEvents<ApmFields>>;
+  infra: Array<SynthtraceEvents<InfraDocument>>;
+  otel: Array<SynthtraceEvents<ApmOtelFields>>;
+}
+
+const getSynthtraceClient = (
+  key: keyof SynthtraceIngestionData,
+  esClient: EsClient,
+  kbnUrl: string,
+  auth: { username: string; password: string },
+  log: ScoutLogger
+) => {
+  switch (key) {
+    case 'apm':
+      const kibanaUrl = new URL(kbnUrl);
+      const kibanaUrlWithAuth = Url.format({
+        protocol: kibanaUrl.protocol,
+        hostname: kibanaUrl.hostname,
+        port: kibanaUrl.port,
+        auth: `${auth.username}:${auth.password}`,
+      });
+      return getApmSynthtraceEsClient(esClient, kibanaUrlWithAuth, log);
+    case 'infra':
+      return getInfraSynthtraceEsClient(esClient, kbnUrl, auth, log);
+    case 'otel':
+      return getOtelSynthtraceEsClient(esClient, log);
+  }
+};
+
+/**
+ * @deprecated Use `globalSetupHook` and synthtrace fixtures instead
+ */
+export async function ingestSynthtraceDataHook(config: FullConfig, data: SynthtraceIngestionData) {
+  const log = getLogger();
+
+  const { apm, infra, otel } = data;
+  const hasApmData = apm.length > 0;
+  const hasInfraData = infra.length > 0;
+  const hasOtelData = otel.length > 0;
+  const hasAnyData = hasApmData || hasInfraData || hasOtelData;
+
+  if (!hasAnyData) {
+    log.debug('[setup] no synthtrace data to ingest');
+    return;
+  }
+
+  return measurePerformanceAsync(log, '[setup]: ingestSynthtraceDataHook', async () => {
+    // TODO: This should be configurable local vs cloud
+
+    const configName = 'local';
+    const projectUse = config.projects[0].use as ScoutTestOptions;
+    const serversConfigDir = projectUse.serversConfigDir;
+    const scoutConfig = createScoutConfig(serversConfigDir, configName, log);
+    const esClient = getEsClient(scoutConfig, log);
+    const kbnUrl = scoutConfig.hosts.kibana;
+
+    for (const key of Object.keys(data)) {
+      const typedKey = key as keyof SynthtraceIngestionData;
+      if (data[typedKey].length > 0) {
+        const client = await getSynthtraceClient(typedKey, esClient, kbnUrl, scoutConfig.auth, log);
+
+        log.debug(`[setup] ingesting ${key} synthtrace data`);
+
+        try {
+          await Promise.all(
+            data[typedKey].map((event) => {
+              return client.index(Readable.from(Array.from(event).flatMap((e) => e.serialize())));
+            })
+          );
+        } catch (e) {
+          log.debug(`[setup] error ingesting ${key} synthtrace data`, e);
+        }
+
+        log.debug(`[setup] ${key} synthtrace data ingested successfully`);
+      } else {
+        log.debug(`[setup] no synthtrace data to ingest for ${key}`);
+      }
+    }
+  });
+}

--- a/src/platform/packages/shared/kbn-scout/tsconfig.json
+++ b/src/platform/packages/shared/kbn-scout/tsconfig.json
@@ -27,6 +27,8 @@
     "@kbn/mock-idp-utils",
     "@kbn/test-subj-selector",
     "@kbn/scout-info",
-    "@kbn/scout-reporting"
+    "@kbn/scout-reporting",
+    "@kbn/apm-synthtrace-client",
+    "@kbn/apm-synthtrace"
   ]
 }

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/adservice_edot.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/adservice_edot.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { apmOtel, timerange } from '@kbn/apm-synthtrace-client';
+
+export function adserviceEdot({ from, to }: { from: number; to: number }) {
+  const range = timerange(from, to);
+  const transactionName = 'oteldemo.AdServiceEdotSynth/GetAds';
+
+  const edotInstance = apmOtel
+    .service({
+      name: 'adservice-edot-synth',
+      namespace: 'opentelemetry-demo',
+      sdkLanguage: 'java',
+      sdkName: 'opentelemetry',
+      distro: 'elastic',
+    })
+    .instance('da7a8507-53be-421c-8d77-984f12397213');
+
+  return range
+    .interval('1s')
+    .rate(1)
+    .generator((timestamp) => [
+      edotInstance
+        .transaction({
+          transactionName,
+        })
+        .overrides({
+          'attributes.server.address': 'otel-demo-blue-adservice-edot-synth',
+          'attributes.server.port': 8080,
+          'attributes.url.path': '/some/path',
+          'attributes.url.scheme': 'https',
+          'attributes.url.full': undefined,
+        })
+        .timestamp(timestamp)
+        .duration(551)
+        .success(),
+    ]);
+}

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/sendotlp.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/fixtures/synthtrace/sendotlp.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { apmOtel, timerange } from '@kbn/apm-synthtrace-client';
+
+export function sendotlp({ from, to }: { from: number; to: number }) {
+  const range = timerange(from, to);
+  const transactionName = 'parent-synth';
+  const transactionType = 'unknown';
+
+  const otelSendotlp = apmOtel
+    .service({
+      name: 'sendotlp-otel-native-synth',
+      sdkName: 'otlp',
+      sdkLanguage: 'go',
+    })
+    .instance('89117ac1-0dbf-4488-9e17-4c2c3b76943a');
+
+  return range
+    .interval('1s')
+    .rate(1)
+    .generator((timestamp) => [
+      otelSendotlp
+        .transaction({
+          transactionName,
+          transactionType,
+        })
+        .defaults({
+          'attributes.transaction.result': 'HTTP 2xx',
+        })
+        .timestamp(timestamp)
+        .duration(15202)
+        .success()
+        .children(
+          otelSendotlp
+            .span({
+              spanName: 'child1',
+              spanType: 'external',
+              spanSubtype: 'http',
+              'attributes.http.request.method': 'GET',
+            })
+            .duration(1000)
+            .destination('foo_service-otel-native-synth:8080')
+            .success()
+            .timestamp(timestamp)
+        ),
+
+      otelSendotlp
+        .transaction({
+          transactionName,
+          transactionType,
+        })
+        .timestamp(timestamp)
+        .duration(1000)
+        .failure()
+        .errors(
+          otelSendotlp
+            .error({
+              message: 'boom',
+              type: '*errors.errorString',
+              stackTrace: 'Error: INTERNAL: Boom',
+            })
+            .timestamp(timestamp + 50)
+        ),
+    ]);
+}

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/synthtrace.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/synthtrace.ts
@@ -4,7 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { Serializable, ApmFields, SynthtraceGenerator } from '@kbn/apm-synthtrace-client';
+import type {
+  Serializable,
+  ApmFields,
+  ApmOtelFields,
+  SynthtraceGenerator,
+} from '@kbn/apm-synthtrace-client';
 
 export const synthtrace = {
   index: (events: SynthtraceGenerator<ApmFields> | Array<Serializable<ApmFields>>) =>
@@ -13,4 +18,13 @@ export const synthtrace = {
       Array.from(events).flatMap((event) => event.serialize())
     ),
   clean: () => cy.task('synthtrace:clean'),
+};
+
+export const synthtraceOtel = {
+  index: (events: SynthtraceGenerator<ApmOtelFields> | Array<Serializable<ApmOtelFields>>) =>
+    cy.task(
+      'synthtraceOtel:index',
+      Array.from(events).flatMap((event) => event.serialize())
+    ),
+  clean: () => cy.task('synthtraceOtel:clean'),
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Synthtrace] Fluent API for APM otel (#216099)](https://github.com/elastic/kibana/pull/216099)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-02T13:27:20Z","message":"[Synthtrace] Fluent API for APM otel (#216099)\n\ncloses https://github.com/elastic/kibana/issues/216032\n\n## Summary\n\nCreate a fluent API for APM Otel. The interface is similar to the one\ncurrently used to create scenarios for elastic APM data.\n\nThis will make it easier to create tests and more flexible synthetic\nscenarios to cover Otel specificities.\n\n### How to test\n\n- run `node scripts/synthtrace otel_simple_trace.ts --live --uniqueIds\n--clean`\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"03f4b4892dc548917c9daeda738a2cbe23b4cd82","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v9.0.0","Team:obs-ux-infra_services","v9.1.0","v8.19.0","v8.17.7","v8.18.2"],"title":"[Synthtrace] Fluent API for APM otel","number":216099,"url":"https://github.com/elastic/kibana/pull/216099","mergeCommit":{"message":"[Synthtrace] Fluent API for APM otel (#216099)\n\ncloses https://github.com/elastic/kibana/issues/216032\n\n## Summary\n\nCreate a fluent API for APM Otel. The interface is similar to the one\ncurrently used to create scenarios for elastic APM data.\n\nThis will make it easier to create tests and more flexible synthetic\nscenarios to cover Otel specificities.\n\n### How to test\n\n- run `node scripts/synthtrace otel_simple_trace.ts --live --uniqueIds\n--clean`\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"03f4b4892dc548917c9daeda738a2cbe23b4cd82"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.17","8.18"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/216099","number":216099,"mergeCommit":{"message":"[Synthtrace] Fluent API for APM otel (#216099)\n\ncloses https://github.com/elastic/kibana/issues/216032\n\n## Summary\n\nCreate a fluent API for APM Otel. The interface is similar to the one\ncurrently used to create scenarios for elastic APM data.\n\nThis will make it easier to create tests and more flexible synthetic\nscenarios to cover Otel specificities.\n\n### How to test\n\n- run `node scripts/synthtrace otel_simple_trace.ts --live --uniqueIds\n--clean`\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"03f4b4892dc548917c9daeda738a2cbe23b4cd82"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"url":"https://github.com/elastic/kibana/pull/219989","number":219989,"branch":"8.19","state":"MERGED","mergeCommit":{"sha":"20c7b1e46ab6f32e2f7b64754e737c0aea76939c","message":"[8.19] [Synthtrace] Fluent API for APM otel (#216099) (#219989)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Synthtrace] Fluent API for APM otel\n(#216099)](https://github.com/elastic/kibana/pull/216099)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>"}}]}] BACKPORT-->