### PR TITLE
[Fleet] Opt-in new cluster into space awareness

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/common/types/models/settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/common/types/models/settings.ts
@@ -8,18 +8,18 @@
 export interface BaseSettings {
   has_seen_add_data_notice?: boolean;
   prerelease_integrations_enabled?: boolean;
+  use_space_awareness_migration_status?: 'pending' | 'success' | 'error';
+  use_space_awareness_migration_started_at?: string | null;
+  preconfigured_fields?: Array<'fleet_server_hosts'>;
+  secret_storage_requirements_met?: boolean;
+  output_secret_storage_requirements_met?: boolean;
+  delete_unenrolled_agents?: {
+    enabled: boolean;
+    is_preconfigured: boolean;
+  };
 }
 
 export interface Settings extends BaseSettings {
   id: string;
   version?: string;
-  preconfigured_fields?: Array<'fleet_server_hosts'>;
-  secret_storage_requirements_met?: boolean;
-  output_secret_storage_requirements_met?: boolean;
-  use_space_awareness_migration_status?: 'pending' | 'success' | 'error';
-  use_space_awareness_migration_started_at?: string | null;
-  delete_unenrolled_agents?: {
-    enabled: boolean;
-    is_preconfigured: boolean;
-  };
 }

--- a/x-pack/platform/plugins/shared/fleet/server/services/settings.test.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/settings.test.ts
@@ -39,6 +39,10 @@ describe('settingsSetup', () => {
     jest.resetAllMocks();
     mockedAppContextService.getCloud.mockReset();
     mockedAppContextService.getConfig.mockReset();
+    mockedAppContextService.getExperimentalFeatures.mockReset();
+  });
+  beforeEach(() => {
+    mockedAppContextService.getExperimentalFeatures.mockReturnValue({} as any);
   });
   it('should create settings if there is no settings', async () => {
     const soClientMock = savedObjectsClientMock.create();
@@ -189,6 +193,12 @@ describe('settingsSetup', () => {
 });
 
 describe('getSettings', () => {
+  beforeEach(() => {
+    mockedAppContextService.getExperimentalFeatures.mockReturnValue({} as any);
+  });
+  afterEach(() => {
+    mockedAppContextService.getExperimentalFeatures.mockReset();
+  });
   it('should call audit logger', async () => {
     const soClient = savedObjectsClientMock.create();
 
@@ -265,6 +275,10 @@ describe('getSettings', () => {
 describe('saveSettings', () => {
   afterEach(() => {
     mockedAuditLoggingService.writeCustomSoAuditLog.mockReset();
+    mockedAppContextService.getExperimentalFeatures.mockReset();
+  });
+  beforeEach(() => {
+    mockedAppContextService.getExperimentalFeatures.mockReturnValue({} as any);
   });
   describe('when settings object exists', () => {
     it('should call audit logger', async () => {
@@ -463,6 +477,9 @@ describe('createDefaultSettings', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
+  beforeEach(() => {
+    mockedAppContextService.getExperimentalFeatures.mockReturnValue({} as any);
+  });
 
   it('should return default settings with prerelease_integrations_enabled set to true if config.prereleaseEnabledByDefault is true', () => {
     mockedAppContextService.getConfig.mockReturnValue({
@@ -508,5 +525,31 @@ describe('createDefaultSettings', () => {
     const result = createDefaultSettings();
 
     expect(result).toEqual({ prerelease_integrations_enabled: false });
+  });
+
+  it('should return default settings with use_space_awareness_migration_status:success if feature flag is enabled', () => {
+    mockedAppContextService.getConfig.mockReturnValue({
+      prereleaseEnabledByDefault: true,
+      enabled: true,
+      agents: {
+        enabled: false,
+        elasticsearch: {
+          hosts: undefined,
+          ca_sha256: undefined,
+          ca_trusted_fingerprint: undefined,
+        },
+      },
+    });
+
+    mockedAppContextService.getExperimentalFeatures.mockReturnValueOnce({
+      useSpaceAwareness: true,
+    } as any);
+
+    const result = createDefaultSettings();
+
+    expect(result).toEqual({
+      prerelease_integrations_enabled: true,
+      use_space_awareness_migration_status: 'success',
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/fleet/server/services/settings.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/settings.ts
@@ -173,5 +173,13 @@ function getConfigFleetServerHosts() {
 
 export function createDefaultSettings(): BaseSettings {
   const config = appContextService.getConfig();
-  return { prerelease_integrations_enabled: !!config?.prereleaseEnabledByDefault };
+  const settings: BaseSettings = {
+    prerelease_integrations_enabled: !!config?.prereleaseEnabledByDefault,
+  };
+
+  if (appContextService.getExperimentalFeatures().useSpaceAwareness) {
+    settings.use_space_awareness_migration_status = 'success';
+  }
+
+  return settings;
 }

--- a/x-pack/test/fleet_api_integration/apis/space_awareness/space_awareness_migration.ts
+++ b/x-pack/test/fleet_api_integration/apis/space_awareness/space_awareness_migration.ts
@@ -6,6 +6,8 @@
  */
 
 import expect from '@kbn/expect';
+import { GLOBAL_SETTINGS_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/server/constants';
+
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { skipIfNoDockerRegistry } from '../../helpers';
 import { SpaceTestApiClient } from './api_helper';
@@ -30,6 +32,13 @@ export default function (providerContext: FtrProviderContext) {
         space: TEST_SPACE_1,
       });
       await cleanFleetIndices(esClient);
+      // Create settings to simulate older cluster
+      await kibanaServer.savedObjects.create({
+        type: GLOBAL_SETTINGS_SAVED_OBJECT_TYPE,
+        id: 'fleet-default-settings',
+        attributes: {},
+        overwrite: true,
+      });
 
       // Create agent policies it should create a enrollment key for every keys
       const [defaultSpacePolicy1, spaceTest1Policy1] = await Promise.all([


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/220084

When the `useSpaceAwareness` feature flag is enabled opt-in new cluster into space awareness without having to call the migration API.

## How to tests

With `xpack.fleet.enableExperimental: ['useSpaceAwareness',]` in your kibana config.
Start a new cluster and test that space awareness is well enabled, you create a policy in default space and check in another space that policy is not visible.

