### PR TITLE
[Attack Discovery][Scheduling] Telemetry (#12008)

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.test.ts
@@ -32,7 +32,7 @@ import {
 } from '../../../schedules/fields/field_names';
 import { v4 as uuidv4 } from 'uuid';
 
-import { transformToAlertDocuments } from '.';
+import { transformToAlertDocuments, transformToBaseAlertDocument } from '.';
 import { mockAuthenticatedUser } from '../../../../../__mocks__/mock_authenticated_user';
 import { mockCreateAttackDiscoveryAlertsParams } from '../../../../../__mocks__/mock_create_attack_discovery_alerts_params';
 
@@ -40,241 +40,357 @@ jest.mock('uuid', () => ({
   v4: jest.fn(),
 }));
 
-describe('transformToAlertDocuments', () => {
-  const mockNow = new Date('2025-04-24T17:36:25.812Z');
-  const spaceId = 'default';
+describe('Transform attack discoveries to alert documents', () => {
+  describe('transformToAlertDocuments', () => {
+    const mockNow = new Date('2025-04-24T17:36:25.812Z');
+    const spaceId = 'default';
 
-  beforeEach(() => {
-    jest.resetAllMocks();
+    beforeEach(() => {
+      jest.resetAllMocks();
 
-    (uuidv4 as unknown as jest.Mock)
-      .mockImplementationOnce(() => '879B171F-428B-4B23-99C3-EDE33334AB71')
-      .mockImplementationOnce(() => '123B171F-428B-4B23-99C3-EDE33334AB72');
-  });
-
-  it(`returns the expected ${ALERT_ATTACK_DISCOVERY_ALERT_IDS} field`, () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
+      (uuidv4 as unknown as jest.Mock)
+        .mockImplementationOnce(() => '879B171F-428B-4B23-99C3-EDE33334AB71')
+        .mockImplementationOnce(() => '123B171F-428B-4B23-99C3-EDE33334AB72');
     });
 
-    expect(result[0][ALERT_ATTACK_DISCOVERY_ALERT_IDS]).toEqual(
-      mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0].alertIds
-    );
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_ALERT_IDS} field`, () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_ALERT_IDS]).toEqual(
+        mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0].alertIds
+      );
+    });
+
+    it(`returns an empty array for ${ALERT_ATTACK_DISCOVERY_ALERT_IDS} if no alertIds are provided`, () => {
+      const params = {
+        ...mockCreateAttackDiscoveryAlertsParams,
+        attackDiscoveries: [
+          {
+            ...mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0],
+            alertIds: [],
+          },
+        ],
+      };
+
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: params,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_ALERT_IDS]).toEqual([]);
+    });
+
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT} field`, () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT]).toEqual(
+        mockCreateAttackDiscoveryAlertsParams.alertsContextCount
+      );
+    });
+
+    it(`returns the expected ${ALERT_UUID}`, () => {
+      uuidv4 as unknown as jest.Mock;
+
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_UUID]).toBe('879B171F-428B-4B23-99C3-EDE33334AB71');
+    });
+
+    it(`returns the same ${ALERT_INSTANCE_ID} as the ${ALERT_UUID}`, () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_INSTANCE_ID]).toEqual(result[0][ALERT_UUID]);
+    });
+
+    it(`returns the expected ${ALERT_RISK_SCORE}`, () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_RISK_SCORE]).toEqual(1316);
+    });
+
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_USER_ID}`, () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_USER_ID]).toEqual(mockAuthenticatedUser.profile_uid);
+    });
+
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_USER_NAME}`, () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_USER_NAME]).toEqual(mockAuthenticatedUser.username);
+    });
+
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_USERS}`, () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_USERS]).toEqual([
+        {
+          id: mockAuthenticatedUser.profile_uid,
+          name: mockAuthenticatedUser.username,
+        },
+      ]);
+    });
+
+    it('generates unique UUIDs for multiple alerts', () => {
+      const params = {
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      };
+
+      const result = transformToAlertDocuments(params);
+
+      const uuids = result.map((alert) => alert[ALERT_UUID]);
+      expect(uuids).toEqual([
+        '879B171F-428B-4B23-99C3-EDE33334AB71',
+        '123B171F-428B-4B23-99C3-EDE33334AB72',
+      ]);
+    });
+
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS}`, () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS]).toEqual(
+        replaceAnonymizedValuesWithOriginalValues({
+          messageContent:
+            mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0].detailsMarkdown,
+          replacements: mockCreateAttackDiscoveryAlertsParams.replacements ?? {},
+        })
+      );
+    });
+
+    it('handles undefined entitySummaryMarkdown correctly', () => {
+      const params: CreateAttackDiscoveryAlertsParams = {
+        ...mockCreateAttackDiscoveryAlertsParams,
+        attackDiscoveries: [
+          {
+            ...mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0],
+            entitySummaryMarkdown: undefined, // <-- undefined
+          },
+        ],
+      };
+
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: params,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(
+        result[0][ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]
+      ).toBeUndefined();
+    });
+
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_REPLACEMENTS}`, () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_REPLACEMENTS]).toEqual(
+        Object.entries(mockCreateAttackDiscoveryAlertsParams.replacements ?? {}).map(
+          ([uuid, value]) => ({
+            uuid,
+            value,
+          })
+        )
+      );
+    });
+
+    it('returns the expected static ALERT_RULE* fields', () => {
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_RULE_CATEGORY]).toBe(
+        'Attack discovery ad hoc (placeholder rule category)'
+      );
+      expect(result[0][ALERT_RULE_NAME]).toBe('Attack discovery ad hoc (placeholder rule name)');
+      expect(result[0][ALERT_RULE_TYPE_ID]).toBe(ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID);
+      expect(result[0][ALERT_RULE_UUID]).toBe(ATTACK_DISCOVERY_AD_HOC_RULE_ID);
+    });
+
+    it('handles empty replacements correctly', () => {
+      const params = {
+        ...mockCreateAttackDiscoveryAlertsParams,
+        replacements: {},
+      };
+
+      const result = transformToAlertDocuments({
+        authenticatedUser: mockAuthenticatedUser,
+        createAttackDiscoveryAlertsParams: params,
+        now: mockNow,
+        spaceId,
+      });
+
+      expect(result[0][ALERT_ATTACK_DISCOVERY_REPLACEMENTS]).toBeUndefined();
+    });
   });
 
-  it(`returns an empty array for ${ALERT_ATTACK_DISCOVERY_ALERT_IDS} if no alertIds are provided`, () => {
-    const params = {
-      ...mockCreateAttackDiscoveryAlertsParams,
-      attackDiscoveries: [
-        {
+  describe('transformToBaseAlertDocument', () => {
+    const { attackDiscoveries, generationUuid, ...alertsParams } =
+      mockCreateAttackDiscoveryAlertsParams;
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+
+      (uuidv4 as unknown as jest.Mock)
+        .mockImplementationOnce(() => '879B171F-428B-4B23-99C3-EDE33334AB71')
+        .mockImplementationOnce(() => '123B171F-428B-4B23-99C3-EDE33334AB72');
+    });
+
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_ALERT_IDS} field`, () => {
+      const result = transformToBaseAlertDocument({
+        attackDiscovery: attackDiscoveries[0],
+        alertsParams,
+      });
+
+      expect(result[ALERT_ATTACK_DISCOVERY_ALERT_IDS]).toEqual(
+        mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0].alertIds
+      );
+    });
+
+    it(`returns an empty array for ${ALERT_ATTACK_DISCOVERY_ALERT_IDS} if no alertIds are provided`, () => {
+      const result = transformToBaseAlertDocument({
+        attackDiscovery: {
           ...mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0],
           alertIds: [],
         },
-      ],
-    };
+        alertsParams,
+      });
 
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: params,
-      now: mockNow,
-      spaceId,
+      expect(result[ALERT_ATTACK_DISCOVERY_ALERT_IDS]).toEqual([]);
     });
 
