### PR TITLE
[8.19] [Custom threshold] Tag log as user-error when user deletes the rule's data view (#220771)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
+++ b/x-pack/solutions/observability/plugins/observability/server/lib/rules/custom_threshold/custom_threshold_executor.ts
@@ -16,9 +16,10 @@ import {
 } from '@kbn/rule-data-utils';
 import { LocatorPublic } from '@kbn/share-plugin/common';
 import { RecoveredActionGroup } from '@kbn/alerting-plugin/common';
-import { IBasePath, Logger } from '@kbn/core/server';
+import { IBasePath, Logger, SavedObjectsErrorHelpers } from '@kbn/core/server';
 import { AlertsClientError, RuleExecutorOptions } from '@kbn/alerting-plugin/server';
 import { getEcsGroups, getFormattedGroupBy, getGroupByObject } from '@kbn/alerting-rule-utils';
+import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import { getEsQueryConfig } from '../../../utils/get_es_query_config';
 import { AlertsLocatorParams, getAlertDetailsUrl } from '../../../../common';
 import { getViewInAppUrl } from '../../../../common/custom_threshold_rule/get_view_in_app_url';
@@ -123,7 +124,16 @@ export const createCustomThresholdExecutor = ({
           )
         : [];
 
-    const initialSearchSource = await searchSourceClient.createLazy(params.searchConfiguration);
+    let initialSearchSource;
+    try {
+      initialSearchSource = await searchSourceClient.createLazy(params.searchConfiguration);
+    } catch (err) {
+      if (SavedObjectsErrorHelpers.isNotFoundError(err)) {
+        throw createTaskRunError(err, TaskErrorSource.USER);
+      }
+      throw err;
+    }
+
     const dataView = initialSearchSource.getField('index')!;
     const { id: dataViewId, timeFieldName } = dataView;
     const runtimeMappings = dataView.getRuntimeMappings();

--- a/x-pack/solutions/observability/plugins/observability/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability/tsconfig.json
@@ -117,7 +117,9 @@
     "@kbn/ebt-tools",
     "@kbn/dashboard-plugin",
     "@kbn/fields-metadata-plugin",
-    "@kbn/object-utils"
+    "@kbn/object-utils",
+    "@kbn/task-manager-plugin",
+    "@kbn/core-saved-objects-server"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Custom threshold] Tag log as user-error when user deletes the rule's data view (#220771)](https://github.com/elastic/kibana/pull/220771)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2025-05-19T13:58:43Z","message":"[Custom threshold] Tag log as user-error when user deletes the rule's data view (#220771)\n\n## Summary\n\nAdjust the log for when a user deletes the rule's data view in the\ncustom threshold, similar to the ES Query rule.\n\n### 🧪 How to test\n\n- Create a custom threshold rule\n- Delete the related data view and wait for the rule to be in error\nstate\n- Check the logs, you should see a \"user-error\" tag in the logs (Note\nthat this info should be available if Kibana logs in JSON format, more\ninfo in\n[Slack](https://elastic.slack.com/archives/C5TQ33ND8/p1747132208948239?thread_ts=1747131199.010089&cid=C5TQ33ND8))\n\nI verified this implementation in the deployment of this PR since it\nself-ingest 🪵\n\n\n![image](https://github.com/user-attachments/assets/eb6eee50-afec-414d-9ec5-df4ccbcced54)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"de4ba4cf8dd431c224682b95a9bd9fd39f3fb394","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0","author:obs-ux-management"],"title":"[Custom threshold] Tag log as user-error when user deletes the rule's data view","number":220771,"url":"https://github.com/elastic/kibana/pull/220771","mergeCommit":{"message":"[Custom threshold] Tag log as user-error when user deletes the rule's data view (#220771)\n\n## Summary\n\nAdjust the log for when a user deletes the rule's data view in the\ncustom threshold, similar to the ES Query rule.\n\n### 🧪 How to test\n\n- Create a custom threshold rule\n- Delete the related data view and wait for the rule to be in error\nstate\n- Check the logs, you should see a \"user-error\" tag in the logs (Note\nthat this info should be available if Kibana logs in JSON format, more\ninfo in\n[Slack](https://elastic.slack.com/archives/C5TQ33ND8/p1747132208948239?thread_ts=1747131199.010089&cid=C5TQ33ND8))\n\nI verified this implementation in the deployment of this PR since it\nself-ingest 🪵\n\n\n![image](https://github.com/user-attachments/assets/eb6eee50-afec-414d-9ec5-df4ccbcced54)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"de4ba4cf8dd431c224682b95a9bd9fd39f3fb394"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220771","number":220771,"mergeCommit":{"message":"[Custom threshold] Tag log as user-error when user deletes the rule's data view (#220771)\n\n## Summary\n\nAdjust the log for when a user deletes the rule's data view in the\ncustom threshold, similar to the ES Query rule.\n\n### 🧪 How to test\n\n- Create a custom threshold rule\n- Delete the related data view and wait for the rule to be in error\nstate\n- Check the logs, you should see a \"user-error\" tag in the logs (Note\nthat this info should be available if Kibana logs in JSON format, more\ninfo in\n[Slack](https://elastic.slack.com/archives/C5TQ33ND8/p1747132208948239?thread_ts=1747131199.010089&cid=C5TQ33ND8))\n\nI verified this implementation in the deployment of this PR since it\nself-ingest 🪵\n\n\n![image](https://github.com/user-attachments/assets/eb6eee50-afec-414d-9ec5-df4ccbcced54)\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"de4ba4cf8dd431c224682b95a9bd9fd39f3fb394"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->