### PR TITLE
[actions] use main branch for label-to-field mapping script

### DIFF
--- a/.github/workflows/pm-map-labels-to-fields.yml
+++ b/.github/workflows/pm-map-labels-to-fields.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'elastic/kibana-github-actions'
-          ref: add-github-projects-actions
+          ref: main
           path: ./actions
 
       - name: Install Actions


### PR DESCRIPTION
## Summary
When testing the script (https://github.com/elastic/kibana/pull/212783), I was using a branch to test the script - it should have been reset to `main`. 