### PR TITLE
[8.18] [Breadcrumbs] Hide "deployment" in breadcrumb when on-prem (#220110)

### DIFF
--- a/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
+++ b/src/core/packages/chrome/browser-internal/src/chrome_service.test.tsx
@@ -462,6 +462,9 @@ describe('start', () => {
     it('allows the project breadcrumb to also be set', async () => {
       const { chrome } = await start();
 
+      chrome.project.setCloudUrls({
+        deploymentUrl: 'my-deployment-url.com',
+      });
       chrome.setBreadcrumbs([{ text: 'foo' }, { text: 'bar' }]); // only setting the classic breadcrumbs
 
       {

--- a/src/core/packages/chrome/browser-internal/src/project_navigation/breadcrumbs.test.ts
+++ b/src/core/packages/chrome/browser-internal/src/project_navigation/breadcrumbs.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type {
+  ChromeBreadcrumb,
+  ChromeProjectNavigationNode,
+  CloudLinks,
+} from '@kbn/core-chrome-browser/src';
+import { buildBreadcrumbs } from './breadcrumbs';
+
+describe('buildBreadcrumbs', () => {
+  const mockCloudLinks = {
+    deployment: { href: '/deployment' },
+    deployments: { href: '/deployments', title: 'All Deployments' },
+  } as CloudLinks;
+
+  it('returns breadcrumbs with root crumb when absolute is true', () => {
+    const projectBreadcrumbs = {
+      breadcrumbs: [{ text: 'Project Crumb', href: '/project' }],
+      params: { absolute: true },
+    };
+    const result = buildBreadcrumbs({
+      projectName: 'Test Project',
+      cloudLinks: mockCloudLinks,
+      projectBreadcrumbs,
+      activeNodes: [],
+      chromeBreadcrumbs: [],
+      isServerless: true,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        text: 'Test Project',
+      }),
+      ...projectBreadcrumbs.breadcrumbs,
+    ]);
+  });
+
+  it('builds breadcrumbs from activeNodes when no project breadcrumbs are set', () => {
+    const activeNodes = [
+      [
+        { title: 'Node 1', breadcrumbStatus: 'visible', href: '/node1' },
+        { title: 'Node 2', breadcrumbStatus: 'visible', href: '/node2' },
+      ],
+    ] as ChromeProjectNavigationNode[][];
+    const result = buildBreadcrumbs({
+      projectName: 'Test Project',
+      cloudLinks: mockCloudLinks,
+      projectBreadcrumbs: { breadcrumbs: [], params: { absolute: false } },
+      activeNodes,
+      chromeBreadcrumbs: [],
+      isServerless: false,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        text: 'Deployment',
+      }),
+      { text: 'Node 1', href: '/node1' },
+      { text: 'Node 2', href: '/node2' },
+    ]);
+  });
+
+  it('merges chromeBreadcrumbs and navBreadcrumbs based on deepLinkId', () => {
+    const activeNodes = [
+      [
+        { title: 'Node 1', breadcrumbStatus: 'visible', href: '/node1', deepLink: { id: '1' } },
+        { title: 'Node 2', breadcrumbStatus: 'visible', href: '/node2', deepLink: { id: '2' } },
+      ],
+    ] as ChromeProjectNavigationNode[][];
+    const chromeBreadcrumbs = [
+      { text: 'Chrome Crumb 1', href: '/chrome1', deepLinkId: '2' },
+      { text: 'Chrome Crumb 2', href: '/chrome2' },
+    ] as ChromeBreadcrumb[];
+    const result = buildBreadcrumbs({
+      projectName: 'Test Project',
+      cloudLinks: mockCloudLinks,
+      projectBreadcrumbs: { breadcrumbs: [], params: { absolute: false } },
+      activeNodes,
+      chromeBreadcrumbs,
+      isServerless: false,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        text: 'Deployment',
+      }),
+      { text: 'Node 1', href: '/node1', deepLinkId: '1' },
+      { text: 'Chrome Crumb 1', href: '/chrome1', deepLinkId: '2' },
+      { text: 'Chrome Crumb 2', href: '/chrome2' },
+    ]);
+  });
+
+  it('returns breadcrumbs without root crumb if projectName/cloudLinks is empty', () => {
+    const activeNodes = [
+      [
+        { title: 'Node 1', breadcrumbStatus: 'visible', href: '/node1', deepLink: { id: '1' } },
+        { title: 'Node 2', breadcrumbStatus: 'visible', href: '/node2', deepLink: { id: '2' } },
+      ],
+    ] as ChromeProjectNavigationNode[][];
+    const chromeBreadcrumbs = [
+      { text: 'Chrome Crumb 1', href: '/chrome1', deepLinkId: '2' },
+      { text: 'Chrome Crumb 2', href: '/chrome2' },
+    ] as ChromeBreadcrumb[];
+    const result = buildBreadcrumbs({
+      projectName: undefined,
+      cloudLinks: {},
+      projectBreadcrumbs: { breadcrumbs: [], params: { absolute: false } },
+      activeNodes,
+      chromeBreadcrumbs,
+      isServerless: false,
+    });
+
+    expect(result).toEqual([
+      { text: 'Node 1', href: '/node1', deepLinkId: '1' },
+      { text: 'Chrome Crumb 1', href: '/chrome1', deepLinkId: '2' },
+      { text: 'Chrome Crumb 2', href: '/chrome2' },
+    ]);
+  });
+});

