### PR TITLE
[Cloud Security] unskip failed tests

### DIFF
--- a/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_aws.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/cis_integrations/cspm/cis_integration_aws.ts
@@ -96,7 +96,7 @@ export default function (providerContext: FtrProviderContext) {
       });
     });
 
-    describe.skip('CIS_AWS Organization Manual Assume Role', () => {
+    describe('CIS_AWS Organization Manual Assume Role', () => {
       it('CIS_AWS Organization Manual Assume Role Workflow', async () => {
         const roleArn = 'RoleArnTestValue';
         await cisIntegration.clickOptionButton(CIS_AWS_OPTION_TEST_ID);

--- a/x-pack/test/cloud_security_posture_functional/pages/findings.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings.ts
@@ -122,8 +122,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     return requestedBenchmarkRules.map((item) => item.attributes);
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/220423
-  describe.skip('Findings Page - DataTable', function () {
+  describe('Findings Page - DataTable', function () {
     this.tags(['cloud_security_posture_findings']);
     let findings: typeof pageObjects.findings;
     let latestFindingsTable: typeof findings.latestFindingsTable;

--- a/x-pack/test/cloud_security_posture_functional/pages/findings_alerts.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings_alerts.ts
@@ -127,9 +127,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   const ruleName1 = data[0].rule.name;
 
-  // Failing: See https://github.com/elastic/kibana/issues/168991
-  // Failing: See https://github.com/elastic/kibana/issues/220375
-  describe.skip('Findings Page - Alerts', function () {
+  describe('Findings Page - Alerts', function () {
     this.tags(['cloud_security_posture_findings_alerts']);
     let findings: typeof pageObjects.findings;
     let latestFindingsTable: typeof findings.latestFindingsTable;

--- a/x-pack/test/cloud_security_posture_functional/pages/findings_grouping.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings_grouping.ts
@@ -149,7 +149,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   };
 
   // FLAKY: https://github.com/elastic/kibana/issues/220357
-  describe.skip('Findings Page - Grouping', function () {
+  describe('Findings Page - Grouping', function () {
     this.tags(['cloud_security_posture_findings_grouping']);
     let findings: typeof pageObjects.findings;
 

--- a/x-pack/test/cloud_security_posture_functional/pages/rules/rules_table.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/rules/rules_table.ts
@@ -77,6 +77,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
       await findings.index.add(k8sFindingsMock);
       await rule.navigateToRulePage('cis_k8s', '1.0.1');
+      await pageObjects.header.waitUntilLoadingHasFinished();
     });
 
     after(async () => {

--- a/x-pack/test/cloud_security_posture_functional/pages/rules/rules_table.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/rules/rules_table.ts
@@ -96,8 +96,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await findings.index.remove();
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/220379
-    describe.skip('Rules Page - Bulk Action buttons', () => {
+    describe('Rules Page - Bulk Action buttons', () => {
       it('It should disable Enable option when there are all rules selected are already enabled ', async () => {
         await rule.rulePage.clickSelectAllRules();
         await rule.rulePage.toggleBulkActionButton();

--- a/x-pack/test/cloud_security_posture_functional/pages/rules/rules_table_headers.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/rules/rules_table_headers.ts
@@ -24,8 +24,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     'findings',
   ]);
 
-  // Failing: See https://github.com/elastic/kibana/issues/220524
-  describe.skip('Cloud Posture Rules Page - Table Headers', function () {
+  describe('Cloud Posture Rules Page - Table Headers', function () {
     this.tags(['cloud_security_posture_rules_page_table_headers']);
     let rule: typeof pageObjects.rule;
     let findings: typeof pageObjects.findings;

--- a/x-pack/test/cloud_security_posture_functional/pages/vulnerabilities.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/vulnerabilities.ts
@@ -20,8 +20,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const resourceName1 = 'name-ng-1-Node';
   const resourceName2 = 'othername-june12-8-8-0-1';
 
-  // Failing: See https://github.com/elastic/kibana/issues/220376
-  describe.skip('Vulnerabilities Page - DataTable', function () {
+  describe('Vulnerabilities Page - DataTable', function () {
     this.tags(['cloud_security_posture_vulnerabilities']);
     let findings: typeof pageObjects.findings;
     let latestVulnerabilitiesTable: typeof findings.latestVulnerabilitiesTable;


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



