### PR TITLE
[9.0] [Lens] Avoid label rounding of percentile value after 3 decimal digits (#220035)

### DIFF
--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/percentile.test.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/percentile.test.tsx
@@ -694,4 +694,26 @@ describe('percentile', () => {
       // ).toEqual(true);
     });
   });
+
+  describe('getDefaultLabel', () => {
+    it('should prevent label percentile rounding after 3 decimal digits', () => {
+      const column: PercentileIndexPatternColumn = {
+        label: '99.9999th percentile of bytes',
+        dataType: 'number',
+        isBucketed: false,
+        sourceField: 'bytes',
+        operationType: 'percentile',
+        params: {
+          percentile: 99.9999,
+        },
+      };
+      const indexPattern = createMockedIndexPattern();
+      const defaultLabel = percentileOperation.getDefaultLabel(
+        column,
+        { columnId: column },
+        indexPattern
+      );
+      expect(defaultLabel).toEqual('99.9999th percentile of bytes');
+    });
+  });
 });

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/percentile.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/percentile.tsx
@@ -7,7 +7,7 @@
 
 import { EuiFieldNumber, EuiRange, EuiRangeProps } from '@elastic/eui';
 import React, { useCallback } from 'react';
-import { i18n } from '@kbn/i18n';
+import { i18n, TranslateArguments } from '@kbn/i18n';
 import { AggFunctionsMapping } from '@kbn/data-plugin/public';
 import {
   buildExpression,
@@ -17,6 +17,8 @@ import {
 } from '@kbn/expressions-plugin/public';
 import { useDebouncedValue } from '@kbn/visualization-utils';
 import { PERCENTILE_ID, PERCENTILE_NAME } from '@kbn/lens-formula-docs';
+import { sanitazeESQLInput } from '@kbn/esql-utils';
+import { memoize } from 'lodash';
 import { OperationDefinition } from '.';
 import {
   getFormatFromPreviousColumn,
@@ -45,17 +47,40 @@ export interface PercentileIndexPatternColumn extends FieldBasedIndexPatternColu
   };
 }
 
