### PR TITLE
[Unified Histogram] Fix Unified Histogram test types

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/tsconfig.json
+++ b/src/platform/packages/shared/kbn-unified-histogram/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "target/types",
-    "types": ["jest", "node", "react", "@emotion/react/types/css-prop"]
+    "outDir": "target/types"
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["target/**/*"],


### PR DESCRIPTION
## Summary

This PR fixes some type issues related to tests in the Unified Histogram package, although I'm not sure why they didn't show up in CI:
![image](https://github.com/user-attachments/assets/9894df2a-c3a8-4d25-ae0e-9b015f01b723)

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)