### PR TITLE
Discover: Show missing values for ESQL breakdown

### DIFF
--- a/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/services/lens_vis_service.ts
@@ -605,7 +605,13 @@ export class LensVisService {
 
     return appendToESQLQuery(
       safeQuery,
-      `| EVAL ${TIMESTAMP_COLUMN}=DATE_TRUNC(${queryInterval}, ${dataView.timeFieldName}) | stats results = count(*) by ${TIMESTAMP_COLUMN}${breakdown}${sortBy}`
+      `${
+        breakdownColumn
+          ? `| EVAL \`${breakdownColumn.name}\` = COALESCE( \`${breakdownColumn.name}\`, "<missing>")`
+          : ''
+      } | EVAL ${TIMESTAMP_COLUMN}=DATE_TRUNC(${queryInterval}, ${
+        dataView.timeFieldName
+      }) | stats results = count(*) by ${TIMESTAMP_COLUMN}${breakdown}${sortBy}`
     );
   };
 


### PR DESCRIPTION
The ESQL histogram breakdown-by functionality uses a simple `STATS by {field name}`. This works OK, but it does not take into account that some docs do not have a value for a field.

This can be very confusing, especially for the case where a default breakdown field is selected, like in the case of the logs profile, which picks `log.level` by default - in this case, the histogram doesn't show all the data it matches but just a subset. It's common for datasets to only have log.level set on a subset of logs.

This PR fixes this problem by using a `COALESCE` function to show docs without a value for the breakdown field as `<missing>`.

To quote @nik9000

> COALESCE is pretty much free if the block doesn't have any null values in it.
