### PR TITLE
POC - Otel-native Hosts View

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/common/constants.ts
@@ -52,6 +52,10 @@ export const EVENT_MODULE = 'event.module';
 export const METRICSET_MODULE = 'metricset.module';
 export const METRICSET_NAME = 'metricset.name';
 
+// OTel hostmetricsreceiver
+export const EVENT_DATASET = 'event.dataset';
+export const OTEL_RECEIVER_DATASET_VALUE = 'hostmetricsreceiver.otel';
+
 // integrations
 export const SYSTEM_INTEGRATION = 'system';
 

--- a/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/helpers/query.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/helpers/query.ts
@@ -11,7 +11,7 @@ import { ApmDocumentType, type TimeRangeMetadata } from '@kbn/apm-data-access-pl
 import type { estypes } from '@elastic/elasticsearch';
 import type { ApmDataAccessServicesWrapper } from '../../../../lib/helpers/get_apm_data_access_client';
 import type { SYSTEM_INTEGRATION } from '../../../../../common/constants';
-import { EVENT_MODULE, METRICSET_MODULE } from '../../../../../common/constants';
+import { EVENT_MODULE, EVENT_DATASET, OTEL_RECEIVER_DATASET_VALUE, METRICSET_MODULE } from '../../../../../common/constants';
 import type { InfraAssetMetricType } from '../../../../../common/http_api/infra';
 
 export const getFilterByIntegration = (integration: typeof SYSTEM_INTEGRATION) => {
@@ -24,6 +24,19 @@ export const getFilterByIntegration = (integration: typeof SYSTEM_INTEGRATION) =
       minimum_should_match: 1,
     },
   };
+};
+
+export const getOTelHostmetricsOrSystemIntegrationFilter = () => {
+    return {
+        bool: {
+        should: [
+            ...termQuery(EVENT_MODULE, 'system'),
+            ...termQuery(METRICSET_MODULE, 'system'),
+            ...termQuery(EVENT_DATASET, OTEL_RECEIVER_DATASET_VALUE),
+        ],
+        minimum_should_match: 1,
+        },
+    };
 };
 
 const getApmDocumentsFilter = async ({
@@ -60,7 +73,7 @@ export const getDocumentsFilter = async ({
   from: number;
   to: number;
 }) => {
-  const filters: estypes.QueryDslQueryContainer[] = [getFilterByIntegration('system')];
+  const filters: estypes.QueryDslQueryContainer[] = [getOTelHostmetricsOrSystemIntegrationFilter()];
   const apmDocumentsFilter =
     apmDataAccessServices && apmDocumentSources
       ? await getApmDocumentsFilter({

--- a/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_filtered_hosts.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/routes/infra/lib/host/get_filtered_hosts.ts
@@ -8,9 +8,9 @@
 import { rangeQuery } from '@kbn/observability-plugin/server';
 import type { estypes } from '@elastic/elasticsearch';
 import { castArray } from 'lodash';
-import { HOST_NAME_FIELD, SYSTEM_INTEGRATION } from '../../../../../common/constants';
+import { HOST_NAME_FIELD } from '../../../../../common/constants';
 import type { GetHostParameters } from '../types';
-import { getFilterByIntegration } from '../helpers/query';
+import { getOTelHostmetricsOrSystemIntegrationFilter } from '../helpers/query';
 
 export const getFilteredHostNames = async ({
   infraMetricsClient,
@@ -30,7 +30,7 @@ export const getFilteredHostNames = async ({
         filter: [
           ...castArray(query),
           ...rangeQuery(from, to),
-          getFilterByIntegration(SYSTEM_INTEGRATION),
+          getOTelHostmetricsOrSystemIntegrationFilter(),
         ],
       },
     },
@@ -70,7 +70,7 @@ export const getHasDataFromSystemIntegration = async ({
         filter: [
           ...castArray(query),
           ...rangeQuery(from, to),
-          getFilterByIntegration(SYSTEM_INTEGRATION),
+          getOTelHostmetricsOrSystemIntegrationFilter(),
         ],
       },
     },

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/charts/disk.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/charts/disk.ts
@@ -75,6 +75,27 @@ const diskUsageByMountPoint: LensConfigWithId = {
         },
       ],
     },
+    {
+      seriesType: 'area',
+      type: 'series',
+      xAxis: '@timestamp',
+      breakdown: {
+        type: 'topValues',
+        field: 'attributes.mountpoint',
+        size: 5,
+      },
+      yAxis: [
+        {
+          ...formulas.diskUsageAverageOTel,
+          label: i18n.translate(
+            'xpack.metricsData.assetDetails.metricsCharts.diskUsage.label.used',
+            {
+              defaultMessage: 'Used',
+            }
+          ),
+        },
+      ],
+    },
   ],
   ...DEFAULT_XY_FITTING_FUNCTION,
   ...DEFAULT_XY_LEGEND,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/cpu.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/cpu.ts
@@ -19,7 +19,13 @@ export const cpuUsageIowait: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.cpuUsage.iowaitLabel', {
     defaultMessage: 'iowait',
   }),
-  value: 'average(system.cpu.iowait.pct) / max(system.cpu.cores)',
+  value: `defaults(
+        average(system.cpu.iowait.pct), 
+        average(metrics.system.cpu.utilization,kql='state: wait')
+    ) / defaults(
+        max(system.cpu.cores),
+        max(metrics.system.cpu.logical.count)
+    )`,
   format: 'percent',
   decimals: 1,
 };
@@ -28,7 +34,13 @@ export const cpuUsageIrq: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.cpuUsage.irqLabel', {
     defaultMessage: 'irq',
   }),
