### PR TITLE
[9.0] Fix: success message and scroll after adding panel from library (#220122)

### DIFF
--- a/examples/embeddable_examples/public/react_embeddables/register_saved_object_example.ts
+++ b/examples/embeddable_examples/public/react_embeddables/register_saved_object_example.ts
@@ -19,7 +19,7 @@ export const registerMyEmbeddableSavedObject = (embeddableSetup: EmbeddableSetup
       container.addNewPanel({
         panelType: MY_EMBEDDABLE_TYPE,
         initialState: savedObject.attributes,
-      });
+      },true); // shows a toast and scrolls to panel
     },
     savedObjectType: MY_SAVED_OBJECT_TYPE,
     savedObjectName: 'Some saved object',

--- a/examples/embeddable_examples/public/react_embeddables/register_saved_object_example.ts
+++ b/examples/embeddable_examples/public/react_embeddables/register_saved_object_example.ts
@@ -16,10 +16,13 @@ const APP_ICON = 'logoKibana';
 export const registerMyEmbeddableSavedObject = (embeddableSetup: EmbeddableSetup) =>
   embeddableSetup.registerAddFromLibraryType({
     onAdd: (container, savedObject) => {
-      container.addNewPanel({
-        panelType: MY_EMBEDDABLE_TYPE,
-        initialState: savedObject.attributes,
-      },true); // shows a toast and scrolls to panel
+      container.addNewPanel(
+        {
+          panelType: MY_EMBEDDABLE_TYPE,
+          initialState: savedObject.attributes,
+        },
+        true
+      ); // shows a toast and scrolls to panel
     },
     savedObjectType: MY_SAVED_OBJECT_TYPE,
     savedObjectName: 'Some saved object',

--- a/src/platform/plugins/private/links/public/plugin.ts
+++ b/src/platform/plugins/private/links/public/plugin.ts
@@ -67,7 +67,7 @@ export class LinksPlugin
           container.addNewPanel<LinksRuntimeState>({
             panelType: CONTENT_ID,
             initialState,
-          });
+          }, true);
         },
         savedObjectType: CONTENT_ID,
         savedObjectName: APP_NAME,

--- a/src/platform/plugins/private/links/public/plugin.ts
+++ b/src/platform/plugins/private/links/public/plugin.ts
@@ -64,10 +64,13 @@ export class LinksPlugin
       plugins.embeddable.registerAddFromLibraryType({
         onAdd: async (container, savedObject) => {
           const initialState = await deserializeLinksSavedObject(savedObject);
-          container.addNewPanel<LinksRuntimeState>({
-            panelType: CONTENT_ID,
-            initialState,
-          }, true);
+          container.addNewPanel<LinksRuntimeState>(
+            {
+              panelType: CONTENT_ID,
+              initialState,
+            },
+            true
+          );
         },
         savedObjectType: CONTENT_ID,
         savedObjectName: APP_NAME,

--- a/src/platform/plugins/shared/discover/public/plugin.tsx
+++ b/src/platform/plugins/shared/discover/public/plugin.tsx
@@ -400,7 +400,7 @@ export class DiscoverPlugin
         container.addNewPanel({
           panelType: SEARCH_EMBEDDABLE_TYPE,
           initialState,
-        });
+        }, true);
       },
       savedObjectType: SavedSearchType,
       savedObjectName: i18n.translate('discover.savedSearch.savedObjectName', {

--- a/src/platform/plugins/shared/discover/public/plugin.tsx
+++ b/src/platform/plugins/shared/discover/public/plugin.tsx
@@ -397,10 +397,13 @@ export class DiscoverPlugin
           },
           discoverServices: services,
         });
