### PR TITLE
[Obs AI Assistant] Hide ELSER and e5 large on EIS temporarily

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/utils/get_model_options_for_inference_endpoints.test.ts
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/utils/get_model_options_for_inference_endpoints.test.ts
@@ -16,9 +16,7 @@ import {
 import type { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import {
   ELSER_ON_ML_NODE_INFERENCE_ID,
-  E5_LARGE_IN_EIS_INFERENCE_ID,
   E5_SMALL_INFERENCE_ID,
-  ELSER_IN_EIS_INFERENCE_ID,
 } from '@kbn/observability-ai-assistant-plugin/public';
 
 describe('getModelOptionsForInferenceEndpoints', () => {
@@ -43,55 +41,6 @@ describe('getModelOptionsForInferenceEndpoints', () => {
         label: e5SmallTitle,
         description: e5SmallDescription,
       },
-    ]);
-  });
-
-  it('shows only ELSER in EIS when both ELSER models are available', () => {
-    const endpoints = [
-      { inference_id: ELSER_ON_ML_NODE_INFERENCE_ID },
-      { inference_id: ELSER_IN_EIS_INFERENCE_ID },
-      { inference_id: E5_SMALL_INFERENCE_ID },
-    ] as InferenceAPIConfigResponse[];
-
-    const options = getModelOptionsForInferenceEndpoints({
-      endpoints,
-    });
-
-    expect(options.map((o) => o.key)).toEqual([ELSER_IN_EIS_INFERENCE_ID, E5_SMALL_INFERENCE_ID]);
-  });
-
-  it('shows only E5-large in EIS when both E5 (small and large) models are available', () => {
-    const endpoints = [
-      { inference_id: ELSER_ON_ML_NODE_INFERENCE_ID },
-      { inference_id: E5_SMALL_INFERENCE_ID },
-      { inference_id: E5_LARGE_IN_EIS_INFERENCE_ID },
-    ] as InferenceAPIConfigResponse[];
-
-    const options = getModelOptionsForInferenceEndpoints({
-      endpoints,
-    });
-
-    expect(options.map((o) => o.key)).toEqual([
-      ELSER_ON_ML_NODE_INFERENCE_ID,
-      E5_LARGE_IN_EIS_INFERENCE_ID,
-    ]);
-  });
-
-  it('shows only EIS models when both ELSER and E5-large pre-configured endpoints are available in EIS', () => {
-    const endpoints = [
-      { inference_id: ELSER_ON_ML_NODE_INFERENCE_ID },
-      { inference_id: ELSER_IN_EIS_INFERENCE_ID },
-      { inference_id: E5_SMALL_INFERENCE_ID },
-      { inference_id: E5_LARGE_IN_EIS_INFERENCE_ID },
-    ] as InferenceAPIConfigResponse[];
-
-    const options = getModelOptionsForInferenceEndpoints({
-      endpoints,
-    });
-
-    expect(options.map((o) => o.key)).toEqual([
-      ELSER_IN_EIS_INFERENCE_ID,
-      E5_LARGE_IN_EIS_INFERENCE_ID,
     ]);
   });
 

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/utils/get_model_options_for_inference_endpoints.ts
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/utils/get_model_options_for_inference_endpoints.ts
@@ -50,21 +50,6 @@ export const e5SmallDescription = i18n.translate(
   }
 );
 
-const e5LargeTitle = i18n.translate(
-  'xpack.aiAssistant.welcomeMessage.knowledgeBase.model.e5largeTitle',
-  {
-    defaultMessage: 'E5-large (multilingual)',
-  }
-);
-
-const e5LargeDescription = i18n.translate(
-  'xpack.aiAssistant.welcomeMessage.knowledgeBase.model.e5largeDescription',
-  {
-    defaultMessage:
-      'E5 is an NLP model by Elastic designed to enhance multilingual semantic search by focusing on query context rather than keywords. E5-large is an optimized version for Intel® silicon.',
-  }
-);
-
 const PRECONFIGURED_INFERENCE_ENDPOINT_METADATA: Record<
   string,
   { title: string; description: string }
@@ -73,17 +58,9 @@ const PRECONFIGURED_INFERENCE_ENDPOINT_METADATA: Record<
     title: elserTitle,
     description: elserDescription,
   },
-  [ELSER_IN_EIS_INFERENCE_ID]: {
-    title: elserTitle,
-    description: elserDescription,
-  },
   [E5_SMALL_INFERENCE_ID]: {
     title: e5SmallTitle,
     description: e5SmallDescription,
-  },
-  [E5_LARGE_IN_EIS_INFERENCE_ID]: {
-    title: e5LargeTitle,
-    description: e5LargeDescription,
   },
 };
 

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/utils/get_model_options_for_inference_endpoints.ts
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/utils/get_model_options_for_inference_endpoints.ts
@@ -9,9 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { InferenceAPIConfigResponse } from '@kbn/ml-trained-models-utils';
 import {
   ELSER_ON_ML_NODE_INFERENCE_ID,
-  E5_LARGE_IN_EIS_INFERENCE_ID,
   E5_SMALL_INFERENCE_ID,
-  ELSER_IN_EIS_INFERENCE_ID,
 } from '@kbn/observability-ai-assistant-plugin/public';
 
 export interface ModelOptionsData {
@@ -69,20 +67,8 @@ export const getModelOptionsForInferenceEndpoints = ({
 }: {
   endpoints: InferenceAPIConfigResponse[];
 }): ModelOptionsData[] => {
-  const hasElserEIS = endpoints.some((ep) => ep.inference_id === ELSER_IN_EIS_INFERENCE_ID);
-  const hasE5EIS = endpoints.some((ep) => ep.inference_id === E5_LARGE_IN_EIS_INFERENCE_ID);
-
   return endpoints
     .filter((endpoint) => {
-      // if ELSER exists in EIS, skip the other ELSER model
-      if (endpoint.inference_id === ELSER_ON_ML_NODE_INFERENCE_ID && hasElserEIS) {
-        return false;
-      }
-
-      if (endpoint.inference_id === E5_SMALL_INFERENCE_ID && hasE5EIS) {
-        return false;
-      }
-
       // Only include preconfigured endpoints and skip custom endpoints
       return Boolean(PRECONFIGURED_INFERENCE_ENDPOINT_METADATA[endpoint.inference_id]);
     })


### PR DESCRIPTION
Related issue - https://github.com/elastic/obs-ai-assistant-team/issues/246
Related PR - https://github.com/elastic/kibana/pull/220096

## Summary

ELSER on EIS is not working as expected in QA and it's not available in production yet. Therefore, this PR hides these models from the KB models list temporarily. 

Once these models are available, we should re-enable them.

Verified ELSER can be installed on serverless:

https://github.com/user-attachments/assets/4f46ed31-0771-4e61-8b6c-73f1ed0b4b4a

### Checklist

- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->