### PR TITLE
[AI4SOC] Remove links to the rule management page

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/promotion_rules/promotion_rules_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/configurations/tabs/promotion_rules/promotion_rules_table.tsx
@@ -14,6 +14,7 @@ import {
   EuiSpacer,
   EuiTab,
   EuiTabs,
+  EuiText,
 } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import type { FindRulesSortField } from '../../../../common/api/detection_engine';
@@ -200,6 +201,7 @@ const useRulesColumns = ({ currentTab }: ColumnsProps): Array<EuiBasicTableColum
       return [
         {
           ...RULE_NAME_COLUMN,
+          render: (value: Rule['name']) => <EuiText size="s">{value}</EuiText>,
           width: '30%',
         } as EuiBasicTableColumn<Rule>,
         INDEXING_DURATION_COLUMN,
@@ -215,6 +217,7 @@ const useRulesColumns = ({ currentTab }: ColumnsProps): Array<EuiBasicTableColum
     return [
       {
         ...RULE_NAME_COLUMN,
+        render: (value: Rule['name']) => <EuiText size="s">{value}</EuiText>,
         width: '100%',
       } as EuiBasicTableColumn<Rule>,
       LAST_EXECUTION_COLUMN,


### PR DESCRIPTION
## Summary

As we discussed, the rules management page should be excluded in AI4SOC. Removing links to the rule details page from the rule tables:

![image](https://github.com/user-attachments/assets/d7abfbd9-4fb7-400c-97b6-775dfdf1262d)




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->