### PR TITLE
Gemini connector _schema_: makes `maxOutputTokens` an optional, configurable request parameter

### DIFF
--- a/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
+++ b/x-pack/platform/plugins/shared/actions/server/integration_tests/__snapshots__/connector_types.test.ts.snap
@@ -5325,6 +5325,19 @@ Object {
     "presence": "optional",
   },
   "keys": Object {
+    "maxOutputTokens": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "number",
+    },
     "messages": Object {
       "flags": Object {
         "error": [Function],
@@ -5638,6 +5651,19 @@ Object {
     "presence": "optional",
   },
   "keys": Object {
+    "maxOutputTokens": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "number",
+    },
     "messages": Object {
       "flags": Object {
         "error": [Function],
@@ -5862,6 +5888,19 @@ Object {
     "presence": "optional",
   },
   "keys": Object {
+    "maxOutputTokens": Object {
+      "flags": Object {
+        "default": [Function],
+        "error": [Function],
+        "presence": "optional",
+      },
+      "metas": Array [
+        Object {
+          "x-oas-optional": true,
+        },
+      ],
+      "type": "number",
+    },
     "messages": Object {
       "flags": Object {
         "error": [Function],

--- a/x-pack/platform/plugins/shared/stack_connectors/common/gemini/schema.ts
+++ b/x-pack/platform/plugins/shared/stack_connectors/common/gemini/schema.ts
@@ -65,6 +65,7 @@ export const RunActionResponseSchema = schema.object(
 export const RunActionRawResponseSchema = schema.any();
 
 export const InvokeAIActionParamsSchema = schema.object({
+  maxOutputTokens: schema.maybe(schema.number()),
   messages: schema.any(),
   systemInstruction: schema.maybe(schema.string()),
   model: schema.maybe(schema.string()),
@@ -83,6 +84,7 @@ export const InvokeAIActionParamsSchema = schema.object({
 });
 
 export const InvokeAIRawActionParamsSchema = schema.object({
+  maxOutputTokens: schema.maybe(schema.number()),
   messages: schema.any(),
   systemInstruction: schema.maybe(schema.string()),
   model: schema.maybe(schema.string()),


### PR DESCRIPTION
### Gemini connector _schema_: makes `maxOutputTokens` an optional, configurable request parameter

This PR updates (only) the Gemini connector _schema_ to make the `maxOutputTokens` request parameter, which was previously included in all requests with a (non configurable) value of `8192`, an optional, configurable request parameter.

- Please see [the PR description of #220586](https://github.com/elastic/kibana/pull/220586) the reasoning behind the new parameter, and the actual changes to the Gemini connector to implement the change.
- This PR contains only schema and integration test changes from <https://github.com/elastic/kibana/pull/220586>

#### Why the original PR is being split (Serverless)

This schema-only PR should be merged one week before <https://github.com/elastic/kibana/pull/220586> is merged, because  @pmuellr [notes](https://elastic.slack.com/archives/CHSSGF015/p1747677304981859?thread_ts=1747671810.307809&cid=CHSSGF015):

> I think this will require an intermediate release, since we're adding a param to a connector.  When an "older" Kibana picks up a connector that's not expecting this field, the connector won't validate (because of the new, unexpected field).
>
> The way we usually do these is to merge the schema changes, but not use the field yet.  Let that get released to serverless, and then NEXT release to serverless (in a week), the rest can be merged.

The original PR [#220586](https://github.com/elastic/kibana/pull/220586) will be rebased with `main` and merged ~ 1 week after this PR is available in Serverless.


<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.18","8.19"]} ONMERGE-->