### PR TITLE
[Obs AI Assistant] Fix re-deploy model timeout and status polling

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
@@ -41,7 +41,9 @@ export function useKnowledgeBase(): UseKnowledgeBaseResult {
 
   // poll for status when installing, until install is complete and the KB is ready
   const isPolling =
-    (isInstalling || isWarmingUpModel) && statusRequest.value?.kbState !== KnowledgeBaseState.READY;
+    ((isInstalling || isWarmingUpModel) &&
+      statusRequest.value?.kbState !== KnowledgeBaseState.READY) ||
+    statusRequest.value?.kbState === KnowledgeBaseState.DEPLOYING_MODEL;
 
   useEffect(() => {
     // toggle installing state to false once KB is ready

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_tab.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/knowledge_base_tab.tsx
@@ -38,6 +38,7 @@ import {
 import { useKnowledgeBase } from '@kbn/ai-assistant/src/hooks';
 import { KnowledgeBaseInstallationStatusPanel } from '@kbn/ai-assistant/src/knowledge_base/knowledge_base_installation_status_panel';
 import { SettingUpKnowledgeBase } from '@kbn/ai-assistant/src/knowledge_base/setting_up_knowledge_base';
+import { InspectKnowledgeBasePopover } from '@kbn/ai-assistant/src/knowledge_base/inspect_knowlegde_base_popover';
 import { useGetKnowledgeBaseEntries } from '../../hooks/use_get_knowledge_base_entries';
 import { categorizeEntries, KnowledgeBaseEntryCategory } from '../../helpers/categorize_entries';
 import { KnowledgeBaseEditManualEntryFlyout } from './knowledge_base_edit_manual_entry_flyout';
@@ -241,7 +242,7 @@ export function KnowledgeBaseTab() {
     setQuery(e?.currentTarget.value || '');
   };
 
-  if (knowledgeBase.status.loading && !knowledgeBase.isInstalling) {
+  if (knowledgeBase.status.loading && !knowledgeBase.isPolling) {
     return (
       <EuiFlexGroup alignItems="center" direction="column">
         <EuiFlexItem grow>
@@ -450,7 +451,10 @@ export function KnowledgeBaseTab() {
       <EuiPanel hasBorder paddingSize="xl" grow={false} className={panelClassname}>
         <EuiFlexItem grow className={centerMaxWidthClassName}>
           {knowledgeBase.isInstalling ? (
-            <SettingUpKnowledgeBase />
+            <>
+              <SettingUpKnowledgeBase />
+              <InspectKnowledgeBasePopover knowledgeBase={knowledgeBase} />
+            </>
           ) : (
             <KnowledgeBaseInstallationStatusPanel knowledgeBase={knowledgeBase} />
           )}

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
@@ -84,7 +84,7 @@ const warmupModelKnowledgeBase = createObservabilityAIAssistantServerRoute({
       requiredPrivileges: ['ai_assistant'],
     },
   },
-  handler: async (resources): Promise<{ currentInferenceId: string }> => {
+  handler: async (resources): Promise<void> => {
     const client = await resources.service.getClient({ request: resources.request });
     const { inference_id: inferenceId } = resources.params.query;
     return client.warmupKbModel(inferenceId);

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
@@ -84,7 +84,7 @@ const warmupModelKnowledgeBase = createObservabilityAIAssistantServerRoute({
       requiredPrivileges: ['ai_assistant'],
     },
   },
-  handler: async (resources): Promise<void> => {
+  handler: async (resources): Promise<{ currentInferenceId: string }> => {
     const client = await resources.service.getClient({ request: resources.request });
     const { inference_id: inferenceId } = resources.params.query;
     return client.warmupKbModel(inferenceId);

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -733,13 +733,11 @@ export class ObservabilityAIAssistantClient {
   };
 
   warmupKbModel = (inferenceId: string) => {
-    return waitForKbModel({
-      core: this.dependencies.core,
-      esClient: this.dependencies.esClient,
-      logger: this.dependencies.logger,
-      config: this.dependencies.config,
-      inferenceId,
-    });
+    const { esClient, logger } = this.dependencies;
+
+    logger.debug(`Warming up model for for inference ID: ${inferenceId}`);
+    warmupModel({ esClient, logger, inferenceId }).catch(() => {});
+    return { currentInferenceId: inferenceId };
   };
 
   reIndexKnowledgeBaseWithLock = (inferenceId: string) => {

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -737,7 +737,7 @@ export class ObservabilityAIAssistantClient {
 
     logger.debug(`Warming up model for for inference ID: ${inferenceId}`);
     warmupModel({ esClient, logger, inferenceId }).catch(() => {});
-    return { currentInferenceId: inferenceId };
+    return;
   };
 
   reIndexKnowledgeBaseWithLock = (inferenceId: string) => {


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-assistant-team/issues/247
Closes https://github.com/elastic/kibana/issues/217912

## Summary

### Problems
- The `/warmup_model` endpoint doesn't return immediately and waits for the KB to be ready. If there is no ML nodes or sufficient capacity in the ML node, the API can timeout.
- Since the endpoint doesn't return immediately, we don't poll for status continuously.
- Knowledge base tab doesn't show `Inspect` if no ML nodes are available.

### Solutions

- Show `Inspect` information in the knowledge base
- Return `/warmup_model` immediately (we don't need to wait for the model to be ready since we are polling), and start polling
- If the user refreshes the browser and if the `kbState` is in `DEPLOYING_MODEL` keep polling for status

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)






<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->