-  value: 'average(system.cpu.irq.pct) / max(system.cpu.cores)',
+  value: `defaults(
+        average(system.cpu.irq.pct), 
+        average(metrics.system.cpu.utilization,kql='state: interrupt')
+    ) / defaults(
+        max(system.cpu.cores),
+        max(metrics.system.cpu.logical.count)
+    )`,
   format: 'percent',
   decimals: 1,
 };
@@ -37,7 +49,13 @@ export const cpuUsageNice: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.cpuUsage.niceLabel', {
     defaultMessage: 'nice',
   }),
-  value: 'average(system.cpu.nice.norm.pct) / max(system.cpu.cores)',
+  value: `defaults(
+        average(system.cpu.nice.norm.pct), 
+        average(metrics.system.cpu.utilization,kql='state: nice')
+    ) / defaults(
+        max(system.cpu.cores),
+        max(metrics.system.cpu.logical.count)
+    )`,
   format: 'percent',
   decimals: 1,
 };
@@ -46,7 +64,13 @@ export const cpuUsageSoftirq: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.cpuUsage.softirqLabel', {
     defaultMessage: 'softirq',
   }),
-  value: 'average(system.cpu.softirq.pct) / max(system.cpu.cores)',
+  value: `defaults(
+        average(system.cpu.softirq.pct), 
+        average(metrics.system.cpu.utilization,kql='state: softirq')
+    ) / defaults(
+        max(system.cpu.cores),
+        max(metrics.system.cpu.logical.count)
+    )`,
   format: 'percent',
   decimals: 1,
 };
@@ -55,7 +79,13 @@ export const cpuUsageSteal: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.cpuUsage.stealLabel', {
     defaultMessage: 'steal',
   }),
-  value: 'average(system.cpu.steal.pct) / max(system.cpu.cores)',
+  value: `defaults(
+        average(system.cpu.steal.pct), 
+        average(metrics.system.cpu.utilization,kql='state: steal')
+    ) / defaults(
+        max(system.cpu.cores),
+        max(metrics.system.cpu.logical.count)
+    )`,
   format: 'percent',
   decimals: 1,
 };
@@ -64,7 +94,13 @@ export const cpuUsageSystem: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.cpuUsage.systemLabel', {
     defaultMessage: 'system',
   }),
