### PR TITLE
[APM]Attempt to fix flaky APM alert tests

### DIFF
--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/alerts/transaction_duration.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/alerts/transaction_duration.spec.ts
@@ -230,7 +230,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       let ruleId: string;
       let alerts: ApmAlertFields[];
 
-      beforeEach(async () => {
+      before(async () => {
         const createdRule = await alertingApi.createRule({
           ruleTypeId: ApmRuleType.TransactionDuration,
           name: 'Apm transaction duration with kql filter',
@@ -261,7 +261,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         ).hits.hits.map((hit) => hit._source) as ApmAlertFields[];
       });
 
-      afterEach(() =>
+      after(() =>
         alertingApi.cleanUpAlerts({
           roleAuthc,
           ruleId,

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/alerts/transaction_error_rate.spec.ts
@@ -240,7 +240,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
       let ruleId: string;
       let alerts: ApmAlertFields[];
 
-      beforeEach(async () => {
+      before(async () => {
         const createdRule = await alertingApi.createRule({
           ruleTypeId: ApmRuleType.TransactionErrorRate,
           name: 'Apm transaction error rate without kql query',
@@ -282,7 +282,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
         ).hits.hits.map((hit) => hit._source) as ApmAlertFields[];
       });
 
-      afterEach(() =>
+      after(() =>
         alertingApi.cleanUpAlerts({
           roleAuthc,
           ruleId,


### PR DESCRIPTION
## Summary

Attempt to fix https://buildkite.com/elastic/appex-qa-stateful-kibana-ftr-tests/builds/240#0196a98c-4e48-4028-9bde-84b04530e63e


<!--ONMERGE {"backportTargets":["7.17","8.17","8.18","8.19","9.0"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->