### PR TITLE
update browserlists/caniuse

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14783,9 +14783,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001335, caniuse-lite@^1.0.30001669:
-  version "1.0.30001716"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz#39220dfbc58c85d9d4519e7090b656aa11ca4b85"
-  integrity sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==
+  version "1.0.30001717"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz"
+  integrity sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==
 
 canvg@^3.0.9:
   version "3.0.9"


### PR DESCRIPTION
## Summary
Updates browserlists to avoid warnings coming up in local dev such as: 
```
 np bld    log   [12:44:51.564] [warning][@kbn/optimizer] worker stderr Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
 np bld    log   [12:44:51.564] [warning][@kbn/optimizer] worker stderr   npx update-browserslist-db@latest
 np bld    log   [12:44:51.564] [warning][@kbn/optimizer] worker stderr   Why you should do it regularly: https://github.com/browserslist/update-db#readme
 np bld    log   [12:44:51.568] [info][@kbn/optimizer] starting worker [28 bundles]
 np bld    log   [12:44:51.569] [warning][@kbn/optimizer] worker stderr Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
 np bld    log   [12:44:51.569] [warning][@kbn/optimizer] worker stderr   npx update-browserslist-db@latest
 ```
 or this, during install
 ```
 
2025-05-07 12:25:55 UTC | [5/5] Building fresh packages...
-- | --
  | 2025-05-07 12:26:11 UTC | [bazel] INFO: Analyzed 3 targets (814 packages loaded, 3258 targets configured).
  | 2025-05-07 12:26:11 UTC | [bazel] INFO: Found 3 targets...
  | 2025-05-07 12:26:22 UTC | [bazel] INFO: From Action src/platform/packages/shared/kbn-monaco/target_workers:
  | 2025-05-07 12:26:22 UTC | [bazel] Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  | 2025-05-07 12:26:22 UTC | [bazel]   npx update-browserslist-db@latest
  | 2025-05-07 12:26:22 UTC | [bazel]   Why you should do it regularly: https://github.com/browserslist/update-db#readme
  | 2025-05-07 12:26:24 UTC | [bazel] INFO: From Action src/platform/packages/private/kbn-ui-shared-deps-src/shared_built_assets:
  | 2025-05-07 12:26:24 UTC | [bazel] Browserslist: browsers data (caniuse-lite) is 6 months old. Please run:
  | 2025-05-07 12:26:24 UTC | [bazel]   npx update-browserslist-db@latest
  | 2025-05-07 12:26:24 UTC | [bazel]   Why you should do it regularly: https://github.com/browserslist/update-db#readme
  | 2025-05-07 12:26:24 UTC | [bazel] INFO: Elapsed time: 52.650s, Critical Path: 12.33s
  | 2025-05-07 12:26:24 UTC | [bazel] INFO: 609 processes: 592 disk cache hit, 7 remote cache hit, 10 internal.
  | 2025-05-07 12:26:24 UTC | [bazel]

```