### PR TITLE
Prevent URL query params reset in Asset Inventory

### DIFF
--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/index.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/index.ts
@@ -9,7 +9,7 @@ export * from './src/types';
 export * from './src/constants/navigation';
 export type { NavFilter } from './src/utils/query_utils';
 export { showErrorToast } from './src/utils/show_error_toast';
-export { encodeQuery, decodeQuery } from './src/utils/query_utils';
+export { updateUrlQuery, encodeQuery, decodeQuery } from './src/utils/query_utils';
 export { CspEvaluationBadge } from './src/components/csp_evaluation_badge';
 export {
   getSeverityStatusColor,

--- a/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/utils/query_utils.ts
+++ b/x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/utils/query_utils.ts
@@ -41,6 +41,23 @@ const decodeRison = <T extends unknown>(query: string): T | undefined => {
 
 const QUERY_PARAM_KEY = 'cspq';
 
+export const updateUrlQuery = <T extends object>(newQuery: Partial<T>, search: string) => {
+  // We can't do params.toString() because, by design, this API escapes special characters in the URL
+  // so we build the new URL manually updating the 'cspq' value while keeping the existing values in other query params
+  const params = new URLSearchParams(search);
+  const queryObj: Record<string, string> = {};
+
+  for (const [k, v] of params.entries()) {
+    queryObj[k] = v;
+  }
+
+  const newQueryString = Object.entries(queryObj)
+    .map(([k, v]) => (k === QUERY_PARAM_KEY ? encodeQuery(newQuery) : `${k}=${v}`))
+    .join('&');
+
+  return newQueryString;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const encodeQuery = (query: any): LocationDescriptorObject['search'] => {
   const risonQuery = encodeRison(query);

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_asset_inventory_url_state/use_url_query.ts
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/hooks/use_asset_inventory_url_state/use_url_query.ts
@@ -6,7 +6,7 @@
  */
 import { useEffect, useCallback, useMemo } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import { encodeQuery, decodeQuery } from '@kbn/cloud-security-posture';
+import { updateUrlQuery, encodeQuery, decodeQuery } from '@kbn/cloud-security-posture';
 
 /**
  * @description uses 'rison' to encode/decode a url query
@@ -14,7 +14,7 @@ import { encodeQuery, decodeQuery } from '@kbn/cloud-security-posture';
  * @note shallow-merges default, current and next query
  */
 export const useUrlQuery = <T extends object>(getDefaultQuery: () => T) => {
-  const { push, replace } = useHistory();
+  const { replace } = useHistory();
   const { search, key } = useLocation();
 
   const urlQuery = useMemo(
@@ -23,11 +23,14 @@ export const useUrlQuery = <T extends object>(getDefaultQuery: () => T) => {
   );
 
   const setUrlQuery = useCallback(
-    (query: Partial<T>) =>
-      push({
-        search: encodeQuery({ ...getDefaultQuery(), ...urlQuery, ...query }),
-      }),
-    [getDefaultQuery, urlQuery, push]
+    (query: Partial<T>) => {
+      const newQuery = { ...getDefaultQuery(), ...urlQuery, ...query };
+
+      replace({
+        search: updateUrlQuery(newQuery, search),
+      });
+    },
+    [getDefaultQuery, search, urlQuery, replace]
   );
 
   // Set initial query


### PR DESCRIPTION
## Summary

Closes 
- https://github.com/elastic/security-team/issues/12544

Introduces a new util function in `x-pack/solutions/security/packages/kbn-cloud-security-posture/public/src/utils/query_utils.ts` to update only the `cspq` URL param while preserving other existing params in the URL.

### Motivation

Applying either the search-bar filters or dropdown filters in Asset Inventory page updates the `cspq` query param, but unexpectedly, it also resets other query params in the URL. This issue affects functionality such as the flyout panel: If the flyout is open and the user reloads, the flyout will go hidden instead of remaining open. 

This updates the correct query param (cspq) while preserving the rest of the URL data.

### Videos

<details><summary>Before</summary>

https://github.com/user-attachments/assets/8c5eabc4-b8bf-4774-8aa6-1db242fa2ad4

</details> 

<details><summary>After</summary>

https://github.com/user-attachments/assets/dc458d1c-f3f9-428f-8d93-3316a5484a02

</details> 

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

No risks yet since feature is gated with ui setting