-    expect(result[0][ALERT_ATTACK_DISCOVERY_ALERT_IDS]).toEqual([]);
-  });
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT} field`, () => {
+      const result = transformToBaseAlertDocument({
+        attackDiscovery: attackDiscoveries[0],
+        alertsParams,
+      });
 
-  it(`returns the expected ${ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT} field`, () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
+      expect(result[ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT]).toEqual(
+        mockCreateAttackDiscoveryAlertsParams.alertsContextCount
+      );
     });
 
-    expect(result[0][ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT]).toEqual(
-      mockCreateAttackDiscoveryAlertsParams.alertsContextCount
-    );
-  });
+    it(`returns the expected ${ALERT_RISK_SCORE}`, () => {
+      const result = transformToBaseAlertDocument({
+        attackDiscovery: attackDiscoveries[0],
+        alertsParams,
+      });
 
-  it(`returns the expected ${ALERT_UUID}`, () => {
-    uuidv4 as unknown as jest.Mock;
-
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
+      expect(result[ALERT_RISK_SCORE]).toEqual(1316);
     });
 
-    expect(result[0][ALERT_UUID]).toBe('879B171F-428B-4B23-99C3-EDE33334AB71');
-  });
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS}`, () => {
+      const result = transformToBaseAlertDocument({
+        attackDiscovery: attackDiscoveries[0],
+        alertsParams,
+      });
 
-  it(`returns the same ${ALERT_INSTANCE_ID} as the ${ALERT_UUID}`, () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
+      expect(result[ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS]).toEqual(
+        replaceAnonymizedValuesWithOriginalValues({
+          messageContent:
+            mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0].detailsMarkdown,
+          replacements: mockCreateAttackDiscoveryAlertsParams.replacements ?? {},
+        })
+      );
     });
 
-    expect(result[0][ALERT_INSTANCE_ID]).toEqual(result[0][ALERT_UUID]);
-  });
-
-  it(`returns the expected ${ALERT_RISK_SCORE}`, () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
-    });
-
-    expect(result[0][ALERT_RISK_SCORE]).toEqual(1316);
-  });
-
-  it(`returns the expected ${ALERT_ATTACK_DISCOVERY_USER_ID}`, () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
-    });
-
-    expect(result[0][ALERT_ATTACK_DISCOVERY_USER_ID]).toEqual(mockAuthenticatedUser.profile_uid);
-  });
-
-  it(`returns the expected ${ALERT_ATTACK_DISCOVERY_USER_NAME}`, () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
-    });
-
-    expect(result[0][ALERT_ATTACK_DISCOVERY_USER_NAME]).toEqual(mockAuthenticatedUser.username);
-  });
-
-  it(`returns the expected ${ALERT_ATTACK_DISCOVERY_USERS}`, () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
-    });
-
-    expect(result[0][ALERT_ATTACK_DISCOVERY_USERS]).toEqual([
-      {
-        id: mockAuthenticatedUser.profile_uid,
-        name: mockAuthenticatedUser.username,
-      },
-    ]);
-  });
-
-  it('generates unique UUIDs for multiple alerts', () => {
-    const params = {
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
-    };
-
-    const result = transformToAlertDocuments(params);
-
-    const uuids = result.map((alert) => alert[ALERT_UUID]);
-    expect(uuids).toEqual([
-      '879B171F-428B-4B23-99C3-EDE33334AB71',
-      '123B171F-428B-4B23-99C3-EDE33334AB72',
-    ]);
-  });
-
-  it(`returns the expected ${ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS}`, () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
-    });
-
-    expect(result[0][ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS]).toEqual(
-      replaceAnonymizedValuesWithOriginalValues({
-        messageContent: mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0].detailsMarkdown,
-        replacements: mockCreateAttackDiscoveryAlertsParams.replacements ?? {},
-      })
-    );
-  });
-
-  it('handles undefined entitySummaryMarkdown correctly', () => {
-    const params: CreateAttackDiscoveryAlertsParams = {
-      ...mockCreateAttackDiscoveryAlertsParams,
-      attackDiscoveries: [
-        {
+    it('handles undefined entitySummaryMarkdown correctly', () => {
+      const result = transformToBaseAlertDocument({
+        attackDiscovery: {
           ...mockCreateAttackDiscoveryAlertsParams.attackDiscoveries[0],
           entitySummaryMarkdown: undefined, // <-- undefined
         },
-      ],
-    };
+        alertsParams,
+      });
 
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: params,
-      now: mockNow,
-      spaceId,
+      expect(
+        result[ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]
+      ).toBeUndefined();
     });
 
-    expect(
-      result[0][ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]
-    ).toBeUndefined();
-  });
+    it(`returns the expected ${ALERT_ATTACK_DISCOVERY_REPLACEMENTS}`, () => {
+      const result = transformToBaseAlertDocument({
+        attackDiscovery: attackDiscoveries[0],
+        alertsParams,
+      });
 
-  it(`returns the expected ${ALERT_ATTACK_DISCOVERY_REPLACEMENTS}`, () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
+      expect(result[ALERT_ATTACK_DISCOVERY_REPLACEMENTS]).toEqual(
+        Object.entries(mockCreateAttackDiscoveryAlertsParams.replacements ?? {}).map(
+          ([uuid, value]) => ({
+            uuid,
+            value,
+          })
+        )
+      );
     });
 
-    expect(result[0][ALERT_ATTACK_DISCOVERY_REPLACEMENTS]).toEqual(
-      Object.entries(mockCreateAttackDiscoveryAlertsParams.replacements ?? {}).map(
-        ([uuid, value]) => ({
-          uuid,
-          value,
-        })
-      )
-    );
-  });
+    it('handles empty replacements correctly', () => {
+      const result = transformToBaseAlertDocument({
+        attackDiscovery: attackDiscoveries[0],
+        alertsParams: {
+          ...alertsParams,
+          replacements: {},
+        },
+      });
 
-  it('returns the expected static ALERT_RULE* fields', () => {
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: mockCreateAttackDiscoveryAlertsParams,
-      now: mockNow,
-      spaceId,
+      expect(result[ALERT_ATTACK_DISCOVERY_REPLACEMENTS]).toBeUndefined();
     });
-
-    expect(result[0][ALERT_RULE_CATEGORY]).toBe(
-      'Attack discovery ad hoc (placeholder rule category)'
-    );
-    expect(result[0][ALERT_RULE_NAME]).toBe('Attack discovery ad hoc (placeholder rule name)');
-    expect(result[0][ALERT_RULE_TYPE_ID]).toBe(ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID);
-    expect(result[0][ALERT_RULE_UUID]).toBe(ATTACK_DISCOVERY_AD_HOC_RULE_ID);
-  });
-
-  it('handles empty replacements correctly', () => {
-    const params = {
-      ...mockCreateAttackDiscoveryAlertsParams,
-      replacements: {},
-    };
-
-    const result = transformToAlertDocuments({
-      authenticatedUser: mockAuthenticatedUser,
-      createAttackDiscoveryAlertsParams: params,
-      now: mockNow,
-      spaceId,
-    });
-
-    expect(result[0][ALERT_ATTACK_DISCOVERY_REPLACEMENTS]).toBeUndefined();
   });
 });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/persistence/transforms/transform_to_alert_documents/index.ts
@@ -6,12 +6,14 @@
  */
 
 import { EcsVersion } from '@elastic/ecs';
