### PR TITLE
[Discover] Support custom cell renderers and row indicators in document profiles

### DIFF
--- a/src/platform/packages/shared/kbn-unified-data-table/README.md
+++ b/src/platform/packages/shared/kbn-unified-data-table/README.md
@@ -3,14 +3,15 @@
 This package contains components and services for the unified data table UI (as used in Discover).
 
 ## UnifiedDataTable Component
+
 Props description:
 | Property | Type | Description |
-| :---   | :--- | :--- |
+| :--- | :--- | :--- |
 | **ariaLabelledBy** | string | Determines which element labels the grid for ARIA. |
 | **className** | (optional) string | Optional class name to apply. |
 | **columns** | string[] | Determines ids of the columns which are displayed. |
-| **expandedDoc** | (optional) DataTableRecord  | If set, the given document is displayed in a flyout. |
-| **enableInTableSearch** | (optional) boolean  | Set to true to allow users to search inside the table. |
+| **expandedDoc** | (optional) DataTableRecord | If set, the given document is displayed in a flyout. |
+| **enableInTableSearch** | (optional) boolean | Set to true to allow users to search inside the table. |
 | **dataView** | DataView | The used data view. |
 | **loadingState** | DataLoadingState | Determines if data is currently loaded. |
 | **onFilter** | DocViewFilterFn | Function to add a filter in the grid cell or document flyout. |
@@ -48,12 +49,13 @@ Props description:
 | **rowsPerPageOptions** | (optional)number[] | Optional list of number type values to set custom UnifiedDataTable paging options to display the records per page. |
 | **renderCustomGridBody** | (optional)(args: EuiDataGridCustomBodyProps) => React.ReactNode; | An optional function called to completely customize and control the rendering of EuiDataGrid's body and cell placement. |
 | **visibleCellActions** | (optional)number | An optional value for a custom number of the visible cell actions in the table. By default is up to 3. |
-| **externalCustomRenderers** | (optional)Record<string,(props: EuiDataGridCellValueElementProps) => React.ReactNode>; | An optional settings for a specified fields rendering like links. Applied only for the listed fields rendering. |
+| **getCustomCellRenderer** | (optional)(props: DataGridCellValueElementProps) => FunctionComponent<DataGridCellValueElementProps> | undefined; | An optional function to provide a custom renderer for data grid cells. |
 | **consumer** | (optional)string | Name of the UnifiedDataTable consumer component or application. |
 | **componentsTourSteps** | (optional)Record<string,string> | Optional key/value pairs to set guided onboarding steps ids for a data table components included to guided tour. |~~~~
 | **onUpdateDataGridDensity** | (optional)(DataGridDensity) => void; | Optional callback when the data grid density configuration is modified. |
 
-*Required **services** list:
+\*Required **services** list:
+
 ```
     theme: ThemeServiceStart;
     fieldFormats: FieldFormatsStart;
@@ -109,7 +111,7 @@ Usage example:
       onUpdateRowsPerPage={(rowHeight: number) => {
         // Do the state update with the new number of the rows per page
       }
-      onFieldEdited={() => 
+      onFieldEdited={() =>
         // Callback to execute on edit runtime field. Refetch data.
       }
       cellActionsTriggerId={SecurityCellActionsTrigger.DEFAULT}
@@ -123,10 +125,10 @@ Usage example:
         data: dataPluginContract,
       }}
       visibleCellActions={3}
-      externalCustomRenderers={{
-        // Set the record style definition for the specific fields rendering Record<string,(props: EuiDataGridCellValueElementProps) => React.ReactNode>
+      getCustomCellRenderer={(props: DataGridCellValueElementProps) => {
+        // An optional function to provide a custom renderer for data grid cells
       }}
-      renderDocumentView={() => 
+      renderDocumentView={() =>
         // Implement similar callback to render the Document flyout
           const renderDetailsPanel = useCallback(
                 () => (
@@ -161,14 +163,15 @@ Usage example:
 ```
 
 ## JsonCodeEditorCommon Component
+
 Props description:
 | Property | Type | Description |
-| :---   | :--- | :--- |
-| **width** | (optional) string or number  | Editor component width. |
-| **height** | (optional) string or number  | Editor component height. |
-| **hasLineNumbers** | (optional) boolean  | Define if the editor component has line numbers style. |
-| **hideCopyButton** | (optional) boolean  | Show/hide setting for Copy button. |
-| **onEditorDidMount** | (editor: monaco.editor.IStandaloneCodeEditor) => void  | Do some logic to update the state with the edotor component value. |
+| :--- | :--- | :--- |
+| **width** | (optional) string or number | Editor component width. |
+| **height** | (optional) string or number | Editor component height. |
+| **hasLineNumbers** | (optional) boolean | Define if the editor component has line numbers style. |
+| **hideCopyButton** | (optional) boolean | Show/hide setting for Copy button. |
+| **onEditorDidMount** | (editor: monaco.editor.IStandaloneCodeEditor) => void | Do some logic to update the state with the edotor component value. |
 
 Usage example:
 
@@ -185,15 +188,15 @@ Usage example:
 
 ## Utils
 
-* `getRowsPerPageOptions(currentRowsPerPage)` - gets list of the table defaults for perPage options.
+- `getRowsPerPageOptions(currentRowsPerPage)` - gets list of the table defaults for perPage options.
 
-* `getDisplayedColumns(currentRowsPerPage)` - gets list of the table columns with the logic to define the empty list with _source column.
+- `getDisplayedColumns(currentRowsPerPage)` - gets list of the table columns with the logic to define the empty list with \_source column.
 
-* `popularizeField(...)` - helper function to define the dataView persistance and save indexPattern update capabilities.
+- `popularizeField(...)` - helper function to define the dataView persistance and save indexPattern update capabilities.
 
 ## Hooks
 
-* `useColumns(...)` - this hook define the state update for the columns event handlers and allows to use them for external components outside the UnifiedDataTable.
+- `useColumns(...)` - this hook define the state update for the columns event handlers and allows to use them for external components outside the UnifiedDataTable.
 
 An example of using hooks for defining event handlers for columns management with setting the consumer specific setAppState:
 

--- a/src/platform/packages/shared/kbn-unified-data-table/index.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/index.ts
@@ -15,6 +15,7 @@ export {
 } from './src/components/row_height_settings';
 export { getDisplayedColumns, SOURCE_COLUMN } from './src/utils/columns';
 export { getTextBasedColumnsMeta } from './src/utils/get_columns_meta';