+const DEFAULT_PERCENTILE_VALUE = 95;
+const ALLOWED_DECIMAL_DIGITS = 4;
+
 function ofName(
   name: string,
   percentile: number,
   timeShift: string | undefined,
   reducedTimeRange: string | undefined
 ) {
+  const formatters: TranslateArguments['formatters'] = {
+    getNumberFormat: memoize(
+      (locale, opts) =>
+        new Intl.NumberFormat(locale, {
+          ...(opts as Intl.NumberFormatOptions), // To resolve a type mismatch in the 'useGrouping' property
+          maximumFractionDigits: ALLOWED_DECIMAL_DIGITS,
+        })
+    ),
+    // @ts-expect-error - There’s a small mismatch between @formatjs type and Intl API that only applies to the date function, we’re ignoring that
+    getDateTimeFormat: memoize((locale, opts) => new Intl.DateTimeFormat(locale, opts)),
+    getPluralRules: memoize(
+      (locale, opts) =>
+        new Intl.PluralRules(locale, {
+          ...opts,
+          maximumFractionDigits: ALLOWED_DECIMAL_DIGITS, // ensures the correct ordinal suffix is selected based on the matching number of decimal digits used in the number formatter
+        })
+    ),
+  };
+
   return adjustTimeScaleLabelSuffix(
     i18n.translate('xpack.lens.indexPattern.percentileOf', {
       defaultMessage:
         '{percentile, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} percentile of {name}',
       values: { name, percentile },
+      formatters,
     }),
     undefined,
     undefined,
@@ -65,9 +90,6 @@ function ofName(
     reducedTimeRange
   );
 }
-
-const DEFAULT_PERCENTILE_VALUE = 95;
-const ALLOWED_DECIMAL_DIGITS = 4;
 
 function getInvalidErrorMessage(
   value: string | undefined,

--- a/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/percentile.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/datasources/form_based/operations/definitions/percentile.tsx
@@ -17,7 +17,6 @@ import {
 } from '@kbn/expressions-plugin/public';
 import { useDebouncedValue } from '@kbn/visualization-utils';
 import { PERCENTILE_ID, PERCENTILE_NAME } from '@kbn/lens-formula-docs';
-import { sanitazeESQLInput } from '@kbn/esql-utils';
 import { memoize } from 'lodash';
 import { OperationDefinition } from '.';
 import {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Lens] Avoid label rounding of percentile value after 3 decimal digits (#220035)](https://github.com/elastic/kibana/pull/220035)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Andreana Malama","email":"72010092+andrimal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-15T15:03:54Z","message":"[Lens] Avoid label rounding of percentile value after 3 decimal digits (#220035)\n\nFix #166585 \n\n## Summary\n\nThis PR fixes the issue of rounding the percentile value after 3 decimal\ndigits in the label.\n\n- Before the fix:\n![Kapture 2025-05-07 at 13 18\n55](https://github.com/user-attachments/assets/b54144b9-3297-456f-8cfe-b450530a9592)\n\n- After the fix:\n![Kapture 2025-05-07 at 13 16\n12](https://github.com/user-attachments/assets/b26de080-5292-46f4-bb5a-bdeb1505d133)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"1611d55ce1847181d51e46f798795b06a35d6d67","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport:version","v9.1.0","v8.19.0","v8.18.2","v9.0.2"],"title":"[Lens] Avoid label rounding of percentile value after 3 decimal digits","number":220035,"url":"https://github.com/elastic/kibana/pull/220035","mergeCommit":{"message":"[Lens] Avoid label rounding of percentile value after 3 decimal digits (#220035)\n\nFix #166585 \n\n## Summary\n\nThis PR fixes the issue of rounding the percentile value after 3 decimal\ndigits in the label.\n\n- Before the fix:\n![Kapture 2025-05-07 at 13 18\n55](https://github.com/user-attachments/assets/b54144b9-3297-456f-8cfe-b450530a9592)\n\n- After the fix:\n![Kapture 2025-05-07 at 13 16\n12](https://github.com/user-attachments/assets/b26de080-5292-46f4-bb5a-bdeb1505d133)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"1611d55ce1847181d51e46f798795b06a35d6d67"}},"sourceBranch":"main","suggestedTargetBranches":["8.18","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220035","number":220035,"mergeCommit":{"message":"[Lens] Avoid label rounding of percentile value after 3 decimal digits (#220035)\n\nFix #166585 \n\n## Summary\n\nThis PR fixes the issue of rounding the percentile value after 3 decimal\ndigits in the label.\n\n- Before the fix:\n![Kapture 2025-05-07 at 13 18\n55](https://github.com/user-attachments/assets/b54144b9-3297-456f-8cfe-b450530a9592)\n\n- After the fix:\n![Kapture 2025-05-07 at 13 16\n12](https://github.com/user-attachments/assets/b26de080-5292-46f4-bb5a-bdeb1505d133)\n\n\n### Checklist\n\nCheck the PR satisfies following conditions. \n\nReviewers should verify this PR satisfies this list as well.\n\n- [x] [Unit or functional\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\nwere updated or added to match the most common scenarios\n- [ ] [Flaky Test\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\nused on any tests changed","sha":"1611d55ce1847181d51e46f798795b06a35d6d67"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220833","number":220833,"state":"MERGED","mergeCommit":{"sha":"189c8a210db3a59da20f33df2c1e8dc0451fdd1a","message":"[8.19] [Lens] Avoid label rounding of percentile value after 3 decimal digits (#220035) (#220833)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [[Lens] Avoid label rounding of percentile value after 3 decimal\ndigits (#220035)](https://github.com/elastic/kibana/pull/220035)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Andreana Malama <72010092+andrimal@users.noreply.github.com>"}},{"branch":"8.18","label":"v8.18.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->