### PR TITLE
[Fleet] Fix updating agentless settings for managed policies

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.test.ts
@@ -62,6 +62,9 @@ describe('correct agentless policy settings', () => {
       {
         data_output_id: 'es-default-output',
         fleet_server_host_id: 'default-fleet-server',
+      },
+      {
+        force: true,
       }
     );
     expect(agentPolicyService.update).toHaveBeenCalledWith(

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.test.ts
@@ -71,6 +71,9 @@ describe('correct agentless policy settings', () => {
       {
         data_output_id: 'es-default-output',
         fleet_server_host_id: 'default-fleet-server',
+      },
+      {
+        force: true,
       }
     );
   });

--- a/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/agentless_settings_ids.ts
@@ -130,6 +130,9 @@ export async function ensureCorrectAgentlessSettingsIds(esClient: ElasticsearchC
         {
           data_output_id: correctOutputId,
           fleet_server_host_id: correctFleetServerId,
+        },
+        {
+          force: true,
         }
       );
     },


### PR DESCRIPTION
## Summary

Agentless policy was created from preconfiguration and was managed at some point. https://github.com/elastic/project-controller/pull/1158/files

This cause the following error on some older project
<img width="1502" alt="Screenshot 2025-05-06 at 9 37 41 AM" src="https://github.com/user-attachments/assets/961f7ed2-2d28-483b-9309-c6a7c3ba2c6a" />


That PR fix that by using the force flag (as we do for other agentPolicy update operation in the setup)

## Workaround 

For existing user with that error it could be solved with

```
PUT kbn:/api/fleet/agent_policies/agentless
{
  "name": "Agentless",
  "namespace": "default",
  "is_managed": false,
  "force": true
}
```

## How to test

You can create a managed agentless policy check the setup is working, (you need a trial license too)
```
PUT .kibana_ingest/_doc/fleet-agent-policies:agentless
{
          "fleet-agent-policies": {
            "monitoring_enabled": [
              "logs",
              "metrics"
            ],
            "is_preconfigured": true,
            "inactivity_timeout": 1209600,
            "data_output_id": null,
            "monitoring_output_id": null,
            "download_source_id": "fleet-default-download-source",
            "fleet_server_host_id": null,
            "namespace": "default",
            "name": "Agentless",
            "supports_agentless": true,
            "is_managed": true,
            "is_protected": false,
            "status": "active",
            "revision": 1,
            "updated_at": "2025-05-06T13:35:52.054Z",
            "updated_by": "system_indices_superuser",
            "schema_version": "1.1.1"
          },
          "type": "fleet-agent-policies",
          "references": [],
          "managed": false,
          "namespaces": [
            "default"
          ],
          "coreMigrationVersion": "8.8.0",
          "typeMigrationVersion": "10.2.0",
          "updated_at": "2025-05-06T13:35:52.054Z",
          "created_at": "2025-05-06T13:35:52.054Z"
        }
```