### PR TITLE
fix: [Security:Assets:Fleet page]Fields missing name from announcement

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/step_define_package_policy.tsx
@@ -23,6 +23,7 @@ import {
   EuiSelect,
   type EuiComboBoxOptionOption,
   EuiIconTip,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 
 import styled from 'styled-components';
@@ -129,6 +130,8 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
       allowedOutputs,
       updatePackagePolicy,
     ]);
+
+    const advancedOptionsTitleId = useGeneratedHtmlId();
 
     // Managed policy
     const isManaged = packagePolicy.is_managed;
@@ -269,11 +272,14 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
                       iconType={isShowingAdvanced ? 'arrowDown' : 'arrowRight'}
                       onClick={() => setIsShowingAdvanced(!isShowingAdvanced)}
                       flush="left"
+                      aria-expanded={isShowingAdvanced}
                     >
-                      <FormattedMessage
-                        id="xpack.fleet.createPackagePolicy.stepConfigure.advancedOptionsToggleLinkText"
-                        defaultMessage="Advanced options"
-                      />
+                      <span id={advancedOptionsTitleId}>
+                        <FormattedMessage
+                          id="xpack.fleet.createPackagePolicy.stepConfigure.advancedOptionsToggleLinkText"
+                          defaultMessage="Advanced options"
+                        />
+                      </span>
                     </EuiButtonEmpty>
                   </EuiFlexItem>
                   {!isShowingAdvanced && !!validationResults.namespace ? (
@@ -294,7 +300,12 @@ export const StepDefinePackagePolicy: React.FunctionComponent<{
             {/* Advanced options content */}
             {isShowingAdvanced ? (
               <EuiFlexItem>
-                <EuiFlexGroup direction="column" gutterSize="m">
+                <EuiFlexGroup
+                  direction="column"
+                  gutterSize="m"
+                  role="group"
+                  aria-labelledby={advancedOptionsTitleId}
+                >
                   {/* Namespace  */}
                   <EuiFlexItem>
                     <EuiFormRow


### PR DESCRIPTION
Closes: #204915
Closes: #209325

## Summary
Collapsed/Expanded buttons have to be correctly announced for users using assistive technology.

## Changes made: 
1. Added required 'aria' attributes

## Screen 

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/e442c3c6-a3ad-47cd-9bdb-b6e3ed514366" />


<!--ONMERGE {"backportTargets":["8.17","8.18","8.19"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->