### PR TITLE
[8.19] Support rrule for task scheduling (#217728)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/lib/next_run.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/lib/next_run.ts
@@ -13,8 +13,11 @@ export const getNextRun = ({
   interval,
 }: {
   startDate?: Date | null;
-  interval: string;
+  interval?: string;
 }) => {
+  if (!interval) {
+    throw new Error('Interval is required to calculate next run');
+  }
   return moment(startDate || new Date())
     .add(parseDuration(interval), 'ms')
     .toISOString();

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -421,69 +421,68 @@ describe('Task Runner', () => {
     });
     expect(AlertingEventLogger).toHaveBeenCalledTimes(1);
 
-      mockGetAlertFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
-      encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
-      await taskRunner.run();
-      expect(enqueueFunction).toHaveBeenCalledTimes(1);
-      expect(enqueueFunction).toHaveBeenCalledWith(
-        generateEnqueueFunctionInput({ isBulk, id: '1', foo: true })
-      );
+    mockGetAlertFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
+    await taskRunner.run();
+    expect(enqueueFunction).toHaveBeenCalledTimes(1);
+    expect(enqueueFunction).toHaveBeenCalledWith(
+      generateEnqueueFunctionInput({ isBulk, id: '1', foo: true })
+    );
 
-      expect(logger.debug).toHaveBeenCalledTimes(6);
-      expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-        tags: ['1', 'test'],
-      });
-      expect(logger.debug).nthCalledWith(
-        2,
-        `rule test:1: '${RULE_NAME}' has 1 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"}]`,
-        { tags: ['1', 'test'] }
-      );
-      expect(logger.debug).nthCalledWith(
-        3,
-        'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}',
-        { tags: ['1', 'test'] }
-      );
-      expect(logger.debug).nthCalledWith(
-        4,
-        'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":1,"new":1,"recovered":0,"ignored":0}}',
-        { tags: ['1', 'test'] }
-      );
-      expect(logger.debug).nthCalledWith(
-        5,
-        'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":1,"numberOfGeneratedActions":1,"numberOfActiveAlerts":1,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":1,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
-        { tags: ['1', 'test'] }
-      );
+    expect(logger.debug).toHaveBeenCalledTimes(6);
+    expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
+      tags: ['1', 'test'],
+    });
+    expect(logger.debug).nthCalledWith(
+      2,
+      `rule test:1: '${RULE_NAME}' has 1 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"}]`,
+      { tags: ['1', 'test'] }
+    );
+    expect(logger.debug).nthCalledWith(
+      3,
+      'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}',
+      { tags: ['1', 'test'] }
+    );
+    expect(logger.debug).nthCalledWith(
+      4,
+      'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":1,"new":1,"recovered":0,"ignored":0}}',
+      { tags: ['1', 'test'] }
+    );
+    expect(logger.debug).nthCalledWith(
+      5,
+      'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":1,"numberOfGeneratedActions":1,"numberOfActiveAlerts":1,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":1,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
+      { tags: ['1', 'test'] }
+    );
 
-      testAlertingEventLogCalls({
-        activeAlerts: 1,
-        generatedActions: 1,
-        newAlerts: 1,
-        triggeredActions: 1,
-        status: 'active',
-        logAlert: 2,
-        logAction: 1,
-      });
-      expect(alertingEventLogger.logAlert).toHaveBeenNthCalledWith(
-        1,
-        generateAlertOpts({
-          action: EVENT_LOG_ACTIONS.newInstance,
-          group: 'default',
-          state: { start: DATE_1970, duration: '0' },
-        })
-      );
-      expect(alertingEventLogger.logAlert).toHaveBeenNthCalledWith(
-        2,
-        generateAlertOpts({
-          action: EVENT_LOG_ACTIONS.activeInstance,
-          group: 'default',
-          state: { start: DATE_1970, duration: '0' },
-        })
-      );
-      expect(alertingEventLogger.logAction).toHaveBeenNthCalledWith(1, generateActionOpts());
+    testAlertingEventLogCalls({
+      activeAlerts: 1,
+      generatedActions: 1,
+      newAlerts: 1,
+      triggeredActions: 1,
+      status: 'active',
+      logAlert: 2,
+      logAction: 1,
+    });
+    expect(alertingEventLogger.logAlert).toHaveBeenNthCalledWith(
+      1,
+      generateAlertOpts({
+        action: EVENT_LOG_ACTIONS.newInstance,
+        group: 'default',
+        state: { start: DATE_1970, duration: '0' },
+      })
+    );
+    expect(alertingEventLogger.logAlert).toHaveBeenNthCalledWith(
+      2,
+      generateAlertOpts({
+        action: EVENT_LOG_ACTIONS.activeInstance,
+        group: 'default',
+        state: { start: DATE_1970, duration: '0' },
+      })
+    );
+    expect(alertingEventLogger.logAction).toHaveBeenNthCalledWith(1, generateActionOpts());
 
