### PR TITLE
[ResponseOps] Update ES|QL ES query rule for context.grouping action variable

### DIFF
--- a/x-pack/platform/plugins/shared/stack_alerts/common/es_query/esql_query_utils.test.ts
+++ b/x-pack/platform/plugins/shared/stack_alerts/common/es_query/esql_query_utils.test.ts
@@ -116,7 +116,7 @@ describe('ESQL query utils', () => {
               buckets: [
                 {
                   doc_count: 1,
-                  key: '1.8.0',
+                  key: ['1.8.0'],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -135,7 +135,7 @@ describe('ESQL query utils', () => {
                 },
                 {
                   doc_count: 1,
-                  key: '1.2.0',
+                  key: ['1.2.0'],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -161,6 +161,7 @@ describe('ESQL query utils', () => {
         },
         isCountAgg: false,
         isGroupAgg: true,
+        termField: ['ecs.version'],
       });
       expect(rows).toEqual([
         {
@@ -200,7 +201,7 @@ describe('ESQL query utils', () => {
               buckets: [
                 {
                   doc_count: 1,
-                  key: '1.8.0',
+                  key: ['1.8.0'],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -219,7 +220,7 @@ describe('ESQL query utils', () => {
                 },
                 {
                   doc_count: 2,
-                  key: '1.2.0',
+                  key: ['1.2.0'],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -254,6 +255,7 @@ describe('ESQL query utils', () => {
         },
         isCountAgg: false,
         isGroupAgg: true,
+        termField: ['ecs.version'],
       });
       expect(duplicateAlertIds?.size).toBe(1);
     });
@@ -323,7 +325,17 @@ describe('ESQL query utils', () => {
               buckets: [
                 {
                   doc_count: 1,
-                  key: '2023-07-12T13:32:04.174Z,1.8.0,www.elastic.co,test,US,Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1,info,test message,/app-search',
+                  key: [
+                    '2023-07-12T13:32:04.174Z',
+                    '1.8.0',
+                    'www.elastic.co',
+                    'test',
+                    'US',
+                    'Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1',
+                    'info',
+                    'test message',
+                    '/app-search',
+                  ],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -350,7 +362,18 @@ describe('ESQL query utils', () => {
                 },
                 {
                   doc_count: 1,
-                  key: '2025-07-12T13:32:04.174Z,1.2.0,400,artifacts.elastic.co,test,US,Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1,info,test message,/app-search',
+                  key: [
+                    '2025-07-12T13:32:04.174Z',
+                    '1.2.0',
+                    '400',
+                    'artifacts.elastic.co',
+                    'test',
+                    'US',
+                    'Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1',
+                    'info',
+                    'test message',
+                    '/app-search',
+                  ],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -387,6 +410,18 @@ describe('ESQL query utils', () => {
         },
         isCountAgg: false,
         isGroupAgg: true,
+        termField: [
+          '@timestamp',
+          'ecs.version',
+          'error.code',
+          'host',
+          'name',
+          'geo.dest',
+          'agent',
+          'tags',
+          'message',
+          'request',
+        ],
       });
       expect(longAlertIds?.size).toBe(1);
     });
@@ -406,7 +441,7 @@ describe('ESQL query utils', () => {
               buckets: [
                 {
                   doc_count: 1,
-                  key: '400',
+                  key: ['400'],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -432,6 +467,7 @@ describe('ESQL query utils', () => {
         },
         isCountAgg: false,
         isGroupAgg: true,
+        termField: ['error.code'],
       });
       expect(rows).toEqual([
         {
@@ -466,7 +502,7 @@ describe('ESQL query utils', () => {
               buckets: [
                 {
                   doc_count: 1,
-                  key: '1.8.0',
+                  key: ['1.8.0'],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -485,7 +521,7 @@ describe('ESQL query utils', () => {
                 },
                 {
                   doc_count: 1,
-                  key: '400,1.2.0',
+                  key: ['400', '1.2.0'],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -504,7 +540,7 @@ describe('ESQL query utils', () => {
                 },
                 {
                   doc_count: 1,
-                  key: '1.2.0',
+                  key: ['1.2.0'],
                   topHitsAgg: {
                     hits: {
                       hits: [
@@ -530,6 +566,7 @@ describe('ESQL query utils', () => {
         },
         isCountAgg: false,
         isGroupAgg: true,
+        termField: ['error.code', 'ecs.version'],
       });
       expect(rows).toEqual([
         {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
@@ -126,15 +126,17 @@ export default function ruleTests({ getService }: FtrProviderContext) {
       const messagePattern =
         /Document count is 1 in the last 30s for group-\d. Alert when greater than 0./;
       const conditionPattern = /Query matched documents for group "group-\d"/;
+      const groupPattern = /{"group":"group-\d"}/;
 
       for (let i = 0; i < docs.length; i++) {
         const doc = docs[i];
-        const { hits } = doc._source;
+        const { hits, grouping } = doc._source;
         const { name, title, message } = doc._source.params;
         expect(name).to.be('always fire');
         expect(title).to.match(titlePattern);
         expect(message).to.match(messagePattern);
         expect(hits).not.to.be.empty();
+        expect(grouping).to.match(groupPattern);
       }
 
       const aadDocs = await getAllAADDocs(3, ALERT_INSTANCE_ID);
@@ -174,15 +176,18 @@ export default function ruleTests({ getService }: FtrProviderContext) {
         /Query matched documents for group "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"/;
       const idPattern =
         /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/;
+      const groupPattern =
+        /{"_id":"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"}/;
 
       for (let i = 0; i < docs.length; i++) {
         const doc = docs[i];
-        const { hits } = doc._source;
+        const { hits, grouping } = doc._source;
         const { name, title, message } = doc._source.params;
         expect(name).to.be('always fire');
         expect(title).to.match(titlePattern);
         expect(message).to.match(messagePattern);
         expect(hits).not.to.be.empty();
+        expect(grouping).to.match(groupPattern);
       }
 
       const aadDocs = await getAllAADDocs(2);
@@ -222,11 +227,23 @@ export default function ruleTests({ getService }: FtrProviderContext) {
       for (let i = 0; i < docs.length; i++) {
         const doc = docs[i];
         const { hits } = doc._source;
+        const grouping = JSON.parse(doc._source.grouping);
         const { name, title, message } = doc._source.params;
         expect(name).to.be('always fire');
         expect(title).to.match(titlePattern);
         expect(message).to.match(messagePattern);
         expect(hits).not.to.be.empty();
+        expect(grouping['@timestamp']).to.be.ok();
+        expect(grouping.date).to.be.ok();
+        expect(grouping.date_epoch_millis).to.be.ok();
+        expect(grouping.group).to.be.ok();
+        expect(grouping.host.hostname).to.be.ok();
+        expect(grouping.host.id).to.be.ok();
+        expect(grouping.host.name).to.be.ok();
+        expect(grouping.reference).to.be.ok();
+        expect(grouping.source).to.be.ok();
+        expect(grouping.testedValue).to.be.ok();
+        expect(grouping.testedValueFloat).to.be.ok();
       }
 
       const aadDocs = await getAllAADDocs(3);
@@ -576,6 +593,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
               hits: '{{context.hits}}',
               date: '{{{context.date}}}',
               previousTimestamp: '{{{state.latestTimestamp}}}',
+              grouping: '{{context.grouping}}',
             },
           ],
         },
@@ -597,6 +615,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
               },
               hits: '{{context.hits}}',
               date: '{{{context.date}}}',
+              grouping: '{{context.grouping}}',
             },
           ],
         },


### PR DESCRIPTION
Follow on from this PR that was merged, https://github.com/elastic/kibana/pull/213550
## Summary

This PR updates the ES|QL grouping processing to work with the `context.grouping` action variable.


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### To verify
1. Create an ES|QL rule with grouping.
2. In "active" and "recovered" action message, use `context.grouping` variable
3. Verify that both "active" and "recovered" alert notifications contain correct information

Example if grouping on `host.name` and `container.id`:

```
{
  "grouping": "{{context.grouping}}",
  "host.name": "{{context.grouping.host.name}}",
  "container.id": "{{context.grouping.container.id}}"
}
```




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->