### PR TITLE
[8.18] [ES|QL] Allows to retrieve empty columns (#218085)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.test.ts
@@ -135,15 +135,13 @@ describe('getSuggestions', () => {
   });
 
   describe('getGridAttrs', () => {
-    const query = {
+    const newQuery = {
       esql: 'from index1 | limit 10 | stats average = avg(bytes)',
     };
-    const mockStartDependencies =
-      createMockStartDependencies() as unknown as LensPluginStartDependencies;
-    const dataViews = dataViewPluginMocks.createStartContract();
+
     dataViews.create.mockResolvedValue(mockDataViewWithTimefield);
     mockStartDependencies.data.dataViews = dataViews;
-    const dataviewSpecArr = [
+    const newdataviewSpecArr = [
       {
         id: 'd2588ae7-9ea0-4439-9f5b-f808754a3b97',
         title: 'index1',
@@ -156,7 +154,7 @@ describe('getSuggestions', () => {
         name: 'index1',
       },
     ];
-    const startDependencies = {
+    const newStartDependencies = {
       ...mockStartDependencies,
       dataViews,
     };
@@ -170,7 +168,7 @@ describe('getSuggestions', () => {
           },
         };
       });
-      const gridAttributes = await getGridAttrs(query, dataviewSpecArr, startDependencies.data);
+      const gridAttributes = await getGridAttrs(newQuery, newdataviewSpecArr, newStartDependencies);
       expect(gridAttributes.columns).toStrictEqual(queryResponseColumns);
     });
 
@@ -194,7 +192,7 @@ describe('getSuggestions', () => {
         };
       });
       mockformatESQLColumns.mockImplementation(() => emptyColumns);
-      const gridAttributes = await getGridAttrs(query, dataviewSpecArr, startDependencies.data);
+      const gridAttributes = await getGridAttrs(query, dataviewSpecArr, startDependencies);
       expect(gridAttributes.columns).toStrictEqual(emptyColumns);
     });
   });

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.test.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
-import { getESQLResults } from '@kbn/esql-utils';
+import { getESQLResults, formatESQLColumns } from '@kbn/esql-utils';
 import type { LensPluginStartDependencies } from '../../../plugin';
 import { createMockStartDependencies } from '../../../editor_frame_service/mocks';
 import {
@@ -15,70 +15,51 @@ import {
   mockAllSuggestions,
 } from '../../../mocks';
 import { suggestionsApi } from '../../../lens_suggestions_api';
-import { getSuggestions } from './helpers';
+import { getSuggestions, getGridAttrs } from './helpers';
 
 const mockSuggestionApi = suggestionsApi as jest.Mock;
 const mockFetchData = getESQLResults as jest.Mock;
+const mockformatESQLColumns = formatESQLColumns as jest.Mock;
 
 jest.mock('../../../lens_suggestions_api', () => ({
   suggestionsApi: jest.fn(() => mockAllSuggestions),
 }));
 
+const queryResponseColumns = [
+  {
+    name: '@timestamp',
+    id: '@timestamp',
+    meta: {
+      type: 'date',
+    },
+  },
+  {
+    name: 'bytes',
+    id: 'bytes',
+    meta: {
+      type: 'number',
+    },
+  },
+  {
+    name: 'memory',
+    id: 'memory',
+    meta: {
+      type: 'number',
+    },
+  },
+];
+
 jest.mock('@kbn/esql-utils', () => {
   return {
     getESQLResults: jest.fn().mockResolvedValue({
       response: {
-        columns: [
-          {
-            name: '@timestamp',
-            id: '@timestamp',
-            meta: {
-              type: 'date',
-            },
-          },
-          {
-            name: 'bytes',
-            id: 'bytes',
-            meta: {
-              type: 'number',
-            },
-          },
-          {
-            name: 'memory',
-            id: 'memory',
-            meta: {
-              type: 'number',
-            },
-          },
-        ],
+        columns: queryResponseColumns,
         values: [],
       },
     }),
     getIndexPatternFromESQLQuery: jest.fn().mockReturnValue('index1'),
     getESQLAdHocDataview: jest.fn().mockResolvedValue({}),
-    formatESQLColumns: jest.fn().mockReturnValue([
-      {
-        name: '@timestamp',
-        id: '@timestamp',
-        meta: {
-          type: 'date',
-        },
-      },
-      {
-        name: 'bytes',
-        id: 'bytes',
-        meta: {
-          type: 'number',
-        },
-      },
-      {
-        name: 'memory',
-        id: 'memory',
-        meta: {
-          type: 'number',
-        },
-      },
-    ]),
+    formatESQLColumns: jest.fn().mockReturnValue(queryResponseColumns),
   };
 });
 
@@ -151,5 +132,70 @@ describe('getSuggestions', () => {
     );
     expect(suggestionsAttributes).toBeUndefined();
     expect(setErrorsSpy).toHaveBeenCalled();
+  });
+
+  describe('getGridAttrs', () => {
+    const query = {
+      esql: 'from index1 | limit 10 | stats average = avg(bytes)',
+    };
+    const mockStartDependencies =
+      createMockStartDependencies() as unknown as LensPluginStartDependencies;
+    const dataViews = dataViewPluginMocks.createStartContract();
+    dataViews.create.mockResolvedValue(mockDataViewWithTimefield);
+    mockStartDependencies.data.dataViews = dataViews;
+    const dataviewSpecArr = [
+      {
+        id: 'd2588ae7-9ea0-4439-9f5b-f808754a3b97',
+        title: 'index1',
+        timeFieldName: '@timestamp',
+        sourceFilters: [],
+        fieldFormats: {},
+        runtimeFieldMap: {},
+        fieldAttrs: {},
+        allowNoIndex: false,
+        name: 'index1',
+      },
+    ];
+    const startDependencies = {
+      ...mockStartDependencies,
+      dataViews,
+    };
+
+    it('returns the columns if the array is not empty in the response', async () => {
+      mockFetchData.mockImplementation(() => {
+        return {
+          response: {
+            columns: queryResponseColumns,
+            values: [],
+          },
+        };
+      });
+      const gridAttributes = await getGridAttrs(query, dataviewSpecArr, startDependencies.data);
+      expect(gridAttributes.columns).toStrictEqual(queryResponseColumns);
+    });
+
+    it('returns all_columns if the columns array is empty in the response and all_columns exist', async () => {
+      const emptyColumns = [
+        {
+          name: 'bytes',
+          id: 'bytes',
+          meta: {
+            type: 'number',
+          },
+        },
+      ];
+      mockFetchData.mockImplementation(() => {
+        return {
+          response: {
+            columns: [],
+            values: [],
+            all_columns: emptyColumns,
+          },
+        };
+      });
+      mockformatESQLColumns.mockImplementation(() => emptyColumns);
+      const gridAttributes = await getGridAttrs(query, dataviewSpecArr, startDependencies.data);
+      expect(gridAttributes.columns).toStrictEqual(emptyColumns);
+    });
   });
 });

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/shared/edit_on_the_fly/helpers.ts
@@ -74,7 +74,14 @@ export const getGridAttrs = async (
     variables: esqlVariables,
   });
 
