### PR TITLE
[8.18] [Response Ops][Alerting] Skip writing alerts when rule exceeds configured timeout (#220147)

### DIFF
--- a/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/initialize_alerts_client.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/alerts_client/lib/initialize_alerts_client.test.ts
@@ -95,6 +95,7 @@ describe('initializeAlertsClient', () => {
         alertingEventLogger,
         flappingSettings: DEFAULT_FLAPPING_SETTINGS,
         maintenanceWindowsService,
+        logger,
         request: fakeRequest,
         ruleId: RULE_ID,
         ruleLogPrefix: `${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`,
@@ -154,6 +155,7 @@ describe('initializeAlertsClient', () => {
       alertsService,
       context: {
         alertingEventLogger,
+        logger,
         maintenanceWindowsService,
         request: fakeRequest,
         ruleId: RULE_ID,
@@ -216,6 +218,7 @@ describe('initializeAlertsClient', () => {
         alertingEventLogger,
         flappingSettings: DEFAULT_FLAPPING_SETTINGS,
         maintenanceWindowsService,
+        logger,
         request: fakeRequest,
         ruleId: RULE_ID,
         ruleLogPrefix: `${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`,
@@ -285,6 +288,7 @@ describe('initializeAlertsClient', () => {
       context: {
         alertingEventLogger,
         flappingSettings: DEFAULT_FLAPPING_SETTINGS,
+        logger,
         maintenanceWindowsService,
         request: fakeRequest,
         ruleId: RULE_ID,

--- a/x-pack/platform/plugins/shared/alerting/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/plugin.test.ts
@@ -239,6 +239,7 @@ describe('Alerting Plugin', () => {
               ...sampleRuleType,
               minimumLicenseRequired: 'basic',
               cancelAlertsOnRuleTimeout: false,
+              autoRecoverAlerts: false,
             } as RuleType<never, never, {}, never, never, 'default', never, {}>;
             setup.registerType(ruleType);
             expect(ruleType.cancelAlertsOnRuleTimeout).toBe(false);

--- a/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.test.ts
@@ -768,7 +768,6 @@ describe('Create Lifecycle', () => {
           executor: jest.fn(),
           category: 'test',
           producer: 'alerts',
-          solution: 'stack',
           validate: {
             params: { validate: (params) => params },
           },
@@ -798,7 +797,6 @@ describe('Create Lifecycle', () => {
           executor: jest.fn(),
           category: 'test',
           producer: 'alerts',
-          solution: 'stack',
           validate: {
             params: { validate: (params) => params },
           },
@@ -826,7 +824,6 @@ describe('Create Lifecycle', () => {
         executor: jest.fn(),
         category: 'test',
         producer: 'alerts',
-        solution: 'stack',
         validate: {
           params: schema.any(),
         },
@@ -854,7 +851,6 @@ describe('Create Lifecycle', () => {
         executor: jest.fn(),
         category: 'test',
         producer: 'alerts',
-        solution: 'stack',
         validate: {
           params: schema.any(),
         },

--- a/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.test.ts
@@ -749,6 +749,121 @@ describe('Create Lifecycle', () => {
       registry.register(ruleType);
       expect(registry.get('test').producer).toEqual('alerts');
     });
+
+    test('should throw an error if cancelAlertsOnRuleTimeout: false and autoRecoverAlerts: true', () => {
+      const registry = new RuleTypeRegistry(ruleTypeRegistryParams);
+      expect(() =>
+        registry.register({
+          id: 'test',
+          name: 'Test',
+          actionGroups: [
+            {
+              id: 'default',
+              name: 'Default',
+            },
+          ],
+          defaultActionGroupId: 'default',
+          minimumLicenseRequired: 'basic',
+          isExportable: true,
+          executor: jest.fn(),
+          category: 'test',
+          producer: 'alerts',
+          solution: 'stack',
+          validate: {
+            params: { validate: (params) => params },
+          },
+          cancelAlertsOnRuleTimeout: false,
+          autoRecoverAlerts: true,
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Rule type \\"test\\" cannot have both cancelAlertsOnRuleTimeout set to false and autoRecoverAlerts set to true."`
+      );
+    });
+
+    test('should throw an error if cancelAlertsOnRuleTimeout: false and autoRecoverAlerts is not set (defaults to true)', () => {
+      const registry = new RuleTypeRegistry(ruleTypeRegistryParams);
+      expect(() =>
+        registry.register({
+          id: 'test',
+          name: 'Test',
+          actionGroups: [
+            {
+              id: 'default',
+              name: 'Default',
+            },
+          ],
+          defaultActionGroupId: 'default',
+          minimumLicenseRequired: 'basic',
+          isExportable: true,
+          executor: jest.fn(),
+          category: 'test',
+          producer: 'alerts',
+          solution: 'stack',
+          validate: {
+            params: { validate: (params) => params },
+          },
+          cancelAlertsOnRuleTimeout: false,
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Rule type \\"test\\" cannot have both cancelAlertsOnRuleTimeout set to false and autoRecoverAlerts set to true."`
+      );
+    });
+
+    test('registers rule if cancelAlertsOnRuleTimeout: true and autoRecoverAlerts: true', () => {
+      const registry = new RuleTypeRegistry(ruleTypeRegistryParams);
+      registry.register({
+        id: 'foo',
+        name: 'Foo',
+        actionGroups: [
+          {
+            id: 'default',
+            name: 'Default',
+          },
+        ],
+        defaultActionGroupId: 'default',
+        minimumLicenseRequired: 'basic',
+        isExportable: true,
+        executor: jest.fn(),
+        category: 'test',
+        producer: 'alerts',
+        solution: 'stack',
+        validate: {
+          params: schema.any(),
+        },
+
+        cancelAlertsOnRuleTimeout: true,
+        autoRecoverAlerts: true,
+      });
+      expect(registry.has('foo')).toEqual(true);
+    });
+
+    test('registers rule if cancelAlertsOnRuleTimeout: false and autoRecoverAlerts: false', () => {
+      const registry = new RuleTypeRegistry(ruleTypeRegistryParams);
+      registry.register({
+        id: 'foo',
+        name: 'Foo',
+        actionGroups: [
+          {
+            id: 'default',
+            name: 'Default',
+          },
+        ],
+        defaultActionGroupId: 'default',
+        minimumLicenseRequired: 'basic',
+        isExportable: true,
+        executor: jest.fn(),
+        category: 'test',
+        producer: 'alerts',
+        solution: 'stack',
+        validate: {
+          params: schema.any(),
+        },
+
+        cancelAlertsOnRuleTimeout: false,
+        autoRecoverAlerts: false,
+      });
+      expect(registry.has('foo')).toEqual(true);
+    });
   });
 
   describe('register() with overwriteProducer', () => {

--- a/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/rule_type_registry.ts
@@ -277,6 +277,22 @@ export class RuleTypeRegistry {
       }
     }
 
+    // validate cancelAlertsOnTimeout if set
+    if (
+      ruleType.cancelAlertsOnRuleTimeout === false &&
+      (ruleType.autoRecoverAlerts == null || ruleType.autoRecoverAlerts === true)
+    ) {
+      throw new Error(
+        i18n.translate('xpack.alerting.ruleTypeRegistry.register.cancelAlertsOnTimeoutError', {
+          defaultMessage:
+            'Rule type "{id}" cannot have both cancelAlertsOnRuleTimeout set to false and autoRecoverAlerts set to true.',
+          values: {
+            id: ruleType.id,
+          },
+        })
+      );
+    }
+
     const normalizedRuleType = augmentActionGroupsWithReserved<
       Params,
       ExtractedParams,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.test.ts
@@ -1390,7 +1390,7 @@ describe('Ad Hoc Task Runner', () => {
         backfillRunAt: schedule1.runAt,
         backfillInterval: schedule1.interval,
       });
-      expect(logger.debug).toHaveBeenCalledTimes(3);
+      expect(logger.debug).toHaveBeenCalledTimes(4);
       expect(logger.debug).nthCalledWith(
         1,
         `Executing ad hoc run for rule test:rule-id for runAt ${schedule1.runAt}`
@@ -1402,6 +1402,10 @@ describe('Ad Hoc Task Runner', () => {
       expect(logger.debug).nthCalledWith(
         3,
         `Aborting any in-progress ES searches for rule type test with id rule-id`
+      );
+      expect(logger.debug).nthCalledWith(
+        4,
+        `skipping persisting alerts for rule test:rule-id: 'test': rule execution has been cancelled.`
       );
       expect(logger.error).not.toHaveBeenCalled();
     });
@@ -1468,7 +1472,7 @@ describe('Ad Hoc Task Runner', () => {
         backfillRunAt: schedule2.runAt,
         backfillInterval: schedule2.interval,
       });
-      expect(logger.debug).toHaveBeenCalledTimes(3);
+      expect(logger.debug).toHaveBeenCalledTimes(4);
       expect(logger.debug).nthCalledWith(
         1,
         `Executing ad hoc run for rule test:rule-id for runAt ${schedule2.runAt}`
@@ -1480,6 +1484,10 @@ describe('Ad Hoc Task Runner', () => {
       expect(logger.debug).nthCalledWith(
         3,
         `Aborting any in-progress ES searches for rule type test with id rule-id`
+      );
+      expect(logger.debug).nthCalledWith(
+        4,
+        `skipping persisting alerts for rule test:rule-id: 'test': rule execution has been cancelled.`
       );
       expect(logger.error).not.toHaveBeenCalled();
     });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/ad_hoc_task_runner.ts
@@ -127,7 +127,6 @@ export class AdHocTaskRunner implements CancellableTask {
       RuleAlertData
     >({
       context: this.context,
-      logger: this.logger,
       task: this.taskInstance,
       timer: this.timer,
     });
@@ -185,6 +184,7 @@ export class AdHocTaskRunner implements CancellableTask {
     const ruleTypeRunnerContext = {
       alertingEventLogger: this.alertingEventLogger,
       namespace: this.context.spaceIdToNamespace(adHocRunData.spaceId),
+      logger: this.logger,
       request: fakeRequest,
       ruleId: rule.id,
       ruleLogPrefix: ruleLabel,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.test.ts
@@ -1355,9 +1355,8 @@ describe('RuleTypeRunner', () => {
         `rule executed: ${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`
       );
       expect(ruleRunMetricsStore.setSearchMetrics).toHaveBeenCalled();
-      expect(alertsClient.processAlerts).toHaveBeenCalledWith();
-      expect(alertsClient.determineFlappingAlerts).toHaveBeenCalledWith();
-      expect(alertsClient.determineDelayedAlerts).toHaveBeenCalledWith({
+      expect(alertsClient.processAlerts).toHaveBeenCalledWith({
+        flappingSettings: DEFAULT_FLAPPING_SETTINGS,
         alertDelay: 0,
         ruleRunMetricsStore,
       });
@@ -1431,9 +1430,8 @@ describe('RuleTypeRunner', () => {
         `rule executed: ${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`
       );
       expect(ruleRunMetricsStore.setSearchMetrics).toHaveBeenCalled();
-      expect(alertsClient.processAlerts).toHaveBeenCalledWith();
-      expect(alertsClient.determineFlappingAlerts).toHaveBeenCalledWith();
-      expect(alertsClient.determineDelayedAlerts).toHaveBeenCalledWith({
+      expect(alertsClient.processAlerts).toHaveBeenCalledWith({
+        flappingSettings: DEFAULT_FLAPPING_SETTINGS,
         alertDelay: 0,
         ruleRunMetricsStore,
       });
@@ -1489,9 +1487,8 @@ describe('RuleTypeRunner', () => {
         `rule executed: ${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`
       );
       expect(ruleRunMetricsStore.setSearchMetrics).toHaveBeenCalled();
-      expect(alertsClient.processAlerts).toHaveBeenCalledWith();
-      expect(alertsClient.determineFlappingAlerts).toHaveBeenCalledWith();
-      expect(alertsClient.determineDelayedAlerts).toHaveBeenCalledWith({
+      expect(alertsClient.processAlerts).toHaveBeenCalledWith({
+        flappingSettings: DEFAULT_FLAPPING_SETTINGS,
         alertDelay: 0,
         ruleRunMetricsStore,
       });

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.test.ts
@@ -168,7 +168,6 @@ describe('RuleTypeRunner', () => {
       {}
     >({
       context,
-      logger,
       task: mockedTaskInstance,
       timer,
     });
@@ -181,6 +180,7 @@ describe('RuleTypeRunner', () => {
       const { state, error, stackTrace } = await ruleTypeRunner.run({
         context: {
           alertingEventLogger,
+          logger,
           maintenanceWindowsService,
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
           queryDelaySec: 0,
@@ -291,6 +291,7 @@ describe('RuleTypeRunner', () => {
         context: {
           alertingEventLogger,
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
+          logger,
           queryDelaySec: 0,
           request: fakeRequest,
           maintenanceWindowsService,
@@ -403,6 +404,7 @@ describe('RuleTypeRunner', () => {
         context: {
           alertingEventLogger,
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
+          logger,
           queryDelaySec: 0,
           maintenanceWindowsService,
           request: fakeRequest,
@@ -466,6 +468,7 @@ describe('RuleTypeRunner', () => {
           alertingEventLogger,
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
           queryDelaySec: 0,
+          logger,
           request: fakeRequest,
           maintenanceWindowsService,
           ruleId: RULE_ID,
@@ -571,6 +574,7 @@ describe('RuleTypeRunner', () => {
           alertingEventLogger,
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
           queryDelaySec: 0,
+          logger,
           maintenanceWindowsService,
           request: fakeRequest,
           ruleId: RULE_ID,
@@ -677,6 +681,7 @@ describe('RuleTypeRunner', () => {
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
           queryDelaySec: 0,
           maintenanceWindowsService,
+          logger,
           request: fakeRequest,
           ruleId: RULE_ID,
           ruleLogPrefix: `${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`,
@@ -715,6 +720,7 @@ describe('RuleTypeRunner', () => {
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
           queryDelaySec: 0,
           request: fakeRequest,
+          logger,
           ruleId: RULE_ID,
           maintenanceWindowsService,
           ruleLogPrefix: `${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`,
@@ -830,6 +836,7 @@ describe('RuleTypeRunner', () => {
           alertingEventLogger,
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
           queryDelaySec: 0,
+          logger,
           request: fakeRequest,
           ruleId: RULE_ID,
           maintenanceWindowsService,
@@ -946,6 +953,7 @@ describe('RuleTypeRunner', () => {
             alertingEventLogger,
             flappingSettings: DEFAULT_FLAPPING_SETTINGS,
             queryDelaySec: 0,
+            logger,
             request: fakeRequest,
             maintenanceWindowsService,
             ruleId: RULE_ID,
@@ -1054,6 +1062,7 @@ describe('RuleTypeRunner', () => {
             flappingSettings: DEFAULT_FLAPPING_SETTINGS,
             request: fakeRequest,
             queryDelaySec: 0,
+            logger,
             ruleId: RULE_ID,
             maintenanceWindowsService,
             ruleLogPrefix: `${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`,
@@ -1161,6 +1170,7 @@ describe('RuleTypeRunner', () => {
             flappingSettings: DEFAULT_FLAPPING_SETTINGS,
             queryDelaySec: 0,
             request: fakeRequest,
+            logger,
             maintenanceWindowsService,
             ruleId: RULE_ID,
             ruleLogPrefix: `${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`,
@@ -1265,6 +1275,7 @@ describe('RuleTypeRunner', () => {
           alertingEventLogger,
           flappingSettings: DEFAULT_FLAPPING_SETTINGS,
           queryDelaySec: 0,
+          logger,
           request: fakeRequest,
           maintenanceWindowsService,
           ruleId: RULE_ID,
@@ -1298,11 +1309,205 @@ describe('RuleTypeRunner', () => {
       );
     });
   });
+
+  describe('cancel', () => {
+    test('should not persist or log alerts if rule run is cancelled due to timeout', async () => {
+      ruleType.executor.mockResolvedValueOnce({ state: { foo: 'bar' } });
+
+      const promise = ruleTypeRunner.run({
+        context: {
+          alertingEventLogger,
+          logger,
+          maintenanceWindowsService,
+          flappingSettings: DEFAULT_FLAPPING_SETTINGS,
+          queryDelaySec: 0,
+          request: fakeRequest,
+          ruleId: RULE_ID,
+          ruleLogPrefix: `${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`,
+          ruleRunMetricsStore,
+          spaceId: 'default',
+          isServerless: false,
+        },
+        alertsClient,
+        executionId: 'abc',
+        executorServices: {
+          getDataViews,
+          ruleMonitoringService: publicRuleMonitoringService,
+          ruleResultService: publicRuleResultService,
+          savedObjectsClient,
+          uiSettingsClient,
+          wrappedScopedClusterClient,
+          getWrappedSearchSourceClient,
+        },
+        rule: mockedRule,
+        ruleType,
+        startedAt: new Date(DATE_1970),
+        state: mockTaskInstance().state,
+        validatedParams: mockedRuleParams,
+      });
+      await Promise.resolve();
+      await ruleTypeRunner.cancelRun();
+      await promise;
+
+      expect(alertsClient.hasReachedAlertLimit).toHaveBeenCalled();
+      expect(alertsClient.checkLimitUsage).toHaveBeenCalled();
+      expect(alertingEventLogger.setExecutionSucceeded).toHaveBeenCalledWith(
+        `rule executed: ${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`
+      );
+      expect(ruleRunMetricsStore.setSearchMetrics).toHaveBeenCalled();
+      expect(alertsClient.processAlerts).toHaveBeenCalledWith();
+      expect(alertsClient.determineFlappingAlerts).toHaveBeenCalledWith();
+      expect(alertsClient.determineDelayedAlerts).toHaveBeenCalledWith({
+        alertDelay: 0,
+        ruleRunMetricsStore,
+      });
+      expect(alertsClient.persistAlerts).not.toHaveBeenCalled();
+      expect(alertsClient.logAlerts).toHaveBeenCalledWith({
+        ruleRunMetricsStore,
+        shouldLogAlerts: false,
+      });
+    });
+
+    test('should persist and log alerts if rule run is cancelled due to timeout but cancelAlertsOnRuleTimeout from config is false', async () => {
+      const newContext = {
+        ...context,
+        cancelAlertsOnRuleTimeout: false,
+      };
+      ruleType.executor.mockResolvedValueOnce({ state: { foo: 'bar' } });
+
+      const thisRuleTypeRunner = new RuleTypeRunner<
+        {},
+        {},
+        { foo: string },
+        {},
+        {},
+        'default',
+        'recovered',
+        {}
+      >({
+        context: newContext,
+        task: mockedTaskInstance,
+        timer,
+      });
+
+      const promise = thisRuleTypeRunner.run({
+        context: {
+          alertingEventLogger,
+          logger,
+          maintenanceWindowsService,
+          flappingSettings: DEFAULT_FLAPPING_SETTINGS,
+          queryDelaySec: 0,
+          request: fakeRequest,
+          ruleId: RULE_ID,
+          ruleLogPrefix: `${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`,
+          ruleRunMetricsStore,
+          spaceId: 'default',
+          isServerless: false,
+        },
+        alertsClient,
+        executionId: 'abc',
+        executorServices: {
+          getDataViews,
+          ruleMonitoringService: publicRuleMonitoringService,
+          ruleResultService: publicRuleResultService,
+          savedObjectsClient,
+          uiSettingsClient,
+          wrappedScopedClusterClient,
+          getWrappedSearchSourceClient,
+        },
+        rule: mockedRule,
+        ruleType,
+        startedAt: new Date(DATE_1970),
+        state: mockTaskInstance().state,
+        validatedParams: mockedRuleParams,
+      });
+      await Promise.resolve();
+      await thisRuleTypeRunner.cancelRun();
+      await promise;
+
+      expect(alertsClient.hasReachedAlertLimit).toHaveBeenCalled();
+      expect(alertsClient.checkLimitUsage).toHaveBeenCalled();
+      expect(alertingEventLogger.setExecutionSucceeded).toHaveBeenCalledWith(
+        `rule executed: ${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`
+      );
+      expect(ruleRunMetricsStore.setSearchMetrics).toHaveBeenCalled();
+      expect(alertsClient.processAlerts).toHaveBeenCalledWith();
+      expect(alertsClient.determineFlappingAlerts).toHaveBeenCalledWith();
+      expect(alertsClient.determineDelayedAlerts).toHaveBeenCalledWith({
+        alertDelay: 0,
+        ruleRunMetricsStore,
+      });
+      expect(alertsClient.persistAlerts).toHaveBeenCalled();
+      expect(alertsClient.logAlerts).toHaveBeenCalledWith({
+        ruleRunMetricsStore,
+        shouldLogAlerts: true,
+      });
+    });
+
+    test('should persist and log alerts if rule run is cancelled due to timeout but cancelAlertsOnRuleTimeout for ruleType is false', async () => {
+      ruleType.cancelAlertsOnRuleTimeout = false;
+      ruleType.executor.mockResolvedValueOnce({ state: { foo: 'bar' } });
+
+      const promise = ruleTypeRunner.run({
+        context: {
+          alertingEventLogger,
+          logger,
+          maintenanceWindowsService,
+          flappingSettings: DEFAULT_FLAPPING_SETTINGS,
+          queryDelaySec: 0,
+          request: fakeRequest,
+          ruleId: RULE_ID,
+          ruleLogPrefix: `${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`,
+          ruleRunMetricsStore,
+          spaceId: 'default',
+          isServerless: false,
+        },
+        alertsClient,
+        executionId: 'abc',
+        executorServices: {
+          getDataViews,
+          ruleMonitoringService: publicRuleMonitoringService,
+          ruleResultService: publicRuleResultService,
+          savedObjectsClient,
+          uiSettingsClient,
+          wrappedScopedClusterClient,
+          getWrappedSearchSourceClient,
+        },
+        rule: mockedRule,
+        ruleType,
+        startedAt: new Date(DATE_1970),
+        state: mockTaskInstance().state,
+        validatedParams: mockedRuleParams,
+      });
+      await Promise.resolve();
+      await ruleTypeRunner.cancelRun();
+      await promise;
+
+      expect(alertsClient.hasReachedAlertLimit).toHaveBeenCalled();
+      expect(alertsClient.checkLimitUsage).toHaveBeenCalled();
+      expect(alertingEventLogger.setExecutionSucceeded).toHaveBeenCalledWith(
+        `rule executed: ${RULE_TYPE_ID}:${RULE_ID}: '${RULE_NAME}'`
+      );
+      expect(ruleRunMetricsStore.setSearchMetrics).toHaveBeenCalled();
+      expect(alertsClient.processAlerts).toHaveBeenCalledWith();
+      expect(alertsClient.determineFlappingAlerts).toHaveBeenCalledWith();
+      expect(alertsClient.determineDelayedAlerts).toHaveBeenCalledWith({
+        alertDelay: 0,
+        ruleRunMetricsStore,
+      });
+      expect(alertsClient.persistAlerts).toHaveBeenCalled();
+      expect(alertsClient.logAlerts).toHaveBeenCalledWith({
+        ruleRunMetricsStore,
+        shouldLogAlerts: true,
+      });
+    });
+  });
 });
 
 // return enough of TaskRunnerContext that RuleTypeRunner needs
 function getTaskRunnerContext() {
   return {
+    cancelAlertsOnRuleTimeout: true,
     maxAlerts: 100,
     executionContext: executionContextServiceMock.createInternalStartContract(),
     share: {} as SharePluginStart,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/rule_type_runner.ts
@@ -7,7 +7,6 @@
 
 import { AlertInstanceContext, AlertInstanceState, RuleTaskState } from '@kbn/alerting-state-types';
 import { DEFAULT_NAMESPACE_STRING } from '@kbn/core-saved-objects-utils-server';
-import { Logger } from '@kbn/core/server';
 import {
   ConcreteTaskInstance,
   createTaskRunError,
@@ -43,7 +42,6 @@ interface ConstructorOpts<
   AlertData extends RuleAlertData
 > {
   context: TaskRunnerContext;
-  logger: Logger;
   task: ConcreteTaskInstance;
   timer: TaskRunnerTimer;
 }
@@ -190,7 +188,7 @@ export class RuleTypeRunner<
         const checkHasReachedAlertLimit = () => {
           const reachedLimit = alertsClient.hasReachedAlertLimit() || false;
           if (reachedLimit) {
-            this.options.logger.warn(
+            context.logger.warn(
               `rule execution generated greater than ${this.options.context.maxAlerts} alerts: ${context.ruleLogPrefix}`
             );
             context.ruleRunMetricsStore.setHasReachedAlertLimit(true);
@@ -276,11 +274,11 @@ export class RuleTypeRunner<
                   snoozeSchedule,
                   alertDelay,
                 },
-                logger: this.options.logger,
+                logger: context.logger,
                 flappingSettings: context.flappingSettings ?? DEFAULT_FLAPPING_SETTINGS,
                 getTimeRange: (timeWindow) =>
                   getTimeRange({
-                    logger: this.options.logger,
+                    logger: context.logger,
                     window: timeWindow,
                     ...(context.queryDelaySec ? { queryDelay: context.queryDelaySec } : {}),
                     ...(startedAtOverridden ? { forceNow: startedAt } : {}),
@@ -349,16 +347,22 @@ export class RuleTypeRunner<
 
     await withAlertingSpan('alerting:index-alerts-as-data', () =>
       this.options.timer.runWithTimer(TaskRunnerTimerSpan.PersistAlerts, async () => {
-        const updateAlertsMaintenanceWindowResult = await alertsClient.persistAlerts();
+        if (this.shouldLogAndScheduleActionsForAlerts(ruleType.cancelAlertsOnRuleTimeout)) {
+          const updateAlertsMaintenanceWindowResult = await alertsClient.persistAlerts();
 
-        // Set the event log MW ids again, this time including the ids that matched alerts with
-        // scoped query
-        if (
-          updateAlertsMaintenanceWindowResult?.maintenanceWindowIds &&
-          updateAlertsMaintenanceWindowResult?.maintenanceWindowIds.length > 0
-        ) {
-          context.alertingEventLogger.setMaintenanceWindowIds(
-            updateAlertsMaintenanceWindowResult.maintenanceWindowIds
+          // Set the event log MW ids again, this time including the ids that matched alerts with
+          // scoped query
+          if (
+            updateAlertsMaintenanceWindowResult?.maintenanceWindowIds &&
+            updateAlertsMaintenanceWindowResult?.maintenanceWindowIds.length > 0
+          ) {
+            context.alertingEventLogger.setMaintenanceWindowIds(
+              updateAlertsMaintenanceWindowResult.maintenanceWindowIds
+            );
+          }
+        } else {
+          context.logger.debug(
+            `skipping persisting alerts for rule ${context.ruleLogPrefix}: rule execution has been cancelled.`
           );
         }
       })

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner.ts
@@ -202,7 +202,6 @@ export class TaskRunner<
       AlertData
     >({
       context: this.context,
-      logger: this.logger,
       task: this.taskInstance,
       timer: this.timer,
     });
@@ -311,6 +310,7 @@ export class TaskRunner<
     const ruleTypeRunnerContext = {
       alertingEventLogger: this.alertingEventLogger,
       flappingSettings,
+      logger: this.logger,
       maintenanceWindowsService: this.context.maintenanceWindowsService,
       namespace: this.context.spaceIdToNamespace(spaceId),
       queryDelaySec: queryDelaySettings.delay,

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/task_runner_cancel.test.ts
@@ -228,6 +228,17 @@ describe('Task Runner Cancel', () => {
       { tags: ['1', 'test'] }
     );
 
+    expect(logger.debug).toHaveBeenNthCalledWith(
+      5,
+      `skipping persisting alerts for rule test:1: 'rule-name': rule execution has been cancelled.`,
+      { tags: ['1', 'test'] }
+    );
+    expect(logger.debug).toHaveBeenNthCalledWith(
+      6,
+      `no scheduling of actions for rule test:1: 'rule-name': rule execution has been cancelled.`,
+      { tags: ['1', 'test'] }
+    );
+
     testAlertingEventLogCalls({ status: 'ok' });
 
     expect(elasticsearchService.client.asInternalUser.update).toHaveBeenCalledTimes(1);

--- a/x-pack/platform/plugins/shared/alerting/server/task_runner/types.ts
+++ b/x-pack/platform/plugins/shared/alerting/server/task_runner/types.ts
@@ -138,6 +138,7 @@ export type Executable<
 export interface RuleTypeRunnerContext {
   alertingEventLogger: AlertingEventLogger;
   flappingSettings?: RulesSettingsFlappingProperties;
+  logger: Logger;
   maintenanceWindowsService?: MaintenanceWindowsService;
   namespace?: string;
   queryDelaySec?: number;

--- a/x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
+++ b/x-pack/test/alerting_api_integration/common/plugins/alerts/server/rule_types.ts
@@ -795,11 +795,34 @@ function getLongRunningPatternRuleType(cancelAlertsOnRuleTimeout: boolean = true
     isExportable: true,
     ruleTaskTimeout: '3s',
     cancelAlertsOnRuleTimeout,
+    autoRecoverAlerts: false,
+    alerts: {
+      context: 'test.patternfiring',
+      shouldWrite: true,
+      mappings: {
+        fieldMap: {
+          patternIndex: {
+            required: false,
+            type: 'long',
+          },
+          instancePattern: {
+            required: false,
+            type: 'boolean',
+            array: true,
+          },
+        },
+      },
+    },
     async executor(ruleExecutorOptions) {
       const { services, params } = ruleExecutorOptions;
       const pattern = params.pattern;
       if (!Array.isArray(pattern)) {
         throw new Error(`pattern is not an array`);
+      }
+
+      const alertsClient = services.alertsClient;
+      if (!alertsClient) {
+        throw new Error(`Expected alertsClient to be defined but it is not`);
       }
 
       // get the pattern index, return if past it
@@ -808,7 +831,7 @@ function getLongRunningPatternRuleType(cancelAlertsOnRuleTimeout: boolean = true
         return { state: {} };
       }
 
-      services.alertFactory.create('alert').scheduleActions('default', {});
+      alertsClient.report({ id: `alert_${globalPatternIndex}`, actionGroup: 'default' });
 
       // run long if pattern says to
       if (pattern[globalPatternIndex++] === true) {

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/long_running/rule.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/builtin_alert_types/long_running/rule.ts
@@ -7,6 +7,9 @@
 
 import expect from '@kbn/expect';
 
+import type { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import type { Alert } from '@kbn/alerts-as-data-utils';
+import { ALERT_INSTANCE_ID } from '@kbn/rule-data-utils';
 import { Spaces } from '../../../../../scenarios';
 import { FtrProviderContext } from '../../../../../../common/ftr_provider_context';
 import { getUrlPrefix, ObjectRemover, getEventLog } from '../../../../../../common/lib';
@@ -15,17 +18,25 @@ const RULE_INTERVAL_SECONDS = 3;
 
 // eslint-disable-next-line import/no-default-export
 export default function ruleTests({ getService }: FtrProviderContext) {
+  const es = getService('es');
   const supertest = getService('supertest');
   const retry = getService('retry');
+
+  const alertsAsDataIndex = '.alerts-test.patternfiring.alerts-default';
 
   describe('long running rule', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     afterEach(async () => {
       await objectRemover.removeAll();
+      await es.deleteByQuery({
+        index: alertsAsDataIndex,
+        query: { match_all: {} },
+        conflicts: 'proceed',
+      });
     });
 
-    it('writes event log document for timeout for each rule execution that ends in timeout - every execution times out', async () => {
+    it('writes event log document for timeout and no alerts for each rule execution that ends in timeout - every execution times out', async () => {
       const ruleId = await createRule({
         name: 'long running rule',
         ruleTypeId: 'test.patternLongRunning.cancelAlertsOnRuleTimeout',
@@ -71,6 +82,10 @@ export default function ruleTests({ getService }: FtrProviderContext) {
       );
       expect(status).to.eql(200);
 
+      // no alerts should exist
+      const alertDocs = await queryForAlertDocs<Alert>();
+      expect(alertDocs.length).to.eql(0);
+
       expect(errorStatuses.length).to.be.greaterThan(0);
       const lastErrorStatus = errorStatuses.pop();
       expect(lastErrorStatus?.status).to.eql('error');
@@ -83,7 +98,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
       expect(['timeout', 'execute'].includes(lastErrorStatus?.error.reason || '')).to.eql(true);
     });
 
-    it('writes event log document for timeout for each rule execution that ends in timeout - some executions times out', async () => {
+    it('writes event log document for timeout and no alerts for each rule execution that ends in timeout - some executions times out', async () => {
       const ruleId = await createRule({
         name: 'long running rule',
         ruleTypeId: 'test.patternLongRunning.cancelAlertsOnRuleTimeout',
@@ -115,7 +130,17 @@ export default function ruleTests({ getService }: FtrProviderContext) {
           `${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule/${ruleId}`
         );
         expect(status).to.eql(200);
-        expect(rule.execution_status.status).to.eql('active');
+        expect(rule.execution_status.status).to.eql('ok');
+      });
+
+      await retry.try(async () => {
+        const alertDocs = await queryForAlertDocs<Alert>();
+        // expect 1 alert for each execution that didn't time out
+        expect(alertDocs.length).to.eql(3);
+
+        expect(alertDocs[0]._source?.[ALERT_INSTANCE_ID]).to.eql(`alert_3`);
+        expect(alertDocs[1]._source?.[ALERT_INSTANCE_ID]).to.eql(`alert_2`);
+        expect(alertDocs[2]._source?.[ALERT_INSTANCE_ID]).to.eql(`alert_0`);
       });
     });
 
@@ -142,6 +167,17 @@ export default function ruleTests({ getService }: FtrProviderContext) {
             ['active-instance', { gte: 3 }],
           ]),
         });
+      });
+
+      await retry.try(async () => {
+        const alertDocs = await queryForAlertDocs<Alert>();
+        // expect 1 alert for each execution bc we're writing alerts even if the rule times out
+        expect(alertDocs.length).to.eql(4);
+
+        expect(alertDocs[0]._source?.[ALERT_INSTANCE_ID]).to.eql(`alert_3`);
+        expect(alertDocs[1]._source?.[ALERT_INSTANCE_ID]).to.eql(`alert_2`);
+        expect(alertDocs[2]._source?.[ALERT_INSTANCE_ID]).to.eql(`alert_1`);
+        expect(alertDocs[3]._source?.[ALERT_INSTANCE_ID]).to.eql(`alert_0`);
       });
     });
 
@@ -174,6 +210,14 @@ export default function ruleTests({ getService }: FtrProviderContext) {
       objectRemover.add(Spaces.space1.id, ruleId, 'rule', 'alerting');
 
       return ruleId;
+    }
+
+    async function queryForAlertDocs<T>(): Promise<Array<SearchHit<T>>> {
+      const searchResult = await es.search({
+        index: alertsAsDataIndex,
+        query: { match_all: {} },
+      });
+      return searchResult.hits.hits as Array<SearchHit<T>>;
     }
   });
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Response Ops][Alerting] Skip writing alerts when rule exceeds configured timeout (#220147)](https://github.com/elastic/kibana/pull/220147)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ying Mao","email":"ying.mao@elastic.co"},"sourceCommit":{"committedDate":"2025-05-09T22:38:30Z","message":"[Response Ops][Alerting] Skip writing alerts when rule exceeds configured timeout (#220147)\n\nFixes https://github.com/elastic/kibana/issues/219152\n\n## Summary\n\nWe added the ability to short circuit rule execution (skip scheduling\nactions and writing event log docs) when an execution is cancelled due\nto timeout but at the time we added this ability, we were not persisting\nalert documents. When we added framework alerts-as-data, we did not add\na check to ensure rule execution had not timed out before writing the\nalerts. This PR adds the missing check. This should also respect the\n`cancelAlertsOnRuleTimeout` flag that can be set in the config or the\nrule type that can force persisting alerts regardless of timeout.\n\n## To verify\n\n1. Set a short `ruleTaskTimeout` on a rule type and add a delay to the\nrule executor that will force the rule to timeout.\n2. Create a rule of that type that generates alerts. Verify that when\nthe rule execution times out, no alerts are written.","sha":"437a9fa4f3c009bd5b1ebc1383de4459f45200f5","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","backport:version","v9.1.0","v8.19.0","v8.18.2","v9.0.2"],"title":"[Response Ops][Alerting] Skip writing alerts when rule exceeds configured timeout","number":220147,"url":"https://github.com/elastic/kibana/pull/220147","mergeCommit":{"message":"[Response Ops][Alerting] Skip writing alerts when rule exceeds configured timeout (#220147)\n\nFixes https://github.com/elastic/kibana/issues/219152\n\n## Summary\n\nWe added the ability to short circuit rule execution (skip scheduling\nactions and writing event log docs) when an execution is cancelled due\nto timeout but at the time we added this ability, we were not persisting\nalert documents. When we added framework alerts-as-data, we did not add\na check to ensure rule execution had not timed out before writing the\nalerts. This PR adds the missing check. This should also respect the\n`cancelAlertsOnRuleTimeout` flag that can be set in the config or the\nrule type that can force persisting alerts regardless of timeout.\n\n## To verify\n\n1. Set a short `ruleTaskTimeout` on a rule type and add a delay to the\nrule executor that will force the rule to timeout.\n2. Create a rule of that type that generates alerts. Verify that when\nthe rule execution times out, no alerts are written.","sha":"437a9fa4f3c009bd5b1ebc1383de4459f45200f5"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220147","number":220147,"mergeCommit":{"message":"[Response Ops][Alerting] Skip writing alerts when rule exceeds configured timeout (#220147)\n\nFixes https://github.com/elastic/kibana/issues/219152\n\n## Summary\n\nWe added the ability to short circuit rule execution (skip scheduling\nactions and writing event log docs) when an execution is cancelled due\nto timeout but at the time we added this ability, we were not persisting\nalert documents. When we added framework alerts-as-data, we did not add\na check to ensure rule execution had not timed out before writing the\nalerts. This PR adds the missing check. This should also respect the\n`cancelAlertsOnRuleTimeout` flag that can be set in the config or the\nrule type that can force persisting alerts regardless of timeout.\n\n## To verify\n\n1. Set a short `ruleTaskTimeout` on a rule type and add a delay to the\nrule executor that will force the rule to timeout.\n2. Create a rule of that type that generates alerts. Verify that when\nthe rule execution times out, no alerts are written.","sha":"437a9fa4f3c009bd5b1ebc1383de4459f45200f5"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220724","number":220724,"state":"OPEN"},{"branch":"8.18","label":"v8.18.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->