### PR TITLE
[8.17] [Infra] Fix processes query (#220381)

### DIFF
--- a/x-pack/plugins/observability_solution/infra/common/constants.ts
+++ b/x-pack/plugins/observability_solution/infra/common/constants.ts
@@ -19,11 +19,23 @@ export type InfraFeatureId = typeof METRICS_FEATURE_ID | typeof LOGS_FEATURE_ID;
 export const TIMESTAMP_FIELD = '@timestamp';
 export const TIEBREAKER_FIELD = '_doc';
 
+// processes
+export const TOP_N = 10;
+export const MANDATORY_PROCESS_FIELDS = [
+  'system.process.cpu.total.pct',
+  'system.process.memory.rss.pct',
+  'system.process.cpu.start_time',
+  'system.process.state',
+  'user.name',
+  'process.pid',
+  'process.command_line',
+];
+export const PROCESS_COMMANDLINE_FIELD = 'process.command_line';
+
 // system
 export const HOST_NAME_FIELD = 'host.name';
 export const CONTAINER_ID_FIELD = 'container.id';
 export const KUBERNETES_POD_UID_FIELD = 'kubernetes.pod.uid';
-export const PROCESS_COMMANDLINE_FIELD = 'process.command_line';
 export const EVENT_MODULE = 'event.module';
 export const METRICSET_MODULE = 'metricset.module';
 export const METRICSET_NAME = 'metricset.name';


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[Infra] Fix processes query (#220381)](https://github.com/elastic/kibana/pull/220381)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"jennypavlova","email":"dzheni.pavlova@elastic.co"},"sourceCommit":{"committedDate":"2025-05-07T16:36:00Z","message":"[Infra] Fix processes query (#220381)\n\nCloses #220289 and\nhttps://github.com/elastic/opentelemetry-lib/issues/168\n## Summary\n\nThis PR fixes an issue with the processes query in case the document is\nmissing some of the required fields for the aggregation (like user.name,\nprocess.pid, system.process.cpu.total.pct, etc.). This PR adds a filter\nto the query to ensure that all the required fields exist\n\n| Before | After |\n| ------ | ------ |\n|\n![image](https://github.com/user-attachments/assets/2dd94bb6-d7b9-453a-a741-dbba734a0b1a)\n|\n![image](https://github.com/user-attachments/assets/bb6a14db-88c2-4bca-beca-577465e1b06e)\n|\n\n## Testing \n> [!NOTE]  \n> With the oblt lite cluster, the issue is reproducible as in the\nscreenshot (one of the hosts using the hostsmetrics receiver),\nI also tested with metricbeat for regressions and the host Otel\nOnboarding steps locally (the processes are not available there, just\nthe summary)\n\n- Go to the asset details page and open the processes tab\n- There shouldn't be an error shown when loading the processes","sha":"c9776687e267c162b7e8eabff69e6213cdadff66","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v9.0.0","backport:prev-major","Team:obs-ux-infra_services","v8.16.0","backport:version","v8.17.0","v8.18.0","v9.1.0","v8.19.0"],"title":"[Infra] Fix processes query","number":220381,"url":"https://github.com/elastic/kibana/pull/220381","mergeCommit":{"message":"[Infra] Fix processes query (#220381)\n\nCloses #220289 and\nhttps://github.com/elastic/opentelemetry-lib/issues/168\n## Summary\n\nThis PR fixes an issue with the processes query in case the document is\nmissing some of the required fields for the aggregation (like user.name,\nprocess.pid, system.process.cpu.total.pct, etc.). This PR adds a filter\nto the query to ensure that all the required fields exist\n\n| Before | After |\n| ------ | ------ |\n|\n![image](https://github.com/user-attachments/assets/2dd94bb6-d7b9-453a-a741-dbba734a0b1a)\n|\n![image](https://github.com/user-attachments/assets/bb6a14db-88c2-4bca-beca-577465e1b06e)\n|\n\n## Testing \n> [!NOTE]  \n> With the oblt lite cluster, the issue is reproducible as in the\nscreenshot (one of the hosts using the hostsmetrics receiver),\nI also tested with metricbeat for regressions and the host Otel\nOnboarding steps locally (the processes are not available there, just\nthe summary)\n\n- Go to the asset details page and open the processes tab\n- There shouldn't be an error shown when loading the processes","sha":"c9776687e267c162b7e8eabff69e6213cdadff66"}},"sourceBranch":"main","suggestedTargetBranches":["8.17"],"targetPullRequestStates":[{"branch":"9.0","label":"v9.0.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220408","number":220408,"state":"OPEN"},{"branch":"8.16","label":"v8.16.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220403","number":220403,"state":"OPEN"},{"branch":"8.17","label":"v8.17.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220406","number":220406,"state":"OPEN"},{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220381","number":220381,"mergeCommit":{"message":"[Infra] Fix processes query (#220381)\n\nCloses #220289 and\nhttps://github.com/elastic/opentelemetry-lib/issues/168\n## Summary\n\nThis PR fixes an issue with the processes query in case the document is\nmissing some of the required fields for the aggregation (like user.name,\nprocess.pid, system.process.cpu.total.pct, etc.). This PR adds a filter\nto the query to ensure that all the required fields exist\n\n| Before | After |\n| ------ | ------ |\n|\n![image](https://github.com/user-attachments/assets/2dd94bb6-d7b9-453a-a741-dbba734a0b1a)\n|\n![image](https://github.com/user-attachments/assets/bb6a14db-88c2-4bca-beca-577465e1b06e)\n|\n\n## Testing \n> [!NOTE]  \n> With the oblt lite cluster, the issue is reproducible as in the\nscreenshot (one of the hosts using the hostsmetrics receiver),\nI also tested with metricbeat for regressions and the host Otel\nOnboarding steps locally (the processes are not available there, just\nthe summary)\n\n- Go to the asset details page and open the processes tab\n- There shouldn't be an error shown when loading the processes","sha":"c9776687e267c162b7e8eabff69e6213cdadff66"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220407","number":220407,"state":"OPEN"}]}] BACKPORT-->