### PR TITLE
[Discover] Update aria-label for field type filter (#217541)

### DIFF
--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.test.tsx
@@ -8,135 +8,140 @@
  */
 
 import React from 'react';
-import { mountWithIntl } from '@kbn/test-jest-helpers';
-import { ReactWrapper } from 'enzyme';
-import { act } from 'react-dom/test-utils';
-import { EuiContextMenuItem } from '@elastic/eui';
 import { stubLogstashDataView as dataView } from '@kbn/data-views-plugin/common/data_view.stub';
 import { coreMock } from '@kbn/core/public/mocks';
 import { type DataViewField } from '@kbn/data-views-plugin/common';
 import { FieldTypeFilter, type FieldTypeFilterProps } from './field_type_filter';
+import { render, screen, within } from '@testing-library/react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { userEvent } from '@testing-library/user-event';
+
+const DATA_TEST_SUBJ = 'filters';
+const TOGGLE_TEST_SUBJ = `${DATA_TEST_SUBJ}FieldTypeFilterToggle`;
+const OPTIONS_TEST_SUBJ = `${DATA_TEST_SUBJ}FieldTypeFilterOptions`;
 
 const docLinks = coreMock.createStart().docLinks;
 
-describe('UnifiedFieldList <FieldTypeFilter />', () => {
-  async function openPopover(wrapper: ReactWrapper, props: FieldTypeFilterProps<DataViewField>) {
-    act(() => {
-      wrapper
-        .find(`[data-test-subj="${props['data-test-subj']}FieldTypeFilterToggle"]`)
-        .last()
-        .simulate('click');
+const setup = (props: Partial<FieldTypeFilterProps<DataViewField>> = {}) => {
+  const user = userEvent.setup();
+
+  const finalProps = {
+    selectedFieldTypes: [],
+    allFields: dataView.fields,
+    docLinks,
+    'data-test-subj': DATA_TEST_SUBJ,
+    getCustomFieldType: jest.fn((field) => field.type),
+    onChange: jest.fn(),
+    ...props,
+  };
+
+  render(
+    <IntlProvider locale="en">
+      <FieldTypeFilter {...finalProps} />
+    </IntlProvider>
+  );
+
+  return { user, props: finalProps };
+};
+
+describe('<FieldTypeFilter />', () => {
+  describe('when the popover is closed', () => {
+    it('should not calculate the counts', () => {
+      const { props } = setup();
+      expect(props.getCustomFieldType).not.toHaveBeenCalled();
     });
-
-    // wait for lazy modules if any
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await wrapper.update();
-  }
-
-  async function toggleType(wrapper: ReactWrapper, fieldType: string) {
-    act(() => {
-      wrapper
-        .find(`EuiContextMenuItem[data-test-subj="typeFilter-${fieldType}"]`)
-        .first()
-        .simulate('click');
-    });
-
-    await wrapper.update();
-  }
-
-  function findClearAllButton(wrapper: ReactWrapper, props: FieldTypeFilterProps<DataViewField>) {
-    return wrapper.find(`[data-test-subj="${props['data-test-subj']}FieldTypeFilterClearAll"]`);
-  }
-
-  it("should render correctly and don't calculate counts unless opened", async () => {
-    const props: FieldTypeFilterProps<DataViewField> = {
-      selectedFieldTypes: [],
-      allFields: dataView.fields,
-      docLinks,
-      'data-test-subj': 'filters',
-      getCustomFieldType: jest.fn((field) => field.type),
-      onChange: jest.fn(),
-    };
-    const wrapper = await mountWithIntl(<FieldTypeFilter {...props} />);
-    expect(wrapper.find(EuiContextMenuItem)?.length).toBe(0);
-    expect(props.getCustomFieldType).not.toBeCalled();
-
-    await openPopover(wrapper, props);
-
-    expect(wrapper.find(EuiContextMenuItem)?.length).toBe(10);
-    expect(
-      wrapper
-        .find(EuiContextMenuItem)
-        .map((item) => item.text())
-        .join(', ')
-    ).toBe(
-      // format:type_icon type_name help_icon count
-      'BooleanBooleanInfo1, ConflictConflictInfo1, DateDateInfo4, Geo pointGeo pointInfo2, Geo shapeGeo shapeInfo1, IP addressIP addressInfo1, KeywordKeywordInfo5, Murmur3Murmur3Info2, NumberNumberInfo3, TextTextInfo5'
-    );
-    expect(props.getCustomFieldType).toHaveBeenCalledTimes(props.allFields?.length ?? 0);
-    expect(props.onChange).not.toBeCalled();
-    expect(findClearAllButton(wrapper, props)?.length).toBe(0);
   });
 
-  it('should exclude custom unsupported fields', async () => {
-    const props: FieldTypeFilterProps<DataViewField> = {
-      selectedFieldTypes: [],
-      allFields: dataView.fields,
-      docLinks,
-      'data-test-subj': 'filters',
-      onSupportedFieldFilter: (field) => ['number', 'date'].includes(field.type),
-      onChange: jest.fn(),
-    };
-    const wrapper = await mountWithIntl(<FieldTypeFilter {...props} />);
-    expect(wrapper.find(EuiContextMenuItem)?.length).toBe(0);
+  describe('when the popover is opened', () => {
+    it.each([
+      { type: 'Boolean', count: 1 },
+      { type: 'Conflict', count: 1 },
+      { type: 'Date', count: 4 },
+      { type: 'Geo point', count: 2 },
+      { type: 'Geo shape', count: 1 },
+      { type: 'IP address', count: 1 },
+      { type: 'Keyword', count: 5 },
+      { type: 'Number', count: 3 },
+      { type: 'Text', count: 5 },
+    ])('should show $type count', async ({ type, count }) => {
+      // When
+      const { user, props } = setup();
 
-    await openPopover(wrapper, props);
+      const button = screen.getByTestId(TOGGLE_TEST_SUBJ);
+      await user.click(button);
 
-    expect(wrapper.find(EuiContextMenuItem)?.length).toBe(2);
-    expect(
-      wrapper
-        .find(EuiContextMenuItem)
-        .map((item) => item.text())
-        .join(', ')
-    ).toBe('DateDateInfo4, NumberNumberInfo3');
-  });
+      // Then
+      expect(props.getCustomFieldType).toHaveBeenCalledTimes(props.allFields?.length ?? 0);
 
-  it('should select items correctly', async () => {
-    const props: FieldTypeFilterProps<DataViewField> = {
-      selectedFieldTypes: ['date', 'number'],
-      allFields: dataView.fields,
-      docLinks,
-      'data-test-subj': 'filters',
-      onChange: jest.fn(),
-    };
-    const wrapper = await mountWithIntl(<FieldTypeFilter {...props} />);
-    expect(wrapper.find(EuiContextMenuItem)?.length).toBe(0);
+      expect(
+        within(screen.getByTestId(OPTIONS_TEST_SUBJ)).getByLabelText(
+          `${type} field count: ${count}`
+        )
+      ).toBeVisible();
+    });
 
-    await openPopover(wrapper, props);
+    describe('when there are supported fields', () => {
+      it('should just include them', async () => {
+        // Given
+        const onSupportedFieldFilter = jest.fn((field) => ['number', 'date'].includes(field.type));
 
-    const clearAllButton = findClearAllButton(wrapper, props)?.first();
-    expect(wrapper.find(EuiContextMenuItem)?.length).toBe(10);
-    expect(clearAllButton?.length).toBe(1);
-    expect(
-      wrapper
-        .find(EuiContextMenuItem)
-        .map((item) => `${item.prop('icon')}-${item.text()}`)
-        .join(', ')
-    ).toBe(
-      // format:selection_icon type_icon type_name help_icon count
-      'empty-BooleanBooleanInfo1, empty-ConflictConflictInfo1, check-DateDateInfo4, empty-Geo pointGeo pointInfo2, empty-Geo shapeGeo shapeInfo1, empty-IP addressIP addressInfo1, empty-KeywordKeywordInfo5, empty-Murmur3Murmur3Info2, check-NumberNumberInfo3, empty-TextTextInfo5'
-    );
+        // When
+        const { user, props } = setup({
+          onSupportedFieldFilter,
+        });
 
-    await toggleType(wrapper, 'boolean');
+        await user.click(screen.getByTestId(TOGGLE_TEST_SUBJ));
 
-    expect(props.onChange).toHaveBeenCalledWith(['date', 'number', 'boolean']);
+        // Then
+        expect(
+          within(screen.getByTestId(OPTIONS_TEST_SUBJ)).getByLabelText('Date field count: 4')
+        ).toBeVisible();
+        expect(
+          within(screen.getByTestId(OPTIONS_TEST_SUBJ)).getByLabelText('Number field count: 3')
+        ).toBeVisible();
+      });
+    });
 
-    await toggleType(wrapper, 'date');
+    it('should select items correctly', async () => {
+      // Given
+      const { user, props } = setup({
+        selectedFieldTypes: ['date', 'number'],
+      });
 
-    expect(props.onChange).toHaveBeenNthCalledWith(2, ['number']);
+      // When
+      await user.click(screen.getByTestId(TOGGLE_TEST_SUBJ));
 
-    clearAllButton.simulate('click');
+      // Then
+      await user.click(screen.getByLabelText('Boolean field count: 1'));
+      expect(props.onChange).toHaveBeenCalledWith(['date', 'number', 'boolean']);
+    });
 
-    expect(props.onChange).toHaveBeenNthCalledWith(3, []);
+    it('should deselect items correctly', async () => {
+      // Given
+      const { user, props } = setup({
+        selectedFieldTypes: ['date', 'number', 'boolean'],
+      });
+
+      // When
+      await user.click(screen.getByTestId(TOGGLE_TEST_SUBJ));
+
+      // Then
+      await user.click(screen.getByLabelText('Boolean field count: 1'));
+      expect(props.onChange).toHaveBeenCalledWith(['date', 'number']);
+    });
+
+    it('should clear all items correctly', async () => {
+      // Given
+      const { user, props } = setup({
+        selectedFieldTypes: ['date', 'number', 'boolean'],
+      });
+
+      // When
+      await user.click(screen.getByTestId(TOGGLE_TEST_SUBJ));
+
+      // Then
+      await user.click(screen.getByText('Clear all'));
+      expect(props.onChange).toHaveBeenCalledWith([]);
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.test.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.test.tsx
@@ -86,7 +86,7 @@ describe('<FieldTypeFilter />', () => {
         const onSupportedFieldFilter = jest.fn((field) => ['number', 'date'].includes(field.type));
 
         // When
-        const { user, props } = setup({
+        const { user } = setup({
           onSupportedFieldFilter,
         });
 

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
@@ -202,56 +202,62 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
         {availableFieldTypes.length > 0 ? (
           <EuiContextMenuPanel
             data-test-subj={`${testSubj}Options`}
-            items={availableFieldTypes.map((type) => (
-              <EuiContextMenuItem
-                aria-label={i18n.translate('unifiedFieldList.fieldTypeFilter.typeButtonAriaLabel', {
-                  defaultMessage: '{type} field count: {count}',
-                  values: {
-                    type: getFieldTypeName(type),
-                    count: typeCounts?.get(type) ?? 0,
-                  },
-                })}
-                aria-describedby={`unifiedFieldList.fieldTypeFilter.${type}.descriptionTooltip`}
-                key={type}
-                icon={selectedFieldTypes.includes(type) ? 'check' : 'empty'}
-                data-test-subj={`typeFilter-${type}`}
-                css={itemStyle}
-                onClick={() => {
-                  onChange(
-                    selectedFieldTypes.includes(type)
-                      ? selectedFieldTypes.filter((t) => t !== type)
-                      : [...selectedFieldTypes, type]
-                  );
-                }}
-              >
-                <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-                  <EuiFlexItem grow={false}>
-                    <FieldIcon aria-hidden type={type} />
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-                      <EuiFlexItem grow={false}>
-                        <EuiText size="s">{getFieldTypeName(type)}</EuiText>
-                      </EuiFlexItem>
-                      <EuiFlexItem grow={false}>
-                        <EuiIconTip
-                          id={`unifiedFieldList.fieldTypeFilter.${type}.descriptionTooltip`}
-                          aria-label={getFieldTypeDescription(type)}
-                          type="questionInCircle"
-                          color="subdued"
-                          content={getFieldTypeDescription(type)}
-                        />
-                      </EuiFlexItem>
-                    </EuiFlexGroup>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiNotificationBadge aria-hidden color="subdued" size="m">
-                      {typeCounts?.get(type) ?? 0}
-                    </EuiNotificationBadge>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiContextMenuItem>
-            ))}
+            items={availableFieldTypes.map((type) => {
+              const fieldTypeName = getFieldTypeName(type);
+              const fieldTypeCount = typeCounts?.get(type) ?? 0;
+
+              return (
+                <EuiContextMenuItem
+                  aria-label={i18n.translate(
+                    'unifiedFieldList.fieldTypeFilter.typeButtonAriaLabel',
+                    {
+                      defaultMessage: '{type} field count: {count}',
+                      values: {
+                        type: fieldTypeName,
+                        count: fieldTypeCount,
+                      },
+                    }
+                  )}
+                  key={type}
+                  icon={selectedFieldTypes.includes(type) ? 'check' : 'empty'}
+                  data-test-subj={`typeFilter-${type}`}
+                  css={itemStyle}
+                  onClick={() => {
+                    onChange(
+                      selectedFieldTypes.includes(type)
+                        ? selectedFieldTypes.filter((t) => t !== type)
+                        : [...selectedFieldTypes, type]
+                    );
+                  }}
+                >
+                  <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+                    <EuiFlexItem grow={false}>
+                      <FieldIcon aria-hidden type={type} />
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+                        <EuiFlexItem grow={false}>
+                          <EuiText size="s">{fieldTypeName}</EuiText>
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiIconTip
+                            aria-label={getFieldTypeDescription(type)}
+                            type="questionInCircle"
+                            color="subdued"
+                            content={getFieldTypeDescription(type)}
+                          />
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <EuiNotificationBadge aria-hidden color="subdued" size="m">
+                        {fieldTypeCount}
+                      </EuiNotificationBadge>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiContextMenuItem>
+              );
+            })}
           />
         ) : (
           <EuiFlexGroup responsive={false} alignItems="center" justifyContent="center">

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
@@ -204,16 +204,13 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
             data-test-subj={`${testSubj}Options`}
             items={availableFieldTypes.map((type) => (
               <EuiContextMenuItem
-                aria-label={i18n.translate(
-                  'unifiedFieldList.fieldTypeFilter.filterByTypeAriaLabel',
-                  {
-                    defaultMessage: '{type} field count: {count}',
-                    values: {
-                      type: getFieldTypeName(type),
-                      count: typeCounts?.get(type) ?? 0,
-                    },
-                  }
-                )}
+                aria-label={i18n.translate('unifiedFieldList.fieldTypeFilter.typeButtonAriaLabel', {
+                  defaultMessage: '{type} field count: {count}',
+                  values: {
+                    type: getFieldTypeName(type),
+                    count: typeCounts?.get(type) ?? 0,
+                  },
+                })}
                 aria-describedby={`unifiedFieldList.fieldTypeFilter.${type}.descriptionTooltip`}
                 key={type}
                 icon={selectedFieldTypes.includes(type) ? 'check' : 'empty'}

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
@@ -28,6 +28,7 @@ import {
   EuiButtonEmpty,
   useEuiTheme,
   EuiTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import type { CoreStart } from '@kbn/core-lifecycle-browser';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -90,6 +91,13 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
   onChange,
 }: FieldTypeFilterProps<T>) {
   const testSubj = `${dataTestSubject}FieldTypeFilter`;
+
+  // This id is used to describe the popover title from the menu for screen readers.
+  const popoverTitleId = useGeneratedHtmlId({
+    prefix: 'unifiedFieldList.fieldTypeFilter',
+    suffix: 'popoverTitle',
+  });
+
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [typeCounts, setTypeCounts] = useState<Map<string, number>>();
 
@@ -181,7 +189,7 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
           <EuiFlexGroup responsive={false} gutterSize="xs" css={titleStyle} alignItems="center">
             <EuiFlexItem css={popoverTitleStyle}>
               <EuiTitle size="xxs">
-                <h5 className="eui-textBreakWord">
+                <h5 id={popoverTitleId} className="eui-textBreakWord">
                   {i18n.translate('unifiedFieldList.fieldTypeFilter.title', {
                     defaultMessage: 'Filter by field type',
                   })}
@@ -203,6 +211,7 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
           <EuiContextMenuPanel
             data-test-subj={`${testSubj}Options`}
             role="menu"
+            aria-labelledby={popoverTitleId}
             items={availableFieldTypes.map((type) => {
               const fieldTypeName = getFieldTypeName(type);
               const fieldTypeCount = typeCounts?.get(type) ?? 0;

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
@@ -202,9 +202,11 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
         {availableFieldTypes.length > 0 ? (
           <EuiContextMenuPanel
             data-test-subj={`${testSubj}Options`}
+            role="menu"
             items={availableFieldTypes.map((type) => {
               const fieldTypeName = getFieldTypeName(type);
               const fieldTypeCount = typeCounts?.get(type) ?? 0;
+              const isSelected = selectedFieldTypes.includes(type);
 
               return (
                 <EuiContextMenuItem
@@ -218,8 +220,10 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
                       },
                     }
                   )}
+                  aria-checked={isSelected}
+                  role="menuitemcheckbox"
                   key={type}
-                  icon={selectedFieldTypes.includes(type) ? 'check' : 'empty'}
+                  icon={isSelected ? 'check' : 'empty'}
                   data-test-subj={`typeFilter-${type}`}
                   css={itemStyle}
                   onClick={() => {

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_list_filters/field_type_filter.tsx
@@ -204,6 +204,17 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
             data-test-subj={`${testSubj}Options`}
             items={availableFieldTypes.map((type) => (
               <EuiContextMenuItem
+                aria-label={i18n.translate(
+                  'unifiedFieldList.fieldTypeFilter.filterByTypeAriaLabel',
+                  {
+                    defaultMessage: '{type} field count: {count}',
+                    values: {
+                      type: getFieldTypeName(type),
+                      count: typeCounts?.get(type) ?? 0,
+                    },
+                  }
+                )}
+                aria-describedby={`unifiedFieldList.fieldTypeFilter.${type}.descriptionTooltip`}
                 key={type}
                 icon={selectedFieldTypes.includes(type) ? 'check' : 'empty'}
                 data-test-subj={`typeFilter-${type}`}
@@ -218,7 +229,7 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
               >
                 <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <FieldIcon type={type} />
+                    <FieldIcon aria-hidden type={type} />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
@@ -227,6 +238,8 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiIconTip
+                          id={`unifiedFieldList.fieldTypeFilter.${type}.descriptionTooltip`}
+                          aria-label={getFieldTypeDescription(type)}
                           type="questionInCircle"
                           color="subdued"
                           content={getFieldTypeDescription(type)}
@@ -235,7 +248,7 @@ export function FieldTypeFilter<T extends FieldListItem = DataViewField>({
                     </EuiFlexGroup>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiNotificationBadge color="subdued" size="m">
+                    <EuiNotificationBadge aria-hidden color="subdued" size="m">
                       {typeCounts?.get(type) ?? 0}
                     </EuiNotificationBadge>
                   </EuiFlexItem>


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/217541

In the `Filter by field type` menu the screen reader announcements were using duplicated information because it was obtained from the children. Now the groups have aria tags to better identify the content.

| Before | After |
|--------|------|
| <img width="398" alt="image" src="https://github.com/user-attachments/assets/5cf408eb-8864-4d1c-9ec6-a597d273c102" /> | <img width="453" alt="image" src="https://github.com/user-attachments/assets/de978114-f3fd-44d0-91bb-457de52949b2" /> |
| <img width="406" alt="image" src="https://github.com/user-attachments/assets/ace576dc-8790-452c-a92f-4e131b3dcf8b" /> | <img width="648" alt="image" src="https://github.com/user-attachments/assets/491ff275-a1a9-4411-9791-04cdc8b472af" /> |


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...





<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->