### PR TITLE
[Security Solution][Data View Manager] Allow passing data view to query bar

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/query_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/query_bar/index.tsx
@@ -20,14 +20,13 @@ import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { css, Global } from '@emotion/react';
 import { useKibana } from '../../lib/kibana';
 import { convertToQueryType } from './convert_to_query_type';
-import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
 
 export interface QueryBarComponentProps {
   dataTestSubj?: string;
   dateRangeFrom?: string;
   dateRangeTo?: string;
   hideSavedQuery?: boolean;
-  indexPattern: DataViewBase;
+  indexPattern: DataView | DataViewBase;
   isLoading?: boolean;
   isRefreshPaused?: boolean;
   filterQuery: Query;
@@ -41,6 +40,7 @@ export interface QueryBarComponentProps {
   displayStyle?: SearchBarProps['displayStyle'];
   isDisabled?: boolean;
   bubbleSubmitEvent?: boolean;
+  preventCacheClearOnUnmount?: boolean;
 }
 
 export const isDataView = (obj: unknown): obj is DataView =>
@@ -87,8 +87,8 @@ export const QueryBar = memo<QueryBarComponentProps>(
     displayStyle,
     isDisabled,
     bubbleSubmitEvent,
+    preventCacheClearOnUnmount = false,
   }) => {
-    const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
     const { data } = useKibana().services;
     const [dataView, setDataView] = useState<DataView>();
     const onQuerySubmit = useCallback(
@@ -160,11 +160,11 @@ export const QueryBar = memo<QueryBarComponentProps>(
         createDataView();
       }
       return () => {
-        if (dv?.id && !newDataViewPickerEnabled) {
+        if (dv?.id && !preventCacheClearOnUnmount) {
           data.dataViews.clearInstanceCache(dv?.id);
         }
       };
-    }, [data.dataViews, indexPattern, isEsql, newDataViewPickerEnabled]);
+    }, [data.dataViews, indexPattern, isEsql, preventCacheClearOnUnmount]);
 
     const searchBarFilters = useMemo(() => {
       if (isDataView(indexPattern) || isEsql) {

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/query_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/query_bar/index.tsx
@@ -160,6 +160,7 @@ export const QueryBar = memo<QueryBarComponentProps>(
         createDataView();
       }
       return () => {
+        // Cache needs to be cleared in certain instances where ad-hoc dataviews are created, like rule creation
         if (dv?.id && !preventCacheClearOnUnmount) {
           data.dataViews.clearInstanceCache(dv?.id);
         }

--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/search_bar/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/search_bar/index.tsx
@@ -42,6 +42,8 @@ import { hostsActions } from '../../../explore/hosts/store';
 import { networkActions } from '../../../explore/network/store';
 import { useSyncSearchBarUrlParams } from '../../hooks/search_bar/use_sync_search_bar_url_param';
 import { useSyncTimerangeUrlParam } from '../../hooks/search_bar/use_sync_timerange_url_param';
+import { useIsExperimentalFeatureEnabled } from '../../hooks/use_experimental_features';
+import { useDataView } from '../../../data_view_manager/hooks/use_data_view';
 
 interface SiemSearchBarProps {
   id: InputsModelId.global | InputsModelId.timeline;
@@ -97,6 +99,9 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
       dispatch(hostsActions.setHostTablesActivePageToZero());
       dispatch(networkActions.setNetworkTablesActivePageToZero());
     }, [dispatch]);
+
+    const newDataViewPickerEnabled = useIsExperimentalFeatureEnabled('newDataViewPickerEnabled');
+    const { dataView: experimentalDataView } = useDataView();
 
     useSyncSearchBarUrlParams();
     useSyncTimerangeUrlParam();
@@ -302,12 +307,19 @@ export const SearchBarComponent = memo<SiemSearchBarProps & PropsFromRedux>(
     }, []);
 
     const dataViews: DataView[] | null = useMemo(() => {
+      if (newDataViewPickerEnabled) {
+        if (experimentalDataView) {
+          return [experimentalDataView];
+        }
+        return null;
+      }
+
       if (sourcererDataView != null) {
         return [new DataView({ spec: sourcererDataView, fieldFormats })];
       } else {
         return null;
       }
-    }, [sourcererDataView, fieldFormats]);
+    }, [sourcererDataView, fieldFormats, newDataViewPickerEnabled, experimentalDataView]);
 
     const onTimeRangeChange = useCallback(
       ({ dateRange }: { dateRange: TimeRange }) => {


### PR DESCRIPTION
## Summary

This PR made an update to the `QueryBar` component to accept `DataView` or `DataViewBase`. There is an existing check that if `indexPattern` is data view, it will use that instead of creating a new one. Because the prop type is `DataViewBase`, that line is never reached.

When `newDataViewPickerEnabled` is enabled, data view manager has timeline data view, this PR passes the timeline data view instead of a data view base. 

This PR also fixed a bug related to alert preview. Currently when the feature flag is on and user previews alerts, there are errors in kibana console about document already exist in that index. In cases like rule creation, clearing the data view is needed.

![image](https://github.com/user-attachments/assets/b0f04fba-31f7-4eae-8ed5-a04ba860412b)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

