### PR TITLE
[ES|QL] Replaces the dataviewService.get with the dataviewService.create

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/esql_layer/text_based_languages.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/esql_layer/text_based_languages.tsx
@@ -677,12 +677,13 @@ export function getTextBasedDatasource({
         return [];
       }
       const indexPatterns: DataView[] = [];
-      const stateLayer = state.layers[0];
-      if (!stateLayer.query) {
-        return [];
+
+      for (const { query } of Object.values(state.layers)) {
+        if (query) {
+          const esqlAdhocDataview = await getESQLAdHocDataview(query.esql, dataViewsService);
+          indexPatterns.push(esqlAdhocDataview);
+        }
       }
-      const esqlAdhocDataview = await getESQLAdHocDataview(stateLayer.query.esql, dataViewsService);
-      indexPatterns.push(esqlAdhocDataview);
 
       return Object.entries(state.layers).reduce<DataSourceInfo[]>((acc, [key, layer]) => {
         const columns = Object.entries(layer.columns).map(([colId, col]) => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/220805

This PR changes the dataviewService.get with the create to be sure that we don't fall into race condition when the adhoc dataview has not been created

The getDatasourceInfo is called only by ML to register an action in Lens dashboard panels



<!--ONMERGE {"backportTargets":["8.18","8.19"]} ONMERGE-->