### PR TITLE
[APM] Fix pagination not working on Service Inventory page when progressive loading is enabled

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/errors/errors_page.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/errors/errors_page.cy.ts
@@ -93,13 +93,23 @@ describe('Errors page', () => {
       });
 
       it('sorts by ocurrences', () => {
+        cy.intercept(
+          'GET',
+          '/internal/apm/services/opbeans-java/errors/groups/main_statistics?*'
+        ).as('errorsMainStatistics');
         cy.visitKibana(javaServiceErrorsPageHref);
+        cy.wait('@errorsMainStatistics');
         cy.contains('span', 'Occurrences').click();
         cy.url().should('include', '&sortField=occurrences&sortDirection=asc');
       });
 
       it('sorts by latest occurrences', () => {
+        cy.intercept(
+          'GET',
+          '/internal/apm/services/opbeans-java/errors/groups/main_statistics?*'
+        ).as('errorsMainStatistics');
         cy.visitKibana(javaServiceErrorsPageHref);
+        cy.wait('@errorsMainStatistics');
         cy.contains('span', 'Last seen').click();
         cy.url().should('include', '&sortField=lastSeen&sortDirection=asc');
       });

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_inventory/generate_data.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_inventory/generate_data.ts
@@ -6,10 +6,13 @@
  */
 import { apm, timerange } from '@kbn/apm-synthtrace-client';
 
-export function generateMultipleServicesData({ from, to }: { from: number; to: number }) {
+export function generateMultipleServicesData(
+  { from, to }: { from: number; to: number },
+  quantity = 50
+) {
   const range = timerange(from, to);
 
-  const services = Array(50)
+  const services = Array(quantity)
     .fill(0)
     .map((_, idx) =>
       apm

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
@@ -180,4 +180,39 @@ describe('Service Inventory', () => {
       });
     });
   });
+
+  describe('Check pagination with progressive loading enabled', () => {
+    before(() => {
+      // clean previous data created
+      synthtrace.clean();
+      const { rangeFrom, rangeTo } = timeRange;
+      synthtrace.index(
+        generateMultipleServicesData(
+          {
+            from: new Date(rangeFrom).getTime(),
+            to: new Date(rangeTo).getTime(),
+          },
+          500
+        )
+      );
+      // enable progressive loading
+      cy.loginAsEditorUser().then(() => {
+        cy.updateAdvancedSettings({
+          'observability:apmProgressiveLoading': 'low',
+        });
+      });
+      cy.visitKibana(serviceInventoryHref);
+    });
+
+    it('should navigate to the next page when clicking on the pagination button', () => {
+      cy.getByTestSubj('pagination-button-1').click();
+      cy.url().should('include', 'page=1');
+    });
+
+    after(() => {
+      cy.updateAdvancedSettings({
+        'observability:apmProgressiveLoading': 'off',
+      });
+    });
+  });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
@@ -165,7 +165,10 @@ function UnoptimizedManagedTable<T extends object>(props: {
   const [tableOptions, setTableOptions] = useState(getStateFromUrl());
 
   // update table options state when url params change
-  useEffect(() => setTableOptions(getStateFromUrl()), [getStateFromUrl]);
+  useEffect(() => {
+    // Prevent updates while data is loading, as this cause pagination issues when observability:apmProgressiveLoading is enabled
+    if (!isLoading) setTableOptions(getStateFromUrl());
+  }, [getStateFromUrl, isLoading]);
 
   // Clean up searchQuery when fast filter is toggled off
   useEffect(() => {
@@ -179,7 +182,7 @@ function UnoptimizedManagedTable<T extends object>(props: {
     (newTableOptions: Partial<TableOptions<T>>) => {
       setTableOptions((oldTableOptions) => merge({}, oldTableOptions, newTableOptions));
 
-      if (saveTableOptionsToUrl) {
+      if (saveTableOptionsToUrl && !isLoading) {
         history.push({
           ...history.location,
           search: fromQuery({
@@ -192,7 +195,7 @@ function UnoptimizedManagedTable<T extends object>(props: {
         });
       }
     },
-    [history, saveTableOptionsToUrl, setTableOptions]
+    [history, saveTableOptionsToUrl, setTableOptions, isLoading]
   );
 
   const filteredItems = useMemo(() => {

--- a/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/shared/managed_table/index.tsx
@@ -167,7 +167,9 @@ function UnoptimizedManagedTable<T extends object>(props: {
   // update table options state when url params change
   useEffect(() => {
     // Prevent updates while data is loading, as this cause pagination issues when observability:apmProgressiveLoading is enabled
-    if (!isLoading) setTableOptions(getStateFromUrl());
+    if (!isLoading) {
+      setTableOptions(getStateFromUrl());
+    }
   }, [getStateFromUrl, isLoading]);
 
   // Clean up searchQuery when fast filter is toggled off


### PR DESCRIPTION
## Summary

While the `observability:apmProgressiveLoading` setting is enabled, pagination on the Service Inventory page does not work properly. This happens due to implementation of [`useProgressiveFetcher`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/hooks/use_progressive_fetcher.tsx), which retains the [`sampled`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/hooks/use_progressive_fetcher.tsx#L92) data between component re-renders instead of returning the already loaded [`unsampled`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/observability/plugins/apm/public/hooks/use_progressive_fetcher.tsx#L105) data. As a result, pagination receives two sets of data sequentially. This behavior causes the page index to revert to the last available index in `sampled` results, preventing users from paginating through the full length of `unsampled` data.

To avoid the issue, we implemented `isLoading` check in pagination to prevent index from reverting while `unsampled` data is being loaded.

Before:

https://github.com/user-attachments/assets/bd54afaf-9e4d-46c5-bac0-ec4d69e84b10

After:

https://github.com/user-attachments/assets/57f1002b-c9d3-43a5-8d9b-01238d70e7cf

## Testing
1. Enable `observability:apmProgressiveLoading` in advance settings
2. Go to Applications -> Service Inventory
3. Iterate through the pagination

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->