### PR TITLE
[Connectors] Fixes OpenAI connector test panel does not update on save

### DIFF
--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/params.test.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/params.test.tsx
@@ -133,4 +133,32 @@ describe('Gen AI Params Fields renders', () => {
       0
     );
   });
+
+  it('resets subActionParams to undefined on component unmount', () => {
+    const editAction = jest.fn();
+    const { unmount } = render(
+      <ParamsFields
+        actionParams={{ subAction: SUB_ACTION.RUN, subActionParams: undefined }}
+        editAction={editAction}
+        index={0}
+        messageVariables={messageVariables}
+        errors={{}}
+        actionConnector={{
+          actionTypeId: '.gen-ai',
+          config: {
+            defaultMode: 'gpt-4o',
+          },
+          id: 'test',
+          isPreconfigured: false,
+          isDeprecated: false,
+          isSystemAction: false,
+          secrets: {},
+          name: 'OpenAI Connector',
+        }}
+      />
+    );
+    expect(editAction).toHaveBeenCalledWith('subActionParams', { body: getDefaultBody() }, 0);
+    unmount();
+    expect(editAction).toHaveBeenCalledWith('subActionParams', undefined, 0);
+  });
 });

--- a/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/params.tsx
+++ b/x-pack/platform/plugins/shared/stack_connectors/public/connector_types/openai/params.tsx
@@ -53,6 +53,15 @@ const ParamsFields: React.FunctionComponent<ActionParamsProps<ActionParams>> = (
     [editAction, index, subActionParams]
   );
 
+  useEffect(() => {
+    return () => {
+      // if we do not reset subActionParams on dismount (switching tabs between test and config)
+      // connector does not get updates from config tab
+      editAction('subActionParams', undefined, index);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <JsonEditorWithMessageVariables
       messageVariables={messageVariables}


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/221162

OpenAI connector test panel would not update on save. You'd need to close and reopen the connector for change to take effect

## Testing

1. Create an OpenAI connector with valid credentials and an invalid model, for example `gpt-4.1:bad`
2. Go to the test tab. Try to submit a message. You'll get an error about the model
3. Go back to the connector edit tab. Correct the model to `gpt-4.1`. 
4. Go back to the test tab. Try to submit a message. You should now succeed. Prior to this PR, it would still fail as it was using outdated config.


**Note about eslint bypass:**
I tried to resolve this without `eslint-disable-next-line react-hooks/exhaustive-deps`. However, because of the `editAction` pattern, this was the only solution I could find. This same pattern is used in Bedrock
