### PR TITLE
[Synthetics] In the status rule locations are considered only if not an empty array

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.ts
@@ -172,9 +172,10 @@ export class StatusRuleExecutor {
     const queryLocations = this.params?.locations;
 
     // Account for locations filter
-    const listOfLocationAfterFilter = queryLocations
-      ? intersection(monitorLocationIds, queryLocations)
-      : monitorLocationIds;
+    const listOfLocationAfterFilter =
+      queryLocations && queryLocations.length
+        ? intersection(monitorLocationIds, queryLocations)
+        : monitorLocationIds;
 
     const currentStatus = await queryMonitorStatusAlert({
       esClient: this.esClient,


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/elastic/sdh-kibana/issues/5452) found when setting an empty array for locations in a monitor status rule.

If passing an empty array the logic should behave as when locations is undefined. 

<!--ONMERGE {"backportTargets":["8.17","8.18","8.19","9.0"]} ONMERGE-->