### PR TITLE
security advisory message added to 8.18.1 release notes (#220497)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -98,6 +98,11 @@ include::upgrade-notes.asciidoc[]
 [[release-notes-8.18.1]]
 == {kib} 8.18.1
 
+[IMPORTANT]
+====
+The 8.18.1 release contains fixes for potential security vulnerabilities. See our https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+====
+
 The 8.18.1 release includes the following enhancements and fixes.
 
 [float]
@@ -468,6 +473,11 @@ Machine Learning::
 
 [[release-notes-8.17.6]]
 == {kib} 8.17.6
+
+[IMPORTANT]
+====
+The 8.17.6 release contains fixes for potential security vulnerabilities. See our https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+====
 
 The 8.17.6 release includes the following enhancements and fixes.
 


### PR DESCRIPTION
## Backport

This will backport the following commits from `8.18` to `8.19`:

- [security advisory message added to 8.18.1 release notes](https://github.com/elastic/kibana/commit/ec0e9ca52fee0008e6d4b14fbff90b177340b34a)


