### PR TITLE
[Docs] Backport 8.17.6 security advisory note to 8.19

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -469,6 +469,11 @@ Machine Learning::
 [[release-notes-8.17.6]]
 == {kib} 8.17.6
 
+[IMPORTANT]
+====
+The 8.17.6 release contains fixes for potential security vulnerabilities. See our https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+====
+
 The 8.17.6 release includes the following enhancements and fixes.
 
 [float]


### PR DESCRIPTION
**----Closed as duplicate----**

## Backport

This will backport the following commits from `8.17` to `8.19`:

- [security advisory message added to 8.17.6 release notes](https://github.com/elastic/kibana/commit/e86dde5efbc99dd7153e2bcebfbadae83e9430fa)


