### PR TITLE
[Synthetics] Hide private location saved objects from management UI !!

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/private_locations.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/server/saved_objects/private_locations.ts
@@ -26,7 +26,7 @@ export const PRIVATE_LOCATION_SAVED_OBJECT_TYPE: SavedObjectsType = {
     },
   },
   management: {
-    importableAndExportable: true,
+    importableAndExportable: false,
   },
 };
 
@@ -46,7 +46,7 @@ export const LEGACY_PRIVATE_LOCATIONS_SAVED_OBJECT_TYPE: SavedObjectsType = {
     },
   },
   management: {
-    importableAndExportable: true,
+    importableAndExportable: false,
   },
   modelVersions: {
     1: modelVersion1,


### PR DESCRIPTION
## Summary

Hide private location saved objects from management UI to prevent accidental deletion !!


<!--ONMERGE {"backportTargets":["8.18","8.19","9.0"]} ONMERGE-->