--- a/src/core/packages/chrome/browser-internal/src/project_navigation/breadcrumbs.tsx
+++ b/src/core/packages/chrome/browser-internal/src/project_navigation/breadcrumbs.tsx
@@ -19,6 +19,13 @@ import type {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+function prependRootCrumb(rootCrumb: ChromeBreadcrumb | undefined, rest: ChromeBreadcrumb[]) {
+  if (rootCrumb) {
+    return [rootCrumb, ...rest];
+  }
+  return rest;
+}
+
 export function buildBreadcrumbs({
   projectName,
   cloudLinks,
@@ -44,7 +51,7 @@ export function buildBreadcrumbs({
   });
 
   if (projectBreadcrumbs.params.absolute) {
-    return [rootCrumb, ...projectBreadcrumbs.breadcrumbs];
+    return prependRootCrumb(rootCrumb, projectBreadcrumbs.breadcrumbs);
   }
 
   // breadcrumbs take the first active path
@@ -62,7 +69,7 @@ export function buildBreadcrumbs({
 
   // if there are project breadcrumbs set, use them
   if (projectBreadcrumbs.breadcrumbs.length !== 0) {
-    return [rootCrumb, ...navBreadcrumbs, ...projectBreadcrumbs.breadcrumbs];
+    return prependRootCrumb(rootCrumb, [...navBreadcrumbs, ...projectBreadcrumbs.breadcrumbs]);
   }
 
   // otherwise try to merge legacy breadcrumbs with navigational project breadcrumbs using deeplinkid
@@ -80,13 +87,12 @@ export function buildBreadcrumbs({
   }
 
   if (chromeBreadcrumbStartIndex === -1) {
-    return [rootCrumb, ...navBreadcrumbs];
+    return prependRootCrumb(rootCrumb, navBreadcrumbs);
   } else {
-    return [
-      rootCrumb,
+    return prependRootCrumb(rootCrumb, [
       ...navBreadcrumbs.slice(0, navBreadcrumbEndIndex),
       ...chromeBreadcrumbs.slice(chromeBreadcrumbStartIndex),
-    ];
+    ]);
   }
 }
 
@@ -98,7 +104,7 @@ function buildRootCrumb({
   projectName?: string;
   cloudLinks: CloudLinks;
   isServerless: boolean;
-}): ChromeBreadcrumb {
+}): ChromeBreadcrumb | undefined {
   if (isServerless) {
     return {
       text:
@@ -131,47 +137,49 @@ function buildRootCrumb({
     };
   }
 
-  return {
-    text: i18n.translate('core.ui.primaryNav.cloud.deploymentLabel', {
-      defaultMessage: 'Deployment',
-    }),
-    'data-test-subj': 'deploymentCrumb',
-    popoverContent: () => (
-      <>
-        {cloudLinks.deployment && (
-          <EuiButtonEmpty
-            href={cloudLinks.deployment.href}
-            color="text"
-            iconType="gear"
-            data-test-subj="manageDeploymentBtn"
-            size="s"
-          >
-            {i18n.translate('core.ui.primaryNav.cloud.breadCrumbDropdown.manageDeploymentLabel', {
-              defaultMessage: 'Manage this deployment',
-            })}
-          </EuiButtonEmpty>
-        )}
+  if (cloudLinks.deployment || cloudLinks.deployments) {
+    return {
+      text: i18n.translate('core.ui.primaryNav.cloud.deploymentLabel', {
+        defaultMessage: 'Deployment',
+      }),
+      'data-test-subj': 'deploymentCrumb',
+      popoverContent: () => (
+        <>
+          {cloudLinks.deployment && (
+            <EuiButtonEmpty
+              href={cloudLinks.deployment.href}
+              color="text"
+              iconType="gear"
+              data-test-subj="manageDeploymentBtn"
+              size="s"
+            >
+              {i18n.translate('core.ui.primaryNav.cloud.breadCrumbDropdown.manageDeploymentLabel', {
+                defaultMessage: 'Manage this deployment',
+              })}
+            </EuiButtonEmpty>
+          )}
 
-        {cloudLinks.deployments && (
-          <EuiButtonEmpty
-            href={cloudLinks.deployments.href}
-            color="text"
-            iconType="spaces"
-            data-test-subj="viewDeploymentsBtn"
-            size="s"
-          >
-            {cloudLinks.deployments.title}
-          </EuiButtonEmpty>
-        )}
-      </>
-    ),
-    popoverProps: {
-      panelPaddingSize: 's',
-      zIndex: 6000,
-      panelStyle: { maxWidth: 240 },
-      panelProps: {
-        'data-test-subj': 'deploymentLinksPanel',
+          {cloudLinks.deployments && (
+            <EuiButtonEmpty
+              href={cloudLinks.deployments.href}
+              color="text"
+              iconType="spaces"
+              data-test-subj="viewDeploymentsBtn"
+              size="s"
+            >
+              {cloudLinks.deployments.title}
+            </EuiButtonEmpty>
+          )}
+        </>
+      ),
+      popoverProps: {
+        panelPaddingSize: 's',
+        zIndex: 6000,
+        panelStyle: { maxWidth: 240 },
+        panelProps: {
+          'data-test-subj': 'deploymentLinksPanel',
+        },
       },
-    },
-  };
+    };
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Breadcrumbs] Hide "deployment" in breadcrumb when on-prem (#220110)](https://github.com/elastic/kibana/pull/220110)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-06T19:43:47Z","message":"[Breadcrumbs] Hide \"deployment\" in breadcrumb when on-prem (#220110)\n\n## Summary\n\nCloses #219869\n\n**Before**\n\n![image](https://github.com/user-attachments/assets/59f0f6fc-2113-44ee-8e36-69c4eb718fad)\n\n\n**After**\n<img width=\"1320\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/85ad1117-4aab-4a8d-807c-4fa90cd8b917\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"0acd88e3b9ce22dc375682735b3a881d6cdc117b","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:version","v9.1.0","v8.19.0","v8.18.2","v9.0.2"],"title":"[Breadcrumbs] Hide \"deployment\" in breadcrumb when on-prem","number":220110,"url":"https://github.com/elastic/kibana/pull/220110","mergeCommit":{"message":"[Breadcrumbs] Hide \"deployment\" in breadcrumb when on-prem (#220110)\n\n## Summary\n\nCloses #219869\n\n**Before**\n\n![image](https://github.com/user-attachments/assets/59f0f6fc-2113-44ee-8e36-69c4eb718fad)\n\n\n**After**\n<img width=\"1320\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/85ad1117-4aab-4a8d-807c-4fa90cd8b917\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"0acd88e3b9ce22dc375682735b3a881d6cdc117b"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","8.18","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220110","number":220110,"mergeCommit":{"message":"[Breadcrumbs] Hide \"deployment\" in breadcrumb when on-prem (#220110)\n\n## Summary\n\nCloses #219869\n\n**Before**\n\n![image](https://github.com/user-attachments/assets/59f0f6fc-2113-44ee-8e36-69c4eb718fad)\n\n\n**After**\n<img width=\"1320\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/85ad1117-4aab-4a8d-807c-4fa90cd8b917\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"0acd88e3b9ce22dc375682735b3a881d6cdc117b"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->