### PR TITLE
Gemini connector: makes maxOutputTokens an optional, configurable request parameter

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini/gemini.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini/gemini.ts
@@ -282,7 +282,6 @@ export class GeminiConnector extends SubActionConnector<Config, Secrets> {
 
   public async invokeAI(
     {
-      maxOutputTokens,
       messages,
       systemInstruction,
       model,
@@ -290,6 +289,7 @@ export class GeminiConnector extends SubActionConnector<Config, Secrets> {
       signal,
       timeout,
       toolConfig,
+      maxOutputTokens,
     }: InvokeAIActionParams,
     connectorUsageCollector: ConnectorUsageCollector
   ): Promise<InvokeAIActionResponse> {
@@ -397,7 +397,7 @@ const formatGeminiPayload = ({
   temperature,
   toolConfig,
 }: {
-  maxOutputTokens?: number | undefined;
+  maxOutputTokens?: number;
   messages: Array<{ role: string; content: string; parts: MessagePart[] }>;
   systemInstruction?: string;
   toolConfig?: InvokeAIActionParams['toolConfig'];

--- a/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini/gemini.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini/gemini.ts
@@ -42,11 +42,7 @@ import type {
   InvokeAIRawActionParams,
   InvokeAIRawActionResponse,
 } from '../../../common/gemini/types';
-import {
-  SUB_ACTION,
-  DEFAULT_TIMEOUT_MS,
-  DEFAULT_TOKEN_LIMIT,
-} from '../../../common/gemini/constants';
+import { SUB_ACTION, DEFAULT_TIMEOUT_MS } from '../../../common/gemini/constants';
 import { DashboardActionParamsSchema } from '../../../common/gemini/schema';
 /** Interfaces to define Gemini model response type */
 
@@ -63,7 +59,7 @@ interface Payload {
   contents: MessageContent[];
   generation_config: {
     temperature: number;
-    maxOutputTokens: number;
+    maxOutputTokens?: number;
   };
   tool_config?: {
     function_calling_config: {
@@ -286,6 +282,7 @@ export class GeminiConnector extends SubActionConnector<Config, Secrets> {
 
   public async invokeAI(
     {
+      maxOutputTokens,
       messages,
       systemInstruction,
       model,
@@ -299,7 +296,13 @@ export class GeminiConnector extends SubActionConnector<Config, Secrets> {
     const res = await this.runApi(
       {
         body: JSON.stringify(
-          formatGeminiPayload({ messages, temperature, toolConfig, systemInstruction })
+          formatGeminiPayload({
+            maxOutputTokens,
+            messages,
+            temperature,
+            toolConfig,
+            systemInstruction,
+          })
         ),
         model,
         signal,
@@ -313,6 +316,7 @@ export class GeminiConnector extends SubActionConnector<Config, Secrets> {
 
   public async invokeAIRaw(
     {
+      maxOutputTokens,
       messages,
       model,
       temperature = 0,
@@ -326,7 +330,7 @@ export class GeminiConnector extends SubActionConnector<Config, Secrets> {
     const res = await this.runApi(
       {
         body: JSON.stringify({
-          ...formatGeminiPayload({ messages, temperature, systemInstruction }),
+          ...formatGeminiPayload({ maxOutputTokens, messages, temperature, systemInstruction }),
           tools,
         }),
         model,
@@ -350,6 +354,7 @@ export class GeminiConnector extends SubActionConnector<Config, Secrets> {
    */
   public async invokeStream(
     {
+      maxOutputTokens,
       messages,
       systemInstruction,
       model,
@@ -365,7 +370,13 @@ export class GeminiConnector extends SubActionConnector<Config, Secrets> {
     return (await this.streamAPI(
       {
         body: JSON.stringify({
-          ...formatGeminiPayload({ messages, temperature, toolConfig, systemInstruction }),
+          ...formatGeminiPayload({
+            maxOutputTokens,
+            messages,
+            temperature,
+            toolConfig,
+            systemInstruction,
+          }),
           tools,
         }),
         model,
@@ -380,11 +391,13 @@ export class GeminiConnector extends SubActionConnector<Config, Secrets> {
 
 /** Format the json body to meet Gemini payload requirements */
 const formatGeminiPayload = ({
+  maxOutputTokens,
   messages,
   systemInstruction,
   temperature,
   toolConfig,
 }: {
+  maxOutputTokens?: number | undefined;
   messages: Array<{ role: string; content: string; parts: MessagePart[] }>;
   systemInstruction?: string;
   toolConfig?: InvokeAIActionParams['toolConfig'];
@@ -394,7 +407,7 @@ const formatGeminiPayload = ({
     contents: [],
     generation_config: {
       temperature,
-      maxOutputTokens: DEFAULT_TOKEN_LIMIT,
+      maxOutputTokens,
     },
     ...(systemInstruction ? { system_instruction: { parts: [{ text: systemInstruction }] } } : {}),
     ...(toolConfig


### PR DESCRIPTION
### Gemini connector: makes `maxOutputTokens` an optional, configurable request parameter

This PR updates the Gemini connector to make the `maxOutputTokens` request parameter, which was previously included in all requests with a (non configurable) value of `8192`, an optional, configurable request parameter.

- `maxOutputTokens` is no longer included in requests to Gemini models by default
- It may be optionally included in requests by passing the new `maxOutputTokens` parameter to the Gemini connector's `invokeAI` and `invokeAIRaw`, and `invokeStream` APIs

The driver for this change was some requests to newer models, e.g. Gemini Pro 2.5 were failing, because previously all requests from the Gemini Connector were sent with the value `8192` [here](https://github.com/elastic/kibana/blob/f3115c6746fe071672911a2e7f74b03bff10b209/x-pack/platform/plugins/shared/stack_connectors/server/connector_types/gemini/gemini.ts#L397).

The previous, non-configurable limit was less than the output token limit of newer Gemini models, as illustrated by the following table:

| Model              | Description                        |
|--------------------|------------------------------------|
| Gemini 1.5 Flash   | 1 (inclusive) to 8193 (exclusive)  |
| Gemini 1.5 Pro     | 1 (inclusive) to 8193 (exclusive)  |
| Gemini 1.5 Pro 002 | 1 (inclusive) to 32769 (exclusive) |
| Gemini 2.5 Pro     | 1 (inclusive) to 65536 (exclusive) |

When newer Gemini models generated a response with more than `8192` output tokens, the API response from Gemini would:

- Not contain the generated output, (because the `maxOutputTokens` limit was reached)
- Include a finish reason of `MAX_TOKENS`,
- Fail response validation in the connector, because the `usageMetadata` response metadata was missing the required `candidatesTokenCount` property, per the _Details_ below.

#### Details

Attack discovery requests to Gemini 2.5 Pro were failing with errors like the following:

```
ActionsClientLlm: action result status is error: an error occurred while running the action - Response validation failed (Error: [usageMetadata.candidatesTokenCount]: expected value of type [number] but got [undefined])
```

A full example error trace appears in the _Details_ below (click to expand):

<details>

```
ActionsClientLlm: action result status is error: an error occurred while running the action - Response validation failed (Error: [usageMetadata.candidatesTokenCount]: expected value of type [number] but got [undefined])

Response validation failed (Error: [usageMetadata.candidatesTokenCount]: expected value of type [number] but got [undefined]): ActionsClientLlm: action result status is error: an error occurred while running the action - Response validation failed (Error: [usageMetadata.candidatesTokenCount]: expected value of type [number] but got [undefined])
    at ActionsClientLlm._call (/Users/$USER/git/kibana/x-pack/platform/packages/shared/kbn-langchain/server/language_models/llm.ts:112:21)
    at async ActionsClientLlm._generate (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:375:29)
    at async ActionsClientLlm._generateUncached (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:176:26)
    at async ActionsClientLlm.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:34:24)
    at async RunnableSequence.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/runnables/base.cjs:1291:27)
    at async RunnableCallable.generate [as func] (/Users/$USER/git/kibana/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/generate/index.ts:61:27)
    at async RunnableCallable.invoke (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/utils.cjs:82:27)
    at async RunnableSequence.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/runnables/base.cjs:1285:33)
    at async _runWithRetry (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/retry.cjs:70:22)
    at async PregelRunner._executeTasksWithRetry (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/runner.cjs:211:33)
    at async PregelRunner.tick (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/runner.cjs:48:40)
    at async CompiledStateGraph._runLoop (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/index.cjs:1018:17)
    at async createAndRunLoop (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/index.cjs:907:17)
    at ActionsClientLlm._generateUncached (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:176:37)
    at ActionsClientLlm._generate (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:374:20)
    at ActionsClientLlm._generateUncached (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:176:37)
    at async ActionsClientLlm.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:34:24)
    at async RunnableSequence.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/runnables/base.cjs:1291:27)
    at async RunnableCallable.generate [as func] (/Users/$USER/git/kibana/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/generate/index.ts:61:27)
    at async RunnableCallable.invoke (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/utils.cjs:82:27)
    at async RunnableSequence.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/runnables/base.cjs:1285:33)
    at async _runWithRetry (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/retry.cjs:70:22)
    at async PregelRunner._executeTasksWithRetry (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/runner.cjs:211:33)
    at async PregelRunner.tick (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/runner.cjs:48:40)
    at async CompiledStateGraph._runLoop (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/index.cjs:1018:17)
    at async createAndRunLoop (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/index.cjs:907:17)
    at ActionsClientLlm._generateUncached (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:142:51)
    at CallbackManager.handleLLMStart (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/callbacks/manager.cjs:464:25)
    at ActionsClientLlm._generateUncached (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:142:51)
    at ActionsClientLlm._generateUncached (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:136:73)
    at ActionsClientLlm._generateUncached (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:136:73)
    at ActionsClientLlm._generateUncached (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:129:28)
    at ActionsClientLlm.generate (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:281:25)
    at ActionsClientLlm.generatePrompt (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:97:21)
    at ActionsClientLlm.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/language_models/llms.cjs:34:35)
    at RunnableSequence.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/runnables/base.cjs:1291:43)
    at async RunnableCallable.generate [as func] (/Users/$USER/git/kibana/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/generate/index.ts:61:27)
    at async RunnableCallable.invoke (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/utils.cjs:82:27)
    at async RunnableSequence.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/runnables/base.cjs:1285:33)
    at async _runWithRetry (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/retry.cjs:70:22)
    at async PregelRunner._executeTasksWithRetry (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/runner.cjs:211:33)
    at async PregelRunner.tick (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/runner.cjs:48:40)
    at async CompiledStateGraph._runLoop (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/index.cjs:1018:17)
    at async createAndRunLoop (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/pregel/index.cjs:907:17)
    at RunnableSequence.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/runnables/base.cjs:1285:70)
    at raceWithSignal (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/utils/signal.cjs:4:30)
    at RunnableSequence.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/runnables/base.cjs:1285:70)
    at async RunnableCallable.generate [as func] (/Users/$USER/git/kibana/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/graphs/default_attack_discovery_graph/nodes/generate/index.ts:61:27)
    at async RunnableCallable.invoke (/Users/$USER/git/kibana/node_modules/@langchain/langgraph/dist/utils.cjs:82:27)
    at async RunnableSequence.invoke (/Users/$USER/git/kibana/node_modules/@langchain/core/dist/runnables/base.cjs:1285:33)

```

</details>

The root cause of the validation error above was models like Gemini 2.5 Pro were generating responses with output tokens that reached the `maxOutputTokens` limit sent in the request.

When this happens, the response from the model:

- Includes a `finishReason` of `MAX_TOKENS`
- The `usageMetadata` does NOT include the `candidatesTokenCount`, which causes the validation error to occur

as illustrated by the following (partial) response:

```json
{
  "candidates": [
    {
      "content": {
        "role": "model",
        "parts": [
          {
            "text": ""
          }
        ]
      },
      "finishReason": "MAX_TOKENS",
      // ...
    }
  ],
  "usageMetadata": {
    "promptTokenCount": 82088,
    "totalTokenCount": 90280,
    "trafficType": "ON_DEMAND",
    "promptTokensDetails": [
      {
        "modality": "TEXT",
        "tokenCount": 82088
      }
    ],
    "thoughtsTokenCount": 8192
  },
  "modelVersion": "gemini-2.5-pro-preview-03-25",
  "createTime": "2025-05-06T18:05:44.475008Z",
  "responseId": "eE8aaID_HJXj-O4PifyReA"
}
```

To resolve this issue, the `maxOutputTokens` request parameter is only sent when it is specified via the Gemini connector's `invokeAI` and `invokeAIRaw` APIs.

#### Alternatives considered

All of the Gemini models tested will fail with errors like the following example when their (model-specific) output token limits are reached:

```
Status code: 400. Message: API Error: INVALID_ARGUMENT: Unable to submit request because it has a maxOutputTokens value of 4096000 but the supported range is from 1 (inclusive) to 65536 (exclusive). Update the value and try again.: ActionsClientLlm: action result status is error: an error occurred while running the action - Status code: 400. Message: API Error: INVALID_ARGUMENT: Unable to submit request because it has a maxOutputTokens value of 4096000 but the supported range is from 1 (inclusive) to 65536 (exclusive). Update the value and try again.
```

For example, passing a `maxOutputTokens` value of `32768` will work OK for `Gemini 1.5 Pro 002` and `Gemini 2.5 Pro`, but fail for `Gemini 1.5 Flash` and `Gemini 1.5 Pro`:

| Model              | Description                        |
|--------------------|------------------------------------|
| Gemini 1.5 Flash   | 1 (inclusive) to 8193 (exclusive)  |
| Gemini 1.5 Pro     | 1 (inclusive) to 8193 (exclusive)  |
| Gemini 1.5 Pro 002 | 1 (inclusive) to 32769 (exclusive) |
| Gemini 2.5 Pro     | 1 (inclusive) to 65536 (exclusive) |

As an alternative to removing `maxOutputTokens` from requests, we could have made it a required parameter to the `invokeAI`, `invokeAIRaw`, and `invokeStream` APIs, but that would require callers of these APIs to know the correct model-specific value to provide.

#### Desk testing

This PR was desk tested:

- Interactively in Attack discovery with the following models:

| Model              |
|--------------------|
| Gemini 1.5 Flash   |
| Gemini 1.5 Pro     |
| Gemini 1.5 Pro 002 |
| Gemini 2.5 Pro     |

- Interactively in Attack discovery with non-Gemini models, e.g. a subset of the GPT and Claude family of models (to test for unintended side effects)

- Via evaluations using `Eval AD: All Scenarios` for the Gemini connectors above, (and with the Claude / OpenAI models for regression testing)

- Interactively via the security assistant, to answer requests in tool calling, and non-tool calling scenarios


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.19"]} ONMERGE-->