### PR TITLE
[ES|QL] Removes SHOW functions from docs

### DIFF
--- a/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
@@ -148,7 +148,6 @@ ROW a = ROUND(1.23, 0)
 The \`SHOW <item>\` source command returns information about the deployment and its capabilities:
 
 * Use \`SHOW INFO\` to return the deployment's version, build date and hash.
-* Use \`SHOW FUNCTIONS\` to return a list of all supported functions and a synopsis of each function.
             `,
             ignoreTag: true,
             description:

--- a/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
+++ b/src/platform/packages/private/kbn-language-documentation/src/sections/esql_documentation_sections.tsx
@@ -145,9 +145,7 @@ ROW a = ROUND(1.23, 0)
         <Markdown
           markdownContent={i18n.translate('languageDocumentation.documentationESQL.show.markdown', {
             defaultMessage: `### SHOW
-The \`SHOW <item>\` source command returns information about the deployment and its capabilities:
-
-* Use \`SHOW INFO\` to return the deployment's version, build date and hash.
+The \`SHOW INFO\` source command returns the deployment's version, build date and hash.
             `,
             ignoreTag: true,
             description:


### PR DESCRIPTION
## Summary

Removes `Show functions` from our docs as it is not supported anymore

<img width="487" alt="image" src="https://github.com/user-attachments/assets/ca385cb4-d96f-4730-891f-b9b50bd34a35" />





<!--ONMERGE {"backportTargets":["8.18","8.19"]} ONMERGE-->