-  value: 'average(system.cpu.system.pct) / max(system.cpu.cores)',
+  value: `defaults(
+        average(system.cpu.system.pct), 
+        average(metrics.system.cpu.utilization,kql='state: system')
+    ) / defaults(
+        max(system.cpu.cores),
+        max(metrics.system.cpu.logical.count)
+    )`,
   format: 'percent',
   decimals: 1,
 };
@@ -73,42 +109,66 @@ export const cpuUsageUser: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.cpuUsage.userLabel', {
     defaultMessage: 'user',
   }),
-  value: 'average(system.cpu.user.pct) / max(system.cpu.cores)',
+  value: `defaults(
+        average(system.cpu.user.pct), 
+        average(metrics.system.cpu.utilization,kql='state: user')
+    ) / defaults(
+        max(system.cpu.cores),
+        max(metrics.system.cpu.logical.count)
+    )`,
   format: 'percent',
   decimals: 1,
 };
 
 export const cpuUsage: LensBaseLayer = {
   label: CPU_USAGE_LABEL,
-  value: 'average(system.cpu.total.norm.pct)',
+  value: `defaults(
+        average(system.cpu.total.norm.pct), 
+        1-(average(metrics.system.cpu.utilization,kql='state: idle') + average(metrics.system.cpu.utilization,kql='state: wait'))
+    )`,
   format: 'percent',
   decimals: 0,
 };
 
 export const load1m: LensBaseLayer = {
   label: LOAD_1M_LABEL,
-  value: 'average(system.load.1)',
+  value: `defaults(
+        average(system.load.1),
+        average(metrics.system.cpu.load_average.1m)
+    )`,
   format: 'number',
   decimals: 1,
 };
 
 export const load5m: LensBaseLayer = {
   label: LOAD_5M_LABEL,
-  value: 'average(system.load.5)',
+  value: `defaults(
+        average(system.load.5),
+        average(metrics.system.cpu.load_average.5m)
+    )`,
   format: 'number',
   decimals: 1,
 };
 
 export const load15m: LensBaseLayer = {
   label: LOAD_15M_LABEL,
-  value: 'average(system.load.15)',
+  value: `defaults(
+        average(system.load.15),
+        average(metrics.system.cpu.load_average.15m)
+    )`,
   format: 'number',
   decimals: 1,
 };
 
 export const normalizedLoad1m: LensBaseLayer = {
   label: NORMALIZED_LOAD_LABEL,
-  value: 'average(system.load.1) / max(system.load.cores)',
+  value: `defaults(
+        average(metrics.system.cpu.load_average.1m), 
+        average(system.load.1)
+    ) / defaults(
+        max(metrics.system.cpu.logical.count),
+        max(system.load.cores)
+    )`,
   format: 'percent',
   decimals: 0,
 };

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/disk.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/disk.ts
@@ -19,7 +19,10 @@ import {
 
 export const diskIORead: LensBaseLayer = {
   label: DISK_READ_IOPS_LABEL,
-  value: "counter_rate(max(system.diskio.read.count), kql='system.diskio.read.count: *')",
+  value: `defaults(
+        counter_rate(max(system.diskio.read.count), kql='system.diskio.read.count: *'),
+        counter_rate(max(system.disk.operations, kql='attributes.direction: read'))    
+    )`,
   format: 'number',
   decimals: 0,
   normalizeByUnit: 's',
@@ -27,7 +30,10 @@ export const diskIORead: LensBaseLayer = {
 
 export const diskReadThroughput: LensBaseLayer = {
   label: DISK_READ_THROUGHPUT_LABEL,
-  value: "counter_rate(max(system.diskio.read.bytes), kql='system.diskio.read.bytes: *')",
+  value: `defaults(
+        counter_rate(max(system.diskio.read.bytes), kql='system.diskio.read.bytes: *'),
+        counter_rate(max(system.disk.io, kql='attributes.direction: read'))    
+    )`,
   format: 'bytes',
   decimals: 1,
   normalizeByUnit: 's',
@@ -35,7 +41,7 @@ export const diskReadThroughput: LensBaseLayer = {
 
 export const diskSpaceAvailable: LensBaseLayer = {
   label: DISK_SPACE_AVAILABLE_LABEL,
-  value: 'average(system.filesystem.free)',
+  value: `defaults(average(system.filesystem.free), average(system.filesystem.usage, kql='state: free'))`,
   format: 'bytes',
   decimals: 0,
 };
@@ -49,7 +55,10 @@ export const diskSpaceAvailability: LensBaseLayer = {
 
 export const diskUsage: LensBaseLayer = {
   label: DISK_USAGE_LABEL,
-  value: 'max(system.filesystem.used.pct)',
+  value: `defaults(
+        max(system.filesystem.used.pct),
+        1 - sum(metrics.system.filesystem.usage, kql='state: free')/sum(metrics.system.filesystem.usage)
+    )`,
   format: 'percent',
   decimals: 0,
 };
@@ -61,9 +70,19 @@ export const diskUsageAverage: LensBaseLayer = {
   decimals: 0,
 };
 
+export const diskUsageAverageOTel: LensBaseLayer = {
+    label: DISK_USAGE_AVERAGE_LABEL,
+    value: `1 - sum(metrics.system.filesystem.usage, kql='state: free')/sum(metrics.system.filesystem.usage)`,
+    format: 'percent',
+    decimals: 0,
+  };
+
 export const diskIOWrite: LensBaseLayer = {
   label: DISK_WRITE_IOPS_LABEL,
-  value: "counter_rate(max(system.diskio.write.count), kql='system.diskio.write.count: *')",
+  value: `defaults(
+        counter_rate(max(system.diskio.write.count), kql='system.diskio.write.count: *'),
+        counter_rate(max(system.disk.operations, kql='attributes.direction: write'))    
+    )`,
   format: 'number',
   decimals: 0,
   normalizeByUnit: 's',
@@ -71,7 +90,10 @@ export const diskIOWrite: LensBaseLayer = {
 
 export const diskWriteThroughput: LensBaseLayer = {
   label: DISK_WRITE_THROUGHPUT_LABEL,
-  value: "counter_rate(max(system.diskio.write.bytes), kql='system.diskio.write.bytes: *')",
+  value: `defaults(
+        counter_rate(max(system.diskio.write.bytes), kql='system.diskio.write.bytes: *'),
+        counter_rate(max(system.disk.io, kql='attributes.direction: write'))    
+    )`,
   format: 'bytes',
   decimals: 1,
   normalizeByUnit: 's',

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/index.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/index.ts
@@ -28,6 +28,7 @@ import {
   diskSpaceAvailability,
   diskUsage,
   diskUsageAverage,
+  diskUsageAverageOTel,
   diskWriteThroughput,
 } from './disk';
 
@@ -59,6 +60,7 @@ export const formulas = {
   diskSpaceAvailable,
   diskUsage,
   diskUsageAverage,
+  diskUsageAverageOTel,
   hostCount,
   logRate,
   normalizedLoad1m,

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/memory.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/memory.ts
@@ -13,14 +13,27 @@ export const memoryCache: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.metric.label.cache', {
     defaultMessage: 'cache',
   }),
-  value: 'average(system.memory.used.bytes) - average(system.memory.actual.used.bytes)',
+  value: `defaults(
+        average(system.memory.used.bytes),
+        average(metrics.system.memory.usage, kql='state: cached')
+    ) - defaults(
+        average(system.memory.actual.used.bytes), 
+        average(metrics.system.memory.usage, kql='state: slab_reclaimable') + 
+        average(metrics.system.memory.usage, kql='state: slab_unreclaimable')
+    )`,
   format: 'bytes',
   decimals: 1,
 };
 
 export const memoryFree: LensBaseLayer = {
   label: MEMORY_FREE_LABEL,
-  value: 'max(system.memory.total) - average(system.memory.actual.used.bytes)',
+  value: `defaults(
+        average(system.memory.actual.free),
+        (average(metrics.system.memory.usage, kql='state: free') +
+        average(metrics.system.memory.usage, kql='state: cached')) - 
+        (average(metrics.system.memory.usage, kql='state: slab_unreclaimable') +
+        average(metrics.system.memory.usage, kql='state: slab_reclaimable')) 
+    )`,
   format: 'bytes',
   decimals: 1,
 };
@@ -29,16 +42,26 @@ export const memoryFreeExcludingCache: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.metric.label.free', {
     defaultMessage: 'free',
   }),
-  value: 'average(system.memory.free)',
+  value: `defaults(
+        average(system.memory.free),
+        average(metrics.system.memory.usage, kql='state: free')
+    )`,
   format: 'bytes',
   decimals: 1,
 };
 
 export const memoryUsage: LensBaseLayer = {
   label: MEMORY_USAGE_LABEL,
-  value: 'average(system.memory.actual.used.pct)',
+  value: `defaults(
+        average(system.memory.actual.used.pct), 
+        (
+            average(system.memory.utilization, kql='state: used') + 
+            average(system.memory.utilization, kql='state: buffered') + 
+            average(system.memory.utilization, kql='state: slab_reclaimable')+ 
+            average(system.memory.utilization, kql='state: slab_unreclaimable')
+        )
+    )`,
   format: 'percent',
-
   decimals: 0,
 };
 
@@ -46,7 +69,13 @@ export const memoryUsed: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.metric.label.used', {
     defaultMessage: 'used',
   }),
-  value: 'average(system.memory.actual.used.bytes)',
+  value: `defaults(
+        average(system.memory.actual.used.bytes),
+        average(metrics.system.memory.usage, kql='state: used') + 
+        average(metrics.system.memory.usage, kql='state: buffered') + 
+        average(metrics.system.memory.usage, kql='state: slab_reclaimable') + 
+        average(metrics.system.memory.usage, kql='state: slab_unreclaimable')
+    )`,
   format: 'bytes',
   decimals: 1,
 };

--- a/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/network.ts
+++ b/x-pack/solutions/observability/plugins/metrics_data_access/common/inventory_models/host/metrics/formulas/network.ts
@@ -12,8 +12,11 @@ export const rx: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.rx', {
     defaultMessage: 'Network Inbound (RX)',
   }),
