### PR TITLE
[LockManager] Update token and metadata when an expired lock is re-acquired

### DIFF
--- a/packages/kbn-lock-manager/src/lock_manager_client.ts
+++ b/packages/kbn-lock-manager/src/lock_manager_client.ts
@@ -87,6 +87,8 @@ export class LockManager {
                 def instantNow = Instant.ofEpochMilli(now);
                 ctx._source.createdAt = instantNow.toString();
                 ctx._source.expiresAt = instantNow.plusMillis(params.ttl).toString();
+                ctx._source.metadata = params.metadata;
+                ctx._source.token = params.token;
               } else {
                 ctx.op = 'noop';
               }
@@ -94,13 +96,11 @@ export class LockManager {
             params: {
               ttl,
               token: this.token,
+              metadata,
             },
           },
           // @ts-expect-error
-          upsert: {
-            metadata,
-            token: this.token,
-          },
+          upsert: {},
         },
         {
           retryOnTimeout: true,
@@ -189,7 +189,7 @@ export class LockManager {
         this.logger.debug(`Lock "${this.lockId}" released with token ${this.token}.`);
         return true;
       case 'noop':
-        this.logger.debug(
+        this.logger.warn(
           `Lock "${this.lockId}" with token = ${this.token} could not be released. Token does not match.`
         );
         return false;


### PR DESCRIPTION
Related: https://github.com/elastic/kibana/pull/216397

This fixes a bug in the Lock Manager where an expired lock can be acquired, but the token and metadata is not updated. This means that the lock cannot be released. Instead it is automatically released when the TTL expires.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->