### PR TITLE
[upgrade assistant] DeprecationLevel use enum instead of literals

### DIFF
--- a/src/core/packages/config/server-internal/src/deprecation/core_deprecations.ts
+++ b/src/core/packages/config/server-internal/src/deprecation/core_deprecations.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ConfigDeprecationProvider, ConfigDeprecation } from '@kbn/config';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 const rewriteBasePathDeprecation: ConfigDeprecation = (settings, fromPath, addDeprecation) => {
   if (settings.server?.basePath && !settings.server?.rewriteBasePath) {

--- a/src/core/packages/config/server-internal/src/deprecation/core_deprecations.ts
+++ b/src/core/packages/config/server-internal/src/deprecation/core_deprecations.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ConfigDeprecationProvider, ConfigDeprecation } from '@kbn/config';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 const rewriteBasePathDeprecation: ConfigDeprecation = (settings, fromPath, addDeprecation) => {
   if (settings.server?.basePath && !settings.server?.rewriteBasePath) {
@@ -19,7 +20,7 @@ const rewriteBasePathDeprecation: ConfigDeprecation = (settings, fromPath, addDe
         'will expect that all requests start with server.basePath rather than expecting you to rewrite ' +
         'the requests in your reverse proxy. Set server.rewriteBasePath to false to preserve the ' +
         'current behavior and silence this warning.',
-      level: 'warning',
+      level: DeprecationSeverity.WARNING,
       correctiveActions: {
         manualSteps: [
           `Set 'server.rewriteBasePath' in the config file, CLI flag, or environment variable (in Docker only).`,
@@ -37,7 +38,7 @@ const rewriteCorsSettings: ConfigDeprecation = (settings, fromPath, addDeprecati
       configPath: 'server.cors',
       title: 'Setting "server.cors" is deprecated',
       message: '"server.cors" is deprecated and has been replaced by "server.cors.enabled"',
-      level: 'warning',
+      level: DeprecationSeverity.WARNING,
       correctiveActions: {
         manualSteps: [
           `Replace "server.cors: ${corsSettings}" with "server.cors.enabled: ${corsSettings}"`,

--- a/src/core/packages/config/server-internal/tsconfig.json
+++ b/src/core/packages/config/server-internal/tsconfig.json
@@ -15,7 +15,7 @@
     "@kbn/config-mocks",
     "@kbn/core-base-server-internal",
     "@kbn/core-test-helpers-deprecations-getters",
-    "@kbn/core-http-common"
+    "@kbn/core-deprecations-common"
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/config/server-internal/tsconfig.json
+++ b/src/core/packages/config/server-internal/tsconfig.json
@@ -14,7 +14,8 @@
     "@kbn/config",
     "@kbn/config-mocks",
     "@kbn/core-base-server-internal",
-    "@kbn/core-test-helpers-deprecations-getters"
+    "@kbn/core-test-helpers-deprecations-getters",
+    "@kbn/core-http-common"
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/deprecations/browser-internal/src/deprecations_client.test.ts
+++ b/src/core/packages/deprecations/browser-internal/src/deprecations_client.test.ts
@@ -9,7 +9,7 @@
 
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { DeprecationsClient } from './deprecations_client';
-import type { DomainDeprecationDetails } from '@kbn/core-deprecations-common';
+import { type DomainDeprecationDetails, DeprecationLevel } from '@kbn/core-deprecations-common';
 
 describe('DeprecationsClient', () => {
   const http = httpServiceMock.createSetupContract();
@@ -86,7 +86,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: 'warning',
+        level: DeprecationLevel.WARNING,
         correctiveActions: {
           api: {
             path: 'some-path',
@@ -107,7 +107,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: 'warning',
+        level: DeprecationLevel.WARNING,
         correctiveActions: {
           manualSteps: ['manual-step'],
         },
@@ -126,7 +126,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: 'warning',
+        level: DeprecationLevel.WARNING,
         correctiveActions: {
           manualSteps: ['manual-step'],
         },
@@ -147,7 +147,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: 'warning',
+        level: DeprecationLevel.WARNING,
         correctiveActions: {
           api: {
             path: 'some-path',
@@ -181,7 +181,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: 'warning',
+        level: DeprecationLevel.WARNING,
         correctiveActions: {
           api: {
             path: 'some-path',
@@ -205,7 +205,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: 'warning',
+        level: DeprecationLevel.WARNING,
         correctiveActions: {
           api: {
             path: 'some-path',

--- a/src/core/packages/deprecations/browser-internal/src/deprecations_client.test.ts
+++ b/src/core/packages/deprecations/browser-internal/src/deprecations_client.test.ts
@@ -9,7 +9,10 @@
 
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { DeprecationsClient } from './deprecations_client';
-import { type DomainDeprecationDetails, DeprecationLevel } from '@kbn/core-deprecations-common';
+import {
+  type DomainDeprecationDetails,
+  DeprecationSeverityOrError,
+} from '@kbn/core-deprecations-common';
 
 describe('DeprecationsClient', () => {
   const http = httpServiceMock.createSetupContract();
@@ -86,7 +89,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: DeprecationLevel.WARNING,
+        level: DeprecationSeverityOrError.WARNING,
         correctiveActions: {
           api: {
             path: 'some-path',
@@ -107,7 +110,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: DeprecationLevel.WARNING,
+        level: DeprecationSeverityOrError.WARNING,
         correctiveActions: {
           manualSteps: ['manual-step'],
         },
@@ -126,7 +129,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: DeprecationLevel.WARNING,
+        level: DeprecationSeverityOrError.WARNING,
         correctiveActions: {
           manualSteps: ['manual-step'],
         },
@@ -147,7 +150,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: DeprecationLevel.WARNING,
+        level: DeprecationSeverityOrError.WARNING,
         correctiveActions: {
           api: {
             path: 'some-path',
@@ -181,7 +184,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: DeprecationLevel.WARNING,
+        level: DeprecationSeverityOrError.WARNING,
         correctiveActions: {
           api: {
             path: 'some-path',
@@ -205,7 +208,7 @@ describe('DeprecationsClient', () => {
         title: 'some-title',
         domainId: 'testPluginId-1',
         message: 'some-message',
-        level: DeprecationLevel.WARNING,
+        level: DeprecationSeverityOrError.WARNING,
         correctiveActions: {
           api: {
             path: 'some-path',

--- a/src/core/packages/deprecations/common/index.ts
+++ b/src/core/packages/deprecations/common/index.ts
@@ -18,4 +18,4 @@ export type {
   DeprecationsGetResponse,
 } from './src/types';
 
-export { DeprecationSeverityOrError } from './src/types';
+export { DeprecationSeverity, DeprecationSeverityOrError } from './src/types';

--- a/src/core/packages/deprecations/common/index.ts
+++ b/src/core/packages/deprecations/common/index.ts
@@ -17,3 +17,5 @@ export type {
   DomainDeprecationDetails,
   DeprecationsGetResponse,
 } from './src/types';
+
+export { DeprecationLevel } from './src/types';

--- a/src/core/packages/deprecations/common/index.ts
+++ b/src/core/packages/deprecations/common/index.ts
@@ -18,4 +18,4 @@ export type {
   DeprecationsGetResponse,
 } from './src/types';
 
-export { DeprecationLevel } from './src/types';
+export { DeprecationSeverityOrError } from './src/types';

--- a/src/core/packages/deprecations/common/src/types.ts
+++ b/src/core/packages/deprecations/common/src/types.ts
@@ -7,22 +7,22 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { RouteDeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 export interface DeprecationDetailsMessage {
   type: 'markdown' | 'text';
   content: string;
 }
 
-enum DeprecationLevelFetchError {
+enum DeprecationFetchError {
   FETCH_ERROR = 'fetch_error',
 }
 
-export type DeprecationLevel = RouteDeprecationSeverity | DeprecationLevelFetchError;
+export type DeprecationSeverityOrError = DeprecationSeverity | DeprecationFetchError;
 
-export const DeprecationLevel = {
-  ...RouteDeprecationSeverity,
-  ...DeprecationLevelFetchError,
+export const DeprecationSeverityOrError = {
+  ...DeprecationSeverity,
+  ...DeprecationFetchError,
 } as const;
 
 /**
@@ -47,7 +47,7 @@ export interface BaseDeprecationDetails {
    * - critical: needs to be addressed before upgrade.
    * - fetch_error: Deprecations service failed to grab the deprecation details for the domain.
    */
-  level: DeprecationLevel;
+  level: DeprecationSeverityOrError;
   /**
    * (optional) Used to identify between different deprecation types.
    * Example use case: in Upgrade Assistant, we may want to allow the user to sort by

--- a/src/core/packages/deprecations/common/src/types.ts
+++ b/src/core/packages/deprecations/common/src/types.ts
@@ -7,11 +7,16 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { DeprecationSeverity } from '@kbn/core-http-common';
-
 export interface DeprecationDetailsMessage {
   type: 'markdown' | 'text';
   content: string;
+}
+
+export enum DeprecationSeverity {
+  NONE = 'none',
+  INFO = 'info',
+  WARNING = 'warning',
+  CRITICAL = 'critical',
 }
 
 enum DeprecationFetchError {

--- a/src/core/packages/deprecations/common/src/types.ts
+++ b/src/core/packages/deprecations/common/src/types.ts
@@ -12,6 +12,12 @@ export interface DeprecationDetailsMessage {
   content: string;
 }
 
+export enum DeprecationLevel {
+  WARNING = 'warning',
+  CRITICAL = 'critical',
+  FETCH_ERROR = 'fetch_error',
+}
+
 /**
  * Base properties shared by all types of deprecations
  *
@@ -34,7 +40,7 @@ export interface BaseDeprecationDetails {
    * - critical: needs to be addressed before upgrade.
    * - fetch_error: Deprecations service failed to grab the deprecation details for the domain.
    */
-  level: 'warning' | 'critical' | 'fetch_error';
+  level: DeprecationLevel;
   /**
    * (optional) Used to identify between different deprecation types.
    * Example use case: in Upgrade Assistant, we may want to allow the user to sort by

--- a/src/core/packages/deprecations/common/src/types.ts
+++ b/src/core/packages/deprecations/common/src/types.ts
@@ -7,16 +7,23 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { RouteDeprecationSeverity } from '@kbn/core-http-common';
+
 export interface DeprecationDetailsMessage {
   type: 'markdown' | 'text';
   content: string;
 }
 
-export enum DeprecationLevel {
-  WARNING = 'warning',
-  CRITICAL = 'critical',
+enum DeprecationLevelFetchError {
   FETCH_ERROR = 'fetch_error',
 }
+
+export type DeprecationLevel = RouteDeprecationSeverity | DeprecationLevelFetchError;
+
+export const DeprecationLevel = {
+  ...RouteDeprecationSeverity,
+  ...DeprecationLevelFetchError,
+} as const;
 
 /**
  * Base properties shared by all types of deprecations

--- a/src/core/packages/deprecations/common/tsconfig.json
+++ b/src/core/packages/deprecations/common/tsconfig.json
@@ -12,5 +12,8 @@
   ],
   "exclude": [
     "target/**/*",
+  ],
+  "kbn_references": [
+    "@kbn/core-http-common",
   ]
 }

--- a/src/core/packages/deprecations/common/tsconfig.json
+++ b/src/core/packages/deprecations/common/tsconfig.json
@@ -12,8 +12,5 @@
   ],
   "exclude": [
     "target/**/*",
-  ],
-  "kbn_references": [
-    "@kbn/core-http-common",
   ]
 }

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
@@ -7,13 +7,13 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import type {
-  ApiDeprecationDetails,
-  DomainDeprecationDetails,
+import {
+  type ApiDeprecationDetails,
+  type DomainDeprecationDetails,
+  DeprecationSeverity,
 } from '@kbn/core-deprecations-common';
 
 import type { PostValidationMetadata } from '@kbn/core-http-server';
-import { DeprecationSeverity } from '@kbn/core-http-common';
 import type { BuildApiDeprecationDetailsParams } from '../types';
 import {
   getApiDeprecationMessage,

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
@@ -13,7 +13,7 @@ import type {
 } from '@kbn/core-deprecations-common';
 
 import type { PostValidationMetadata } from '@kbn/core-http-server';
-import { RouteDeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 import type { BuildApiDeprecationDetailsParams } from '../types';
 import {
   getApiDeprecationMessage,
@@ -39,7 +39,7 @@ export const buildApiAccessDeprecationDetails = ({
   const { apiId, apiTotalCalls, totalMarkedAsResolved } = apiUsageStats;
   const { routeVersion, routePath, routeDeprecationOptions, routeMethod } = deprecatedApiDetails;
 
-  const deprecationLevel = routeDeprecationOptions?.severity || RouteDeprecationSeverity.WARNING;
+  const deprecationLevel = routeDeprecationOptions?.severity || DeprecationSeverity.WARNING;
 
   return {
     apiId,

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/access/access_deprecations.ts
@@ -13,6 +13,7 @@ import type {
 } from '@kbn/core-deprecations-common';
 
 import type { PostValidationMetadata } from '@kbn/core-http-server';
+import { RouteDeprecationSeverity } from '@kbn/core-http-common';
 import type { BuildApiDeprecationDetailsParams } from '../types';
 import {
   getApiDeprecationMessage,
@@ -38,7 +39,7 @@ export const buildApiAccessDeprecationDetails = ({
   const { apiId, apiTotalCalls, totalMarkedAsResolved } = apiUsageStats;
   const { routeVersion, routePath, routeDeprecationOptions, routeMethod } = deprecatedApiDetails;
 
-  const deprecationLevel = routeDeprecationOptions?.severity || 'warning';
+  const deprecationLevel = routeDeprecationOptions?.severity || RouteDeprecationSeverity.WARNING;
 
   return {
     apiId,

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
@@ -13,7 +13,7 @@ import type {
 } from '@kbn/core-deprecations-common';
 import _ from 'lodash';
 import type { PostValidationMetadata } from '@kbn/core-http-server';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import {
   getApiDeprecationMessage,
   getApiDeprecationsManualSteps,

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
@@ -13,7 +13,7 @@ import type {
 } from '@kbn/core-deprecations-common';
 import _ from 'lodash';
 import type { PostValidationMetadata } from '@kbn/core-http-server';
-import { RouteDeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 import {
   getApiDeprecationMessage,
   getApiDeprecationsManualSteps,
@@ -42,7 +42,7 @@ export const buildApiRouteDeprecationDetails = ({
     throw new Error(`Expecing deprecated to be defined for route ${apiId}`);
   }
 
-  const deprecationLevel = routeDeprecationOptions.severity || RouteDeprecationSeverity.WARNING;
+  const deprecationLevel = routeDeprecationOptions.severity || DeprecationSeverity.WARNING;
 
   return {
     apiId,

--- a/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/api_deprecations/route/route_deprecations.ts
@@ -13,6 +13,7 @@ import type {
 } from '@kbn/core-deprecations-common';
 import _ from 'lodash';
 import type { PostValidationMetadata } from '@kbn/core-http-server';
+import { RouteDeprecationSeverity } from '@kbn/core-http-common';
 import {
   getApiDeprecationMessage,
   getApiDeprecationsManualSteps,
@@ -41,7 +42,7 @@ export const buildApiRouteDeprecationDetails = ({
     throw new Error(`Expecing deprecated to be defined for route ${apiId}`);
   }
 
-  const deprecationLevel = routeDeprecationOptions.severity || 'warning';
+  const deprecationLevel = routeDeprecationOptions.severity || RouteDeprecationSeverity.WARNING;
 
   return {
     apiId,

--- a/src/core/packages/deprecations/server-internal/src/deprecations/config_deprecations.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/config_deprecations.test.ts
@@ -11,7 +11,7 @@ import { registerConfigDeprecationsInfo } from './config_deprecations';
 import { mockDeprecationsRegistry, mockDeprecationsFactory } from '../mocks';
 import { mockCoreContext } from '@kbn/core-base-server-mocks';
 import { configServiceMock } from '@kbn/config-mocks';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 describe('#registerConfigDeprecationsInfo', () => {
   let coreContext: ReturnType<typeof mockCoreContext.create>;

--- a/src/core/packages/deprecations/server-internal/src/deprecations/config_deprecations.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations/config_deprecations.test.ts
@@ -11,6 +11,7 @@ import { registerConfigDeprecationsInfo } from './config_deprecations';
 import { mockDeprecationsRegistry, mockDeprecationsFactory } from '../mocks';
 import { mockCoreContext } from '@kbn/core-base-server-mocks';
 import { configServiceMock } from '@kbn/config-mocks';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 describe('#registerConfigDeprecationsInfo', () => {
   let coreContext: ReturnType<typeof mockCoreContext.create>;
@@ -34,7 +35,7 @@ describe('#registerConfigDeprecationsInfo', () => {
         [
           {
             configPath: 'test',
-            level: 'critical',
+            level: DeprecationSeverity.CRITICAL,
             message: 'testMessage',
             documentationUrl: 'testDocUrl',
             correctiveActions: {
@@ -91,7 +92,7 @@ describe('#registerConfigDeprecationsInfo', () => {
           {
             configPath: 'test',
             message: 'testMessage',
-            level: 'warning',
+            level: DeprecationSeverity.WARNING,
             correctiveActions: {
               manualSteps: ['step a'],
             },

--- a/src/core/packages/deprecations/server-internal/src/deprecations_factory.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_factory.test.ts
@@ -11,6 +11,7 @@ import type { GetDeprecationsContext } from '@kbn/core-deprecations-server';
 import { DeprecationsFactory, DeprecationsFactoryConfig } from './deprecations_factory';
 import { loggerMock } from '@kbn/logging-mocks';
 import type { DeprecationsDetails } from '@kbn/core-deprecations-common';
+import { RouteDeprecationSeverity } from '@kbn/core-http-common';
 
 describe('DeprecationsFactory', () => {
   let logger: ReturnType<typeof loggerMock.create>;
@@ -201,7 +202,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'mockPlugin.foo',
           title: 'mockPlugin.foo is deprecated',
           message: 'mockPlugin.foo is deprecated and will be removed in a future Kibana version',
-          level: 'critical',
+          level: RouteDeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -211,7 +212,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'mockPlugin.bar',
           title: 'mockPlugin.bar is deprecated',
           message: 'mockPlugin.bar is deprecated and will be removed in a future Kibana version',
-          level: 'critical',
+          level: RouteDeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -224,7 +225,7 @@ describe('DeprecationsFactory', () => {
           title: 'anotherMockPlugin.foo is deprecated',
           message:
             'anotherMockPlugin.foo is deprecated and will be removed in a future Kibana version',
-          level: 'critical',
+          level: RouteDeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -235,7 +236,7 @@ describe('DeprecationsFactory', () => {
           title: 'anotherMockPlugin.bar is deprecated',
           message:
             'anotherMockPlugin.bar is deprecated and will be removed in a future Kibana version',
-          level: 'critical',
+          level: RouteDeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -280,7 +281,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'mockPlugin.foo',
           title: 'mockPlugin.foo is deprecated',
           message: 'mockPlugin.foo is deprecated and will be removed in a future Kibana version',
-          level: 'critical',
+          level: RouteDeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -290,7 +291,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'mockPlugin.bar',
           title: 'mockPlugin.bar is deprecated',
           message: 'mockPlugin.bar is deprecated and will be removed in a future Kibana version',
-          level: 'critical',
+          level: RouteDeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -361,7 +362,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'test.foo',
           title: 'test.foo is deprecated',
           message: 'test.foo is deprecated and will be removed in a future Kibana version',
-          level: 'critical',
+          level: RouteDeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -371,7 +372,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'test.bar',
           title: 'test.bar is deprecated',
           message: 'test.bar is deprecated and will be removed in a future Kibana version',
-          level: 'critical',
+          level: RouteDeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],

--- a/src/core/packages/deprecations/server-internal/src/deprecations_factory.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_factory.test.ts
@@ -11,7 +11,7 @@ import type { GetDeprecationsContext } from '@kbn/core-deprecations-server';
 import { DeprecationsFactory, DeprecationsFactoryConfig } from './deprecations_factory';
 import { loggerMock } from '@kbn/logging-mocks';
 import type { DeprecationsDetails } from '@kbn/core-deprecations-common';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 describe('DeprecationsFactory', () => {
   let logger: ReturnType<typeof loggerMock.create>;

--- a/src/core/packages/deprecations/server-internal/src/deprecations_factory.test.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_factory.test.ts
@@ -11,7 +11,7 @@ import type { GetDeprecationsContext } from '@kbn/core-deprecations-server';
 import { DeprecationsFactory, DeprecationsFactoryConfig } from './deprecations_factory';
 import { loggerMock } from '@kbn/logging-mocks';
 import type { DeprecationsDetails } from '@kbn/core-deprecations-common';
-import { RouteDeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 describe('DeprecationsFactory', () => {
   let logger: ReturnType<typeof loggerMock.create>;
@@ -202,7 +202,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'mockPlugin.foo',
           title: 'mockPlugin.foo is deprecated',
           message: 'mockPlugin.foo is deprecated and will be removed in a future Kibana version',
-          level: RouteDeprecationSeverity.CRITICAL,
+          level: DeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -212,7 +212,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'mockPlugin.bar',
           title: 'mockPlugin.bar is deprecated',
           message: 'mockPlugin.bar is deprecated and will be removed in a future Kibana version',
-          level: RouteDeprecationSeverity.CRITICAL,
+          level: DeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -225,7 +225,7 @@ describe('DeprecationsFactory', () => {
           title: 'anotherMockPlugin.foo is deprecated',
           message:
             'anotherMockPlugin.foo is deprecated and will be removed in a future Kibana version',
-          level: RouteDeprecationSeverity.CRITICAL,
+          level: DeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -236,7 +236,7 @@ describe('DeprecationsFactory', () => {
           title: 'anotherMockPlugin.bar is deprecated',
           message:
             'anotherMockPlugin.bar is deprecated and will be removed in a future Kibana version',
-          level: RouteDeprecationSeverity.CRITICAL,
+          level: DeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -281,7 +281,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'mockPlugin.foo',
           title: 'mockPlugin.foo is deprecated',
           message: 'mockPlugin.foo is deprecated and will be removed in a future Kibana version',
-          level: RouteDeprecationSeverity.CRITICAL,
+          level: DeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -291,7 +291,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'mockPlugin.bar',
           title: 'mockPlugin.bar is deprecated',
           message: 'mockPlugin.bar is deprecated and will be removed in a future Kibana version',
-          level: RouteDeprecationSeverity.CRITICAL,
+          level: DeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -362,7 +362,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'test.foo',
           title: 'test.foo is deprecated',
           message: 'test.foo is deprecated and will be removed in a future Kibana version',
-          level: RouteDeprecationSeverity.CRITICAL,
+          level: DeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],
@@ -372,7 +372,7 @@ describe('DeprecationsFactory', () => {
           configPath: 'test.bar',
           title: 'test.bar is deprecated',
           message: 'test.bar is deprecated and will be removed in a future Kibana version',
-          level: RouteDeprecationSeverity.CRITICAL,
+          level: DeprecationSeverity.CRITICAL,
           deprecationType: 'config',
           correctiveActions: {
             manualSteps: ['come on', 'do something'],

--- a/src/core/packages/deprecations/server-internal/src/deprecations_factory.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_factory.ts
@@ -105,7 +105,7 @@ export class DeprecationsFactory {
                 defaultMessage: 'Unable to fetch deprecations info for plugin {domainId}.',
                 values: { domainId },
               }),
-              level: DeprecationLevel.CRITICAL,
+              level: DeprecationLevel.FETCH_ERROR,
               correctiveActions: {
                 manualSteps: [
                   i18n.translate(

--- a/src/core/packages/deprecations/server-internal/src/deprecations_factory.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_factory.ts
@@ -9,7 +9,11 @@
 
 import { i18n } from '@kbn/i18n';
 import type { Logger } from '@kbn/logging';
-import type { DomainDeprecationDetails, DeprecationsDetails } from '@kbn/core-deprecations-common';
+import {
+  type DomainDeprecationDetails,
+  type DeprecationsDetails,
+  DeprecationLevel,
+} from '@kbn/core-deprecations-common';
 import type { GetDeprecationsContext } from '@kbn/core-deprecations-server';
 import { DeprecationsRegistry } from './deprecations_registry';
 
@@ -101,7 +105,7 @@ export class DeprecationsFactory {
                 defaultMessage: 'Unable to fetch deprecations info for plugin {domainId}.',
                 values: { domainId },
               }),
-              level: 'fetch_error',
+              level: DeprecationLevel.CRITICAL,
               correctiveActions: {
                 manualSteps: [
                   i18n.translate(

--- a/src/core/packages/deprecations/server-internal/src/deprecations_factory.ts
+++ b/src/core/packages/deprecations/server-internal/src/deprecations_factory.ts
@@ -12,7 +12,7 @@ import type { Logger } from '@kbn/logging';
 import {
   type DomainDeprecationDetails,
   type DeprecationsDetails,
-  DeprecationLevel,
+  DeprecationSeverityOrError,
 } from '@kbn/core-deprecations-common';
 import type { GetDeprecationsContext } from '@kbn/core-deprecations-server';
 import { DeprecationsRegistry } from './deprecations_registry';
@@ -105,7 +105,7 @@ export class DeprecationsFactory {
                 defaultMessage: 'Unable to fetch deprecations info for plugin {domainId}.',
                 values: { domainId },
               }),
-              level: DeprecationLevel.FETCH_ERROR,
+              level: DeprecationSeverityOrError.FETCH_ERROR,
               correctiveActions: {
                 manualSteps: [
                   i18n.translate(

--- a/src/core/packages/deprecations/server-internal/tsconfig.json
+++ b/src/core/packages/deprecations/server-internal/tsconfig.json
@@ -41,6 +41,7 @@
     "@kbn/core-logging-server-internal",
     "@kbn/core-doc-links-server",
     "@kbn/core-doc-links-server-mocks",
+    "@kbn/core-http-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/deprecations/server-internal/tsconfig.json
+++ b/src/core/packages/deprecations/server-internal/tsconfig.json
@@ -41,7 +41,7 @@
     "@kbn/core-logging-server-internal",
     "@kbn/core-doc-links-server",
     "@kbn/core-doc-links-server-mocks",
-    "@kbn/core-http-common",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
@@ -13,7 +13,7 @@ import { readPkcs12Keystore, readPkcs12Truststore } from '@kbn/crypto';
 import { i18n } from '@kbn/i18n';
 import { schema, offeringBasedSchema, ByteSizeValue, type TypeOf } from '@kbn/config-schema';
 import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import type { ConfigDeprecationProvider } from '@kbn/config';
 import type {
   IElasticsearchConfig,

--- a/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
+++ b/src/core/packages/elasticsearch/server-internal/src/elasticsearch_config.ts
@@ -13,6 +13,7 @@ import { readPkcs12Keystore, readPkcs12Truststore } from '@kbn/crypto';
 import { i18n } from '@kbn/i18n';
 import { schema, offeringBasedSchema, ByteSizeValue, type TypeOf } from '@kbn/config-schema';
 import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 import type { ConfigDeprecationProvider } from '@kbn/config';
 import type {
   IElasticsearchConfig,
@@ -214,7 +215,7 @@ const deprecations: ConfigDeprecationProvider = () => [
             'Kibana is configured to authenticate to Elasticsearch with the "{username}" user. Use a service account token instead.',
           values: { username },
         }),
-        level: 'warning',
+        level: DeprecationSeverity.WARNING,
         documentationUrl: `https://www.elastic.co/guide/en/elasticsearch/reference/${branch}/service-accounts.html`,
         correctiveActions: {
           manualSteps: [
@@ -246,7 +247,7 @@ const deprecations: ConfigDeprecationProvider = () => [
             'Use both "{existingSetting}" and "{missingSetting}" to enable Kibana to use Mutual TLS authentication with Elasticsearch.',
           values: { existingSetting, missingSetting },
         }),
-        level: 'warning',
+        level: DeprecationSeverity.WARNING,
         documentationUrl: `https://www.elastic.co/guide/en/kibana/${branch}/elasticsearch-mutual-tls.html`,
         correctiveActions: {
           manualSteps: [
@@ -273,7 +274,7 @@ const deprecations: ConfigDeprecationProvider = () => [
     if (es.logQueries === true) {
       addDeprecation({
         configPath: `${fromPath}.logQueries`,
-        level: 'warning',
+        level: DeprecationSeverity.WARNING,
         message: `Setting [${fromPath}.logQueries] is deprecated and no longer used. You should set the log level to "debug" for the "elasticsearch.query" context in "logging.loggers".`,
         correctiveActions: {
           manualSteps: [

--- a/src/core/packages/elasticsearch/server-internal/tsconfig.json
+++ b/src/core/packages/elasticsearch/server-internal/tsconfig.json
@@ -34,7 +34,7 @@
     "@kbn/config-mocks",
     "@kbn/core-execution-context-server-mocks",
     "@kbn/core-http-server-mocks",
-    "@kbn/core-http-common",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/elasticsearch/server-internal/tsconfig.json
+++ b/src/core/packages/elasticsearch/server-internal/tsconfig.json
@@ -34,6 +34,7 @@
     "@kbn/config-mocks",
     "@kbn/core-execution-context-server-mocks",
     "@kbn/core-http-server-mocks",
+    "@kbn/core-http-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/http/common/index.ts
+++ b/src/core/packages/http/common/index.ts
@@ -16,5 +16,5 @@ export {
   ELASTIC_INTERNAL_ORIGIN_QUERY_PARAM,
   X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
   KIBANA_BUILD_NR_HEADER,
-  RouteDeprecationSeverity,
+  DeprecationSeverity,
 } from './src/constants';

--- a/src/core/packages/http/common/index.ts
+++ b/src/core/packages/http/common/index.ts
@@ -16,4 +16,5 @@ export {
   ELASTIC_INTERNAL_ORIGIN_QUERY_PARAM,
   X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
   KIBANA_BUILD_NR_HEADER,
+  RouteDeprecationSeverity,
 } from './src/constants';

--- a/src/core/packages/http/common/index.ts
+++ b/src/core/packages/http/common/index.ts
@@ -16,5 +16,4 @@ export {
   ELASTIC_INTERNAL_ORIGIN_QUERY_PARAM,
   X_ELASTIC_INTERNAL_ORIGIN_REQUEST,
   KIBANA_BUILD_NR_HEADER,
-  DeprecationSeverity,
 } from './src/constants';

--- a/src/core/packages/http/common/src/constants.ts
+++ b/src/core/packages/http/common/src/constants.ts
@@ -13,6 +13,8 @@ export const ELASTIC_HTTP_VERSION_QUERY_PARAM = 'apiVersion' as const;
 export const ELASTIC_INTERNAL_ORIGIN_QUERY_PARAM = 'elasticInternalOrigin' as const;
 export const X_ELASTIC_INTERNAL_ORIGIN_REQUEST = 'x-elastic-internal-origin' as const;
 export enum DeprecationSeverity {
+  NONE = 'none',
+  INFO = 'info',
   WARNING = 'warning',
   CRITICAL = 'critical',
 }

--- a/src/core/packages/http/common/src/constants.ts
+++ b/src/core/packages/http/common/src/constants.ts
@@ -12,12 +12,6 @@ export const ELASTIC_HTTP_VERSION_HEADER = 'elastic-api-version' as const;
 export const ELASTIC_HTTP_VERSION_QUERY_PARAM = 'apiVersion' as const;
 export const ELASTIC_INTERNAL_ORIGIN_QUERY_PARAM = 'elasticInternalOrigin' as const;
 export const X_ELASTIC_INTERNAL_ORIGIN_REQUEST = 'x-elastic-internal-origin' as const;
-export enum DeprecationSeverity {
-  NONE = 'none',
-  INFO = 'info',
-  WARNING = 'warning',
-  CRITICAL = 'critical',
-}
 
 /** @internal */
 export const KIBANA_BUILD_NR_HEADER = 'kbn-build-number' as const;

--- a/src/core/packages/http/common/src/constants.ts
+++ b/src/core/packages/http/common/src/constants.ts
@@ -12,6 +12,10 @@ export const ELASTIC_HTTP_VERSION_HEADER = 'elastic-api-version' as const;
 export const ELASTIC_HTTP_VERSION_QUERY_PARAM = 'apiVersion' as const;
 export const ELASTIC_INTERNAL_ORIGIN_QUERY_PARAM = 'elasticInternalOrigin' as const;
 export const X_ELASTIC_INTERNAL_ORIGIN_REQUEST = 'x-elastic-internal-origin' as const;
+export enum RouteDeprecationSeverity {
+  WARNING = 'warning',
+  CRITICAL = 'critical',
+}
 
 /** @internal */
 export const KIBANA_BUILD_NR_HEADER = 'kbn-build-number' as const;

--- a/src/core/packages/http/common/src/constants.ts
+++ b/src/core/packages/http/common/src/constants.ts
@@ -12,7 +12,7 @@ export const ELASTIC_HTTP_VERSION_HEADER = 'elastic-api-version' as const;
 export const ELASTIC_HTTP_VERSION_QUERY_PARAM = 'apiVersion' as const;
 export const ELASTIC_INTERNAL_ORIGIN_QUERY_PARAM = 'elasticInternalOrigin' as const;
 export const X_ELASTIC_INTERNAL_ORIGIN_REQUEST = 'x-elastic-internal-origin' as const;
-export enum RouteDeprecationSeverity {
+export enum DeprecationSeverity {
   WARNING = 'warning',
   CRITICAL = 'critical',
 }

--- a/src/core/packages/http/router-server-internal/src/get_warning_header_message.test.ts
+++ b/src/core/packages/http/router-server-internal/src/get_warning_header_message.test.ts
@@ -8,6 +8,7 @@
  */
 
 import type { RouteDeprecationInfo } from '@kbn/core-http-server';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 import { getWarningHeaderMessageFromRouteDeprecation } from './get_warning_header_message';
 
 describe('getWarningHeaderMessageFromRouteDeprecation', () => {
@@ -16,7 +17,7 @@ describe('getWarningHeaderMessageFromRouteDeprecation', () => {
     const expectedMessage = `299 Kibana-${kibanaVersion} "This endpoint deprecated"`;
     const deprecationObject: RouteDeprecationInfo = {
       reason: { type: 'deprecate' },
-      severity: 'warning',
+      severity: DeprecationSeverity.WARNING,
       documentationUrl: 'fakeurl.com',
     };
     expect(getWarningHeaderMessageFromRouteDeprecation(deprecationObject, expectedMessage)).toMatch(
@@ -30,7 +31,7 @@ describe('getWarningHeaderMessageFromRouteDeprecation', () => {
     const expectedMessage = `299 Kibana-${kibanaVersion} "${msg}"`;
     const deprecationObject: RouteDeprecationInfo = {
       reason: { type: 'deprecate' },
-      severity: 'warning',
+      severity: DeprecationSeverity.WARNING,
       documentationUrl: 'fakeurl.com',
       message: msg,
     };

--- a/src/core/packages/http/router-server-internal/src/get_warning_header_message.test.ts
+++ b/src/core/packages/http/router-server-internal/src/get_warning_header_message.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { RouteDeprecationInfo } from '@kbn/core-http-server';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import { getWarningHeaderMessageFromRouteDeprecation } from './get_warning_header_message';
 
 describe('getWarningHeaderMessageFromRouteDeprecation', () => {

--- a/src/core/packages/http/router-server-internal/src/route.test.ts
+++ b/src/core/packages/http/router-server-internal/src/route.test.ts
@@ -16,6 +16,7 @@ import { RouteValidator } from './validator';
 import { schema } from '@kbn/config-schema';
 import { Router } from './router';
 import { RouteAccess } from '@kbn/core-http-server';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 import { createRequest } from './versioned_router/core_versioned_route.test.util';
 import { kibanaResponseFactory } from './response';
 
@@ -50,7 +51,7 @@ describe('handle', () => {
           validate,
           options: {
             deprecated: {
-              severity: 'warning',
+              severity: DeprecationSeverity.WARNING,
               reason: { type: 'bump', newApiVersion: '123' },
               documentationUrl: 'http://test.foo',
             },
@@ -89,7 +90,7 @@ describe('handle', () => {
           validate: false,
           options: {
             deprecated: {
-              severity: 'warning',
+              severity: DeprecationSeverity.WARNING,
               reason: { type: 'bump', newApiVersion: '123' },
               documentationUrl: 'http://test.foo',
             },

--- a/src/core/packages/http/router-server-internal/src/route.test.ts
+++ b/src/core/packages/http/router-server-internal/src/route.test.ts
@@ -16,7 +16,7 @@ import { RouteValidator } from './validator';
 import { schema } from '@kbn/config-schema';
 import { Router } from './router';
 import { RouteAccess } from '@kbn/core-http-server';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import { createRequest } from './versioned_router/core_versioned_route.test.util';
 import { kibanaResponseFactory } from './response';
 

--- a/src/core/packages/http/router-server-internal/src/router.test.ts
+++ b/src/core/packages/http/router-server-internal/src/router.test.ts
@@ -15,6 +15,7 @@ import { createFooValidation } from './router.test.util';
 import { Router, type RouterOptions } from './router';
 import type { RouteValidatorRequestAndResponses } from '@kbn/core-http-server';
 import { getEnvOptions, createTestEnv } from '@kbn/config-mocks';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 const mockResponse = {
   code: jest.fn().mockImplementation(() => mockResponse),
@@ -62,7 +63,7 @@ describe('Router', () => {
             deprecated: {
               documentationUrl: 'https://fake-url.com',
               reason: { type: 'remove' },
-              severity: 'warning',
+              severity: DeprecationSeverity.WARNING,
             },
             discontinued: 'post test discontinued',
             summary: 'post test summary',

--- a/src/core/packages/http/router-server-internal/src/router.test.ts
+++ b/src/core/packages/http/router-server-internal/src/router.test.ts
@@ -15,7 +15,7 @@ import { createFooValidation } from './router.test.util';
 import { Router, type RouterOptions } from './router';
 import type { RouteValidatorRequestAndResponses } from '@kbn/core-http-server';
 import { getEnvOptions, createTestEnv } from '@kbn/config-mocks';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 const mockResponse = {
   code: jest.fn().mockImplementation(() => mockResponse),

--- a/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
+++ b/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
@@ -22,7 +22,7 @@ import { isConfigSchema } from '@kbn/config-schema';
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { getEnvOptions, createTestEnv } from '@kbn/config-mocks';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 const notDevOptions = getEnvOptions();
 notDevOptions.cliArgs.dev = false;

--- a/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
+++ b/src/core/packages/http/router-server-internal/src/versioned_router/core_versioned_route.test.ts
@@ -22,6 +22,7 @@ import { isConfigSchema } from '@kbn/config-schema';
 import { ELASTIC_HTTP_VERSION_HEADER } from '@kbn/core-http-common';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { getEnvOptions, createTestEnv } from '@kbn/config-mocks';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 const notDevOptions = getEnvOptions();
 notDevOptions.cliArgs.dev = false;
@@ -915,7 +916,7 @@ describe('Versioned route', () => {
             validate: fooValidation,
             options: {
               deprecated: {
-                severity: 'warning',
+                severity: DeprecationSeverity.WARNING,
                 reason: { type: 'bump', newApiVersion: '123' },
                 documentationUrl: 'http://test.foo',
               },
@@ -982,7 +983,7 @@ describe('Versioned route', () => {
             validate: false,
             options: {
               deprecated: {
-                severity: 'warning',
+                severity: DeprecationSeverity.WARNING,
                 reason: { type: 'bump', newApiVersion: '123' },
                 documentationUrl: 'http://test.foo',
               },

--- a/src/core/packages/http/router-server-internal/tsconfig.json
+++ b/src/core/packages/http/router-server-internal/tsconfig.json
@@ -22,7 +22,8 @@
     "@kbn/logging-mocks",
     "@kbn/config-mocks",
     "@kbn/config",
-    "@kbn/core-security-server"
+    "@kbn/core-security-server",
+    "@kbn/core-deprecations-common"
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/http/server-internal/src/http_config.ts
+++ b/src/core/packages/http/server-internal/src/http_config.ts
@@ -15,6 +15,7 @@ import { IHttpConfig, SslConfig, sslSchema, TLS_V1_2, TLS_V1_3 } from '@kbn/serv
 import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
 import { uuidRegexp } from '@kbn/core-base-server-internal';
 import type { HttpProtocol, ICspConfig, IExternalUrlConfig } from '@kbn/core-http-server';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 import type { IHttpEluMonitorConfig } from '@kbn/core-http-server/src/elu_monitor';
 import type { HandlerResolutionStrategy } from '@kbn/core-http-router-server-internal';
 import { get } from 'lodash';
@@ -302,12 +303,12 @@ export const config: ServiceConfigDescriptor<HttpConfigType> = {
   path: 'server' as const,
   schema: configSchema,
   deprecations: ({ rename }) => [
-    rename('maxPayloadBytes', 'maxPayload', { level: 'warning' }),
+    rename('maxPayloadBytes', 'maxPayload', { level: DeprecationSeverity.WARNING }),
     (settings, fromPath, addDeprecation, { docLinks }) => {
       const cfg = get(settings, fromPath);
       if (!cfg?.ssl?.enabled || cfg?.protocol === 'http1') {
         addDeprecation({
-          level: 'warning',
+          level: DeprecationSeverity.WARNING,
           title: `Consider enabling TLS and using HTTP/2 to improve security and performance.`,
           configPath: `${fromPath}.protocol,${fromPath}.ssl.enabled`,
           message: `TLS is not enabled, or the HTTP protocol is set to HTTP/1. Enabling TLS and using HTTP/2 improves security and performance.`,

--- a/src/core/packages/http/server-internal/src/http_config.ts
+++ b/src/core/packages/http/server-internal/src/http_config.ts
@@ -15,7 +15,7 @@ import { IHttpConfig, SslConfig, sslSchema, TLS_V1_2, TLS_V1_3 } from '@kbn/serv
 import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
 import { uuidRegexp } from '@kbn/core-base-server-internal';
 import type { HttpProtocol, ICspConfig, IExternalUrlConfig } from '@kbn/core-http-server';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import type { IHttpEluMonitorConfig } from '@kbn/core-http-server/src/elu_monitor';
 import type { HandlerResolutionStrategy } from '@kbn/core-http-router-server-internal';
 import { get } from 'lodash';

--- a/src/core/packages/http/server-internal/tsconfig.json
+++ b/src/core/packages/http/server-internal/tsconfig.json
@@ -35,6 +35,7 @@
     "@kbn/logging-mocks",
     "@kbn/router-to-openapispec",
     "@kbn/core-base-server-mocks",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/http/server/index.ts
+++ b/src/core/packages/http/server/index.ts
@@ -124,6 +124,7 @@ export type {
   RouteSecurity,
   RouteSecurityGetter,
   InternalRouteSecurity,
+  RouteDeprecationInfo,
   PostValidationMetadata,
   AnyKibanaRequest,
 } from './src/router';

--- a/src/core/packages/http/server/index.ts
+++ b/src/core/packages/http/server/index.ts
@@ -124,7 +124,6 @@ export type {
   RouteSecurity,
   RouteSecurityGetter,
   InternalRouteSecurity,
-  RouteDeprecationInfo,
   PostValidationMetadata,
   AnyKibanaRequest,
 } from './src/router';

--- a/src/core/packages/http/server/src/router/route.ts
+++ b/src/core/packages/http/server/src/router/route.ts
@@ -9,6 +9,7 @@
 
 import type { OpenAPIV3 } from 'openapi-types';
 import type { DeepPartial } from '@kbn/utility-types';
+import type { RouteDeprecationSeverity } from '@kbn/core-http-common';
 import type { RouteValidator } from './route_validator';
 
 /**
@@ -140,7 +141,7 @@ export interface RouteDeprecationInfo {
    * - warning: will not break deployment upon upgrade.
    * - critical: needs to be addressed before upgrade.
    */
-  severity: 'warning' | 'critical';
+  severity: RouteDeprecationSeverity;
   /**
    * API deprecation reason:
    * - bump: New version of the API is available.

--- a/src/core/packages/http/server/src/router/route.ts
+++ b/src/core/packages/http/server/src/router/route.ts
@@ -9,7 +9,7 @@
 
 import type { OpenAPIV3 } from 'openapi-types';
 import type { DeepPartial } from '@kbn/utility-types';
-import type { RouteDeprecationSeverity } from '@kbn/core-http-common';
+import type { DeprecationSeverity } from '@kbn/core-http-common';
 import type { RouteValidator } from './route_validator';
 
 /**
@@ -141,7 +141,7 @@ export interface RouteDeprecationInfo {
    * - warning: will not break deployment upon upgrade.
    * - critical: needs to be addressed before upgrade.
    */
-  severity: RouteDeprecationSeverity;
+  severity: DeprecationSeverity;
   /**
    * API deprecation reason:
    * - bump: New version of the API is available.

--- a/src/core/packages/http/server/src/router/route.ts
+++ b/src/core/packages/http/server/src/router/route.ts
@@ -9,7 +9,7 @@
 
 import type { OpenAPIV3 } from 'openapi-types';
 import type { DeepPartial } from '@kbn/utility-types';
-import type { DeprecationSeverity } from '@kbn/core-http-common';
+import type { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import type { RouteValidator } from './route_validator';
 
 /**

--- a/src/core/packages/http/server/tsconfig.json
+++ b/src/core/packages/http/server/tsconfig.json
@@ -16,6 +16,7 @@
     "@kbn/core-base-common",
     "@kbn/core-http-common",
     "@kbn/zod",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/plugins/server-internal/src/plugins_service.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_service.test.ts
@@ -29,6 +29,7 @@ import { config, PluginsConfigType } from './plugins_config';
 import { take } from 'rxjs';
 import type { PluginConfigDescriptor } from '@kbn/core-plugins-server';
 import { DiscoveredPlugin, PluginType } from '@kbn/core-base-common';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 const MockPluginsSystem: jest.Mock<PluginsSystem<PluginType>> = PluginsSystem as any;
 
@@ -1143,7 +1144,7 @@ describe('PluginsService', () => {
           }),
           deprecations: ({ renameFromRoot }) => [
             renameFromRoot('plugin-1-deprecations.toBeRenamed', 'plugin-2-deprecations.renamed', {
-              level: 'critical',
+              level: DeprecationSeverity.CRITICAL,
             }),
           ],
         },

--- a/src/core/packages/plugins/server-internal/src/plugins_service.test.ts
+++ b/src/core/packages/plugins/server-internal/src/plugins_service.test.ts
@@ -29,7 +29,7 @@ import { config, PluginsConfigType } from './plugins_config';
 import { take } from 'rxjs';
 import type { PluginConfigDescriptor } from '@kbn/core-plugins-server';
 import { DiscoveredPlugin, PluginType } from '@kbn/core-base-common';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 const MockPluginsSystem: jest.Mock<PluginsSystem<PluginType>> = PluginsSystem as any;
 

--- a/src/core/packages/plugins/server-internal/tsconfig.json
+++ b/src/core/packages/plugins/server-internal/tsconfig.json
@@ -41,6 +41,7 @@
     "@kbn/utility-types",
     "@kbn/core-plugins-contracts-server",
     "@kbn/projects-solutions-groups",
+    "@kbn/core-http-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/plugins/server-internal/tsconfig.json
+++ b/src/core/packages/plugins/server-internal/tsconfig.json
@@ -41,7 +41,7 @@
     "@kbn/utility-types",
     "@kbn/core-plugins-contracts-server",
     "@kbn/projects-solutions-groups",
-    "@kbn/core-http-common",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/saved-objects/server-internal/src/deprecations/unknown_object_types.ts
+++ b/src/core/packages/saved-objects/server-internal/src/deprecations/unknown_object_types.ts
@@ -8,7 +8,10 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { type DeprecationsDetails, DeprecationLevel } from '@kbn/core-deprecations-common';
+import {
+  type DeprecationsDetails,
+  DeprecationSeverityOrError,
+} from '@kbn/core-deprecations-common';
 import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { ISavedObjectTypeRegistry } from '@kbn/core-saved-objects-server';
 import { getIndexForType } from '@kbn/core-saved-objects-base-server-internal';
@@ -92,7 +95,7 @@ export const getUnknownTypesDeprecations = async (
           objectCount: unknownDocs.length,
         },
       }),
-      level: DeprecationLevel.CRITICAL,
+      level: DeprecationSeverityOrError.CRITICAL,
       requireRestart: false,
       deprecationType: undefined, // not config nor feature...
       correctiveActions: {

--- a/src/core/packages/saved-objects/server-internal/src/deprecations/unknown_object_types.ts
+++ b/src/core/packages/saved-objects/server-internal/src/deprecations/unknown_object_types.ts
@@ -8,7 +8,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import type { DeprecationsDetails } from '@kbn/core-deprecations-common';
+import { type DeprecationsDetails, DeprecationLevel } from '@kbn/core-deprecations-common';
 import type { IScopedClusterClient } from '@kbn/core-elasticsearch-server';
 import type { ISavedObjectTypeRegistry } from '@kbn/core-saved-objects-server';
 import { getIndexForType } from '@kbn/core-saved-objects-base-server-internal';
@@ -92,7 +92,7 @@ export const getUnknownTypesDeprecations = async (
           objectCount: unknownDocs.length,
         },
       }),
-      level: 'critical',
+      level: DeprecationLevel.CRITICAL,
       requireRestart: false,
       deprecationType: undefined, // not config nor feature...
       correctiveActions: {

--- a/src/core/packages/saved-objects/server-internal/src/routes/index.ts
+++ b/src/core/packages/saved-objects/server-internal/src/routes/index.ts
@@ -16,6 +16,7 @@ import type {
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import { RouteDeprecationInfo } from '@kbn/core-http-server';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 import type { InternalSavedObjectsRequestHandlerContext } from '../internal_types';
 import { registerGetRoute } from './get';
 import { registerResolveRoute } from './resolve';
@@ -61,7 +62,7 @@ export function registerRoutes({
   const internalOnServerless = isServerless ? 'internal' : 'public';
   const deprecationInfo: RouteDeprecationInfo = {
     documentationUrl: `${docLinks.links.management.savedObjectsApiList}`,
-    severity: 'warning' as const, // will not break deployment upon upgrade
+    severity: DeprecationSeverity.WARNING as const, // will not break deployment upon upgrade
     reason: {
       type: 'deprecate' as const,
     },

--- a/src/core/packages/saved-objects/server-internal/src/routes/index.ts
+++ b/src/core/packages/saved-objects/server-internal/src/routes/index.ts
@@ -16,7 +16,7 @@ import type {
 import type { InternalCoreUsageDataSetup } from '@kbn/core-usage-data-base-server-internal';
 import { DocLinksServiceSetup } from '@kbn/core-doc-links-server';
 import { RouteDeprecationInfo } from '@kbn/core-http-server';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import type { InternalSavedObjectsRequestHandlerContext } from '../internal_types';
 import { registerGetRoute } from './get';
 import { registerResolveRoute } from './resolve';

--- a/src/core/packages/saved-objects/server-internal/tsconfig.json
+++ b/src/core/packages/saved-objects/server-internal/tsconfig.json
@@ -47,7 +47,7 @@
     "@kbn/core-http-router-server-internal",
     "@kbn/logging-mocks",
     "@kbn/std",
-    "@kbn/core-http-common",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/saved-objects/server-internal/tsconfig.json
+++ b/src/core/packages/saved-objects/server-internal/tsconfig.json
@@ -47,6 +47,7 @@
     "@kbn/core-http-router-server-internal",
     "@kbn/logging-mocks",
     "@kbn/std",
+    "@kbn/core-http-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/ui-settings/server-internal/src/ui_settings_config.ts
+++ b/src/core/packages/ui-settings/server-internal/src/ui_settings_config.ts
@@ -11,10 +11,13 @@ import { schema, TypeOf, offeringBasedSchema } from '@kbn/config-schema';
 import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
 import { DEFAULT_THEME_NAME } from '@kbn/core-ui-settings-common';
 import { ConfigDeprecationProvider } from '@kbn/config';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 const deprecations: ConfigDeprecationProvider = ({ unused, renameFromRoot }) => [
-  unused('enabled', { level: 'warning' }),
-  renameFromRoot('server.defaultRoute', 'uiSettings.overrides.defaultRoute', { level: 'warning' }),
+  unused('enabled', { level: DeprecationSeverity.WARNING }),
+  renameFromRoot('server.defaultRoute', 'uiSettings.overrides.defaultRoute', {
+    level: DeprecationSeverity.WARNING,
+  }),
 ];
 
 export const defaultThemeSchema = schema.oneOf([

--- a/src/core/packages/ui-settings/server-internal/src/ui_settings_config.ts
+++ b/src/core/packages/ui-settings/server-internal/src/ui_settings_config.ts
@@ -11,7 +11,7 @@ import { schema, TypeOf, offeringBasedSchema } from '@kbn/config-schema';
 import type { ServiceConfigDescriptor } from '@kbn/core-base-server-internal';
 import { DEFAULT_THEME_NAME } from '@kbn/core-ui-settings-common';
 import { ConfigDeprecationProvider } from '@kbn/config';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 const deprecations: ConfigDeprecationProvider = ({ unused, renameFromRoot }) => [
   unused('enabled', { level: DeprecationSeverity.WARNING }),

--- a/src/core/packages/ui-settings/server-internal/tsconfig.json
+++ b/src/core/packages/ui-settings/server-internal/tsconfig.json
@@ -33,6 +33,7 @@
     "@kbn/core-saved-objects-api-server-internal",
     "@kbn/core-saved-objects-common",
     "@kbn/utility-types",
+    "@kbn/core-http-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/packages/ui-settings/server-internal/tsconfig.json
+++ b/src/core/packages/ui-settings/server-internal/tsconfig.json
@@ -33,7 +33,7 @@
     "@kbn/core-saved-objects-api-server-internal",
     "@kbn/core-saved-objects-common",
     "@kbn/utility-types",
-    "@kbn/core-http-common",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/core/server/integration_tests/http/lifecycle.test.ts
+++ b/src/core/server/integration_tests/http/lifecycle.test.ts
@@ -19,6 +19,7 @@ import { createHttpService } from '@kbn/core-http-server-mocks';
 import { Env } from '@kbn/config';
 import { REPO_ROOT } from '@kbn/repo-info';
 import { getEnvOptions } from '@kbn/config-mocks';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 let server: HttpService;
 
@@ -1684,7 +1685,7 @@ describe('runs with default preResponse deprecation handlers', () => {
           deprecated: {
             documentationUrl: 'https://fake-url.com',
             reason: { type: 'deprecate' },
-            severity: 'warning',
+            severity: DeprecationSeverity.WARNING,
             message: deprecationMessage,
           },
         },
@@ -1733,7 +1734,7 @@ describe('runs with default preResponse deprecation handlers', () => {
           deprecated: {
             documentationUrl: 'https://fake-url.com',
             reason: { type: 'deprecate' },
-            severity: 'warning',
+            severity: DeprecationSeverity.WARNING,
             message: deprecationMessage,
           },
         },
@@ -1766,7 +1767,7 @@ describe('runs with default preResponse deprecation handlers', () => {
             deprecated: {
               documentationUrl: 'https://fake-url.com',
               reason: { type: 'deprecate' },
-              severity: 'warning',
+              severity: DeprecationSeverity.WARNING,
               message: deprecationMessage,
             },
           },
@@ -1825,7 +1826,7 @@ describe('runs with default preResponse deprecation handlers', () => {
             deprecated: {
               documentationUrl: 'https://fake-url.com',
               reason: { type: 'deprecate' },
-              severity: 'warning',
+              severity: DeprecationSeverity.WARNING,
               message: deprecationMessage,
             },
           },

--- a/src/core/server/integration_tests/saved_objects/routes/routes_test_utils.ts
+++ b/src/core/server/integration_tests/saved_objects/routes/routes_test_utils.ts
@@ -8,6 +8,7 @@
  */
 
 import { SavedObjectConfig } from '@kbn/core-saved-objects-base-server-internal';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 export function setupConfig(allowAccess: boolean = false) {
   const config = {
@@ -18,7 +19,7 @@ export function setupConfig(allowAccess: boolean = false) {
 
 export const deprecationMock = {
   documentationUrl: 'http://elastic.co',
-  severity: 'warning' as const,
+  severity: DeprecationSeverity.WARNING as const,
   reason: {
     type: 'deprecate' as const,
   },
@@ -26,7 +27,7 @@ export const deprecationMock = {
 
 export const legacyDeprecationMock = {
   documentationUrl: 'http://elastic.co',
-  severity: 'warning' as const,
+  severity: DeprecationSeverity.WARNING as const,
   reason: {
     type: 'remove' as const,
   },

--- a/src/platform/packages/shared/kbn-config/src/config_service.test.ts
+++ b/src/platform/packages/shared/kbn-config/src/config_service.test.ts
@@ -9,7 +9,7 @@
 
 import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
 import { first, map, take } from 'rxjs';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 import {
   mockApplyDeprecations,

--- a/src/platform/packages/shared/kbn-config/src/config_service.test.ts
+++ b/src/platform/packages/shared/kbn-config/src/config_service.test.ts
@@ -9,7 +9,7 @@
 
 import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
 import { first, map, take } from 'rxjs';
-import { RouteDeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 import {
   mockApplyDeprecations,
@@ -492,13 +492,13 @@ test('logs deprecation warning during validation', async () => {
     const addDeprecation = createAddDeprecation!('');
     addDeprecation({
       configPath: 'test1',
-      level: RouteDeprecationSeverity.WARNING,
+      level: DeprecationSeverity.WARNING,
       message: 'some deprecation message',
       correctiveActions: { manualSteps: ['do X'] },
     });
     addDeprecation({
       configPath: 'test2',
-      level: RouteDeprecationSeverity.WARNING,
+      level: DeprecationSeverity.WARNING,
       message: 'another deprecation message',
       correctiveActions: { manualSteps: ['do Y'] },
     });
@@ -568,14 +568,14 @@ test('does not log warnings for silent deprecations during validation', async ()
       const addDeprecation = createAddDeprecation!('');
       addDeprecation({
         configPath: 'test1',
-        level: RouteDeprecationSeverity.WARNING,
+        level: DeprecationSeverity.WARNING,
         message: 'some deprecation message',
         correctiveActions: { manualSteps: ['do X'] },
         silent: true,
       });
       addDeprecation({
         configPath: 'test2',
-        level: RouteDeprecationSeverity.WARNING,
+        level: DeprecationSeverity.WARNING,
         message: 'another deprecation message',
         correctiveActions: { manualSteps: ['do Y'] },
       });
@@ -585,7 +585,7 @@ test('does not log warnings for silent deprecations during validation', async ()
       const addDeprecation = createAddDeprecation!('');
       addDeprecation({
         configPath: 'silent',
-        level: RouteDeprecationSeverity.WARNING,
+        level: DeprecationSeverity.WARNING,
         message: 'I am silent',
         silent: true,
         correctiveActions: { manualSteps: ['do Z'] },
@@ -664,7 +664,7 @@ describe('getHandledDeprecatedConfigs', () => {
     const configService = new ConfigService(rawConfig, defaultEnv, logger);
 
     configService.addDeprecationProvider('base', ({ unused }) => [
-      unused('unused', { level: RouteDeprecationSeverity.WARNING }),
+      unused('unused', { level: DeprecationSeverity.WARNING }),
     ]);
 
     mockApplyDeprecations.mockImplementationOnce((config, deprecations, createAddDeprecation) => {
@@ -672,7 +672,7 @@ describe('getHandledDeprecatedConfigs', () => {
         const addDeprecation = createAddDeprecation!(deprecation.path);
         addDeprecation({
           configPath: 'test1',
-          level: RouteDeprecationSeverity.WARNING,
+          level: DeprecationSeverity.WARNING,
           message: `some deprecation message`,
           documentationUrl: 'some-url',
           correctiveActions: { manualSteps: ['do X'] },

--- a/src/platform/packages/shared/kbn-config/src/config_service.test.ts
+++ b/src/platform/packages/shared/kbn-config/src/config_service.test.ts
@@ -9,6 +9,7 @@
 
 import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
 import { first, map, take } from 'rxjs';
+import { RouteDeprecationSeverity } from '@kbn/core-http-common';
 
 import {
   mockApplyDeprecations,
@@ -491,13 +492,13 @@ test('logs deprecation warning during validation', async () => {
     const addDeprecation = createAddDeprecation!('');
     addDeprecation({
       configPath: 'test1',
-      level: 'warning',
+      level: RouteDeprecationSeverity.WARNING,
       message: 'some deprecation message',
       correctiveActions: { manualSteps: ['do X'] },
     });
     addDeprecation({
       configPath: 'test2',
-      level: 'warning',
+      level: RouteDeprecationSeverity.WARNING,
       message: 'another deprecation message',
       correctiveActions: { manualSteps: ['do Y'] },
     });
@@ -567,14 +568,14 @@ test('does not log warnings for silent deprecations during validation', async ()
       const addDeprecation = createAddDeprecation!('');
       addDeprecation({
         configPath: 'test1',
-        level: 'warning',
+        level: RouteDeprecationSeverity.WARNING,
         message: 'some deprecation message',
         correctiveActions: { manualSteps: ['do X'] },
         silent: true,
       });
       addDeprecation({
         configPath: 'test2',
-        level: 'warning',
+        level: RouteDeprecationSeverity.WARNING,
         message: 'another deprecation message',
         correctiveActions: { manualSteps: ['do Y'] },
       });
@@ -584,7 +585,7 @@ test('does not log warnings for silent deprecations during validation', async ()
       const addDeprecation = createAddDeprecation!('');
       addDeprecation({
         configPath: 'silent',
-        level: 'warning',
+        level: RouteDeprecationSeverity.WARNING,
         message: 'I am silent',
         silent: true,
         correctiveActions: { manualSteps: ['do Z'] },
@@ -663,7 +664,7 @@ describe('getHandledDeprecatedConfigs', () => {
     const configService = new ConfigService(rawConfig, defaultEnv, logger);
 
     configService.addDeprecationProvider('base', ({ unused }) => [
-      unused('unused', { level: 'warning' }),
+      unused('unused', { level: RouteDeprecationSeverity.WARNING }),
     ]);
 
     mockApplyDeprecations.mockImplementationOnce((config, deprecations, createAddDeprecation) => {
@@ -671,7 +672,7 @@ describe('getHandledDeprecatedConfigs', () => {
         const addDeprecation = createAddDeprecation!(deprecation.path);
         addDeprecation({
           configPath: 'test1',
-          level: 'warning',
+          level: RouteDeprecationSeverity.WARNING,
           message: `some deprecation message`,
           documentationUrl: 'some-url',
           correctiveActions: { manualSteps: ['do X'] },

--- a/src/platform/packages/shared/kbn-config/src/deprecation/apply_deprecations.test.ts
+++ b/src/platform/packages/shared/kbn-config/src/deprecation/apply_deprecations.test.ts
@@ -11,7 +11,7 @@ import type { DocLinks } from '@kbn/doc-links';
 import { applyDeprecations } from './apply_deprecations';
 import { ConfigDeprecation, ConfigDeprecationContext, ConfigDeprecationWithContext } from './types';
 import { configDeprecationFactory as deprecations } from './deprecation_factory';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 describe('applyDeprecations', () => {
   const context: ConfigDeprecationContext = {

--- a/src/platform/packages/shared/kbn-config/src/deprecation/apply_deprecations.test.ts
+++ b/src/platform/packages/shared/kbn-config/src/deprecation/apply_deprecations.test.ts
@@ -11,6 +11,7 @@ import type { DocLinks } from '@kbn/doc-links';
 import { applyDeprecations } from './apply_deprecations';
 import { ConfigDeprecation, ConfigDeprecationContext, ConfigDeprecationWithContext } from './types';
 import { configDeprecationFactory as deprecations } from './deprecation_factory';
+import { RouteDeprecationSeverity } from '@kbn/core-http-common';
 
 describe('applyDeprecations', () => {
   const context: ConfigDeprecationContext = {
@@ -112,8 +113,10 @@ describe('applyDeprecations', () => {
     const initialConfig = { foo: 'bar', deprecated: 'deprecated', renamed: 'renamed' };
 
     const { config: migrated } = applyDeprecations(initialConfig, [
-      wrapHandler(deprecations.unused('deprecated', { level: 'critical' })),
-      wrapHandler(deprecations.rename('renamed', 'newname', { level: 'critical' })),
+      wrapHandler(deprecations.unused('deprecated', { level: RouteDeprecationSeverity.CRITICAL })),
+      wrapHandler(
+        deprecations.rename('renamed', 'newname', { level: RouteDeprecationSeverity.CRITICAL })
+      ),
     ]);
 
     expect(migrated).toEqual({ foo: 'bar', newname: 'renamed' });
@@ -134,9 +137,13 @@ describe('applyDeprecations', () => {
     };
 
     const { config: migrated } = applyDeprecations(initialConfig, [
-      wrapHandler(deprecations.unused('deprecated.nested', { level: 'critical' })),
       wrapHandler(
-        deprecations.rename('nested.from.rename', 'nested.to.renamed', { level: 'critical' })
+        deprecations.unused('deprecated.nested', { level: RouteDeprecationSeverity.CRITICAL })
+      ),
+      wrapHandler(
+        deprecations.rename('nested.from.rename', 'nested.to.renamed', {
+          level: RouteDeprecationSeverity.CRITICAL,
+        })
       ),
     ]);
 
@@ -155,7 +162,7 @@ describe('applyDeprecations', () => {
     const initialConfig = { foo: 'bar', deprecated: 'deprecated' };
 
     const { config: migrated } = applyDeprecations(initialConfig, [
-      wrapHandler(deprecations.unused('deprecated', { level: 'critical' })),
+      wrapHandler(deprecations.unused('deprecated', { level: RouteDeprecationSeverity.CRITICAL })),
     ]);
 
     expect(initialConfig).toEqual({ foo: 'bar', deprecated: 'deprecated' });

--- a/src/platform/packages/shared/kbn-config/src/deprecation/apply_deprecations.test.ts
+++ b/src/platform/packages/shared/kbn-config/src/deprecation/apply_deprecations.test.ts
@@ -11,7 +11,7 @@ import type { DocLinks } from '@kbn/doc-links';
 import { applyDeprecations } from './apply_deprecations';
 import { ConfigDeprecation, ConfigDeprecationContext, ConfigDeprecationWithContext } from './types';
 import { configDeprecationFactory as deprecations } from './deprecation_factory';
-import { RouteDeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 describe('applyDeprecations', () => {
   const context: ConfigDeprecationContext = {
@@ -113,9 +113,9 @@ describe('applyDeprecations', () => {
     const initialConfig = { foo: 'bar', deprecated: 'deprecated', renamed: 'renamed' };
 
     const { config: migrated } = applyDeprecations(initialConfig, [
-      wrapHandler(deprecations.unused('deprecated', { level: RouteDeprecationSeverity.CRITICAL })),
+      wrapHandler(deprecations.unused('deprecated', { level: DeprecationSeverity.CRITICAL })),
       wrapHandler(
-        deprecations.rename('renamed', 'newname', { level: RouteDeprecationSeverity.CRITICAL })
+        deprecations.rename('renamed', 'newname', { level: DeprecationSeverity.CRITICAL })
       ),
     ]);
 
@@ -138,11 +138,11 @@ describe('applyDeprecations', () => {
 
     const { config: migrated } = applyDeprecations(initialConfig, [
       wrapHandler(
-        deprecations.unused('deprecated.nested', { level: RouteDeprecationSeverity.CRITICAL })
+        deprecations.unused('deprecated.nested', { level: DeprecationSeverity.CRITICAL })
       ),
       wrapHandler(
         deprecations.rename('nested.from.rename', 'nested.to.renamed', {
-          level: RouteDeprecationSeverity.CRITICAL,
+          level: DeprecationSeverity.CRITICAL,
         })
       ),
     ]);
@@ -162,7 +162,7 @@ describe('applyDeprecations', () => {
     const initialConfig = { foo: 'bar', deprecated: 'deprecated' };
 
     const { config: migrated } = applyDeprecations(initialConfig, [
-      wrapHandler(deprecations.unused('deprecated', { level: RouteDeprecationSeverity.CRITICAL })),
+      wrapHandler(deprecations.unused('deprecated', { level: DeprecationSeverity.CRITICAL })),
     ]);
 
     expect(initialConfig).toEqual({ foo: 'bar', deprecated: 'deprecated' });

--- a/src/platform/packages/shared/kbn-config/src/deprecation/deprecation_factory.test.ts
+++ b/src/platform/packages/shared/kbn-config/src/deprecation/deprecation_factory.test.ts
@@ -10,7 +10,7 @@
 import { DeprecatedConfigDetails } from './types';
 import { createMockedContext } from '../internal_mocks';
 import { configDeprecationFactory } from './deprecation_factory';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 describe('DeprecationFactory', () => {
   const { deprecate, deprecateFromRoot, rename, renameFromRoot, unused, unusedFromRoot } =

--- a/src/platform/packages/shared/kbn-config/src/deprecation/deprecation_factory.test.ts
+++ b/src/platform/packages/shared/kbn-config/src/deprecation/deprecation_factory.test.ts
@@ -10,6 +10,7 @@
 import { DeprecatedConfigDetails } from './types';
 import { createMockedContext } from '../internal_mocks';
 import { configDeprecationFactory } from './deprecation_factory';
+import { RouteDeprecationSeverity } from '@kbn/core-http-common';
 
 describe('DeprecationFactory', () => {
   const { deprecate, deprecateFromRoot, rename, renameFromRoot, unused, unusedFromRoot } =
@@ -33,12 +34,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = deprecate('deprecated', '8.0.0', { level: 'critical' })(
-        rawConfig,
-        'myplugin',
-        addDeprecation,
-        context
-      );
+      const commands = deprecate('deprecated', '8.0.0', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation.mock.calls).toMatchInlineSnapshot(`
         Array [
@@ -71,12 +69,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = deprecate('section.deprecated', '8.0.0', { level: 'critical' })(
-        rawConfig,
-        'myplugin',
-        addDeprecation,
-        context
-      );
+      const commands = deprecate('section.deprecated', '8.0.0', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation.mock.calls).toMatchInlineSnapshot(`
         Array [
@@ -106,12 +101,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = deprecate('deprecated', '8.0.0', { level: 'critical' })(
-        rawConfig,
-        'myplugin',
-        addDeprecation,
-        context
-      );
+      const commands = deprecate('deprecated', '8.0.0', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation).toBeCalledTimes(0);
     });
@@ -128,12 +120,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = deprecateFromRoot('myplugin.deprecated', '8.0.0', { level: 'critical' })(
-        rawConfig,
-        'does-not-matter',
-        addDeprecation,
-        context
-      );
+      const commands = deprecateFromRoot('myplugin.deprecated', '8.0.0', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation.mock.calls).toMatchInlineSnapshot(`
         Array [
@@ -163,12 +152,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = deprecateFromRoot('myplugin.deprecated', '8.0.0', { level: 'critical' })(
-        rawConfig,
-        'does-not-matter',
-        addDeprecation,
-        context
-      );
+      const commands = deprecateFromRoot('myplugin.deprecated', '8.0.0', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation).toBeCalledTimes(0);
     });
@@ -185,12 +171,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = rename('deprecated', 'renamed', { level: 'critical' })(
-        rawConfig,
-        'myplugin',
-        addDeprecation,
-        context
-      );
+      const commands = rename('deprecated', 'renamed', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toEqual({
         set: [
           {
@@ -228,7 +211,7 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = rename('deprecated', 'new', { level: 'critical' })(
+      const commands = rename('deprecated', 'new', { level: RouteDeprecationSeverity.CRITICAL })(
         rawConfig,
         'myplugin',
         addDeprecation,
@@ -249,12 +232,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = rename('oldsection.deprecated', 'newsection.renamed', { level: 'critical' })(
-        rawConfig,
-        'myplugin',
-        addDeprecation,
-        context
-      );
+      const commands = rename('oldsection.deprecated', 'newsection.renamed', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toEqual({
         set: [
           {
@@ -289,12 +269,9 @@ describe('DeprecationFactory', () => {
           renamed: 'renamed',
         },
       };
-      const commands = rename('deprecated', 'renamed', { level: 'critical' })(
-        rawConfig,
-        'myplugin',
-        addDeprecation,
-        context
-      );
+      const commands = rename('deprecated', 'renamed', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toEqual({
         unset: [{ path: 'myplugin.deprecated' }],
       });
@@ -331,7 +308,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = renameFromRoot('myplugin.deprecated', 'myplugin.renamed', {
-        level: 'critical',
+        level: RouteDeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toEqual({
         set: [
@@ -372,7 +349,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = renameFromRoot('oldplugin.deprecated', 'newplugin.renamed', {
-        level: 'critical',
+        level: RouteDeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toEqual({
         set: [
@@ -412,12 +389,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = renameFromRoot('myplugin.deprecated', 'myplugin.new', { level: 'critical' })(
-        rawConfig,
-        'does-not-matter',
-        addDeprecation,
-        context
-      );
+      const commands = renameFromRoot('myplugin.deprecated', 'myplugin.new', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation).toBeCalledTimes(0);
     });
@@ -430,7 +404,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = renameFromRoot('myplugin.deprecated', 'myplugin.renamed', {
-        level: 'critical',
+        level: RouteDeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toEqual({
         unset: [{ path: 'myplugin.deprecated' }],
@@ -468,7 +442,7 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = unused('deprecated', { level: 'critical' })(
+      const commands = unused('deprecated', { level: RouteDeprecationSeverity.CRITICAL })(
         rawConfig,
         'myplugin',
         addDeprecation,
@@ -508,7 +482,7 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = unused('section.deprecated', { level: 'critical' })(
+      const commands = unused('section.deprecated', { level: RouteDeprecationSeverity.CRITICAL })(
         rawConfig,
         'myplugin',
         addDeprecation,
@@ -545,7 +519,7 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = unused('deprecated', { level: 'critical' })(
+      const commands = unused('deprecated', { level: RouteDeprecationSeverity.CRITICAL })(
         rawConfig,
         'myplugin',
         addDeprecation,
@@ -567,12 +541,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = unusedFromRoot('myplugin.deprecated', { level: 'critical' })(
-        rawConfig,
-        'does-not-matter',
-        addDeprecation,
-        context
-      );
+      const commands = unusedFromRoot('myplugin.deprecated', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toEqual({
         unset: [{ path: 'myplugin.deprecated' }],
       });
@@ -604,12 +575,9 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = unusedFromRoot('myplugin.deprecated', { level: 'critical' })(
-        rawConfig,
-        'does-not-matter',
-        addDeprecation,
-        context
-      );
+      const commands = unusedFromRoot('myplugin.deprecated', {
+        level: RouteDeprecationSeverity.CRITICAL,
+      })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation).toBeCalledTimes(0);
     });

--- a/src/platform/packages/shared/kbn-config/src/deprecation/deprecation_factory.test.ts
+++ b/src/platform/packages/shared/kbn-config/src/deprecation/deprecation_factory.test.ts
@@ -10,7 +10,7 @@
 import { DeprecatedConfigDetails } from './types';
 import { createMockedContext } from '../internal_mocks';
 import { configDeprecationFactory } from './deprecation_factory';
-import { RouteDeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 
 describe('DeprecationFactory', () => {
   const { deprecate, deprecateFromRoot, rename, renameFromRoot, unused, unusedFromRoot } =
@@ -35,7 +35,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = deprecate('deprecated', '8.0.0', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation.mock.calls).toMatchInlineSnapshot(`
@@ -70,7 +70,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = deprecate('section.deprecated', '8.0.0', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation.mock.calls).toMatchInlineSnapshot(`
@@ -102,7 +102,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = deprecate('deprecated', '8.0.0', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation).toBeCalledTimes(0);
@@ -121,7 +121,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = deprecateFromRoot('myplugin.deprecated', '8.0.0', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation.mock.calls).toMatchInlineSnapshot(`
@@ -153,7 +153,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = deprecateFromRoot('myplugin.deprecated', '8.0.0', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation).toBeCalledTimes(0);
@@ -172,7 +172,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = rename('deprecated', 'renamed', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toEqual({
         set: [
@@ -211,7 +211,7 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = rename('deprecated', 'new', { level: RouteDeprecationSeverity.CRITICAL })(
+      const commands = rename('deprecated', 'new', { level: DeprecationSeverity.CRITICAL })(
         rawConfig,
         'myplugin',
         addDeprecation,
@@ -233,7 +233,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = rename('oldsection.deprecated', 'newsection.renamed', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toEqual({
         set: [
@@ -270,7 +270,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = rename('deprecated', 'renamed', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'myplugin', addDeprecation, context);
       expect(commands).toEqual({
         unset: [{ path: 'myplugin.deprecated' }],
@@ -308,7 +308,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = renameFromRoot('myplugin.deprecated', 'myplugin.renamed', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toEqual({
         set: [
@@ -349,7 +349,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = renameFromRoot('oldplugin.deprecated', 'newplugin.renamed', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toEqual({
         set: [
@@ -390,7 +390,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = renameFromRoot('myplugin.deprecated', 'myplugin.new', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation).toBeCalledTimes(0);
@@ -404,7 +404,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = renameFromRoot('myplugin.deprecated', 'myplugin.renamed', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toEqual({
         unset: [{ path: 'myplugin.deprecated' }],
@@ -442,7 +442,7 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = unused('deprecated', { level: RouteDeprecationSeverity.CRITICAL })(
+      const commands = unused('deprecated', { level: DeprecationSeverity.CRITICAL })(
         rawConfig,
         'myplugin',
         addDeprecation,
@@ -482,7 +482,7 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = unused('section.deprecated', { level: RouteDeprecationSeverity.CRITICAL })(
+      const commands = unused('section.deprecated', { level: DeprecationSeverity.CRITICAL })(
         rawConfig,
         'myplugin',
         addDeprecation,
@@ -519,7 +519,7 @@ describe('DeprecationFactory', () => {
           property: 'value',
         },
       };
-      const commands = unused('deprecated', { level: RouteDeprecationSeverity.CRITICAL })(
+      const commands = unused('deprecated', { level: DeprecationSeverity.CRITICAL })(
         rawConfig,
         'myplugin',
         addDeprecation,
@@ -542,7 +542,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = unusedFromRoot('myplugin.deprecated', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toEqual({
         unset: [{ path: 'myplugin.deprecated' }],
@@ -576,7 +576,7 @@ describe('DeprecationFactory', () => {
         },
       };
       const commands = unusedFromRoot('myplugin.deprecated', {
-        level: RouteDeprecationSeverity.CRITICAL,
+        level: DeprecationSeverity.CRITICAL,
       })(rawConfig, 'does-not-matter', addDeprecation, context);
       expect(commands).toBeUndefined();
       expect(addDeprecation).toBeCalledTimes(0);

--- a/src/platform/packages/shared/kbn-config/src/deprecation/types.ts
+++ b/src/platform/packages/shared/kbn-config/src/deprecation/types.ts
@@ -9,6 +9,7 @@
 
 import type { RecursiveReadonly } from '@kbn/utility-types';
 import type { DocLinks } from '@kbn/doc-links';
+import type { RouteDeprecationSeverity } from '@kbn/core-http-common';
 
 /**
  * Config deprecation hook used when invoking a {@link ConfigDeprecation}
@@ -34,7 +35,7 @@ export interface DeprecatedConfigDetails {
    * - warning: will not break deployment upon upgrade
    * - critical: needs to be addressed before upgrade.
    */
-  level: 'warning' | 'critical';
+  level: RouteDeprecationSeverity;
   /** (optional) set to `true` to prevent the config service from logging the deprecation message. */
   silent?: boolean;
   /** (optional) link to the documentation for more details on the deprecation. */

--- a/src/platform/packages/shared/kbn-config/src/deprecation/types.ts
+++ b/src/platform/packages/shared/kbn-config/src/deprecation/types.ts
@@ -9,7 +9,7 @@
 
 import type { RecursiveReadonly } from '@kbn/utility-types';
 import type { DocLinks } from '@kbn/doc-links';
-import type { DeprecationSeverity } from '@kbn/core-http-common';
+import type { DeprecationSeverity } from '@kbn/core-deprecations-common';
 
 /**
  * Config deprecation hook used when invoking a {@link ConfigDeprecation}

--- a/src/platform/packages/shared/kbn-config/src/deprecation/types.ts
+++ b/src/platform/packages/shared/kbn-config/src/deprecation/types.ts
@@ -9,7 +9,7 @@
 
 import type { RecursiveReadonly } from '@kbn/utility-types';
 import type { DocLinks } from '@kbn/doc-links';
-import type { RouteDeprecationSeverity } from '@kbn/core-http-common';
+import type { DeprecationSeverity } from '@kbn/core-http-common';
 
 /**
  * Config deprecation hook used when invoking a {@link ConfigDeprecation}
@@ -35,7 +35,7 @@ export interface DeprecatedConfigDetails {
    * - warning: will not break deployment upon upgrade
    * - critical: needs to be addressed before upgrade.
    */
-  level: RouteDeprecationSeverity;
+  level: DeprecationSeverity;
   /** (optional) set to `true` to prevent the config service from logging the deprecation message. */
   silent?: boolean;
   /** (optional) link to the documentation for more details on the deprecation. */

--- a/src/platform/packages/shared/kbn-config/tsconfig.json
+++ b/src/platform/packages/shared/kbn-config/tsconfig.json
@@ -19,7 +19,8 @@
     "@kbn/utility-types",
     "@kbn/i18n",
     "@kbn/doc-links",
-    "@kbn/repo-packages"
+    "@kbn/repo-packages",
+    "@kbn/core-http-common"
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/packages/shared/kbn-config/tsconfig.json
+++ b/src/platform/packages/shared/kbn-config/tsconfig.json
@@ -20,7 +20,7 @@
     "@kbn/i18n",
     "@kbn/doc-links",
     "@kbn/repo-packages",
-    "@kbn/core-http-deprecations",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/packages/shared/kbn-config/tsconfig.json
+++ b/src/platform/packages/shared/kbn-config/tsconfig.json
@@ -20,7 +20,7 @@
     "@kbn/i18n",
     "@kbn/doc-links",
     "@kbn/repo-packages",
-    "@kbn/core-http-common"
+    "@kbn/core-http-deprecations",
   ],
   "exclude": [
     "target/**/*",

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.util.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.util.ts
@@ -11,7 +11,7 @@ import type { ZodType } from '@kbn/zod';
 import { schema, Type } from '@kbn/config-schema';
 import type { CoreVersionedRouter, Router } from '@kbn/core-http-router-server-internal';
 import type { RouterRoute, VersionedRouterRoute } from '@kbn/core-http-server';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import { createLargeSchema } from './oas_converter/kbn_config_schema/lib.test.util';
 
 type RoutesMeta = ReturnType<Router['getRoutes']>[number];

--- a/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.util.ts
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/src/generate_oas.test.util.ts
@@ -11,6 +11,7 @@ import type { ZodType } from '@kbn/zod';
 import { schema, Type } from '@kbn/config-schema';
 import type { CoreVersionedRouter, Router } from '@kbn/core-http-router-server-internal';
 import type { RouterRoute, VersionedRouterRoute } from '@kbn/core-http-server';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 import { createLargeSchema } from './oas_converter/kbn_config_schema/lib.test.util';
 
 type RoutesMeta = ReturnType<Router['getRoutes']>[number];
@@ -84,7 +85,7 @@ export const getVersionedRouterDefaults = (bodySchema?: RuntimeSchema): Versione
           deprecated: {
             documentationUrl: 'https://fake-url',
             reason: { type: 'remove' },
-            severity: 'critical',
+            severity: DeprecationSeverity.CRITICAL,
           },
         },
         validate: {

--- a/src/platform/packages/shared/kbn-router-to-openapispec/tsconfig.json
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/tsconfig.json
@@ -20,6 +20,6 @@
     "@kbn/zod",
     "@kbn/zod-helpers",
     "@kbn/utility-types",
-    "@kbn/core-http-common",
+    "@kbn/core-deprecations-common",
   ]
 }

--- a/src/platform/packages/shared/kbn-router-to-openapispec/tsconfig.json
+++ b/src/platform/packages/shared/kbn-router-to-openapispec/tsconfig.json
@@ -20,5 +20,6 @@
     "@kbn/zod",
     "@kbn/zod-helpers",
     "@kbn/utility-types",
+    "@kbn/core-http-common",
   ]
 }

--- a/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.stories.tsx
+++ b/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.stories.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react';
-import { DeprecationLevel } from '@kbn/core-deprecations-common';
+import { DeprecationSeverityOrError } from '@kbn/core-deprecations-common';
 import { DeprecationBadge } from './deprecation_badge';
 
 const meta: Meta<typeof DeprecationBadge> = {
@@ -19,7 +19,7 @@ const meta: Meta<typeof DeprecationBadge> = {
     },
     isResolved: {
       name: 'Deprecation is resolved?',
-      control: { type: 'select', options: Object.values(DeprecationLevel) },
+      control: { type: 'select', options: Object.values(DeprecationSeverityOrError) },
     },
   },
 };
@@ -29,7 +29,7 @@ type Story = StoryObj<typeof DeprecationBadge>;
 
 export const Primary: Story = {
   args: {
-    level: DeprecationLevel.WARNING,
+    level: DeprecationSeverityOrError.WARNING,
     isResolved: false,
   },
 };

--- a/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.stories.tsx
+++ b/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.stories.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react';
-
+import { DeprecationLevel } from '@kbn/core-deprecations-common';
 import { DeprecationBadge } from './deprecation_badge';
 
 const meta: Meta<typeof DeprecationBadge> = {
@@ -19,7 +19,7 @@ const meta: Meta<typeof DeprecationBadge> = {
     },
     isResolved: {
       name: 'Deprecation is resolved?',
-      control: { type: 'select', options: ['none', 'info', 'warning', 'critical', 'fetch_error'] },
+      control: { type: 'select', options: Object.values(DeprecationLevel) },
     },
   },
 };
@@ -29,7 +29,7 @@ type Story = StoryObj<typeof DeprecationBadge>;
 
 export const Primary: Story = {
   args: {
-    level: 'info',
+    level: DeprecationLevel.WARNING,
     isResolved: false,
   },
 };

--- a/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.tsx
+++ b/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.tsx
@@ -8,7 +8,7 @@
 import React, { FunctionComponent } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiBadge } from '@elastic/eui';
-import { DeprecationLevel } from '@kbn/core-deprecations-common';
+import { DeprecationSeverityOrError } from '@kbn/core-deprecations-common';
 
 const i18nTexts = {
   criticalBadgeLabel: i18n.translate('xpack.upgradeAssistant.deprecationBadge.criticalBadgeLabel', {
@@ -23,7 +23,7 @@ const i18nTexts = {
 };
 
 interface Props {
-  level: DeprecationLevel;
+  level: DeprecationSeverityOrError;
   isResolved?: boolean;
 }
 
@@ -36,7 +36,7 @@ export const DeprecationBadge: FunctionComponent<Props> = ({ level, isResolved }
     );
   }
 
-  if (level === DeprecationLevel.CRITICAL) {
+  if (level === DeprecationSeverityOrError.CRITICAL) {
     return (
       <EuiBadge color="danger" data-test-subj="criticalDeprecationBadge">
         {i18nTexts.criticalBadgeLabel}

--- a/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.tsx
+++ b/x-pack/platform/packages/private/upgrade-assistant/src/components/deprecation_badge.tsx
@@ -8,6 +8,7 @@
 import React, { FunctionComponent } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiBadge } from '@elastic/eui';
+import { DeprecationLevel } from '@kbn/core-deprecations-common';
 
 const i18nTexts = {
   criticalBadgeLabel: i18n.translate('xpack.upgradeAssistant.deprecationBadge.criticalBadgeLabel', {
@@ -22,7 +23,7 @@ const i18nTexts = {
 };
 
 interface Props {
-  level: 'none' | 'info' | 'warning' | 'critical' | 'fetch_error';
+  level: DeprecationLevel;
   isResolved?: boolean;
 }
 
@@ -35,7 +36,7 @@ export const DeprecationBadge: FunctionComponent<Props> = ({ level, isResolved }
     );
   }
 
-  if (level === 'critical') {
+  if (level === DeprecationLevel.CRITICAL) {
     return (
       <EuiBadge color="danger" data-test-subj="criticalDeprecationBadge">
         {i18nTexts.criticalBadgeLabel}

--- a/x-pack/platform/packages/private/upgrade-assistant/tsconfig.json
+++ b/x-pack/platform/packages/private/upgrade-assistant/tsconfig.json
@@ -15,5 +15,5 @@
   "exclude": [
     "target/**/*"
   ],
-  "kbn_references": ["@kbn/i18n"]
+  "kbn_references": ["@kbn/i18n", "@kbn/core-deprecations-common"]
 }

--- a/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
@@ -8,7 +8,7 @@
 import { HealthReportImpact } from '@elastic/elasticsearch/lib/api/types';
 import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { SavedObject } from '@kbn/core/types';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import type { DataStreamsAction } from './data_stream_types';
 
 export * from './data_stream_types';

--- a/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
@@ -8,6 +8,7 @@
 import { HealthReportImpact } from '@elastic/elasticsearch/lib/api/types';
 import type * as estypes from '@elastic/elasticsearch/lib/api/types';
 import { SavedObject } from '@kbn/core/types';
+import { DeprecationSeverity } from '@kbn/core-http-common';
 import type { DataStreamsAction } from './data_stream_types';
 
 export * from './data_stream_types';
@@ -182,10 +183,8 @@ export interface UpgradeAssistantTelemetry {
   };
 }
 
-// todo
-export type MIGRATION_DEPRECATION_LEVEL = 'none' | 'info' | 'warning' | 'critical';
 export interface DeprecationInfo {
-  level: MIGRATION_DEPRECATION_LEVEL;
+  level: DeprecationSeverity;
   message: string;
   url: string;
   details?: string;
@@ -277,7 +276,7 @@ export interface EnrichedDeprecationInfo
     | 'health_indicator'
     | 'ilm_policies'
     | 'templates';
-  level: MIGRATION_DEPRECATION_LEVEL;
+  level: DeprecationSeverity;
   status?: estypes.HealthReportIndicatorHealthStatus;
   index?: string;
   correctiveAction?: CorrectiveAction;

--- a/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/common/types.ts
@@ -182,6 +182,7 @@ export interface UpgradeAssistantTelemetry {
   };
 }
 
+// todo
 export type MIGRATION_DEPRECATION_LEVEL = 'none' | 'info' | 'warning' | 'critical';
 export interface DeprecationInfo {
   level: MIGRATION_DEPRECATION_LEVEL;

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
@@ -11,7 +11,7 @@ import type {
 } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 import { omit } from 'lodash';
-import { DeprecationSeverity } from '@kbn/core-http-common';
+import { DeprecationSeverity } from '@kbn/core-deprecations-common';
 import type { CorrectiveAction, EnrichedDeprecationInfo } from '../../../common/types';
 import {
   convertFeaturesToIndicesArray,

--- a/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
+++ b/x-pack/platform/plugins/private/upgrade_assistant/server/lib/es_deprecations_status/migrations.ts
@@ -30,6 +30,10 @@ interface EsDeprecations extends MigrationDeprecationsResponse {
   templates: Record<string, MigrationDeprecationsDeprecation[]>;
   ilm_policies: Record<string, MigrationDeprecationsDeprecation[]>;
 }
+
+// todo this is accurate to the ES side of things.
+// do these stay on on the server or do they get transfered to the client?
+// perhaps none and info are filtered out
 type DeprecationLevel = 'none' | 'info' | 'warning' | 'critical';
 
 export interface BaseDeprecation {

--- a/x-pack/platform/plugins/private/upgrade_assistant/tsconfig.json
+++ b/x-pack/platform/plugins/private/upgrade_assistant/tsconfig.json
@@ -44,6 +44,7 @@
     "@kbn/core-http-server-utils",
     "@kbn/core-elasticsearch-server",
     "@kbn/upgrade-assistant",
+    "@kbn/core-http-common",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/platform/plugins/private/upgrade_assistant/tsconfig.json
+++ b/x-pack/platform/plugins/private/upgrade_assistant/tsconfig.json
@@ -44,7 +44,7 @@
     "@kbn/core-http-server-utils",
     "@kbn/core-elasticsearch-server",
     "@kbn/upgrade-assistant",
-    "@kbn/core-http-common",
+    "@kbn/core-deprecations-common",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

The Upgrade Assistant UI had its own list of deprecation states that differed from the deprecation package, in part because both sides were using string literal types. Now they're using the same enum. The changes also clarify where `fetch_error` is a reasonable possibility.

One compromise in this change is that previously there was some code that used a subset of deprecation severities (`warning` and `critical`) whereas others used the full list (`none`, `info`, `warning`, `critical`) - I had trouble determining where the subset should be used vs the full set. Also, since the lists were defined in different places and sometimes the same, I couldn't really tell if the different sets where purposeful or merely a consequence of working from a limited view.

Came out of work on adding storybook functionality to Upgrade Assistant components - https://github.com/elastic/kibana/pull/219453