### PR TITLE
Add secondary chromedriver rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3476,6 +3476,12 @@
       "enabled": true
     },
     {
+      "matchDepNames": [
+        "chromedriver"
+      ],
+      "enabled": true
+    },
+    {
       "groupName": "chromedriver",
       "matchDepNames": [
         "chromedriver"


### PR DESCRIPTION
## Summary

There is a bit of strange behavior with how Renovate parses some rules because everything is disabled at first. Eng-Prod dug into this and this was the recommended solution - having a rule just to enable `chromedriver` and a second rule with our config. See [Slack](https://elastic.slack.com/archives/C07AMD4CNUR/p1746479094816819) for full context.


