### PR TITLE
[8.19] [Oblt Onboarding] Unify API keys naming (#220074)

### DIFF
--- a/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/use_onboarding_flow.tsx
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/public/application/quickstart_flows/auto_detect/use_onboarding_flow.tsx
@@ -40,14 +40,7 @@ export function useOnboardingFlow() {
 
   // Create onboarding session
   const { data, error, refetch } = useFetcher(
-    (callApi) =>
-      callApi('POST /internal/observability_onboarding/flow', {
-        params: {
-          body: {
-            name: 'auto-detect',
-          },
-        },
-      }),
+    (callApi) => callApi('POST /internal/observability_onboarding/flow'),
     [],
     { showToastOnError: false }
   );

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/api_key/create_install_api_key.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/api_key/create_install_api_key.ts
@@ -12,8 +12,10 @@ import type { CreateAPIKeyParams } from '@kbn/security-plugin/server';
  * Creates a short lived API key with the necessary permissions to install integrations
  */
 export function createInstallApiKey(name: string): CreateAPIKeyParams {
+  const timestamp = new Date().toISOString();
+
   return {
-    name,
+    name: `${name}-${timestamp}`,
     expiration: '1h', // This API key is only used for initial setup and should be short lived
     metadata: {
       managed: true,

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/api_key/create_shipper_api_key.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/lib/api_key/create_shipper_api_key.ts
@@ -14,9 +14,11 @@ import {
 
 export function createShipperApiKey(esClient: ElasticsearchClient, name: string, withAPM = false) {
   // Based on https://www.elastic.co/guide/en/fleet/master/grant-access-to-elasticsearch.html#create-api-key-standalone-agent
+  const timestamp = new Date().toISOString();
+
   return esClient.security.createApiKey({
     body: {
-      name,
+      name: `${name}-${timestamp}`,
       metadata: {
         managed: true,
         application: 'logs',

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/firehose/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/firehose/route.ts
@@ -59,7 +59,7 @@ const createFirehoseOnboardingFlowRoute = createObservabilityOnboardingServerRou
     const packageClient = fleetPluginStart.packageService.asScoped(request);
 
     const [{ encoded: apiKeyEncoded }] = await Promise.all([
-      createShipperApiKey(client.asCurrentUser, 'firehose_onboarding'),
+      createShipperApiKey(client.asCurrentUser, 'firehose'),
       packageClient.ensureInstalledPackage({ pkgName: 'awsfirehose' }),
       packageClient.ensureInstalledPackage({ pkgName: 'aws' }),
     ]);

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/flow/route.ts
@@ -162,22 +162,8 @@ const getProgressRoute = createObservabilityOnboardingServerRoute({
 const createFlowRoute = createObservabilityOnboardingServerRoute({
   endpoint: 'POST /internal/observability_onboarding/flow',
   options: { tags: [] },
-  params: t.type({
-    body: t.type({
-      name: t.string,
-    }),
-  }),
   async handler(resources) {
-    const {
-      context,
-      params: {
-        body: { name },
-      },
-      core,
-      request,
-      plugins,
-      kibanaVersion,
-    } = resources;
+    const { context, core, request, plugins, kibanaVersion } = resources;
     const coreStart = await core.start();
     const {
       elasticsearch: { client },
@@ -201,10 +187,10 @@ const createFlowRoute = createObservabilityOnboardingServerRoute({
             progress: {},
           },
         }),
-        createShipperApiKey(client.asCurrentUser, `onboarding_ingest_${name}`),
+        createShipperApiKey(client.asCurrentUser, 'standalone-elastic-agent'),
         (
           await context.resolve(['core'])
-        ).core.security.authc.apiKeys.create(createInstallApiKey(`onboarding_install_${name}`)),
+        ).core.security.authc.apiKeys.create(createInstallApiKey('onboarding-install')),
         getAgentVersionInfo(fleetPluginStart, kibanaVersion),
       ]);
 

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/kubernetes/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/kubernetes/route.ts
@@ -65,7 +65,11 @@ const createKubernetesOnboardingFlowRoute = createObservabilityOnboardingServerR
     const packageClient = fleetPluginStart.packageService.asScoped(request);
 
     const [{ encoded: apiKeyEncoded }, elasticAgentVersionInfo] = await Promise.all([
-      createShipperApiKey(client.asCurrentUser, `${params.body.pkgName}_onboarding`, true),
+      createShipperApiKey(
+        client.asCurrentUser,
+        params.body.pkgName === 'kubernetes_otel' ? 'otel-kubernetes' : 'kubernetes',
+        true
+      ),
       getAgentVersionInfo(fleetPluginStart, kibanaVersion, params.body.agentVersionPattern),
       // System package is always required
       packageClient.ensureInstalledPackage({ pkgName: 'system' }),

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/otel_host/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/otel_host/route.ts
@@ -60,10 +60,9 @@ const setupFlowRoute = createObservabilityOnboardingServerRoute({
       ? [plugins.cloud?.setup?.elasticsearchUrl]
       : await getFallbackESUrl(esLegacyConfigService);
 
-    const timestamp = new Date().toISOString();
     const { encoded: apiKeyEncoded } = await createShipperApiKey(
       client.asCurrentUser,
-      `otel-host-${timestamp}`
+      `otel-host`
     );
 
     return {

--- a/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/otel_host/route.ts
+++ b/x-pack/solutions/observability/plugins/observability_onboarding/server/routes/otel_host/route.ts
@@ -60,10 +60,7 @@ const setupFlowRoute = createObservabilityOnboardingServerRoute({
       ? [plugins.cloud?.setup?.elasticsearchUrl]
       : await getFallbackESUrl(esLegacyConfigService);
 
-    const { encoded: apiKeyEncoded } = await createShipperApiKey(
-      client.asCurrentUser,
-      `otel-host`
-    );
+    const { encoded: apiKeyEncoded } = await createShipperApiKey(client.asCurrentUser, `otel-host`);
 
     return {
       elasticsearchUrl: elasticsearchUrlList.length > 0 ? elasticsearchUrlList[0] : '',

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/onboarding/get_progress.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/onboarding/get_progress.ts
@@ -30,11 +30,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
         useCookieHeader: true,
       });
 
-      const createFlowResponse = await adminClient
-        .post('/internal/observability_onboarding/flow')
-        .send({
-          name: 'test-onboarding',
-        });
+      const createFlowResponse = await adminClient.post('/internal/observability_onboarding/flow');
 
       onboardingId = createFlowResponse.body.onboardingFlow.id;
     });

--- a/x-pack/test/observability_onboarding_api_integration/tests/flow/progress/progress.spec.ts
+++ b/x-pack/test/observability_onboarding_api_integration/tests/flow/progress/progress.spec.ts
@@ -38,11 +38,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     before(async () => {
       const req = await observabilityOnboardingApiClient.logMonitoringUser({
         endpoint: 'POST /internal/observability_onboarding/flow',
-        params: {
-          body: {
-            name: 'test-onboarding',
-          },
-        },
       });
 
       onboardingId = req.body.onboardingFlow.id;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Oblt Onboarding] Unify API keys naming (#220074)](https://github.com/elastic/kibana/pull/220074)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Mykola Harmash","email":"mykola.harmash@gmail.com"},"sourceCommit":{"committedDate":"2025-05-20T08:17:08Z","message":"[Oblt Onboarding] Unify API keys naming (#220074)\n\nCloses https://github.com/elastic/kibana/issues/214204\n\nThis change adds a more consistent naming to API keys generated as part\nof onboarding quickstart flows, this will make finding and managing them\neasier for the users.\n\nChanges:\n* Removed `name` parameter from the\n`/internal/observability_onboarding/flow`. Previous this endpoint was\nused by multiple quickstart flows and `name` was there to distinguish\nAPI keys generated by them, but now this endpoint is only used by auto\ndetect flow.\n* Renamed API keys generated by the Firehose, Auto Detect, K8S and Otel\nflows\n* Added timestamp for each key\n\n![CleanShot 2025-05-05 at 15 02\n24@2x](https://github.com/user-attachments/assets/a0a340e1-fa4a-4b1a-8636-1650781efdfb)\n\n## How to test\n1. Open each quickstart flow in Kibana and wait until it generates an\nAPI key (it usually appears in the provided code snippet)\n2. Go to API keys management UI and confirm that key names are as\nexpected.","sha":"d844bb3132c09a9a17621bade9fb51dd0f0142fe","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","ci:project-deploy-observability","backport:version","v9.1.0","v8.19.0","v9.0.2"],"title":"[Oblt Onboarding] Unify API keys naming","number":220074,"url":"https://github.com/elastic/kibana/pull/220074","mergeCommit":{"message":"[Oblt Onboarding] Unify API keys naming (#220074)\n\nCloses https://github.com/elastic/kibana/issues/214204\n\nThis change adds a more consistent naming to API keys generated as part\nof onboarding quickstart flows, this will make finding and managing them\neasier for the users.\n\nChanges:\n* Removed `name` parameter from the\n`/internal/observability_onboarding/flow`. Previous this endpoint was\nused by multiple quickstart flows and `name` was there to distinguish\nAPI keys generated by them, but now this endpoint is only used by auto\ndetect flow.\n* Renamed API keys generated by the Firehose, Auto Detect, K8S and Otel\nflows\n* Added timestamp for each key\n\n![CleanShot 2025-05-05 at 15 02\n24@2x](https://github.com/user-attachments/assets/a0a340e1-fa4a-4b1a-8636-1650781efdfb)\n\n## How to test\n1. Open each quickstart flow in Kibana and wait until it generates an\nAPI key (it usually appears in the provided code snippet)\n2. Go to API keys management UI and confirm that key names are as\nexpected.","sha":"d844bb3132c09a9a17621bade9fb51dd0f0142fe"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.0"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/220074","number":220074,"mergeCommit":{"message":"[Oblt Onboarding] Unify API keys naming (#220074)\n\nCloses https://github.com/elastic/kibana/issues/214204\n\nThis change adds a more consistent naming to API keys generated as part\nof onboarding quickstart flows, this will make finding and managing them\neasier for the users.\n\nChanges:\n* Removed `name` parameter from the\n`/internal/observability_onboarding/flow`. Previous this endpoint was\nused by multiple quickstart flows and `name` was there to distinguish\nAPI keys generated by them, but now this endpoint is only used by auto\ndetect flow.\n* Renamed API keys generated by the Firehose, Auto Detect, K8S and Otel\nflows\n* Added timestamp for each key\n\n![CleanShot 2025-05-05 at 15 02\n24@2x](https://github.com/user-attachments/assets/a0a340e1-fa4a-4b1a-8636-1650781efdfb)\n\n## How to test\n1. Open each quickstart flow in Kibana and wait until it generates an\nAPI key (it usually appears in the provided code snippet)\n2. Go to API keys management UI and confirm that key names are as\nexpected.","sha":"d844bb3132c09a9a17621bade9fb51dd0f0142fe"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->