### PR TITLE
[8.19] [SLO] Check for unique SLO ids across spaces (#214496)

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/create_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/create_slo.ts
@@ -22,8 +22,14 @@ export const createSLORoute = createSloServerRoute({
   handler: async ({ context, params, logger, request, plugins, corePlugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
 
-    const { scopedClusterClient, spaceId, repository, transformManager, summaryTransformManager } =
-      await getScopedClients({ request, logger });
+    const {
+      scopedClusterClient,
+      internalSoClient,
+      spaceId,
+      repository,
+      transformManager,
+      summaryTransformManager,
+    } = await getScopedClients({ request, logger });
 
     const core = await context.core;
     const userId = core.security.authc.getCurrentUser()?.username!;
@@ -32,6 +38,7 @@ export const createSLORoute = createSloServerRoute({
     const createSLO = new CreateSLO(
       scopedClusterClient,
       repository,
+      internalSoClient,
       transformManager,
       summaryTransformManager,
       logger,

--- a/x-pack/solutions/observability/plugins/slo/server/routes/slo/inspect_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/routes/slo/inspect_slo.ts
@@ -22,8 +22,14 @@ export const inspectSLORoute = createSloServerRoute({
   handler: async ({ context, params, logger, request, plugins, corePlugins, getScopedClients }) => {
     await assertPlatinumLicense(plugins);
 
-    const { scopedClusterClient, spaceId, repository, transformManager, summaryTransformManager } =
-      await getScopedClients({ request, logger });
+    const {
+      scopedClusterClient,
+      internalSoClient,
+      spaceId,
+      repository,
+      transformManager,
+      summaryTransformManager,
+    } = await getScopedClients({ request, logger });
 
     const core = await context.core;
     const basePath = corePlugins.http.basePath;
@@ -32,6 +38,7 @@ export const inspectSLORoute = createSloServerRoute({
     const createSLO = new CreateSLO(
       scopedClusterClient,
       repository,
+      internalSoClient,
       transformManager,
       summaryTransformManager,
       logger,

--- a/x-pack/solutions/observability/plugins/slo/server/services/create_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/create_slo.test.ts
@@ -6,12 +6,14 @@
  */
 
 import { SecurityHasPrivilegesResponse } from '@elastic/elasticsearch/lib/api/types';
+import { SavedObjectsClientContract } from '@kbn/core/packages/saved-objects/api-server';
 import {
   elasticsearchServiceMock,
   httpServiceMock,
   loggingSystemMock,
   ScopedClusterClientMock,
 } from '@kbn/core/server/mocks';
+import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
 import { MockedLogger } from '@kbn/logging-mocks';
 import { CreateSLO } from './create_slo';
 import { fiveMinute, oneMinute } from './fixtures/duration';
@@ -26,6 +28,7 @@ import { TransformManager } from './transform_manager';
 
 describe('CreateSLO', () => {
   let mockScopedClusterClient: ScopedClusterClientMock;
+  let mockSavedObjectsClient: jest.Mocked<SavedObjectsClientContract>;
   let mockLogger: jest.Mocked<MockedLogger>;
   let mockRepository: jest.Mocked<SLORepository>;
   let mockTransformManager: jest.Mocked<TransformManager>;
@@ -36,6 +39,7 @@ describe('CreateSLO', () => {
 
   beforeEach(() => {
     mockScopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+    mockSavedObjectsClient = savedObjectsClientMock.create();
     mockLogger = loggingSystemMock.createLogger();
     mockRepository = createSLORepositoryMock();
     mockTransformManager = createTransformManagerMock();
@@ -43,6 +47,7 @@ describe('CreateSLO', () => {
     createSLO = new CreateSLO(
       mockScopedClusterClient,
       mockRepository,
+      mockSavedObjectsClient,
       mockTransformManager,
       mockSummaryTransformManager,
       mockLogger,
@@ -57,6 +62,12 @@ describe('CreateSLO', () => {
       mockScopedClusterClient.asCurrentUser.security.hasPrivileges.mockResolvedValue({
         has_all_requested: true,
       } as SecurityHasPrivilegesResponse);
+      mockSavedObjectsClient.find.mockResolvedValue({
+        saved_objects: [],
+        per_page: 20,
+        page: 0,
+        total: 0,
+      });
     });
 
     it('calls the expected services', async () => {
@@ -166,14 +177,12 @@ describe('CreateSLO', () => {
       mockScopedClusterClient.asCurrentUser.security.hasPrivileges.mockResolvedValue({
         has_all_requested: true,
       } as SecurityHasPrivilegesResponse);
-    });
-
-    it('throws a SLOIdConflict error when the SLO already exists', async () => {
-      mockRepository.exists.mockResolvedValue(true);
-
-      const sloParams = createSLOParams({ indicator: createAPMTransactionErrorRateIndicator() });
-
-      await expect(createSLO.execute(sloParams)).rejects.toThrowError(/SLO \[.*\] already exists/);
+      mockSavedObjectsClient.find.mockResolvedValue({
+        saved_objects: [],
+        per_page: 20,
+        page: 0,
+        total: 0,
+      });
     });
 
     it('throws a SecurityException error when the user does not have the required privileges', async () => {

--- a/x-pack/solutions/observability/plugins/slo/server/services/create_slo.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/create_slo.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { SecurityHasPrivilegesResponse } from '@elastic/elasticsearch/lib/api/types';
-import { SavedObjectsClientContract } from '@kbn/core/packages/saved-objects/api-server';
+import { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
 import {
   elasticsearchServiceMock,
   httpServiceMock,

--- a/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/create_slo.ts
@@ -4,13 +4,21 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { IngestPutPipelineRequest } from '@elastic/elasticsearch/lib/api/types';
-import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { IBasePath, IScopedClusterClient, Logger } from '@kbn/core/server';
+import {
+  IngestPutPipelineRequest,
+  TransformPutTransformRequest,
+} from '@elastic/elasticsearch/lib/api/types';
+import {
+  IBasePath,
+  IScopedClusterClient,
+  Logger,
+  SavedObjectsClientContract,
+} from '@kbn/core/server';
 import { ALL_VALUE, CreateSLOParams, CreateSLOResponse } from '@kbn/slo-schema';
 import { asyncForEach } from '@kbn/std';
 import { merge } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
+import { ALL_SPACES_ID } from '@kbn/spaces-plugin/common/constants';
 import {
   SLO_MODEL_VERSION,
   SUMMARY_TEMP_INDEX_NAME,
@@ -21,7 +29,7 @@ import {
 } from '../../common/constants';
 import { getSLIPipelineTemplate } from '../assets/ingest_templates/sli_pipeline_template';
 import { getSummaryPipelineTemplate } from '../assets/ingest_templates/summary_pipeline_template';
-import { Duration, DurationUnit, SLODefinition } from '../domain/models';
+import { Duration, DurationUnit, SLODefinition, StoredSLODefinition } from '../domain/models';
 import { validateSLO } from '../domain/services';
 import { SLOIdConflict, SecurityException } from '../errors';
 import { retryTransientEsErrors } from '../utils/retry';
@@ -30,11 +38,13 @@ import { createTempSummaryDocument } from './summary_transform_generator/helpers
 import { TransformManager } from './transform_manager';
 import { assertExpectedIndicatorSourceIndexPrivileges } from './utils/assert_expected_indicator_source_index_privileges';
 import { getTransformQueryComposite } from './utils/get_transform_compite_query';
+import { SO_SLO_TYPE } from '../saved_objects';
 
 export class CreateSLO {
   constructor(
     private scopedClusterClient: IScopedClusterClient,
     private repository: SLORepository,
+    private internalSOClient: SavedObjectsClientContract,
     private transformManager: TransformManager,
     private summaryTransformManager: TransformManager,
     private logger: Logger,
@@ -122,7 +132,15 @@ export class CreateSLO {
   }
 
   private async assertSLOInexistant(slo: SLODefinition) {
-    const exists = await this.repository.exists(slo.id);
+    const findResponse = await this.internalSOClient.find<StoredSLODefinition>({
+      type: SO_SLO_TYPE,
+      perPage: 0,
+      filter: `slo.attributes.id:(${slo.id})`,
+      namespaces: [ALL_SPACES_ID],
+    });
+
+    const exists = findResponse.total > 0;
+
     if (exists) {
       throw new SLOIdConflict(`SLO [${slo.id}] already exists`);
     }
@@ -192,9 +210,7 @@ export class CreateSLO {
       temporaryDoc,
       summaryTransform,
       rollUpTransform,
-      // @ts-expect-error there is some issue with deprecated types being used in es types
       rollUpTransformCompositeQuery: getTransformQueryComposite(rollUpTransform),
-      // @ts-expect-error there is some issue with deprecated types being used in es types
       summaryTransformCompositeQuery: getTransformQueryComposite(summaryTransform),
     };
   }

--- a/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/mocks/index.ts
@@ -50,7 +50,6 @@ const createSLORepositoryMock = (): jest.Mocked<SLORepository> => {
     findAllByIds: jest.fn(),
     deleteById: jest.fn(),
     search: jest.fn(),
-    exists: jest.fn(),
   };
 };
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/slo_repository.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/slo_repository.ts
@@ -16,7 +16,6 @@ import { SLONotFound } from '../errors';
 import { SO_SLO_TYPE } from '../saved_objects';
 
 export interface SLORepository {
-  exists(id: string): Promise<boolean>;
   create(slo: SLODefinition): Promise<SLODefinition>;
   update(slo: SLODefinition): Promise<SLODefinition>;
   findAllByIds(ids: string[]): Promise<SLODefinition[]>;
@@ -34,16 +33,6 @@ export interface SLORepository {
 
 export class KibanaSavedObjectsSLORepository implements SLORepository {
   constructor(private soClient: SavedObjectsClientContract, private logger: Logger) {}
-
-  async exists(id: string) {
-    const findResponse = await this.soClient.find<StoredSLODefinition>({
-      type: SO_SLO_TYPE,
-      perPage: 0,
-      filter: `slo.attributes.id:(${id})`,
-    });
-
-    return findResponse.total > 0;
-  }
 
   async create(slo: SLODefinition): Promise<SLODefinition> {
     await this.soClient.create<StoredSLODefinition>(SO_SLO_TYPE, toStoredSLO(slo));

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/transform_generator.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_generators/transform_generator.ts
@@ -5,12 +5,10 @@
  * 2.0.
  */
 
-import {
-  MappingRuntimeFields,
-  TransformPutTransformRequest,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { MappingRuntimeFields } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { DataView, DataViewsService } from '@kbn/data-views-plugin/common';
 import { ALL_VALUE, timeslicesBudgetingMethodSchema } from '@kbn/slo-schema';
+import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import { TransformSettings } from '../../assets/transform_templates/slo_transform_template';
 import { SLODefinition } from '../../domain/models';
 

--- a/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/transform_manager.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { IScopedClusterClient, Logger } from '@kbn/core/server';
+import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import { IndicatorTypes, SLODefinition } from '../domain/models';
 import { SecurityException } from '../errors';
 import { retryTransientEsErrors } from '../utils/retry';

--- a/x-pack/solutions/observability/plugins/slo/server/services/utils/get_transform_compite_query.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/services/utils/get_transform_compite_query.ts
@@ -8,10 +8,10 @@
 import {
   AggregationsCompositeAggregationSource,
   TransformPutTransformRequest,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+} from '@elastic/elasticsearch/lib/api/types';
 import { createEsParams } from '../../utils/queries';
 
-export function getTransformQueryComposite(transform: TransformPutTransformRequest['body']) {
+export function getTransformQueryComposite(transform: TransformPutTransformRequest) {
   let transformQueryString: string = '';
   if (transform) {
     const pivotGroupBy = transform.pivot?.group_by ?? {};

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/slo/create_slo.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/slo/create_slo.ts
@@ -17,6 +17,7 @@ import { TransformHelper, createTransformHelper } from './helpers/transform';
 
 export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
   const esClient = getService('es');
+  const spaceApi = getService('spaces');
   const sloApi = getService('sloApi');
   const logger = getService('log');
   const retry = getService('retry');
@@ -51,6 +52,8 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
       await cleanup({ client: esClient, config: DATA_FORGE_CONFIG, logger });
       await sloApi.deleteAllSLOs(adminRoleAuthc);
       await samlAuth.invalidateM2mApiKeyWithRoleScope(adminRoleAuthc);
+      await spaceApi.delete('space1');
+      await spaceApi.delete('space2');
     });
 
     it('creates a new slo and transforms', async () => {
@@ -119,6 +122,40 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         index: '.slo-observability.summary-v3.4',
         pipeline: `.slo-observability.summary.pipeline-${id}-1`,
       });
+    });
+
+    it('creates two SLOs with matching ids across different spaces', async () => {
+      const spaceApiResponse = await spaceApi.create({
+        name: 'space1',
+        id: 'space1',
+        initials: '1',
+      });
+      expect(spaceApiResponse.space).property('id');
+
+      const {
+        space: { id: spaceId1 },
+      } = spaceApiResponse;
+      const sloApiResponse = await sloApi.createWithSpace(
+        DEFAULT_SLO,
+        spaceId1,
+        adminRoleAuthc,
+        200
+      );
+      expect(sloApiResponse).property('id');
+
+      const { id } = sloApiResponse;
+      const spaceApiResponse2 = await spaceApi.create({
+        name: 'space2',
+        id: 'space2',
+        initials: '2',
+      });
+
+      const {
+        space: { id: spaceId2 },
+      } = spaceApiResponse;
+      expect(spaceApiResponse2.space).property('id');
+
+      await sloApi.createWithSpace({ ...DEFAULT_SLO, id }, spaceId2, adminRoleAuthc, 409);
     });
 
     describe('groupBy smoke tests', () => {

--- a/x-pack/test/api_integration/deployment_agnostic/services/slo_api.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/services/slo_api.ts
@@ -44,6 +44,21 @@ export function SloApiProvider({ getService }: DeploymentAgnosticFtrProviderCont
       return body;
     },
 
+    async createWithSpace(
+      slo: CreateSLOInput & { id?: string },
+      spaceId: string,
+      roleAuthc: RoleCredentials,
+      expectedStatus: 200 | 409
+    ) {
+      const { body } = await supertestWithoutAuth
+        .post(`/s/${spaceId}/api/observability/slos`)
+        .set(roleAuthc.apiKeyHeader)
+        .set(samlAuth.getInternalRequestHeader())
+        .send(slo)
+        .expect(expectedStatus);
+      return body;
+    },
+
     async reset(id: string, roleAuthc: RoleCredentials) {
       const { body } = await supertestWithoutAuth
         .post(`/api/observability/slos/${id}/_reset`)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[SLO] Check for unique SLO ids across spaces (#214496)](https://github.com/elastic/kibana/pull/214496)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2025-03-18T14:44:58Z","message":"[SLO] Check for unique SLO ids across spaces (#214496)\n\n## Summary \nResolves #212784 \nEnsure that when an SLO is created, the id is verified across all\nspaces.\n\n## Release Notes\nEnsure that when an SLO is created, the id is verified across all\nspaces.\n\n## Testing\n1. Create an SLO and save the id returned in the response in a space \"A\"\n2. Create a second SLO with the id saved from the first SLO in the\nrequest in a different space \"B\"\n3. User should receive a 409 error from the SLO API.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"56f1ebfca6300b1da68cf6fa721f450077aa1878","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Security","v9.0.0","backport:prev-minor","Team:obs-ux-management","v9.1.0"],"title":"[SLO] Check for unique SLO ids across spaces","number":214496,"url":"https://github.com/elastic/kibana/pull/214496","mergeCommit":{"message":"[SLO] Check for unique SLO ids across spaces (#214496)\n\n## Summary \nResolves #212784 \nEnsure that when an SLO is created, the id is verified across all\nspaces.\n\n## Release Notes\nEnsure that when an SLO is created, the id is verified across all\nspaces.\n\n## Testing\n1. Create an SLO and save the id returned in the response in a space \"A\"\n2. Create a second SLO with the id saved from the first SLO in the\nrequest in a different space \"B\"\n3. User should receive a 409 error from the SLO API.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"56f1ebfca6300b1da68cf6fa721f450077aa1878"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/215379","number":215379,"state":"MERGED","mergeCommit":{"sha":"6fe83990788ecf41c2cf171c36ff4fa171ea1e33","message":"[9.0] [SLO] Check for unique SLO ids across spaces (#214496) (#215379)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [[SLO] Check for unique SLO ids across spaces\n(#214496)](https://github.com/elastic/kibana/pull/214496)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>"}},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214496","number":214496,"mergeCommit":{"message":"[SLO] Check for unique SLO ids across spaces (#214496)\n\n## Summary \nResolves #212784 \nEnsure that when an SLO is created, the id is verified across all\nspaces.\n\n## Release Notes\nEnsure that when an SLO is created, the id is verified across all\nspaces.\n\n## Testing\n1. Create an SLO and save the id returned in the response in a space \"A\"\n2. Create a second SLO with the id saved from the first SLO in the\nrequest in a different space \"B\"\n3. User should receive a 409 error from the SLO API.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"56f1ebfca6300b1da68cf6fa721f450077aa1878"}}]}] BACKPORT-->