+import { Alert } from '@kbn/alerts-as-data-utils';
 import { AuthenticatedUser } from '@kbn/core/server';
 import {
   ATTACK_DISCOVERY_AD_HOC_RULE_ID,
   ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID,
   type CreateAttackDiscoveryAlertsParams,
   replaceAnonymizedValuesWithOriginalValues,
+  AttackDiscovery,
 } from '@kbn/elastic-assistant-common';
 import {
   ALERT_INSTANCE_ID,
@@ -55,6 +57,80 @@ import {
 } from '../../../schedules/fields/field_names';
 import { AttackDiscoveryAlertDocument } from '../../../schedules/types';
 
+type AttackDiscoveryAlertDocumentBase = Omit<AttackDiscoveryAlertDocument, keyof Alert>;
+
+export const transformToBaseAlertDocument = ({
+  attackDiscovery,
+  alertsParams,
+}: {
+  attackDiscovery: AttackDiscovery;
+  alertsParams: Omit<CreateAttackDiscoveryAlertsParams, 'attackDiscoveries' | 'generationUuid'>;
+}): AttackDiscoveryAlertDocumentBase => {
+  const { alertsContextCount, anonymizedAlerts, apiConfig, connectorName, replacements } =
+    alertsParams;
+
+  const {
+    alertIds,
+    entitySummaryMarkdown,
+    detailsMarkdown,
+    mitreAttackTactics,
+    summaryMarkdown,
+    title,
+  } = attackDiscovery;
+
+  return {
+    // Alert base fields
+    [ECS_VERSION]: EcsVersion,
+    [ALERT_RISK_SCORE]: getAlertRiskScore({
+      alertIds,
+      anonymizedAlerts,
+    }),
+
+    // Attack discovery fields
+    [ALERT_ATTACK_DISCOVERY_ALERT_IDS]: alertIds,
+    [ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT]: alertsContextCount,
+    [ALERT_ATTACK_DISCOVERY_API_CONFIG]: {
+      action_type_id: apiConfig.actionTypeId,
+      connector_id: apiConfig.connectorId,
+      model: apiConfig.model,
+      name: connectorName,
+      provider: apiConfig.provider,
+    },
+    [ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN]: detailsMarkdown,
+    [ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS]:
+      replaceAnonymizedValuesWithOriginalValues({
+        messageContent: detailsMarkdown,
+        replacements,
+      }),
+    [ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN]: entitySummaryMarkdown,
+    [ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]:
+      entitySummaryMarkdown != null
+        ? replaceAnonymizedValuesWithOriginalValues({
+            messageContent: entitySummaryMarkdown,
+            replacements,
+          })
+        : undefined,
+    [ALERT_ATTACK_DISCOVERY_MITRE_ATTACK_TACTICS]: mitreAttackTactics,
+    [ALERT_ATTACK_DISCOVERY_REPLACEMENTS]: !isEmpty(replacements)
+      ? Object.entries(replacements).map(([uuid, value]) => ({
+          uuid,
+          value,
+        }))
+      : undefined,
+    [ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN]: summaryMarkdown,
+    [ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]:
+      replaceAnonymizedValuesWithOriginalValues({
+        messageContent: summaryMarkdown,
+        replacements,
+      }),
+    [ALERT_ATTACK_DISCOVERY_TITLE]: title,
+    [ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS]: replaceAnonymizedValuesWithOriginalValues({
+      messageContent: title,
+      replacements,
+    }),
+  };
+};
+
 export const transformToAlertDocuments = ({
   authenticatedUser,
   createAttackDiscoveryAlertsParams,
@@ -66,102 +142,42 @@ export const transformToAlertDocuments = ({
   now: Date;
   spaceId: string;
 }): AttackDiscoveryAlertDocument[] => {
-  const {
-    alertsContextCount,
-    anonymizedAlerts,
-    apiConfig,
-    attackDiscoveries,
-    connectorName,
-    generationUuid,
-    replacements,
-  } = createAttackDiscoveryAlertsParams;
+  const { attackDiscoveries, generationUuid, ...restParams } = createAttackDiscoveryAlertsParams;
 
-  const replacementsOrEmpty = replacements ?? {};
+  return attackDiscoveries.map((attackDiscovery) => {
+    const alertUuid = uuidv4();
 
-  return attackDiscoveries.map(
-    ({
-      alertIds,
-      entitySummaryMarkdown,
-      detailsMarkdown,
-      mitreAttackTactics,
-      summaryMarkdown,
-      title,
-    }) => {
-      const alertUuid = uuidv4();
+    const baseAlertDocument = transformToBaseAlertDocument({
+      attackDiscovery,
+      alertsParams: restParams,
+    });
 
-      return {
-        '@timestamp': now.toISOString(),
-        [ALERT_ATTACK_DISCOVERY_ALERT_IDS]: alertIds,
-        [ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT]: alertsContextCount,
-        [ALERT_ATTACK_DISCOVERY_API_CONFIG]: {
-          action_type_id: apiConfig.actionTypeId,
-          connector_id: apiConfig.connectorId,
-          model: apiConfig.model,
-          name: connectorName,
-          provider: apiConfig.provider,
+    return {
+      ...baseAlertDocument,
+
+      '@timestamp': now.toISOString(),
+      [ALERT_ATTACK_DISCOVERY_USER_ID]: authenticatedUser.profile_uid,
+      [ALERT_ATTACK_DISCOVERY_USER_NAME]: authenticatedUser.username,
+      [ALERT_ATTACK_DISCOVERY_USERS]: [
+        {
+          id: authenticatedUser.profile_uid,
+          name: authenticatedUser.username,
         },
-        [ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN]: detailsMarkdown,
-        [ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS]:
-          replaceAnonymizedValuesWithOriginalValues({
-            messageContent: detailsMarkdown,
-            replacements: replacementsOrEmpty,
-          }),
-        [ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN]: entitySummaryMarkdown,
-        [ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]:
-          entitySummaryMarkdown != null
-            ? replaceAnonymizedValuesWithOriginalValues({
-                messageContent: entitySummaryMarkdown,
-                replacements: replacementsOrEmpty,
-              })
-            : undefined,
-        [ALERT_ATTACK_DISCOVERY_MITRE_ATTACK_TACTICS]: mitreAttackTactics,
-        [ALERT_ATTACK_DISCOVERY_REPLACEMENTS]: !isEmpty(replacementsOrEmpty)
-          ? Object.entries(replacementsOrEmpty).map(([uuid, value]) => ({
-              uuid,
-              value,
-            }))
-          : undefined,
-        [ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN]: summaryMarkdown,
-        [ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]:
-          replaceAnonymizedValuesWithOriginalValues({
-            messageContent: summaryMarkdown,
-            replacements: replacementsOrEmpty,
-          }),
-        [ALERT_ATTACK_DISCOVERY_TITLE]: title,
-        [ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS]: replaceAnonymizedValuesWithOriginalValues(
-          {
-            messageContent: title,
-            replacements: replacementsOrEmpty,
-          }
-        ),
-        [ALERT_ATTACK_DISCOVERY_USER_ID]: authenticatedUser.profile_uid,
-        [ALERT_ATTACK_DISCOVERY_USER_NAME]: authenticatedUser.username,
-        [ALERT_ATTACK_DISCOVERY_USERS]: [
-          {
-            id: authenticatedUser.profile_uid,
-            name: authenticatedUser.username,
-          },
-        ],
-        [ALERT_RULE_EXECUTION_UUID]: generationUuid,
-        [ALERT_INSTANCE_ID]: alertUuid,
-        [ALERT_RISK_SCORE]: getAlertRiskScore({
-          alertIds,
-          anonymizedAlerts,
-        }),
-        [ALERT_RULE_CATEGORY]: 'Attack discovery ad hoc (placeholder rule category)',
-        [ALERT_RULE_CONSUMER]: 'siem',
-        [ALERT_RULE_NAME]: 'Attack discovery ad hoc (placeholder rule name)',
-        [ALERT_RULE_PRODUCER]: 'siem',
-        [ALERT_RULE_REVISION]: 1,
-        [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID, // sentinel value
-        [ALERT_RULE_UUID]: ATTACK_DISCOVERY_AD_HOC_RULE_ID, // sentinel value
-        [ALERT_STATUS]: 'active',
-        [ALERT_UUID]: alertUuid, // IMPORTANT: the document _id should be the same as this field when it's bulk inserted
-        [ALERT_WORKFLOW_STATUS]: 'open',
-        [ECS_VERSION]: EcsVersion,
-        [EVENT_KIND]: 'signal',
-        [SPACE_IDS]: [spaceId],
-      };
-    }
-  );
+      ],
+      [ALERT_RULE_EXECUTION_UUID]: generationUuid,
+      [ALERT_INSTANCE_ID]: alertUuid,
+      [ALERT_RULE_CATEGORY]: 'Attack discovery ad hoc (placeholder rule category)',
+      [ALERT_RULE_CONSUMER]: 'siem',
+      [ALERT_RULE_NAME]: 'Attack discovery ad hoc (placeholder rule name)',
+      [ALERT_RULE_PRODUCER]: 'siem',
+      [ALERT_RULE_REVISION]: 1,
+      [ALERT_RULE_TYPE_ID]: ATTACK_DISCOVERY_AD_HOC_RULE_TYPE_ID, // sentinel value
+      [ALERT_RULE_UUID]: ATTACK_DISCOVERY_AD_HOC_RULE_ID, // sentinel value
+      [ALERT_STATUS]: 'active',
+      [ALERT_UUID]: alertUuid, // IMPORTANT: the document _id should be the same as this field when it's bulk inserted
+      [ALERT_WORKFLOW_STATUS]: 'open',
+      [EVENT_KIND]: 'signal',
+      [SPACE_IDS]: [spaceId],
+    };
+  });
 };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/definition.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/definition.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { loggerMock } from '@kbn/logging-mocks';
+import { analyticsServiceMock } from '@kbn/core/server/mocks';
 import {
   ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
   AttackDiscoveryScheduleParams,
@@ -16,13 +17,17 @@ import { ATTACK_DISCOVERY_ALERTS_AAD_CONFIG } from '../constants';
 
 describe('getAttackDiscoveryScheduleType', () => {
   const mockLogger = loggerMock.create();
+  const mockTelemetry = analyticsServiceMock.createAnalyticsServiceSetup();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should return schedule type definition', async () => {
-    const scheduleType = getAttackDiscoveryScheduleType({ logger: mockLogger });
+    const scheduleType = getAttackDiscoveryScheduleType({
+      logger: mockLogger,
+      telemetry: mockTelemetry,
+    });
 
     expect(scheduleType).toEqual({
       id: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/definition.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/definition.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { DEFAULT_APP_CATEGORIES, Logger } from '@kbn/core/server';
+import { AnalyticsServiceSetup, DEFAULT_APP_CATEGORIES, Logger } from '@kbn/core/server';
 import {
   ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
   AttackDiscoveryScheduleParams,
@@ -17,10 +17,12 @@ import { attackDiscoveryScheduleExecutor } from './executor';
 
 export interface GetAttackDiscoveryScheduleParams {
   logger: Logger;
+  telemetry: AnalyticsServiceSetup;
 }
 
 export const getAttackDiscoveryScheduleType = ({
   logger,
+  telemetry,
 }: GetAttackDiscoveryScheduleParams): AttackDiscoveryScheduleType => {
   return {
     id: ATTACK_DISCOVERY_SCHEDULES_ALERT_TYPE_ID,
@@ -52,6 +54,7 @@ export const getAttackDiscoveryScheduleType = ({
       return attackDiscoveryScheduleExecutor({
         options,
         logger,
+        telemetry,
       });
     },
   };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
@@ -97,7 +97,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
   };
   const executorOptions = {
     params,
-    rule: { id: 'rule-1', name: 'Test Rule' },
+    rule: { id: 'rule-1', interval: '12m' },
     services: {
       ...services,
       actionsClient,
@@ -221,7 +221,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     expect(reportAttackDiscoveryGenerationFailure).toHaveBeenCalledWith({
       apiConfig: params.apiConfig,
       errorMessage: 'Big time failure',
-      schedule: { id: 'rule-1', name: 'Test Rule' },
+      schedule: { id: 'rule-1', interval: '12m' },
       telemetry: mockTelemetry,
     });
   });
@@ -241,7 +241,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
       attackDiscoveries: mockAttackDiscoveries,
       durationMs: 0,
       hasFilter: true,
-      schedule: { id: 'rule-1', name: 'Test Rule' },
+      schedule: { id: 'rule-1', interval: '12m' },
       size: 123,
       start: 'now-24h',
       telemetry: mockTelemetry,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
@@ -97,7 +97,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
   };
   const executorOptions = {
     params,
-    rule: { id: 'rule-1', interval: '12m' },
+    rule: { id: 'rule-1', schedule: { interval: '12m' } },
     services: {
       ...services,
       actionsClient,
@@ -320,6 +320,7 @@ describe('attackDiscoveryScheduleExecutor', () => {
     const attackDiscoveryScheduleExecutorPromise = attackDiscoveryScheduleExecutor({
       logger: mockLogger,
       options,
+      telemetry: mockTelemetry,
     });
     await expect(attackDiscoveryScheduleExecutorPromise).rejects.toThrowErrorMatchingInlineSnapshot(
       '"Rule execution cancelled due to timeout"'

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.test.ts
@@ -10,10 +10,15 @@ import { loggerMock } from '@kbn/logging-mocks';
 import { actionsClientMock } from '@kbn/actions-plugin/server/mocks';
 import { AlertsClientError, RuleExecutorOptions } from '@kbn/alerting-plugin/server';
 import { alertsMock } from '@kbn/alerting-plugin/server/mocks';
+import { analyticsServiceMock } from '@kbn/core/server/mocks';
 
 import { attackDiscoveryScheduleExecutor } from './executor';
 import { findDocuments } from '../../../../ai_assistant_data_clients/find';
 import { generateAttackDiscoveries } from '../../../../routes/attack_discovery/helpers/generate_discoveries';
+import {
+  reportAttackDiscoveryGenerationFailure,
+  reportAttackDiscoveryGenerationSuccess,
+} from '../../../../routes/attack_discovery/helpers/telemetry';
 import {
   mockAnonymizedAlerts,
   mockAnonymizedAlertsReplacements,
@@ -29,9 +34,16 @@ jest.mock('../../../../routes/attack_discovery/helpers/generate_discoveries', ()
   ...jest.requireActual('../../../../routes/attack_discovery/helpers/generate_discoveries'),
   generateAttackDiscoveries: jest.fn(),
 }));
+jest.mock('../../../../routes/attack_discovery/helpers/telemetry', () => ({
+  ...jest.requireActual('../../../../routes/attack_discovery/helpers/telemetry'),
+  reportAttackDiscoveryGenerationFailure: jest.fn(),
+  reportAttackDiscoveryGenerationSuccess: jest.fn(),
+}));
 
 describe('attackDiscoveryScheduleExecutor', () => {
+  const date = '2025-05-20T15:18:21.000Z';
   const mockLogger = loggerMock.create();
+  const mockTelemetry = analyticsServiceMock.createAnalyticsServiceSetup();
   const services = alertsMock.createRuleExecutorServices();
   const actionsClient = actionsClientMock.create();
   const spaceId = 'test-space';
@@ -80,11 +92,12 @@ describe('attackDiscoveryScheduleExecutor', () => {
         must_not: [],
       },
     },
-    size: '123',
+    size: 123,
     start: 'now-24h',
   };
   const executorOptions = {
     params,
+    rule: { id: 'rule-1', name: 'Test Rule' },
     services: {
       ...services,
       actionsClient,
@@ -93,8 +106,16 @@ describe('attackDiscoveryScheduleExecutor', () => {
     state: {},
   };
 
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.setSystemTime(new Date(date));
 
     (findDocuments as jest.Mock).mockResolvedValue(getFindAnonymizationFieldsResultWithSingleHit());
     (generateAttackDiscoveries as jest.Mock).mockResolvedValue({
@@ -114,8 +135,9 @@ describe('attackDiscoveryScheduleExecutor', () => {
     } as unknown as RuleExecutorOptions;
 
     const attackDiscoveryScheduleExecutorPromise = attackDiscoveryScheduleExecutor({
-      logger: mockLogger,
       options,
+      logger: mockLogger,
+      telemetry: mockTelemetry,
     });
     await expect(attackDiscoveryScheduleExecutorPromise).rejects.toBeInstanceOf(AlertsClientError);
   });
@@ -126,8 +148,9 @@ describe('attackDiscoveryScheduleExecutor', () => {
     } as unknown as RuleExecutorOptions;
 
     const attackDiscoveryScheduleExecutorPromise = attackDiscoveryScheduleExecutor({
-      logger: mockLogger,
       options,
+      logger: mockLogger,
+      telemetry: mockTelemetry,
     });
     await expect(attackDiscoveryScheduleExecutorPromise).rejects.toThrowErrorMatchingInlineSnapshot(
       '"Expected actionsClient not to be null!"'
@@ -137,7 +160,11 @@ describe('attackDiscoveryScheduleExecutor', () => {
   it('should call `findDocuments` with the correct arguments', async () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
-    await attackDiscoveryScheduleExecutor({ logger: mockLogger, options });
+    await attackDiscoveryScheduleExecutor({
+      options,
+      logger: mockLogger,
+      telemetry: mockTelemetry,
+    });
 
     expect(findDocuments).toHaveBeenCalledWith({
       esClient: services.scopedClusterClient.asCurrentUser,
@@ -151,7 +178,11 @@ describe('attackDiscoveryScheduleExecutor', () => {
   it('should call `generateAttackDiscoveries` with the correct arguments', async () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
-    await attackDiscoveryScheduleExecutor({ logger: mockLogger, options });
+    await attackDiscoveryScheduleExecutor({
+      options,
+      logger: mockLogger,
+      telemetry: mockTelemetry,
+    });
     const anonymizationFields = [
       {
         timestamp: '2019-12-13T16:40:33.400Z',
@@ -175,10 +206,56 @@ describe('attackDiscoveryScheduleExecutor', () => {
     });
   });
 
+  it('should call `reportAttackDiscoveryGenerationFailure` with the correct arguments', async () => {
+    const options = { ...executorOptions } as unknown as RuleExecutorOptions;
+    (generateAttackDiscoveries as jest.Mock).mockRejectedValue(new Error('Big time failure'));
+
+    await expect(async () => {
+      await attackDiscoveryScheduleExecutor({
+        options,
+        logger: mockLogger,
+        telemetry: mockTelemetry,
+      });
+    }).rejects.toThrow();
+
+    expect(reportAttackDiscoveryGenerationFailure).toHaveBeenCalledWith({
+      apiConfig: params.apiConfig,
+      errorMessage: 'Big time failure',
+      schedule: { id: 'rule-1', name: 'Test Rule' },
+      telemetry: mockTelemetry,
+    });
+  });
+
+  it('should call `reportAttackDiscoveryGenerationSuccess` with the correct arguments', async () => {
+    const options = { ...executorOptions } as unknown as RuleExecutorOptions;
+
+    await attackDiscoveryScheduleExecutor({
+      options,
+      logger: mockLogger,
+      telemetry: mockTelemetry,
+    });
+
+    expect(reportAttackDiscoveryGenerationSuccess).toHaveBeenCalledWith({
+      alertsContextCount: 2,
+      apiConfig: params.apiConfig,
+      attackDiscoveries: mockAttackDiscoveries,
+      durationMs: 0,
+      hasFilter: true,
+      schedule: { id: 'rule-1', name: 'Test Rule' },
+      size: 123,
+      start: 'now-24h',
+      telemetry: mockTelemetry,
+    });
+  });
+
   it('should report generated attack discoveries as alerts', async () => {
     const options = { ...executorOptions } as unknown as RuleExecutorOptions;
 
-    await attackDiscoveryScheduleExecutor({ logger: mockLogger, options });
+    await attackDiscoveryScheduleExecutor({
+      options,
+      logger: mockLogger,
+      telemetry: mockTelemetry,
+    });
 
     const { id, ...restDiscovery } = mockAttackDiscoveries[0];
     expect(services.alertsClient.report).toHaveBeenCalledWith({

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
@@ -86,7 +86,7 @@ export const attackDiscoveryScheduleExecutor = async ({
       durationMs,
       end: restParams.end,
       hasFilter: !!(combinedFilter && Object.keys(combinedFilter).length),
-      schedule: { id: rule.id, name: rule.name },
+      schedule: { id: rule.id, interval: rule.schedule.interval },
       size: restParams.size,
       start: restParams.start,
       telemetry,
@@ -120,7 +120,7 @@ export const attackDiscoveryScheduleExecutor = async ({
     reportAttackDiscoveryGenerationFailure({
       apiConfig: params.apiConfig,
       errorMessage: transformedError.message,
-      schedule: { id: rule.id, name: rule.name },
+      schedule: { id: rule.id, interval: rule.schedule.interval },
       telemetry,
     });
     throw error;

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/attack_discovery/schedules/register_schedule/executor.ts
@@ -5,50 +5,38 @@
  * 2.0.
  */
 
+import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
-import { EcsVersion } from '@elastic/ecs';
-import { Logger } from '@kbn/core/server';
-import { Alert } from '@kbn/alerts-as-data-utils';
+import { AnalyticsServiceSetup, Logger } from '@kbn/core/server';
 import { AlertsClientError } from '@kbn/alerting-plugin/server';
-import { replaceAnonymizedValuesWithOriginalValues } from '@kbn/elastic-assistant-common';
-import { ECS_VERSION } from '@kbn/rule-data-utils';
+import { transformError } from '@kbn/securitysolution-es-utils';
 
+import {
+  reportAttackDiscoveryGenerationFailure,
+  reportAttackDiscoveryGenerationSuccess,
+} from '../../../../routes/attack_discovery/helpers/telemetry';
 import { ANONYMIZATION_FIELDS_RESOURCE } from '../../../../ai_assistant_service/constants';
 import { transformESSearchToAnonymizationFields } from '../../../../ai_assistant_data_clients/anonymization_fields/helpers';
 import { getResourceName } from '../../../../ai_assistant_service';
 import { EsAnonymizationFieldsSchema } from '../../../../ai_assistant_data_clients/anonymization_fields/types';
 import { findDocuments } from '../../../../ai_assistant_data_clients/find';
 import { generateAttackDiscoveries } from '../../../../routes/attack_discovery/helpers/generate_discoveries';
-import { AttackDiscoveryAlertDocument, AttackDiscoveryExecutorOptions } from '../types';
-import {
-  ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT,
-  ALERT_ATTACK_DISCOVERY_ALERT_IDS,
-  ALERT_ATTACK_DISCOVERY_API_CONFIG,
-  ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN,
-  ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS,
-  ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN,
-  ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS,
-  ALERT_ATTACK_DISCOVERY_MITRE_ATTACK_TACTICS,
-  ALERT_ATTACK_DISCOVERY_REPLACEMENTS,
-  ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN,
-  ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS,
-  ALERT_ATTACK_DISCOVERY_TITLE,
-  ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS,
-} from '../fields';
+import { AttackDiscoveryExecutorOptions } from '../types';
 import { getIndexTemplateAndPattern } from '../../../data_stream/helpers';
-
-type AttackDiscoveryAlertDocumentBase = Omit<AttackDiscoveryAlertDocument, keyof Alert>;
+import { transformToBaseAlertDocument } from '../../persistence/transforms/transform_to_alert_documents';
 
 export interface AttackDiscoveryScheduleExecutorParams {
   options: AttackDiscoveryExecutorOptions;
   logger: Logger;
+  telemetry: AnalyticsServiceSetup;
 }
 
 export const attackDiscoveryScheduleExecutor = async ({
   options,
   logger,
+  telemetry,
 }: AttackDiscoveryScheduleExecutorParams) => {
-  const { params, services, spaceId } = options;
+  const { params, rule, services, spaceId } = options;
   const { alertsClient, actionsClient, savedObjectsClient, scopedClusterClient } = services;
   if (!alertsClient) {
     throw new AlertsClientError();
@@ -72,73 +60,71 @@ export const attackDiscoveryScheduleExecutor = async ({
 
   const { query, filters, combinedFilter, ...restParams } = params;
 
-  const { anonymizedAlerts, attackDiscoveries, replacements } = await generateAttackDiscoveries({
-    actionsClient,
-    config: {
-      ...restParams,
-      filter: combinedFilter,
-      anonymizationFields,
-      subAction: 'invokeAI',
-    },
-    esClient,
-    logger,
-    savedObjectsClient,
-  });
+  const startTime = moment(); // start timing the generation
 
-  attackDiscoveries?.forEach((attack) => {
-    const payload: AttackDiscoveryAlertDocumentBase = {
-      [ECS_VERSION]: EcsVersion,
-      // TODO: ALERT_RISK_SCORE
-      [ALERT_ATTACK_DISCOVERY_ALERTS_CONTEXT_COUNT]: anonymizedAlerts.length,
-      [ALERT_ATTACK_DISCOVERY_ALERT_IDS]: attack.alertIds,
-      [ALERT_ATTACK_DISCOVERY_API_CONFIG]: {
-        action_type_id: params.apiConfig.actionTypeId,
-        connector_id: params.apiConfig.connectorId,
-        model: params.apiConfig.model,
-        name: params.apiConfig.name,
-        provider: params.apiConfig.provider,
+  try {
+    const { anonymizedAlerts, attackDiscoveries, replacements } = await generateAttackDiscoveries({
+      actionsClient,
+      config: {
+        ...restParams,
+        filter: combinedFilter,
+        anonymizationFields,
+        subAction: 'invokeAI',
       },
-      [ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN]: attack.detailsMarkdown,
-      [ALERT_ATTACK_DISCOVERY_DETAILS_MARKDOWN_WITH_REPLACEMENTS]:
-        replaceAnonymizedValuesWithOriginalValues({
-          messageContent: attack.detailsMarkdown,
-          replacements,
-        }),
-      [ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN]: attack.entitySummaryMarkdown,
-      [ALERT_ATTACK_DISCOVERY_ENTITY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]:
-        attack.entitySummaryMarkdown
-          ? replaceAnonymizedValuesWithOriginalValues({
-              messageContent: attack.entitySummaryMarkdown,
-              replacements,
-            })
-          : undefined,
-      [ALERT_ATTACK_DISCOVERY_MITRE_ATTACK_TACTICS]: attack.mitreAttackTactics,
-      [ALERT_ATTACK_DISCOVERY_REPLACEMENTS]: replacements
-        ? Object.keys(replacements).map((key) => ({
-            uuid: key,
-            value: replacements[key],
-          }))
-        : undefined,
-      [ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN]: attack.summaryMarkdown,
-      [ALERT_ATTACK_DISCOVERY_SUMMARY_MARKDOWN_WITH_REPLACEMENTS]:
-        replaceAnonymizedValuesWithOriginalValues({
-          messageContent: attack.summaryMarkdown,
-          replacements,
-        }),
-      [ALERT_ATTACK_DISCOVERY_TITLE]: attack.title,
-      [ALERT_ATTACK_DISCOVERY_TITLE_WITH_REPLACEMENTS]: replaceAnonymizedValuesWithOriginalValues({
-        messageContent: attack.title,
-        replacements,
-      }),
-    };
-    const { id, ...restAttack } = attack;
-    alertsClient.report({
-      id: uuidv4(),
-      actionGroup: 'default',
-      payload,
-      context: { attack: restAttack },
+      esClient,
+      logger,
+      savedObjectsClient,
     });
-  });
+
+    const endTime = moment();
+    const durationMs = endTime.diff(startTime);
+
+    reportAttackDiscoveryGenerationSuccess({
+      alertsContextCount: anonymizedAlerts.length,
+      apiConfig: params.apiConfig,
+      attackDiscoveries,
+      durationMs,
+      end: restParams.end,
+      hasFilter: !!(combinedFilter && Object.keys(combinedFilter).length),
+      schedule: { id: rule.id, name: rule.name },
+      size: restParams.size,
+      start: restParams.start,
+      telemetry,
+    });
+
+    const alertsParams = {
+      alertsContextCount: anonymizedAlerts.length,
+      anonymizedAlerts,
+      apiConfig: params.apiConfig,
+      connectorName: params.apiConfig.name,
+      replacements,
+    };
+
+    attackDiscoveries?.forEach((attack) => {
+      const payload = transformToBaseAlertDocument({
+        attackDiscovery: attack,
+        alertsParams,
+      });
+
+      const { id, ...restAttack } = attack;
+      alertsClient.report({
+        id: uuidv4(),
+        actionGroup: 'default',
+        payload,
+        context: { attack: restAttack },
+      });
+    });
+  } catch (error) {
+    logger.error(error);
+    const transformedError = transformError(error);
+    reportAttackDiscoveryGenerationFailure({
+      apiConfig: params.apiConfig,
+      errorMessage: transformedError.message,
+      schedule: { id: rule.id, name: rule.name },
+      telemetry,
+    });
+    throw error;
+  }
 
   return { state: {} };
 };

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { EventTypeOpts } from '@kbn/core/server';
+import type { EventTypeOpts, SchemaValue } from '@kbn/core/server';
 
 export const KNOWLEDGE_BASE_EXECUTION_SUCCESS_EVENT: EventTypeOpts<{
   model: string;
@@ -236,7 +236,33 @@ export const INVOKE_ASSISTANT_ERROR_EVENT: EventTypeOpts<{
   },
 };
 
-export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
+interface AttackDiscoveryScheduleInfo {
+  id: string;
+  name: string;
+}
+
+const scheduleInfoSchema: SchemaValue<AttackDiscoveryScheduleInfo | undefined> = {
+  properties: {
+    id: {
+      type: 'keyword',
+      _meta: {
+        description: 'Attack discovery schedule id',
+      },
+    },
+    name: {
+      type: 'keyword',
+      _meta: {
+        description: 'Attack discovery schedule name',
+      },
+    },
+  },
+  _meta: {
+    description: 'Attack discovery schedule info',
+    optional: true,
+  },
+};
+
+interface AttackDiscoverySuccessTelemetryEvent {
   actionTypeId: string;
   alertsContextCount: number;
   alertsCount: number;
@@ -248,7 +274,10 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
   isDefaultDateRange: boolean;
   model?: string;
   provider?: string;
-}> = {
+  schedule?: AttackDiscoveryScheduleInfo;
+}
+
+export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<AttackDiscoverySuccessTelemetryEvent> = {
   eventType: 'attack_discovery_success',
   schema: {
     actionTypeId: {
@@ -328,15 +357,19 @@ export const ATTACK_DISCOVERY_SUCCESS_EVENT: EventTypeOpts<{
         optional: true,
       },
     },
+    schedule: scheduleInfoSchema,
   },
 };
 
-export const ATTACK_DISCOVERY_ERROR_EVENT: EventTypeOpts<{
+interface AttackDiscoveryErrorTelemetryEvent {
   actionTypeId: string;
   errorMessage: string;
   model?: string;
   provider?: string;
-}> = {
+  schedule?: AttackDiscoveryScheduleInfo;
+}
+
+export const ATTACK_DISCOVERY_ERROR_EVENT: EventTypeOpts<AttackDiscoveryErrorTelemetryEvent> = {
   eventType: 'attack_discovery_error',
   schema: {
     actionTypeId: {
@@ -367,6 +400,7 @@ export const ATTACK_DISCOVERY_ERROR_EVENT: EventTypeOpts<{
         optional: true,
       },
     },
+    schedule: scheduleInfoSchema,
   },
 };
 
@@ -564,7 +598,12 @@ export const DEFEND_INSIGHT_ERROR_EVENT: EventTypeOpts<{
   },
 };
 
-export const events: Array<EventTypeOpts<{ [key: string]: unknown }>> = [
+export type ElasticAssistantTelemetryEvents =
+  | { [key: string]: unknown }
+  | AttackDiscoveryErrorTelemetryEvent
+  | AttackDiscoverySuccessTelemetryEvent;
+
+export const events: Array<EventTypeOpts<ElasticAssistantTelemetryEvents>> = [
   KNOWLEDGE_BASE_EXECUTION_SUCCESS_EVENT,
   KNOWLEDGE_BASE_EXECUTION_ERROR_EVENT,
   CREATE_KNOWLEDGE_BASE_ENTRY_SUCCESS_EVENT,

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/telemetry/event_based_telemetry.ts
@@ -238,7 +238,7 @@ export const INVOKE_ASSISTANT_ERROR_EVENT: EventTypeOpts<{
 
 interface AttackDiscoveryScheduleInfo {
   id: string;
-  name: string;
+  interval: string;
 }
 
 const scheduleInfoSchema: SchemaValue<AttackDiscoveryScheduleInfo | undefined> = {
@@ -249,10 +249,10 @@ const scheduleInfoSchema: SchemaValue<AttackDiscoveryScheduleInfo | undefined> =
         description: 'Attack discovery schedule id',
       },
     },
-    name: {
+    interval: {
       type: 'keyword',
       _meta: {
-        description: 'Attack discovery schedule name',
+        description: 'Attack discovery schedule interval',
       },
     },
   },

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/plugin.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/plugin.ts
@@ -123,6 +123,7 @@ export class ElasticAssistantPlugin
             plugins.alerting.registerType(
               getAttackDiscoveryScheduleType({
                 logger: this.logger,
+                telemetry: core.analytics,
               })
             );
           }

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/telemetry.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/telemetry.test.ts
@@ -51,7 +51,7 @@ describe('telemetry', () => {
       reportAttackDiscoveryGenerationFailure({
         apiConfig: mockApiConfig,
         errorMessage: 'Epic fail!',
-        schedule: { id: 'fake-id-1', name: 'Fake Schedule 1' },
+        schedule: { id: 'fake-id-1', interval: '21d' },
         telemetry: mockTelemetry,
       });
 
@@ -61,7 +61,7 @@ describe('telemetry', () => {
         model: 'gpt-4',
         schedule: {
           id: 'fake-id-1',
-          name: 'Fake Schedule 1',
+          interval: '21d',
         },
       });
     });
@@ -114,7 +114,7 @@ describe('telemetry', () => {
         durationMs: 456000,
         end: 'now',
         hasFilter: false,
-        schedule: { id: 'fake-id-2', name: 'Fake Schedule 2' },
+        schedule: { id: 'fake-id-2', interval: '32m' },
         size: 10,
         start: 'now-24h',
         telemetry: mockTelemetry,
@@ -133,7 +133,7 @@ describe('telemetry', () => {
         model: 'gpt-4',
         schedule: {
           id: 'fake-id-2',
-          name: 'Fake Schedule 2',
+          interval: '32m',
         },
       });
     });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/telemetry.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/telemetry.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  reportAttackDiscoveryGenerationFailure,
+  reportAttackDiscoveryGenerationSuccess,
+} from './telemetry';
+import { mockAttackDiscoveries } from '../../../lib/attack_discovery/evaluation/__mocks__/mock_attack_discoveries';
+import { coreMock } from '@kbn/core/server/mocks';
+
+jest.mock('lodash/fp', () => ({
+  uniq: jest.fn((arr) => Array.from(new Set(arr))),
+}));
+
+describe('telemetry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('reportAttackDiscoveryGenerationFailure', () => {
+    const mockTelemetry = coreMock.createSetup().analytics;
+    const mockApiConfig = {
+      actionTypeId: '.gen-ai',
+      connectorId: 'my-gen-ai',
+      model: 'gpt-4',
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should report error event without schedule information', () => {
+      reportAttackDiscoveryGenerationFailure({
+        apiConfig: mockApiConfig,
+        errorMessage: 'Epic fail!',
+        telemetry: mockTelemetry,
+      });
+
+      expect(mockTelemetry.reportEvent).toHaveBeenCalledWith('attack_discovery_error', {
+        actionTypeId: '.gen-ai',
+        errorMessage: 'Epic fail!',
+        model: 'gpt-4',
+      });
+    });
+
+    it('should report error event with schedule information', () => {
+      reportAttackDiscoveryGenerationFailure({
+        apiConfig: mockApiConfig,
+        errorMessage: 'Epic fail!',
+        schedule: { id: 'fake-id-1', name: 'Fake Schedule 1' },
+        telemetry: mockTelemetry,
+      });
+
+      expect(mockTelemetry.reportEvent).toHaveBeenCalledWith('attack_discovery_error', {
+        actionTypeId: '.gen-ai',
+        errorMessage: 'Epic fail!',
+        model: 'gpt-4',
+        schedule: {
+          id: 'fake-id-1',
+          name: 'Fake Schedule 1',
+        },
+      });
+    });
+  });
+
+  describe('reportAttackDiscoveryGenerationSuccess', () => {
+    const mockTelemetry = coreMock.createSetup().analytics;
+    const mockApiConfig = {
+      actionTypeId: '.gen-ai',
+      connectorId: 'my-gen-ai',
+      model: 'gpt-4',
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should report success event without schedule information', async () => {
+      reportAttackDiscoveryGenerationSuccess({
+        alertsContextCount: 2,
+        apiConfig: mockApiConfig,
+        attackDiscoveries: mockAttackDiscoveries,
+        durationMs: 123000,
+        end: 'now',
+        hasFilter: false,
+        size: 10,
+        start: 'now-24h',
+        telemetry: mockTelemetry,
+      });
+
+      expect(mockTelemetry.reportEvent).toHaveBeenCalledWith('attack_discovery_success', {
+        actionTypeId: '.gen-ai',
+        alertsContextCount: 2,
+        alertsCount: 8,
+        configuredAlertsCount: 10,
+        dateRangeDuration: 24,
+        discoveriesGenerated: 1,
+        durationMs: 123000,
+        hasFilter: false,
+        isDefaultDateRange: true,
+        model: 'gpt-4',
+      });
+    });
+
+    it('should report success event with schedule information', async () => {
+      reportAttackDiscoveryGenerationSuccess({
+        alertsContextCount: 2,
+        apiConfig: mockApiConfig,
+        attackDiscoveries: mockAttackDiscoveries,
+        durationMs: 456000,
+        end: 'now',
+        hasFilter: false,
+        schedule: { id: 'fake-id-2', name: 'Fake Schedule 2' },
+        size: 10,
+        start: 'now-24h',
+        telemetry: mockTelemetry,
+      });
+
+      expect(mockTelemetry.reportEvent).toHaveBeenCalledWith('attack_discovery_success', {
+        actionTypeId: '.gen-ai',
+        alertsContextCount: 2,
+        alertsCount: 8,
+        configuredAlertsCount: 10,
+        dateRangeDuration: 24,
+        discoveriesGenerated: 1,
+        durationMs: 456000,
+        hasFilter: false,
+        isDefaultDateRange: true,
+        model: 'gpt-4',
+        schedule: {
+          id: 'fake-id-2',
+          name: 'Fake Schedule 2',
+        },
+      });
+    });
+  });
+});

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/telemetry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/telemetry.ts
@@ -36,7 +36,7 @@ export const reportAttackDiscoveryGenerationSuccess = ({
   hasFilter: boolean;
   schedule?: {
     id: string;
-    name: string;
+    interval: string;
   };
   size: number;
   start?: string;
@@ -73,7 +73,7 @@ export const reportAttackDiscoveryGenerationFailure = ({
   errorMessage: string;
   schedule?: {
     id: string;
-    name: string;
+    interval: string;
   };
   telemetry: AnalyticsServiceSetup;
 }) => {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/telemetry.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/helpers/telemetry.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AnalyticsServiceSetup } from '@kbn/core/server';
+import { ApiConfig, AttackDiscovery } from '@kbn/elastic-assistant-common';
+import moment from 'moment/moment';
+import { uniq } from 'lodash/fp';
+
+import dateMath from '@kbn/datemath';
+import {
+  ATTACK_DISCOVERY_ERROR_EVENT,
+  ATTACK_DISCOVERY_SUCCESS_EVENT,
+} from '../../../lib/telemetry/event_based_telemetry';
+
+export const reportAttackDiscoveryGenerationSuccess = ({
+  alertsContextCount,
+  apiConfig,
+  attackDiscoveries,
+  durationMs,
+  end,
+  hasFilter,
+  schedule,
+  size,
+  start,
+  telemetry,
+}: {
+  alertsContextCount: number;
+  apiConfig: ApiConfig;
+  attackDiscoveries: AttackDiscovery[] | null;
+  durationMs: number;
+  end?: string;
+  hasFilter: boolean;
+  schedule?: {
+    id: string;
+    name: string;
+  };
+  size: number;
+  start?: string;
+  telemetry: AnalyticsServiceSetup;
+}) => {
+  const { dateRangeDuration, isDefaultDateRange } = getTimeRangeDuration({ start, end });
+
+  telemetry.reportEvent(ATTACK_DISCOVERY_SUCCESS_EVENT.eventType, {
+    actionTypeId: apiConfig.actionTypeId,
+    alertsContextCount,
+    alertsCount:
+      uniq(
+        attackDiscoveries?.flatMap((attackDiscovery: AttackDiscovery) => attackDiscovery.alertIds)
+      ).length ?? 0,
+    configuredAlertsCount: size,
+    dateRangeDuration,
+    discoveriesGenerated: attackDiscoveries?.length ?? 0,
+    durationMs,
+    hasFilter,
+    isDefaultDateRange,
+    model: apiConfig.model,
+    provider: apiConfig.provider,
+    schedule,
+  });
+};
+
+export const reportAttackDiscoveryGenerationFailure = ({
+  apiConfig,
+  errorMessage,
+  schedule,
+  telemetry,
+}: {
+  apiConfig: ApiConfig;
+  errorMessage: string;
+  schedule?: {
+    id: string;
+    name: string;
+  };
+  telemetry: AnalyticsServiceSetup;
+}) => {
+  telemetry.reportEvent(ATTACK_DISCOVERY_ERROR_EVENT.eventType, {
+    actionTypeId: apiConfig.actionTypeId,
+    errorMessage,
+    model: apiConfig.model,
+    provider: apiConfig.provider,
+    schedule,
+  });
+};
+
+const getTimeRangeDuration = ({
+  start,
+  end,
+}: {
+  start?: string;
+  end?: string;
+}): {
+  dateRangeDuration: number;
+  isDefaultDateRange: boolean;
+} => {
+  if (start && end) {
+    const forceNow = moment().toDate();
+    const dateStart = dateMath.parse(start, {
+      roundUp: false,
+      momentInstance: moment,
+      forceNow,
+    });
+    const dateEnd = dateMath.parse(end, {
+      roundUp: false,
+      momentInstance: moment,
+      forceNow,
+    });
+    if (dateStart && dateEnd) {
+      const dateRangeDuration = moment.duration(dateEnd.diff(dateStart)).asHours();
+      return {
+        dateRangeDuration,
+        isDefaultDateRange: end === 'now' && start === 'now-24h',
+      };
+    }
+  }
+  return {
+    // start and/or end undefined, return 0 hours
+    dateRangeDuration: 0,
+    isDefaultDateRange: false,
+  };
+};

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/helpers/handle_graph_error/index.tsx
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/routes/attack_discovery/post/helpers/handle_graph_error/index.tsx
@@ -11,7 +11,7 @@ import { transformError } from '@kbn/securitysolution-es-utils';
 
 import { AttackDiscoveryDataClient } from '../../../../../lib/attack_discovery/persistence';
 import { attackDiscoveryStatus } from '../../../helpers/helpers';
-import { ATTACK_DISCOVERY_ERROR_EVENT } from '../../../../../lib/telemetry/event_based_telemetry';
+import { reportAttackDiscoveryGenerationFailure } from '../../../helpers/telemetry';
 
 export const handleGraphError = async ({
   apiConfig,
@@ -55,19 +55,17 @@ export const handleGraphError = async ({
       },
       authenticatedUser,
     });
-    telemetry.reportEvent(ATTACK_DISCOVERY_ERROR_EVENT.eventType, {
-      actionTypeId: apiConfig.actionTypeId,
+    reportAttackDiscoveryGenerationFailure({
+      apiConfig,
       errorMessage: error.message,
-      model: apiConfig.model,
-      provider: apiConfig.provider,
+      telemetry,
     });
   } catch (updateErr) {
     const updateError = transformError(updateErr);
-    telemetry.reportEvent(ATTACK_DISCOVERY_ERROR_EVENT.eventType, {
-      actionTypeId: apiConfig.actionTypeId,
+    reportAttackDiscoveryGenerationFailure({
+      apiConfig,
       errorMessage: updateError.message,
-      model: apiConfig.model,
-      provider: apiConfig.provider,
+      telemetry,
     });
   }
 };


### PR DESCRIPTION
## Summary

Main ticket ([Internal link](https://github.com/elastic/security-team/issues/12008))

These changes add attack discovery schedules telemetry similarly to existing manually generated attack discoveries added in this commit https://github.com/elastic/kibana/pull/184949/commits/3c419729337cf3fa9f1ff5ddb49a4ed07d102324.

## NOTES

The feature is hidden behind the feature flag (in `kibana.dev.yml`):

```
feature_flags.overrides:
  securitySolution.assistantAttackDiscoverySchedulingEnabled: true
```



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->