### PR TITLE
fix(slo): handle undefined createdBy/updatedBy fields in pipeline

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/assets/ingest_templates/summary_pipeline_template.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/assets/ingest_templates/summary_pipeline_template.ts
@@ -238,14 +238,14 @@ export const getSummaryPipelineTemplate = (
       {
         set: {
           field: 'slo.updatedBy',
-          value: slo.updatedBy,
+          value: slo.updatedBy ?? '',
           ignore_failure: true,
         },
       },
       {
         set: {
           field: 'slo.createdBy',
-          value: slo.createdBy,
+          value: slo.createdBy ?? '',
           ignore_failure: true,
         },
       },


### PR DESCRIPTION
## Summary

This PR fixes an issue with updating SLO created prior to 8.18 which don't have a createdBy and updatedBy values. When updating the SLO we create the new summary pipeline that uses the slo.createdBy and slo.updatedBy optional values. 

The fix consists on handling the undefined values.

### Release note

Updating SLO created in an older version than 8.18 was failing due to an invalid ingest pipeline.

<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->