### PR TITLE
[Discovery] Hide "Selected only" toggle in pages that don't filter by value (#215315)

### DIFF
--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.test.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { render, screen, act, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { buildDataTableRecord } from '@kbn/discover-utils';
 import { createStubDataView } from '@kbn/data-views-plugin/common/data_view.stub';
@@ -17,6 +17,7 @@ import { generateEsHits } from '@kbn/discover-utils/src/__mocks__';
 import { DocViewerTable, SHOW_ONLY_SELECTED_FIELDS } from './table';
 import { mockUnifiedDocViewerServices } from '../../__mocks__';
 import { setUnifiedDocViewerServices } from '../../plugin';
+import { userEvent } from '@testing-library/user-event';
 
 const storage = new Storage(window.localStorage);
 
@@ -80,6 +81,18 @@ const dataView = createStubDataView({
 });
 const hit = buildDataTableRecord(generateEsHits(dataView, 1)[0], dataView);
 
+const setupComponent = (props: Partial<React.ComponentProps<typeof DocViewerTable>> = {}) => {
+  const user = userEvent.setup();
+
+  render(
+    <IntlProvider locale="en">
+      <DocViewerTable dataView={dataView} hit={hit} columns={[]} {...props} />
+    </IntlProvider>
+  );
+
+  return { user };
+};
+
 describe('DocViewerTable', () => {
   afterEach(() => {
     storage.clear();
@@ -87,11 +100,7 @@ describe('DocViewerTable', () => {
 
   describe('table cells', () => {
     it('should render cells', async () => {
-      render(
-        <IntlProvider locale="en">
-          <DocViewerTable dataView={dataView} hit={hit} columns={[]} />
-        </IntlProvider>
-      );
+      setupComponent();
 
       expect(screen.getByText('@timestamp')).toBeInTheDocument();
       expect(screen.getByText(hit.flattened['@timestamp'] as string)).toBeInTheDocument();
@@ -108,21 +117,13 @@ describe('DocViewerTable', () => {
     });
 
     it('should find by field name', async () => {
-      render(
-        <IntlProvider locale="en">
-          <DocViewerTable dataView={dataView} hit={hit} columns={[]} />
-        </IntlProvider>
-      );
+      const { user } = setupComponent();
 
       expect(screen.getByText('@timestamp')).toBeInTheDocument();
       expect(screen.getByText('bytes')).toBeInTheDocument();
       expect(screen.getByText('extension.keyword')).toBeInTheDocument();
 
-      act(() => {
-        fireEvent.change(screen.getByTestId('unifiedDocViewerFieldsSearchInput'), {
-          target: { value: 'bytes' },
-        });
-      });
+      await user.type(screen.getByTestId('unifiedDocViewerFieldsSearchInput'), 'bytes');
 
       expect(screen.queryByText('@timestamp')).toBeNull();
       expect(screen.queryByText('bytes')).toBeInTheDocument();
@@ -130,21 +131,16 @@ describe('DocViewerTable', () => {
     });
 
     it('should find by field value', async () => {
-      render(
-        <IntlProvider locale="en">
-          <DocViewerTable dataView={dataView} hit={hit} columns={[]} />
-        </IntlProvider>
-      );
+      const { user } = setupComponent();
 
       expect(screen.getByText('@timestamp')).toBeInTheDocument();
       expect(screen.getByText('bytes')).toBeInTheDocument();
       expect(screen.getByText('extension.keyword')).toBeInTheDocument();
 
-      act(() => {
-        fireEvent.change(screen.getByTestId('unifiedDocViewerFieldsSearchInput'), {
-          target: { value: hit.flattened['extension.keyword'] as string },
-        });
-      });
+      await user.type(
+        screen.getByTestId('unifiedDocViewerFieldsSearchInput'),
+        String(hit.flattened['extension.keyword'])
+      );
 
       expect(screen.queryByText('@timestamp')).toBeNull();
       expect(screen.queryByText('bytes')).toBeNull();
@@ -153,83 +149,75 @@ describe('DocViewerTable', () => {
   });
 
   describe('switch - show only selected fields', () => {
-    it('should disable the switch if columns is empty', async () => {
-      render(
-        <IntlProvider locale="en">
-          <DocViewerTable dataView={dataView} hit={hit} columns={[]} />
-        </IntlProvider>
-      );
+    describe('when there is a filter function', () => {
+      it('should disable the switch if columns is empty', async () => {
+        setupComponent({ filter: jest.fn() });
 
-      expect(screen.getByTestId('unifiedDocViewerShowOnlySelectedFieldsSwitch')).toBeDisabled();
-      expect(screen.getByText('@timestamp')).toBeInTheDocument();
-      expect(screen.getByText('bytes')).toBeInTheDocument();
-      expect(screen.getByText('extension.keyword')).toBeInTheDocument();
-    });
-
-    it('should disable the switch even if it was previously switched on', async () => {
-      storage.set(SHOW_ONLY_SELECTED_FIELDS, true);
-
-      render(
-        <IntlProvider locale="en">
-          <DocViewerTable dataView={dataView} hit={hit} columns={[]} />
-        </IntlProvider>
-      );
-
-      expect(screen.getByTestId('unifiedDocViewerShowOnlySelectedFieldsSwitch')).toBeDisabled();
-      expect(screen.getByText('@timestamp')).toBeInTheDocument();
-      expect(screen.getByText('bytes')).toBeInTheDocument();
-      expect(screen.getByText('extension.keyword')).toBeInTheDocument();
-    });
-
-    it('should show only selected fields if it was previously switched on', async () => {
-      storage.set(SHOW_ONLY_SELECTED_FIELDS, true);
-
-      render(
-        <IntlProvider locale="en">
-          <DocViewerTable dataView={dataView} hit={hit} columns={['extension.keyword']} />
-        </IntlProvider>
-      );
-
-      expect(screen.getByTestId('unifiedDocViewerShowOnlySelectedFieldsSwitch')).toBeEnabled();
-      expect(screen.getByText('@timestamp')).toBeInTheDocument();
-      expect(screen.queryByText('bytes')).toBeNull();
-      expect(screen.getByText('extension.keyword')).toBeInTheDocument();
-    });
-
-    it('should allow toggling the switch', async () => {
-      render(
-        <IntlProvider locale="en">
-          <DocViewerTable dataView={dataView} hit={hit} columns={['bytes']} />
-        </IntlProvider>
-      );
-
-      const showOnlySelectedFieldsSwitch = screen.getByTestId(
-        'unifiedDocViewerShowOnlySelectedFieldsSwitch'
-      );
-
-      expect(showOnlySelectedFieldsSwitch).toBeEnabled();
-      expect(showOnlySelectedFieldsSwitch).toHaveValue('');
-      expect(screen.getByText('@timestamp')).toBeInTheDocument();
-      expect(screen.getByText('bytes')).toBeInTheDocument();
-      expect(screen.getByText('extension.keyword')).toBeInTheDocument();
-
-      act(() => {
-        showOnlySelectedFieldsSwitch.click();
+        expect(screen.getByTestId('unifiedDocViewerShowOnlySelectedFieldsSwitch')).toBeDisabled();
+        expect(screen.getByText('@timestamp')).toBeInTheDocument();
+        expect(screen.getByText('bytes')).toBeInTheDocument();
+        expect(screen.getByText('extension.keyword')).toBeInTheDocument();
       });
 
-      expect(screen.getByText('@timestamp')).toBeInTheDocument();
-      expect(screen.getByText('bytes')).toBeInTheDocument();
-      expect(screen.queryByText('extension.keyword')).toBeNull();
-      expect(storage.get(SHOW_ONLY_SELECTED_FIELDS)).toBe(true);
+      it('should disable the switch even if it was previously switched on', async () => {
+        storage.set(SHOW_ONLY_SELECTED_FIELDS, true);
 
-      act(() => {
-        showOnlySelectedFieldsSwitch.click();
+        setupComponent({ filter: jest.fn() });
+
+        expect(screen.getByTestId('unifiedDocViewerShowOnlySelectedFieldsSwitch')).toBeDisabled();
+        expect(screen.getByText('@timestamp')).toBeInTheDocument();
+        expect(screen.getByText('bytes')).toBeInTheDocument();
+        expect(screen.getByText('extension.keyword')).toBeInTheDocument();
       });
 
-      expect(screen.getByText('@timestamp')).toBeInTheDocument();
-      expect(screen.getByText('bytes')).toBeInTheDocument();
-      expect(screen.getByText('extension.keyword')).toBeInTheDocument();
-      expect(storage.get(SHOW_ONLY_SELECTED_FIELDS)).toBe(false);
+      it('should show only selected fields if it was previously switched on', async () => {
+        storage.set(SHOW_ONLY_SELECTED_FIELDS, true);
+
+        setupComponent({ columns: ['extension.keyword'], filter: jest.fn() });
+
+        expect(screen.getByTestId('unifiedDocViewerShowOnlySelectedFieldsSwitch')).toBeEnabled();
+        expect(screen.getByText('@timestamp')).toBeInTheDocument();
+        expect(screen.queryByText('bytes')).toBeNull();
+        expect(screen.getByText('extension.keyword')).toBeInTheDocument();
+      });
+
+      it('should allow toggling the switch', async () => {
+        const { user } = setupComponent({ columns: ['bytes'], filter: jest.fn() });
+
+        const showOnlySelectedFieldsSwitch = screen.getByTestId(
+          'unifiedDocViewerShowOnlySelectedFieldsSwitch'
+        );
+
+        expect(showOnlySelectedFieldsSwitch).toBeEnabled();
+        expect(showOnlySelectedFieldsSwitch).toHaveValue('');
+        expect(screen.getByText('@timestamp')).toBeInTheDocument();
+        expect(screen.getByText('bytes')).toBeInTheDocument();
+        expect(screen.getByText('extension.keyword')).toBeInTheDocument();
+
+        await user.click(showOnlySelectedFieldsSwitch);
+
+        expect(screen.getByText('@timestamp')).toBeInTheDocument();
+        expect(screen.getByText('bytes')).toBeInTheDocument();
+        expect(screen.queryByText('extension.keyword')).toBeNull();
+        expect(storage.get(SHOW_ONLY_SELECTED_FIELDS)).toBe(true);
+
+        await user.click(showOnlySelectedFieldsSwitch);
+
+        expect(screen.getByText('@timestamp')).toBeInTheDocument();
+        expect(screen.getByText('bytes')).toBeInTheDocument();
+        expect(screen.getByText('extension.keyword')).toBeInTheDocument();
+        expect(storage.get(SHOW_ONLY_SELECTED_FIELDS)).toBe(false);
+      });
+    });
+
+    describe('when there is no filter function', () => {
+      it('should not render the switch', () => {
+        setupComponent({ columns: ['bytes'] });
+
+        expect(
+          screen.queryByTestId('unifiedDocViewerShowOnlySelectedFieldsSwitch')
+        ).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_table/table.tsx
@@ -464,19 +464,21 @@ export const DocViewerTable = ({
           alignItems="center"
           gutterSize="m"
         >
-          <EuiFlexItem grow={false}>
-            <EuiSwitch
-              label={i18n.translate('unifiedDocViewer.showOnlySelectedFields.switchLabel', {
-                defaultMessage: 'Selected only',
-                description: 'Switch label to show only selected fields in the table',
-              })}
-              checked={showOnlySelectedFields ?? false}
-              disabled={isShowOnlySelectedFieldsDisabled}
-              onChange={onShowOnlySelectedFieldsChange}
-              compressed
-              data-test-subj="unifiedDocViewerShowOnlySelectedFieldsSwitch"
-            />
-          </EuiFlexItem>
+          {filter && (
+            <EuiFlexItem grow={false}>
+              <EuiSwitch
+                label={i18n.translate('unifiedDocViewer.showOnlySelectedFields.switchLabel', {
+                  defaultMessage: 'Selected only',
+                  description: 'Switch label to show only selected fields in the table',
+                })}
+                checked={showOnlySelectedFields ?? false}
+                disabled={isShowOnlySelectedFieldsDisabled}
+                onChange={onShowOnlySelectedFieldsChange}
+                compressed
+                data-test-subj="unifiedDocViewerShowOnlySelectedFieldsSwitch"
+              />
+            </EuiFlexItem>
+          )}
           {isEsqlMode && (
             <EuiFlexItem grow={false}>
               <EuiSwitch


### PR DESCRIPTION
## Summary

The doc viewer table was always showing the "Selected only" toggle even if the user couldn't filter by value. With this change the toggle is only shown when that filter is available.

| Before | After |
|--------|------|
| ![image](https://github.com/user-attachments/assets/55ce55ff-8c51-45f8-af5b-a3f1e0ef46f9) | ![image](https://github.com/user-attachments/assets/9588bfc8-96f2-40d3-96c7-d68668ea7b72) |

Solves https://github.com/elastic/kibana/issues/215315

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->