### PR TITLE
[8.19] [Synthtrace] Allow synthtrace to run multiple scenarios (#218263)

### DIFF
--- a/src/platform/packages/private/kbn-journeys/services/synthtrace.ts
+++ b/src/platform/packages/private/kbn-journeys/services/synthtrace.ts
@@ -84,9 +84,10 @@ async function initApmSynthtraceClient(options: SynthtraceClientOptions) {
     logger,
     refreshAfterIndex: true,
     version: packageVersion,
+    pipeline: {
+      includeSerialization: false,
+    },
   });
-
-  synthEsClient.pipeline(synthEsClient.getDefaultPipeline({ includeSerialization: false }));
 
   return synthEsClient;
 }

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/run_synthtrace.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/run_synthtrace.ts
@@ -23,8 +23,8 @@ function getBuiltinScenarios() {
 
 function options(y: Argv) {
   return y
-    .usage('$0 <file>')
-    .positional('file', {
+    .usage('$0 <files ...>')
+    .positional('files', {
       describe: 'Name of scenario',
       demandOption: true,
       string: true,

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/scenario.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/scenario.ts
@@ -25,4 +25,5 @@ export type Scenario<TFields extends Fields = Fields> = (options: ScenarioInitOp
   bootstrap?: (options: ScenarioPhaseOptions) => Promise<void>;
   generate: Generate<TFields>;
   teardown?: (options: ScenarioPhaseOptions) => Promise<void>;
+  setupPipeline?: (options: ScenarioPhaseOptions) => void;
 }>;

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/index_data.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/index_data.ts
@@ -7,16 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { castArray } from 'lodash';
-import { memoryUsage } from 'process';
 import { timerange } from '@kbn/apm-synthtrace-client';
+import { castArray } from 'lodash';
 import { Logger } from '../../lib/utils/create_logger';
 import { SynthtraceClients } from './get_clients';
 import { getScenario } from './get_scenario';
-import { WorkerData } from './synthtrace_worker';
+import { BaseWorkerData } from './workers/types';
 import { StreamManager } from './stream_manager';
+import { startPerformanceLogger } from './performance_logger';
 
-export async function indexHistoricalData({
+export async function indexData({
+  file,
   bucketFrom,
   bucketTo,
   runOptions,
@@ -26,9 +27,13 @@ export async function indexHistoricalData({
   from,
   to,
   streamManager,
-}: WorkerData & { logger: Logger; clients: SynthtraceClients; streamManager: StreamManager }) {
-  const file = runOptions.file;
-
+  autoTerminateStreams = true,
+}: BaseWorkerData & {
+  logger: Logger;
+  clients: SynthtraceClients;
+  streamManager: StreamManager;
+  autoTerminateStreams?: boolean;
+}) {
   const scenario = await logger.perf('get_scenario', () => getScenario({ file, logger }));
 
   logger.info(
@@ -37,7 +42,7 @@ export async function indexHistoricalData({
     })`
   );
 
-  const { generate } = await scenario({ ...runOptions, logger, from, to });
+  const { generate, setupPipeline } = await scenario({ ...runOptions, logger, from, to });
 
   logger.debug('Generating scenario');
 
@@ -50,31 +55,27 @@ export async function indexHistoricalData({
     )
   );
 
-  logger.debug('Indexing scenario');
-
-  function mb(value: number): string {
-    return Math.round(value / 1024 ** 2).toString() + 'mb';
+  if (setupPipeline) {
+    setupPipeline(clients);
   }
 
-  let cpuUsage = process.cpuUsage();
+  logger.debug('Indexing scenario');
 
-  const intervalId = setInterval(async () => {
-    cpuUsage = process.cpuUsage(cpuUsage);
-    const mem = memoryUsage();
-    logger.debug(
-      `cpu time: (user: ${Math.round(cpuUsage.user / 1000)}mss, sys: ${Math.round(
-        cpuUsage.system / 1000
-      )}ms), memory: ${mb(mem.heapUsed)}/${mb(mem.heapTotal)}`
-    );
-  }, 5000);
+  const stopPerformanceLogger = startPerformanceLogger({ logger });
 
   await logger.perf('index_scenario', async () => {
     await Promise.all(
       generatorsAndClients.map(async ({ client, generator }) => {
         await streamManager.index(client, generator);
       })
-    ).finally(() => {
-      clearInterval(intervalId);
+    ).finally(async () => {
+      if (autoTerminateStreams) {
+        await streamManager.teardown();
+      }
+
+      stopPerformanceLogger();
     });
   });
+
+  return generatorsAndClients;
 }

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/logger_proxy.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/logger_proxy.ts
@@ -9,9 +9,9 @@
 
 import { parentPort, isMainThread, workerData } from 'worker_threads';
 import { createLogger, Logger, LogLevel } from '../../lib/utils/create_logger';
-import { WorkerData } from './synthtrace_worker';
+import { BaseWorkerData } from './workers/types';
 
-const { workerId } = isMainThread ? { workerId: -1 } : (workerData as WorkerData);
+const { workerId } = isMainThread ? { workerId: -1 } : (workerData as BaseWorkerData);
 // logging proxy to main thread, ensures we see real time logging
 export const loggerProxy: Logger = isMainThread
   ? createLogger(LogLevel.verbose)

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/parse_run_cli_flags.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/parse_run_cli_flags.ts
@@ -13,27 +13,30 @@ import path from 'path';
 import { LogLevel } from '../../lib/utils/create_logger';
 import { RunCliFlags } from '../run_synthtrace';
 
-function getParsedFile(flags: RunCliFlags) {
-  const { file, _ } = flags;
-  const parsedFile = (file || _[0]) as string;
+function getParsedFiles(flags: RunCliFlags) {
+  const { _: parsedFiles } = flags;
 
-  if (!parsedFile) {
-    throw new Error('Please specify a scenario to run');
+  if (!parsedFiles.length) {
+    throw new Error('Please specify at least one scenario to run');
   }
 
-  const filepath = [
-    path.resolve(parsedFile),
-    path.resolve(`${parsedFile}.ts`),
-    path.resolve(__dirname, '../../scenarios', parsedFile),
-    path.resolve(__dirname, '../../scenarios', `${parsedFile}.ts`),
-    path.resolve(__dirname, '../../scenarios', `${parsedFile}.js`),
-  ].find((p) => existsSync(p));
+  const filesPath = parsedFiles.map((parsedFile) => {
+    const foundPath = [
+      path.resolve(parsedFile),
+      path.resolve(`${parsedFile}.ts`),
+      path.resolve(__dirname, '../../scenarios', parsedFile),
+      path.resolve(__dirname, '../../scenarios', `${parsedFile}.ts`),
+      path.resolve(__dirname, '../../scenarios', `${parsedFile}.js`),
+    ].find((p) => existsSync(p));
 
-  if (!filepath) {
-    throw new Error(`Could not find scenario file: "${parsedFile}"`);
-  }
+    if (!foundPath) {
+      throw new Error(`Could not find scenario file for: "${parsedFile}"`);
+    }
 
-  return filepath;
+    return foundPath;
+  });
+
+  return filesPath;
 }
 
 export function parseRunCliFlags(flags: RunCliFlags) {
@@ -41,7 +44,7 @@ export function parseRunCliFlags(flags: RunCliFlags) {
   if (target?.includes('.kb.')) {
     throw new Error(`Target URL seems to be a Kibana URL, please provide Elasticsearch URL`);
   }
-  const parsedFile = getParsedFile(flags);
+  const parsedFiles = getParsedFiles(flags);
 
   let parsedLogLevel = verbose ? LogLevel.verbose : debug ? LogLevel.debug : LogLevel.info;
 
@@ -80,7 +83,7 @@ export function parseRunCliFlags(flags: RunCliFlags) {
     ),
     scenarioOpts: flags.scenarioOpts as unknown as Record<string, any>,
     logLevel: parsedLogLevel,
-    file: parsedFile,
+    files: parsedFiles,
   };
 }
 

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/performance_logger.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/performance_logger.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { memoryUsage } from 'process';
+import { Logger } from '../../lib/utils/create_logger';
+
+export function startPerformanceLogger({
+  logger,
+  interval = 5000,
+}: {
+  logger: Logger;
+  interval?: number;
+}) {
+  function mb(value: number): string {
+    return Math.round(value / 1024 ** 2).toString() + 'mb';
+  }
+
+  let cpuUsage = process.cpuUsage();
+
+  const intervalId = setInterval(async () => {
+    cpuUsage = process.cpuUsage(cpuUsage);
+    const mem = memoryUsage();
+    logger.debug(
+      `cpu time: (user: ${Math.round(cpuUsage.user / 1000)}mss, sys: ${Math.round(
+        cpuUsage.system / 1000
+      )}ms), memory: ${mb(mem.heapUsed)}/${mb(mem.heapTotal)}`
+    );
+  }, interval);
+
+  return clearInterval.bind(null, intervalId);
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/start_historical_data_upload.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/start_historical_data_upload.ts
@@ -11,14 +11,13 @@ import { once, range } from 'lodash';
 import moment from 'moment';
 import { cpus } from 'os';
 import Path from 'path';
-import { Worker } from 'worker_threads';
-import { LogLevel } from '../../..';
 import { bootstrap } from './bootstrap';
 import { RunOptions } from './parse_run_cli_flags';
-import { WorkerData } from './synthtrace_worker';
 import { getScenario } from './get_scenario';
 import { StreamManager } from './stream_manager';
-import { indexHistoricalData } from './index_historical_data';
+import { indexData } from './index_data';
+import { runWorker } from './workers/run_worker';
+import { WorkerData } from './workers/historical_data/synthtrace_historical_data_worker';
 
 export async function startHistoricalDataUpload({
   runOptions,
@@ -31,29 +30,41 @@ export async function startHistoricalDataUpload({
 }) {
   const { logger, clients } = await bootstrap(runOptions);
 
-  const file = runOptions.file;
+  const files = runOptions.files;
 
-  const scenario = await logger.perf('get_scenario', async () => {
-    const fn = await getScenario({ file, logger });
-    return fn({
-      ...runOptions,
-      logger,
-      from,
-      to,
-    });
-  });
+  const scenarios = await logger.perf('get_scenario', async () =>
+    Promise.all(
+      files.map(async (file) => {
+        const fn = await getScenario({ file, logger });
+        return fn({
+          ...runOptions,
+          logger,
+          from,
+          to,
+        });
+      })
+    )
+  );
 
   const teardown = once(async () => {
-    if (scenario.teardown) {
-      await scenario.teardown(clients);
-    }
+    await Promise.all(
+      scenarios.map(async (scenario) => {
+        if (scenario.teardown) {
+          return scenario.teardown(clients);
+        }
+      })
+    );
   });
 
   const streamManager = new StreamManager(logger, teardown);
 
-  if (scenario.bootstrap) {
-    await scenario.bootstrap(clients);
-  }
+  await Promise.all(
+    scenarios.map(async (scenario) => {
+      if (scenario.bootstrap) {
+        return scenario.bootstrap(clients);
+      }
+    })
+  );
 
   const cores = cpus().length;
 
@@ -95,76 +106,17 @@ export async function startHistoricalDataUpload({
       workerIndex: index,
       bucketFrom: rangeStep(interval),
       bucketTo: rangeStep(interval + intervalSpan),
+      file: files[index % files.length],
     }));
-
-  function runService({
-    bucketFrom,
-    bucketTo,
-    workerIndex,
-  }: {
-    bucketFrom: Date;
-    bucketTo: Date;
-    workerIndex: number;
-  }) {
-    return new Promise((resolve, reject) => {
-      logger.debug(`Setting up Worker: ${workerIndex}`);
-      const workerData: WorkerData = {
-        runOptions,
-        bucketFrom,
-        bucketTo,
-        workerId: workerIndex.toString(),
-        from,
-        to,
-      };
-      const worker = new Worker(Path.join(__dirname, './worker.js'), {
-        workerData,
-      });
-
-      streamManager.trackWorker(worker);
-
-      worker.on('message', ([logLevel, msg]: [string, string]) => {
-        switch (logLevel) {
-          case LogLevel.debug:
-            logger.debug(msg);
-            return;
-          case LogLevel.info:
-            logger.info(msg);
-            return;
-          case LogLevel.verbose:
-            logger.verbose(msg);
-            return;
-          case LogLevel.warn:
-            logger.warning(msg);
-            return;
-          case LogLevel.error:
-            logger.error(msg);
-            return;
-          default:
-            logger.info(msg);
-        }
-      });
-      worker.on('error', (message) => {
-        logger.error(message);
-        reject();
-      });
-      worker.on('exit', (code) => {
-        if (code === 2) reject(new Error(`Worker ${workerIndex} exited with error: ${code}`));
-        if (code === 1) {
-          logger.info(`Worker ${workerIndex} exited early because cancellation was requested`);
-        }
-        resolve(null);
-      });
-      worker.postMessage('start');
-    });
-  }
 
   const workerServices =
     intervals.length === 1
       ? // just run in this process. it's hard to attach
         // a debugger to a worker_thread, see:
         // https://issues.chromium.org/issues/41461728
-        [
-          indexHistoricalData({
+        files.map((file) =>
+          indexData({
+            file,
             bucketFrom: intervals[0].bucketFrom,
             bucketTo: intervals[0].bucketTo,
             clients,
@@ -174,9 +126,17 @@ export async function startHistoricalDataUpload({
             from,
             to,
             streamManager,
-          }),
-        ]
-      : range(0, intervals.length).map((index) => runService(intervals[index]));
+          })
+        )
+      : range(0, intervals.length).map((index) =>
+          runWorker<WorkerData>({
+            logger,
+            streamManager,
+            workerIndex: index,
+            workerScriptPath: Path.join(__dirname, './workers/historical_data/worker.js'),
+            workerData: { ...intervals[index], workerId: index.toString(), from, to, runOptions },
+          })
+        );
 
   await Promise.race(workerServices);
 

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/stream_manager.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/stream_manager.ts
@@ -51,7 +51,7 @@ const asyncNoop = async () => {};
 export class StreamManager {
   private readonly clientStreams: Map<SynthtraceEsClient<Fields>, PassThrough> = new Map();
   private readonly trackedGeneratorStreams: Writable[] = [];
-  private readonly trackedWorkers: Worker[] = [];
+  public readonly trackedWorkers: Worker[] = [];
 
   constructor(
     private readonly logger: ToolingLog,
@@ -145,6 +145,7 @@ export class StreamManager {
       this.clientStreams.set(client, stream);
       client.index(stream);
     }
+
     return stream;
   }
 

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/historical_data/synthtrace_historical_data_worker.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/historical_data/synthtrace_historical_data_worker.ts
@@ -8,22 +8,15 @@
  */
 
 import { parentPort, workerData } from 'worker_threads';
-import { bootstrap } from './bootstrap';
-import { indexHistoricalData } from './index_historical_data';
-import { loggerProxy } from './logger_proxy';
-import { RunOptions } from './parse_run_cli_flags';
-import { StreamManager } from './stream_manager';
+import { bootstrap } from '../../bootstrap';
+import { indexData } from '../../index_data';
+import { loggerProxy } from '../../logger_proxy';
+import { StreamManager } from '../../stream_manager';
+import { BaseWorkerData } from '../types';
 
-export interface WorkerData {
-  from: number;
-  to: number;
-  bucketFrom: Date;
-  bucketTo: Date;
-  runOptions: RunOptions;
-  workerId: string;
-}
+export type WorkerData = BaseWorkerData;
 
-const { bucketFrom, bucketTo, runOptions, workerId, from, to } = workerData as WorkerData;
+const { file, bucketFrom, bucketTo, runOptions, workerId, from, to } = workerData as WorkerData;
 
 async function start() {
   const logger = loggerProxy;
@@ -36,7 +29,8 @@ async function start() {
     clean: false,
   });
 
-  await indexHistoricalData({
+  await indexData({
+    file,
     bucketFrom,
     bucketTo,
     clients,

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/historical_data/worker.js
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/historical_data/worker.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires*/
+require('@babel/register')({
+  extensions: ['.ts', '.js'],
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+});
+
+require('./synthtrace_historical_data_worker');

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/live_data/synthtrace_live_data_worker.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/live_data/synthtrace_live_data_worker.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { parentPort, workerData } from 'worker_threads';
+import { bootstrap } from '../../bootstrap';
+import { indexData } from '../../index_data';
+import { loggerProxy } from '../../logger_proxy';
+import { StreamManager } from '../../stream_manager';
+import { BaseWorkerData } from '../types';
+
+export interface WorkerData extends Omit<BaseWorkerData, 'bucketFrom' | 'bucketTo'> {
+  bucketSizeInMs: number;
+}
+
+const { file, runOptions, workerId, from, to, bucketSizeInMs } = workerData as WorkerData;
+
+async function start() {
+  const logger = loggerProxy;
+  logger.debug(`Worker ${workerId} started`);
+  const streamManager = new StreamManager(logger);
+
+  const { clients } = await bootstrap({
+    ...runOptions,
+    skipClientBootstrap: true,
+    clean: false,
+  });
+
+  let requestedUntil = from;
+
+  async function uploadNextBatch() {
+    const now = Date.now();
+
+    if (now > requestedUntil) {
+      const bucketCount = Math.floor((now - requestedUntil) / bucketSizeInMs);
+
+      const rangeStart = requestedUntil;
+      const rangeEnd = rangeStart + bucketCount * bucketSizeInMs;
+
+      logger.info(`Requesting ${bucketCount} bucket(s)`);
+
+      const generatorsAndClients = await indexData({
+        file,
+        bucketFrom: new Date(rangeStart),
+        bucketTo: new Date(rangeEnd),
+        clients,
+        logger,
+        runOptions,
+        workerId,
+        from,
+        to,
+        streamManager,
+        autoTerminateStreams: false,
+      });
+
+      requestedUntil = rangeEnd;
+
+      return generatorsAndClients;
+    }
+  }
+
+  do {
+    const generatorsAndClients = await uploadNextBatch();
+
+    logger.debug(
+      `Worker ${workerId} - Indices to refresh: ${generatorsAndClients?.map(({ client }) =>
+        client.getAllIndices().join(',')
+      )}`
+    );
+
+    parentPort!.postMessage({
+      status: 'done',
+      workerId,
+      indicesToRefresh: generatorsAndClients?.map(({ client }) => client.getAllIndices().join(',')),
+    });
+
+    logger.debug(`Worker ${workerId} is waiting for the main thread finish refreshing indices`);
+    const continueMessage = await new Promise<string>((resolve) => {
+      parentPort!.once('message', (message: string) => resolve(message));
+    });
+
+    if (continueMessage !== 'continue') {
+      break;
+    }
+
+    await delay(bucketSizeInMs);
+  } while (true);
+}
+
+parentPort!.on('message', (message) => {
+  if (message !== 'start') {
+    return;
+  }
+
+  start().catch((err) => {
+    loggerProxy.error(err);
+    process.exit(1);
+  });
+});
+
+async function delay(ms: number) {
+  return await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/live_data/worker.js
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/live_data/worker.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires*/
+require('@babel/register')({
+  extensions: ['.ts', '.js'],
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+});
+
+require('./synthtrace_live_data_worker');

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/log_message.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/log_message.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { LogLevel, Logger } from '../../../lib/utils/create_logger';
+
+export function logMessage(logger: Logger, [logLevel, msg]: [LogLevel, string]) {
+  switch (logLevel) {
+    case LogLevel.debug:
+      logger.debug(msg);
+      break;
+    case LogLevel.info:
+      logger.info(msg);
+      break;
+    case LogLevel.verbose:
+      logger.verbose(msg);
+      break;
+    case LogLevel.warn:
+      logger.warning(msg);
+      break;
+    case LogLevel.error:
+      logger.error(msg);
+      break;
+    default:
+      logger.info(msg);
+  }
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/run_worker.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/run_worker.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { Worker } from 'worker_threads';
+import { Logger } from '../../../lib/utils/create_logger';
+import { StreamManager } from '../stream_manager';
+import { logMessage } from './log_message';
+
+interface WorkerServiceOptions<TWorkerData> {
+  logger: Logger;
+  streamManager: StreamManager;
+  workerIndex: number;
+  workerScriptPath: string;
+
+  workerData: TWorkerData;
+  onMessage?: (message: any) => void;
+}
+
+export function runWorker<TWorkerData>({
+  workerIndex,
+  workerScriptPath,
+  streamManager,
+  workerData,
+  onMessage,
+  logger,
+}: WorkerServiceOptions<TWorkerData>) {
+  return new Promise((resolve, reject) => {
+    logger.debug(`Setting up Worker: ${workerIndex}`);
+
+    const worker = new Worker(workerScriptPath, { workerData });
+
+    streamManager.trackWorker(worker);
+
+    worker.on('message', (message) => {
+      if (onMessage) {
+        onMessage(message);
+      } else {
+        logMessage(logger, message);
+      }
+    });
+
+    worker.on('error', (error) => {
+      logger.error(error);
+      reject();
+    });
+
+    worker.on('exit', (code) => {
+      if (code === 2) reject(new Error(`Worker ${workerIndex} exited with error: ${code}`));
+      if (code === 1) {
+        logger.info(`Worker ${workerIndex} exited early because cancellation was requested`);
+      }
+      resolve(null);
+    });
+
+    worker.postMessage('start');
+  });
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/types.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/cli/utils/workers/types.ts
@@ -7,10 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-/* eslint-disable @typescript-eslint/no-var-requires*/
-require('@babel/register')({
-  extensions: ['.ts', '.js'],
-  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
-});
+import { RunOptions } from '../parse_run_cli_flags';
 
-require('./synthtrace_worker');
+export interface BaseWorkerData {
+  bucketFrom: Date;
+  bucketTo: Date;
+  workerId: string;
+  file: string;
+  from: number;
+  to: number;
+  runOptions: RunOptions;
+}

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/entities/entities_synthtrace_es_client.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/entities/entities_synthtrace_es_client.ts
@@ -22,16 +22,20 @@ interface Pipeline {
 }
 
 export class EntitiesSynthtraceEsClient extends SynthtraceEsClient<EntityFields> {
-  constructor(options: { client: Client; logger: Logger } & EntitiesSynthtraceEsClientOptions) {
+  constructor(
+    options: {
+      client: Client;
+      logger: Logger;
+      pipeline?: Pipeline;
+    } & EntitiesSynthtraceEsClientOptions
+  ) {
     super({
       ...options,
-      pipeline: entitiesPipeline(),
+      pipeline: entitiesPipeline({
+        includeSerialization: options.pipeline?.includeSerialization,
+      }),
     });
     this.indices = ['.entities.v1.latest.builtin*'];
-  }
-
-  getDefaultPipeline({ includeSerialization }: Pipeline = { includeSerialization: true }) {
-    return entitiesPipeline({ includeSerialization });
   }
 }
 

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/infra/infra_synthtrace_es_client.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/infra/infra_synthtrace_es_client.ts
@@ -22,10 +22,16 @@ interface Pipeline {
 }
 
 export class InfraSynthtraceEsClient extends SynthtraceEsClient<InfraDocument> {
-  constructor(options: { client: Client; logger: Logger } & InfraSynthtraceEsClientOptions) {
+  constructor(
+    private readonly options: {
+      client: Client;
+      logger: Logger;
+      pipeline?: Pipeline;
+    } & InfraSynthtraceEsClientOptions
+  ) {
     super({
       ...options,
-      pipeline: infraPipeline(),
+      pipeline: infraPipeline({ includeSerialization: options.pipeline?.includeSerialization }),
     });
     this.dataStreams = [
       'metrics-system*',
@@ -35,18 +41,12 @@ export class InfraSynthtraceEsClient extends SynthtraceEsClient<InfraDocument> {
     ];
   }
 
-  getDefaultPipeline(
-    {
-      includeSerialization,
-    }: {
-      includeSerialization?: boolean;
-    } = { includeSerialization: true }
-  ) {
-    return infraPipeline({ includeSerialization });
+  clone(): this {
+    return new InfraSynthtraceEsClient(this.options) as this;
   }
 }
 
-function infraPipeline({ includeSerialization }: Pipeline = { includeSerialization: true }) {
+function infraPipeline({ includeSerialization = true }: Pipeline) {
   return (base: Readable) => {
     const serializationTransform = includeSerialization ? [getSerializeTransform()] : [];
 

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/logs/logs_synthtrace_es_client.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/lib/logs/logs_synthtrace_es_client.ts
@@ -28,10 +28,12 @@ interface Pipeline {
 }
 
 export class LogsSynthtraceEsClient extends SynthtraceEsClient<LogDocument> {
-  constructor(options: { client: Client; logger: Logger } & LogsSynthtraceEsClientOptions) {
+  constructor(
+    options: { client: Client; logger: Logger; pipeline?: Pipeline } & LogsSynthtraceEsClientOptions
+  ) {
     super({
       ...options,
-      pipeline: logsPipeline(),
+      pipeline: logsPipeline({ includeSerialization: options.pipeline?.includeSerialization }),
     });
     this.dataStreams = ['logs-*-*'];
     this.indices = ['cloud-logs-*-*'];
@@ -169,13 +171,9 @@ export class LogsSynthtraceEsClient extends SynthtraceEsClient<LogDocument> {
       this.logger.error(`Custom pipeline deletion failed: ${id} - ${err.message}`);
     }
   }
-
-  getDefaultPipeline({ includeSerialization }: Pipeline = { includeSerialization: true }) {
-    return logsPipeline({ includeSerialization });
-  }
 }
 
-function logsPipeline({ includeSerialization }: Pipeline = { includeSerialization: true }) {
+function logsPipeline({ includeSerialization = true }: Pipeline) {
   return (base: Readable) => {
     const serializationTransform = includeSerialization
       ? [getSerializeTransform<LogDocument>()]

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_logs_and_metrics_only.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_logs_and_metrics_only.ts
@@ -64,9 +64,8 @@ const scenario: Scenario<OtelLogDocument> = async (runOptions) => {
   };
 
   return {
-    bootstrap: async ({ logsEsClient, apmEsClient }) => {
+    bootstrap: async ({ logsEsClient }) => {
       await logsEsClient.createIndexTemplate(IndexTemplateName.LogsDb);
-      apmEsClient.pipeline(apmEsClient.getPipeline(ApmSynthtracePipelineSchema.Otel));
     },
     generate: ({ range, clients: { logsEsClient, apmEsClient } }) => {
       const {
@@ -121,6 +120,9 @@ const scenario: Scenario<OtelLogDocument> = async (runOptions) => {
           logger.perf('generating_apm_metrics', () => metricsets)
         ),
       ];
+    },
+    setupPipeline({ apmEsClient }) {
+      apmEsClient.setPipeline(apmEsClient.resolvePipelineType(ApmSynthtracePipelineSchema.Otel));
     },
   };
 };

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts
@@ -21,9 +21,6 @@ const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
 const scenario: Scenario<ApmOtelFields> = async (runOptions) => {
   return {
-    bootstrap: async ({ apmEsClient }) => {
-      apmEsClient.pipeline(apmEsClient.getPipeline(ApmSynthtracePipelineSchema.Otel));
-    },
     generate: ({ range, clients: { apmEsClient } }) => {
       const transactionName = 'oteldemo.AdServiceSynth/GetAds';
 
@@ -108,6 +105,9 @@ const scenario: Scenario<ApmOtelFields> = async (runOptions) => {
           )
         ),
       ];
+    },
+    setupPipeline: ({ apmEsClient }) => {
+      apmEsClient.setPipeline(apmEsClient.resolvePipelineType(ApmSynthtracePipelineSchema.Otel));
     },
   };
 };

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/service_summary_field_version_dependent.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/service_summary_field_version_dependent.ts
@@ -22,15 +22,6 @@ const scenario: Scenario<ApmFields> = async ({
   const version = versionOverride as string;
   const isLegacy = version ? semver.lt(version as string, '8.7.0') : false;
   return {
-    bootstrap: async ({ apmEsClient }) => {
-      if (isLegacy) {
-        apmEsClient.pipeline(
-          apmEsClient.getPipeline(ApmSynthtracePipelineSchema.Default, {
-            versionOverride: version,
-          })
-        );
-      }
-    },
     generate: ({ range, clients: { apmEsClient } }) => {
       const successfulTimestamps = range.ratePerMinute(6);
       const instance = apm
@@ -54,6 +45,15 @@ const scenario: Scenario<ApmFields> = async ({
             .success();
         })
       );
+    },
+    setupPipeline: ({ apmEsClient }) => {
+      if (isLegacy) {
+        apmEsClient.setPipeline(
+          apmEsClient.resolvePipelineType(ApmSynthtracePipelineSchema.Default, {
+            versionOverride: version,
+          })
+        );
+      }
     },
   };
 };

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
@@ -23,9 +23,6 @@ const scenario: Scenario<ApmFields> = async (runOptions) => {
   );
 
   return {
-    bootstrap: async ({ apmEsClient }) => {
-      apmEsClient.pipeline(apmEsClient.getPipeline(pipeline));
-    },
     generate: ({ range, clients: { apmEsClient } }) => {
       const transactionName = '240rpm/75% 1000ms';
 
@@ -106,6 +103,8 @@ const scenario: Scenario<ApmFields> = async (runOptions) => {
         )
       );
     },
+    setupPipeline: ({ apmEsClient }) =>
+      apmEsClient.setPipeline(apmEsClient.resolvePipelineType(pipeline)),
   };
 };
 

--- a/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/span_links.ts
+++ b/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/span_links.ts
@@ -43,9 +43,6 @@ function getSpanLinksFromEvents(events: ApmFields[]) {
 const scenario: Scenario<ApmFields> = async ({ logger, scenarioOpts }) => {
   const { pipeline = ApmSynthtracePipelineSchema.Default } = parseApmScenarioOpts(scenarioOpts);
   return {
-    bootstrap: async ({ apmEsClient }) => {
-      apmEsClient.pipeline(apmEsClient.getPipeline(pipeline));
-    },
     generate: ({ range, clients: { apmEsClient } }) => {
       const producerTimestamps = range.ratePerMinute(1);
       const producerConsumerTimestamps = range.ratePerMinute(1);
@@ -145,6 +142,8 @@ const scenario: Scenario<ApmFields> = async ({ logger, scenarioOpts }) => {
         )
       );
     },
+    setupPipeline: ({ apmEsClient }) =>
+      apmEsClient.setPipeline(apmEsClient.resolvePipelineType(pipeline)),
   };
 };
 

--- a/src/platform/packages/shared/kbn-scout/src/common/services/synthtrace.ts
+++ b/src/platform/packages/shared/kbn-scout/src/common/services/synthtrace.ts
@@ -40,11 +40,10 @@ export async function getApmSynthtraceEsClient(
       logger,
       refreshAfterIndex: true,
       version,
+      pipeline: {
+        includeSerialization: false,
+      },
     });
-
-    apmSynthtraceEsClientInstance.pipeline(
-      apmSynthtraceEsClientInstance.getDefaultPipeline({ includeSerialization: false })
-    );
 
     log.serviceLoaded('apmSynthtraceClient');
   }
@@ -72,11 +71,10 @@ export async function getInfraSynthtraceEsClient(
       client: esClient,
       logger,
       refreshAfterIndex: true,
+      pipeline: {
+        includeSerialization: false,
+      },
     });
-
-    infraSynthtraceEsClientInstance.pipeline(
-      infraSynthtraceEsClientInstance.getDefaultPipeline({ includeSerialization: false })
-    );
 
     log.serviceLoaded('infraSynthtraceClient');
   }

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/setup_cypress_node_events.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/setup_cypress_node_events.ts
@@ -44,11 +44,10 @@ export function setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.Plugin
       events: Array<Record<string, any>>;
       pipeline: ApmSynthtracePipelines;
     }) {
-      synthtraceEsClient.pipeline(
-        synthtraceEsClient.getPipeline(pipeline, { includeSerialization: false })
+      await synthtraceEsClient.index(
+        Readable.from(events),
+        synthtraceEsClient.resolvePipelineType(pipeline, { includeSerialization: false })
       );
-
-      await synthtraceEsClient.index(Readable.from(events));
       return null;
     },
     async 'synthtrace:clean'() {

--- a/x-pack/solutions/observability/plugins/inventory/e2e/setup_cypress_node_events.ts
+++ b/x-pack/solutions/observability/plugins/inventory/e2e/setup_cypress_node_events.ts
@@ -32,6 +32,9 @@ export function setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.Plugin
     client,
     logger,
     refreshAfterIndex: true,
+    pipeline: {
+      includeSerialization: false,
+    },
   });
 
   const apmSynthtraceEsClient = new ApmSynthtraceEsClient({
@@ -39,35 +42,28 @@ export function setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.Plugin
     logger,
     refreshAfterIndex: true,
     version: config.env.APM_PACKAGE_VERSION,
+    pipeline: {
+      includeSerialization: false,
+    },
   });
 
   const logsSynthtraceEsClient = new LogsSynthtraceEsClient({
     client,
     logger,
     refreshAfterIndex: true,
+    pipeline: {
+      includeSerialization: false,
+    },
   });
 
   const infraSynthtraceEsClient = new InfraSynthtraceEsClient({
     client,
     logger,
     refreshAfterIndex: true,
+    pipeline: {
+      includeSerialization: false,
+    },
   });
-
-  entitiesSynthtraceEsClient.pipeline(
-    entitiesSynthtraceEsClient.getDefaultPipeline({ includeSerialization: false })
-  );
-
-  apmSynthtraceEsClient.pipeline(
-    apmSynthtraceEsClient.getDefaultPipeline({ includeSerialization: false })
-  );
-
-  logsSynthtraceEsClient.pipeline(
-    logsSynthtraceEsClient.getDefaultPipeline({ includeSerialization: false })
-  );
-
-  infraSynthtraceEsClient.pipeline(
-    infraSynthtraceEsClient.getDefaultPipeline({ includeSerialization: false })
-  );
 
   initPlugin(on, config);
 

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/span_links/span_links.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/span_links/span_links.spec.ts
@@ -47,7 +47,7 @@ export default function ApiTest({ getService }: DeploymentAgnosticFtrProviderCon
               Readable.from(spanLinksData.events.producerConsumer),
               Readable.from(spanLinksData.events.producerMultiple),
             ],
-            apmSynthtraceEsClient.getPipeline(pipeline)
+            apmSynthtraceEsClient.resolvePipelineType(pipeline)
           );
         });
 

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/time_range_metadata/many_apm_server_versions.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/time_range_metadata/many_apm_server_versions.spec.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import expect from '@kbn/expect';
-import { apm, timerange } from '@kbn/apm-synthtrace-client';
+import { ApmSynthtracePipelineSchema, apm, timerange } from '@kbn/apm-synthtrace-client';
 import moment from 'moment';
 import { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
 import {
@@ -269,7 +269,9 @@ function generateTraceDataForService({
     );
 
   const apmPipeline = (base: Readable) => {
-    return synthtrace.getDefaultPipeline({ versionOverride: '8.5.0' })(base);
+    return synthtrace.resolvePipelineType(ApmSynthtracePipelineSchema.Default, {
+      versionOverride: '8.5.0',
+    })(base);
   };
 
   return synthtrace.index(events, isLegacy ? apmPipeline : undefined);

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/time_range_metadata/time_range_metadata.spec.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/apm/time_range_metadata/time_range_metadata.spec.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { apm, timerange } from '@kbn/apm-synthtrace-client';
+import { ApmSynthtracePipelineSchema, apm, timerange } from '@kbn/apm-synthtrace-client';
 import expect from '@kbn/expect';
 import { APIClientRequestParamsOf } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
 import { omit, sortBy } from 'lodash';
@@ -667,7 +667,9 @@ function getTransactionEvents({
   ];
 
   const apmPipeline = (base: Readable) => {
-    return synthtrace.getDefaultPipeline({ versionOverride: '8.5.0' })(base);
+    return synthtrace.resolvePipelineType(ApmSynthtracePipelineSchema.Default, {
+      versionOverride: '8.5.0',
+    })(base);
   };
 
   return synthtrace.index(events, isLegacy ? apmPipeline : undefined);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Synthtrace] Allow synthtrace to run multiple scenarios (#218263)](https://github.com/elastic/kibana/pull/218263)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-19T14:55:57Z","message":"[Synthtrace] Allow synthtrace to run multiple scenarios (#218263)\n\ncloses [#188176](https://github.com/elastic/kibana/issues/188176)\n\n## Summary\n\nAllows for multiple scenarios to be executed in a single command\n\n**Live data**\n```bash\n node scripts/synthtrace simple_trace otel_simple_trace simple_logs --live --clean --logLevel=debug\n```\n\n**Output Example**\n\n```bash\n\ndebg No target provided, defaulting Kibana to http://localhost:5601\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Installing APM package 9.0.0-preview-1738343125\n info Installed APM package 9.0.0-preview-1738343125\n debg Using package version: 9.0.0-preview-1738343125\n info Cleaning data streams: \"traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\"\n info Cleaning data streams: \"\"\n info Cleaning data streams: \"metrics-system*,metrics-kubernetes*,metrics-docker*,metrics-aws*\"\n info Cleaning data streams: \"logs-*-*\"\n info Cleaning data streams: \"logs,logs.*\"\n info Cleaning data streams: \"synthetics-*-*\"\n debg Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Setting up Worker: 0\n debg Setting up Worker: 1\n debg Setting up Worker: 2\n debg No target provided, defaulting Kibana to http://localhost:5601\n debg No target provided, defaulting Kibana to http://localhost:5601\n debg No target provided, defaulting Kibana to http://localhost:5601\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Using package version: 9.0.0-preview-1738343125\n info [2] Requesting 64 bucket(s)\n debg [2] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Using package version: 9.0.0-preview-1738343125\n info [1] Requesting 64 bucket(s)\n debg [1] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg [1] get_scenario: 6.907125ms\n info [1] Running scenario from 2025-04-29T07:49:14.104Z to 2025-04-29T07:50:18.104Z (pid: 17158)\n debg [1] Generating scenario\n debg [1] generating_otel_trace: 0.070125ms\n debg [1] generate_scenario: 0.418167ms\n debg [1] Indexing scenario\n debg Using package version: 9.0.0-preview-1738343125\n info [0] Requesting 64 bucket(s)\n debg [0] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg [0] get_scenario: 10.501333ms\n info [0] Running scenario from 2025-04-29T07:49:14.104Z to 2025-04-29T07:50:18.104Z (pid: 17158)\n debg [0] Generating scenario\n debg [0] generating_apm_events: 0.087292ms\n debg [0] generate_scenario: 0.415ms\n debg [0] Indexing scenario\n debg Bulk indexing 1 stream(s)\n debg [2] get_scenario: 119.145917ms\n info [2] Running scenario from 2025-04-29T07:49:14.104Z to 2025-04-29T07:50:18.104Z (pid: 17158)\n debg [2] Generating scenario\n debg [2] generating_logs: 0.009875ms\n debg [2] generate_scenario: 0.427917ms\n debg [2] Indexing scenario\n debg Bulk indexing 1 stream(s)\n debg [2] index_scenario: 5.883125ms\n debg [2] Worker 2 - Indices to refresh: logs-*-*,cloud-logs-*-*\n debg [2] Worker 2 is waiting for the main thread finish refreshing indices\n debg Bulk indexing 1 stream(s)\n debg cpu time: (user: 5225mss, sys: 924ms), memory: 166mb/191mb\n debg [1] cpu time: (user: 866mss, sys: 78ms), memory: 171mb/206mb\n debg [0] cpu time: (user: 748mss, sys: 70ms), memory: 176mb/208mb\n info [1] progress=0.00%, duration=a few seconds, eta=in a few seconds\n info [1] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n debg [1] index_scenario: 6081.150667ms\n debg [1] Worker 1 - Indices to refresh: traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\n debg [1] Worker 1 is waiting for the main thread finish refreshing indices\n info [0] progress=19.4%, duration=a few seconds, eta=in a few seconds\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n^C info Tearing down after kill signal\n debg Shutting down 3 workers\n info [1] Tearing down worker after shutdown message\n info [2] Tearing down worker after shutdown message\n info [0] Tearing down worker after shutdown message\n debg [1] Ending 1 client streams\n debg [2] Ending 1 client streams\n debg [0] Ending 1 generator streams\n debg [0] Ending 1 client streams\n debg [0] index_scenario: 7682.833167ms\n debg [0] Worker 0 - Indices to refresh: traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\n info Refreshing \"logs-*-*,cloud-logs-*-*\"\n info Refreshing \"traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\"\n debg [0] Worker 0 is waiting for the main thread finish refreshing indices\n```\n\n\n** Historical data **\n```bash\nnode scripts/synthtrace simple_trace otel_simple_trace simple_logs --from=now-15m --to=now --clean --logLevel=debug\n```\n\n** Output example ** \n\n```bash\n  debg [0] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg [7] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg [8] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [1] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [2] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [6] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [4] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg [3] get_scenario: 133.820458ms\n info [3] Running scenario from 2025-04-29T07:38:18.547Z to 2025-04-29T07:39:58.547Z (pid: 14929)\n debg [3] Generating scenario\n debg [3] generating_apm_events: 0.087458ms\n debg [3] generate_scenario: 0.428875ms\n debg [3] Indexing scenario\n debg [7] get_scenario: 99.69775ms\n info [7] Running scenario from 2025-04-29T07:44:58.547Z to 2025-04-29T07:46:38.547Z (pid: 14929)\n debg [7] Generating scenario\n debg [7] generating_otel_trace: 0.067084ms\n debg [7] generate_scenario: 0.423875ms\n debg [7] Indexing scenario\n debg [1] get_scenario: 95.459625ms\n info [1] Running scenario from 2025-04-29T07:34:58.547Z to 2025-04-29T07:36:38.547Z (pid: 14929)\n debg [1] Generating scenario\n debg [1] generating_otel_trace: 0.0655ms\n debg [1] generate_scenario: 0.389458ms\n debg [1] Indexing scenario\n debg [0] get_scenario: 110.619375ms\n info [0] Running scenario from 2025-04-29T07:33:18.547Z to 2025-04-29T07:34:58.547Z (pid: 14929)\n debg [0] Generating scenario\n debg [0] generating_apm_events: 0.082917ms\n debg [0] generate_scenario: 0.413583ms\n debg [0] Indexing scenario\n debg [4] get_scenario: 94.146458ms\n info [4] Running scenario from 2025-04-29T07:39:58.547Z to 2025-04-29T07:41:38.547Z (pid: 14929)\n debg [4] Generating scenario\n debg [4] generating_otel_trace: 0.064708ms\n debg [4] generate_scenario: 0.407875ms\n debg [4] Indexing scenario\n debg [6] get_scenario: 121.74525ms\n info [6] Running scenario from 2025-04-29T07:43:18.547Z to 2025-04-29T07:44:58.547Z (pid: 14929)\n debg [6] Generating scenario\n debg [6] generating_apm_events: 0.085291ms\n debg [6] generate_scenario: 0.437833ms\n debg [6] Indexing scenario\n```\n\n### How to test\n\n- Run the commands above and confirm that the data was ingested\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5af3e0f8cd549feb0ac8720c46d783280ccee232","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-ux-infra_services","backport:version","v9.1.0","v8.19.0"],"title":"[Synthtrace] Allow synthtrace to run multiple scenarios","number":218263,"url":"https://github.com/elastic/kibana/pull/218263","mergeCommit":{"message":"[Synthtrace] Allow synthtrace to run multiple scenarios (#218263)\n\ncloses [#188176](https://github.com/elastic/kibana/issues/188176)\n\n## Summary\n\nAllows for multiple scenarios to be executed in a single command\n\n**Live data**\n```bash\n node scripts/synthtrace simple_trace otel_simple_trace simple_logs --live --clean --logLevel=debug\n```\n\n**Output Example**\n\n```bash\n\ndebg No target provided, defaulting Kibana to http://localhost:5601\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Installing APM package 9.0.0-preview-1738343125\n info Installed APM package 9.0.0-preview-1738343125\n debg Using package version: 9.0.0-preview-1738343125\n info Cleaning data streams: \"traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\"\n info Cleaning data streams: \"\"\n info Cleaning data streams: \"metrics-system*,metrics-kubernetes*,metrics-docker*,metrics-aws*\"\n info Cleaning data streams: \"logs-*-*\"\n info Cleaning data streams: \"logs,logs.*\"\n info Cleaning data streams: \"synthetics-*-*\"\n debg Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Setting up Worker: 0\n debg Setting up Worker: 1\n debg Setting up Worker: 2\n debg No target provided, defaulting Kibana to http://localhost:5601\n debg No target provided, defaulting Kibana to http://localhost:5601\n debg No target provided, defaulting Kibana to http://localhost:5601\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Using package version: 9.0.0-preview-1738343125\n info [2] Requesting 64 bucket(s)\n debg [2] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Using package version: 9.0.0-preview-1738343125\n info [1] Requesting 64 bucket(s)\n debg [1] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg [1] get_scenario: 6.907125ms\n info [1] Running scenario from 2025-04-29T07:49:14.104Z to 2025-04-29T07:50:18.104Z (pid: 17158)\n debg [1] Generating scenario\n debg [1] generating_otel_trace: 0.070125ms\n debg [1] generate_scenario: 0.418167ms\n debg [1] Indexing scenario\n debg Using package version: 9.0.0-preview-1738343125\n info [0] Requesting 64 bucket(s)\n debg [0] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg [0] get_scenario: 10.501333ms\n info [0] Running scenario from 2025-04-29T07:49:14.104Z to 2025-04-29T07:50:18.104Z (pid: 17158)\n debg [0] Generating scenario\n debg [0] generating_apm_events: 0.087292ms\n debg [0] generate_scenario: 0.415ms\n debg [0] Indexing scenario\n debg Bulk indexing 1 stream(s)\n debg [2] get_scenario: 119.145917ms\n info [2] Running scenario from 2025-04-29T07:49:14.104Z to 2025-04-29T07:50:18.104Z (pid: 17158)\n debg [2] Generating scenario\n debg [2] generating_logs: 0.009875ms\n debg [2] generate_scenario: 0.427917ms\n debg [2] Indexing scenario\n debg Bulk indexing 1 stream(s)\n debg [2] index_scenario: 5.883125ms\n debg [2] Worker 2 - Indices to refresh: logs-*-*,cloud-logs-*-*\n debg [2] Worker 2 is waiting for the main thread finish refreshing indices\n debg Bulk indexing 1 stream(s)\n debg cpu time: (user: 5225mss, sys: 924ms), memory: 166mb/191mb\n debg [1] cpu time: (user: 866mss, sys: 78ms), memory: 171mb/206mb\n debg [0] cpu time: (user: 748mss, sys: 70ms), memory: 176mb/208mb\n info [1] progress=0.00%, duration=a few seconds, eta=in a few seconds\n info [1] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n debg [1] index_scenario: 6081.150667ms\n debg [1] Worker 1 - Indices to refresh: traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\n debg [1] Worker 1 is waiting for the main thread finish refreshing indices\n info [0] progress=19.4%, duration=a few seconds, eta=in a few seconds\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n^C info Tearing down after kill signal\n debg Shutting down 3 workers\n info [1] Tearing down worker after shutdown message\n info [2] Tearing down worker after shutdown message\n info [0] Tearing down worker after shutdown message\n debg [1] Ending 1 client streams\n debg [2] Ending 1 client streams\n debg [0] Ending 1 generator streams\n debg [0] Ending 1 client streams\n debg [0] index_scenario: 7682.833167ms\n debg [0] Worker 0 - Indices to refresh: traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\n info Refreshing \"logs-*-*,cloud-logs-*-*\"\n info Refreshing \"traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\"\n debg [0] Worker 0 is waiting for the main thread finish refreshing indices\n```\n\n\n** Historical data **\n```bash\nnode scripts/synthtrace simple_trace otel_simple_trace simple_logs --from=now-15m --to=now --clean --logLevel=debug\n```\n\n** Output example ** \n\n```bash\n  debg [0] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg [7] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg [8] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [1] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [2] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [6] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [4] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg [3] get_scenario: 133.820458ms\n info [3] Running scenario from 2025-04-29T07:38:18.547Z to 2025-04-29T07:39:58.547Z (pid: 14929)\n debg [3] Generating scenario\n debg [3] generating_apm_events: 0.087458ms\n debg [3] generate_scenario: 0.428875ms\n debg [3] Indexing scenario\n debg [7] get_scenario: 99.69775ms\n info [7] Running scenario from 2025-04-29T07:44:58.547Z to 2025-04-29T07:46:38.547Z (pid: 14929)\n debg [7] Generating scenario\n debg [7] generating_otel_trace: 0.067084ms\n debg [7] generate_scenario: 0.423875ms\n debg [7] Indexing scenario\n debg [1] get_scenario: 95.459625ms\n info [1] Running scenario from 2025-04-29T07:34:58.547Z to 2025-04-29T07:36:38.547Z (pid: 14929)\n debg [1] Generating scenario\n debg [1] generating_otel_trace: 0.0655ms\n debg [1] generate_scenario: 0.389458ms\n debg [1] Indexing scenario\n debg [0] get_scenario: 110.619375ms\n info [0] Running scenario from 2025-04-29T07:33:18.547Z to 2025-04-29T07:34:58.547Z (pid: 14929)\n debg [0] Generating scenario\n debg [0] generating_apm_events: 0.082917ms\n debg [0] generate_scenario: 0.413583ms\n debg [0] Indexing scenario\n debg [4] get_scenario: 94.146458ms\n info [4] Running scenario from 2025-04-29T07:39:58.547Z to 2025-04-29T07:41:38.547Z (pid: 14929)\n debg [4] Generating scenario\n debg [4] generating_otel_trace: 0.064708ms\n debg [4] generate_scenario: 0.407875ms\n debg [4] Indexing scenario\n debg [6] get_scenario: 121.74525ms\n info [6] Running scenario from 2025-04-29T07:43:18.547Z to 2025-04-29T07:44:58.547Z (pid: 14929)\n debg [6] Generating scenario\n debg [6] generating_apm_events: 0.085291ms\n debg [6] generate_scenario: 0.437833ms\n debg [6] Indexing scenario\n```\n\n### How to test\n\n- Run the commands above and confirm that the data was ingested\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5af3e0f8cd549feb0ac8720c46d783280ccee232"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/218263","number":218263,"mergeCommit":{"message":"[Synthtrace] Allow synthtrace to run multiple scenarios (#218263)\n\ncloses [#188176](https://github.com/elastic/kibana/issues/188176)\n\n## Summary\n\nAllows for multiple scenarios to be executed in a single command\n\n**Live data**\n```bash\n node scripts/synthtrace simple_trace otel_simple_trace simple_logs --live --clean --logLevel=debug\n```\n\n**Output Example**\n\n```bash\n\ndebg No target provided, defaulting Kibana to http://localhost:5601\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Installing APM package 9.0.0-preview-1738343125\n info Installed APM package 9.0.0-preview-1738343125\n debg Using package version: 9.0.0-preview-1738343125\n info Cleaning data streams: \"traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\"\n info Cleaning data streams: \"\"\n info Cleaning data streams: \"metrics-system*,metrics-kubernetes*,metrics-docker*,metrics-aws*\"\n info Cleaning data streams: \"logs-*-*\"\n info Cleaning data streams: \"logs,logs.*\"\n info Cleaning data streams: \"synthetics-*-*\"\n debg Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Setting up Worker: 0\n debg Setting up Worker: 1\n debg Setting up Worker: 2\n debg No target provided, defaulting Kibana to http://localhost:5601\n debg No target provided, defaulting Kibana to http://localhost:5601\n debg No target provided, defaulting Kibana to http://localhost:5601\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Checking Kibana URL http://elastic:changeme@localhost:5601/ for a redirect\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Discovered kibana running at: http://elastic:changeme@localhost:5601/ftw\n debg Fetching latest APM package version\n debg Fetching from URL: /api/fleet/epm/packages/apm?prerelease=true\n debg Using package version: 9.0.0-preview-1738343125\n info [2] Requesting 64 bucket(s)\n debg [2] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Using package version: 9.0.0-preview-1738343125\n info [1] Requesting 64 bucket(s)\n debg [1] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg [1] get_scenario: 6.907125ms\n info [1] Running scenario from 2025-04-29T07:49:14.104Z to 2025-04-29T07:50:18.104Z (pid: 17158)\n debg [1] Generating scenario\n debg [1] generating_otel_trace: 0.070125ms\n debg [1] generate_scenario: 0.418167ms\n debg [1] Indexing scenario\n debg Using package version: 9.0.0-preview-1738343125\n info [0] Requesting 64 bucket(s)\n debg [0] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg [0] get_scenario: 10.501333ms\n info [0] Running scenario from 2025-04-29T07:49:14.104Z to 2025-04-29T07:50:18.104Z (pid: 17158)\n debg [0] Generating scenario\n debg [0] generating_apm_events: 0.087292ms\n debg [0] generate_scenario: 0.415ms\n debg [0] Indexing scenario\n debg Bulk indexing 1 stream(s)\n debg [2] get_scenario: 119.145917ms\n info [2] Running scenario from 2025-04-29T07:49:14.104Z to 2025-04-29T07:50:18.104Z (pid: 17158)\n debg [2] Generating scenario\n debg [2] generating_logs: 0.009875ms\n debg [2] generate_scenario: 0.427917ms\n debg [2] Indexing scenario\n debg Bulk indexing 1 stream(s)\n debg [2] index_scenario: 5.883125ms\n debg [2] Worker 2 - Indices to refresh: logs-*-*,cloud-logs-*-*\n debg [2] Worker 2 is waiting for the main thread finish refreshing indices\n debg Bulk indexing 1 stream(s)\n debg cpu time: (user: 5225mss, sys: 924ms), memory: 166mb/191mb\n debg [1] cpu time: (user: 866mss, sys: 78ms), memory: 171mb/206mb\n debg [0] cpu time: (user: 748mss, sys: 70ms), memory: 176mb/208mb\n info [1] progress=0.00%, duration=a few seconds, eta=in a few seconds\n info [1] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n debg [1] index_scenario: 6081.150667ms\n debg [1] Worker 1 - Indices to refresh: traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\n debg [1] Worker 1 is waiting for the main thread finish refreshing indices\n info [0] progress=19.4%, duration=a few seconds, eta=in a few seconds\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n info [0] progress=0.00%, duration=a few seconds, eta=in 2 minutes\n^C info Tearing down after kill signal\n debg Shutting down 3 workers\n info [1] Tearing down worker after shutdown message\n info [2] Tearing down worker after shutdown message\n info [0] Tearing down worker after shutdown message\n debg [1] Ending 1 client streams\n debg [2] Ending 1 client streams\n debg [0] Ending 1 generator streams\n debg [0] Ending 1 client streams\n debg [0] index_scenario: 7682.833167ms\n debg [0] Worker 0 - Indices to refresh: traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\n info Refreshing \"logs-*-*,cloud-logs-*-*\"\n info Refreshing \"traces-apm*,metrics-apm*,logs-apm*,metrics-*.otel*,traces-*.otel*,logs-*.otel*\"\n debg [0] Worker 0 is waiting for the main thread finish refreshing indices\n```\n\n\n** Historical data **\n```bash\nnode scripts/synthtrace simple_trace otel_simple_trace simple_logs --from=now-15m --to=now --clean --logLevel=debug\n```\n\n** Output example ** \n\n```bash\n  debg [0] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg [7] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg [8] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [1] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [2] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_logs.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [6] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/simple_trace.ts\n debg Using package version: 9.0.0-preview-1738343125\n debg [4] Loading scenario from /Users/carloscrespo/Documents/dev/kibana/src/platform/packages/shared/kbn-apm-synthtrace/src/scenarios/otel_simple_trace.ts\n debg [3] get_scenario: 133.820458ms\n info [3] Running scenario from 2025-04-29T07:38:18.547Z to 2025-04-29T07:39:58.547Z (pid: 14929)\n debg [3] Generating scenario\n debg [3] generating_apm_events: 0.087458ms\n debg [3] generate_scenario: 0.428875ms\n debg [3] Indexing scenario\n debg [7] get_scenario: 99.69775ms\n info [7] Running scenario from 2025-04-29T07:44:58.547Z to 2025-04-29T07:46:38.547Z (pid: 14929)\n debg [7] Generating scenario\n debg [7] generating_otel_trace: 0.067084ms\n debg [7] generate_scenario: 0.423875ms\n debg [7] Indexing scenario\n debg [1] get_scenario: 95.459625ms\n info [1] Running scenario from 2025-04-29T07:34:58.547Z to 2025-04-29T07:36:38.547Z (pid: 14929)\n debg [1] Generating scenario\n debg [1] generating_otel_trace: 0.0655ms\n debg [1] generate_scenario: 0.389458ms\n debg [1] Indexing scenario\n debg [0] get_scenario: 110.619375ms\n info [0] Running scenario from 2025-04-29T07:33:18.547Z to 2025-04-29T07:34:58.547Z (pid: 14929)\n debg [0] Generating scenario\n debg [0] generating_apm_events: 0.082917ms\n debg [0] generate_scenario: 0.413583ms\n debg [0] Indexing scenario\n debg [4] get_scenario: 94.146458ms\n info [4] Running scenario from 2025-04-29T07:39:58.547Z to 2025-04-29T07:41:38.547Z (pid: 14929)\n debg [4] Generating scenario\n debg [4] generating_otel_trace: 0.064708ms\n debg [4] generate_scenario: 0.407875ms\n debg [4] Indexing scenario\n debg [6] get_scenario: 121.74525ms\n info [6] Running scenario from 2025-04-29T07:43:18.547Z to 2025-04-29T07:44:58.547Z (pid: 14929)\n debg [6] Generating scenario\n debg [6] generating_apm_events: 0.085291ms\n debg [6] generate_scenario: 0.437833ms\n debg [6] Indexing scenario\n```\n\n### How to test\n\n- Run the commands above and confirm that the data was ingested\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"5af3e0f8cd549feb0ac8720c46d783280ccee232"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->