### PR TITLE
Serverless QA quality gate - soft-fail Fleet smoke tests

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
@@ -24,6 +24,7 @@ steps:
 
   - label: ":ship: Fleet serverless smoke tests for ${ENVIRONMENT}"
     trigger: fleet-smoke-tests # https://buildkite.com/elastic/fleet-smoke-tests
+    soft_fail: true
     build:
       env:
         ENVIRONMENT: ${ENVIRONMENT}


### PR DESCRIPTION
## Summary

This PR sets the Fleet smoke tests in the serverless release QA quality gates pipeline to soft-fail.

Every now and then, we see flaky behavior of the Fleet smoke test pipeline. Having it on hard-fail means, that the underlying argo workflow also fails, so we have to re-submit the workflow. Setting it to soft-fail allows us to just re-run the Buildkite pipeline (or assess otherwise that we're good to continue the release) and still continue with the argo workflow. At this stage, the risk of this change is low because a release manager is manually reviewing the results of the QA quality gates before unlocking promotion to staging.
