### PR TITLE
[8.19] [Response Ops] [Dashboard] Create a rule from a dashboard ES|QL visualization (#217719)

### DIFF
--- a/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
+++ b/src/platform/packages/private/kbn-esql-editor/src/esql_editor.tsx
@@ -112,6 +112,7 @@ export const ESQLEditor = memo(function ESQLEditor({
   disableAutoFocus,
   controlsContext,
   esqlVariables,
+  expandToFitQueryOnMount,
 }: ESQLEditorProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const editorModel = useRef<monaco.editor.ITextModel>();
@@ -858,8 +859,14 @@ export const ESQLEditor = memo(function ESQLEditor({
                       monaco.KeyMod.CtrlCmd | monaco.KeyCode.Slash,
                       onCommentLine
                     );
-
                     setMeasuredEditorWidth(editor.getLayoutInfo().width);
+                    if (expandToFitQueryOnMount) {
+                      const lineHeight = editor.getOption(monaco.editor.EditorOption.lineHeight);
+                      const lineCount = editor.getModel()?.getLineCount() || 1;
+                      const padding = lineHeight * 1.25; // Extra line at the bottom, plus a bit more to compensate for hidden vertical scrollbars
+                      const height = editor.getTopForLineNumber(lineCount + 1) + padding;
+                      if (height > editorHeight) setEditorHeight(height);
+                    }
                     editor.onDidLayoutChange((layoutInfoEvent) => {
                       onLayoutChangeRef.current(layoutInfoEvent);
                     });

--- a/src/platform/packages/private/kbn-esql-editor/src/types.ts
+++ b/src/platform/packages/private/kbn-esql-editor/src/types.ts
@@ -84,6 +84,8 @@ export interface ESQLEditorProps {
   controlsContext?: ControlsContext;
   /** The available ESQL variables from the page context this editor was opened in */
   esqlVariables?: ESQLControlVariable[];
+  /** Resize the editor to fit the initially passed query on mount */
+  expandToFitQueryOnMount?: boolean;
 }
 
 export interface JoinIndicesAutocompleteResult {

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/index.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/index.ts
@@ -23,3 +23,5 @@ export * from './src/check_action_type_enabled';
 export * from './src/action_variables';
 
 export { useFetchFlappingSettings } from './src/common/hooks/use_fetch_flapping_settings';
+
+export type { AlertRuleFromVisUIActionData } from './src/alert_rule_from_vis_ui_action/types';

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_rule_from_vis_ui_action/types.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_rule_from_vis_ui_action/types.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+export interface AlertRuleFromVisUIActionData {
+  query: string | null;
+  thresholdValues: Array<{ values: Record<string, number | string>; yField: string }>;
+  xValues: Record<string, string | number | null | undefined>;
+  usesPlaceholderValues?: boolean;
+}

--- a/src/platform/packages/shared/kbn-ui-actions-browser/src/triggers/alert_rule_trigger.ts
+++ b/src/platform/packages/shared/kbn-ui-actions-browser/src/triggers/alert_rule_trigger.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { i18n } from '@kbn/i18n';
+import { Trigger } from '.';
+
+export const ALERT_RULE_TRIGGER = 'alertRule';
+
+export const alertRuleTrigger: Trigger = {
+  id: ALERT_RULE_TRIGGER,
+  title: i18n.translate('uiActions.triggers.dashboard.alertRule.title', {
+    defaultMessage: 'Create alert rule',
+  }),
+  description: i18n.translate('uiActions.triggers.dashboard.alertRule.description', {
+    defaultMessage: 'Create an alert rule from this dashboard panel',
+  }),
+};

--- a/src/platform/packages/shared/kbn-ui-actions-browser/src/triggers/index.ts
+++ b/src/platform/packages/shared/kbn-ui-actions-browser/src/triggers/index.ts
@@ -13,3 +13,4 @@ export * from './default_trigger';
 export * from './visualize_field_trigger';
 export * from './visualize_geo_field_trigger';
 export * from './dashboard_app_panel_trigger';
+export * from './alert_rule_trigger';

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_definition.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_definition/rule_definition.tsx
@@ -24,6 +24,7 @@ import {
   EuiText,
   useEuiTheme,
   useEuiFontSize,
+  EuiTitle,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { RuleSpecificFlappingProperties } from '@kbn/alerting-types';
@@ -76,6 +77,9 @@ export const RuleDefinition = () => {
   const dispatch = useRuleFormDispatch();
 
   const ruleDefinitionContainerCss = css`
+    .ruleDefinitionHeader {
+      align-items: center;
+    }
     @container (max-width: 767px) {
       .euiDescribedFormGroup {
         flex-direction: column;
@@ -85,15 +89,12 @@ export const RuleDefinition = () => {
       }
       .ruleDefinitionHeader {
         flex-direction: column;
-        gap: ${euiTheme.size.m};
-      }
-      .ruleDefinitionHeaderRuleTypeName {
-        font-size: ${useEuiFontSize('m')}
-        margin-bottom: ${euiTheme.size.xs}
+        align-items: flex-start;
+        gap: ${euiTheme.size.xs};
       }
       .ruleDefinitionHeaderRuleTypeDescription,
       .ruleDefinitionHeaderDocsLink {
-        font-size: ${useEuiFontSize('s')};
+        ${useEuiFontSize('s')}
       }
     }
   `;
@@ -225,12 +226,12 @@ export const RuleDefinition = () => {
       <EuiSplitPanel.Inner color="subdued">
         <EuiFlexGroup gutterSize="s" className="ruleDefinitionHeader">
           <EuiFlexItem grow={false} data-test-subj="ruleDefinitionHeaderRuleTypeName">
-            <EuiText size="xs" className="ruleDefinitionHeaderRuleTypeName">
-              <strong>{selectedRuleType.name}</strong>
-            </EuiText>
+            <EuiTitle size="s" className="ruleDefinitionHeaderRuleTypeName">
+              <h3>{selectedRuleType.name}</h3>
+            </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false} data-test-subj="ruleDefinitionHeaderRuleTypeDescription">
-            <EuiText size="xs" className="ruleDefinitionHeaderRuleTypeDescription">
+            <EuiText size="s" className="ruleDefinitionHeaderRuleTypeDescription">
               <p>{selectedRuleTypeModel.description}</p>
             </EuiText>
           </EuiFlexItem>

--- a/src/platform/packages/shared/response-ops/rule_form/src/rule_details/rule_details.tsx
+++ b/src/platform/packages/shared/response-ops/rule_form/src/rule_details/rule_details.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
+import { css } from '@emotion/react';
 import {
   EuiDescribedFormGroup,
   EuiFormRow,
@@ -32,6 +33,17 @@ export const RuleDetails = () => {
   const dispatch = useRuleFormDispatch();
 
   const { tags = [], name } = formData;
+
+  const ruleDetailsContainerCss = css`
+    @container (max-width: 767px) {
+      &.euiDescribedFormGroup {
+        flex-direction: column;
+      }
+      &.euiDescribedFormGroup > .euiFlexItem {
+        width: 100%;
+      }
+    }
+  `;
 
   const tagsOptions = useMemo(() => {
     return tags.map((tag: string) => ({ label: tag }));
@@ -78,6 +90,7 @@ export const RuleDetails = () => {
 
   return (
     <EuiDescribedFormGroup
+      css={ruleDetailsContainerCss}
       fullWidth
       title={<h3>{RULE_DETAILS_TITLE}</h3>}
       description={

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/common/utils/log_datatables.ts
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/common/utils/log_datatables.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { DimensionType } from '@kbn/expressions-plugin/common';
 import { QueryPointEventAnnotationOutput } from '@kbn/event-annotation-plugin/common';
 import {
   Datatable,
@@ -14,7 +15,11 @@ import {
   ExecutionContext,
 } from '@kbn/expressions-plugin/common';
 import { ExpressionValueVisDimension } from '@kbn/visualizations-plugin/common';
-import { Dimension, prepareLogTable } from '@kbn/visualizations-plugin/common/utils';
+import {
+  Dimension,
+  LayerDimension,
+  prepareLogTable,
+} from '@kbn/visualizations-plugin/common/utils';
 import { LayerTypes, REFERENCE_LINE } from '../constants';
 import { strings } from '../i18n';
 import {
@@ -49,10 +54,12 @@ export const logDatatables = (
     layerDimensions.push([
       splitColumnAccessor ? [splitColumnAccessor] : undefined,
       strings.getSplitColumnHelp(),
+      DimensionType.SPLIT_COLUMN,
     ]);
     layerDimensions.push([
       splitRowAccessor ? [splitRowAccessor] : undefined,
       strings.getSplitRowHelp(),
+      DimensionType.SPLIT_ROW,
     ]);
 
     const logTable = prepareLogTable(layer.table, layerDimensions, true);
@@ -100,7 +107,7 @@ export const logDatatable = (
     handlers.inspectorAdapters.tables.reset();
     handlers.inspectorAdapters.tables.allowCsvExport = true;
 
-    const layerDimensions = layers.reduce<Dimension[]>((dimensions, layer) => {
+    const layerDimensions = layers.reduce<LayerDimension[]>((dimensions, layer) => {
       if (layer.layerType === LayerTypes.ANNOTATIONS || layer.type === REFERENCE_LINE) {
         return dimensions;
       }
@@ -111,10 +118,12 @@ export const logDatatable = (
     layerDimensions.push([
       splitColumnAccessor ? [splitColumnAccessor] : undefined,
       strings.getSplitColumnHelp(),
+      DimensionType.SPLIT_COLUMN,
     ]);
     layerDimensions.push([
       splitRowAccessor ? [splitRowAccessor] : undefined,
       strings.getSplitRowHelp(),
+      DimensionType.SPLIT_ROW,
     ]);
 
     const logTable = prepareLogTable(data, layerDimensions, true);
@@ -124,7 +133,7 @@ export const logDatatable = (
 
 export const getLayerDimensions = (
   layer: CommonXYDataLayerConfig | ReferenceLineLayerConfig
-): Dimension[] => {
+): LayerDimension[] => {
   let xAccessor;
   let splitAccessors;
   let markSizeAccessor;
@@ -139,9 +148,18 @@ export const getLayerDimensions = (
     [
       accessors ? accessors : undefined,
       layerType === LayerTypes.DATA ? strings.getMetricHelp() : strings.getReferenceLineHelp(),
+      layerType === LayerTypes.DATA ? DimensionType.Y_AXIS : DimensionType.REFERENCE_LINE,
     ],
-    [xAccessor ? [xAccessor] : undefined, strings.getXAxisHelp()],
-    [splitAccessors ? splitAccessors : undefined, strings.getBreakdownHelp()],
-    [markSizeAccessor ? [markSizeAccessor] : undefined, strings.getMarkSizeHelp()],
+    [xAccessor ? [xAccessor] : undefined, strings.getXAxisHelp(), DimensionType.X_AXIS],
+    [
+      splitAccessors ? splitAccessors : undefined,
+      strings.getBreakdownHelp(),
+      DimensionType.BREAKDOWN,
+    ],
+    [
+      markSizeAccessor ? [markSizeAccessor] : undefined,
+      strings.getMarkSizeHelp(),
+      DimensionType.MARK_SIZE,
+    ],
   ];
 };

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/components/xy_chart.test.tsx
@@ -152,6 +152,7 @@ describe('XYChart component', () => {
       renderComplete: jest.fn(),
       timeFormat: 'MMM D, YYYY @ HH:mm:ss.SSS',
       setChartSize: jest.fn(),
+      onCreateAlertRule: jest.fn(),
     };
   });
 

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/public/expression_renderers/xy_chart_renderer.tsx
@@ -37,6 +37,8 @@ import {
   extractVisualizationType,
 } from '@kbn/chart-expressions-common';
 
+import type { AlertRuleFromVisUIActionData } from '@kbn/alerts-ui-shared';
+import { ALERT_RULE_TRIGGER } from '@kbn/ui-actions-browser/src/triggers';
 import type { getDataLayers } from '../helpers';
 import { LayerTypes, SeriesTypes } from '../../common/constants';
 import type { CommonXYDataLayerConfig, XYChartProps } from '../../common';
@@ -232,6 +234,9 @@ export const getXyChartRenderer = ({
     const onClickMultiValue = (data: MultiFilterEvent['data']) => {
       handlers.event({ name: 'multiFilter', data });
     };
+    const onCreateAlertRule = (data: AlertRuleFromVisUIActionData) => {
+      handlers.event({ name: ALERT_RULE_TRIGGER, data });
+    };
     const setChartSize = (data: ChartSizeSpec) => {
       const event: ChartSizeEvent = { name: 'chartSize', data };
       handlers.event(event);
@@ -293,6 +298,7 @@ export const getXyChartRenderer = ({
             interactive={handlers.isInteractive()}
             onClickValue={onClickValue}
             onClickMultiValue={onClickMultiValue}
+            onCreateAlertRule={onCreateAlertRule}
             layerCellValueActions={layerCellValueActions}
             onSelectRange={onSelectRange}
             renderMode={handlers.getRenderMode()}

--- a/src/platform/plugins/shared/chart_expressions/expression_xy/tsconfig.json
+++ b/src/platform/plugins/shared/chart_expressions/expression_xy/tsconfig.json
@@ -37,6 +37,8 @@
     "@kbn/cell-actions",
     "@kbn/react-kibana-context-render",
     "@kbn/core-rendering-browser",
+    "@kbn/alerts-ui-shared",
+    "@kbn/ui-actions-browser",
     "@kbn/ebt-tools",
   ],
   "exclude": [

--- a/src/platform/plugins/shared/data/common/search/expressions/esql.ts
+++ b/src/platform/plugins/shared/data/common/search/expressions/esql.ts
@@ -371,9 +371,11 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
                           appliedTimeRange,
                           params: {},
                           indexPattern,
+                          sourceField: name,
                         }
                       : {
                           indexPattern,
+                          sourceField: name,
                         },
                 },
                 isNull: hasEmptyColumns ? !lookup.has(name) : false,

--- a/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
+++ b/src/platform/plugins/shared/expressions/common/expression_types/specs/datatable.ts
@@ -15,6 +15,16 @@ import { ExpressionTypeDefinition, ExpressionValueBoxed } from '../types';
 import { PointSeries, PointSeriesColumn } from './pointseries';
 import { ExpressionValueRender } from './render';
 
+export enum DimensionType {
+  Y_AXIS = 'y',
+  X_AXIS = 'x',
+  REFERENCE_LINE = 'reference',
+  BREAKDOWN = 'breakdown',
+  MARK_SIZE = 'markSize',
+  SPLIT_COLUMN = 'splitCol',
+  SPLIT_ROW = 'splitRow',
+}
+
 const name = 'datatable';
 
 /**
@@ -73,9 +83,13 @@ export interface DatatableColumnMeta {
    */
   index?: string;
   /**
-   * names the domain this column represents
+   * i18nized names the domain this column represents
    */
   dimensionName?: string;
+  /**
+   * types of dimension this column represents
+   */
+  dimensionType?: string;
   /**
    * serialized field format
    */

--- a/src/platform/plugins/shared/expressions/common/index.ts
+++ b/src/platform/plugins/shared/expressions/common/index.ts
@@ -93,6 +93,7 @@ export {
   isDatatable,
   ExpressionType,
   PointSeriesColumnNames,
+  DimensionType,
 } from './expression_types';
 export type {
   AnyExpressionTypeDefinition,

--- a/src/platform/plugins/shared/ui_actions/public/plugin.ts
+++ b/src/platform/plugins/shared/ui_actions/public/plugin.ts
@@ -14,6 +14,7 @@ import {
   visualizeFieldTrigger,
   visualizeGeoFieldTrigger,
   addPanelMenuTrigger,
+  alertRuleTrigger,
 } from '@kbn/ui-actions-browser/src/triggers';
 import { UiActionsService } from './service';
 import { setAnalytics, setI18n, setNotifications, setTheme, setUserProfile } from './services';
@@ -54,6 +55,7 @@ export class UiActionsPlugin
   public setup(_core: CoreSetup): UiActionsPublicSetup {
     this.service.registerTrigger(addPanelMenuTrigger);
     this.service.registerTrigger(rowClickTrigger);
+    this.service.registerTrigger(alertRuleTrigger);
     this.service.registerTrigger(visualizeFieldTrigger);
     this.service.registerTrigger(visualizeGeoFieldTrigger);
     return this.service;

--- a/src/platform/plugins/shared/visualizations/common/utils/index.ts
+++ b/src/platform/plugins/shared/visualizations/common/utils/index.ts
@@ -8,7 +8,7 @@
  */
 
 export { prepareLogTable } from './prepare_log_table';
-export type { Dimension } from './prepare_log_table';
+export type { Dimension, LayerDimension } from './prepare_log_table';
 export {
   findAccessor,
   findAccessorOrFail,

--- a/src/platform/plugins/shared/visualizations/common/utils/prepare_log_table.test.ts
+++ b/src/platform/plugins/shared/visualizations/common/utils/prepare_log_table.test.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { DimensionType } from '@kbn/expressions-plugin/common';
 import { prepareLogTable } from './prepare_log_table';
 
 describe('prepareLogTable', () => {
@@ -74,5 +75,51 @@ describe('prepareLogTable', () => {
       }
     `
     );
+  });
+  test('returns passed dimension types', () => {
+    const datatable = {
+      columns: [
+        {
+          meta: {},
+        },
+        {
+          meta: {},
+        },
+        {
+          id: 'd3',
+          meta: {},
+        },
+      ],
+    };
+    const logTable = prepareLogTable(datatable as any, [
+      [[{ accessor: 0 } as any], 'dimension1', DimensionType.Y_AXIS],
+      [[{ accessor: { id: 'd3' } } as any], 'dimension3', DimensionType.X_AXIS],
+      [[{ accessor: 1 } as any], 'dimension2', DimensionType.BREAKDOWN],
+    ]);
+    expect(logTable).toMatchInlineSnapshot(`
+      Object {
+        "columns": Array [
+          Object {
+            "meta": Object {
+              "dimensionName": "dimension1",
+              "dimensionType": "y",
+            },
+          },
+          Object {
+            "meta": Object {
+              "dimensionName": "dimension2",
+              "dimensionType": "breakdown",
+            },
+          },
+          Object {
+            "id": "d3",
+            "meta": Object {
+              "dimensionName": "dimension3",
+              "dimensionType": "x",
+            },
+          },
+        ],
+      }
+    `);
   });
 });

--- a/src/platform/plugins/shared/visualizations/common/utils/prepare_log_table.ts
+++ b/src/platform/plugins/shared/visualizations/common/utils/prepare_log_table.ts
@@ -7,13 +7,21 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { Datatable, DatatableColumn } from '@kbn/expressions-plugin/common/expression_types/specs';
+import {
+  Datatable,
+  DatatableColumn,
+  DimensionType,
+} from '@kbn/expressions-plugin/common/expression_types/specs';
 import { ExpressionValueVisDimension } from '../expression_functions/vis_dimension';
 import { ExpressionValueXYDimension } from '../expression_functions/xy_dimension';
 
 type DimensionColumn = ExpressionValueVisDimension | ExpressionValueXYDimension | string;
 
 export type Dimension = [DimensionColumn[] | undefined, string];
+export type LayerDimension = [DimensionColumn[] | undefined, string, DimensionType];
+const isLayerDimensions = (
+  dimensions: Dimension[] | LayerDimension[]
+): dimensions is LayerDimension[] => dimensions[0].length === 3;
 
 const isColumnEqualToAccessor = (
   column: DatatableColumn,
@@ -45,7 +53,7 @@ const getAccessorFromDimension = (dimension: DimensionColumn) => {
 const getDimensionName = (
   column: DatatableColumn,
   columnIndex: number,
-  dimensions: Dimension[]
+  dimensions: LayerDimension[] | Dimension[]
 ) => {
   for (const dimension of dimensions) {
     if (
@@ -58,11 +66,28 @@ const getDimensionName = (
   }
 };
 
+const getDimensionType = (
+  column: DatatableColumn,
+  columnIndex: number,
+  dimensions: LayerDimension[]
+) => {
+  for (const dimension of dimensions) {
+    if (
+      dimension[0]?.find((d) =>
+        isColumnEqualToAccessor(column, columnIndex, getAccessorFromDimension(d))
+      )
+    ) {
+      return dimension[2];
+    }
+  }
+};
+
 export const prepareLogTable = (
   datatable: Datatable,
-  dimensions: Dimension[],
+  dimensions: LayerDimension[] | Dimension[],
   removeUnmappedColumns: boolean = false
 ) => {
+  const hasLayerDimensions = isLayerDimensions(dimensions);
   return {
     ...datatable,
     columns: datatable.columns
@@ -72,6 +97,9 @@ export const prepareLogTable = (
           meta: {
             ...column.meta,
             dimensionName: getDimensionName(column, columnIndex, dimensions),
+            ...(hasLayerDimensions
+              ? { dimensionType: getDimensionType(column, columnIndex, dimensions) }
+              : {}),
           },
         };
       })

--- a/src/platform/plugins/shared/visualizations/public/embeddable/events.ts
+++ b/src/platform/plugins/shared/visualizations/public/embeddable/events.ts
@@ -14,6 +14,7 @@ import {
   VALUE_CLICK_TRIGGER,
   MULTI_VALUE_CLICK_TRIGGER,
 } from '@kbn/embeddable-plugin/public';
+import { ALERT_RULE_TRIGGER } from '@kbn/ui-actions-browser/src/triggers';
 
 export interface VisEventToTrigger {
   ['applyFilter']: typeof APPLY_FILTER_TRIGGER;
@@ -21,6 +22,7 @@ export interface VisEventToTrigger {
   ['filter']: typeof VALUE_CLICK_TRIGGER;
   ['multiFilter']: typeof MULTI_VALUE_CLICK_TRIGGER;
   ['tableRowContextMenuClick']: typeof ROW_CLICK_TRIGGER;
+  ['alertRule']: typeof ALERT_RULE_TRIGGER;
 }
 
 export const VIS_EVENT_TO_TRIGGER: VisEventToTrigger = {
@@ -29,4 +31,5 @@ export const VIS_EVENT_TO_TRIGGER: VisEventToTrigger = {
   filter: VALUE_CLICK_TRIGGER,
   multiFilter: MULTI_VALUE_CLICK_TRIGGER,
   tableRowContextMenuClick: ROW_CLICK_TRIGGER,
+  alertRule: ALERT_RULE_TRIGGER,
 };

--- a/src/platform/plugins/shared/visualizations/tsconfig.json
+++ b/src/platform/plugins/shared/visualizations/tsconfig.json
@@ -74,7 +74,8 @@
     "@kbn/embeddable-enhanced-plugin",
     "@kbn/content-management-utils",
     "@kbn/react-hooks",
-    "@kbn/presentation-panel-plugin"
+    "@kbn/presentation-panel-plugin",
+    "@kbn/ui-actions-browser",
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/lens/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/lens/kibana.jsonc
@@ -46,7 +46,8 @@
       "savedObjectsTagging",
       "spaces",
       "serverless",
-      "licensing"
+      "licensing",
+      "fieldsMetadata",
     ],
     "requiredBundles": [
       "unifiedSearch",

--- a/x-pack/platform/plugins/shared/lens/public/index.ts
+++ b/x-pack/platform/plugins/shared/lens/public/index.ts
@@ -92,6 +92,7 @@ export type {
   TimeScaleIndexPatternColumn,
   FormBasedLayer,
 } from './datasources/form_based/types';
+export type { TextBasedPersistedState } from './datasources/form_based/esql_layer/types';
 export type {
   XYArgs,
   XYRender,

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -67,6 +67,7 @@ import { i18n } from '@kbn/i18n';
 import type { ChartType } from '@kbn/visualization-utils';
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import { LicensingPluginStart } from '@kbn/licensing-plugin/public';
+import { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { EditorFrameService as EditorFrameServiceType } from './editor_frame_service';
 import type {
   FormBasedDatasource as FormBasedDatasourceType,
@@ -192,6 +193,7 @@ export interface LensPluginStartDependencies {
   serverless?: ServerlessPluginStart;
   licensing?: LicensingPluginStart;
   embeddableEnhanced?: EmbeddableEnhancedPluginStart;
+  fieldsMetadata?: FieldsMetadataPublicStart;
 }
 
 export interface LensPublicSetup {
@@ -693,6 +695,7 @@ export class LensPlugin {
       return getAddLensPanelAction(startDependencies);
     });
     startDependencies.uiActions.attachAction(ADD_PANEL_TRIGGER, 'addLensPanelAction');
+
     if (startDependencies.uiActions.hasTrigger('ADD_CANVAS_ELEMENT_TRIGGER')) {
       // Because Canvas is not enabled in Serverless, this trigger might not be registered - only attach
       // the create action if the Canvas-specific trigger does indeed exist.

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/on_event.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/expressions/on_event.ts
@@ -9,6 +9,7 @@ import { ExpressionRendererEvent } from '@kbn/expressions-plugin/public';
 import { VIS_EVENT_TO_TRIGGER } from '@kbn/visualizations-plugin/public';
 import { type AggregateQuery, type Query, isOfAggregateQueryType } from '@kbn/es-query';
 import {
+  isLensAlertRule,
   isLensBrushEvent,
   isLensEditEvent,
   isLensFilterEvent,
@@ -51,6 +52,19 @@ export const prepareEventHandler =
       eventHandler = callbacks.onFilter;
     } else if (isLensTableRowContextMenuClickEvent(event)) {
       eventHandler = callbacks.onTableRowClick;
+    } else if (isLensAlertRule(event)) {
+      // TODO: here is where we run the uiActions on the embeddable for the alert rule
+      eventHandler = callbacks.onAlertRule;
+      if (shouldExecuteDefaultTriggers) {
+        // this runs the function that we define in addTriggerAction in the plugin.ts file in alertRulesDefinition
+        uiActions.getTrigger(VIS_EVENT_TO_TRIGGER[event.name]).exec(
+          {
+            data: event.data,
+            embeddable: api,
+          },
+          true
+        );
+      }
     }
     const currentState = getState();
 

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_alert_rules.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_alert_rules.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { last } from 'lodash';
+import React from 'react';
+import type { ActionTypeRegistryContract, RuleTypeRegistryContract } from '@kbn/alerts-ui-shared';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { BehaviorSubject } from 'rxjs';
+import { createEsqlVariablesApi, makeEmbeddableServices } from '../mocks';
+import { initializeAlertRules } from './initialize_alert_rules';
+import { ESQLVariableType } from '@kbn/esql-types';
+
+const mockRender = render;
+const mockRuleFormFlyout = jest.fn((props) => <div data-test-subj={props['data-test-subj']} />);
+jest.mock('@kbn/react-kibana-mount', () => ({
+  toMountPoint: jest.fn((node: ReactNode) => mockRender(node)),
+}));
+
+jest.mock('@kbn/response-ops-rule-form/flyout', () => ({
+  RuleFormFlyout: (...args: Parameters<typeof mockRuleFormFlyout>) => mockRuleFormFlyout(...args),
+}));
+const ruleTypeRegistry: jest.Mocked<RuleTypeRegistryContract> = {
+  has: jest.fn(),
+  register: jest.fn(),
+  get: jest.fn(),
+  list: jest.fn(),
+};
+const actionTypeRegistry: jest.Mocked<ActionTypeRegistryContract> = {
+  has: jest.fn(),
+  register: jest.fn(),
+  get: jest.fn(),
+  list: jest.fn(),
+};
+const parentApiMock = {
+  ...createEsqlVariablesApi(),
+};
+
+const startDependenciesMock = makeEmbeddableServices(new BehaviorSubject<string>(''), undefined, {
+  visOverrides: { id: 'lnsXY' },
+  dataOverrides: { id: 'formBased' },
+});
+
+const uuid = '000-000-000';
+
+const getLastCalledInitialValues = () => last(mockRuleFormFlyout.mock.calls)![0].initialValues;
+
+describe('Alert rules API', () => {
+  const { api } = initializeAlertRules(uuid, parentApiMock, startDependenciesMock);
+
+  describe('createAlertRule', () => {
+    it('should pass initial values to the rule form and open it', async () => {
+      api.createAlertRule(
+        {
+          params: {
+            searchType: 'esqlQuery',
+            esqlQuery: {
+              esql: 'FROM index | STATS `number of documents` = COUNT(*)',
+            },
+          },
+        },
+        ruleTypeRegistry,
+        actionTypeRegistry
+      );
+      expect(await screen.findByTestId('lensEmbeddableRuleForm')).toBeInTheDocument();
+      expect(getLastCalledInitialValues()).toMatchInlineSnapshot(`
+        Object {
+          "name": "Elasticsearch query rule from visualization",
+          "params": Object {
+            "esqlQuery": Object {
+              "esql": "FROM index | STATS \`number of documents\` = COUNT(*)",
+            },
+            "searchType": "esqlQuery",
+          },
+        }
+      `);
+    });
+
+    it('should parse esql variables in the query', async () => {
+      parentApiMock.esqlVariables$.next([
+        { type: ESQLVariableType.FIELDS, key: 'field', value: 'field.zero' },
+        { type: ESQLVariableType.FIELDS, key: 'field1', value: 'field.one' },
+        { type: ESQLVariableType.TIME_LITERAL, key: 'interval', value: '5 minutes' },
+      ]);
+      api.createAlertRule(
+        {
+          params: {
+            searchType: 'esqlQuery',
+            esqlQuery: {
+              // Put ??field1 before ??field intentionally; /field/ is a part of /field1/ so we want to ensure
+              // regexp logic doesn't accidentally replace /??field/1 instead of /??field1/
+              esql: 'FROM index | STATS aggregatedFields = ??field1, ??field BY BUCKET(@timestamp, ?interval)',
+            },
+          },
+        },
+        ruleTypeRegistry,
+        actionTypeRegistry
+      );
+      expect(await screen.findByTestId('lensEmbeddableRuleForm')).toBeInTheDocument();
+      expect(getLastCalledInitialValues()).toMatchInlineSnapshot(`
+        Object {
+          "name": "Elasticsearch query rule from visualization",
+          "params": Object {
+            "esqlQuery": Object {
+              "esql": "FROM index | STATS aggregatedFields = field.one, field.zero BY BUCKET(@timestamp, 5 minutes)",
+            },
+            "searchType": "esqlQuery",
+          },
+        }
+      `);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_alert_rules.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_alert_rules.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { escapeRegExp } from 'lodash';
+import type { ActionTypeRegistryContract } from '@kbn/alerts-ui-shared';
+import { ESQLControlVariable, apiPublishesESQLVariables } from '@kbn/esql-types';
+import { parse, Walker } from '@kbn/esql-ast';
+import type { AggregateQuery } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { tracksOverlays } from '@kbn/presentation-containers';
+import type { RuleTypeRegistryContract } from '@kbn/response-ops-rule-form';
+import { isValidRuleFormPlugins } from '@kbn/response-ops-rule-form/lib';
+import { ES_QUERY_ID } from '@kbn/rule-data-utils';
+import React from 'react';
+import type {
+  LensAlertRulesApi,
+  LensCreateAlertRuleInitialValues,
+  LensEmbeddableStartServices,
+} from '../types';
+import { mountInlinePanel } from '../inline_editing/mount';
+
+export function initializeAlertRules(
+  uuid: string,
+  parentApi: unknown,
+  startDependencies: LensEmbeddableStartServices
+): { api: LensAlertRulesApi } {
+  return {
+    api: {
+      createAlertRule: async (
+        passedInitialValues: LensCreateAlertRuleInitialValues,
+        ruleTypeRegistry: RuleTypeRegistryContract,
+        actionTypeRegistry: ActionTypeRegistryContract
+      ) => {
+        const { coreStart } = startDependencies;
+        const ruleFormPlugins = {
+          ...startDependencies,
+          ...coreStart,
+          http: startDependencies.coreHttp,
+        };
+        const canShowRuleForm =
+          isValidRuleFormPlugins(ruleFormPlugins) && ruleTypeRegistry && actionTypeRegistry;
+
+        if (!canShowRuleForm) {
+          throw new Error(
+            i18n.translate('xpack.lens.createAlertRuleError', {
+              defaultMessage: 'Unable to open the alert rule form, some services are missing',
+            })
+          );
+        }
+
+        const esqlVariables$ = apiPublishesESQLVariables(parentApi)
+          ? parentApi.esqlVariables$
+          : undefined;
+        let initialValues = { ...passedInitialValues };
+
+        const esqlVariables = esqlVariables$?.getValue() ?? [];
+        if (esqlVariables.length) {
+          initialValues = {
+            params: {
+              ...initialValues.params,
+              esqlQuery: parseEsqlVariables(initialValues.params?.esqlQuery, esqlVariables),
+            },
+          };
+        }
+
+        const overlayTracker = tracksOverlays(parentApi) ? parentApi : undefined;
+
+        const closeRuleForm = () => {
+          overlayTracker?.clearOverlays();
+        };
+
+        const { RuleFormFlyout } = await import('@kbn/response-ops-rule-form/flyout');
+
+        mountInlinePanel(
+          <KibanaContextProvider services={ruleFormPlugins}>
+            <RuleFormFlyout
+              data-test-subj="lensEmbeddableRuleForm"
+              plugins={{ ...ruleFormPlugins, ruleTypeRegistry, actionTypeRegistry }}
+              ruleTypeId={ES_QUERY_ID}
+              initialValues={{
+                ...initialValues,
+                name: i18n.translate('xpack.lens.embeddable.alertRuleTitle.defaultName', {
+                  defaultMessage: 'Elasticsearch query rule from visualization',
+                }),
+              }}
+              initialMetadata={{
+                isManagementPage: false,
+              }}
+              onCancel={closeRuleForm}
+              onSubmit={closeRuleForm}
+            />
+          </KibanaContextProvider>,
+          coreStart,
+          overlayTracker,
+          { dataTestSubj: 'lensAlertRule', uuid }
+        );
+      },
+    },
+  };
+}
+
+function parseEsqlVariables(query: AggregateQuery | undefined, variables: ESQLControlVariable[]) {
+  if (!query) return query;
+  let parsedQuery = query.esql;
+
+  const variableLookup: Record<string, string | number> = variables.reduce(
+    (result, { key, value }) => ({
+      ...result,
+      [key]: value,
+    }),
+    {}
+  );
+
+  const { root } = parse(query.esql);
+  const params = Walker.params(root);
+
+  params.forEach(({ value: variableName, text }) => {
+    if (variableName in variableLookup) {
+      const value = variableLookup[variableName];
+      // Do NOT use a global regexp, `params` lists all variables in the query in the order they occur, including duplicates
+      // We want to make sure we replace params one by one, in order, in case any param is a substring of a longer param
+      // e.g. ??field and ??field1
+      parsedQuery = parsedQuery.replace(new RegExp(escapeRegExp(text)), String(value));
+    }
+  });
+
+  return { esql: parsedQuery };
+}

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_edit.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/initializers/initialize_edit.tsx
@@ -31,7 +31,7 @@ import {
 import { extractInheritedViewModeObservable } from '../helper';
 import { prepareInlineEditPanel } from '../inline_editing/setup_inline_editing';
 import { setupPanelManagement } from '../inline_editing/panel_management';
-import { mountInlineEditPanel } from '../inline_editing/mount';
+import { mountInlinePanel } from '../inline_editing/mount';
 import { StateManagementConfig } from './initialize_state_management';
 import { apiPublishesInlineEditingCapabilities } from '../type_guards';
 import { SearchContextConfig } from './initialize_search_context';
@@ -244,7 +244,7 @@ export function initializeEditApi(
           onCancel: () => updateState({ ...firstState }),
         });
         if (ConfigPanel) {
-          mountInlineEditPanel(ConfigPanel, startDependencies.coreStart, overlayTracker, uuid);
+          mountInlinePanel(ConfigPanel, startDependencies.coreStart, overlayTracker, { uuid });
         }
       },
       /**

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/mount.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/inline_editing/mount.tsx
@@ -20,19 +20,27 @@ import { type UseEuiTheme } from '@elastic/eui';
  * @param uuid
  * @param container
  */
-export function mountInlineEditPanel(
-  ConfigPanel: JSX.Element,
+export function mountInlinePanel(
+  InlinePanel: JSX.Element,
   coreStart: CoreStart,
   overlayTracker: TracksOverlays | undefined,
-  uuid?: string,
-  container?: HTMLElement | null
+  {
+    container,
+    dataTestSubj,
+    uuid,
+  }: {
+    dataTestSubj?: string;
+    uuid?: string;
+    container?: HTMLElement | null;
+  } = {}
 ) {
+  const dataTestSubjFinal = dataTestSubj ?? 'customizeLens';
   if (container) {
-    ReactDOM.render(ConfigPanel, container);
+    ReactDOM.render(InlinePanel, container);
   } else {
     const handle = coreStart.overlays.openFlyout(
       toMountPoint(
-        React.cloneElement(ConfigPanel, {
+        React.cloneElement(InlinePanel, {
           closeFlyout: () => {
             overlayTracker?.clearOverlays();
             handle.close();
@@ -44,7 +52,7 @@ export function mountInlineEditPanel(
         className: 'lnsConfigPanel__overlay',
         css: inlineFlyoutStyles,
         size: 's',
-        'data-test-subj': 'customizeLens',
+        'data-test-subj': dataTestSubjFinal,
         type: 'push',
         paddingSize: 'm',
         maxWidth: 800,

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/lens_embeddable.tsx
@@ -35,6 +35,7 @@ import { initializeActionApi } from './initializers/initialize_actions';
 import { initializeIntegrations } from './initializers/initialize_integrations';
 import { initializeStateManagement } from './initializers/initialize_state_management';
 import { LensEmbeddableComponent } from './renderer/lens_embeddable_component';
+import { initializeAlertRules } from './initializers/initialize_alert_rules';
 
 export const createLensEmbeddableFactory = (
   services: LensEmbeddableStartServices
@@ -125,6 +126,8 @@ export const createLensEmbeddableFactory = (
         services
       );
 
+      const alertRulesConfig = initializeAlertRules(uuid, parentApi, services);
+
       /**
        * This is useful to have always the latest version of the state
        * at hand when calling callbacks or performing actions
@@ -189,6 +192,7 @@ export const createLensEmbeddableFactory = (
           ...integrationsConfig.api,
           ...stateConfig.api,
           ...dashboardConfig.api,
+          ...alertRulesConfig.api,
         }
       );
 

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/mocks/index.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/mocks/index.tsx
@@ -19,6 +19,8 @@ import { expressionsPluginMock } from '@kbn/expressions-plugin/public/mocks';
 import { embeddablePluginMock } from '@kbn/embeddable-plugin/public/mocks';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
 import { ReactExpressionRendererProps } from '@kbn/expressions-plugin/public';
+import { fieldsMetadataPluginPublicMock } from '@kbn/fields-metadata-plugin/public/mocks';
+import { ESQLControlVariable } from '@kbn/esql-types';
 import { EmbeddableDynamicActionsManager } from '@kbn/embeddable-enhanced-plugin/public/plugin';
 import { DOC_TYPE } from '../../../common/constants';
 import { createEmptyLensState } from '../helper';
@@ -79,6 +81,7 @@ function getDefaultLensApiMock() {
     getTypeDisplayName: jest.fn(() => 'Lens'),
     setTitle: jest.fn(),
     setHideTitle: jest.fn(),
+    createAlertRule: jest.fn(),
     phase$: new BehaviorSubject<PhaseEvent | undefined>({
       id: faker.random.uuid(),
       status: 'rendered',
@@ -207,6 +210,7 @@ export function makeEmbeddableServices(
           } as EmbeddableDynamicActionsManager)
       ),
     },
+    fieldsMetadata: fieldsMetadataPluginPublicMock.createStartContract(),
   };
 }
 
@@ -315,5 +319,11 @@ export function createUnifiedSearchApi(
     filters$: new BehaviorSubject<Filter[] | undefined>(filters),
     query$: new BehaviorSubject<Query | AggregateQuery | undefined>(query),
     timeRange$: new BehaviorSubject<TimeRange | undefined>(timeRange),
+  };
+}
+
+export function createEsqlVariablesApi() {
+  return {
+    esqlVariables$: new BehaviorSubject<ESQLControlVariable[]>([]),
   };
 }

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.test.tsx
@@ -6,7 +6,12 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { getLensApiMock, getLensInternalApiMock, getValidExpressionParams } from '../mocks';
+import {
+  getLensApiMock,
+  getLensInternalApiMock,
+  getValidExpressionParams,
+  makeEmbeddableServices,
+} from '../mocks';
 import { LensApi, LensInternalApi } from '../types';
 import { BehaviorSubject } from 'rxjs';
 import { PublishingSubject } from '@kbn/presentation-publishing';
@@ -32,6 +37,7 @@ function getDefaultProps({
     internalApi,
     api: getLensApiMock(apiOverrides),
     onUnmount: jest.fn(),
+    services: makeEmbeddableServices(),
   };
 }
 

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/renderer/lens_embeddable_component.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useBatchedPublishingSubjects } from '@kbn/presentation-publishing';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { ExpressionWrapper } from '../expression_wrapper';
 import { LensInternalApi, LensApi } from '../types';
 import { UserMessages } from '../user_messages/container';
@@ -58,9 +58,13 @@ export function LensEmbeddableComponent({
   const rootRef = useDispatcher(hasRendered, api);
 
   // Publish the data attributes only if avaialble/visible
-  const title = internalApi.getDisplayOptions()?.noPanelTitle
-    ? undefined
-    : { 'data-title': api.title$?.getValue() ?? api.defaultTitle$?.getValue() };
+  const title = useMemo(
+    () =>
+      internalApi.getDisplayOptions()?.noPanelTitle
+        ? undefined
+        : { 'data-title': api.title$?.getValue() ?? api.defaultTitle$?.getValue() },
+    [api.defaultTitle$, api.title$, internalApi]
+  );
   const description = api.description$?.getValue()
     ? {
         'data-description': api.description$?.getValue() ?? api.defaultDescription$?.getValue(),

--- a/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/react_embeddable/types.ts
@@ -64,6 +64,9 @@ import type { AllowedPartitionOverrides } from '@kbn/expression-partition-vis-pl
 import type { AllowedXYOverrides } from '@kbn/expression-xy-plugin/common';
 import type { Action } from '@kbn/ui-actions-plugin/public';
 import { PublishesSearchSession } from '@kbn/presentation-publishing/interfaces/fetch/publishes_search_session';
+import type { RuleFormData, RuleTypeRegistryContract } from '@kbn/response-ops-rule-form';
+import type { ActionTypeRegistryContract } from '@kbn/alerts-ui-shared';
+import { EsQueryRuleParams } from '@kbn/response-ops-rule-params/es_query';
 import { CanAddNewPanel } from '@kbn/presentation-containers';
 import type { LegacyMetricState } from '../../common';
 import type { LensDocument } from '../persistence';
@@ -228,6 +231,7 @@ export interface LensPublicCallbacks extends LensApiProps {
    * Let the consumer overwrite embeddable user messages
    */
   onBeforeBadgesRender?: (userMessages: UserMessage[]) => UserMessage[];
+  onAlertRule?: (data: unknown) => void;
 }
 
 /**
@@ -374,6 +378,15 @@ export interface LensInspectorAdapters {
   adapters$: PublishingSubject<Adapters>;
 }
 
+export type LensCreateAlertRuleInitialValues = Partial<RuleFormData<Partial<EsQueryRuleParams>>>;
+export interface LensAlertRulesApi {
+  createAlertRule: (
+    initialValues: LensCreateAlertRuleInitialValues,
+    ruleTypeRegistry: RuleTypeRegistryContract,
+    actionTypeRegistry: ActionTypeRegistryContract
+  ) => void;
+}
+
 export type LensApi = Simplify<
   DefaultEmbeddableApi<LensSerializedState> &
     // This is used by actions to operate the edit action
@@ -406,7 +419,8 @@ export type LensApi = Simplify<
     // Let the container know when the data has been loaded/updated
     LensInspectorAdapters &
     LensRequestHandlersProps &
-    LensApiCallbacks
+    LensApiCallbacks &
+    LensAlertRulesApi
 >;
 
 // This is an API only used internally to the embeddable but not exported elsewhere

--- a/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/in_app_embeddable_edit/in_app_embeddable_edit_action_helpers.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/trigger_actions/open_lens_config/in_app_embeddable_edit/in_app_embeddable_edit_action_helpers.tsx
@@ -15,7 +15,7 @@ import { DatasourceMap, VisualizationMap } from '../../../types';
 import { generateId } from '../../../id_generator';
 import { setupPanelManagement } from '../../../react_embeddable/inline_editing/panel_management';
 import { prepareInlineEditPanel } from '../../../react_embeddable/inline_editing/setup_inline_editing';
-import { mountInlineEditPanel } from '../../../react_embeddable/inline_editing/mount';
+import { mountInlinePanel } from '../../../react_embeddable/inline_editing/mount';
 import type { TypedLensByValueInput, LensRuntimeState } from '../../../react_embeddable/types';
 import type { LensChartLoadEvent } from './types';
 
@@ -92,6 +92,6 @@ export async function executeEditEmbeddableAction({
   });
   if (ConfigPanel) {
     // no need to pass the uuid in this use case
-    mountInlineEditPanel(ConfigPanel, core, undefined, undefined, container);
+    mountInlinePanel(ConfigPanel, core, undefined, { container });
   }
 }

--- a/x-pack/platform/plugins/shared/lens/public/types.ts
+++ b/x-pack/platform/plugins/shared/lens/public/types.ts
@@ -45,6 +45,7 @@ import { EventAnnotationGroupConfig } from '@kbn/event-annotation-common';
 import type { DraggingIdentifier, DragDropIdentifier, DropType } from '@kbn/dom-drag-drop';
 import type { AccessorConfig } from '@kbn/visualization-ui-components';
 import type { ChartSizeEvent } from '@kbn/chart-expressions-common';
+import { AlertRuleFromVisUIActionData } from '@kbn/alerts-ui-shared';
 import type { DateRange, LayerType, SortingHint } from '../common/types';
 import type {
   LensSortActionData,
@@ -1405,11 +1406,17 @@ export interface LensTableRowContextMenuEvent {
   data: RowClickContext['data'];
 }
 
+export interface LensAlertRulesEvent {
+  name: 'alertRule';
+  data: AlertRuleFromVisUIActionData;
+}
+
 export type TriggerEvent =
   | BrushTriggerEvent
   | ClickTriggerEvent
   | MultiClickTriggerEvent
-  | LensTableRowContextMenuEvent;
+  | LensTableRowContextMenuEvent
+  | LensAlertRulesEvent;
 
 export function isLensFilterEvent(event: ExpressionRendererEvent): event is ClickTriggerEvent {
   return event.name === 'filter';
@@ -1435,6 +1442,10 @@ export function isLensTableRowContextMenuClickEvent(
   event: ExpressionRendererEvent
 ): event is LensTableRowContextMenuEvent {
   return event.name === 'tableRowContextMenuClick';
+}
+
+export function isLensAlertRule(event: ExpressionRendererEvent): event is LensAlertRulesEvent {
+  return event.name === 'alertRule';
 }
 
 /**

--- a/x-pack/platform/plugins/shared/lens/tsconfig.json
+++ b/x-pack/platform/plugins/shared/lens/tsconfig.json
@@ -119,6 +119,12 @@
     "@kbn/core-capabilities-common",
     "@kbn/presentation-panel-plugin",
     "@kbn/esql-types",
+    "@kbn/fields-metadata-plugin",
+    "@kbn/response-ops-rule-form",
+    "@kbn/alerts-ui-shared",
+    "@kbn/rule-data-utils",
+    "@kbn/response-ops-rule-params",
+    "@kbn/esql-ast"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/esql_query_expression.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/esql_query_expression.tsx
@@ -116,6 +116,18 @@ export const EsqlQueryExpression: React.FC<
     [setRuleParams]
   );
 
+  const clearParam = useCallback(
+    (paramField: string) => {
+      setCurrentRuleParams((currentParams) => {
+        const nextParams = { ...currentParams };
+        delete nextParams[paramField];
+        return nextParams;
+      });
+      setRuleParams(paramField, undefined);
+    },
+    [setRuleParams]
+  );
+
   const setDefaultExpressionValues = () => {
     setRuleProperty('params', currentRuleParams);
     if (esqlQuery?.esql) {
@@ -213,24 +225,17 @@ export const EsqlQueryExpression: React.FC<
       if (!timeField && timestampField) {
         setParam('timeField', timestampField);
       }
+      if (!newTimeFieldOptions.find(({ value }) => value === timeField)) {
+        clearParam('timeField');
+      }
       setDetectedTimestamp(timestampField);
     },
-    [timeField, setParam, dataViews, http]
+    [timeField, setParam, clearParam, dataViews, http]
   );
 
   return (
     <Fragment>
-      <EuiFormRow
-        id="queryEditor"
-        data-test-subj="queryEsqlEditor"
-        fullWidth
-        label={
-          <FormattedMessage
-            id="xpack.stackAlerts.esQuery.ui.defineEsqlQueryPrompt"
-            defaultMessage="Define your query using ES|QL"
-          />
-        }
-      >
+      <EuiFormRow id="queryEditor" data-test-subj="queryEsqlEditor" fullWidth>
         <ESQLLangEditor
           query={query}
           onTextLangQueryChange={(q: AggregateQuery) => {
@@ -240,11 +245,12 @@ export const EsqlQueryExpression: React.FC<
           }}
           onTextLangQuerySubmit={async () => {}}
           detectedTimestamp={detectedTimestamp}
-          hideRunQueryText={true}
+          hideRunQueryText
+          hideRunQueryButton
           isLoading={isLoading}
           editorIsInline
+          expandToFitQueryOnMount
           hasOutline
-          hideRunQueryButton={true}
         />
       </EuiFormRow>
       <EuiSpacer />

--- a/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/expression.tsx
+++ b/x-pack/platform/plugins/shared/stack_alerts/public/rule_types/es_query/expression/expression.tsx
@@ -38,7 +38,7 @@ export const EsQueryRuleTypeExpression: React.FunctionComponent<
   const { ruleParams, errors, setRuleProperty, setRuleParams } = props;
   const isSearchSource = isSearchSourceRule(ruleParams);
   const isEsqlQuery = isEsqlQueryRule(ruleParams);
-  // metadata provided only when open alert from Discover page
+  // metadata provided only when the user opens the alert from the Discover page or a dashboard
   const isManagementPage = props.metadata?.isManagementPage ?? true;
 
   const formTypeSelected = useCallback(

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/kibana.jsonc
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/kibana.jsonc
@@ -32,7 +32,8 @@
       "lens",
       "controls",
       "embeddable",
-      "fieldsMetadata"
+      "fieldsMetadata",
+      "uiActions"
     ],
     "optionalPlugins": [
       "cloud",

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/alert_rule_from_vis_ui_action.test.tsx
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/alert_rule_from_vis_ui_action.test.tsx
@@ -1,0 +1,488 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ActionTypeRegistryContract, RuleTypeRegistryContract } from '@kbn/alerts-ui-shared';
+import type { LensApi } from '@kbn/lens-plugin/public';
+import { getLensApiMock } from '@kbn/lens-plugin/public/react_embeddable/mocks';
+import { DimensionType } from '@kbn/expressions-plugin/common';
+import { last } from 'lodash';
+import { BehaviorSubject } from 'rxjs';
+import { AlertRuleFromVisAction } from './alert_rule_from_vis_ui_action';
+
+const ruleTypeRegistry: jest.Mocked<RuleTypeRegistryContract> = {
+  has: jest.fn(),
+  register: jest.fn(),
+  get: jest.fn(),
+  list: jest.fn(),
+};
+const actionTypeRegistry: jest.Mocked<ActionTypeRegistryContract> = {
+  has: jest.fn(),
+  register: jest.fn(),
+  get: jest.fn(),
+  list: jest.fn(),
+};
+
+const embeddableMock = getLensApiMock({
+  serializeState: jest.fn(() => ({
+    rawState: {
+      attributes: {
+        state: {
+          datasourceStates: {
+            textBased: {
+              layers: [
+                {
+                  timeField: '@timestamp',
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  })) as unknown as LensApi['serializeState'],
+  getInspectorAdapters: jest.fn(() => ({
+    tables: {
+      tables: [],
+    },
+  })),
+}) as jest.Mocked<LensApi>;
+const getCreateAlertRuleLastCalledInitialValues = () =>
+  last(embeddableMock.createAlertRule.mock.calls)![0];
+
+describe('AlertRuleFromVisAction', () => {
+  const action = new AlertRuleFromVisAction(ruleTypeRegistry, actionTypeRegistry);
+  it("creates a rule with the visualization's ES|QL query plus an additional threshold line", () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query: 'FROM index | STATS count = COUNT(*)',
+        thresholdValues: [{ values: { count: 210 }, yField: 'count' }],
+        xValues: {},
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM index | STATS count = COUNT(*)
+      // Threshold automatically generated from the selected value on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE count >= 210",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  it('appends a single xValue to the threshold line with an AND operator', () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query: 'FROM index | STATS count = COUNT(*) BY uhhhhhhhh.field',
+        thresholdValues: [{ values: { count: 210 }, yField: 'count' }],
+        xValues: { 'uhhhhhhhh.field': 'zoop' },
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM index | STATS count = COUNT(*) BY uhhhhhhhh.field
+      // Threshold automatically generated from the selected value on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE uhhhhhhhh.field == \\"zoop\\" AND count >= 210",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  it('appends multiple fields in the threshold value with an AND operator', () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query: 'FROM index | STATS count = COUNT(*) BY uhhhhhhhh.field',
+        thresholdValues: [{ values: { count: 210, 'uhhhhhhhh.field': 'zoop' }, yField: 'count' }],
+        xValues: {},
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM index | STATS count = COUNT(*) BY uhhhhhhhh.field
+      // Threshold automatically generated from the selected value on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE uhhhhhhhh.field == \\"zoop\\" AND count >= 210",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  it('appends multiple thresholdValues threshold line in parentheses separated by OR operators', () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query: 'FROM index | KEEP geo.dest, bytes, memory, extension.keyword',
+        thresholdValues: [
+          { values: { bytes: 5000, 'extension.keyword': 'deb' }, yField: 'bytes' },
+          { values: { memory: 50000, 'extension.keyword': 'rpm' }, yField: 'memory' },
+        ],
+        xValues: { 'geo.dest': 'JP' },
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM index | KEEP geo.dest, bytes, memory, extension.keyword
+      // Threshold automatically generated from the selected values on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE geo.dest == \\"JP\\" AND ((extension.keyword == \\"deb\\" AND bytes >= 5000) OR (extension.keyword == \\"rpm\\" AND memory >= 50000))",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  it('converts an array xValue to MATCH queries', () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query: 'FROM index | KEEP tags, something.else',
+        thresholdValues: [{ values: { 'something.else': 3087 }, yField: 'something.else' }],
+        xValues: { tags: 'shibbity,bee,bop,doowop' },
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM index | KEEP tags, something.else
+      // Threshold automatically generated from the selected value on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE MATCH(tags, \\"shibbity\\") AND MATCH(tags, \\"bee\\") AND MATCH(tags, \\"bop\\") AND MATCH(tags, \\"doowop\\") AND something.else >= 3087",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  it('converts an array in a threshold value to MATCH queries', () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query: 'FROM index | KEEP something.else, @tags.keyword',
+        thresholdValues: [
+          {
+            values: {
+              'something.else': 3087,
+              '@tags.keyword': 'login,warning',
+            },
+            yField: 'something.else',
+          },
+        ],
+        xValues: {},
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM index | KEEP something.else, @tags.keyword
+      // Threshold automatically generated from the selected value on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE MATCH(@tags.keyword, \\"login\\") AND MATCH(@tags.keyword, \\"warning\\") AND something.else >= 3087",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  it('renders empty splitValues as empty strings', () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query: 'FROM index | KEEP tags, something.else',
+        thresholdValues: [
+          {
+            values: { 'something.else': 3087, tags: '' },
+            yField: 'something.else',
+          },
+        ],
+        xValues: {},
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM index | KEEP tags, something.else
+      // Threshold automatically generated from the selected value on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE tags == \\"\\" AND something.else >= 3087",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  it('escapes unnamed function columns', () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query:
+          'FROM index | RENAME bytes as `meow bytes` | STATS COUNT(*), PERCENTILE(owowo, 99), COUNT(`meow bytes`)',
+        thresholdValues: [
+          {
+            values: { 'COUNT(*)': 210 },
+            yField: 'COUNT(*)',
+          },
+          { values: { 'PERCENTILE(owowo, 99)': 42.6 }, yField: 'PERCENTILE(owowo, 99)' },
+          { values: { 'COUNT(`meow bytes`)': 1312 }, yField: 'COUNT(`meow bytes`)' },
+        ],
+        xValues: {},
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM index | RENAME bytes as \`meow bytes\` | STATS COUNT(*), PERCENTILE(owowo, 99), COUNT(\`meow bytes\`)
+      // Rename the following columns so they can be used as part of the alerting threshold:
+      | RENAME \`COUNT(*)\` as _count | RENAME \`PERCENTILE(owowo,99)\` as _percentile_owowo_99 | RENAME \`COUNT(\`\`meow bytes\`\`)\` as _count_meow_bytes 
+      // Threshold automatically generated from the selected values on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE _count >= 210 OR _percentile_owowo_99 >= 42.6 OR _count_meow_bytes >= 1312",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  it('does not duplicate function column renames when they are included in multiple threshold values', () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query:
+          'FROM logst* | RENAME bytes as `meow bytes` | STATS COUNT(`meow bytes`) BY clientip, extension',
+        thresholdValues: [
+          {
+            values: { 'COUNT(`meow bytes`)': 634, clientip: '131.250.144.62' },
+            yField: 'COUNT(`meow bytes`)',
+          },
+          {
+            values: { 'COUNT(`meow bytes`)': 682, clientip: '7.203.207.131' },
+            yField: 'COUNT(`meow bytes`)',
+          },
+        ],
+        xValues: { extension: 'jpg' },
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM logst* | RENAME bytes as \`meow bytes\` | STATS COUNT(\`meow bytes\`) BY clientip, extension
+      // Rename the following columns so they can be used as part of the alerting threshold:
+      | RENAME \`COUNT(\`\`meow bytes\`\`)\` as _count_meow_bytes 
+      // Threshold automatically generated from the selected values on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE extension == \\"jpg\\" AND ((clientip == \\"131.250.144.62\\" AND _count_meow_bytes >= 634) OR (clientip == \\"7.203.207.131\\" AND _count_meow_bytes >= 682))",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  it('escapes string values with backlashes in them', () => {
+    action.execute({
+      embeddable: embeddableMock,
+      data: {
+        query: 'FROM index | STATS count = COUNT(*) BY CATEGORIZE(message)',
+        thresholdValues: [
+          {
+            values: { 'COUNT(*)': 1 },
+            yField: 'COUNT(*)',
+          },
+        ],
+        xValues: {
+          'CATEGORIZE(message)':
+            '.*?GET .+?HTTP/1\\.1.+?Mozilla/5\\.0.+?X11.+?Linux.+?x86_64.+?rv.+?Gecko/20110421.+?Firefox/6\\.0a',
+        },
+      },
+    });
+    expect(getCreateAlertRuleLastCalledInitialValues()).toMatchInlineSnapshot(`
+      Object {
+        "params": Object {
+          "esqlQuery": Object {
+            "esql": "// Original ES|QL query derived from the visualization:
+      FROM index | STATS count = COUNT(*) BY CATEGORIZE(message)
+      // Rename the following columns so they can be used as part of the alerting threshold:
+      | RENAME \`COUNT(*)\` as _count | RENAME \`CATEGORIZE(message)\` as _categorize_message 
+      // Threshold automatically generated from the selected value on the chart. This rule will generate an alert based on the following conditions:
+      | WHERE _categorize_message == \\".*?GET .+?HTTP/1\\\\\\\\.1.+?Mozilla/5\\\\\\\\.0.+?X11.+?Linux.+?x86_64.+?rv.+?Gecko/20110421.+?Firefox/6\\\\\\\\.0a\\" AND _count >= 1",
+          },
+          "searchType": "esqlQuery",
+          "timeField": "@timestamp",
+        },
+      }
+    `);
+  });
+
+  describe('when executed without a data parameter', () => {
+    it('derives data from the embeddable and uses placeholder threshold values', () => {
+      const embeddable = getLensApiMock({
+        query$: new BehaviorSubject({
+          esql: 'FROM index | STATS count = COUNT(*)',
+        }),
+        getInspectorAdapters: jest.fn(() => ({
+          tables: {
+            tables: {
+              foo: {
+                columns: [
+                  {
+                    meta: {
+                      dimensionName: 'Vertical axis',
+                      dimensionType: DimensionType.Y_AXIS,
+                      sourceParams: { sourceField: 'count' },
+                      type: 'number',
+                    },
+                  },
+                  {
+                    meta: {
+                      dimensionName: 'Horizontal axis',
+                      dimensionType: DimensionType.X_AXIS,
+                      sourceParams: { sourceField: 'timestamp' },
+                      type: 'date',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })),
+        serializeState: jest.fn(() => ({
+          rawState: {
+            state: {
+              attributes: {
+                datasourceStates: {
+                  textBased: {
+                    layers: [
+                      {
+                        timeField: 'timestamp',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        })),
+      } as Partial<LensApi>) as jest.Mocked<LensApi>;
+      action.execute({ embeddable });
+      expect(last(embeddable.createAlertRule.mock.calls)![0]).toMatchInlineSnapshot(`
+        Object {
+          "params": Object {
+            "esqlQuery": Object {
+              "esql": "// Original ES|QL query derived from the visualization:
+        FROM index | STATS count = COUNT(*)
+        // Modify the following conditions to set an alert threshold for this rule:
+        | WHERE count >= [THRESHOLD]",
+            },
+            "searchType": "esqlQuery",
+            "timeField": "timestamp",
+          },
+        }
+      `);
+    });
+    it('uses placeholder split values when the X axis is not a timestamp', () => {
+      const embeddable = getLensApiMock({
+        query$: new BehaviorSubject({
+          esql: 'FROM index | STATS count = COUNT(*) BY group',
+        }),
+        getInspectorAdapters: jest.fn(() => ({
+          tables: {
+            tables: {
+              foo: {
+                columns: [
+                  {
+                    meta: {
+                      dimensionName: 'Vertical axis',
+                      dimensionType: DimensionType.Y_AXIS,
+                      sourceParams: { sourceField: 'count' },
+                      type: 'number',
+                    },
+                  },
+                  {
+                    meta: {
+                      dimensionName: 'Horizontal axis',
+                      dimensionType: DimensionType.X_AXIS,
+                      sourceParams: { sourceField: 'group' },
+                      type: 'keyword',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })),
+        serializeState: jest.fn(() => ({
+          rawState: {
+            state: {
+              attributes: {
+                datasourceStates: {
+                  textBased: {
+                    layers: [
+                      {
+                        timeField: 'timestamp',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        })),
+      } as Partial<LensApi>) as jest.Mocked<LensApi>;
+      action.execute({ embeddable });
+      expect(last(embeddable.createAlertRule.mock.calls)![0]).toMatchInlineSnapshot(`
+        Object {
+          "params": Object {
+            "esqlQuery": Object {
+              "esql": "// Original ES|QL query derived from the visualization:
+        FROM index | STATS count = COUNT(*) BY group
+        // Modify the following conditions to set an alert threshold for this rule:
+        | WHERE group == \\"[VALUE]\\" AND count >= [THRESHOLD]",
+            },
+            "searchType": "esqlQuery",
+            "timeField": "timestamp",
+          },
+        }
+      `);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/alert_rule_from_vis_ui_action.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/alert_rule_from_vis_ui_action.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type {
+  ActionTypeRegistryContract,
+  AlertRuleFromVisUIActionData,
+  RuleTypeRegistryContract,
+} from '@kbn/alerts-ui-shared';
+import { DimensionType } from '@kbn/expressions-plugin/common';
+import type { Datatable } from '@kbn/expressions-plugin/common';
+import { i18n } from '@kbn/i18n';
+import type { LensApi, TextBasedPersistedState } from '@kbn/lens-plugin/public';
+import { apiIsOfType, hasBlockingError } from '@kbn/presentation-publishing';
+import type { RuleFormData } from '@kbn/response-ops-rule-form';
+import type { EsQueryRuleParams } from '@kbn/response-ops-rule-params/es_query';
+import { ALERT_RULE_TRIGGER } from '@kbn/ui-actions-browser/src/triggers';
+import type { Action } from '@kbn/ui-actions-plugin/public';
+import { pick } from 'lodash';
+import { buildAdditionalQuery } from './build_additional_query';
+
+interface Context {
+  data?: AlertRuleFromVisUIActionData;
+  embeddable: LensApi;
+}
+
+export class AlertRuleFromVisAction implements Action<Context> {
+  private ruleTypeRegistry: RuleTypeRegistryContract;
+  private actionTypeRegistry: ActionTypeRegistryContract;
+
+  public type = ALERT_RULE_TRIGGER;
+  public id = ALERT_RULE_TRIGGER;
+
+  constructor(
+    ruleTypeRegistry: RuleTypeRegistryContract,
+    actionTypeRegistry: ActionTypeRegistryContract
+  ) {
+    this.ruleTypeRegistry = ruleTypeRegistry;
+    this.actionTypeRegistry = actionTypeRegistry;
+  }
+
+  public getIconType = () => 'bell';
+
+  public async isCompatible({ embeddable }: Context) {
+    const isLensApi = apiIsOfType(embeddable, 'lens');
+    if (!isLensApi || hasBlockingError(embeddable)) return false;
+    const query = embeddable.query$.getValue();
+    return Boolean(query && 'esql' in query);
+  }
+
+  public getDisplayName = () =>
+    i18n.translate('xpack.triggersActionsUI.alertRuleFromVis.actionName', {
+      defaultMessage: 'Create alert rule',
+    });
+
+  public shouldAutoExecute = async () => true;
+
+  public async execute({ embeddable, data }: Context) {
+    const embeddableData = data?.query
+      ? data
+      : data
+      ? {
+          ...data,
+          ...pick(getDataFromEmbeddable(embeddable), [
+            'query',
+            'dataView',
+            'usesPlaceholderValues',
+          ]),
+        }
+      : getDataFromEmbeddable(embeddable);
+    const { query } = embeddableData;
+
+    // Get the timeField, default to `timestamp` if it can't be found
+    const datatable = getDataTableFromEmbeddable(embeddable);
+    const dataView = query
+      ? undefined
+      : embeddable.dataViews$.getValue()?.find((view) => view.id === datatable?.meta?.source);
+    const { state } = embeddable.serializeState().rawState.attributes ?? {};
+    const layers = (state?.datasourceStates?.textBased as TextBasedPersistedState | undefined)
+      ?.layers;
+    const [firstLayer] = Object.values(layers ?? {});
+    const { timeField = 'timestamp' } = firstLayer ?? { timeField: dataView?.timeFieldName };
+
+    // Generate additional query to append to the base ES|QL query from the visualization
+    const additionalQuery = buildAdditionalQuery(embeddableData);
+
+    // Assemble the full ES|QL code
+    let initialValues: Partial<RuleFormData<Partial<EsQueryRuleParams>>>;
+    if (query) {
+      const queryHeader = i18n.translate(
+        'xpack.triggersActionsUI.alertRuleFromVis.queryHeaderComment',
+        {
+          defaultMessage: 'Original ES|QL query derived from the visualization:',
+        }
+      );
+
+      initialValues = {
+        params: {
+          searchType: 'esqlQuery',
+          esqlQuery: {
+            esql: `// ${queryHeader}\n${query}\n${additionalQuery}`,
+          },
+          timeField,
+        },
+      };
+    } else {
+      const missingQueryComment = `// ${i18n.translate(
+        'xpack.triggersActionsUI.alertRuleFromVis.missingQueryComment',
+        {
+          defaultMessage: 'Unable to generate an ES|QL query from the visualization.',
+        }
+      )}`;
+      let esql = missingQueryComment;
+
+      if (dataView) {
+        const [index] = dataView.matchedIndices;
+        const esqlFromDataviewComment = `// ${i18n.translate(
+          'xpack.triggersActionsUI.alertRuleFromVis.esqlFromDataviewComment',
+          {
+            defaultMessage:
+              'Unable to automatically generate an ES|QL query that produces the same data as this visualization. You may be able to reproduce it manually using this data source:',
+          }
+        )}`;
+        const dataViewQuery = `FROM ${index}`;
+        esql = `${esqlFromDataviewComment}\n${dataViewQuery}\n${additionalQuery}`;
+      }
+      initialValues = {
+        params: {
+          searchType: 'esqlQuery',
+          esqlQuery: {
+            esql,
+          },
+          timeField,
+        },
+      };
+    }
+
+    embeddable.createAlertRule(initialValues, this.ruleTypeRegistry, this.actionTypeRegistry);
+  }
+}
+
+const getDataTableFromEmbeddable = (embeddable: Context['embeddable']) =>
+  Object.values(embeddable.getInspectorAdapters().tables.tables ?? {})[0] as unknown as
+    | Datatable
+    | undefined;
+
+const getDataFromEmbeddable = (embeddable: Context['embeddable']): AlertRuleFromVisUIActionData => {
+  const queryValue = embeddable.query$.getValue();
+  const query = queryValue && 'esql' in queryValue ? queryValue.esql : null;
+  const datatable = getDataTableFromEmbeddable(embeddable);
+  const thresholdValues = datatable
+    ? datatable.columns
+        .filter((col) => col.meta.dimensionType === DimensionType.Y_AXIS)
+        .map(({ meta }) => {
+          const { sourceField = missingYFieldPlaceholder } = meta.sourceParams ?? {};
+          return {
+            values: {
+              [String(sourceField)]: i18n.translate(
+                'xpack.triggersActionsUI.alertRuleFromVis.thresholdPlaceholder',
+                {
+                  defaultMessage: '[THRESHOLD]',
+                }
+              ),
+            },
+            yField: String(sourceField),
+          };
+        })
+    : [];
+
+  const xColumns = datatable?.columns.filter(
+    (col) => col.meta.dimensionType === DimensionType.X_AXIS
+  );
+  const isTimeViz = xColumns?.some(({ meta }) => meta.type === 'date');
+  const xValues =
+    isTimeViz || !xColumns
+      ? {}
+      : xColumns.reduce((result, { meta }) => {
+          const { sourceField = missingXFieldPlaceholder } = meta.sourceParams ?? {};
+          return {
+            ...result,
+            [String(sourceField)]: [
+              i18n.translate('xpack.triggersActionsUI.alertRuleFromVis.splitValuePlaceholder', {
+                defaultMessage: '[VALUE]',
+              }),
+            ],
+          };
+        }, {});
+
+  return {
+    query,
+    xValues,
+    thresholdValues,
+    usesPlaceholderValues: true,
+  };
+};
+
+const missingYFieldPlaceholder = i18n.translate(
+  'xpack.triggersActionsUI.alertRuleFromVis.yAxisPlaceholder',
+  {
+    defaultMessage: '[Y AXIS]',
+  }
+);
+
+const missingXFieldPlaceholder = i18n.translate(
+  'xpack.triggersActionsUI.alertRuleFromVis.xAxisPlaceholder',
+  {
+    defaultMessage: '[X AXIS]',
+  }
+);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/build_additional_query.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/build_additional_query.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import type { AlertRuleFromVisUIActionData } from '@kbn/alerts-ui-shared';
+import { escapeFieldNameFactory } from './escape_field_name_factory';
+
+export const buildAdditionalQuery = ({
+  thresholdValues,
+  usesPlaceholderValues,
+  xValues,
+  query,
+}: AlertRuleFromVisUIActionData) => {
+  const { escapeFieldName, stringValueToESQLCondition, getRenameQuery } =
+    escapeFieldNameFactory(query);
+  const thresholdQuery = thresholdValues
+    .map(({ values, yField }) => {
+      const conditions = Object.entries(values)
+        // Always move the Y axis value to the end of the query
+        .sort(([sourceField]) => (sourceField === yField ? 1 : -1))
+        .map(([sourceField, value]) =>
+          sourceField === yField
+            ? `${escapeFieldName(sourceField)} >= ${value}`
+            : stringValueToESQLCondition(sourceField, value)
+        )
+        .join(' AND ');
+      return thresholdValues.length > 1 && Object.keys(values).length > 1
+        ? `(${conditions})`
+        : conditions;
+    })
+    .join(' OR ');
+  const thresholdQueryComment = usesPlaceholderValues
+    ? i18n.translate('xpack.triggersActionsUI.alertRuleFromVis.thresholdPlaceholderComment', {
+        defaultMessage: 'Modify the following conditions to set an alert threshold for this rule:',
+      })
+    : i18n.translate('xpack.triggersActionsUI.alertRuleFromVis.thresholdComment', {
+        defaultMessage:
+          'Threshold automatically generated from the selected {thresholdValues, plural, one {value} other {values} } on the chart. This rule will generate an alert based on the following conditions:',
+        values: { thresholdValues: Object.keys(thresholdValues).length },
+      });
+
+  const xValueQueries = Object.entries(xValues).map(([fieldName, value]) =>
+    stringValueToESQLCondition(fieldName, value)
+  );
+
+  const conditionsQuery = [
+    ...xValueQueries,
+    xValueQueries.length && thresholdValues.length > 1 ? `(${thresholdQuery})` : thresholdQuery,
+  ].join(' AND ');
+
+  // Generate ES|QL to escape function columns
+  let renameQuery = getRenameQuery();
+  if (renameQuery.length)
+    renameQuery = `// ${i18n.translate('xpack.triggersActionsUI.alertRuleFromVis.renameComment', {
+      defaultMessage:
+        'Rename the following columns so they can be used as part of the alerting threshold:',
+    })}\n${renameQuery}\n`;
+
+  // Combine the escaped columns with the threshold conditions query
+  return `${renameQuery}// ${thresholdQueryComment}\n| WHERE ${conditionsQuery}`;
+};

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/escape_field_name_factory.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/escape_field_name_factory.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { sanitazeESQLInput } from '@kbn/esql-utils';
+import { parse, walk, type ESQLColumn, type ESQLFunction } from '@kbn/esql-ast';
+import { i18n } from '@kbn/i18n';
+import { snakeCase } from 'lodash';
+
+export const escapeFieldNameFactory = (query: string | null) => {
+  const { root } = parse(query ?? '');
+  const columns: ESQLColumn[] = [];
+  const functions: ESQLFunction[] = [];
+
+  walk(root, {
+    visitColumn: (node) => columns.push(node),
+  });
+
+  walk(root, {
+    visitFunction: (node) => functions.push(node),
+  });
+
+  let renameQuery = '';
+  const escapeFieldName = (fieldName: string) => {
+    if (!fieldName || fieldName === 'undefined') return missingSourceFieldPlaceholder;
+    const column = columns.find((col) => col.name === fieldName);
+    if (column) {
+      return column.name;
+    }
+
+    // Find all ESQL functions and rename them
+    const WHITESPACE_AFTER_COMMA_REGEX = /, +/g;
+    const esqlFunction = functions.find(
+      (func) => func.text === fieldName.replace(WHITESPACE_AFTER_COMMA_REGEX, ',')
+    );
+    if (esqlFunction) {
+      const colName = `_${snakeCase(fieldName)}`;
+      const sanitizedFieldName = sanitazeESQLInput(esqlFunction.text);
+      // Add this to the renameQuery as a side effect
+      const renameClause = `| RENAME ${sanitizedFieldName} as ${colName} `;
+      if (!renameQuery.includes(renameClause)) renameQuery += renameClause;
+      return colName;
+    }
+
+    return fieldName;
+  };
+
+  const stringValueToESQLCondition = (fieldName: string, v: string | number | null | undefined) => {
+    try {
+      // If the value is a string containing a comma, first attempt to parse it as a JSON-formatted array
+      if (typeof v === 'string' && v.includes(',')) {
+        const stringToParse = v.startsWith('[')
+          ? v
+          : `[${v
+              .split(',')
+              .map((item) => `"${item}"`)
+              .join()}]`;
+        const parsed = JSON.parse(stringToParse);
+        if (Array.isArray(parsed)) {
+          return parsed
+            .map(
+              (multiVal) => `MATCH(${escapeFieldName(fieldName)}, ${formatStringForESQL(multiVal)})`
+            )
+            .join(' AND ');
+        }
+      }
+    } catch {
+      // Do nothing, continue to return statement
+    }
+    return `${escapeFieldName(fieldName)} == ${
+      typeof v === 'number' ? v : formatStringForESQL(v ?? '')
+    }`;
+  };
+
+  const getRenameQuery = () => renameQuery.slice(); // Copy string to keep it private
+
+  return { escapeFieldName, stringValueToESQLCondition, getRenameQuery };
+};
+
+const formatStringForESQL = (value: string) => {
+  let sanitizedValue = value;
+  // This is how you escape backslashes in Javascript. This language was invented in 10 days in 1995 and now we have to do this
+
+  // This translates to "If value includes a '\' character" in reasonable human being language
+  if (value.includes('\\')) {
+    // Split value by every '\' and replace them all with '\\'. I promise this is what this code means.
+    sanitizedValue = value.split('\\').join('\\\\');
+  }
+  return `"${sanitizedValue}"`;
+};
+
+const missingSourceFieldPlaceholder = i18n.translate(
+  'xpack.triggersActionsUI.alertRuleFromVis.fieldNamePlaceholder',
+  {
+    defaultMessage: '[FIELD NAME]',
+  }
+);

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/index.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/common/alert_rule_from_vis_ui_action/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './alert_rule_from_vis_ui_action';

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/public/plugin.ts
@@ -34,6 +34,9 @@ import type { RRuleParams, RuleAction, RuleTypeParams } from '@kbn/alerting-plug
 import { TypeRegistry } from '@kbn/alerts-ui-shared/src/common/type_registry';
 import type { CloudSetup } from '@kbn/cloud-plugin/public';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
+import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
+import { ALERT_RULE_TRIGGER } from '@kbn/ui-actions-browser/src/triggers';
+import { CONTEXT_MENU_TRIGGER } from '@kbn/embeddable-plugin/public';
 import type { Rule, RuleUiAction } from './types';
 import type { AlertsSearchBarProps } from './application/sections/alerts_search_bar';
 
@@ -65,6 +68,7 @@ import { getAlertSummaryWidgetLazy } from './common/get_rule_alerts_summary';
 import { getRuleDefinitionLazy } from './common/get_rule_definition';
 import { getRuleSnoozeModalLazy } from './common/get_rule_snooze_modal';
 import { getRulesSettingsLinkLazy } from './common/get_rules_settings_link';
+import { AlertRuleFromVisAction } from './common/alert_rule_from_vis_ui_action';
 
 import type {
   ActionTypeModel,
@@ -166,6 +170,7 @@ interface PluginsStart {
   fieldFormats: FieldFormatsRegistry;
   lens: LensPublicStart;
   fieldsMetadata: FieldsMetadataPublicStart;
+  uiActions: UiActionsStart;
 }
 
 export class Plugin
@@ -424,6 +429,23 @@ export class Plugin
   }
 
   public start(core: CoreStart, plugins: PluginsStart): TriggersAndActionsUIPublicPluginStart {
+    const createAlertRuleAction = async () => {
+      const action = new AlertRuleFromVisAction(this.ruleTypeRegistry, this.actionTypeRegistry);
+      return action;
+    };
+
+    plugins.uiActions.addTriggerActionAsync(
+      ALERT_RULE_TRIGGER,
+      ALERT_RULE_TRIGGER,
+      createAlertRuleAction
+    );
+
+    plugins.uiActions.addTriggerActionAsync(
+      CONTEXT_MENU_TRIGGER,
+      ALERT_RULE_TRIGGER,
+      createAlertRuleAction
+    );
+
     return {
       actionTypeRegistry: this.actionTypeRegistry,
       ruleTypeRegistry: this.ruleTypeRegistry,

--- a/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
+++ b/x-pack/platform/plugins/shared/triggers_actions_ui/tsconfig.json
@@ -79,7 +79,13 @@
     "@kbn/response-ops-rule-params",
     "@kbn/response-ops-rules-apis",
     "@kbn/fields-metadata-plugin",
-    "@kbn/share-plugin"
+    "@kbn/share-plugin",
+    "@kbn/ui-actions-plugin",
+    "@kbn/ui-actions-browser",
+    "@kbn/embeddable-plugin",
+    "@kbn/presentation-publishing",
+    "@kbn/esql-utils",
+    "@kbn/esql-ast"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Response Ops] [Dashboard] Create a rule from a dashboard ES|QL visualization (#217719)](https://github.com/elastic/kibana/pull/217719)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Zacqary Adam Xeper","email":"Zacqary@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-09T19:04:00Z","message":"[Response Ops] [Dashboard] Create a rule from a dashboard ES|QL visualization (#217719)\n\n## Summary\n\nCloses #208854 \n\nThis adds a tooltip action and a context menu action to the **ES|QL**\npanel type allowing the user to create an Elasticsearch Query rule from\nthe visualization on the panel. Lens panels are currently not supported.\n\n### Tooltip action\n<img width=\"1081\" alt=\"Screenshot 2025-04-09 at 11 06 25 AM\"\nsrc=\"https://github.com/user-attachments/assets/3315cd9f-6dda-44b0-8e7c-eb295c08b89f\"\n/>\n\nPrefill the time field from the chart, and the alert window from the\ndashboard's current displayed time range:\n<img width=\"588\" alt=\"Screenshot 2025-04-09 at 11 06 46 AM\"\nsrc=\"https://github.com/user-attachments/assets/c06a99ab-ce67-4c88-b4ff-dd6edd9e864a\"\n/>\n\nAdd an extra clause to the end of the visualization's ES|QL query to set\nan alert threshold based on the data point that the user clicked on:\n<img width=\"562\" alt=\"Screenshot 2025-04-09 at 11 06 55 AM\"\nsrc=\"https://github.com/user-attachments/assets/27a6552b-b5be-4cb7-80aa-74c683b93ae4\"\n/>\n\n\n\n### Context menu action\n<img width=\"1107\" alt=\"Screenshot 2025-04-09 at 11 07 41 AM\"\nsrc=\"https://github.com/user-attachments/assets/fe6d7f76-68e6-4345-b2a8-e47d1363d7d8\"\n/>\n\nCreating a rule from the context menu instead of from a tooltip doesn't\ngive us a pre-filled threshold value, so we ask the user to specify it:\n<img width=\"563\" alt=\"Screenshot 2025-04-09 at 11 07 48 AM\"\nsrc=\"https://github.com/user-attachments/assets/83a7f51b-bb87-4637-b602-b169b3f0a375\"\n/>\n\n### Supported cases\n#### Breakdowns and split values:\n<img width=\"1077\" alt=\"Screenshot 2025-04-09 at 11 14 47 AM\"\nsrc=\"https://github.com/user-attachments/assets/d691d247-27af-45d1-82ac-b50aaa20e9f9\"\n/>\n<img width=\"556\" alt=\"Screenshot 2025-04-09 at 11 14 56 AM\"\nsrc=\"https://github.com/user-attachments/assets/3b97f08d-00b5-464d-8700-59d6d4a4d473\"\n/>\n\n#### Escaping column names\n<img width=\"668\" alt=\"Screenshot 2025-04-09 at 11 18 08 AM\"\nsrc=\"https://github.com/user-attachments/assets/ad98cb2a-d167-4175-acd5-bc81822a2d1c\"\n/>\n<img width=\"574\" alt=\"Screenshot 2025-04-09 at 11 18 42 AM\"\nsrc=\"https://github.com/user-attachments/assets/d6805e93-2592-4a66-b59e-7ceffca579c7\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n## Release note\nAdds the Create alert rule action to ES|QL dashboard panels, usable from\nthe panel context menu or by right-clicking a data point on the\nvisualization. This allows you to generate an alert when the data on the\nchart crosses a certain threshold.\n\n---------\n\nCo-authored-by: mbondyra <marta.bondyra@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\nCo-authored-by: Marco Vettorello <vettorello.marco@gmail.com>\nCo-authored-by: Marco Liberati <dej611@users.noreply.github.com>\nCo-authored-by: dej611 <dej611@gmail.com>","sha":"7e5c77474ab5f036ac93fcde90bd58ced2d94a51","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Dashboard","Team:Presentation","Feature:ExpressionLanguage","loe:large","Team:Visualizations","impact:high","Team:ResponseOps","release_note:feature","Feature:Alerting/RulesManagement","ci:build-webpack-bundle-analyzer","Feature:ES|QL","backport:version","v9.1.0","v8.19.0"],"title":"[Response Ops] [Dashboard] Create a rule from a dashboard ES|QL visualization","number":217719,"url":"https://github.com/elastic/kibana/pull/217719","mergeCommit":{"message":"[Response Ops] [Dashboard] Create a rule from a dashboard ES|QL visualization (#217719)\n\n## Summary\n\nCloses #208854 \n\nThis adds a tooltip action and a context menu action to the **ES|QL**\npanel type allowing the user to create an Elasticsearch Query rule from\nthe visualization on the panel. Lens panels are currently not supported.\n\n### Tooltip action\n<img width=\"1081\" alt=\"Screenshot 2025-04-09 at 11 06 25 AM\"\nsrc=\"https://github.com/user-attachments/assets/3315cd9f-6dda-44b0-8e7c-eb295c08b89f\"\n/>\n\nPrefill the time field from the chart, and the alert window from the\ndashboard's current displayed time range:\n<img width=\"588\" alt=\"Screenshot 2025-04-09 at 11 06 46 AM\"\nsrc=\"https://github.com/user-attachments/assets/c06a99ab-ce67-4c88-b4ff-dd6edd9e864a\"\n/>\n\nAdd an extra clause to the end of the visualization's ES|QL query to set\nan alert threshold based on the data point that the user clicked on:\n<img width=\"562\" alt=\"Screenshot 2025-04-09 at 11 06 55 AM\"\nsrc=\"https://github.com/user-attachments/assets/27a6552b-b5be-4cb7-80aa-74c683b93ae4\"\n/>\n\n\n\n### Context menu action\n<img width=\"1107\" alt=\"Screenshot 2025-04-09 at 11 07 41 AM\"\nsrc=\"https://github.com/user-attachments/assets/fe6d7f76-68e6-4345-b2a8-e47d1363d7d8\"\n/>\n\nCreating a rule from the context menu instead of from a tooltip doesn't\ngive us a pre-filled threshold value, so we ask the user to specify it:\n<img width=\"563\" alt=\"Screenshot 2025-04-09 at 11 07 48 AM\"\nsrc=\"https://github.com/user-attachments/assets/83a7f51b-bb87-4637-b602-b169b3f0a375\"\n/>\n\n### Supported cases\n#### Breakdowns and split values:\n<img width=\"1077\" alt=\"Screenshot 2025-04-09 at 11 14 47 AM\"\nsrc=\"https://github.com/user-attachments/assets/d691d247-27af-45d1-82ac-b50aaa20e9f9\"\n/>\n<img width=\"556\" alt=\"Screenshot 2025-04-09 at 11 14 56 AM\"\nsrc=\"https://github.com/user-attachments/assets/3b97f08d-00b5-464d-8700-59d6d4a4d473\"\n/>\n\n#### Escaping column names\n<img width=\"668\" alt=\"Screenshot 2025-04-09 at 11 18 08 AM\"\nsrc=\"https://github.com/user-attachments/assets/ad98cb2a-d167-4175-acd5-bc81822a2d1c\"\n/>\n<img width=\"574\" alt=\"Screenshot 2025-04-09 at 11 18 42 AM\"\nsrc=\"https://github.com/user-attachments/assets/d6805e93-2592-4a66-b59e-7ceffca579c7\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n## Release note\nAdds the Create alert rule action to ES|QL dashboard panels, usable from\nthe panel context menu or by right-clicking a data point on the\nvisualization. This allows you to generate an alert when the data on the\nchart crosses a certain threshold.\n\n---------\n\nCo-authored-by: mbondyra <marta.bondyra@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\nCo-authored-by: Marco Vettorello <vettorello.marco@gmail.com>\nCo-authored-by: Marco Liberati <dej611@users.noreply.github.com>\nCo-authored-by: dej611 <dej611@gmail.com>","sha":"7e5c77474ab5f036ac93fcde90bd58ced2d94a51"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/217719","number":217719,"mergeCommit":{"message":"[Response Ops] [Dashboard] Create a rule from a dashboard ES|QL visualization (#217719)\n\n## Summary\n\nCloses #208854 \n\nThis adds a tooltip action and a context menu action to the **ES|QL**\npanel type allowing the user to create an Elasticsearch Query rule from\nthe visualization on the panel. Lens panels are currently not supported.\n\n### Tooltip action\n<img width=\"1081\" alt=\"Screenshot 2025-04-09 at 11 06 25 AM\"\nsrc=\"https://github.com/user-attachments/assets/3315cd9f-6dda-44b0-8e7c-eb295c08b89f\"\n/>\n\nPrefill the time field from the chart, and the alert window from the\ndashboard's current displayed time range:\n<img width=\"588\" alt=\"Screenshot 2025-04-09 at 11 06 46 AM\"\nsrc=\"https://github.com/user-attachments/assets/c06a99ab-ce67-4c88-b4ff-dd6edd9e864a\"\n/>\n\nAdd an extra clause to the end of the visualization's ES|QL query to set\nan alert threshold based on the data point that the user clicked on:\n<img width=\"562\" alt=\"Screenshot 2025-04-09 at 11 06 55 AM\"\nsrc=\"https://github.com/user-attachments/assets/27a6552b-b5be-4cb7-80aa-74c683b93ae4\"\n/>\n\n\n\n### Context menu action\n<img width=\"1107\" alt=\"Screenshot 2025-04-09 at 11 07 41 AM\"\nsrc=\"https://github.com/user-attachments/assets/fe6d7f76-68e6-4345-b2a8-e47d1363d7d8\"\n/>\n\nCreating a rule from the context menu instead of from a tooltip doesn't\ngive us a pre-filled threshold value, so we ask the user to specify it:\n<img width=\"563\" alt=\"Screenshot 2025-04-09 at 11 07 48 AM\"\nsrc=\"https://github.com/user-attachments/assets/83a7f51b-bb87-4637-b602-b169b3f0a375\"\n/>\n\n### Supported cases\n#### Breakdowns and split values:\n<img width=\"1077\" alt=\"Screenshot 2025-04-09 at 11 14 47 AM\"\nsrc=\"https://github.com/user-attachments/assets/d691d247-27af-45d1-82ac-b50aaa20e9f9\"\n/>\n<img width=\"556\" alt=\"Screenshot 2025-04-09 at 11 14 56 AM\"\nsrc=\"https://github.com/user-attachments/assets/3b97f08d-00b5-464d-8700-59d6d4a4d473\"\n/>\n\n#### Escaping column names\n<img width=\"668\" alt=\"Screenshot 2025-04-09 at 11 18 08 AM\"\nsrc=\"https://github.com/user-attachments/assets/ad98cb2a-d167-4175-acd5-bc81822a2d1c\"\n/>\n<img width=\"574\" alt=\"Screenshot 2025-04-09 at 11 18 42 AM\"\nsrc=\"https://github.com/user-attachments/assets/d6805e93-2592-4a66-b59e-7ceffca579c7\"\n/>\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] Any text added follows [EUI's writing\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\nsentence case text and includes [i18n\nsupport](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\n\n## Release note\nAdds the Create alert rule action to ES|QL dashboard panels, usable from\nthe panel context menu or by right-clicking a data point on the\nvisualization. This allows you to generate an alert when the data on the\nchart crosses a certain threshold.\n\n---------\n\nCo-authored-by: mbondyra <marta.bondyra@elastic.co>\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>\nCo-authored-by: Marco Vettorello <vettorello.marco@gmail.com>\nCo-authored-by: Marco Liberati <dej611@users.noreply.github.com>\nCo-authored-by: dej611 <dej611@gmail.com>","sha":"7e5c77474ab5f036ac93fcde90bd58ced2d94a51"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->