### PR TITLE
[Synthetics] Receive `aria-labelledby` from Elastic Charts svg

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item.tsx
@@ -123,6 +123,8 @@ export const MetricItem = ({
           trendMessage,
         },
       })}
+      // this is the ID the Chart child will expect in its `aria-labelledby` attribute
+      id={`echMetric-${monitor.configId}-${monitor.locationId}-metric-chart-0-0-trend-title_echMetric-${monitor.configId}-${monitor.locationId}-metric-chart-0-0-trend-description`}
       style={style ?? { height: METRIC_ITEM_HEIGHT }}
     >
       <EuiPanel
@@ -153,7 +155,7 @@ export const MetricItem = ({
         `}
         title={moment(timestamp).format('LLL')}
       >
-        <Chart>
+        <Chart id={`${monitor.configId}-${monitor.locationId}-metric-chart`}>
           <Settings
             onElementClick={() => {
               if (testInProgress) {

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item.tsx
@@ -11,7 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import moment from 'moment';
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { OverviewStatusMetaData } from '../../../../../../../../common/runtime_types';
 import { ClientPluginsStart } from '../../../../../../../plugin';
@@ -86,9 +86,43 @@ export const MetricItem = ({
 
   const dispatch = useDispatch();
 
+  const trendMessage = useMemo(() => {
+    if (trendData === 'loading') {
+      return i18n.translate('xpack.synthetics.overview.metricItem.trendMessage.loadingCase', {
+        defaultMessage: 'Metrics are loading and have no value to display.',
+      });
+    }
+
+    if (trendData === null) {
+      return i18n.translate('xpack.synthetics.overview.metricItem.trendMessage.noData', {
+        defaultMessage: 'No data available for the selected time window.',
+      });
+    }
+
+    return i18n.translate('xpack.synthetics.overview.metricItem.trendMessage', {
+      defaultMessage:
+        'The duration statistics currently shown by the chart are: average: {avg}, median: {median}, max: {max}, min: {min}.',
+      values: {
+        max: trendData.max,
+        min: trendData.min,
+        median: trendData.median,
+        avg: trendData.avg,
+      },
+    });
+  }, [trendData]);
+
   return (
     <div
       data-test-subj={`${monitor.name}-${monitor.locationId}-metric-item`}
+      aria-label={i18n.translate('xpack.synthetics.overview.metricItem.label', {
+        defaultMessage:
+          'Monitor {name} in {location}. The background of this element also contains a sparkline chart indicating the status of test duration over the selected time window. {trendMessage}',
+        values: {
+          name: monitor.name,
+          location: locationName,
+          trendMessage,
+        },
+      })}
       style={style ?? { height: METRIC_ITEM_HEIGHT }}
     >
       <EuiPanel


### PR DESCRIPTION
## Summary

Resolves #212242.

This resolves an accessibility failure in the `MetricItem` component where Elastic Charts renders an svg with `role="img"` but no `alt`.

The svg renders an `aria-labelledby` attribute that is generated from the supplied chart ID. This PR will create an ID for each chart and pass it as a prop, and then reverse-engineer the expected ID to apply to the wrapper div, which also contains a label that specifies some of the data we are passing to `MetricItem`. This will allow screen reader users to have an idea of the information displayed for a given `MetricItem` if they choose to zero in on any of the charts on the page.

_NOTE:_ we cannot merge this until Kibana bumps its dependency of Elastic Charts to [v70.0.1](https://github.com/elastic/elastic-charts/releases/tag/v70.0.1), because I had to make an upstream contribution to fix a bug with the generated `aria-labelledby` ID.

Needs to be tested once https://github.com/elastic/kibana/pull/210579 is merged.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->