### PR TITLE
[8.19] [ci] Increase disk 80 for jest tests (#219520)

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -487,7 +487,7 @@ export async function pickTestGroupRunOrder() {
             key: 'jest',
             agents: {
               ...expandAgentQueue('n2-4-spot'),
-              diskSizeGb: 75,
+              diskSizeGb: 80,
             },
             retry: {
               automatic: [


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.18` to `8.19`:
 - [[ci] Increase disk 80 for jest tests (#219520)](https://github.com/elastic/kibana/pull/219520)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Alex Szabo","email":"alex.szabo@elastic.co"},"sourceCommit":{"committedDate":"2025-04-29T11:53:42Z","message":"[ci] Increase disk 80 for jest tests (#219520)\n\n## Summary\nSimilarly to https://github.com/elastic/kibana/pull/219506 - increase\nthe disk size for jest tests.\n\nContext:\nhttps://elastic.slack.com/archives/C013B57RRGE/p1745911271021589","sha":"1c7a552e8376c894bf8508800739b812cd667e27","branchLabelMapping":{"^v8.16.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","skip-ci","backport:version","v8.19.0"],"title":"[ci][8.18] Increase disk 80 for jest tests","number":219520,"url":"https://github.com/elastic/kibana/pull/219520","mergeCommit":{"message":"[ci] Increase disk 80 for jest tests (#219520)\n\n## Summary\nSimilarly to https://github.com/elastic/kibana/pull/219506 - increase\nthe disk size for jest tests.\n\nContext:\nhttps://elastic.slack.com/archives/C013B57RRGE/p1745911271021589","sha":"1c7a552e8376c894bf8508800739b812cd667e27"}},"sourceBranch":"8.18","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->