-      expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
-    }
-  );
+    expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
+  });
 
   test('actionsPlugin.execute is skipped if muteAll is true', async () => {
     taskRunnerFactoryInitializerParams.actionsPlugin.isActionTypeEnabled.mockReturnValue(true);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.test.ts
@@ -393,96 +393,102 @@ describe('Task Runner', () => {
       '"Interval is required to calculate next run"'
     );
   });
+  test.each(ephemeralTestParams)(
+    'actionsPlugin.execute is called per alert alert that is scheduled %s',
+    async (nameExtension, customTaskRunnerFactoryInitializerParams, enqueueFunction, isBulk) => {
+      customTaskRunnerFactoryInitializerParams.actionsPlugin.isActionTypeEnabled.mockReturnValue(
+        true
+      );
+      customTaskRunnerFactoryInitializerParams.actionsPlugin.isActionExecutable.mockReturnValue(
+        true
+      );
+      ruleType.executor.mockImplementation(
+        async ({
+          services: executorServices,
+        }: RuleExecutorOptions<
+          RuleTypeParams,
+          RuleTypeState,
+          AlertInstanceState,
+          AlertInstanceContext,
+          string,
+          RuleAlertData
+        >) => {
+          executorServices.alertFactory.create('1').scheduleActions('default');
+          return { state: {} };
+        }
+      );
+      const taskRunner = new TaskRunner({
+        ruleType,
+        taskInstance: mockedTaskInstance,
+        context: customTaskRunnerFactoryInitializerParams,
+        inMemoryMetrics,
+        internalSavedObjectsRepository,
+      });
+      expect(AlertingEventLogger).toHaveBeenCalledTimes(1);
 
-  test('actionsPlugin.execute is called per alert alert that is scheduled', async () => {
-    taskRunnerFactoryInitializerParams.actionsPlugin.isActionTypeEnabled.mockReturnValue(true);
-    taskRunnerFactoryInitializerParams.actionsPlugin.isActionExecutable.mockReturnValue(true);
-    ruleType.executor.mockImplementation(
-      async ({
-        services: executorServices,
-      }: RuleExecutorOptions<
-        RuleTypeParams,
-        RuleTypeState,
-        AlertInstanceState,
-        AlertInstanceContext,
-        string,
-        RuleAlertData
-      >) => {
-        executorServices.alertFactory.create('1').scheduleActions('default');
-        return { state: {} };
-      }
-    );
-    const taskRunner = new TaskRunner({
-      ruleType,
-      taskInstance: mockedTaskInstance,
-      context: taskRunnerFactoryInitializerParams,
-      inMemoryMetrics,
-      internalSavedObjectsRepository,
-    });
-    expect(AlertingEventLogger).toHaveBeenCalledTimes(1);
+      mockGetAlertFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
+      encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
+      await taskRunner.run();
+      expect(enqueueFunction).toHaveBeenCalledTimes(1);
+      expect(enqueueFunction).toHaveBeenCalledWith(
+        generateEnqueueFunctionInput({ isBulk, id: '1', foo: true })
+      );
 
-    mockGetAlertFromRaw.mockReturnValue(mockedRuleTypeSavedObject as Rule);
-    encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValue(mockedRawRuleSO);
-    await taskRunner.run();
-    expect(enqueueFunction).toHaveBeenCalledTimes(1);
-    expect(enqueueFunction).toHaveBeenCalledWith(
-      generateEnqueueFunctionInput({ isBulk, id: '1', foo: true })
-    );
+      expect(logger.debug).toHaveBeenCalledTimes(6);
+      expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
+        tags: ['1', 'test'],
+      });
+      expect(logger.debug).nthCalledWith(
+        2,
+        `rule test:1: '${RULE_NAME}' has 1 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"}]`,
+        { tags: ['1', 'test'] }
+      );
+      expect(logger.debug).nthCalledWith(
+        3,
+        'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}',
+        { tags: ['1', 'test'] }
+      );
+      expect(logger.debug).nthCalledWith(
+        4,
+        'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":1,"new":1,"recovered":0,"ignored":0}}',
+        { tags: ['1', 'test'] }
+      );
+      expect(logger.debug).nthCalledWith(
+        5,
+        'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":1,"numberOfGeneratedActions":1,"numberOfActiveAlerts":1,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":1,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
+        { tags: ['1', 'test'] }
+      );
 
-    expect(logger.debug).toHaveBeenCalledTimes(6);
-    expect(logger.debug).nthCalledWith(1, 'executing rule test:1 at 1970-01-01T00:00:00.000Z', {
-      tags: ['1', 'test'],
-    });
-    expect(logger.debug).nthCalledWith(
-      2,
-      `rule test:1: '${RULE_NAME}' has 1 active alerts: [{\"instanceId\":\"1\",\"actionGroup\":\"default\"}]`,
-      { tags: ['1', 'test'] }
-    );
-    expect(logger.debug).nthCalledWith(
-      3,
-      'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"active"}',
-      { tags: ['1', 'test'] }
-    );
-    expect(logger.debug).nthCalledWith(
-      4,
-      'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":1,"new":1,"recovered":0,"ignored":0}}',
-      { tags: ['1', 'test'] }
-    );
-    expect(logger.debug).nthCalledWith(
-      5,
-      'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":1,"numberOfGeneratedActions":1,"numberOfActiveAlerts":1,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":1,"numberOfDelayedAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}',
-      { tags: ['1', 'test'] }
-    );
+      testAlertingEventLogCalls({
+        activeAlerts: 1,
+        generatedActions: 1,
+        newAlerts: 1,
+        triggeredActions: 1,
+        status: 'active',
+        logAlert: 2,
+        logAction: 1,
+      });
+      expect(alertingEventLogger.logAlert).toHaveBeenNthCalledWith(
+        1,
+        generateAlertOpts({
+          action: EVENT_LOG_ACTIONS.newInstance,
+          group: 'default',
+          state: { start: DATE_1970, duration: '0' },
+        })
+      );
+      expect(alertingEventLogger.logAlert).toHaveBeenNthCalledWith(
+        2,
+        generateAlertOpts({
+          action: EVENT_LOG_ACTIONS.activeInstance,
+          group: 'default',
+          state: { start: DATE_1970, duration: '0' },
+        })
+      );
+      expect(alertingEventLogger.logAction).toHaveBeenNthCalledWith(1, generateActionOpts());
 
-    testAlertingEventLogCalls({
-      activeAlerts: 1,
-      generatedActions: 1,
-      newAlerts: 1,
-      triggeredActions: 1,
-      status: 'active',
-      logAlert: 2,
-      logAction: 1,
-    });
-    expect(alertingEventLogger.logAlert).toHaveBeenNthCalledWith(
-      1,
-      generateAlertOpts({
-        action: EVENT_LOG_ACTIONS.newInstance,
-        group: 'default',
-        state: { start: DATE_1970, duration: '0' },
-      })
-    );
-    expect(alertingEventLogger.logAlert).toHaveBeenNthCalledWith(
-      2,
-      generateAlertOpts({
-        action: EVENT_LOG_ACTIONS.activeInstance,
-        group: 'default',
-        state: { start: DATE_1970, duration: '0' },
-      })
-    );
-    expect(alertingEventLogger.logAction).toHaveBeenNthCalledWith(1, generateActionOpts());
-
-    expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
-  });
+      expect(mockUsageCounter.incrementCounter).not.toHaveBeenCalled();
+    }
+  );
 
   test('actionsPlugin.execute is skipped if muteAll is true', async () => {
     taskRunnerFactoryInitializerParams.actionsPlugin.isActionTypeEnabled.mockReturnValue(true);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -593,6 +593,7 @@ export class TaskRunner<
         if (isOk(schedule)) {
           nextRun = getNextRun({ startDate: startedAt, interval: schedule.value.interval });
         } else if (taskSchedule) {
+          // rules cannot use rrule for scheduling yet
           nextRun = getNextRun({ startDate: startedAt, interval: taskSchedule.interval });
         }
 
@@ -828,6 +829,7 @@ export class TaskRunner<
 
     let nextRun: string | null = null;
     if (taskSchedule) {
+      // rules cannot use rrule for scheduling yet
       nextRun = getNextRun({ startDate: startedAt, interval: taskSchedule.interval });
     }
 

--- a/x-pack/platform/plugins/shared/task_manager/README.md
+++ b/x-pack/platform/plugins/shared/task_manager/README.md
@@ -130,7 +130,7 @@ export class Plugin {
   }
 
   public start(core: CoreStart, plugins: { taskManager }) {
-    
+
   }
 }
 ```
@@ -160,12 +160,12 @@ When Kibana attempts to claim and run a task instance, it looks its definition u
 
 The task runner's `run` method is expected to return a promise that resolves to undefined or to an object that looks like the following:
 
-|Property|Description|Type|
-|---|---|---|
-|runAt| Optional. If specified, this is used as the tasks' next `runAt`, overriding the default system scheduler. | Date ISO String | 
-|schedule| Optional. If specified, this is used as the tasks' new recurring schedule, overriding the default system scheduler and any existing schedule.  | { interval: string } | 
-|error| Optional, an error object, logged out as a warning. The pressence of this property indicates that the task did not succeed.| Error |
-|state| Optional, this will be passed into the next run of the task, if this is a recurring task. |Record<string, unknown>|
+| Property | Description                                                                                                                                   | Type                    |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| runAt    | Optional. If specified, this is used as the tasks' next `runAt`, overriding the default system scheduler.                                     | Date ISO String         |
+| schedule | Optional. If specified, this is used as the tasks' new recurring schedule, overriding the default system scheduler and any existing schedule. | { interval: string }    |
+| error    | Optional, an error object, logged out as a warning. The pressence of this property indicates that the task did not succeed.                   | Error                   |
+| state    | Optional, this will be passed into the next run of the task, if this is a recurring task.                                                     | Record<string, unknown> |
 
 ### Examples
 
@@ -186,7 +186,7 @@ The task runner's `run` method is expected to return a promise that resolves to 
 ```js
 {
   schedule: { interval: '30s' },
-  
+
   state: {
     anything: 'goes here',
   },
@@ -196,16 +196,19 @@ The task runner's `run` method is expected to return a promise that resolves to 
 Other return values will result in a warning, but the system should continue to work.
 
 ### Task retries when the Task Runner fails
+
 If a task runner throws an error, task manager will try to rerun the task shortly after (up to the task definition's `maxAttempts`).
 Normal tasks will wait a default amount of 5m before trying again and every subsequent attempt will add an additonal 5m cool off period to avoid a stampeding herd of failed tasks from storming Elasticsearch.
 
 Recurring tasks will also get retried, but instead of using the 5m interval for the retry, they will be retried on their next scheduled run.
 
 ### Force failing a task
+
 If you wish to purposfully fail a task, you can throw an error of any kind and the retry logic will apply.
 If, on the other hand, you wish not only to fail the task, but you'd also like to indicate the Task Manager that it shouldn't retry the task, you can throw an Unrecoverable Error, using the `throwUnrecoverableError` helper function.
 
 For example:
+
 ```js
   taskManager.registerTaskDefinitions({
     myTask: {
@@ -305,12 +308,15 @@ The data stored for a task instance looks something like this:
 The task manager mixin exposes a taskManager object on the Kibana server which plugins can use to manage scheduled tasks. Each method takes an optional `scope` argument and ensures that only tasks with the specified scope(s) will be affected.
 
 ### Overview
+
 Interaction with the TaskManager Plugin is done via the Kibana Platform Plugin system.
 When developing your Plugin, you're asked to define a `setup` method and a `start` method.
 These methods are handed Kibana's Plugin APIs for these two stages, which means you'll have access to the following apis in these two stages:
 
 #### Setup
+
 The _Setup_ Plugin api includes methods which configure Task Manager to support your Plugin's requirements, such as defining custom Middleware and Task Definitions.
+
 ```js
 {
   addMiddleware: (middleware: Middleware) => {
@@ -323,6 +329,7 @@ The _Setup_ Plugin api includes methods which configure Task Manager to support 
 ```
 
 #### Start
+
 The _Start_ Plugin api allow you to use Task Manager to facilitate your Plugin's behaviour, such as scheduling tasks.
 
 ```js
@@ -360,8 +367,9 @@ The _Start_ Plugin api allow you to use Task Manager to facilitate your Plugin's
 ### Detailed APIs
 
 #### schedule
-Using `schedule` you can instruct TaskManger to schedule an instance of a TaskType at some point in the future.
 
+Using `schedule` you can instruct TaskManger to schedule an instance of a TaskType at some point in the future.
+Please check the [Schedule options](#schedule-options) for the scheduling config details
 
 ```js
 export class Plugin {
@@ -394,27 +402,32 @@ export class Plugin {
   }
 }
 ```
-*results* then look something like this:
+
+_results_ then look something like this:
 
 ```json
+{
+  "searchAfter": ["233322"],
+  // Tasks is an array of task instances
+  "tasks": [
     {
-      "searchAfter": ["233322"],
-      // Tasks is an array of task instances
-      "tasks": [{
-        "id": "3242342",
-        "taskType": "reporting",
-        // etc
-      }]
+      "id": "3242342",
+      "taskType": "reporting"
+      // etc
     }
+  ]
+}
 ```
 
 #### ensureScheduling
+
 When using the `schedule` api to schedule a Task you can provide a hard coded `id` on the Task. This tells TaskManager to use this `id` to identify the Task Instance rather than generate an `id` on its own.
 The danger is that in such a situation, a Task with that same `id` might already have been scheduled at some earlier point, and this would result in an error. In some cases, this is the expected behavior, but often you only care about ensuring the task has been _scheduled_ and don't need it to be scheduled a fresh.
 
 To achieve this you should use the `ensureScheduling` api which has the exact same behavior as `schedule`, except it allows the scheduling of a Task with an `id` that's already in assigned to another Task and it will assume that the existing Task is the one you wished to `schedule`, treating this as a successful operation.
 
 #### runSoon
+
 Using `runSoon` you can instruct TaskManager to run an existing task as soon as possible by updating the next scheduled run date to be now
 
 ```js
@@ -433,15 +446,17 @@ export class Plugin {
       // If running the task has failed, we throw an error with an appropriate message.
       // For example, if the requested task doesnt exist: `Error: failed to run task "91760f10-ba42-de9799" as it does not exist`
       // Or if, for example, the task is already running: `Error: failed to run task "91760f10-ba42-de9799" as it is currently running`
-    }    
+    }
   }
 }
 ```
 
 #### bulkDisable
+
 Using `bulkDisable` you can instruct TaskManger to disable tasks by setting the `enabled` status of specific tasks to `false`.
 
 Example:
+
 ```js
 export class Plugin {
   constructor() {
@@ -459,15 +474,17 @@ export class Plugin {
       // But some updates of some tasks can be failed, due to OCC 409 conflict for example
     } catch(err: Error) {
       // if error is caught, means the whole method requested has failed and tasks weren't updated
-    }    
+    }
   }
 }
 ```
 
 #### bulkEnable
+
 Using `bulkEnable` you can instruct TaskManger to enable tasks by setting the `enabled` status of specific tasks to `true`. Specify the `runSoon` parameter to run the task immediately on enable.
 
 Example:
+
 ```js
 export class Plugin {
   constructor() {
@@ -486,20 +503,23 @@ export class Plugin {
       // But some updates of some tasks can be failed, due to OCC 409 conflict for example
     } catch(err: Error) {
       // if error is caught, means the whole method requested has failed and tasks weren't updated
-    }    
+    }
   }
 }
 ```
 
 #### bulkUpdateSchedules
+
 Using `bulkUpdatesSchedules` you can instruct TaskManger to update interval of tasks that are in `idle` status
-(for the tasks which have `running` status,  `schedule` and `runAt` will be recalculated after task run finishes).
+(for the tasks which have `running` status, `schedule` and `runAt` will be recalculated after task run finishes).
 When interval updated, new `runAt` will be computed and task will be updated with that value, using formula
+
 ```
 newRunAt = oldRunAt - oldInterval + newInterval
 ```
 
 Example:
+
 ```js
 export class Plugin {
   constructor() {
@@ -518,7 +538,7 @@ export class Plugin {
       // But some updates of some tasks can be failed, due to OCC 409 conflict for example
     } catch(err: Error) {
       // if error is caught, means the whole method requested has failed and tasks weren't updated
-    }    
+    }
   }
 }
 ```
@@ -532,6 +552,7 @@ More custom access to the tasks can be done directly via Elasticsearch, though t
 The task manager exposes a middleware layer that allows modifying tasks before they are scheduled / persisted to the task manager index, and modifying tasks / the run context before a task is run.
 
 For example:
+
 ```js
 export class Plugin {
   constructor() {
@@ -567,12 +588,13 @@ export class Plugin {
   }
 
   public start(core: CoreStart, plugins: { taskManager }) {
-    
+
   }
 }
 ```
 
 ## Task Poller: polling for work
+
 TaskManager used to work in a `pull` model, but it now needs to support both `push` and `pull`, so it has been remodeled internally to support a single `push` model.
 
 Task Manager's _push_ mechanism is driven by the following operations:
@@ -595,11 +617,12 @@ Luckily, `Polling Interval` and `Task Scheduled` simply denote a request to "pol
 We achieve this model by buffering requests into a queue using a Set (which removes duplicated). As we don't want an unbounded queue in our system, we have limited the size of this queue (configurable by the `xpack.task_manager.request_capacity` config, defaulting to 1,000 requests) which forces us to throw an error once this cap is reached until the queue drain bellow the cap.
 
 Our current model, then, is this:
+
 ```
-  Polling Interval  --> filter(availableWorkers > 0) - mapTo([]) -------\\ 
+  Polling Interval  --> filter(availableWorkers > 0) - mapTo([]) -------\\
   Task Scheduled    --> filter(availableWorkers > 0) - mapTo([]) --------||==>Set([]+[]+[`1`,`2`]) ==> work([`1`,`2`])
   Run Task `1` Now --\                                                  //
-                      ----> buffer(availableWorkers > 0) -- [`1`,`2`] -// 
+                      ----> buffer(availableWorkers > 0) -- [`1`,`2`] -//
   Run Task `2` Now --/
 ```
 
@@ -615,16 +638,17 @@ The task manager's public API is create / delete / list. Updates aren't directly
 
 - Unit tests:
 
-   Documentation: https://www.elastic.co/guide/en/kibana/current/development-tests.html#_unit_testing
+  Documentation: https://www.elastic.co/guide/en/kibana/current/development-tests.html#_unit_testing
 
-   ```
-   yarn test:jest x-pack/platform/plugins/shared/task_manager --watch
-   ```
+  ```
+  yarn test:jest x-pack/platform/plugins/shared/task_manager --watch
+  ```
+
 - Integration tests:
-   ```
-   node scripts/functional_tests_server.js --config x-pack/test/plugin_api_integration/config.ts
-   node scripts/functional_test_runner --config x-pack/test/plugin_api_integration/config.ts
-   ```
+  ```
+  node scripts/functional_tests_server.js --config x-pack/test/plugin_api_integration/config.ts
+  node scripts/functional_test_runner --config x-pack/test/plugin_api_integration/config.ts
+  ```
 
 ## Monitoring
 
@@ -632,3 +656,122 @@ Task Manager exposes runtime statistics which enable basic observability into it
 
 Public Documentation: https://www.elastic.co/guide/en/kibana/master/task-manager-health-monitoring.html
 Developer Documentation: [./MONITORING](./MONITORING.MD)
+
+### Schedule options
+
+We keep the scheduling config under the schedule field.
+And there are 2 different config options for scheduling a task:
+
+- `schedule.interval`
+  This is a basic interval string such as `1h`,`3m` or `7d` etc.
+
+- `schedule.rrule`
+  This is a subset of the rrule library.
+  We support only daily, weekly and monthly schedules so far.
+
+Monthly schedule options:
+
+```typescript
+  freq: Frequency.MONTHLY, -> Import the enum Frequency from TaskManager (Required field)
+  interval: number; -> Any number. 1 means `every 1 month` (Required field)
+  tzid: string; -> Timezone e.g.: 'UTC' (Required field)
+  bymonthday: number[]; -> number between 1 and 31
+  byhour?: number[]; -> number between 0 and 23
+  byminute?: number[]; -> number between 0 and 59
+  byweekday?: Weekday[]; -> Import the enum Weekday from TaskManager. Weekday.MO is monday
+```
+
+Weekly schedule options:
+
+```typescript
+  freq: Frequency.WEEKLY, -> Import the enum Frequency from TaskManager (Required field)
+  interval: number; -> Any number. 1 means `every 1 week` (Required field)
+  tzid: string; -> Timezone e.g.: 'UTC' (Required field)
+  byhour?: number[]; -> number between 0 and 23
+  byminute?: number[]; -> number between 0 and 59
+  byweekday?: Weekday[]; -> Import the enum Weekday from TaskManager. Weekday.MO is monday
+```
+
+Daily schedule options:
+
+```typescript
+  freq: Frequency.DAILY, -> Import the enum Frequency from TaskManager (Required field)
+  interval: number; -> Any number. 1 means `every 1 day` (Required field)
+  tzid: string; -> Timezone e.g.: 'UTC' (Required field)
+  byhour?: number[]; -> number between 0 and 23
+  byminute?: number[]; -> number between 0 and 59
+  byweekday?: Weekday[]; -> Import the enum Weekday from TaskManager. Weekday.MO is monday
+```
+
+Examples:
+
+Every day at current time:
+
+```js
+  schedule: {
+    rrule: {
+      freq: Frequency.DAILY,
+      tzid: 'UTC',
+      interval: 1
+    }
+  }
+```
+
+Every day at 13:15:
+
+```js
+  schedule: {
+    rrule: {
+      freq: Frequency.DAILY,
+      tzid: 'UTC',
+      interval: 1,
+      byhour: [13],
+      byminute: [15]
+    }
+  }
+```
+
+Every Monday at 17:30
+
+```js
+  schedule: {
+    rrule: {
+      freq: Frequency.DAILY,
+      tzid: 'UTC',
+      interval: 1,
+      byhour: [17],
+      byminute: [30]
+      byweekday: Weekday.MO
+    }
+  }
+```
+
+Every 2 weeks on Friday at 08:45
+
+```js
+  schedule: {
+    rrule: {
+      freq: Frequency.WEEKLY,
+      tzid: 'UTC',
+      interval: 2,
+      byhour: [8],
+      byminute: [45]
+      byweekday: Weekday.FR
+    }
+  }
+```
+
+Every Month on 1st, 15th and 30th at 12:10 and 18:10
+
+```js
+  schedule: {
+    rrule: {
+      freq: Frequency.MONTHLY,
+      tzid: 'UTC',
+      interval: 1,
+      byhour: [12,18],
+      byminute: [10]
+      bymonthday: [1,15,30]
+    }
+  }
+```

--- a/x-pack/platform/plugins/shared/task_manager/server/index.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/index.ts
@@ -24,6 +24,8 @@ export type {
   IntervalSchedule,
 } from './task';
 
+export { Frequency, Weekday } from '@kbn/rrule';
+
 export { TaskStatus, TaskPriority, TaskCost } from './task';
 
 export type { TaskRegisterDefinition, TaskDefinitionRegistry } from './task_type_dictionary';

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_first_run_at.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_first_run_at.test.ts
@@ -1,0 +1,300 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { mockLogger } from '../test_utils';
+import { getFirstRunAt } from './get_first_run_at';
+
+describe('getFirstRunAt', () => {
+  const logger = mockLogger();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-04-15T13:01:02Z'));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
+  test('should return runAt when provided', () => {
+    const runAt = new Date(Date.now() + 3000);
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      runAt,
+    };
+
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    expect(firstRunAt).toEqual(runAt.toISOString());
+  });
+
+  test('should return now when there is neither runAt nor rrule provided ', () => {
+    const now = new Date();
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+    };
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    expect(firstRunAt).toEqual(now.toISOString());
+  });
+
+  test('should return now when an rrule with simple interval is provided ', () => {
+    const now = new Date();
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 3,
+          interval: 1,
+          tzid: 'UTC',
+        },
+      },
+    };
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    expect(firstRunAt).toEqual(now.toISOString());
+  });
+
+  test('should return now when a simple interval is provided ', () => {
+    const now = new Date();
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+
+      schedule: {
+        interval: '1m',
+      },
+    };
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    expect(firstRunAt).toEqual(now.toISOString());
+  });
+
+  test('should return the calculated runAt when an rrule with fixed time is provided', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 3,
+          interval: 1,
+          tzid: 'UTC',
+          byhour: [12],
+          byminute: [15],
+        },
+      },
+    };
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+    // The next day from 2025-04-15 is 2025-04-16
+    // The time is set to 12:15
+    expect(firstRunAtDate).toEqual(new Date('2025-04-16T12:15:00Z'));
+  });
+
+  test('should return the calculated runAt when an rrule with only byhour is provided', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 3,
+          interval: 1,
+          tzid: 'UTC',
+          byhour: [12],
+        },
+      },
+    };
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+    // The next day from 2025-04-15 is 2025-04-16
+    // The hour is set to 12, default minute and second becomes 0
+    expect(firstRunAtDate).toEqual(new Date('2025-04-16T12:00:00Z'));
+  });
+
+  test('should return the calculated runAt when an rrule with byminute is provided', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 3,
+          interval: 1,
+          tzid: 'UTC',
+          byminute: [17],
+        },
+      },
+    };
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+    // The minute is set to 17, default second is 0, hour becomes the current hour
+    expect(firstRunAtDate).toEqual(new Date('2025-04-15T13:17:00Z'));
+  });
+
+  test('should return the calculated runAt when an rrule only with weekly interval time is provided', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 2, // Weekly
+          interval: 1,
+          tzid: 'UTC',
+          byweekday: [1], // Monday
+        },
+      },
+    };
+
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+    // The next Monday from 2025-04-15 is 2025-04-21
+    // The time is set to midnight
+    expect(firstRunAtDate).toEqual(new Date('2025-04-21T00:00:00.000Z'));
+  });
+
+  test('should return the calculated runAt when an rrule with weekly fixed time interval time is provided', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 2, // Weekly
+          interval: 1,
+          tzid: 'UTC',
+          byweekday: [1], // Monday
+          byhour: [12],
+          byminute: [15],
+        },
+      },
+    };
+
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+    // The next Monday from 2025-04-15 is 2025-04-21
+    // The time is set to 12:15
+    expect(firstRunAtDate).toEqual(new Date('2025-04-21T12:15:00.000Z'));
+  });
+
+  test('should return the calculated runAt when an rrule only with monthly interval is provided', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 1, // Monthly
+          interval: 1,
+          tzid: 'UTC',
+          bymonthday: [3],
+        },
+      },
+    };
+
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+    // The next month from 2025-04 is 2025-05
+    // The day is set to 3
+    // The time is set to midnight
+    expect(firstRunAtDate).toEqual(new Date('2025-05-03T00:00:00.000Z'));
+  });
+
+  test('should return the calculated runAt when an rrule with monthly interval with fixed time is provided', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 1, // Monthly
+          interval: 1,
+          tzid: 'UTC',
+          bymonthday: [3],
+          byhour: [12],
+          byminute: [17],
+        },
+      },
+    };
+
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+    // The next month from 2025-04 is 2025-05
+    // The day is set to 3
+    // The time is set to 12:17:00
+    expect(firstRunAtDate).toEqual(new Date('2025-05-03T12:17:00.000Z'));
+  });
+
+  test('should return the calculated runAt when an rrule with monthly interval with weekday is provided', () => {
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 1, // Monthly
+          interval: 1,
+          tzid: 'UTC',
+          byweekday: [3], // Wednesday
+          byhour: [12],
+          byminute: [17],
+        },
+      },
+    };
+
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+
+    // The next occurence is in the same month and is 2025-04-16
+    // The time is set to 12:17
+    expect(firstRunAtDate).toEqual(new Date('2025-04-16T12:17:00.000Z'));
+  });
+
+  test('should log an error and return now if rrule fails', () => {
+    const now = new Date();
+    const taskInstance = {
+      id: 'id',
+      params: {},
+      state: {},
+      taskType: 'report',
+      schedule: {
+        rrule: {
+          freq: 3,
+          interval: 1,
+          tzid: 'invalid-timezone',
+          bymonthday: [1],
+        },
+      },
+    };
+
+    const firstRunAt = getFirstRunAt({ taskInstance, logger });
+    const firstRunAtDate = new Date(firstRunAt);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('runAt for the rrule with fixed time could not be calculated')
+    );
+    expect(firstRunAtDate).toEqual(now);
+  });
+});

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_first_run_at.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_first_run_at.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { RRule } from '@kbn/rrule';
+import type { Logger } from '@kbn/core/server';
+import type { RruleSchedule, TaskInstance } from '../task';
+
+export function getFirstRunAt({
+  taskInstance,
+  logger,
+}: {
+  taskInstance: TaskInstance;
+  logger: Logger;
+}): string {
+  if (taskInstance.runAt) {
+    return taskInstance.runAt.toISOString();
+  }
+  const now = new Date();
+  const nowString = now.toISOString();
+
+  if (taskInstance.schedule?.rrule && rruleHasFixedTime(taskInstance.schedule.rrule)) {
+    try {
+      const rrule = new RRule({
+        ...taskInstance.schedule.rrule,
+        bysecond: [0],
+        dtstart: now,
+      });
+      return rrule.after(now)?.toISOString() || nowString;
+    } catch (e) {
+      logger.error(`runAt for the rrule with fixed time could not be calculated: ${e}`);
+    }
+  }
+
+  return nowString;
+}
+
+// This function checks if the rrule has fixed time by checking if it has any fields other than
+// 'freq', 'interval', and 'tzid'. If it does, it means the rrule has fixed time.
+// The first run of a rule that has a fixed time has to be on the expected time,
+// therefore should be calculated using the rrule library, otherwise it can be `now`.
+function rruleHasFixedTime(schedule: RruleSchedule['rrule']): boolean {
+  const keys = Object.keys(schedule);
+  const baseFields = ['freq', 'interval', 'tzid'];
+
+  if (keys.length === baseFields.length && keys.every((key) => baseFields.includes(key))) {
+    return false;
+  }
+
+  return true;
+}

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.test.ts
@@ -8,8 +8,13 @@
 import { taskManagerMock } from '../mocks';
 
 import { getNextRunAt } from './get_next_run_at';
