### PR TITLE
[8.19] Expose frozen indices information on the rule health endpoint (#219703)

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/health_endpoints.md
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/health_endpoints.md
@@ -200,7 +200,8 @@ Response:
           "message": "day were not queried between this rule execution and the last execution so signals may have been missed Consider increasing your look behind time or adding more Kibana instances"
         }
       ],
-      "top_warnings": []
+      "top_warnings": [],
+      "frozen_indices_queried_max_count": 0
     },
     "history_over_interval": {
       "buckets": [
@@ -272,7 +273,8 @@ Response:
                 "95.0": 0,
                 "99.0": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         },
         {
@@ -343,7 +345,8 @@ Response:
                 "95.0": 0,
                 "99.0": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         }
       ]
@@ -564,7 +567,8 @@ Response:
           "count": 2129,
           "message": "This rule is attempting to query data from Elasticsearch indices listed in the Index pattern section of the rule definition however no index matching was found This warning will continue to appear until matching index is created or this rule is disabled"
         }
-      ]
+      ],
+      "frozen_indices_queried_max_count": 0
     },
     "history_over_interval": {
       "buckets": [
@@ -636,7 +640,8 @@ Response:
                 "95.0": 0,
                 "99.0": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         },
         {
@@ -707,7 +712,8 @@ Response:
                 "95.0": 0,
                 "99.0": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         }
       ]
@@ -888,7 +894,8 @@ Response:
           "count": 240,
           "message": "This rule is attempting to query data from Elasticsearch indices listed in the Index pattern section of the rule definition however no index matching filebeat logs-aws was found This warning will continue to appear until matching index is created or this rule is disabled"
         }
-      ]
+      ],
+      "frozen_indices_queried_max_count": 0
     },
     "history_over_interval": {
       "buckets": [
@@ -948,7 +955,8 @@ Response:
                 "99.0": 0,
                 "99.9": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         },
         {
@@ -1007,7 +1015,8 @@ Response:
                 "99.0": 0,
                 "99.9": 0
               }
-            }
+            },
+            "frozen_indices_queried_max_count": 0
           }
         }
       ]

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/model/health_stats.mock.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/model/health_stats.mock.ts
@@ -64,6 +64,7 @@ const getEmptyHealthOverviewStats = (): HealthOverviewStats => {
     indexing_duration_ms: getZeroAggregatedMetric(),
     top_errors: [],
     top_warnings: [],
+    frozen_indices_queried_max_count: 0,
   };
 };
 

