### PR TITLE
release notes security advisor message added to 9.0.1 release notes

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -25,6 +25,10 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ## 9.0.1 [kibana-9.0.1-release-notes]
 
+::::{important}
+The 9.0.1 release contains fixes for potential security vulnerabilities. See our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
+::::
+
 ### Enhancements [kibana-9.0.1-features-enhancements]
 **Data ingestion and Fleet**:
 * Reuse shared integration policies when duplicating agent policies [#217872](https://github.com/elastic/kibana/pull/217872).


### PR DESCRIPTION
Updating release notes for 9.0.1 (docs V3) in main branch.

Not sure how we plan to deal with the security advisor messages in the release notes in the new docs system, considering the release notes page include a generic message at the beginning pointing to the security advisory board.

Also I'm not totally sure if this needs to be merged into any other branch, I'll let @wajihaparvez  and @florent-leborgne to determine how this should be done, and approve or reject the PR.

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->