### PR TITLE
[Kibana Dev Server] Fix `DELETE` requests without a body in Safari

### DIFF
--- a/packages/kbn-cli-dev-mode/src/base_path_proxy/http1.ts
+++ b/packages/kbn-cli-dev-mode/src/base_path_proxy/http1.ts
@@ -126,12 +126,6 @@ export class Http1BasePathProxyServer implements BasePathProxyServer {
           xforward: true,
           mapUri: async (request: Request) => {
             return {
-              // Passing in this header to merge it is a workaround until this is fixed:
-              // https://github.com/hapijs/h2o2/issues/124
-              headers:
-                request.headers['content-length'] != null
-                  ? { 'content-length': request.headers['content-length'] }
-                  : undefined,
               uri: Url.format({
                 hostname: request.server.info.host,
                 port: this.devConfig.basePathProxyTargetPort,


### PR DESCRIPTION
Recently, we discovered that a `DELETE` request to one of our ML endpoints does not work correctly in Safari.
After further investigation, it turns out that `DELETE` requests without a body fail in Safari.
The issue occurs only within the Kibana Dev server, so there is no impact on end users.
This is most likely due to a header set in the `packages/kbn-cli-dev-mode/src/base_path_proxy/http1.ts` file. The issue mentioned in the comment has already been resolved, and everything appears to work correctly without this outdated workaround. 

To reproduce the error:
1. Start Kibana locally and open it with Safari.
2. Find an endpoint that uses the `DELETE` method and does not have a body specified.
3. ^ For example, go to Observability -> Cases and create a new case.
4. Go back to the cases list and try to delete the case

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->