+export { getCellRendererFromColumnMap } from './src/utils/get_render_cell_value';
 export { ROWS_HEIGHT_OPTIONS, DataGridDensity, DEFAULT_PAGINATION_MODE } from './src/constants';
 
 export { JSONCodeEditorCommonMemoized } from './src/components/json_code_editor/json_code_editor_common';

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.test.tsx
@@ -47,7 +47,7 @@ import {
 import { DatatableColumnType } from '@kbn/expressions-plugin/common';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { CELL_CLASS } from '../utils/get_render_cell_value';
+import { CELL_CLASS, getCellRendererFromColumnMap } from '../utils/get_render_cell_value';
 import { defaultTimeColumnWidth } from '../constants';
 import { useColumns } from '../hooks/use_data_grid_columns';
 import { capabilitiesServiceMock } from '@kbn/core-capabilities-browser-mocks';
@@ -912,18 +912,18 @@ describe('UnifiedDataTable', () => {
     );
   });
 
-  describe('externalCustomRenderers', () => {
+  describe('getCustomCellRenderer', () => {
     it(
       'should render only host column with the custom renderer, message should be rendered with the default cell renderer',
       async () => {
         const component = await getComponent({
           ...getProps(),
           columns: ['message', 'host'],
-          externalCustomRenderers: {
+          getCustomCellRenderer: getCellRendererFromColumnMap({
             host: (props: EuiDataGridCellValueElementProps) => (
               <div data-test-subj={`test-renderer-${props.columnId}`}>{props.columnId}</div>
             ),
-          },
+          }),
         });
 
         expect(findTestSubject(component, 'test-renderer-host').exists()).toBeTruthy();

--- a/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/components/data_table.tsx
@@ -57,9 +57,9 @@ import {
   UnifiedDataTableSettings,
   ValueToStringConverter,
   DataTableColumnsMeta,
-  CustomCellRenderer,
   CustomGridColumnsConfiguration,
   DataGridPaginationMode,
+  GetCustomCellRenderer,
 } from '../types';
 import { getDisplayedColumns } from '../utils/columns';
 import { convertValueToString } from '../utils/convert_value_to_string';
@@ -391,9 +391,9 @@ export interface UnifiedDataTableProps {
    **/
   visibleCellActions?: number;
   /**
-   * An optional settings for a specified fields rendering like links. Applied only for the listed fields rendering.
+   * An optional function to provide a custom renderer for data grid cells
    */
-  externalCustomRenderers?: CustomCellRenderer;
+  getCustomCellRenderer?: GetCustomCellRenderer;
   /**
    * An optional prop to provide awareness of additional field groups when paired with the Unified Field List.
    */
@@ -502,7 +502,7 @@ export const UnifiedDataTable = ({
   maxDocFieldsDisplayed = 50,
   externalAdditionalControls,
   rowsPerPageOptions,
-  externalCustomRenderers,
+  getCustomCellRenderer,
   additionalFieldGroups,
   consumer = 'discover',
   componentsTourSteps,
@@ -744,7 +744,7 @@ export const UnifiedDataTable = ({
         closePopover: () => dataGridRef.current?.closeCellPopover(),
         fieldFormats,
         maxEntries: maxDocFieldsDisplayed,
-        externalCustomRenderers,
+        getCustomCellRenderer,
         isPlainRecord,
         isCompressed: dataGridDensity === DataGridDensity.COMPACT,
         columnsMeta,
@@ -753,9 +753,9 @@ export const UnifiedDataTable = ({
       dataView,
       displayedRows,
       shouldShowFieldHandler,
-      maxDocFieldsDisplayed,
       fieldFormats,
-      externalCustomRenderers,
+      maxDocFieldsDisplayed,
+      getCustomCellRenderer,
       isPlainRecord,
       dataGridDensity,
       columnsMeta,

--- a/src/platform/packages/shared/kbn-unified-data-table/src/types.ts
+++ b/src/platform/packages/shared/kbn-unified-data-table/src/types.ts
@@ -46,7 +46,14 @@ export type DataGridCellValueElementProps = EuiDataGridCellValueElementProps & {
   isCompressed?: boolean;
 };
 
-export type CustomCellRenderer = Record<string, FunctionComponent<DataGridCellValueElementProps>>;
+export type CellRendererColumnMap = Record<
+  string,
+  FunctionComponent<DataGridCellValueElementProps>
+>;
+
+export type GetCustomCellRenderer = (
+  props: DataGridCellValueElementProps
+) => FunctionComponent<DataGridCellValueElementProps> | undefined;
 
 export interface CustomGridColumnProps {
   column: EuiDataGridColumn;

--- a/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
+++ b/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
@@ -29,12 +29,7 @@ import {
   SHOW_MULTIFIELDS,
 } from '@kbn/discover-utils';
 import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
-import {
-  DataLoadingState,
-  getCellRendererFromColumnMap,
-  getDataGridDensity,
-  getRowHeight,
-} from '@kbn/unified-data-table';
+import { DataLoadingState, getDataGridDensity, getRowHeight } from '@kbn/unified-data-table';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import { useQuerySubscriber } from '@kbn/unified-field-list';
 import useObservable from 'react-use/lib/useObservable';
@@ -53,7 +48,7 @@ import { onResizeGridColumn } from '../../utils/on_resize_grid_column';
 import {
   DISCOVER_CELL_ACTIONS_TRIGGER,
   useAdditionalCellActions,
-  useProfileAccessor,
+  useCustomCellRenderers,
 } from '../../context_awareness';
 import { createDataSource } from '../../../common/data_sources';
 
@@ -177,10 +172,8 @@ export function ContextAppContent({
   );
 
   const configRowHeight = services.uiSettings.get(ROW_HEIGHT_OPTION);
-  const getCellRenderersAccessor = useProfileAccessor('getCellRenderers');
-  const getCustomCellRenderer = useMemo(() => {
-    const getCellRenderers = getCellRenderersAccessor(() => ({}));
-    const cellRenderers = getCellRenderers({
+  const cellRendererParams = useMemo(
+    () => ({
       actions: { addFilter },
       dataView,
       density: getDataGridDensity(services.storage, 'discover'),
@@ -189,9 +182,10 @@ export function ContextAppContent({
         consumer: 'discover',
         configRowHeight,
       }),
-    });
-    return getCellRendererFromColumnMap(cellRenderers);
-  }, [addFilter, configRowHeight, dataView, getCellRenderersAccessor, services.storage]);
+    }),
+    [addFilter, configRowHeight, dataView, services.storage]
+  );
+  const getCustomCellRenderer = useCustomCellRenderers(cellRendererParams);
 
   const dataSource = useMemo(() => createDataSource({ dataView, query: undefined }), [dataView]);
   const { filters } = useQuerySubscriber({ data: services.data });

--- a/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
+++ b/src/platform/plugins/shared/discover/public/application/context/context_app_content.tsx
@@ -29,7 +29,12 @@ import {
   SHOW_MULTIFIELDS,
 } from '@kbn/discover-utils';
 import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
-import { DataLoadingState, getDataGridDensity, getRowHeight } from '@kbn/unified-data-table';
+import {
+  DataLoadingState,
+  getCellRendererFromColumnMap,
+  getDataGridDensity,
+  getRowHeight,
+} from '@kbn/unified-data-table';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import { useQuerySubscriber } from '@kbn/unified-field-list';
 import useObservable from 'react-use/lib/useObservable';
@@ -173,9 +178,9 @@ export function ContextAppContent({
 
   const configRowHeight = services.uiSettings.get(ROW_HEIGHT_OPTION);
   const getCellRenderersAccessor = useProfileAccessor('getCellRenderers');
-  const cellRenderers = useMemo(() => {
+  const getCustomCellRenderer = useMemo(() => {
     const getCellRenderers = getCellRenderersAccessor(() => ({}));
-    return getCellRenderers({
+    const cellRenderers = getCellRenderers({
       actions: { addFilter },
       dataView,
       density: getDataGridDensity(services.storage, 'discover'),
@@ -185,6 +190,7 @@ export function ContextAppContent({
         configRowHeight,
       }),
     });
+    return getCellRendererFromColumnMap(cellRenderers);
   }, [addFilter, configRowHeight, dataView, getCellRenderersAccessor, services.storage]);
 
   const dataSource = useMemo(() => createDataSource({ dataView, query: undefined }), [dataView]);
@@ -251,7 +257,7 @@ export function ContextAppContent({
             configHeaderRowHeight={3}
             settings={grid}
             onResize={onResize}
-            externalCustomRenderers={cellRenderers}
+            getCustomCellRenderer={getCustomCellRenderer}
           />
         </CellActionsProvider>
       </div>

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.test.tsx
@@ -31,6 +31,15 @@ import { DiscoverGrid } from '../../../../components/discover_grid';
 import { createDataViewDataSource } from '../../../../../common/data_sources';
 import type { ProfilesManager } from '../../../../context_awareness';
 import { CurrentTabProvider, internalStateActions } from '../../state_management/redux';
+import { getCellRendererFromColumnMap } from '@kbn/unified-data-table';
+
+jest.mock('@kbn/unified-data-table', () => {
+  const actual = jest.requireActual('@kbn/unified-data-table');
+  return {
+    ...actual,
+    getCellRendererFromColumnMap: jest.fn(actual.getCellRendererFromColumnMap),
+  };
+});
 
 const customisationService = createCustomizationService();
 
@@ -158,7 +167,7 @@ describe('Discover documents layout', () => {
     expect(discoverGridComponent.prop('rowAdditionalLeadingControls')).toBe(
       customization.rowAdditionalLeadingControls
     );
-    expect(discoverGridComponent.prop('externalCustomRenderers')).toBeDefined();
+    expect(discoverGridComponent.prop('getCustomCellRenderer')).toBeDefined();
     expect(discoverGridComponent.prop('customGridColumnsConfiguration')).toBeDefined();
   });
 
@@ -172,10 +181,13 @@ describe('Discover documents layout', () => {
       const component = await mountComponent(FetchStatus.COMPLETE, esHitsMock);
       const discoverGridComponent = component.find(DiscoverGrid);
       expect(discoverGridComponent.exists()).toBeTruthy();
-      expect(Object.keys(discoverGridComponent.prop('externalCustomRenderers')!)).toEqual([
-        '_source',
-        'rootProfile',
-      ]);
+      expect(getCellRendererFromColumnMap).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          _source: expect.any(Function),
+          rootProfile: expect.any(Function),
+        })
+      );
+      expect(discoverGridComponent.prop('getCustomCellRenderer')).toEqual(expect.any(Function));
     });
   });
 });

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -36,7 +36,6 @@ import {
   getRenderCustomToolbarWithElements,
   getDataGridDensity,
   getRowHeight,
-  getCellRendererFromColumnMap,
 } from '@kbn/unified-data-table';
 import {
   DOC_HIDE_TIME_COLUMN_SETTING,
@@ -74,7 +73,7 @@ import type { CellRenderersExtensionParams } from '../../../../context_awareness
 import {
   DISCOVER_CELL_ACTIONS_TRIGGER,
   useAdditionalCellActions,
-  useProfileAccessor,
+  useCustomCellRenderers,
 } from '../../../../context_awareness';
 import {
   internalStateActions,
@@ -348,14 +347,7 @@ function DiscoverDocumentsComponent({
   const { customCellRenderer, customGridColumnsConfiguration } =
     useContextualGridCustomisations(cellRendererParams) || {};
   const additionalFieldGroups = useAdditionalFieldGroups();
-
-  const getCellRenderersAccessor = useProfileAccessor('getCellRenderers');
-  const getCustomCellRenderer = useMemo(() => {
-    const getCellRenderers = getCellRenderersAccessor(() => customCellRenderer ?? {});
-    const cellRenderers = getCellRenderers(cellRendererParams);
-    return getCellRendererFromColumnMap(cellRenderers);
-  }, [cellRendererParams, customCellRenderer, getCellRenderersAccessor]);
-
+  const getCustomCellRenderer = useCustomCellRenderers(cellRendererParams, customCellRenderer);
   const documents = useObservable(stateContainer.dataState.data$.documents$);
 
   const callouts = useMemo(

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -36,6 +36,7 @@ import {
   getRenderCustomToolbarWithElements,
   getDataGridDensity,
   getRowHeight,
+  getCellRendererFromColumnMap,
 } from '@kbn/unified-data-table';
 import {
   DOC_HIDE_TIME_COLUMN_SETTING,
@@ -349,9 +350,10 @@ function DiscoverDocumentsComponent({
   const additionalFieldGroups = useAdditionalFieldGroups();
 
   const getCellRenderersAccessor = useProfileAccessor('getCellRenderers');
-  const cellRenderers = useMemo(() => {
+  const getCustomCellRenderer = useMemo(() => {
     const getCellRenderers = getCellRenderersAccessor(() => customCellRenderer ?? {});
-    return getCellRenderers(cellRendererParams);
+    const cellRenderers = getCellRenderers(cellRendererParams);
+    return getCellRendererFromColumnMap(cellRenderers);
   }, [cellRendererParams, customCellRenderer, getCellRenderersAccessor]);
 
   const documents = useObservable(stateContainer.dataState.data$.documents$);
@@ -467,7 +469,7 @@ function DiscoverDocumentsComponent({
             services={services}
             totalHits={totalHits}
             onFetchMoreRecords={onFetchMoreRecords}
-            externalCustomRenderers={cellRenderers}
+            getCustomCellRenderer={getCustomCellRenderer}
             customGridColumnsConfiguration={customGridColumnsConfiguration}
             rowAdditionalLeadingControls={rowAdditionalLeadingControls}
             additionalFieldGroups={additionalFieldGroups}

--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -94,19 +94,21 @@ export const onResize = (
   stateContainer.appState.update({ grid: newGrid });
 };
 
+export interface DiscoverDocumentsProps {
+  viewModeToggle: React.ReactElement | undefined;
+  dataView: DataView;
+  onAddFilter?: DocViewFilterFn;
+  stateContainer: DiscoverStateContainer;
+  onFieldEdited?: () => void;
+}
+
 function DiscoverDocumentsComponent({
   viewModeToggle,
   dataView,
   onAddFilter,
   stateContainer,
   onFieldEdited,
-}: {
-  viewModeToggle: React.ReactElement | undefined;
-  dataView: DataView;
-  onAddFilter?: DocViewFilterFn;
-  stateContainer: DiscoverStateContainer;
-  onFieldEdited?: () => void;
-}) {
+}: DiscoverDocumentsProps) {
   const services = useDiscoverServices();
   const dispatch = useInternalStateDispatch();
   const documents$ = stateContainer.dataState.data$.documents$;

--- a/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid/discover_grid.tsx
@@ -14,7 +14,11 @@ import {
   UnifiedDataTable,
   type UnifiedDataTableProps,
 } from '@kbn/unified-data-table';
-import { useProfileAccessor } from '../../context_awareness';
+import {
+  type RowIndicatorExtensionParams,
+  useProfileAccessor,
+  useRowIndicatorProvider,
+} from '../../context_awareness';
 import type { DiscoverAppState } from '../../application/main/state_management/discover_app_state_container';
 import type { DiscoverStateContainer } from '../../application/main/state_management/discover_state';
 
@@ -34,10 +38,11 @@ export const DiscoverGrid: React.FC<DiscoverGridProps> = ({
   ...props
 }) => {
   const { dataView, setExpandedDoc } = props;
-  const getRowIndicatorProvider = useProfileAccessor('getRowIndicatorProvider');
-  const getRowIndicator = useMemo(() => {
-    return getRowIndicatorProvider(() => undefined)({ dataView: props.dataView });
-  }, [getRowIndicatorProvider, props.dataView]);
+  const rowIndicatorParams = useMemo<RowIndicatorExtensionParams>(
+    () => ({ dataView: props.dataView }),
+    [props.dataView]
+  );
+  const getRowIndicator = useRowIndicatorProvider(rowIndicatorParams);
 
   const getRowAdditionalLeadingControlsAccessor = useProfileAccessor(
     'getRowAdditionalLeadingControls'

--- a/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
@@ -42,6 +42,10 @@ export const createContextAwarenessMocks = ({
         ...prev(params),
         rootProfile: () => <span data-test-subj="root-profile-renderer">root-profile</span>,
       })),
+      getRowIndicatorProvider: jest.fn(() => () => () => ({
+        label: 'root-indicator',
+        color: 'red',
+      })),
       getAdditionalCellActions: jest.fn((prev) => () => [
         ...prev(),
         {
@@ -71,6 +75,10 @@ export const createContextAwarenessMocks = ({
         dataSourceProfile: () => (
           <span data-test-subj="data-source-profile-renderer">data-source-profile</span>
         ),
+      })),
+      getRowIndicatorProvider: jest.fn(() => () => () => ({
+        label: 'data-source-indicator',
+        color: 'blue',
       })),
       getDefaultAppState: jest.fn(() => () => ({
         columns: [
@@ -126,6 +134,10 @@ export const createContextAwarenessMocks = ({
         documentProfile: () => (
           <span data-test-subj="document-profile-renderer">document-profile</span>
         ),
+      })),
+      getRowIndicatorProvider: jest.fn(() => () => () => ({
+        label: 'document-indicator',
+        color: 'green',
       })),
       getDocViewer: (prev) => (params) => {
         const recordId = params.record.id;

--- a/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/__mocks__/index.tsx
@@ -40,7 +40,7 @@ export const createContextAwarenessMocks = ({
     profile: {
       getCellRenderers: jest.fn((prev) => (params) => ({
         ...prev(params),
-        rootProfile: () => <>root-profile</>,
+        rootProfile: () => <span data-test-subj="root-profile-renderer">root-profile</span>,
       })),
       getAdditionalCellActions: jest.fn((prev) => () => [
         ...prev(),
@@ -68,7 +68,9 @@ export const createContextAwarenessMocks = ({
     profile: {
       getCellRenderers: jest.fn((prev) => (params) => ({
         ...prev(params),
-        rootProfile: () => <>data-source-profile</>,
+        dataSourceProfile: () => (
+          <span data-test-subj="data-source-profile-renderer">data-source-profile</span>
+        ),
       })),
       getDefaultAppState: jest.fn(() => () => ({
         columns: [
@@ -119,9 +121,11 @@ export const createContextAwarenessMocks = ({
   const documentProfileProviderMock: DocumentProfileProvider = {
     profileId: 'document-profile',
     profile: {
-      getCellRenderers: jest.fn((prev) => () => ({
-        ...prev(),
-        rootProfile: () => 'document-profile',
+      getCellRenderers: jest.fn((prev) => (params) => ({
+        ...prev(params),
+        documentProfile: () => (
+          <span data-test-subj="document-profile-renderer">document-profile</span>
+        ),
       })),
       getDocViewer: (prev) => (params) => {
         const recordId = params.record.id;

--- a/src/platform/plugins/shared/discover/public/context_awareness/hooks/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/hooks/index.ts
@@ -11,3 +11,4 @@ export { useProfileAccessor } from './use_profile_accessor';
 export { useRootProfile, BaseAppWrapper, type RootProfileState } from './use_root_profile';
 export { useAdditionalCellActions } from './use_additional_cell_actions';
 export { useDefaultAdHocDataViews } from './use_default_ad_hoc_data_views';
+export { useCustomCellRenderers } from './use_custom_cell_renderers';

--- a/src/platform/plugins/shared/discover/public/context_awareness/hooks/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/hooks/index.ts
@@ -12,3 +12,4 @@ export { useRootProfile, BaseAppWrapper, type RootProfileState } from './use_roo
 export { useAdditionalCellActions } from './use_additional_cell_actions';
 export { useDefaultAdHocDataViews } from './use_default_ad_hoc_data_views';
 export { useCustomCellRenderers } from './use_custom_cell_renderers';
+export { useRowIndicatorProvider } from './use_row_indicator_provider';

--- a/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_custom_cell_renderers.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_custom_cell_renderers.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { render, renderHook, screen } from '@testing-library/react';
+import { useCustomCellRenderers } from './use_custom_cell_renderers';
+import React from 'react';
+import { buildDataViewMock, generateEsHits } from '@kbn/discover-utils/src/__mocks__';
+import { createDiscoverServicesMock } from '../../__mocks__/services';
+import { buildDataTableRecord } from '@kbn/discover-utils';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import type { DataGridCellValueElementProps } from '@kbn/unified-data-table';
+
+const renderHookWrapper = async () => {
+  const services = createDiscoverServicesMock();
+  await services.profilesManager.resolveRootProfile({});
+  await services.profilesManager.resolveDataSourceProfile({});
+  const dataView = buildDataViewMock({});
+  const hit = generateEsHits(dataView, 1)[0];
+  const record = services.profilesManager.resolveDocumentProfile({
+    record: buildDataTableRecord(hit, dataView),
+  });
+  const hook = renderHook(
+    () =>
+      useCustomCellRenderers({
+        actions: {
+          addFilter: jest.fn(),
+        },
+        dataView,
+        density: undefined,
+        rowHeight: undefined,
+      }),
+    {
+      wrapper: ({ children }) => (
+        <KibanaContextProvider services={services}>{children}</KibanaContextProvider>
+      ),
+    }
+  );
+  const getCellProps = (
+    props: Pick<DataGridCellValueElementProps, 'columnId'>
+  ): DataGridCellValueElementProps => ({
+    row: record,
+    dataView,
+    fieldFormats: services.fieldFormats,
+    colIndex: 0,
+    rowIndex: 0,
+    isExpandable: false,
+    isExpanded: false,
+    isDetails: false,
+    setCellProps: jest.fn(),
+    closePopover: jest.fn(),
+    ...props,
+  });
+  return { hook, getCellProps };
+};
+
+describe('useCustomCellRenderers', () => {
+  it('should render root profile cell renderer', async () => {
+    const { hook, getCellProps } = await renderHookWrapper();
+    const cellProps = getCellProps({ columnId: 'rootProfile' });
+    const CellRenderer = hook.result.current(cellProps)!;
+    render(<CellRenderer {...cellProps} />);
+    expect(screen.getByText('root-profile')).toBeInTheDocument();
+  });
+
+  it('should render data source profile cell renderer', async () => {
+    const { hook, getCellProps } = await renderHookWrapper();
+    const cellProps = getCellProps({ columnId: 'dataSourceProfile' });
+    const CellRenderer = hook.result.current(cellProps)!;
+    render(<CellRenderer {...cellProps} />);
+    expect(screen.getByText('data-source-profile')).toBeInTheDocument();
+  });
+
+  it('should render document profile cell renderer', async () => {
+    const { hook, getCellProps } = await renderHookWrapper();
+    const cellProps = getCellProps({ columnId: 'documentProfile' });
+    const CellRenderer = hook.result.current(cellProps)!;
+    render(<CellRenderer {...cellProps} />);
+    expect(screen.getByText('document-profile')).toBeInTheDocument();
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_custom_cell_renderers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_custom_cell_renderers.ts
@@ -9,8 +9,9 @@
 
 import { type CellRendererColumnMap, type GetCustomCellRenderer } from '@kbn/unified-data-table';
 import { useCallback } from 'react';
-import { getMergedAccessor, type CellRenderersExtensionParams } from '..';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
+import type { CellRenderersExtensionParams } from '../types';
+import { getMergedAccessor } from '../composable_profile';
 
 export const useCustomCellRenderers = (
   cellRendererParams: CellRenderersExtensionParams,

--- a/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_custom_cell_renderers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_custom_cell_renderers.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { type CellRendererColumnMap, type GetCustomCellRenderer } from '@kbn/unified-data-table';
+import { useCallback } from 'react';
+import { getMergedAccessor, type CellRenderersExtensionParams } from '..';
+import { useDiscoverServices } from '../../hooks/use_discover_services';
+
+export const useCustomCellRenderers = (
+  cellRendererParams: CellRenderersExtensionParams,
+  defaultCellRenderers?: CellRendererColumnMap
+) => {
+  const { profilesManager } = useDiscoverServices();
+
+  return useCallback<GetCustomCellRenderer>(
+    (params) => {
+      const profiles = profilesManager.getProfiles({ record: params.row });
+      const getCellRenderersAccessor = getMergedAccessor(
+        profiles,
+        'getCellRenderers',
+        () => defaultCellRenderers ?? {}
+      );
+      const cellRenderers = getCellRenderersAccessor(cellRendererParams);
+      return cellRenderers[params.columnId];
+    },
+    [cellRendererParams, defaultCellRenderers, profilesManager]
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_row_indicator_provider.test.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_row_indicator_provider.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { buildDataViewMock, generateEsHits } from '@kbn/discover-utils/src/__mocks__';
+import { createDiscoverServicesMock } from '../../__mocks__/services';
+import { type DataTableRecord, buildDataTableRecord } from '@kbn/discover-utils';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { useRowIndicatorProvider } from './use_row_indicator_provider';
+import { useEuiTheme } from '@elastic/eui';
+import type { DiscoverServices } from '../../build_services';
+import type { DataView } from '@kbn/data-views-plugin/common';
+
+const renderHookWrapper = async ({
+  services,
+  params,
+}: {
+  services: DiscoverServices;
+  params?: { dataView: DataView; record: DataTableRecord };
+}) => {
+  const dataView = params?.dataView ?? buildDataViewMock({});
+  const record = params?.record ?? buildDataTableRecord(generateEsHits(dataView, 1)[0], dataView);
+  const hook = renderHook(
+    () => {
+      const { euiTheme } = useEuiTheme();
+      const getRowIndicator = useRowIndicatorProvider({ dataView });
+      return getRowIndicator(record, euiTheme);
+    },
+    {
+      wrapper: ({ children }) => (
+        <KibanaContextProvider services={services}>{children}</KibanaContextProvider>
+      ),
+    }
+  );
+  return { hook };
+};
+
+describe('useRowIndicatorProvider', () => {
+  it('should return undefined when no profile is found', async () => {
+    const services = createDiscoverServicesMock();
+    const { hook } = await renderHookWrapper({ services });
+    expect(hook.result.current).toBeUndefined();
+  });
+
+  it('should return root profile indicator', async () => {
+    const services = createDiscoverServicesMock();
+    await services.profilesManager.resolveRootProfile({});
+    const { hook } = await renderHookWrapper({ services });
+    expect(hook.result.current).toEqual({ label: 'root-indicator', color: 'red' });
+  });
+
+  it('should return data source profile indicator', async () => {
+    const services = createDiscoverServicesMock();
+    await services.profilesManager.resolveRootProfile({});
+    await services.profilesManager.resolveDataSourceProfile({});
+    const { hook } = await renderHookWrapper({ services });
+    expect(hook.result.current).toEqual({ label: 'data-source-indicator', color: 'blue' });
+  });
+
+  it('should return document profile indicator', async () => {
+    const services = createDiscoverServicesMock();
+    await services.profilesManager.resolveRootProfile({});
+    await services.profilesManager.resolveDataSourceProfile({});
+    const dataView = buildDataViewMock({});
+    const hit = generateEsHits(dataView, 1)[0];
+    const record = services.profilesManager.resolveDocumentProfile({
+      record: buildDataTableRecord(hit, dataView),
+    });
+    const { hook } = await renderHookWrapper({ services, params: { dataView, record } });
+    expect(hook.result.current).toEqual({ label: 'document-indicator', color: 'green' });
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_row_indicator_provider.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/hooks/use_row_indicator_provider.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { useCallback } from 'react';
+import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
+import { useDiscoverServices } from '../../hooks/use_discover_services';
+import type { RowIndicatorExtensionParams } from '../types';
+import { getMergedAccessor } from '../composable_profile';
+
+export const useRowIndicatorProvider = (rowIndicatorParams: RowIndicatorExtensionParams) => {
+  const { profilesManager } = useDiscoverServices();
+
+  return useCallback<NonNullable<UnifiedDataTableProps['getRowIndicator']>>(
+    (record, euiTheme) => {
+      const profiles = profilesManager.getProfiles({ record });
+      const getRowIndicatorProviderAccessor = getMergedAccessor(
+        profiles,
+        'getRowIndicatorProvider',
+        () => undefined
+      );
+      const getRowIndicator = getRowIndicatorProviderAccessor(rowIndicatorParams);
+      return getRowIndicator?.(record, euiTheme);
+    },
+    [profilesManager, rowIndicatorParams]
+  );
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/index.ts
@@ -16,6 +16,7 @@ export {
   useRootProfile,
   useAdditionalCellActions,
   useDefaultAdHocDataViews,
+  useCustomCellRenderers,
   BaseAppWrapper,
   type RootProfileState,
 } from './hooks';

--- a/src/platform/plugins/shared/discover/public/context_awareness/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/index.ts
@@ -17,6 +17,7 @@ export {
   useAdditionalCellActions,
   useDefaultAdHocDataViews,
   useCustomCellRenderers,
+  useRowIndicatorProvider,
   BaseAppWrapper,
   type RootProfileState,
 } from './hooks';

--- a/src/platform/plugins/shared/discover/public/context_awareness/profiles/document_profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profiles/document_profile.ts
@@ -27,7 +27,7 @@ export enum DocumentType {
 /**
  * The document profile interface
  */
-export type DocumentProfile = Pick<Profile, 'getDocViewer'>;
+export type DocumentProfile = Pick<Profile, 'getDocViewer' | 'getCellRenderers'>;
 
 /**
  * Parameters for the document profile provider `resolve` method

--- a/src/platform/plugins/shared/discover/public/context_awareness/types.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/types.ts
@@ -9,7 +9,7 @@
 
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/common';
 import type {
-  CustomCellRenderer,
+  CellRendererColumnMap,
   DataGridDensity,
   UnifiedDataTableProps,
   DataGridPaginationMode,
@@ -312,7 +312,7 @@ export interface Profile {
    * Gets a map of column names to custom cell renderers to use in the data grid
    * @returns The custom cell renderers to use in the data grid
    */
-  getCellRenderers: (params: CellRenderersExtensionParams) => CustomCellRenderer;
+  getCellRenderers: (params: CellRenderersExtensionParams) => CellRendererColumnMap;
 
   /**
    * Gets a row indicator provider, allowing rows in the data grid to be given coloured highlights

--- a/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
@@ -19,14 +19,13 @@ import {
   getRenderCustomToolbarWithElements,
   getDataGridDensity,
   getRowHeight,
-  getCellRendererFromColumnMap,
 } from '@kbn/unified-data-table';
 import type { DocViewerApi } from '@kbn/unified-doc-viewer';
 import { DiscoverGrid } from '../../components/discover_grid';
 import { DiscoverGridFlyout } from '../../components/discover_grid_flyout';
 import { SavedSearchEmbeddableBase } from './saved_search_embeddable_base';
 import { TotalDocuments } from '../../application/main/components/total_documents/total_documents';
-import { useProfileAccessor } from '../../context_awareness';
+import { useCustomCellRenderers } from '../../context_awareness';
 
 interface DiscoverGridEmbeddableProps extends Omit<UnifiedDataTableProps, 'sampleSizeState'> {
   sampleSizeState: number; // a required prop
@@ -110,10 +109,8 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
     [props.totalHitCount, props.isPlainRecord]
   );
 
-  const getCellRenderersAccessor = useProfileAccessor('getCellRenderers');
-  const getCustomCellRenderer = useMemo(() => {
-    const getCellRenderers = getCellRenderersAccessor(() => ({}));
-    const cellRenderers = getCellRenderers({
+  const cellRendererParams = useMemo(
+    () => ({
       actions: { addFilter: props.onFilter },
       dataView: props.dataView,
       density:
@@ -124,17 +121,17 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
         rowHeightState: gridProps.rowHeightState,
         configRowHeight: props.configRowHeight,
       }),
-    });
-    return getCellRendererFromColumnMap(cellRenderers);
-  }, [
-    getCellRenderersAccessor,
-    props.onFilter,
-    props.dataView,
-    props.services.storage,
-    props.configRowHeight,
-    gridProps.dataGridDensityState,
-    gridProps.rowHeightState,
-  ]);
+    }),
+    [
+      gridProps.dataGridDensityState,
+      gridProps.rowHeightState,
+      props.configRowHeight,
+      props.dataView,
+      props.onFilter,
+      props.services.storage,
+    ]
+  );
+  const getCustomCellRenderer = useCustomCellRenderers(cellRendererParams);
 
   return (
     <SavedSearchEmbeddableBase

--- a/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/components/saved_search_grid.tsx
@@ -19,6 +19,7 @@ import {
   getRenderCustomToolbarWithElements,
   getDataGridDensity,
   getRowHeight,
+  getCellRendererFromColumnMap,
 } from '@kbn/unified-data-table';
 import type { DocViewerApi } from '@kbn/unified-doc-viewer';
 import { DiscoverGrid } from '../../components/discover_grid';
@@ -110,9 +111,9 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
   );
 
   const getCellRenderersAccessor = useProfileAccessor('getCellRenderers');
-  const cellRenderers = useMemo(() => {
+  const getCustomCellRenderer = useMemo(() => {
     const getCellRenderers = getCellRenderersAccessor(() => ({}));
-    return getCellRenderers({
+    const cellRenderers = getCellRenderers({
       actions: { addFilter: props.onFilter },
       dataView: props.dataView,
       density:
@@ -124,6 +125,7 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
         configRowHeight: props.configRowHeight,
       }),
     });
+    return getCellRendererFromColumnMap(cellRenderers);
   }, [
     getCellRenderersAccessor,
     props.onFilter,
@@ -151,7 +153,7 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
         maxDocFieldsDisplayed={props.services.uiSettings.get(MAX_DOC_FIELDS_DISPLAYED)}
         renderDocumentView={enableDocumentViewer ? renderDocumentView : undefined}
         renderCustomToolbar={renderCustomToolbarWithElements}
-        externalCustomRenderers={cellRenderers}
+        getCustomCellRenderer={getCustomCellRenderer}
         enableComparisonMode
         showColumnTokens
         showFullScreenButton={false}

--- a/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.test.tsx
+++ b/src/platform/plugins/shared/discover/public/embeddable/get_search_embeddable_factory.test.tsx
@@ -17,7 +17,7 @@ import { buildDataViewMock, deepMockedFields } from '@kbn/discover-utils/src/__m
 import type { PresentationContainer } from '@kbn/presentation-containers';
 import type { PhaseEvent, PublishesUnifiedSearch } from '@kbn/presentation-publishing';
 import { VIEW_MODE } from '@kbn/saved-search-plugin/common';
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
 import type { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
 import { createDataViewDataSource } from '../../common/data_sources';
@@ -281,11 +281,11 @@ describe('saved search embeddable', () => {
       expect(resolveDataSourceProfileSpy).toHaveBeenCalled();
     });
 
-    it('should pass cell renderers from profile', async () => {
+    it('should use cell renderers from profile', async () => {
       const { search, resolveSearch } = createSearchFnMock(1);
       runtimeState = getInitialRuntimeState({
         searchMock: search,
-        partialState: { columns: ['rootProfile', 'message', 'extension'] },
+        partialState: { columns: ['rootProfile', 'dataSourceProfile', 'documentProfile'] },
       });
       const { Component, api } = await factory.buildEmbeddable({
         initialState: { rawState: {} }, // runtimeState passed via mocked deserializeState
@@ -295,7 +295,7 @@ describe('saved search embeddable', () => {
       });
       await waitOneTick(); // wait for build to complete
 
-      const discoverComponent = render(<Component />);
+      render(<Component />);
 
       // wait for data fetching
       expect(api.dataLoading$.getValue()).toBe(true);
@@ -304,9 +304,9 @@ describe('saved search embeddable', () => {
       expect(api.dataLoading$.getValue()).toBe(false);
 
       await waitFor(() => {
-        const discoverGridComponent = discoverComponent.queryByTestId('discoverDocTable');
-        expect(discoverGridComponent).toBeInTheDocument();
-        expect(discoverComponent.queryByText('data-source-profile')).toBeInTheDocument();
+        expect(screen.queryByText('root-profile')).toBeInTheDocument();
+        expect(screen.queryByText('data-source-profile')).toBeInTheDocument();
+        expect(screen.queryByText('document-profile')).toBeInTheDocument();
       });
     });
   });

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -10,6 +10,7 @@ import {
   DataGridDensity,
   UnifiedDataTableSettings,
   UnifiedDataTableSettingsColumn,
+  getCellRendererFromColumnMap,
   useColumns,
 } from '@kbn/unified-data-table';
 import { UnifiedDataTable, DataLoadingState } from '@kbn/unified-data-table';
@@ -240,11 +241,12 @@ export const CloudSecurityDataTable = ({
         : undefined,
     [dataView, filterManager, setUrlQuery]
   );
-  const externalCustomRenderers = useMemo(() => {
+  const getCustomCellRenderer = useMemo(() => {
     if (!customCellRenderer) {
       return undefined;
     }
-    return customCellRenderer(rows);
+    const cellRenderers = customCellRenderer(rows);
+    return getCellRendererFromColumnMap(cellRenderers);
   }, [customCellRenderer, rows]);
 
   const { expandedDoc, onExpandDocClick } = useExpandableFlyoutCsp();
@@ -353,7 +355,7 @@ export const CloudSecurityDataTable = ({
           settings={settings}
           onFetchMoreRecords={loadMore}
           externalControlColumns={externalControlColumns}
-          externalCustomRenderers={externalCustomRenderers}
+          getCustomCellRenderer={getCustomCellRenderer}
           externalAdditionalControls={externalAdditionalControls}
           gridStyleOverride={gridStyle}
           rowLineHeightOverride="24px"

--- a/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/vulnerability_security_data_table.tsx
+++ b/x-pack/solutions/security/plugins/cloud_security_posture/public/components/cloud_security_data_table/vulnerability_security_data_table.tsx
@@ -10,6 +10,7 @@ import {
   DataGridDensity,
   UnifiedDataTableSettings,
   UnifiedDataTableSettingsColumn,
+  getCellRendererFromColumnMap,
   useColumns,
 } from '@kbn/unified-data-table';
 import { UnifiedDataTable, DataLoadingState } from '@kbn/unified-data-table';
@@ -266,11 +267,12 @@ export const VulnerabilityCloudSecurityDataTable = ({
     setPersistedSettings(newGrid);
   };
 
-  const externalCustomRenderers = useMemo(() => {
+  const getCustomCellRenderer = useMemo(() => {
     if (!customCellRenderer) {
       return undefined;
     }
-    return customCellRenderer(rows);
+    const cellRenderers = customCellRenderer(rows);
+    return getCellRendererFromColumnMap(cellRenderers);
   }, [customCellRenderer, rows]);
 
   const onResetColumns = () => {
@@ -354,7 +356,7 @@ export const VulnerabilityCloudSecurityDataTable = ({
           settings={settings}
           onFetchMoreRecords={loadMore}
           externalControlColumns={externalControlColumns}
-          externalCustomRenderers={externalCustomRenderers}
+          getCustomCellRenderer={getCustomCellRenderer}
           externalAdditionalControls={externalAdditionalControls}
           gridStyleOverride={gridStyle}
           rowLineHeightOverride="24px"

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_data_table.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_data_table.tsx
@@ -15,7 +15,8 @@ import {
   useColumns,
   type UnifiedDataTableSettings,
   type UnifiedDataTableSettingsColumn,
-  type CustomCellRenderer,
+  type CellRendererColumnMap,
+  getCellRendererFromColumnMap,
 } from '@kbn/unified-data-table';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import { SHOW_MULTIFIELDS, SORT_DEFAULT_ORDER_SETTING } from '@kbn/discover-utils';
@@ -91,7 +92,7 @@ const columnHeaders: Record<string, string> = {
   ),
 } as const;
 
-const customCellRenderer = (rows: DataTableRecord[]): CustomCellRenderer => ({
+const customCellRenderer = (rows: DataTableRecord[]): CellRendererColumnMap => ({
   [ASSET_FIELDS.ENTITY_RISK]: ({ rowIndex }: EuiDataGridCellValueElementProps) => {
     const risk = rows[rowIndex].flattened[ASSET_FIELDS.ENTITY_RISK] as number;
     return <RiskBadge risk={risk} />;
@@ -308,7 +309,10 @@ export const AssetInventoryDataTable = ({
     setPersistedSettings(newGrid);
   };
 
-  const externalCustomRenderers = useMemo(() => customCellRenderer(rows), [rows]);
+  const getCustomCellRenderer = useMemo(() => {
+    const cellRenderers = customCellRenderer(rows);
+    return getCellRendererFromColumnMap(cellRenderers);
+  }, [rows]);
 
   const onResetColumns = () => {
     setLocalStorageColumns(defaultColumns.map((c) => c.id));
@@ -372,7 +376,7 @@ export const AssetInventoryDataTable = ({
             showTimeCol={false}
             settings={settings}
             onFetchMoreRecords={loadMore}
-            externalCustomRenderers={externalCustomRenderers}
+            getCustomCellRenderer={getCustomCellRenderer}
             externalAdditionalControls={externalAdditionalControls}
             gridStyleOverride={gridStyle}
             rowLineHeightOverride="24px"

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/unified_components/data_table/index.tsx
@@ -13,7 +13,11 @@ import type {
   UnifiedDataTableProps,
   UnifiedDataTableSettingsColumn,
 } from '@kbn/unified-data-table';
-import { UnifiedDataTable, DataLoadingState } from '@kbn/unified-data-table';
+import {
+  UnifiedDataTable,
+  DataLoadingState,
+  getCellRendererFromColumnMap,
+} from '@kbn/unified-data-table';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type {
   EuiDataGridControlColumn,
@@ -235,15 +239,14 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
       [dispatch, timelineId]
     );
 
-    const customColumnRenderers = useMemo(
-      () =>
-        getFormattedFields({
-          dataTableRows: tableRows,
-          scopeId: 'timeline',
-          headers: columns,
-        }),
-      [columns, tableRows]
-    );
+    const getCustomCellRenderer = useMemo(() => {
+      const cellRenderers = getFormattedFields({
+        dataTableRows: tableRows,
+        scopeId: 'timeline',
+        headers: columns,
+      });
+      return getCellRendererFromColumnMap(cellRenderers);
+    }, [columns, tableRows]);
 
     const handleFetchMoreRecords = useCallback(() => {
       onFetchMoreRecords();
@@ -417,7 +420,7 @@ export const TimelineDataTableComponent: React.FC<DataTableProps> = memo(
             cellActionsTriggerId={SecurityCellActionsTrigger.DEFAULT}
             services={dataGridServices}
             visibleCellActions={3}
-            externalCustomRenderers={customColumnRenderers}
+            getCustomCellRenderer={getCustomCellRenderer}
             renderDocumentView={EmptyComponent}
             rowsPerPageOptions={itemsPerPageOptions}
             showFullScreenButton={false}


### PR DESCRIPTION
## Summary

This PR updates Discover to support the custom cell renderer and row indicator extensions at the document profile level, allowing consumers to mix and match e.g. Summary column renderers and severity indicators between document profiles.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)