### PR TITLE
[Docs] Add behavioral analytics removal to Kibana 9.0 breaking changes

### DIFF
--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -239,6 +239,20 @@ $$$kibana-162389$$$
 The `visualization:colorMapping` advanced setting for TSVB and Visualize charts has been removed. You can switch to Lens charts, which offer a more advanced, per-chart color mapping feature with enhanced configuration options. View [#162389](https://github.com/elastic/kibana/pull/162389).
 ::::
 
+**Elasticsearch solution**
+
+$$$kibana-212031$$$
+::::{dropdown} Removed Behavioral Analytics
+:name: breaking-212031
+
+**Details**
+
+The Behavioral Analytics feature is removed from the Kibana interface in 9.0 and its associated [APIs are deprecated](https://www.elastic.co/docs/release-notes/elasticsearch/deprecations#elasticsearch-900-deprecations).
+
+View [#212031]({{kib-pull}}212031).
+::::
+
+
 **Elastic Observability solution**
 
 $$$kibana-202278$$$


### PR DESCRIPTION
Behavioral analytics was hidden from the UI and its associated APIs were deprecated in 9.0, but only the API deprecation was called out in Elasticseach release notes. This PR addresses the UI communication gap by adding a mention to the 9.0 breaking changes (while it's technically a deprecation, the fact that it's been hidden in Kibana makes it look more like a breaking change from a customer perspective).

Rel: https://github.com/elastic/docs-content/issues/1417
Rel: https://github.com/elastic/kibana/pull/212031

<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->