### PR TITLE
remove timeRange: undefined since its provided by ...timeRangeManager.getLatestState()

### DIFF
--- a/src/platform/packages/shared/presentation/presentation_publishing/state_manager/types.ts
+++ b/src/platform/packages/shared/presentation/presentation_publishing/state_manager/types.ts
@@ -46,7 +46,7 @@ type SettersOf<T extends object> = {
 };
 
 export interface StateManager<StateType extends object> {
-  getLatestState: () => StateType;
+  getLatestState: () => WithAllKeys<StateType>;
   reinitializeState: (newState?: Partial<StateType>) => void;
   api: SettersOf<StateType> & SubjectsOf<StateType>;
   anyStateChange$: Observable<void>;

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/embeddable_change_point_chart_factory.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/change_point_chart/embeddable_change_point_chart_factory.tsx
@@ -83,7 +83,6 @@ export const getChangePointChartEmbeddableFactory = (
         const dataViewId = changePointManager.api.dataViewId.getValue();
         return {
           rawState: {
-            timeRange: undefined,
             ...titleManager.getLatestState(),
             ...timeRangeManager.getLatestState(),
             ...changePointManager.getLatestState(),

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/log_rate_analysis/embeddable_log_rate_analysis_factory.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/log_rate_analysis/embeddable_log_rate_analysis_factory.tsx
@@ -88,7 +88,6 @@ export const getLogRateAnalysisEmbeddableFactory = (
         const dataViewId = logRateAnalysisControlsApi.dataViewId.getValue();
         return {
           rawState: {
-            timeRange: undefined,
             ...titleManager.getLatestState(),
             ...timeRangeManager.getLatestState(),
             ...serializeLogRateAnalysisChartState(),

--- a/x-pack/platform/plugins/shared/aiops/public/embeddables/pattern_analysis/embeddable_pattern_analysis_factory.tsx
+++ b/x-pack/platform/plugins/shared/aiops/public/embeddables/pattern_analysis/embeddable_pattern_analysis_factory.tsx
@@ -85,7 +85,6 @@ export const getPatternAnalysisEmbeddableFactory = (
         const dataViewId = patternAnalysisControlsApi.dataViewId.getValue();
         return {
           rawState: {
-            timeRange: undefined,
             ...titleManager.getLatestState(),
             ...timeRangeManager.getLatestState(),
             ...serializePatternAnalysisChartState(),

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable_factory.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_charts/anomaly_charts_embeddable_factory.tsx
@@ -69,7 +69,6 @@ export const getAnomalyChartsReactEmbeddableFactory = (
       function serializeState() {
         return {
           rawState: {
-            timeRange: undefined,
             ...titleManager.getLatestState(),
             ...timeRangeManager.getLatestState(),
             ...chartsManager.getLatestState(),

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable_factory.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_swimlane/anomaly_swimlane_embeddable_factory.tsx
@@ -137,7 +137,6 @@ export const getAnomalySwimLaneEmbeddableFactory = (
       function serializeState() {
         return {
           rawState: {
-            timeRange: undefined,
             ...titleManager.getLatestState(),
             ...timeRangeManager.getLatestState(),
             ...swimlaneManager.getLatestState(),

--- a/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.tsx
+++ b/x-pack/platform/plugins/shared/ml/public/embeddables/single_metric_viewer/single_metric_viewer_embeddable_factory.tsx
@@ -58,7 +58,6 @@ export const getSingleMetricViewerEmbeddableFactory = (
       function serializeState() {
         return {
           rawState: {
-            timeRange: undefined,
             ...titleManager.getLatestState(),
             ...timeRangeManager.getLatestState(),
             ...singleMetricManager.getLatestState(),


### PR DESCRIPTION
This PR does not need to be reviewed by external teams. This PR merges into a feature branch that Kibana presentation team is working on to convert the embeddable framework to only expose serialized state. Your team will be pinged for review once the work is complete and the final PR opens that merges the feature branch into main