+import { loggerMock } from '@kbn/logging-mocks';
+const mockLogger = loggerMock.create();
 
 describe('getNextRunAt', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   test('should use startedAt when the task delay is greater than the threshold', () => {
     const now = new Date();
     // Use time in the past to ensure the task delay calculation isn't relative to "now"
@@ -21,7 +26,8 @@ describe('getNextRunAt', () => {
         runAt: fiveSecondsAgo,
         startedAt: fourSecondsAgo,
       }),
-      500
+      500,
+      mockLogger
     );
     expect(nextRunAt).toEqual(new Date(fourSecondsAgo.getTime() + 60000));
   });
@@ -37,7 +43,8 @@ describe('getNextRunAt', () => {
         runAt: fiveSecondsAgo,
         startedAt: aBitLessThanFiveSecondsAgo,
       }),
-      500
+      500,
+      mockLogger
     );
     expect(nextRunAt).toEqual(new Date(fiveSecondsAgo.getTime() + 60000));
   });
@@ -51,8 +58,105 @@ describe('getNextRunAt', () => {
         runAt: fiveMinsAgo,
         startedAt: fiveMinsAgo,
       }),
-      0
+      0,
+      mockLogger
     );
     expect(nextRunAt.getTime()).toBeGreaterThanOrEqual(testStart.getTime());