-  const columns = formatESQLColumns(results.response.columns);
+  let queryColumns = results.response.columns;
+  // if the query columns are empty, we need to use the all_columns property
+  // which has all columns regardless if they have data or not
+  if (queryColumns.length === 0 && results.response.all_columns) {
+    queryColumns = results.response.all_columns;
+  }
+
+  const columns = formatESQLColumns(queryColumns);
 
   return {
     rows: results.response.values,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ES|QL] Allows to retrieve empty columns (#218085)](https://github.com/elastic/kibana/pull/218085)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2025-04-15T08:28:38Z","message":"[ES|QL] Allows to retrieve empty columns (#218085)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/200039\n\nHere we are asking ES to do a grouping between empty columns and\nnon-empty. The `dropNullColumns: true` in the request does the trick.\n\nIn case of true the response comes as:\n\n```\n// only columns with data\ncolumns: [...]\n// all columns\nall_columns: [...]\n```\n\nWhen the query is empty the columns array comes empty but the\nall_columns has all the columns information. The PR just takes the empty\ncolumns scenario under consideration in order to serve the `all_columns`\ninstead. In that case the text based datasource has the info it needs to\nserve a valid visualization state.\n\n\n<img width=\"990\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/7d0b2c58-eda2-4807-9203-36f7da48a6ff\"\n/>\n\n\n<img width=\"814\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/8b0ef3bf-14d5-4438-b8fd-a13d346da420\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"3c1f04dbb4483b4d4665c49c9d43430050d0fbe9","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Visualizations","Feature:Lens","Feature:ES|QL","backport:version","v9.1.0","v8.19.0","v8.18.2"],"title":"[ES|QL] Allows to retrieve empty columns","number":218085,"url":"https://github.com/elastic/kibana/pull/218085","mergeCommit":{"message":"[ES|QL] Allows to retrieve empty columns (#218085)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/200039\n\nHere we are asking ES to do a grouping between empty columns and\nnon-empty. The `dropNullColumns: true` in the request does the trick.\n\nIn case of true the response comes as:\n\n```\n// only columns with data\ncolumns: [...]\n// all columns\nall_columns: [...]\n```\n\nWhen the query is empty the columns array comes empty but the\nall_columns has all the columns information. The PR just takes the empty\ncolumns scenario under consideration in order to serve the `all_columns`\ninstead. In that case the text based datasource has the info it needs to\nserve a valid visualization state.\n\n\n<img width=\"990\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/7d0b2c58-eda2-4807-9203-36f7da48a6ff\"\n/>\n\n\n<img width=\"814\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/8b0ef3bf-14d5-4438-b8fd-a13d346da420\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"3c1f04dbb4483b4d4665c49c9d43430050d0fbe9"}},"sourceBranch":"main","suggestedTargetBranches":["8.18"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218085","number":218085,"mergeCommit":{"message":"[ES|QL] Allows to retrieve empty columns (#218085)\n\n## Summary\n\nCloses https://github.com/elastic/kibana/issues/200039\n\nHere we are asking ES to do a grouping between empty columns and\nnon-empty. The `dropNullColumns: true` in the request does the trick.\n\nIn case of true the response comes as:\n\n```\n// only columns with data\ncolumns: [...]\n// all columns\nall_columns: [...]\n```\n\nWhen the query is empty the columns array comes empty but the\nall_columns has all the columns information. The PR just takes the empty\ncolumns scenario under consideration in order to serve the `all_columns`\ninstead. In that case the text based datasource has the info it needs to\nserve a valid visualization state.\n\n\n<img width=\"990\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/7d0b2c58-eda2-4807-9203-36f7da48a6ff\"\n/>\n\n\n<img width=\"814\" alt=\"image\"\nsrc=\"https://github.com/user-attachments/assets/8b0ef3bf-14d5-4438-b8fd-a13d346da420\"\n/>\n\n\n### Checklist\n\n- [ ] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios","sha":"3c1f04dbb4483b4d4665c49c9d43430050d0fbe9"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/218205","number":218205,"state":"MERGED","mergeCommit":{"sha":"a8c8ab367a59948313e73cbff9f628c72c27317a","message":"[8.x] [ES|QL] Allows to retrieve empty columns (#218085) (#218205)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.x`:\n- [[ES|QL] Allows to retrieve empty columns\n(#218085)](https://github.com/elastic/kibana/pull/218085)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Stratoula Kalafateli <efstratia.kalafateli@elastic.co>"}},{"branch":"8.18","label":"v8.18.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->