### PR TITLE
[8.18] Update dependency semver to ^7.7.2 (main) (#220932)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1264,7 +1264,7 @@
     "rxjs": "^7.8.2",
     "safe-squel": "^5.12.5",
     "seedrandom": "^3.0.5",
-    "semver": "^7.7.1",
+    "semver": "^7.7.2",
     "set-value": "^4.1.0",
     "snakecase-keys": "^8.0.1",
     "source-map-support": "^0.5.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29848,7 +29848,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.2, semver@^7.6.3, semver@^7.7.1, semver@^7.7.2:
+semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.3, semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -29848,10 +29848,10 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.3, semver@^7.7.1:
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.2, semver@^7.6.3, semver@^7.7.1, semver@^7.7.2:
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 send@0.19.0:
   version "0.19.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Update dependency semver to ^7.7.2 (main) (#220932)](https://github.com/elastic/kibana/pull/220932)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"elastic-renovate-prod[bot]","email":"174716857+elastic-renovate-prod[bot]@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-19T22:01:34Z","message":"Update dependency semver to ^7.7.2 (main) (#220932)\n\nCo-authored-by: elastic-renovate-prod[bot] <174716857+elastic-renovate-prod[bot]@users.noreply.github.com>","sha":"dccd491080bb55f02a5309ab1fde5a37cf13d765","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","release_note:skip","backport:all-open","v9.1.0","v8.19.0"],"title":"Update dependency semver to ^7.7.2 (main)","number":220932,"url":"https://github.com/elastic/kibana/pull/220932","mergeCommit":{"message":"Update dependency semver to ^7.7.2 (main) (#220932)\n\nCo-authored-by: elastic-renovate-prod[bot] <174716857+elastic-renovate-prod[bot]@users.noreply.github.com>","sha":"dccd491080bb55f02a5309ab1fde5a37cf13d765"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220932","number":220932,"mergeCommit":{"message":"Update dependency semver to ^7.7.2 (main) (#220932)\n\nCo-authored-by: elastic-renovate-prod[bot] <174716857+elastic-renovate-prod[bot]@users.noreply.github.com>","sha":"dccd491080bb55f02a5309ab1fde5a37cf13d765"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/220941","number":220941,"state":"MERGED","mergeCommit":{"sha":"6c804fd761cbbc8c9fd69fef0724ac4c755361a3","message":"[8.19] Update dependency semver to ^7.7.2 (main) (#220932) (#220941)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.19`:\n- [Update dependency semver to ^7.7.2 (main)\n(#220932)](https://github.com/elastic/kibana/pull/220932)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: elastic-renovate-prod[bot] <174716857+elastic-renovate-prod[bot]@users.noreply.github.com>"}},{"url":"https://github.com/elastic/kibana/pull/220942","number":220942,"branch":"9.0","state":"OPEN"}]}] BACKPORT-->