### PR TITLE
🌊 Migration on read: Fix missing cases

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/client.ts
@@ -325,6 +325,15 @@ export class StreamsClient {
     throw streamDefinition;
   }
 
+  private getStreamDefinitionFromSource(source: Streams.all.Definition | undefined) {
+    if (!source) {
+      throw new DefinitionNotFoundError(`Cannot find stream definition`);
+    }
+    const migratedSource = migrateOnRead(source);
+    Streams.all.Definition.asserts(migratedSource);
+    return migratedSource;
+  }
+
   /**
    * Returns a stream definition for the given name:
    * - if a wired stream definition exists
@@ -340,9 +349,7 @@ export class StreamsClient {
     try {
       const response = await this.dependencies.storageClient.get({ id: name });
 
-      const streamDefinition = migrateOnRead(response._source!);
-
-      Streams.all.Definition.asserts(streamDefinition);
+      const streamDefinition = this.getStreamDefinitionFromSource(response._source);
 
       if (Streams.ingest.all.Definition.is(streamDefinition)) {
         const privileges = await checkAccess({
@@ -373,9 +380,7 @@ export class StreamsClient {
   private async getStoredStreamDefinition(name: string): Promise<Streams.all.Definition> {
     return await Promise.all([
       this.dependencies.storageClient.get({ id: name }).then((response) => {
-        const source = response._source!;
-        Streams.all.Definition.asserts(source);
-        return source;
+        return this.getStreamDefinitionFromSource(response._source);
       }),
       checkAccess({ name, scopedClusterClient: this.dependencies.scopedClusterClient }).then(
         (privileges) => {
@@ -563,11 +568,9 @@ export class StreamsClient {
       query,
     });
 
-    const streams = streamsSearchResponse.hits.hits.flatMap((hit) => {
-      const source = hit._source!;
-      Streams.all.Definition.asserts(source);
-      return source;
-    });
+    const streams = streamsSearchResponse.hits.hits.flatMap((hit) =>
+      this.getStreamDefinitionFromSource(hit._source)
+    );
 
     const privileges = await checkAccessBulk({
       names: streams

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/migration_on_read.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/migration_on_read.ts
@@ -70,20 +70,13 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
   // This test verifies that it's still possible to read an existing stream definition without
   // error. If it fails, it indicates that the migration logic is not working as expected.
-  describe('read existing stream definition format', function () {
+  describe.only('read existing stream definition format', function () {
     // This test can't run on MKI because there is no way to create a stream definition document that doesn't match the
     // currently valid format. The test is designed to verify that the migration logic is working correctly.
     this.tags(['failsOnMKI']);
     before(async () => {
       apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
       await enableStreams(apiClient);
-    });
-
-    after(async () => {
-      await disableStreams(apiClient);
-    });
-
-    it('should read and return existing orphaned classic stream', async () => {
       await esClient.index({
         index: '.kibana_streams-000001',
         id: TEST_STREAM_NAME,
@@ -92,6 +85,13 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
       // Refresh the index to make the document searchable
       await esClient.indices.refresh({ index: '.kibana_streams-000001' });
+    });
+
+    after(async () => {
+      await disableStreams(apiClient);
+    });
+
+    it('should read and return existing orphaned classic stream', async () => {
       const getResponse = await apiClient.fetch('GET /api/streams/{name} 2023-10-31', {
         params: {
           path: { name: TEST_STREAM_NAME },
@@ -100,6 +100,20 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
       expect(getResponse.status).to.eql(200);
       expect(getResponse.body.stream).to.eql(expectedStreamsResponse);
+
+      const listResponse = await apiClient.fetch('GET /api/streams 2023-10-31');
+      expect(listResponse.status).to.eql(200);
+      expect(listResponse.body.streams).to.have.length(2); // logs stream + classic stream
+
+      const dashboardResponse = await apiClient.fetch(
+        'GET /api/streams/{name}/dashboards 2023-10-31',
+        {
+          params: {
+            path: { name: TEST_STREAM_NAME },
+          },
+        }
+      );
+      expect(dashboardResponse.status).to.eql(200);
     });
 
     it('should read and return existing regular classic stream', async () => {
@@ -116,6 +130,20 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
       expect(getResponse.status).to.eql(200);
       expect(getResponse.body.stream).to.eql(expectedStreamsResponse);
+
+      const listResponse = await apiClient.fetch('GET /api/streams 2023-10-31');
+      expect(listResponse.status).to.eql(200);
+      expect(listResponse.body.streams).to.have.length(2); // logs stream + classic stream
+
+      const dashboardResponse = await apiClient.fetch(
+        'GET /api/streams/{name}/dashboards 2023-10-31',
+        {
+          params: {
+            path: { name: TEST_STREAM_NAME },
+          },
+        }
+      );
+      expect(dashboardResponse.status).to.eql(200);
     });
   });
 }

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/migration_on_read.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/streams/migration_on_read.ts
@@ -70,7 +70,7 @@ export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
 
   // This test verifies that it's still possible to read an existing stream definition without
   // error. If it fails, it indicates that the migration logic is not working as expected.
-  describe.only('read existing stream definition format', function () {
+  describe('read existing stream definition format', function () {
     // This test can't run on MKI because there is no way to create a stream definition document that doesn't match the
     // currently valid format. The test is designed to verify that the migration logic is working correctly.
     this.tags(['failsOnMKI']);


### PR DESCRIPTION
Follow-up of https://github.com/elastic/kibana/pull/220878

The previous PR didn't fix all places where we load stream definition and then assert its schema. This PR adds the same logic to the remaining places and extends the test to hit those.

Now all should be captured.

To test, you can log in as `system_indices_superuser:changeme` and update the definition docs to something invalid, like here with a null description:
```
POST .kibana_streams-000001/_update/logs
{
  "doc": {
    "name": "logs",
    "description": null,
    "ingest": {
      "lifecycle": {
        "dsl": {}
      },
      "processing": [],
      "wired": {
        "routing": [],
        "fields": {
          "@timestamp": {
            "type": "date"
          },
          "message": {
            "type": "match_only_text"
          },
          "host.name": {
            "type": "keyword"
          },
          "log.level": {
            "type": "keyword"
          },
          "stream.name": {
            "type": "system"
          }
        }
      }
    }
  }
}
```

On a follow-up I will move this logic into the storage adapter so it's harder to cause problems in the future and add tests for the current state of queries and asset links as well.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->