-        container.addNewPanel({
-          panelType: SEARCH_EMBEDDABLE_TYPE,
-          initialState,
-        }, true);
+        container.addNewPanel(
+          {
+            panelType: SEARCH_EMBEDDABLE_TYPE,
+            initialState,
+          },
+          true
+        );
       },
       savedObjectType: SavedSearchType,
       savedObjectName: i18n.translate('discover.savedSearch.savedObjectName', {

--- a/src/platform/plugins/shared/embeddable/public/add_from_library/add_from_library_flyout.tsx
+++ b/src/platform/plugins/shared/embeddable/public/add_from_library/add_from_library_flyout.tsx
@@ -68,7 +68,6 @@ export const AddFromLibraryFlyout = ({
         );
         return;
       }
-
       libraryType.onAdd(container, savedObject);
       runAddTelemetry(container, savedObject, libraryType.savedObjectMetaData);
     },

--- a/src/platform/plugins/shared/embeddable/public/types.ts
+++ b/src/platform/plugins/shared/embeddable/public/types.ts
@@ -38,13 +38,21 @@ export interface EmbeddableSetup {
   /**
    * Register a saved object type with the "Add from library" flyout.
    *
+   * `onAdd` receives the container and the saved object. You may pass a second boolean parameter
+   *  to `addNewPanel` to enable a success message and automatic scrolling.
+   *
    * @example
    *  registerAddFromLibraryType({
    *    onAdd: (container, savedObject) => {
-   *      container.addNewPanel({
-   *        panelType: CONTENT_ID,
-   *        initialState: savedObject.attributes,
-   *      });
+   *     container.addNewPanel(
+   *         {
+   *           panelType: MY_EMBEDDABLE_TYPE,
+   *           serializedState: {
+   *             rawState: savedObject.attributes,
+   *           },
+   *         },
+   *         true // shows a toast and scrolls to panel
+   *       );
    *    },
    *    savedObjectType: MAP_SAVED_OBJECT_TYPE,
    *    savedObjectName: i18n.translate('xpack.maps.mapSavedObjectLabel', {

--- a/src/platform/plugins/shared/visualizations/public/plugin.ts
+++ b/src/platform/plugins/shared/visualizations/public/plugin.ts
@@ -415,7 +415,7 @@ export class VisualizationsPlugin
         container.addNewPanel<VisualizeSerializedState>({
           panelType: VISUALIZE_EMBEDDABLE_TYPE,
           initialState,
-        });
+        }, true);
       },
       savedObjectType: VISUALIZE_EMBEDDABLE_TYPE,
       savedObjectName: i18n.translate('visualizations.visualizeSavedObjectName', {

--- a/src/platform/plugins/shared/visualizations/public/plugin.ts
+++ b/src/platform/plugins/shared/visualizations/public/plugin.ts
@@ -412,10 +412,13 @@ export class VisualizationsPlugin
           rawState: { savedObjectId: savedObject.id },
           references: savedObject.references,
         });
-        container.addNewPanel<VisualizeSerializedState>({
-          panelType: VISUALIZE_EMBEDDABLE_TYPE,
-          initialState,
-        }, true);
+        container.addNewPanel<VisualizeSerializedState>(
+          {
+            panelType: VISUALIZE_EMBEDDABLE_TYPE,
+            initialState,
+          },
+          true
+        );
       },
       savedObjectType: VISUALIZE_EMBEDDABLE_TYPE,
       savedObjectName: i18n.translate('visualizations.visualizeSavedObjectName', {

--- a/test/accessibility/apps/dashboard.ts
+++ b/test/accessibility/apps/dashboard.ts
@@ -17,11 +17,13 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const listingTable = getService('listingTable');
 
-  describe('Dashboard', () => {
+  // https://github.com/elastic/kibana/issues/220515
+  describe.skip('Dashboard', () => {
     const dashboardName = 'Dashboard Listing A11y';
     const clonedDashboardName = 'Dashboard Listing A11y (1)';
 
-    it('navitate to dashboard app', async () => {
+    // https://github.com/elastic/kibana/issues/220515
+    it.skip('navigate to dashboard app', async () => {
       await common.navigateToApp('dashboard');
       await a11y.testAppSnapshot();
     });

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -410,7 +410,7 @@ export class LensPlugin {
           container.addNewPanel({
             panelType: LENS_EMBEDDABLE_TYPE,
             initialState: state,
-          });
+          }, true);
         },
         savedObjectType: LENS_EMBEDDABLE_TYPE,
         savedObjectName: i18n.translate('xpack.lens.mapSavedObjectLabel', {

--- a/x-pack/platform/plugins/shared/lens/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/lens/public/plugin.ts
@@ -407,10 +407,13 @@ export class LensPlugin {
             { savedObjectId: savedObject.id },
             savedObject.references
           );
-          container.addNewPanel({
-            panelType: LENS_EMBEDDABLE_TYPE,
-            initialState: state,
-          }, true);
+          container.addNewPanel(
+            {
+              panelType: LENS_EMBEDDABLE_TYPE,
+              initialState: state,
+            },
+            true
+          );
         },
         savedObjectType: LENS_EMBEDDABLE_TYPE,
         savedObjectName: i18n.translate('xpack.lens.mapSavedObjectLabel', {

--- a/x-pack/platform/plugins/shared/maps/public/react_embeddable/setup_map_embeddable.ts
+++ b/x-pack/platform/plugins/shared/maps/public/react_embeddable/setup_map_embeddable.ts
@@ -27,7 +27,7 @@ export function setupMapEmbeddable(embeddableSetup: EmbeddableSetup) {
       container.addNewPanel({
         panelType: MAP_SAVED_OBJECT_TYPE,
         initialState: { savedObjectId: savedObject.id },
-      });
+      }, true);
     },
     savedObjectType: MAP_SAVED_OBJECT_TYPE,
     savedObjectName: i18n.translate('xpack.maps.mapSavedObjectLabel', {

--- a/x-pack/platform/plugins/shared/maps/public/react_embeddable/setup_map_embeddable.ts
+++ b/x-pack/platform/plugins/shared/maps/public/react_embeddable/setup_map_embeddable.ts
@@ -24,10 +24,13 @@ export function setupMapEmbeddable(embeddableSetup: EmbeddableSetup) {
 
   embeddableSetup.registerAddFromLibraryType<MapAttributes>({
     onAdd: (container, savedObject) => {
-      container.addNewPanel({
-        panelType: MAP_SAVED_OBJECT_TYPE,
-        initialState: { savedObjectId: savedObject.id },
-      }, true);
+      container.addNewPanel(
+        {
+          panelType: MAP_SAVED_OBJECT_TYPE,
+          initialState: { savedObjectId: savedObject.id },
+        },
+        true
+      );
     },
     savedObjectType: MAP_SAVED_OBJECT_TYPE,
     savedObjectName: i18n.translate('xpack.maps.mapSavedObjectLabel', {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Fix: success message and scroll after adding panel from library (#220122)](https://github.com/elastic/kibana/pull/220122)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Ola Pawlus","email":"98127445+olapawlus@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-09T17:24:49Z","message":"Fix: success message and scroll after adding panel from library (#220122)\n\nInitially there was no success message for any type in the library and\nthere was no scrolling to added panel.\n\nThis change sets displaySuccessMessage to true for each plugin\nregistered in the Add from Library flyout.\n\nIt ensures that:\n- users see a success toast after adding a panel,\n- the newly added panel is automatically scrolled into view.\n\nCloses: #188775\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e7e8d2f13b44ae78b33ada4a3904b17066c6fd37","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Feature:Dashboard","Feature:Embedding","regression","release_note:fix","Team:Presentation","loe:small","impact:high","backport:version","v9.1.0","v8.19.0","v8.18.2","v9.0.2"],"title":"Fix: success message and scroll after adding panel from library","number":220122,"url":"https://github.com/elastic/kibana/pull/220122","mergeCommit":{"message":"Fix: success message and scroll after adding panel from library (#220122)\n\nInitially there was no success message for any type in the library and\nthere was no scrolling to added panel.\n\nThis change sets displaySuccessMessage to true for each plugin\nregistered in the Add from Library flyout.\n\nIt ensures that:\n- users see a success toast after adding a panel,\n- the newly added panel is automatically scrolled into view.\n\nCloses: #188775\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e7e8d2f13b44ae78b33ada4a3904b17066c6fd37"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220122","number":220122,"mergeCommit":{"message":"Fix: success message and scroll after adding panel from library (#220122)\n\nInitially there was no success message for any type in the library and\nthere was no scrolling to added panel.\n\nThis change sets displaySuccessMessage to true for each plugin\nregistered in the Add from Library flyout.\n\nIt ensures that:\n- users see a success toast after adding a panel,\n- the newly added panel is automatically scrolled into view.\n\nCloses: #188775\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"e7e8d2f13b44ae78b33ada4a3904b17066c6fd37"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220703","number":220703,"state":"MERGED","mergeCommit":{"sha":"7501611e3277d378ea00e1731b39be0ebeb7769b","message":"[8.19] Fix: success message and scroll after adding panel from library (#220122) (#220703)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [Fix: success message and scroll after adding panel from library\n(#220122)](https://github.com/elastic/kibana/pull/220122)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Ola Pawlus <98127445+olapawlus@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->