### PR TITLE
security advisory message added to 8.17.6 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -96,6 +96,11 @@ include::upgrade-notes.asciidoc[]
 [[release-notes-8.17.6]]
 == {kib} 8.17.6
 
+[IMPORTANT]
+====
+The 8.17.6 release contains fixes for potential security vulnerabilities. See our https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+====
+
 The 8.17.6 release includes the following enhancements and fixes.
 
 [float]


### PR DESCRIPTION
Updated release notes for security advisory message.

cc: @florent-leborgne , @leemthompo 