### PR TITLE
[8.19] [SLO] add ability to select all services for apm slos (#214653)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
+++ b/src/platform/packages/shared/kbn-esql-validation-autocomplete/src/definitions/commands.ts
@@ -9,10 +9,8 @@
 import {
   ESQLCommandMode,
   ESQLCommandOption,
-  Walker,
   isFunctionExpression,
   isWhereExpression,
-  type ESQLAstRenameExpression,
   type ESQLColumn,
   type ESQLCommand,
   type ESQLFunction,

--- a/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_apm_suggestions.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/hooks/use_fetch_apm_suggestions.ts
@@ -7,6 +7,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import moment from 'moment';
+import { ALL_VALUE } from '@kbn/slo-schema';
 import { useKibana } from './use_kibana';
 
 export type Suggestion = string;
@@ -47,11 +48,10 @@ export function useFetchApmSuggestions({
             start: moment().subtract(2, 'days').toISOString(),
             end: moment().toISOString(),
             fieldValue: search,
-            ...(!!serviceName && fieldName !== 'service.name' && { serviceName }),
+            ...(serviceName !== ALL_VALUE && fieldName !== 'service.name' && { serviceName }),
           },
           signal,
         });
-
         return terms;
       } catch (error) {
         // ignore error

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/apm_availability/apm_availability_indicator_type_form.tsx
@@ -59,7 +59,6 @@ export function ApmAvailabilityIndicatorTypeForm() {
     <EuiFlexGroup direction="column" gutterSize="m">
       <EuiFlexGroup direction="row" gutterSize="m">
         <FieldSelector
-          allowAllOption={false}
           label={i18n.translate('xpack.slo.sloEdit.apmAvailability.serviceName', {
             defaultMessage: 'Service name',
           })}

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/apm_common/field_selector.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/apm_common/field_selector.tsx
@@ -20,7 +20,6 @@ interface Option {
 }
 
 export interface Props {
-  allowAllOption?: boolean;
   dataTestSubj: string;
   fieldName: string;
   label: string;
@@ -30,7 +29,6 @@ export interface Props {
 }
 
 export function FieldSelector({
-  allowAllOption = true,
   dataTestSubj,
   fieldName,
   label,
@@ -49,20 +47,14 @@ export function FieldSelector({
 
   const debouncedSearch = debounce((value) => setSearch(value), 200);
 
-  const options = (
-    allowAllOption
-      ? [
-          {
-            value: ALL_VALUE,
-            label: i18n.translate('xpack.slo.sloEdit.fieldSelector.all', {
-              defaultMessage: 'All',
-            }),
-          },
-        ]
-      : []
-  ).concat(createOptions(suggestions));
-
-  const isDisabled = name !== 'indicator.params.service' && !serviceName;
+  const options = [
+    {
+      value: ALL_VALUE,
+      label: i18n.translate('xpack.slo.sloEdit.fieldSelector.all', {
+        defaultMessage: 'All',
+      }),
+    },
+  ].concat(createOptions(suggestions));
 
   return (
     <EuiFlexItem>
@@ -82,7 +74,7 @@ export function FieldSelector({
           defaultValue=""
           name={name}
           control={control}
-          rules={{ required: !isDisabled }}
+          rules={{ required: true }}
           render={({ field, fieldState }) => (
             <EuiComboBox
               {...field}
@@ -90,7 +82,6 @@ export function FieldSelector({
               async
               data-test-subj={dataTestSubj}
               isClearable
-              isDisabled={isDisabled}
               isInvalid={fieldState.invalid}
               isLoading={isLoading}
               onChange={(selected: EuiComboBoxOptionOption[]) => {

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/indicator_section/apm_latency/apm_latency_indicator_type_form.tsx
@@ -61,7 +61,6 @@ export function ApmLatencyIndicatorTypeForm() {
     <EuiFlexGroup direction="column" gutterSize="m">
       <EuiFlexGroup direction="row" gutterSize="m">
         <FieldSelector
-          allowAllOption={false}
           label={i18n.translate('xpack.slo.sloEdit.apmLatency.serviceName', {
             defaultMessage: 'Service name',
           })}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[SLO] add ability to select all services for apm slos (#214653)](https://github.com/elastic/kibana/pull/214653)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2025-03-18T19:23:19Z","message":"[SLO] add ability to select all services for apm slos (#214653)\n\n## Summary\n\nResolves #212981\n\n![Screenshot 2025-03-14 at 4 32\n57 PM](https://github.com/user-attachments/assets/37ce3d96-1337-4106-91de-6de0f3057fee)\n\n## Release Notes\n\nAdds the ability to create an APM availability or latency SLO for all\nservices\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Kevin Delemme <kdelemme@gmail.com>","sha":"0a10127efccc07846efdf6fe1e63bdbd75d62f4f","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport:skip","Team:obs-ux-management","v9.1.0"],"title":"[SLO] add ability to select all services for apm slos","number":214653,"url":"https://github.com/elastic/kibana/pull/214653","mergeCommit":{"message":"[SLO] add ability to select all services for apm slos (#214653)\n\n## Summary\n\nResolves #212981\n\n![Screenshot 2025-03-14 at 4 32\n57 PM](https://github.com/user-attachments/assets/37ce3d96-1337-4106-91de-6de0f3057fee)\n\n## Release Notes\n\nAdds the ability to create an APM availability or latency SLO for all\nservices\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Kevin Delemme <kdelemme@gmail.com>","sha":"0a10127efccc07846efdf6fe1e63bdbd75d62f4f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214653","number":214653,"mergeCommit":{"message":"[SLO] add ability to select all services for apm slos (#214653)\n\n## Summary\n\nResolves #212981\n\n![Screenshot 2025-03-14 at 4 32\n57 PM](https://github.com/user-attachments/assets/37ce3d96-1337-4106-91de-6de0f3057fee)\n\n## Release Notes\n\nAdds the ability to create an APM availability or latency SLO for all\nservices\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>\nCo-authored-by: Kevin Delemme <kdelemme@gmail.com>","sha":"0a10127efccc07846efdf6fe1e63bdbd75d62f4f"}}]}] BACKPORT-->