+  });
+
+  test('should use the rrule with a fixed time when it is given to calculate the next runAt', () => {
+    const now = new Date();
+    const testStart = new Date(now.getTime() - 500);
+    const testRunAt = new Date(now.getTime() - 1000);
+    const nextRunAt = getNextRunAt(
+      taskManagerMock.createTask({
+        schedule: {
+          rrule: {
+            freq: 3, // Daily
+            interval: 1,
+            tzid: 'UTC',
+            byhour: [12],
+            byminute: [15],
+          },
+        },
+        runAt: testRunAt,
+        startedAt: testStart,
+      }),
+      0,
+      mockLogger
+    );
+
+    const currentDay = testStart.getUTCDay();
+    const currentHour = testStart.getUTCHours();
+    const currentSecond = testStart.getUTCSeconds();
+    const currentMilliseconds = testStart.getUTCMilliseconds();
+
+    if (currentHour < 12) {
+      expect(nextRunAt.getUTCDay()).toBe(currentDay);
+    } else {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      expect(nextRunAt.getUTCDay()).toBe(tomorrow.getUTCDay());
+    }
+    expect(nextRunAt.getUTCHours()).toBe(12);
+    expect(nextRunAt.getUTCMinutes()).toBe(15);
+    expect(nextRunAt.getUTCSeconds()).toBe(currentSecond);
+    expect(nextRunAt.getUTCMilliseconds()).toBe(currentMilliseconds);
+  });
+
+  test('should use the rrule with a basic interval time when it is given to calculate the next runAt', () => {
+    const now = new Date();
+    const testStart = now;
+    const testRunAt = new Date(now.getTime() - 1000);
+    const nextRunAt = getNextRunAt(
+      taskManagerMock.createTask({
+        schedule: {
+          rrule: {
+            freq: 3, // Daily
+            interval: 1,
+            tzid: 'UTC',
+          },
+        },
+        runAt: testRunAt,
+        startedAt: testStart,
+      }),
+      0,
+      mockLogger
+    );
+
+    const oneDay = 24 * 60 * 60 * 1000;
+    const expectedNextRunAt = new Date(testStart.getTime() + oneDay);
+
+    expect(nextRunAt).toEqual(expectedNextRunAt);
+  });
+
+  test('should throw an error if the next runAt cannot be calculated', () => {
+    const now = new Date();
+    const testStart = now;
+    const testRunAt = new Date(now.getTime() - 1000);
+
+    expect(() =>
+      getNextRunAt(
+        taskManagerMock.createTask({
+          schedule: {
+            rrule: {
+              freq: 3, // Daily
+              interval: 1,
+              tzid: 'UTC',
+              // @ts-ignore
+              count: 1, // Invalid field for rrule
+            },
+          },
+          runAt: testRunAt,
+          startedAt: testStart,
+        }),
+        0,
+        mockLogger
+      )
+    ).toThrow(`Cannot read properties of null (reading 'getTime')`);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "The next runAt for the task with a fixed time schedule could not be calculated: TypeError: Cannot read properties of null (reading 'getTime')"
+    );
   });
 });

