### PR TITLE
[8.18] [9.0] [Dashboard] Keep panel state when saved in an error state (#220841)

### DIFF
--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/panels_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/panels_manager.ts
@@ -395,9 +395,11 @@ export function initializePanelsManager(
           const childApi = children$.value[id];
           const serializeResult = apiHasSerializableState(childApi)
             ? childApi.serializeState()
-            : { rawState: {} };
+            : {
+                rawState: panels$.value[id].explicitInput ?? {},
+                references: getReferencesForPanelId(id),
+              };
           acc[id] = { ...panels$.value[id], explicitInput: { ...serializeResult.rawState, id } };
-
           references.push(...prefixReferencesFromPanel(id, serializeResult.references ?? []));
 
           return acc;


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.0` to `8.18`:
 - [[9.0] [Dashboard] Keep panel state when saved in an error state (#220841)](https://github.com/elastic/kibana/pull/220841)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Hannah Mudge","email":"Heenawter@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-15T20:25:37Z","message":"[9.0] [Dashboard] Keep panel state when saved in an error state (#220841)\n\nCloses https://github.com/elastic/kibana/issues/220799\n\n## Summary\n\nThis PR ensures that, if a panel has an error that causes the child API\nto not be available, we default to the state stored in the `panels# Backport

This will backport the following commits from `9.0` to `8.18`:
{{{{raw}}}} - [[9.0] [Dashboard] Keep panel state when saved in an error state (#220841)](https://github.com/elastic/kibana/pull/220841){{{{/raw}}}}

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT \nbehaviour subject rather than `{ rawState: {} }`. Otherwise, **all state\nis lost** when saving a dashboard in an error state, which makes it\nimpossible to restore the panel even once the error has been resolved.\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"e9e3b2eb43410f2d974f4f27d4d25cf83604d7c5","branchLabelMapping":{"^v9.0.0$":"main","^v8.18.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["regression","release_note:fix","Team:Presentation","loe:small","impact:high","backport:version","v8.17.7","v8.18.2"],"title":"[9.0] [Dashboard] Keep panel state when saved in an error state","number":220841,"url":"https://github.com/elastic/kibana/pull/220841","mergeCommit":{"message":"[9.0] [Dashboard] Keep panel state when saved in an error state (#220841)\n\nCloses https://github.com/elastic/kibana/issues/220799\n\n## Summary\n\nThis PR ensures that, if a panel has an error that causes the child API\nto not be available, we default to the state stored in the `panels# Backport

This will backport the following commits from `9.0` to `8.18`:
{{{{raw}}}} - [[9.0] [Dashboard] Keep panel state when saved in an error state (#220841)](https://github.com/elastic/kibana/pull/220841){{{{/raw}}}}

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT \nbehaviour subject rather than `{ rawState: {} }`. Otherwise, **all state\nis lost** when saving a dashboard in an error state, which makes it\nimpossible to restore the panel even once the error has been resolved.\n\n### Checklist\n\n- [x] The PR description includes the appropriate Release Notes section,\nand the correct `release_note:*` label is applied per the\n[guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"e9e3b2eb43410f2d974f4f27d4d25cf83604d7c5"}},"sourceBranch":"9.0","suggestedTargetBranches":["8.17","8.18"],"targetPullRequestStates":[{"branch":"8.17","label":"v8.17.7","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->