### PR TITLE
[Discover][APM] Fix absolute timestamp used to load Waterfall

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/observability/traces/components/trace.tsx
@@ -28,11 +28,7 @@ export interface TraceProps {
 export const Trace = ({ traceId, fields, displayType, docId }: TraceProps) => {
   const { data } = getUnifiedDocViewerServices();
 
-  const {
-    timeState: {
-      asAbsoluteTimeRange: { from: rangeFrom, to: rangeTo },
-    },
-  } = data.query.timefilter.timefilter.useTimefilter();
+  const { from: rangeFrom, to: rangeTo } = data.query.timefilter.timefilter.getAbsoluteTime();
 
   const getParentApi = useCallback(
     () => ({


### PR DESCRIPTION
## Summary

This bugfix solves an issue with trace documents loaded in Discover with the relative timeframe of "now" to last n minutes, where the traces that are the closest to "now" do not load their waterfal widget on the document profile overview tab. The use of `useTimeFilter` yields an incorrect absolute timestamp that does not correspond to the time range of the data loaded, with a slight discrepancy for the `end` parameter, where the trace's timestamp could be later than what is provided for the `end` timestamp. This then causes the traces waterfall endpoint to return no data, due to an incorrect timestamp.

Switching to `getAbsoluteTime()` appears to resolve this by returning a more accurate absolute timestamp, which corresponds more directly to the data loaded, not when the page was accessed/loaded. As a result, the endpoint request becomes well-formed and returns the trace waterfall data correctly.

Closes #220383

## How to test

* Add this to your kibana.dev.yml file:
```yaml
discover.experimental.enabledProfiles:
  - observability-traces-data-source-profile
  - observability-traces-transaction-document-profile
  - observability-traces-span-document-profile
```
* Enable the Observability mode for the current space, then navigate to Discover
* Create/use a data-view or use an ES|QL query that targets a traces-* index.
* Ensure the time filter is set to `Last 15 minutes` and select the first/latest trace document and open the document view for it.
* Check that the trace loads the Trace Waterfall widget correctly.
* Repeat with older traces, and with a changed time filter where the `end` is not `now`.
* All opened traces should show a trace waterfall on the overview tab.



