### PR TITLE
[8.19] [Search] Fix Pagination when number of documents is changed (#220139)

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -125,7 +125,7 @@ export const SearchIndexDocuments: React.FC = () => {
               mappings={mappingData ? { [indexName]: mappingData } : undefined}
               meta={data?.meta ?? DEFAULT_PAGINATION}
               onPaginate={(pageIndex) => setPagination({ ...pagination, pageIndex })}
-              setDocsPerPage={(pageSize) => setPagination({ ...pagination, pageSize })}
+              setDocsPerPage={(pageSize) => setPagination({ ...DEFAULT_PAGINATION, pageSize })}
             />
           )}
         </>

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_documents/documents.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_documents/documents.tsx
@@ -66,7 +66,7 @@ export const IndexDocuments: React.FC<IndexDocumentsProps> = ({ indexName }) => 
               mappings={mappingData ? { [indexName]: mappingData } : undefined}
               meta={documentsMeta ?? DEFAULT_PAGINATION}
               onPaginate={(pageIndex) => setPagination({ ...pagination, pageIndex })}
-              setDocsPerPage={(pageSize) => setPagination({ ...pagination, pageSize })}
+              setDocsPerPage={(pageSize) => setPagination({ ...DEFAULT_PAGINATION, pageSize })}
             />
           )}
         </>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Search] Fix Pagination when number of documents is changed (#220139)](https://github.com/elastic/kibana/pull/220139)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Saarika Bhasi","email":"55930906+saarikabhasi@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-05T20:48:37Z","message":"[Search] Fix Pagination when number of documents is changed (#220139)\n\n## Summary\n**Problem** \nWhen number of documents is changed, the total number of pages are\nrecalculated but current page is not changed. This works fine, but when\non last page and changing to larger number of documents makes the page\nto show zero documents\n\n**Fix**\nChanged to reset pagination to first page when number of documents is\nchanged.\n\n\nhttps://github.com/user-attachments/assets/02eab354-b4bd-40cf-af47-1a692951f08e","sha":"f1187b4e9129215e7373b3ba772e306e0af4bdd2","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v9.0.0","backport:version","v8.17.0","v8.18.0","v9.1.0","v8.19.0"],"title":"[Search] Fix Pagination when number of documents is changed","number":220139,"url":"https://github.com/elastic/kibana/pull/220139","mergeCommit":{"message":"[Search] Fix Pagination when number of documents is changed (#220139)\n\n## Summary\n**Problem** \nWhen number of documents is changed, the total number of pages are\nrecalculated but current page is not changed. This works fine, but when\non last page and changing to larger number of documents makes the page\nto show zero documents\n\n**Fix**\nChanged to reset pagination to first page when number of documents is\nchanged.\n\n\nhttps://github.com/user-attachments/assets/02eab354-b4bd-40cf-af47-1a692951f08e","sha":"f1187b4e9129215e7373b3ba772e306e0af4bdd2"}},"sourceBranch":"main","suggestedTargetBranches":["9.0","8.19"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220271","number":220271,"state":"OPEN"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220274","number":220274,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220139","number":220139,"mergeCommit":{"message":"[Search] Fix Pagination when number of documents is changed (#220139)\n\n## Summary\n**Problem** \nWhen number of documents is changed, the total number of pages are\nrecalculated but current page is not changed. This works fine, but when\non last page and changing to larger number of documents makes the page\nto show zero documents\n\n**Fix**\nChanged to reset pagination to first page when number of documents is\nchanged.\n\n\nhttps://github.com/user-attachments/assets/02eab354-b4bd-40cf-af47-1a692951f08e","sha":"f1187b4e9129215e7373b3ba772e306e0af4bdd2"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->