### PR TITLE
[AI4SOC] Pin the prebuilt rules package version

### DIFF
--- a/config/serverless.security.search_ai_lake.yml
+++ b/config/serverless.security.search_ai_lake.yml
@@ -72,3 +72,6 @@ xpack.features.overrides:
 xpack.fleet.agentless.isDefault: true
 xpack.fleet.integrationsHomeOverride: '/app/security/configurations/integrations'
 xpack.fleet.prereleaseEnabledByDefault: true
+
+# Pin the prebuilt rules package version to the version that contains promotion rules
+xpack.securitySolution.prebuiltRulesPackageVersion: '9.0.5-beta.1'


### PR DESCRIPTION
## Summary

Pin the prebuilt rules package version to the one containing promotion rules needed for AI4SOC to work.

Note: this is only for test purposes, the package will be removed once AI4SOC is ready to be released and the promotion rules are added to the production rules package.





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->