### PR TITLE
[Discover][APM] Add field action popover to span/transaction title

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
@@ -54,7 +54,10 @@ export function SpanOverview({
       >
         <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
           <EuiSpacer size="m" />
-          <SpanSummaryTitle name={parsedDoc[SPAN_NAME_FIELD]} id={parsedDoc[SPAN_ID_FIELD]} />
+          <SpanSummaryTitle
+            name={{ value: parsedDoc[SPAN_NAME_FIELD], field: SPAN_NAME_FIELD }}
+            id={{ value: parsedDoc[SPAN_ID_FIELD], field: SPAN_ID_FIELD }}
+          />
           <EuiSpacer size="m" />
           {spanFields.map((fieldId) => (
             <SpanSummaryField

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/span_overview.tsx
@@ -54,10 +54,7 @@ export function SpanOverview({
       >
         <EuiPanel color="transparent" hasShadow={false} paddingSize="none">
           <EuiSpacer size="m" />
-          <SpanSummaryTitle
-            name={{ value: parsedDoc[SPAN_NAME_FIELD], field: SPAN_NAME_FIELD }}
-            id={{ value: parsedDoc[SPAN_ID_FIELD], field: SPAN_ID_FIELD }}
-          />
+          <SpanSummaryTitle name={parsedDoc[SPAN_NAME_FIELD]} id={parsedDoc[SPAN_ID_FIELD]} />
           <EuiSpacer size="m" />
           {spanFields.map((fieldId) => (
             <SpanSummaryField

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_title.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_title.tsx
@@ -9,38 +9,34 @@
 
 import { EuiText, EuiTitle } from '@elastic/eui';
 import React from 'react';
+import { SPAN_ID_FIELD, SPAN_NAME_FIELD } from '@kbn/discover-utils';
 import { FieldHoverActionPopover } from '../../components/field_with_actions/field_hover_popover_action';
 
-interface SpanSummaryField {
-  field: string;
-  value?: string;
-}
-
 export interface SpanSummaryTitleProps {
-  name: SpanSummaryField;
-  id: Required<SpanSummaryField>;
+  name?: string;
+  id: string;
 }
 
 export const SpanSummaryTitle = ({ name, id }: SpanSummaryTitleProps) => {
-  return name?.value ? (
+  return name ? (
     <>
       <div>
-        <FieldHoverActionPopover title={name.value} value={name.value} field={name.field}>
+        <FieldHoverActionPopover title={name} value={name} field={SPAN_NAME_FIELD}>
           <EuiTitle size="xs">
-            <h2>{name.value}</h2>
+            <h2>{name}</h2>
           </EuiTitle>
         </FieldHoverActionPopover>
       </div>
-      <FieldHoverActionPopover title={id.value} value={id.value} field={id.field}>
+      <FieldHoverActionPopover title={id} value={id} field={SPAN_ID_FIELD}>
         <EuiText size="xs" color="subdued">
-          {id.value}
+          {id}
         </EuiText>
       </FieldHoverActionPopover>
     </>
   ) : (
-    <FieldHoverActionPopover title={id.value!} value={id.value} field={id.field}>
+    <FieldHoverActionPopover title={id} value={id} field={SPAN_ID_FIELD}>
       <EuiTitle size="xs">
-        <h2>{id.value}</h2>
+        <h2>{id}</h2>
       </EuiTitle>
     </FieldHoverActionPopover>
   );

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_title.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_span_overview/sub_components/span_summary_title.tsx
@@ -9,25 +9,39 @@
 
 import { EuiText, EuiTitle } from '@elastic/eui';
 import React from 'react';
+import { FieldHoverActionPopover } from '../../components/field_with_actions/field_hover_popover_action';
+
+interface SpanSummaryField {
+  field: string;
+  value?: string;
+}
 
 export interface SpanSummaryTitleProps {
-  name?: string;
-  id: string;
+  name: SpanSummaryField;
+  id: Required<SpanSummaryField>;
 }
 
 export const SpanSummaryTitle = ({ name, id }: SpanSummaryTitleProps) => {
-  return name ? (
+  return name?.value ? (
     <>
-      <EuiTitle size="xs">
-        <h2>{name}</h2>
-      </EuiTitle>
-      <EuiText size="xs" color="subdued">
-        {id}
-      </EuiText>
+      <div>
+        <FieldHoverActionPopover title={name.value} value={name.value} field={name.field}>
+          <EuiTitle size="xs">
+            <h2>{name.value}</h2>
+          </EuiTitle>
+        </FieldHoverActionPopover>
+      </div>
+      <FieldHoverActionPopover title={id.value} value={id.value} field={id.field}>
+        <EuiText size="xs" color="subdued">
+          {id.value}
+        </EuiText>
+      </FieldHoverActionPopover>
     </>
   ) : (
-    <EuiTitle size="xs">
-      <h2>{id}</h2>
-    </EuiTitle>
+    <FieldHoverActionPopover title={id.value!} value={id.value} field={id.field}>
+      <EuiTitle size="xs">
+        <h2>{id.value}</h2>
+      </EuiTitle>
+    </FieldHoverActionPopover>
   );
 };

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_title.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_title.tsx
@@ -10,11 +10,17 @@
 import { EuiText, EuiTitle } from '@elastic/eui';
 import React from 'react';
 import { TransactionNameLink } from '../../components/transaction_name_link';
+import { FieldHoverActionPopover } from '../../components/field_with_actions/field_hover_popover_action';
+
+interface TransactionSummaryField {
+  field: string;
+  value?: string;
+}
 
 export interface TransactionSummaryTitleProps {
   serviceName: string;
-  name?: string;
-  id?: string;
+  name: TransactionSummaryField;
+  id: TransactionSummaryField;
 }
 
 const renderTransactionTitle = (transactionName: string) => <strong>{transactionName}</strong>;
@@ -28,22 +34,26 @@ export const TransactionSummaryTitle = ({
     <>
       <EuiTitle size="xs">
         <h2>
-          {name ? (
-            <TransactionNameLink
-              serviceName={serviceName}
-              transactionName={name}
-              renderContent={renderTransactionTitle}
-            />
+          {name.value ? (
+            <FieldHoverActionPopover title={name.value} value={name.value} field={name.field}>
+              <TransactionNameLink
+                serviceName={serviceName}
+                transactionName={name.value}
+                renderContent={renderTransactionTitle}
+              />
+            </FieldHoverActionPopover>
           ) : (
             serviceName
           )}
         </h2>
       </EuiTitle>
 
-      {id && (
-        <EuiText size="xs" color="subdued">
-          {id}
-        </EuiText>
+      {id.value && (
+        <FieldHoverActionPopover title={id.value} value={id.value} field={id.field}>
+          <EuiText size="xs" color="subdued">
+            {id.value}
+          </EuiText>
+        </FieldHoverActionPopover>
       )}
     </>
   );

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_title.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/sub_components/transaction_summary_title.tsx
@@ -9,18 +9,18 @@
 
 import { EuiText, EuiTitle } from '@elastic/eui';
 import React from 'react';
+import {
+  SERVICE_NAME_FIELD,
+  TRANSACTION_ID_FIELD,
+  TRANSACTION_NAME_FIELD,
+} from '@kbn/discover-utils';
 import { TransactionNameLink } from '../../components/transaction_name_link';
 import { FieldHoverActionPopover } from '../../components/field_with_actions/field_hover_popover_action';
 
-interface TransactionSummaryField {
-  field: string;
-  value?: string;
-}
-
 export interface TransactionSummaryTitleProps {
   serviceName: string;
-  name: TransactionSummaryField;
-  id: TransactionSummaryField;
+  name?: string;
+  id?: string;
 }
 
 const renderTransactionTitle = (transactionName: string) => <strong>{transactionName}</strong>;
@@ -34,24 +34,30 @@ export const TransactionSummaryTitle = ({
     <>
       <EuiTitle size="xs">
         <h2>
-          {name.value ? (
-            <FieldHoverActionPopover title={name.value} value={name.value} field={name.field}>
+          {name ? (
+            <FieldHoverActionPopover title={name} value={name} field={TRANSACTION_NAME_FIELD}>
               <TransactionNameLink
                 serviceName={serviceName}
-                transactionName={name.value}
+                transactionName={name}
                 renderContent={renderTransactionTitle}
               />
             </FieldHoverActionPopover>
           ) : (
-            serviceName
+            <FieldHoverActionPopover
+              title={serviceName}
+              value={serviceName}
+              field={SERVICE_NAME_FIELD}
+            >
+              {serviceName}
+            </FieldHoverActionPopover>
           )}
         </h2>
       </EuiTitle>
 
-      {id.value && (
-        <FieldHoverActionPopover title={id.value} value={id.value} field={id.field}>
+      {id && (
+        <FieldHoverActionPopover title={id} value={id} field={TRANSACTION_ID_FIELD}>
           <EuiText size="xs" color="subdued">
-            {id.value}
+            {id}
           </EuiText>
         </FieldHoverActionPopover>
       )}

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
@@ -60,8 +60,8 @@ export function TransactionOverview({
           <EuiSpacer size="m" />
           <TransactionSummaryTitle
             serviceName={parsedDoc[SERVICE_NAME_FIELD]}
-            id={{ value: transactionId, field: TRANSACTION_ID_FIELD }}
-            name={{ value: parsedDoc[TRANSACTION_NAME_FIELD], field: TRANSACTION_NAME_FIELD }}
+            id={transactionId}
+            name={parsedDoc[TRANSACTION_NAME_FIELD]}
           />
           <EuiSpacer size="m" />
           {transactionFields.map((fieldId) => (

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/doc_viewer_transaction_overview/transaction_overview.tsx
@@ -60,8 +60,8 @@ export function TransactionOverview({
           <EuiSpacer size="m" />
           <TransactionSummaryTitle
             serviceName={parsedDoc[SERVICE_NAME_FIELD]}
-            id={transactionId}
-            name={parsedDoc[TRANSACTION_NAME_FIELD]!}
+            id={{ value: transactionId, field: TRANSACTION_ID_FIELD }}
+            name={{ value: parsedDoc[TRANSACTION_NAME_FIELD], field: TRANSACTION_NAME_FIELD }}
           />
           <EuiSpacer size="m" />
           {transactionFields.map((fieldId) => (


### PR DESCRIPTION
## Summary

As the Span/Transaction name and id were moved to be the Title/Subtitle of the Span/Transaction document overview, they initially lost the field actions popover they had before. This PR adds the popover back.

Closes #220066

![Screenshot 2025-05-06 153849](https://github.com/user-attachments/assets/6075e836-b665-454a-8199-18edf747f4b2)

### How to test

* Add this to your `kibana.dev.yml` file:
```yaml
discover.experimental.enabledProfiles:
  - observability-traces-data-source-profile
  - observability-traces-transaction-document-profile
  - observability-traces-span-document-profile
```
* Enable the Observability mode for the current space, then navigate to Discover
* Create/use a data-view or use an ES|QL query that targets a `traces-*` index.
* Open the overview for a resulting Span/Transaction and hover over the title/name. A popover should appear.