--- a/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/model/health_stats.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/api/detection_engine/rule_monitoring/detection_engine_health/model/health_stats.ts
@@ -160,6 +160,11 @@ export interface HealthOverviewStats {
    * N most frequent warning messages logged by rule(s) to Event Log.
    */
   top_warnings?: TopMessages;
+
+  /**
+   * Max count of frozen indices queried during rule execution
+   */
+  frozen_indices_queried_max_count: number;
 }
 
 /**

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/detection_engine_health/event_log/aggregations/rule_execution_stats.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/detection_engine_health/event_log/aggregations/rule_execution_stats.ts
@@ -121,6 +121,20 @@ export const getRuleExecutionStatsAggregation = (
             },
           },
         },
+        frozenIndices: {
+          filter: {
+            exists: {
+              field: f.RULE_EXECUTION_FROZEN_INDICES_QUERIED_COUNT,
+            },
+          },
+          aggs: {
+            frozenIndicesQueriedCount: {
+              max: {
+                field: f.RULE_EXECUTION_FROZEN_INDICES_QUERIED_COUNT,
+              },
+            },
+          },
+        },
         searchDurationMs: {
           percentiles: {
             field: f.RULE_EXECUTION_SEARCH_DURATION_MS,
@@ -212,6 +226,7 @@ export const normalizeRuleExecutionStatsAggregationResult = (
   const gaps = executionMetricsEvents.gaps || {};
   const searchDurationMs = executionMetricsEvents.searchDurationMs || {};
   const indexingDurationMs = executionMetricsEvents.indexingDurationMs || {};
+  const frozenIndices = executionMetricsEvents.frozenIndices || {};
 
   return {
     number_of_executions: normalizeNumberOfExecutions(totalExecutions, executionsByStatus),
@@ -229,6 +244,7 @@ export const normalizeRuleExecutionStatsAggregationResult = (
       aggregationLevel === 'whole-interval'
         ? normalizeTopWarnings(messageContainingEvents)
         : undefined,
+    frozen_indices_queried_max_count: normalizeFrozenQueriedIndices(frozenIndices),
   };
 };
 
@@ -278,6 +294,10 @@ const normalizeNumberOfDetectedGaps = (gaps: RawData): NumberOfDetectedGaps => {
     total: Number(gaps.doc_count || 0),
     total_duration_s: Number(gaps.totalGapDurationS?.value || 0),
   };
+};
+
+const normalizeFrozenQueriedIndices = (frozenQueriedIndices: RawData): number => {
+  return Number(frozenQueriedIndices?.frozenIndicesQueriedCount?.value || 0);
 };
 
 const normalizeAggregatedMetric = (

--- a/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/event_log/event_log_fields.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/event_log/event_log_fields.ts
@@ -42,6 +42,9 @@ export const RULE_EXECUTION_INDEXING_DURATION_MS =
 export const RULE_EXECUTION_GAP_DURATION_S =
   `${RULE_EXECUTION_METRICS}.execution_gap_duration_s` as const;
 
+export const RULE_EXECUTION_FROZEN_INDICES_QUERIED_COUNT =
+  `${RULE_EXECUTION_METRICS}.frozen_indices_queried_count` as const;
+
 export const RULE_EXECUTION_SCHEDULE_DELAY_NS = 'kibana.task.schedule_delay' as const;
 
 export const NUMBER_OF_ALERTS_GENERATED = `${RULE_EXECUTION_METRICS}.alert_counts.new` as const;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Expose frozen indices information on the rule health endpoint (#219703)](https://github.com/elastic/kibana/pull/219703)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Edgar Santos","email":"edgar.santos@elastic.co"},"sourceCommit":{"committedDate":"2025-05-08T15:11:38Z","message":"Expose frozen indices information on the rule health endpoint (#219703)\n\n## Summary\nThis is a follow up PR to expose the metric\n`frozen_indices_queried_max_count` on the rule healthcheck endpoint.\nThis metric is an aggregation of the metric\n`frozen_indices_queried_count` which is calculated upon rule execution.\nRefer to [this PR](https://github.com/elastic/kibana/pull/218435) to see\nmore details about it.\n\n## How to test this?\n- Run Elastic locally with these additional parameters in order to\nenable the frozen data tier: -E path.repo=\"/tmp\" -E\nxpack.searchable.snapshot.shared_cache.size=20GB.\n- Use [this\ntutorial](https://docs.elastic.dev/security-soution/analyst-experience-team/eng-prod/how-to/configure-local-frozen-tier)\nto create the snapshot repository and an ILM policy. You can disable\nrollover for the ILM policy and configure indices to be moved to frozen\nafter 0 days.\n- Create an index manually and populate it with a couple of documents.\n- Assign the ILM policy to the index you created in the previous step\nand wait for it to be rolled to frozen. You can run this command to\nspeed up the process:\n```\nPUT /_cluster/settings\n{\n  \"persistent\": {\n    \"indices.lifecycle.poll_interval\": \"10s\"\n  }\n}\n```\nYou can confirm that the index is indeed in frozen by calling\n```\nGET <YOUR_IDX_HERE>/_ilm/explain\n```\n`phase` should be `frozen` and `step` should be `complete`.\n- Create a rule querying the frozen index.\n- Call the rule health endpoint with:\n```\ncurl -X POST --user elastic:changeme \"http://localhost:5601/internal/detection_engine/health/_rule?date_start=2025-04-29T09:07:39.489Z&date_end=2025-05-01T09:08:39.489Z\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"elastic-api-version: 1\" \\\n  -H 'kbn-xsrf: 123' \\\n  -H \"x-elastic-internal-origin: Kibana\" \\\n  --data '{\"rule_id\":\"2f9780b5-7819-4685-ab8e-d817d3701d10\"}'\n```\nYou should see `frozen_indices_queried_max_count` populated with `1`.","sha":"054412570946ed0a2056ff5259388e9df08d7d37","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detection Engine","backport:version","v9.1.0","v8.19.0"],"title":"Expose frozen indices information on the rule health endpoint","number":219703,"url":"https://github.com/elastic/kibana/pull/219703","mergeCommit":{"message":"Expose frozen indices information on the rule health endpoint (#219703)\n\n## Summary\nThis is a follow up PR to expose the metric\n`frozen_indices_queried_max_count` on the rule healthcheck endpoint.\nThis metric is an aggregation of the metric\n`frozen_indices_queried_count` which is calculated upon rule execution.\nRefer to [this PR](https://github.com/elastic/kibana/pull/218435) to see\nmore details about it.\n\n## How to test this?\n- Run Elastic locally with these additional parameters in order to\nenable the frozen data tier: -E path.repo=\"/tmp\" -E\nxpack.searchable.snapshot.shared_cache.size=20GB.\n- Use [this\ntutorial](https://docs.elastic.dev/security-soution/analyst-experience-team/eng-prod/how-to/configure-local-frozen-tier)\nto create the snapshot repository and an ILM policy. You can disable\nrollover for the ILM policy and configure indices to be moved to frozen\nafter 0 days.\n- Create an index manually and populate it with a couple of documents.\n- Assign the ILM policy to the index you created in the previous step\nand wait for it to be rolled to frozen. You can run this command to\nspeed up the process:\n```\nPUT /_cluster/settings\n{\n  \"persistent\": {\n    \"indices.lifecycle.poll_interval\": \"10s\"\n  }\n}\n```\nYou can confirm that the index is indeed in frozen by calling\n```\nGET <YOUR_IDX_HERE>/_ilm/explain\n```\n`phase` should be `frozen` and `step` should be `complete`.\n- Create a rule querying the frozen index.\n- Call the rule health endpoint with:\n```\ncurl -X POST --user elastic:changeme \"http://localhost:5601/internal/detection_engine/health/_rule?date_start=2025-04-29T09:07:39.489Z&date_end=2025-05-01T09:08:39.489Z\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"elastic-api-version: 1\" \\\n  -H 'kbn-xsrf: 123' \\\n  -H \"x-elastic-internal-origin: Kibana\" \\\n  --data '{\"rule_id\":\"2f9780b5-7819-4685-ab8e-d817d3701d10\"}'\n```\nYou should see `frozen_indices_queried_max_count` populated with `1`.","sha":"054412570946ed0a2056ff5259388e9df08d7d37"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219703","number":219703,"mergeCommit":{"message":"Expose frozen indices information on the rule health endpoint (#219703)\n\n## Summary\nThis is a follow up PR to expose the metric\n`frozen_indices_queried_max_count` on the rule healthcheck endpoint.\nThis metric is an aggregation of the metric\n`frozen_indices_queried_count` which is calculated upon rule execution.\nRefer to [this PR](https://github.com/elastic/kibana/pull/218435) to see\nmore details about it.\n\n## How to test this?\n- Run Elastic locally with these additional parameters in order to\nenable the frozen data tier: -E path.repo=\"/tmp\" -E\nxpack.searchable.snapshot.shared_cache.size=20GB.\n- Use [this\ntutorial](https://docs.elastic.dev/security-soution/analyst-experience-team/eng-prod/how-to/configure-local-frozen-tier)\nto create the snapshot repository and an ILM policy. You can disable\nrollover for the ILM policy and configure indices to be moved to frozen\nafter 0 days.\n- Create an index manually and populate it with a couple of documents.\n- Assign the ILM policy to the index you created in the previous step\nand wait for it to be rolled to frozen. You can run this command to\nspeed up the process:\n```\nPUT /_cluster/settings\n{\n  \"persistent\": {\n    \"indices.lifecycle.poll_interval\": \"10s\"\n  }\n}\n```\nYou can confirm that the index is indeed in frozen by calling\n```\nGET <YOUR_IDX_HERE>/_ilm/explain\n```\n`phase` should be `frozen` and `step` should be `complete`.\n- Create a rule querying the frozen index.\n- Call the rule health endpoint with:\n```\ncurl -X POST --user elastic:changeme \"http://localhost:5601/internal/detection_engine/health/_rule?date_start=2025-04-29T09:07:39.489Z&date_end=2025-05-01T09:08:39.489Z\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"elastic-api-version: 1\" \\\n  -H 'kbn-xsrf: 123' \\\n  -H \"x-elastic-internal-origin: Kibana\" \\\n  --data '{\"rule_id\":\"2f9780b5-7819-4685-ab8e-d817d3701d10\"}'\n```\nYou should see `frozen_indices_queried_max_count` populated with `1`.","sha":"054412570946ed0a2056ff5259388e9df08d7d37"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->