### PR TITLE
[Security Solutions] fix defend insights evaluations

### DIFF
--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/evaluation/example_input/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/evaluation/example_input/index.test.ts
@@ -26,7 +26,7 @@ const mockDefendInsight = {
 const validInput = {
   insights: [mockDefendInsight],
   prompt: 'test prompt',
-  anonymizedEvents: [
+  anonymizedDocuments: [
     {
       pageContent: 'event content',
       metadata: {

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/evaluation/example_input/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/evaluation/example_input/index.ts
@@ -16,7 +16,7 @@ const Document = z.object({
 export const ExampleDefendInsightsInput = z.object({
   insights: z.array(DefendInsight).nullable().optional(),
   prompt: z.string().optional(),
-  anonymizedEvents: z.array(Document).optional(),
+  anonymizedDocuments: z.array(Document).optional(),
   combinedGenerations: z.string().optional(),
   combinedRefinements: z.string().optional(),
   errors: z.array(z.string()).optional(),

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/evaluation/helpers/get_graph_input_overrides/index.test.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/evaluation/helpers/get_graph_input_overrides/index.test.ts
@@ -20,9 +20,9 @@ const mockReplacements = {
 };
 
 describe('getDefendInsightsGraphInputOverrides', () => {
-  it('should return root-level anonymizedEvents and replacements plus overrides', () => {
+  it('should return root-level anonymizedDocuments and replacements plus overrides', () => {
     const input = {
-      anonymizedEvents: [mockDoc],
+      anonymizedDocuments: [mockDoc],
       replacements: mockReplacements,
       overrides: {
         prompt: 'new prompt',
@@ -34,7 +34,7 @@ describe('getDefendInsightsGraphInputOverrides', () => {
     const result = getDefendInsightsGraphInputOverrides(input);
 
     expect(result).toEqual({
-      anonymizedEvents: [mockDoc],
+      anonymizedDocuments: [mockDoc],
       replacements: mockReplacements,
       prompt: 'new prompt',
       generationAttempts: 2,
@@ -43,14 +43,14 @@ describe('getDefendInsightsGraphInputOverrides', () => {
 
   it('should return only picked values when no overrides are present', () => {
     const input = {
-      anonymizedEvents: [mockDoc],
+      anonymizedDocuments: [mockDoc],
       replacements: mockReplacements,
     };
 
     const result = getDefendInsightsGraphInputOverrides(input);
 
     expect(result).toEqual({
-      anonymizedEvents: [mockDoc],
+      anonymizedDocuments: [mockDoc],
       replacements: mockReplacements,
     });
   });

--- a/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/evaluation/helpers/get_graph_input_overrides/index.ts
+++ b/x-pack/solutions/security/plugins/elastic_assistant/server/lib/defend_insights/evaluation/helpers/get_graph_input_overrides/index.ts
@@ -22,9 +22,9 @@ export const getDefendInsightsGraphInputOverrides = (
 
   // return all overrides at the root level:
   return {
-    // pick extracts just the anonymizedEvents and replacements from the root level of the input,
-    // and only adds the anonymizedEvents key if it exists in the input
-    ...pick('anonymizedEvents', validatedInput),
+    // pick extracts just the anonymizedDocuments and replacements from the root level of the input,
+    // and only adds the anonymizedDocuments key if it exists in the input
+    ...pick('anonymizedDocuments', validatedInput),
     ...pick('replacements', validatedInput),
     ...overrides, // bring all other overrides to the root level
   };


### PR DESCRIPTION
## Summary

Fixes an issue where defend insights evaluations always returned no insights resulting in a score of 0.

The `anonymizedEvents` key was renamed to `anonymizedDocuments` in [this PR](https://github.com/elastic/kibana/pull/216757). The relevant datasets have already been updated in langsmith.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios