### PR TITLE
Add a11y alerts flyout labels

### DIFF
--- a/src/platform/packages/shared/response-ops/rule_form/src/components/confirm_rule_close/confirm_rule_close.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/components/confirm_rule_close/confirm_rule_close.tsx
@@ -34,6 +34,7 @@ export const ConfirmRuleClose = (props: ConfirmRuleCloseRuleProps) => {
       title={RULE_FORM_CANCEL_MODAL_TITLE}
       confirmButtonText={RULE_FORM_CANCEL_MODAL_CONFIRM}
       cancelButtonText={RULE_FORM_CANCEL_MODAL_CANCEL}
+      aria-label={RULE_FORM_CANCEL_MODAL_TITLE}
     >
       <EuiText>
         <p>{RULE_FORM_CANCEL_MODAL_DESCRIPTION}</p>

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_schedule.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_schedule.tsx
@@ -132,6 +132,9 @@ export const RuleSchedule = () => {
             data-test-subj="ruleScheduleNumberInput"
             onChange={onIntervalNumberChange}
             onKeyDown={onKeyDown}
+            id="ruleScheduleNumberInput"
+            itemID="ruleScheduleNumberInput"
+            aria-label={SCHEDULE_TITLE_PREFIX}
           />
         </EuiFlexItem>
         <EuiFlexItem grow={3}>

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_body.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_flyout/rule_flyout_body.tsx
@@ -143,7 +143,11 @@ export const RuleFlyoutBody = ({
     <>
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="s" data-test-subj={isEdit ? 'editRuleFlyoutTitle' : 'addRuleFlyoutTitle'}>
-          <h3 id="flyoutTitle" data-test-subj="ruleFlyoutTitle">
+          <h3
+            id="flyoutTitle"
+            data-test-subj="ruleFlyoutTitle"
+            aria-label={isEdit ? RULE_FLYOUT_HEADER_EDIT_TITLE : RULE_FLYOUT_HEADER_CREATE_TITLE}
+          >
             {isEdit ? RULE_FLYOUT_HEADER_EDIT_TITLE : RULE_FLYOUT_HEADER_CREATE_TITLE}
           </h3>
         </EuiTitle>


### PR DESCRIPTION
Part of #212947 

## Summary

This PR improves the accessibility of the alerts flyout by adding `aria-label`s and `id`s


## Testing ( Mac OS VoiceOver utility )

https://github.com/user-attachments/assets/0a3e7357-45fd-4ef6-94d0-a35693520626

