### PR TITLE
[DataView] Fix inability to clear Document ID in data view field editor preview

### DIFF
--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/documents_nav_preview.test.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/documents_nav_preview.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { getDocInputIdValue } from './documents_nav_preview';
+
+describe('getDocInputIdValue', () => {
+  it('returns customId if customId is an empty string', () => {
+    expect(getDocInputIdValue('', 'doc-123')).toBe('');
+  });
+
+  it('returns customId if customId is a non-empty string', () => {
+    expect(getDocInputIdValue('custom-456', 'doc-123')).toBe('custom-456');
+  });
+
+  it('returns documentId if customId is undefined', () => {
+    expect(getDocInputIdValue(undefined, 'doc-123')).toBe('doc-123');
+  });
+
+  it('returns empty string if both customId and documentId are undefined', () => {
+    expect(getDocInputIdValue(undefined, undefined)).toBe('');
+  });
+});

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/documents_nav_preview.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/documents_nav_preview.tsx
@@ -29,6 +29,19 @@ const docIdSelector = (state: PreviewState) => {
     customId: state.customId,
   };
 };
+
+export const getDocInputIdValue = (
+  customId: string | undefined,
+  documentId: string | undefined
+): string => {
+  if (typeof customId === 'string') {
+    return customId;
+  }
+  if (documentId) {
+    return documentId;
+  }
+  return '';
+};
 const fetchDocErrorSelector = (state: PreviewState) => state.fetchDocError;
 
 export const DocumentsNavPreview = () => {
@@ -64,7 +77,7 @@ export const DocumentsNavPreview = () => {
           >
             <EuiFieldText
               isInvalid={isInvalid}
-              value={customId || documentId || ''}
+              value={getDocInputIdValue(customId, documentId)}
               onChange={onDocumentIdChange}
               fullWidth
               data-test-subj="documentIdField"

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/preview_controller.test.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/preview_controller.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { PreviewController, PreviewControllerDependencies } from './preview_controller';
+import type {
+  DataViewLazy,
+  DataView,
+  DataViewsPublicPluginStart,
+} from '@kbn/data-views-plugin/public';
+import { DebouncedFuncLeading } from 'lodash';
+import type { InternalFieldType } from '../../types';
+import type { NotificationsStart } from '@kbn/core/public';
+import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import type { ISearchStart } from '@kbn/data-plugin/public';
+import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
+
+describe('PreviewController', () => {
+  describe('setCustomDocIdToLoad', () => {
+    // Create mock dependencies with the necessary types to satisfy TypeScript
+    const mockDeps: PreviewControllerDependencies = {
+      search: {
+        search: jest.fn(() => ({
+          toPromise: jest.fn().mockResolvedValue({ rawResponse: { hits: { hits: [] } } }),
+        })),
+      } as unknown as ISearchStart,
+      fieldFormats: {
+        getInstance: jest.fn(),
+        getDefaultInstance: jest.fn(),
+      } as unknown as FieldFormatsStart,
+      usageCollection: {
+        reportUiCounter: jest.fn(),
+      } as unknown as UsageCollectionStart,
+      notifications: {
+        toasts: {
+          addSuccess: jest.fn(),
+          addError: jest.fn(),
+          add: jest.fn(),
+          remove: jest.fn(),
+          addInfo: jest.fn(),
+          addWarning: jest.fn(),
+          get$: jest.fn(),
+        },
+      } as unknown as NotificationsStart,
+      dataViews: {
+        updateSavedObject: jest.fn(),
+      } as unknown as DataViewsPublicPluginStart,
+    };
+
+    // Mock data view with enough properties to pass type checks
+    const mockDataView = {
+      getIndexPattern: jest.fn().mockReturnValue('test-index'),
+      getFields: jest.fn().mockReturnValue({
+        getFieldMapSorted: jest.fn().mockReturnValue({}),
+        getFieldMap: jest.fn().mockReturnValue({}),
+      }),
+      // Add more required properties as TypeScript needs them
+      fields: { getByName: jest.fn() },
+      title: 'test-index',
+      isPersisted: jest.fn().mockReturnValue(true),
+    };
+
+    let controller: PreviewController;
+    type ControllerWithPrivate = PreviewController & {
+      debouncedLoadDocument: DebouncedFuncLeading<(id: string) => Promise<void>>;
+    };
+    let debouncedLoadDocumentMock: jest.Mock;
+
+    beforeEach(() => {
+      controller = new PreviewController({
+        deps: mockDeps,
+        dataView: mockDataView as unknown as DataViewLazy,
+        dataViewToUpdate: mockDataView as unknown as DataView,
+        onSave: jest.fn(),
+        fieldTypeToProcess: 'runtime' as InternalFieldType,
+      });
+      debouncedLoadDocumentMock = jest.fn();
+      (controller as ControllerWithPrivate).debouncedLoadDocument =
+        debouncedLoadDocumentMock as unknown as DebouncedFuncLeading<(id: string) => Promise<void>>;
+    });
+
+    it('should properly handle empty string for customDocIdToLoad', () => {
+      controller.setCustomDocIdToLoad('');
+      const state = controller.state$.getValue();
+      expect(state.customId).toBe('');
+      expect(state.customDocIdToLoad).toBe('');
+      expect(debouncedLoadDocumentMock).not.toHaveBeenCalled();
+    });
+
+    it('should properly handle valid IDs for customDocIdToLoad', () => {
+      controller.setCustomDocIdToLoad('doc123');
+      const state = controller.state$.getValue();
+      expect(state.customId).toBe('doc123');
+      expect(state.customDocIdToLoad).toBe('doc123');
+      expect(debouncedLoadDocumentMock).toHaveBeenCalledWith('doc123');
+    });
+
+    it('should properly handle null for customDocIdToLoad', () => {
+      controller.setCustomDocIdToLoad(null);
+      const state = controller.state$.getValue();
+      expect(state.customId).toBeUndefined();
+      expect(state.customDocIdToLoad).toBeNull();
+      expect(debouncedLoadDocumentMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/platform/plugins/shared/data_view_field_editor/public/components/preview/preview_controller.tsx
+++ b/src/platform/plugins/shared/data_view_field_editor/public/components/preview/preview_controller.tsx
@@ -46,7 +46,7 @@ interface PreviewControllerArgs {
   deps: PreviewControllerDependencies;
 }
 
-interface PreviewControllerDependencies {
+export interface PreviewControllerDependencies {
   search: ISearchStart;
   fieldFormats: FieldFormatsStart;
   usageCollection: UsageCollectionStart;
@@ -372,7 +372,7 @@ export class PreviewController {
   setCustomDocIdToLoad = (customDocIdToLoad: string | null) => {
     this.updateState({
       customDocIdToLoad,
-      customId: customDocIdToLoad || undefined,
+      customId: customDocIdToLoad ?? undefined,
       isPreviewAvailable: this.getIsPreviewAvailable({ customDocIdToLoad }),
     });
     // load document if id is present


### PR DESCRIPTION
## Summary

Resolves #151245 

With this PR the Document ID can be cleared in the data view field editor preview. Before it was just reset to the original ID. Here's a video showing how the id can be cleared



https://github.com/user-attachments/assets/593c3d8c-182d-45d9-943b-d74236ad7715




### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->