### PR TITLE
[ci] skip scheduled run on forks

### DIFF
--- a/.github/workflows/pm-map-labels-to-fields.yml
+++ b/.github/workflows/pm-map-labels-to-fields.yml
@@ -7,6 +7,7 @@ jobs:
   map-labels-to-fields:
     name: 'Map issue labels to project fields'
     runs-on: ubuntu-latest
+    if: github.repository == 'elastic/kibana'
     steps:
       - name: Checkout Actions
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary
Apparently, scheduled github actions are running on all forks. 

This tries to prevent failures on forks due to missing credentials.

Context: https://elastic.slack.com/archives/C5UDAFZQU/p1747654016486709

