### PR TITLE
[Cloud Security] Cloud Security Posture - remove GCP required error state

### DIFF
--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
@@ -711,8 +711,6 @@ export const GcpInputVarFields = ({
                   onChange={(value) => {
                     onChange(credentialJSONFields.id, value);
                   }}
-                  errors={credentialJSONFieldsInvalid ? [credentialJSONError] : []}
-                  forceShowErrors={false}
                   isEditPage={isEditPage}
                 />
               </Suspense>

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/fleet_extensions/gcp_credentials_form/gcp_credential_form.tsx
@@ -577,28 +577,8 @@ export const GcpInputVarFields = ({
   };
 
   const organizationIdFields = getFieldById('gcp.organization_id');
-  const organizationIdValueInvalid = fieldIsInvalid(
-    organizationIdFields?.value,
-    hasInvalidRequiredVars
-  );
-  const organizationIdError = i18n.translate(
-    'xpack.csp.cspmIntegration.integration.fieldRequired',
-    {
-      defaultMessage: '{field} is required',
-      values: {
-        field: organizationIdFields?.label,
-      },
-    }
-  );
 
   const projectIdFields = getFieldById('gcp.project_id');
-  const projectIdValueInvalid = fieldIsInvalid(projectIdFields?.value, hasInvalidRequiredVars);
-  const projectIdError = i18n.translate('xpack.csp.cspmIntegration.integration.fieldRequired', {
-    defaultMessage: '{field} is required',
-    values: {
-      field: projectIdFields?.label,
-    },
-  });
 
   const credentialsTypeFields = getFieldById('gcp.credentials.type');
 
@@ -644,12 +624,7 @@ export const GcpInputVarFields = ({
     <div>
       <EuiForm component="form">
         {organizationIdFields && isOrganization && (
-          <EuiFormRow
-            fullWidth
-            label={gcpField.fields['gcp.organization_id'].label}
-            isInvalid={organizationIdValueInvalid}
-            error={organizationIdValueInvalid ? organizationIdError : undefined}
-          >
+          <EuiFormRow fullWidth label={gcpField.fields['gcp.organization_id'].label}>
             <EuiFieldText
               disabled={disabled}
               data-test-subj={CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.ORGANIZATION_ID}
@@ -657,17 +632,11 @@ export const GcpInputVarFields = ({
               fullWidth
               value={organizationIdFields.value || ''}
               onChange={(event) => onChange(organizationIdFields.id, event.target.value)}
-              isInvalid={organizationIdValueInvalid}
             />
           </EuiFormRow>
         )}
         {projectIdFields && (
-          <EuiFormRow
-            fullWidth
-            label={gcpField.fields['gcp.project_id'].label}
-            isInvalid={projectIdValueInvalid}
-            error={projectIdValueInvalid ? projectIdError : undefined}
-          >
+          <EuiFormRow fullWidth label={gcpField.fields['gcp.project_id'].label}>
             <EuiFieldText
               disabled={disabled}
               data-test-subj={CIS_GCP_INPUT_FIELDS_TEST_SUBJECTS.PROJECT_ID}
@@ -675,7 +644,6 @@ export const GcpInputVarFields = ({
               fullWidth
               value={projectIdFields.value || ''}
               onChange={(event) => onChange(projectIdFields.id, event.target.value)}
-              isInvalid={projectIdValueInvalid}
             />
           </EuiFormRow>
         )}


### PR DESCRIPTION
## Summary

Removed the error state from the project and organization ID fields in the GCP CSPM policy onboarding.

![Screenshot 2025-05-09 at 11 15 39 AM](https://github.com/user-attachments/assets/dcfbad90-c258-447e-9e9f-3372a5d6ede1)

### Testing

1. Using this branch's deployment or local instance navigate to the CSPM integration using version 1.13.1
2. Select GCP as the cloud provider
3. Switch between the options and organization and project ID fields should not be required to save a new policy. 


<!--ONMERGE {"backportTargets":["8.19","9.0"]} ONMERGE-->