### PR TITLE
[8.19] [Obs Alerting] integrate alert groupings into url state (#219013)

### DIFF
--- a/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
+++ b/src/platform/packages/shared/kbn-grouping/src/hooks/use_grouping.tsx
@@ -10,11 +10,11 @@
 import { FieldSpec } from '@kbn/data-views-plugin/common';
 import React, { useCallback, useMemo, useReducer } from 'react';
 import { UiCounterMetricType } from '@kbn/analytics';
-import { groupsReducerWithStorage, initialState } from './state/reducer';
+import { groupsReducerWithStorage, initialState as reducerInitialGroupings } from './state/reducer';
 import { GroupingProps, GroupSelectorProps, isNoneGroup } from '..';
 import { groupActions, groupByIdSelector } from './state';
 import { useGetGroupSelector } from './use_get_group_selector';
-import { defaultGroup, GroupOption } from './types';
+import { defaultGroup, GroupMap, GroupOption } from './types';
 import { Grouping as GroupingComponent } from '../components/grouping';
 
 /** Interface for grouping object where T is the `GroupingAggregation`
@@ -66,6 +66,7 @@ export interface GroupingArgs<T> {
   /** for tracking
    * @param param { groupByField: string; tableId: string } selected group and table id
    */
+  initialGroupings?: GroupMap;
   onGroupChange?: (param: {
     groupByField: string;
     groupByFields: string[];
@@ -85,6 +86,7 @@ export interface GroupingArgs<T> {
  * @param componentProps {@link StaticGroupingProps} props passed to the grouping component.
  * These props are static compared to the dynamic props passed later to getGrouping
  * @param defaultGroupingOptions defines the grouping options as an array of {@link GroupOption}
+ * @param initialGroupings represents the initial groupingState value
  * @param fields FieldSpec array serialized version of DataViewField fields. Available in the custom grouping options
  * @param groupingId Unique identifier of the grouping component. Used in local storage
  * @param maxGroupingLevels maximum group nesting levels (optional)
@@ -97,6 +99,7 @@ export interface GroupingArgs<T> {
 export const useGrouping = <T,>({
   componentProps,
   defaultGroupingOptions,
+  initialGroupings,
   fields,
   groupingId,
   maxGroupingLevels,
@@ -105,7 +108,10 @@ export const useGrouping = <T,>({
   tracker,
   title,
 }: GroupingArgs<T>): UseGrouping<T> => {
-  const [groupingState, dispatch] = useReducer(groupsReducerWithStorage, initialState);
+  const [groupingState, dispatch] = useReducer(
+    groupsReducerWithStorage,
+    initialGroupings ?? reducerInitialGroupings
+  );
   const { activeGroups: selectedGroups } = useMemo(
     () => groupByIdSelector({ groups: groupingState }, groupingId) ?? defaultGroup,
     [groupingId, groupingState]

--- a/x-pack/solutions/observability/packages/kbn-alerts-grouping/src/contexts/alerts_grouping_context.tsx
+++ b/x-pack/solutions/observability/packages/kbn-alerts-grouping/src/contexts/alerts_grouping_context.tsx
@@ -24,8 +24,11 @@ export const AlertsGroupingContext = createContext({
   setGroupingState: (() => {}) as Dispatch<SetStateAction<AlertsGroupingState>>,
 });
 
-export const AlertsGroupingContextProvider = ({ children }: PropsWithChildren<{}>) => {
-  const [groupingState, setGroupingState] = useState<AlertsGroupingState>({});
+export const AlertsGroupingContextProvider = ({
+  initialState = {},
+  children,
+}: PropsWithChildren<{ initialState?: AlertsGroupingState }>) => {
+  const [groupingState, setGroupingState] = useState<AlertsGroupingState>(initialState);
   return (
     <AlertsGroupingContext.Provider
       value={useMemo(

--- a/x-pack/solutions/observability/packages/kbn-alerts-grouping/src/types.ts
+++ b/x-pack/solutions/observability/packages/kbn-alerts-grouping/src/types.ts
@@ -99,6 +99,14 @@ export interface AlertsGroupingProps<
     dataViews: DataViewsServicePublic;
     http: HttpSetup;
   };
+  /**
+   * Initial groupings configuration
+   */
+  initialGroupings?: string[];
+  /**
+   * Callback for when the groupings change
+   */
+  onGroupingsChange?: (groupings: GroupModel) => void;
 }
 
 export interface AlertsGroupAggregationBucket {

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/state_container.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/state_container.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { alertSearchBarStateContainer, DEFAULT_STATE } from './state_container';
+import { AlertStatus } from '../../../../common/typings';
+import { Filter } from '@kbn/es-query';
+import { FilterControlConfig } from '@kbn/alerts-ui-shared';
+
+describe('alertSearchBarStateContainer', () => {
+  it('should initialize with the default state', () => {
+    expect(alertSearchBarStateContainer.get()).toEqual(DEFAULT_STATE);
+  });
+
+  it('should update rangeFrom using setRangeFrom', () => {
+    const newRangeFrom = 'now-7d';
+    alertSearchBarStateContainer.transitions.setRangeFrom(newRangeFrom);
+    expect(alertSearchBarStateContainer.get().rangeFrom).toBe(newRangeFrom);
+  });
+
+  it('should update rangeTo using setRangeTo', () => {
+    const newRangeTo = 'now-1h';
+    alertSearchBarStateContainer.transitions.setRangeTo(newRangeTo);
+    expect(alertSearchBarStateContainer.get().rangeTo).toBe(newRangeTo);
+  });
+
+  it('should update kuery using setKuery', () => {
+    const newKuery = 'host.name: "test-host"';
+    alertSearchBarStateContainer.transitions.setKuery(newKuery);
+    expect(alertSearchBarStateContainer.get().kuery).toBe(newKuery);
+  });
+
+  it('should update status using setStatus', () => {
+    const newStatus: AlertStatus = 'active';
+    alertSearchBarStateContainer.transitions.setStatus(newStatus);
+    expect(alertSearchBarStateContainer.get().status).toBe(newStatus);
+  });
+
+  it('should update filters using setFilters', () => {
+    const newFilters: Filter[] = [
+      {
+        meta: { alias: null, disabled: false, negate: false, key: 'host.name', value: 'test-host' },
+        query: { match_phrase: { 'host.name': 'test-host' } },
+      },
+    ];
+    alertSearchBarStateContainer.transitions.setFilters(newFilters);
+    expect(alertSearchBarStateContainer.get().filters).toEqual(newFilters);
+  });
+
+  it('should update savedQueryId using setSavedQueryId', () => {
+    const newSavedQueryId = 'test-query-id';
+    alertSearchBarStateContainer.transitions.setSavedQueryId(newSavedQueryId);
+    expect(alertSearchBarStateContainer.get().savedQueryId).toBe(newSavedQueryId);
+  });
+
+  it('should update controlConfigs using setControlConfigs', () => {
+    const newControlConfigs: FilterControlConfig[] = [{ fieldName: 'host.name' }];
+    alertSearchBarStateContainer.transitions.setControlConfigs(newControlConfigs);
+    expect(alertSearchBarStateContainer.get().controlConfigs).toEqual(newControlConfigs);
+  });
+
+  it('should update groupings using setGroupings', () => {
+    const newGroupings = ['group1', 'group2'];
+    alertSearchBarStateContainer.transitions.setGroupings(newGroupings);
+    expect(alertSearchBarStateContainer.get().groupings).toEqual(newGroupings);
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/state_container.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/state_container.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Filter } from '@kbn/es-query';
+import { type FilterControlConfig } from '@kbn/alerts-ui-shared';
 import {
   createStateContainer,
   createStateContainerReactHelpers,
@@ -33,6 +34,12 @@ interface AlertSearchBarStateTransitions {
   setSavedQueryId: (
     state: AlertSearchBarContainerState
   ) => (savedQueryId?: string) => AlertSearchBarContainerState;
+  setControlConfigs: (
+    state: AlertSearchBarContainerState
+  ) => (controlConfigs: FilterControlConfig[]) => AlertSearchBarContainerState;
+  setGroupings: (
+    state: AlertSearchBarContainerState
+  ) => (groupings: string[]) => AlertSearchBarContainerState;
 }
 
 const DEFAULT_STATE: AlertSearchBarContainerState = {
@@ -41,6 +48,7 @@ const DEFAULT_STATE: AlertSearchBarContainerState = {
   kuery: '',
   status: ALL_ALERTS.status,
   filters: [],
+  groupings: [],
 };
 
 const transitions: AlertSearchBarStateTransitions = {
@@ -50,6 +58,8 @@ const transitions: AlertSearchBarStateTransitions = {
   setStatus: (state) => (status) => ({ ...state, status }),
   setFilters: (state) => (filters) => ({ ...state, filters }),
   setSavedQueryId: (state) => (savedQueryId) => ({ ...state, savedQueryId }),
+  setControlConfigs: (state) => (controlConfigs) => ({ ...state, controlConfigs }),
+  setGroupings: (state) => (groupings) => ({ ...state, groupings }),
 };
 
 const alertSearchBarStateContainer = createStateContainer(DEFAULT_STATE, transitions);

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/use_alert_search_bar_state_container.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/use_alert_search_bar_state_container.test.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useAlertSearchBarStateContainer } from './use_alert_search_bar_state_container';
+import { useContainer } from './state_container';
+import { useTimefilterService } from '../../../hooks/use_timefilter_service';
+import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
+import { AlertStatus } from '@kbn/rule-data-utils';
+
+const MOCK_DEFAULT_STATE = {
+  rangeFrom: 'now-30m',
+  rangeTo: 'now',
+  kuery: '',
+  status: 'all' as AlertStatus,
+  filters: [],
+  controlConfigs: [],
+  groupings: [],
+};
+
+jest.mock('../../../hooks/use_timefilter_service', () => ({
+  useTimefilterService: jest.fn(),
+}));
+
+jest.mock('@kbn/kibana-utils-plugin/public', () => ({
+  createKbnUrlStateStorage: jest.fn(),
+  syncState: jest.fn(() => ({ start: jest.fn(), stop: jest.fn() })),
+  useContainerSelector: jest.fn(() => {
+    return MOCK_DEFAULT_STATE;
+  }),
+  createStateContainer: jest.fn(() => ({
+    get: jest.fn(),
+    set: jest.fn(),
+    state$: { subscribe: jest.fn() },
+    transitions: {
+      setRangeFrom: jest.fn(),
+      setRangeTo: jest.fn(),
+      setKuery: jest.fn(),
+      setStatus: jest.fn(),
+      setFilters: jest.fn(),
+      setSavedQueryId: jest.fn(),
+      setControlConfigs: jest.fn(),
+      setGroupings: jest.fn(),
+    },
+  })),
+  createStateContainerReactHelpers: jest.fn(() => ({
+    useContainer: jest.fn(),
+  })),
+}));
+
+describe('useAlertSearchBarStateContainer', () => {
+  const mockSet = jest.fn();
+  const mockTransitions = {
+    setRangeFrom: jest.fn(),
+    setRangeTo: jest.fn(),
+    setKuery: jest.fn(),
+    setStatus: jest.fn(),
+    setFilters: jest.fn(),
+    setSavedQueryId: jest.fn(),
+    setControlConfigs: jest.fn(),
+    setGroupings: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useContainer as jest.Mock).mockReturnValue({
+      transitions: mockTransitions,
+      set: mockSet,
+    });
+    (useTimefilterService as jest.Mock).mockReturnValue({
+      getTime: jest.fn(() => ({ from: 'now-15m', to: 'now' })),
+      isTimeTouched: jest.fn(() => false),
+    });
+    (createKbnUrlStateStorage as jest.Mock).mockReturnValue({
+      get: jest.fn(),
+      set: jest.fn(),
+      kbnUrlControls: { flush: jest.fn() },
+    });
+  });
+
+  it('should initialize with default state', () => {
+    const { result } = renderHook(
+      () => useAlertSearchBarStateContainer('testKey', { replace: true }, MOCK_DEFAULT_STATE),
+      { wrapper: MemoryRouter }
+    );
+
+    expect(result.current.rangeFrom).toBe('now-30m');
+    expect(result.current.rangeTo).toBe('now');
+    expect(result.current.kuery).toBe('');
+    expect(result.current.status).toBe('all');
+  });
+
+  it('should update kuery when onKueryChange is called', () => {
+    const { result } = renderHook(() => useAlertSearchBarStateContainer('testKey'), {
+      wrapper: MemoryRouter,
+    });
+
+    act(() => {
+      result.current.onKueryChange('newKuery');
+    });
+
+    expect(mockTransitions.setKuery).toHaveBeenCalledWith('newKuery');
+  });
+
+  it('should update rangeFrom when onRangeFromChange is called', () => {
+    const { result } = renderHook(() => useAlertSearchBarStateContainer('testKey'), {
+      wrapper: MemoryRouter,
+    });
+
+    act(() => {
+      result.current.onRangeFromChange('now-1h');
+    });
+
+    expect(mockTransitions.setRangeFrom).toHaveBeenCalledWith('now-1h');
+  });
+
+  it('should update rangeTo when onRangeToChange is called', () => {
+    const { result } = renderHook(() => useAlertSearchBarStateContainer('testKey'), {
+      wrapper: MemoryRouter,
+    });
+
+    act(() => {
+      result.current.onRangeToChange('now');
+    });
+
+    expect(mockTransitions.setRangeTo).toHaveBeenCalledWith('now');
+  });
+
+  it('should update status when onStatusChange is called', () => {
+    const { result } = renderHook(() => useAlertSearchBarStateContainer('testKey'), {
+      wrapper: MemoryRouter,
+    });
+
+    act(() => {
+      result.current.onStatusChange('active');
+    });
+
+    expect(mockTransitions.setStatus).toHaveBeenCalledWith('active');
+  });
+
+  it('should update filters when onFiltersChange is called', () => {
+    const { result } = renderHook(() => useAlertSearchBarStateContainer('testKey'), {
+      wrapper: MemoryRouter,
+    });
+
+    const newFilters = [{ meta: { key: 'test' } }];
+    act(() => {
+      result.current.onFiltersChange(newFilters);
+    });
+
+    expect(mockTransitions.setFilters).toHaveBeenCalledWith(newFilters);
+  });
+
+  it('should update controlConfigs when onControlConfigsChange is called', () => {
+    const { result } = renderHook(() => useAlertSearchBarStateContainer('testKey'), {
+      wrapper: MemoryRouter,
+    });
+
+    const newControlConfigs = [{ dataViewId: 'test-view', fieldName: 'host.name' }];
+    act(() => {
+      result.current.onControlConfigsChange(newControlConfigs);
+    });
+
+    expect(mockTransitions.setControlConfigs).toHaveBeenCalledWith(newControlConfigs);
+  });
+
+  it('should update groupings when onGroupingsChange is called', () => {
+    const { result } = renderHook(() => useAlertSearchBarStateContainer('testKey'), {
+      wrapper: MemoryRouter,
+    });
+
+    const newGroupings = ['group1', 'group2'];
+    act(() => {
+      result.current.onGroupingsChange(newGroupings);
+    });
+
+    expect(mockTransitions.setGroupings).toHaveBeenCalledWith(newGroupings);
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/use_alert_search_bar_state_container.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/use_alert_search_bar_state_container.tsx
@@ -38,6 +38,7 @@ export const alertSearchBarState = t.partial({
     t.literal(ALERT_STATUS_RECOVERED),
     t.literal(ALERT_STATUS_ALL),
   ]),
+  groupings: t.array(t.string),
 });
 
 export function useAlertSearchBarStateContainer(
@@ -50,12 +51,18 @@ export function useAlertSearchBarStateContainer(
 
   useUrlStateSyncEffect(stateContainer, urlStorageKey, replace, defaultState);
 
-  const { setRangeFrom, setRangeTo, setKuery, setStatus, setFilters, setSavedQueryId } =
-    stateContainer.transitions;
-  const { rangeFrom, rangeTo, kuery, status, filters, savedQueryId } = useContainerSelector(
-    stateContainer,
-    (state) => state
-  );
+  const {
+    setRangeFrom,
+    setRangeTo,
+    setKuery,
+    setStatus,
+    setFilters,
+    setSavedQueryId,
+    setControlConfigs,
+    setGroupings,
+  } = stateContainer.transitions;
+  const { rangeFrom, rangeTo, kuery, status, filters, savedQueryId, controlConfigs, groupings } =
+    useContainerSelector(stateContainer, (state) => state);
 
   useEffect(() => {
     if (!savedQuery) {
@@ -94,12 +101,16 @@ export function useAlertSearchBarStateContainer(
     onRangeToChange: setRangeTo,
     onStatusChange: setStatus,
     onFiltersChange: setFilters,
+    onControlConfigsChange: setControlConfigs,
+    onGroupingsChange: setGroupings,
+    controlConfigs,
     filters,
     rangeFrom,
     rangeTo,
     status,
     savedQuery,
     setSavedQuery,
+    groupings,
   };
 }
 

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/types.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/types.ts
@@ -6,6 +6,7 @@
  */
 
 import { ReactElement } from 'react';
+import { type FilterControlConfig } from '@kbn/alerts-ui-shared';
 import { ToastsStart } from '@kbn/core-notifications-browser';
 import { type SavedQuery, TimefilterContract } from '@kbn/data-plugin/public';
 import { AlertsSearchBarProps } from '@kbn/triggers-actions-ui-plugin/public/application/sections/alerts_search_bar';
@@ -57,6 +58,8 @@ export interface AlertSearchBarContainerState {
   status: AlertStatus;
   filters?: Filter[];
   savedQueryId?: string;
+  controlConfigs?: FilterControlConfig[];
+  groupings?: string[];
 }
 
 interface AlertSearchBarStateTransitions {

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { BrushEndListener, XYBrushEvent } from '@elastic/charts';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { BoolQuery, Filter } from '@kbn/es-query';
@@ -116,6 +116,13 @@ function InternalAlertsPage() {
       });
     }
   };
+
+  const onGroupingsChange = useCallback(
+    ({ activeGroups }: { activeGroups: string[] }) => {
+      alertSearchBarStateProps.onGroupingsChange(activeGroups);
+    },
+    [alertSearchBarStateProps]
+  );
 
   useEffect(() => {
     return setScreenContext?.({
@@ -298,6 +305,12 @@ function InternalAlertsPage() {
                 globalQuery={{ query: alertSearchBarStateProps.kuery, language: 'kuery' }}
                 groupingId={ALERTS_PAGE_ALERTS_TABLE_CONFIG_ID}
                 defaultGroupingOptions={DEFAULT_GROUPING_OPTIONS}
+                initialGroupings={
+                  alertSearchBarStateProps?.groupings?.length
+                    ? alertSearchBarStateProps.groupings
+                    : undefined
+                }
+                onGroupingsChange={onGroupingsChange}
                 getAggregationsByGroupingField={getAggregationsByGroupingField}
                 renderGroupPanel={renderGroupPanel}
                 getGroupStats={getGroupStats}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Obs Alerting] integrate alert groupings into url state (#219013)](https://github.com/elastic/kibana/pull/219013)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Bailey Cash","email":"bailey.cash@elastic.co"},"sourceCommit":{"committedDate":"2025-04-30T10:26:31Z","message":"[Obs Alerting] integrate alert groupings into url state (#219013)\n\n## Summary\n\nBuilds on [PR 197771](https://github.com/elastic/kibana/pull/197771)\nResolves #195627 \n\nIntegrates url state management with alerts grouping by creating an\ninitial state within the component\nComponent would take in url state and automatically group alerts **and**\nupdate the url whenever the user changes their grouping option\n\n<img width=\"1725\" alt=\"Screenshot 2025-04-23 at 2 53 48 PM\"\nsrc=\"https://github.com/user-attachments/assets/890d10a1-e583-4c6f-a54d-38bbb95371a2\"\n/>\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>\nCo-authored-by: Umberto Pepato <umbopepato@users.noreply.github.com>","sha":"410b4e86319b9e072204ac22cec909d6c60e8f10","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport missing","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Obs Alerting] integrate alert groupings into url state","number":219013,"url":"https://github.com/elastic/kibana/pull/219013","mergeCommit":{"message":"[Obs Alerting] integrate alert groupings into url state (#219013)\n\n## Summary\n\nBuilds on [PR 197771](https://github.com/elastic/kibana/pull/197771)\nResolves #195627 \n\nIntegrates url state management with alerts grouping by creating an\ninitial state within the component\nComponent would take in url state and automatically group alerts **and**\nupdate the url whenever the user changes their grouping option\n\n<img width=\"1725\" alt=\"Screenshot 2025-04-23 at 2 53 48 PM\"\nsrc=\"https://github.com/user-attachments/assets/890d10a1-e583-4c6f-a54d-38bbb95371a2\"\n/>\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>\nCo-authored-by: Umberto Pepato <umbopepato@users.noreply.github.com>","sha":"410b4e86319b9e072204ac22cec909d6c60e8f10"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219013","number":219013,"mergeCommit":{"message":"[Obs Alerting] integrate alert groupings into url state (#219013)\n\n## Summary\n\nBuilds on [PR 197771](https://github.com/elastic/kibana/pull/197771)\nResolves #195627 \n\nIntegrates url state management with alerts grouping by creating an\ninitial state within the component\nComponent would take in url state and automatically group alerts **and**\nupdate the url whenever the user changes their grouping option\n\n<img width=\"1725\" alt=\"Screenshot 2025-04-23 at 2 53 48 PM\"\nsrc=\"https://github.com/user-attachments/assets/890d10a1-e583-4c6f-a54d-38bbb95371a2\"\n/>\n\n---------\n\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>\nCo-authored-by: Umberto Pepato <umbopepato@users.noreply.github.com>","sha":"410b4e86319b9e072204ac22cec909d6c60e8f10"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->