### PR TITLE
[upgrade assistant] Upgrade Assistant - Deprecation Badge storybook fix

### DIFF
--- a/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.stories.tsx
+++ b/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.stories.tsx
@@ -7,19 +7,21 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { DeprecationBadge } from './deprecation_badge';
+import { DeprecationBadge, WarningLevels } from './deprecation_badge';
 
 const meta: Meta<typeof DeprecationBadge> = {
   component: DeprecationBadge,
   title: 'Upgrade Assistant/Deprecation Badge',
   argTypes: {
     level: {
-      name: 'Deprecation is critical?',
-      control: { type: 'boolean' },
+      name: 'Deprecation level',
+      options: Object.values(WarningLevels),
+
+      control: { type: 'select' },
     },
     isResolved: {
       name: 'Deprecation is resolved?',
-      control: { type: 'select', options: ['none', 'info', 'warning', 'critical', 'fetch_error'] },
+      control: { type: 'boolean' },
     },
   },
 };
@@ -29,7 +31,7 @@ type Story = StoryObj<typeof DeprecationBadge>;
 
 export const Primary: Story = {
   args: {
-    level: 'info',
+    level: WarningLevels.CRITICAL,
     isResolved: false,
   },
 };

--- a/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.tsx
+++ b/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.tsx
@@ -8,6 +8,7 @@
 import React, { FunctionComponent } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiBadge } from '@elastic/eui';
+import { MIGRATION_DEPRECATION_LEVEL } from '../types';
 
 const i18nTexts = {
   criticalBadgeLabel: i18n.translate('xpack.upgradeAssistant.deprecationBadge.criticalBadgeLabel', {
@@ -21,8 +22,18 @@ const i18nTexts = {
   }),
 };
 
+enum WarningLevelsFetchError {
+  FETCH_ERROR = 'fetch_error',
+}
+
+type WarningLevels = MIGRATION_DEPRECATION_LEVEL | WarningLevelsFetchError;
+export const WarningLevels = {
+  ...MIGRATION_DEPRECATION_LEVEL,
+  ...WarningLevelsFetchError,
+} as const;
+
 interface Props {
-  level: 'none' | 'info' | 'warning' | 'critical' | 'fetch_error';
+  level: WarningLevels;
   isResolved?: boolean;
 }
 
@@ -35,7 +46,7 @@ export const DeprecationBadge: FunctionComponent<Props> = ({ level, isResolved }
     );
   }
 
-  if (level === 'critical') {
+  if (level === WarningLevels.CRITICAL) {
     return (
       <EuiBadge color="danger" data-test-subj="criticalDeprecationBadge">
         {i18nTexts.criticalBadgeLabel}

--- a/x-pack/platform/packages/private/upgrade-assistant/src/index.ts
+++ b/x-pack/platform/packages/private/upgrade-assistant/src/index.ts
@@ -5,4 +5,5 @@
  * 2.0.
  */
 
-export { DeprecationBadge } from './components/deprecation_badge';
+export { DeprecationBadge, WarningLevels } from './components/deprecation_badge';
+export { MIGRATION_DEPRECATION_LEVEL } from './types';

--- a/x-pack/platform/packages/private/upgrade-assistant/src/types.ts
+++ b/x-pack/platform/packages/private/upgrade-assistant/src/types.ts
@@ -5,4 +5,9 @@
  * 2.0.
  */
 
-export { DeprecationBadge, WarningLevels } from './deprecation_badge';
+export enum MIGRATION_DEPRECATION_LEVEL {
+  NONE = 'none',
+  INFO = 'info',
+  WARNING = 'warning',
+  CRITICAL = 'critical',
+}

--- a/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
@@ -8,6 +8,7 @@
 import { HealthReportImpact } from '@elastic/elasticsearch/lib/api/types';
 import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { SavedObject } from '@kbn/core/types';
+import type { MIGRATION_DEPRECATION_LEVEL } from '@kbn/upgrade-assistant';
 import type { DataStreamsAction } from './data_stream_types';
 
 export * from './data_stream_types';
@@ -182,7 +183,6 @@ export interface UpgradeAssistantTelemetry {
   };
 }
 
-export type MIGRATION_DEPRECATION_LEVEL = 'none' | 'info' | 'warning' | 'critical';
 export interface DeprecationInfo {
   level: MIGRATION_DEPRECATION_LEVEL;
   message: string;

--- a/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/shared/index.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/public/application/components/shared/index.ts
@@ -7,7 +7,7 @@
 
 export { NoDeprecationsPrompt } from './no_deprecations';
 export { DeprecationCount } from './deprecation_count';
-export { DeprecationBadge } from '@kbn/upgrade-assistant';
+export { DeprecationBadge, WarningLevels } from '@kbn/upgrade-assistant';
 export { DeprecationsPageLoadingError } from './deprecations_page_loading_error';
 export { DeprecationFlyoutLearnMoreLink } from './deprecation_flyout_learn_more_link';
 export { LevelInfoTip } from './level_info_tip';


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



