### PR TITLE
🌊 Fix root stream check

### DIFF
--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/is_root.test.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/is_root.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { isRootStreamDefinition } from './is_root';
+
+describe('isRootStreamDefinition', () => {
+  it('returns true for a valid root wired stream definition', () => {
+    const validWired = {
+      name: 'logs',
+      description: '',
+      ingest: {
+        lifecycle: { inherit: {} },
+        processing: [],
+        wired: { fields: {}, routing: [] },
+      },
+    };
+    expect(isRootStreamDefinition(validWired)).toBe(true);
+  });
+
+  it('returns false for a wired stream definition with a non-root name', () => {
+    const nonRootWired = {
+      name: 'logs.bar',
+      description: '',
+      ingest: {
+        lifecycle: { inherit: {} },
+        processing: [],
+        wired: { fields: {}, routing: [] },
+      },
+    };
+    expect(isRootStreamDefinition(nonRootWired)).toBe(false);
+  });
+
+  it('returns false for an unwired stream definition even with a root name', () => {
+    const unwired = {
+      name: 'logs-test-default',
+      description: '',
+      ingest: {
+        lifecycle: { inherit: {} },
+        processing: [],
+        unwired: {},
+      },
+    };
+    expect(isRootStreamDefinition(unwired)).toBe(false);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/is_root.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/is_root.ts
@@ -9,8 +9,8 @@ import { Streams } from '../models/streams';
 import { createIsNarrowSchema } from '../shared/type_guards';
 
 export const isRootStreamDefinition = createIsNarrowSchema(
-  Streams.all.Definition.right,
-  Streams.all.Definition.right.refine((stream) => {
+  Streams.WiredStream.Definition.right,
+  Streams.WiredStream.Definition.right.refine((stream) => {
     return stream.name.split('.').length === 1;
   })
 );

--- a/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/is_root.ts
+++ b/x-pack/platform/packages/shared/kbn-streams-schema/src/helpers/is_root.ts
@@ -9,7 +9,7 @@ import { Streams } from '../models/streams';
 import { createIsNarrowSchema } from '../shared/type_guards';
 
 export const isRootStreamDefinition = createIsNarrowSchema(
-  Streams.WiredStream.Definition.right,
+  Streams.all.Definition.right,
   Streams.WiredStream.Definition.right.refine((stream) => {
     return stream.name.split('.').length === 1;
   })


### PR DESCRIPTION
`isRootStreamDefinition` didn't check properly for a root stream. A root stream is a wired stream that doesn't contain dots.

After this change:
* classic stream processing should be editable
* wired stream processing should be editable as long as not root stream
* root stream processing should be editable

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->