--- a/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/lib/get_next_run_at.ts
@@ -5,21 +5,44 @@
  * 2.0.
  */
 
+import { RRule } from '@kbn/rrule';
+import type { Logger } from '@kbn/core/server';
 import { intervalFromDate } from './intervals';
 import type { ConcreteTaskInstance } from '../task';
 
 export function getNextRunAt(
   { runAt, startedAt, schedule }: Pick<ConcreteTaskInstance, 'runAt' | 'startedAt' | 'schedule'>,
-  taskDelayThresholdForPreciseScheduling: number = 0
+  taskDelayThresholdForPreciseScheduling: number = 0,
+  logger: Logger
 ): Date {
   const taskDelay = startedAt!.getTime() - runAt.getTime();
   const scheduleFromDate = taskDelay < taskDelayThresholdForPreciseScheduling ? runAt : startedAt!;
 
-  // Ensure we also don't schedule in the past by performing the Math.max with Date.now()
-  const nextCalculatedRunAt = Math.max(
-    intervalFromDate(scheduleFromDate, schedule!.interval)!.getTime(),
-    Date.now()
-  );
+  const { rrule, interval } = schedule || {};
+  let nextCalculatedRunAt: number;
+
+  try {
+    let nextRunAt: Date | undefined | null;
+
+    if (interval) {
+      nextRunAt = intervalFromDate(scheduleFromDate, interval);
+    } else if (rrule) {
+      const _rrule = new RRule({
+        ...rrule,
+        dtstart: scheduleFromDate,
+      });
+      // adding 1ms to ensure the next run is always in the future
+      // if scheduleFromDate is equal to now (very low possibility), the next run will be now again, which causes loops
+      nextRunAt = _rrule.after(new Date(Date.now() + 1));
+    }
+    // Ensure we also don't schedule in the past by performing the Math.max with Date.now
+    nextCalculatedRunAt = Math.max(nextRunAt!.getTime(), Date.now());
+  } catch (e) {
+    logger.error(
+      `The next runAt for the task with a fixed time schedule could not be calculated: ${e}`
+    );
+    throw e;
+  }
 
   return new Date(nextCalculatedRunAt);
 }

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.test.ts
@@ -1168,7 +1168,7 @@ describe('TaskManagerRunner', () => {
       const schedule = {
         interval: '1m',
       };
-      const { instance, runner, store } = await readyToRunStageSetup({
+      const { instance, runner, store, logger } = await readyToRunStageSetup({
         instance: {
           status: TaskStatus.Running,
           startedAt: new Date(),
@@ -1195,7 +1195,8 @@ describe('TaskManagerRunner', () => {
 
       expect(getNextRunAtSpy).toHaveBeenCalledWith(
         expect.objectContaining({ schedule }),
-        expect.any(Number)
+        expect.any(Number),
+        logger
       );
     });
 

--- a/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_running/task_runner.ts
@@ -677,7 +677,8 @@ export class TaskManagerRunner implements TaskRunner {
                   startedAt: this.instance.task.startedAt,
                   schedule: updatedTaskSchedule,
                 },
-                this.getPollInterval()
+                this.getPollInterval(),
+                this.logger
               ),
             state,
             schedule: updatedTaskSchedule,

--- a/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
+++ b/x-pack/platform/plugins/shared/task_manager/server/task_store.ts
@@ -63,6 +63,7 @@ import { MsearchError } from './lib/msearch_error';
 import { BulkUpdateError } from './lib/bulk_update_error';
 import { TASK_SO_NAME } from './saved_objects';
 import { getApiKeyAndUserScope } from './lib/api_key_utils';
+import { getFirstRunAt } from './lib/get_first_run_at';
 
 export interface StoreOpts {
   esClient: ElasticsearchClient;
@@ -150,6 +151,7 @@ export class TaskStore {
   private security: SecurityServiceStart;
   private canEncryptSavedObjects?: boolean;
   private spaces?: SpacesPluginStart;
+  private logger: Logger;
 
   /**
    * Constructs a new TaskStore.
@@ -184,6 +186,7 @@ export class TaskStore {
     this.security = opts.security;
     this.spaces = opts.spaces;
     this.canEncryptSavedObjects = opts.canEncryptSavedObjects;
+    this.logger = opts.logger;
   }
 
   public registerEncryptedSavedObjectsClient(client: EncryptedSavedObjectsClient) {
@@ -314,16 +317,21 @@ export class TaskStore {
       const id = taskInstance.id || v4();
       const validatedTaskInstance =
         this.taskValidator.getValidatedTaskInstanceForUpdating(taskInstance);
+
       savedObject = await soClient.create<SerializedConcreteTaskInstance>(
         'task',
         {
           ...taskInstanceToAttributes(validatedTaskInstance, id),
           ...(userScope ? { userScope } : {}),
           ...(apiKey ? { apiKey } : {}),
+          runAt: getFirstRunAt({ taskInstance: validatedTaskInstance, logger: this.logger }),
         },
         { id, refresh: false }
       );
-      if (get(taskInstance, 'schedule.interval', null) == null) {
+      if (
+        get(taskInstance, 'schedule.interval', null) == null &&
+        get(taskInstance, 'schedule.rrule', null) == null
+      ) {
         this.adHocTaskCounter.increment();
       }
     } catch (e) {
@@ -355,12 +363,14 @@ export class TaskStore {
       this.definitions.ensureHas(taskInstance.taskType);
       const validatedTaskInstance =
         this.taskValidator.getValidatedTaskInstanceForUpdating(taskInstance);
+
       return {
         type: 'task',
         attributes: {
           ...taskInstanceToAttributes(validatedTaskInstance, id),
           ...(apiKey ? { apiKey } : {}),
           ...(userScope ? { userScope } : {}),
+          runAt: getFirstRunAt({ taskInstance: validatedTaskInstance, logger: this.logger }),
         },
         id,
       };

--- a/x-pack/platform/plugins/shared/task_manager/tsconfig.json
+++ b/x-pack/platform/plugins/shared/task_manager/tsconfig.json
@@ -35,7 +35,8 @@
     "@kbn/encrypted-saved-objects-shared",
     "@kbn/core-saved-objects-api-server-mocks",
     "@kbn/core-http-server-utils",
-    "@kbn/rrule"
+    "@kbn/rrule",
+    "@kbn/logging-mocks"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/init_routes.ts
+++ b/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/init_routes.ts
@@ -40,9 +40,22 @@ const taskSchema = schema.object({
     enabled: schema.boolean({ defaultValue: true }),
     taskType: schema.string(),
     schedule: schema.maybe(
-      schema.object({
-        interval: schema.string(),
-      })
+      schema.oneOf([
+        schema.object({
+          interval: schema.string(),
+        }),
+        schema.object({
+          rrule: schema.object({
+            freq: schema.number(),
+            interval: schema.number(),
+            tzid: schema.string({ defaultValue: 'UTC' }),
+            byhour: schema.maybe(schema.arrayOf(schema.number({ min: 0, max: 23 }))),
+            byminute: schema.maybe(schema.arrayOf(schema.number({ min: 0, max: 59 }))),
+            byweekday: schema.maybe(schema.arrayOf(schema.number({ min: 1, max: 7 }))),
+            bymonthday: schema.maybe(schema.arrayOf(schema.number({ min: 1, max: 31 }))),
+          }),
+        }),
+      ])
     ),
     interval: schema.maybe(schema.string()),
     params: schema.recordOf(schema.string(), schema.any(), { defaultValue: {} }),

--- a/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
+++ b/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
@@ -110,6 +110,42 @@ export class SampleTaskManagerFixturePlugin
           },
         },
       },
+      sampleRecurringTask: {
+        timeout: '1m',
+        title: 'Sample Recurring Task',
+        description: 'A sample recurring task for testing the task_manager.',
+        stateSchemaByVersion: {
+          1: {
+            up: (state: Record<string, unknown>) => ({ count: state.count }),
+            schema: schema.object({
+              count: schema.maybe(schema.number()),
+            }),
+          },
+        },
+        createTaskRunner: ({ taskInstance }: { taskInstance: ConcreteTaskInstance }) => ({
+          async run() {
+            const { params, state, schedule } = taskInstance;
+
+            const [{ elasticsearch }] = await core.getStartServices();
+            await elasticsearch.client.asInternalUser.index({
+              index: '.kibana_task_manager_test_result',
+              document: {
+                type: 'task',
+                taskId: taskInstance.id,
+                params: JSON.stringify(params),
+                state: JSON.stringify(state),
+                ranAt: new Date(),
+              },
+              refresh: true,
+            });
+
+            return {
+              state: {},
+              schedule,
+            };
+          },
+        }),
+      },
       singleAttemptSampleTask: {
         ...defaultSampleTaskConfig,
         title: 'Failing Sample Task',

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -27,6 +27,7 @@ export default function ({ getService }: FtrProviderContext) {
     'sampleRecurringTaskWhichHangs',
     'sampleRecurringTaskThatDeletesItself',
     'sampleTask',
+    'sampleRecurringTask',
     'sampleTaskWithLimitedConcurrency',
     'sampleTaskWithSingleConcurrency',
     'sampleTaskSharedConcurrencyType1',

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/task_management.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/task_management.ts
@@ -10,7 +10,11 @@ import { random } from 'lodash';
 import expect from '@kbn/expect';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { taskMappings as TaskManagerMapping } from '@kbn/task-manager-plugin/server/saved_objects/mappings';
-import { ConcreteTaskInstance, BulkUpdateTaskResult } from '@kbn/task-manager-plugin/server';
+import {
+  ConcreteTaskInstance,
+  BulkUpdateTaskResult,
+  Frequency,
+} from '@kbn/task-manager-plugin/server';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 const { properties: taskManagerIndexMapping } = TaskManagerMapping;
@@ -265,6 +269,71 @@ export default function ({ getService }: FtrProviderContext) {
         .send({ event: taskId, data })
         .expect(200);
     }
+    it('should schedule a task with rrule', async () => {
+      const dailyTask = await scheduleTask({
+        id: 'sample-recurring-task-id',
+        taskType: 'sampleRecurringTask',
+        schedule: { rrule: { freq: Frequency.DAILY, tzid: 'UTC', interval: 1 } },
+        params: {},
+      });
+
+      await retry.try(async () => {
+        const history = await historyDocs();
+        expect(history.length).to.eql(1);
+      });
+
+      await retry.try(async () => {
+        const task = await currentTask(dailyTask.id);
+        expect(task.status).to.be('idle');
+        const runAt = new Date(task.runAt).getTime();
+        const scheduledAt = new Date(task.scheduledAt).getTime();
+        // scheduled to run 24 hours from now
+        expect(runAt).to.greaterThan(scheduledAt + 1000 * 59 * 60 * 24);
+        expect(runAt).to.lessThan(scheduledAt + 1000 * 61 * 60 * 24);
+      });
+    });
+
+    it('should schedule a task with rrule with fixed time', async () => {
+      const dailyTask = await scheduleTask({
+        id: 'sample-recurring-task-id',
+        taskType: 'sampleRecurringTask',
+        schedule: {
+          rrule: { freq: Frequency.DAILY, tzid: 'UTC', interval: 1, byhour: [15], byminute: [27] },
+        },
+        params: {},
+      });
+
+      await retry.try(async () => {
+        const task = await currentTask(dailyTask.id);
+        expect(task.status).to.be('idle');
+        const runAt = new Date(task.runAt);
+        expect(runAt.getUTCHours()).to.be(15);
+        expect(runAt.getUTCMinutes()).to.be(27);
+      });
+
+      // should not run immediately as the task is scheduled to run at 15:27 UTC
+      expect((await historyDocs()).length).to.eql(0);
+    });
+
+    it('should not schedule a task with invalid rrule config', async () => {
+      await supertest
+        .post('/api/sample_tasks/schedule')
+        .set('kbn-xsrf', 'xxx')
+        .send({
+          id: 'sample-recurring-task-id',
+          taskType: 'sampleRecurringTask',
+          schedule: {
+            rrule: {
+              freq: Frequency.DAILY,
+              interval: 1,
+              byhour: [30], // invalid
+              byminute: [27],
+            },
+          },
+          params: {},
+        })
+        .expect(400);
+    });
 
     it('should support middleware', async () => {
       const historyItem = random(1, 100);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Support rrule for task scheduling (#217728)](https://github.com/elastic/kibana/pull/217728)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ersin Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-07T12:39:11Z","message":"Support rrule for task scheduling (#217728)\n\nResolves: https://github.com/elastic/kibana/issues/216308\n\nThis PR adds rrule notation support to the task scheduling.\n\nCurrently we use a simple interval string (such as `1h` or `45m`) to\ncalculate the next `runAt` that we use to decide if the task should be\npicked up or not. With this PR, we will be able to use rrule as well.\n\nWe set the `runAt` field in 3 places:\n- At task creation: when the task is created for the first time, this is\nalways `now` if a specific runAt is not provided.\n- At task update. We update runAt on task update as well but only when\nit is provided. We don't update it when the schedule config changes.\n- After task run: to decide when the next run will be after a task is\nrun.\n\nThis PR modifies:\n- At task creation: It still uses the `runAt` when it is provided but\ncalculates a runAt by using rrule if the config has a fixed time (like\nevery day at 13:00) config. Becausethe task should not run immediately\nwhen there is a fixed time to run.\n- After task run: It calculates the next `runAt` with rrule when it is\nprovided.\n\nThis PR doesn't apply any change on `At task update` as it requires a\nfurther investigation and consideration. We will handle it with a\nfollow-on issue.\n\n## To verify:\nYou can use the test task `sampleRecurringTask` to test the feature.\nJust create a task with rrule in the schedule config.\nThen check the runAt field in the task SO to see if it is the expected\ndatetime.\nThen run the task one more time and check the new `runAt`\n\nI also used the usage reporting task in the actions plugin to test the\nfeature.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0878a095a556b09bd05695469539c25be2c3423d","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:ResponseOps","backport missing","release_note:feature","backport:version","v9.1.0","v8.19.0"],"title":"Support rrule for task scheduling","number":217728,"url":"https://github.com/elastic/kibana/pull/217728","mergeCommit":{"message":"Support rrule for task scheduling (#217728)\n\nResolves: https://github.com/elastic/kibana/issues/216308\n\nThis PR adds rrule notation support to the task scheduling.\n\nCurrently we use a simple interval string (such as `1h` or `45m`) to\ncalculate the next `runAt` that we use to decide if the task should be\npicked up or not. With this PR, we will be able to use rrule as well.\n\nWe set the `runAt` field in 3 places:\n- At task creation: when the task is created for the first time, this is\nalways `now` if a specific runAt is not provided.\n- At task update. We update runAt on task update as well but only when\nit is provided. We don't update it when the schedule config changes.\n- After task run: to decide when the next run will be after a task is\nrun.\n\nThis PR modifies:\n- At task creation: It still uses the `runAt` when it is provided but\ncalculates a runAt by using rrule if the config has a fixed time (like\nevery day at 13:00) config. Becausethe task should not run immediately\nwhen there is a fixed time to run.\n- After task run: It calculates the next `runAt` with rrule when it is\nprovided.\n\nThis PR doesn't apply any change on `At task update` as it requires a\nfurther investigation and consideration. We will handle it with a\nfollow-on issue.\n\n## To verify:\nYou can use the test task `sampleRecurringTask` to test the feature.\nJust create a task with rrule in the schedule config.\nThen check the runAt field in the task SO to see if it is the expected\ndatetime.\nThen run the task one more time and check the new `runAt`\n\nI also used the usage reporting task in the actions plugin to test the\nfeature.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0878a095a556b09bd05695469539c25be2c3423d"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217728","number":217728,"mergeCommit":{"message":"Support rrule for task scheduling (#217728)\n\nResolves: https://github.com/elastic/kibana/issues/216308\n\nThis PR adds rrule notation support to the task scheduling.\n\nCurrently we use a simple interval string (such as `1h` or `45m`) to\ncalculate the next `runAt` that we use to decide if the task should be\npicked up or not. With this PR, we will be able to use rrule as well.\n\nWe set the `runAt` field in 3 places:\n- At task creation: when the task is created for the first time, this is\nalways `now` if a specific runAt is not provided.\n- At task update. We update runAt on task update as well but only when\nit is provided. We don't update it when the schedule config changes.\n- After task run: to decide when the next run will be after a task is\nrun.\n\nThis PR modifies:\n- At task creation: It still uses the `runAt` when it is provided but\ncalculates a runAt by using rrule if the config has a fixed time (like\nevery day at 13:00) config. Becausethe task should not run immediately\nwhen there is a fixed time to run.\n- After task run: It calculates the next `runAt` with rrule when it is\nprovided.\n\nThis PR doesn't apply any change on `At task update` as it requires a\nfurther investigation and consideration. We will handle it with a\nfollow-on issue.\n\n## To verify:\nYou can use the test task `sampleRecurringTask` to test the feature.\nJust create a task with rrule in the schedule config.\nThen check the runAt field in the task SO to see if it is the expected\ndatetime.\nThen run the task one more time and check the new `runAt`\n\nI also used the usage reporting task in the actions plugin to test the\nfeature.\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0878a095a556b09bd05695469539c25be2c3423d"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->