-  value: 'sum(host.network.ingress.bytes) * 8',
-  format: 'bits',
+  value: `defaults(
+        counter_rate(max(system.network.in.bytes)),
+        counter_rate(max(metrics.system.network.io, kql='direction: receive'))
+    )`,
+  format: 'bytes',
   decimals: 1,
 };
 
@@ -21,7 +24,10 @@ export const tx: LensBaseLayer = {
   label: i18n.translate('xpack.metricsData.assetDetails.formulas.tx', {
     defaultMessage: 'Network Outbound (TX)',
   }),
-  value: 'sum(host.network.egress.bytes) * 8',
-  format: 'bits',
+  value: `defaults(
+        counter_rate(max(system.network.out.bytes)),
+        counter_rate(max(metrics.system.network.io, kql='direction: transmit'))
+    )`,
+  format: 'bytes',
   decimals: 1,
 };


### PR DESCRIPTION
## Summary

This PR is a POC that shows that all of Hosts View can show ECS-based and OTel-native data at once.

Only thing missing in this PR is the custom Hosts overview table. All other charts are showing both ecs and otel-native metrics charts.
Screenshots show identical data from the same host (suffixed with ecs and otel for ecs data and Otel data).
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/4f212157-ec48-4792-a04a-452847f92c85" />

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/c4b2c5c2-1e8e-4ab6-bbdc-ccb3b95a0563" />

As you can see in the screenshots the data is identical for both cases.
