### PR TITLE
[8.19] [Profiling]: Fix color for Go Frametype (#219524)

### DIFF
--- a/x-pack/solutions/observability/plugins/profiling/common/frame_type_colors.ts
+++ b/x-pack/solutions/observability/plugins/profiling/common/frame_type_colors.ts
@@ -44,7 +44,7 @@ export const FRAME_TYPE_COLOR_MAP = {
   [FrameType.JavaScript]: [0xcbc3e3, 0xd5cfe8, 0xdfdbee, 0xeae7f3],
   [FrameType.PHPJIT]: [0xccfc82, 0xd1fc8e, 0xd6fc9b, 0xdbfca7],
   [FrameType.DotNET]: [0x6c60e1, 0x8075e5, 0x948be9, 0xa8a0ed],
-  [FrameType.Go]: [0x00add8, 0x31bee0, 0x68cce7],
+  [FrameType.Go]: [0x00add8, 0x31bee0, 0x68cce7, 0x9cdbed],
   [FrameType.ErrorFlag]: [0x0, 0x0, 0x0, 0x0], // This is a special case, it's not a real frame type
   [FrameType.Error]: [0xfd8484, 0xfd9d9d, 0xfeb5b5, 0xfecece],
   [FrameType.Root]: [RED, RED, RED, RED],


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Profiling]: Fix color for Go Frametype (#219524)](https://github.com/elastic/kibana/pull/219524)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Florian Lehner","email":"florianl@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-04-30T05:56:51Z","message":"[Profiling]: Fix color for Go Frametype (#219524)\n\n## Summary\n\nFixes a bug, where https://github.com/elastic/kibana/pull/215697 added\nonly three colors but four colors are expected.\n\nFixes https://github.com/elastic/kibana/issues/218839 and fixes\nhttps://github.com/elastic/elastic-charts/issues/2652\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- [ ]\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [ ] ~~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~~\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- [ ] ~~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- `release_note:skip`\n\nSigned-off-by: Florian Lehner <florian.lehner@elastic.co>","sha":"9cbbf78abe2d542f9b6d1b080f3355552a2724f4","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","backport:skip","Team:obs-ux-infra_services","9.1 candidate","v9.1.0"],"title":"[Profiling]: Fix color for Go Frametype","number":219524,"url":"https://github.com/elastic/kibana/pull/219524","mergeCommit":{"message":"[Profiling]: Fix color for Go Frametype (#219524)\n\n## Summary\n\nFixes a bug, where https://github.com/elastic/kibana/pull/215697 added\nonly three colors but four colors are expected.\n\nFixes https://github.com/elastic/kibana/issues/218839 and fixes\nhttps://github.com/elastic/elastic-charts/issues/2652\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- [ ]\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [ ] ~~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~~\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- [ ] ~~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- `release_note:skip`\n\nSigned-off-by: Florian Lehner <florian.lehner@elastic.co>","sha":"9cbbf78abe2d542f9b6d1b080f3355552a2724f4"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219524","number":219524,"mergeCommit":{"message":"[Profiling]: Fix color for Go Frametype (#219524)\n\n## Summary\n\nFixes a bug, where https://github.com/elastic/kibana/pull/215697 added\nonly three colors but four colors are expected.\n\nFixes https://github.com/elastic/kibana/issues/218839 and fixes\nhttps://github.com/elastic/elastic-charts/issues/2652\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [ ] ~~Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)~~\n- [ ]\n~~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\nwas added for features that require explanation or tutorials~~\n- [ ] ~~[Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios~~\n- [ ] ~~If a plugin configuration key changed, check if it needs to be\nallowlisted in the cloud and added to the [docker\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~\n- [ ] ~~This was checked for breaking HTTP API changes, and any breaking\nchanges have been approved by the breaking-change committee. The\n`release_note:breaking` label should be applied in these situations.~~\n- [ ] ~~[Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed~~\n- [ ] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n- `release_note:skip`\n\nSigned-off-by: Florian Lehner <florian.lehner@elastic.co>","sha":"9cbbf78abe2d542f9b6d1b080f3355552a2724f4"}}]}] BACKPORT-->