### PR TITLE
[8.19] [Response Ops][Reporting] Updating health API to return whether notification email service is available (#219785)

### DIFF
--- a/src/platform/packages/private/kbn-reporting/common/types.ts
+++ b/src/platform/packages/private/kbn-reporting/common/types.ts
@@ -112,6 +112,7 @@ export interface ReportingServerInfo {
 export interface ReportingHealthInfo {
   isSufficientlySecure: boolean;
   hasPermanentEncryptionKey: boolean;
+  areNotificationsEnabled: boolean;
 }
 
 export type IlmPolicyMigrationStatus = 'policy-not-found' | 'indices-not-managed-by-policy' | 'ok';

--- a/x-pack/platform/plugins/private/reporting/kibana.jsonc
+++ b/x-pack/platform/plugins/private/reporting/kibana.jsonc
@@ -22,6 +22,7 @@
       "fieldFormats",
       "home",
       "management",
+      "notifications",
       "licensing",
       "uiActions",
       "taskManager",

--- a/x-pack/platform/plugins/private/reporting/server/core.ts
+++ b/x-pack/platform/plugins/private/reporting/server/core.ts
@@ -47,6 +47,7 @@ import type {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
+import type { NotificationsPluginStart } from '@kbn/notifications-plugin/server';
 
 import { checkLicense } from '@kbn/reporting-server/check_license';
 import { ExportTypesRegistry } from '@kbn/reporting-server/export_types_registry';
@@ -84,6 +85,7 @@ export interface ReportingInternalStart {
   fieldFormats: FieldFormatsStart;
   licensing: LicensingPluginStart;
   logger: Logger;
+  notifications: NotificationsPluginStart;
   screenshotting?: ScreenshottingStart;
   securityService: SecurityServiceStart;
   taskManager: TaskManagerStartContract;
@@ -258,7 +260,7 @@ export class ReportingCore {
 
   public async getHealthInfo(): Promise<ReportingHealthInfo> {
     const { encryptedSavedObjects } = this.getPluginSetupDeps();
-    const { securityService } = await this.getPluginStartDeps();
+    const { notifications, securityService } = await this.getPluginStartDeps();
     const isSecurityEnabled = await this.isSecurityEnabled();
 
     let isSufficientlySecure: boolean;
@@ -279,6 +281,7 @@ export class ReportingCore {
     return {
       isSufficientlySecure,
       hasPermanentEncryptionKey: encryptedSavedObjects.canEncrypt,
+      areNotificationsEnabled: notifications.isEmailServiceAvailable(),
     };
   }
 

--- a/x-pack/platform/plugins/private/reporting/server/lib/tasks/execute_report.test.ts
+++ b/x-pack/platform/plugins/private/reporting/server/lib/tasks/execute_report.test.ts
@@ -170,9 +170,11 @@ describe('Execute Report Task', () => {
   });
 
   it('schedules task with request if health indicates security and api keys are enabled', async () => {
-    jest
-      .spyOn(mockReporting, 'getHealthInfo')
-      .mockResolvedValueOnce({ isSufficientlySecure: true, hasPermanentEncryptionKey: true });
+    jest.spyOn(mockReporting, 'getHealthInfo').mockResolvedValueOnce({
+      isSufficientlySecure: true,
+      hasPermanentEncryptionKey: true,
+      areNotificationsEnabled: true,
+    });
     const task = new ExecuteReportTask(mockReporting, configType, logger);
     const mockTaskManager = taskManagerMock.createStart();
     await task.init(mockTaskManager);
@@ -201,9 +203,11 @@ describe('Execute Report Task', () => {
   });
 
   it('schedules task without request if health indicates security is disabled', async () => {
-    jest
-      .spyOn(mockReporting, 'getHealthInfo')
-      .mockResolvedValueOnce({ isSufficientlySecure: false, hasPermanentEncryptionKey: true });
+    jest.spyOn(mockReporting, 'getHealthInfo').mockResolvedValueOnce({
+      isSufficientlySecure: false,
+      hasPermanentEncryptionKey: true,
+      areNotificationsEnabled: false,
+    });
     const task = new ExecuteReportTask(mockReporting, configType, logger);
     const mockTaskManager = taskManagerMock.createStart();
     await task.init(mockTaskManager);
@@ -229,9 +233,11 @@ describe('Execute Report Task', () => {
   });
 
   it('schedules task without request if health indicates no permanent encryption key', async () => {
-    jest
-      .spyOn(mockReporting, 'getHealthInfo')
-      .mockResolvedValueOnce({ isSufficientlySecure: true, hasPermanentEncryptionKey: false });
+    jest.spyOn(mockReporting, 'getHealthInfo').mockResolvedValueOnce({
+      isSufficientlySecure: true,
+      hasPermanentEncryptionKey: false,
+      areNotificationsEnabled: true,
+    });
     const task = new ExecuteReportTask(mockReporting, configType, logger);
     const mockTaskManager = taskManagerMock.createStart();
     await task.init(mockTaskManager);

--- a/x-pack/platform/plugins/private/reporting/server/routes/internal/health/health.ts
+++ b/x-pack/platform/plugins/private/reporting/server/routes/internal/health/health.ts
@@ -33,6 +33,7 @@ export const registerHealthRoute = (reporting: ReportingCore, logger: Logger) =>
           body: {
             has_permanent_encryption_key: healthInfo.hasPermanentEncryptionKey,
             is_sufficiently_secure: healthInfo.isSufficientlySecure,
+            are_notifications_enabled: healthInfo.areNotificationsEnabled,
           },
         });
       } catch (err) {

--- a/x-pack/platform/plugins/private/reporting/server/test_helpers/create_mock_reportingplugin.ts
+++ b/x-pack/platform/plugins/private/reporting/server/test_helpers/create_mock_reportingplugin.ts
@@ -30,6 +30,7 @@ import { setFieldFormats } from '@kbn/reporting-server';
 import { createMockScreenshottingStart } from '@kbn/screenshotting-plugin/server/mock';
 import { securityMock } from '@kbn/security-plugin/server/mocks';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
+import { notificationsMock } from '@kbn/notifications-plugin/server/mocks';
 import { ReportingCore } from '..';
 
 import type { ReportingInternalSetup, ReportingInternalStart } from '../core';
@@ -76,6 +77,7 @@ export const createMockPluginStart = async (
     data: dataPluginMock.createStartContract(),
     fieldFormats: () => Promise.resolve(fieldFormatsMock),
     store: await createMockReportingStore(config),
+    notifications: notificationsMock.createStart(),
     taskManager: {
       schedule: jest.fn().mockImplementation(() => ({ id: 'taskId' })),
       ensureScheduled: jest.fn(),

--- a/x-pack/platform/plugins/private/reporting/server/types.ts
+++ b/x-pack/platform/plugins/private/reporting/server/types.ts
@@ -28,6 +28,7 @@ import type {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
+import type { NotificationsPluginStart } from '@kbn/notifications-plugin/server';
 
 import { ExportTypesRegistry } from '@kbn/reporting-server/export_types_registry';
 import type { AuthenticatedUser } from '@kbn/core-security-common';
@@ -67,6 +68,7 @@ export interface ReportingStartDeps {
   discover: DiscoverServerPluginStart;
   fieldFormats: FieldFormatsStart;
   licensing: LicensingPluginStart;
+  notifications: NotificationsPluginStart;
   taskManager: TaskManagerStartContract;
   screenshotting?: ScreenshottingStart;
 }

--- a/x-pack/platform/plugins/private/reporting/tsconfig.json
+++ b/x-pack/platform/plugins/private/reporting/tsconfig.json
@@ -53,6 +53,7 @@
     "@kbn/react-kibana-mount",
     "@kbn/core-security-common",
     "@kbn/core-http-server-utils",
+    "@kbn/notifications-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Response Ops][Reporting] Updating health API to return whether notification email service is available (#219785)](https://github.com/elastic/kibana/pull/219785)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-05-08T14:11:53Z","message":"[Response Ops][Reporting] Updating health API to return whether notification email service is available (#219785)\n\n## Summary\n\nUpdates the internal reporting health API from\nhttps://github.com/elastic/kibana/pull/216857 to return whether the\nnotification email service is available. We'll be using this\nnotification email service to send the scheduled report notifications so\nthis lets us know if that service is available.\n\n```\nGET kbn:/internal/reporting/_health\n\nResponse \n{\n  \"has_permanent_encryption_key\": true,\n  \"is_sufficiently_secure\": true,\n  \"are_notifications_enabled\": true\n}\n```\n\n## To Verify\n1. Run kibana and ES with a preconfigured email connector in the\n`kibana.yml` and the notification configured to use the connector\n\n```\nnotifications.connectors.default.email: gmail\nxpack.actions.preconfigured:\n  gmail:\n    name: 'email: my gmail'\n    actionTypeId: '.email'\n    config:\n      <config>\n    secrets:\n      <secrets>\n```\n2. Access the health API, `are_notifications_enabled` should be `true`\n3. Remove the config and restart Kibana\n4. Access the health API, `are_notifications_enabled` should be `false`\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"25a873c86c2c7fe1f5b5f345d2ee349f721c7c2a","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Feature:Reporting:Framework","backport:version","v9.1.0","v8.19.0"],"title":"[Response Ops][Reporting] Updating health API to return whether notification email service is available","number":219785,"url":"https://github.com/elastic/kibana/pull/219785","mergeCommit":{"message":"[Response Ops][Reporting] Updating health API to return whether notification email service is available (#219785)\n\n## Summary\n\nUpdates the internal reporting health API from\nhttps://github.com/elastic/kibana/pull/216857 to return whether the\nnotification email service is available. We'll be using this\nnotification email service to send the scheduled report notifications so\nthis lets us know if that service is available.\n\n```\nGET kbn:/internal/reporting/_health\n\nResponse \n{\n  \"has_permanent_encryption_key\": true,\n  \"is_sufficiently_secure\": true,\n  \"are_notifications_enabled\": true\n}\n```\n\n## To Verify\n1. Run kibana and ES with a preconfigured email connector in the\n`kibana.yml` and the notification configured to use the connector\n\n```\nnotifications.connectors.default.email: gmail\nxpack.actions.preconfigured:\n  gmail:\n    name: 'email: my gmail'\n    actionTypeId: '.email'\n    config:\n      <config>\n    secrets:\n      <secrets>\n```\n2. Access the health API, `are_notifications_enabled` should be `true`\n3. Remove the config and restart Kibana\n4. Access the health API, `are_notifications_enabled` should be `false`\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"25a873c86c2c7fe1f5b5f345d2ee349f721c7c2a"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219785","number":219785,"mergeCommit":{"message":"[Response Ops][Reporting] Updating health API to return whether notification email service is available (#219785)\n\n## Summary\n\nUpdates the internal reporting health API from\nhttps://github.com/elastic/kibana/pull/216857 to return whether the\nnotification email service is available. We'll be using this\nnotification email service to send the scheduled report notifications so\nthis lets us know if that service is available.\n\n```\nGET kbn:/internal/reporting/_health\n\nResponse \n{\n  \"has_permanent_encryption_key\": true,\n  \"is_sufficiently_secure\": true,\n  \"are_notifications_enabled\": true\n}\n```\n\n## To Verify\n1. Run kibana and ES with a preconfigured email connector in the\n`kibana.yml` and the notification configured to use the connector\n\n```\nnotifications.connectors.default.email: gmail\nxpack.actions.preconfigured:\n  gmail:\n    name: 'email: my gmail'\n    actionTypeId: '.email'\n    config:\n      <config>\n    secrets:\n      <secrets>\n```\n2. Access the health API, `are_notifications_enabled` should be `true`\n3. Remove the config and restart Kibana\n4. Access the health API, `are_notifications_enabled` should be `false`\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"25a873c86c2c7fe1f5b5f345d2ee349f721c7c2a"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->