### PR TITLE
[Search] add longer timeouts to ingest examples for semantic_text

### DIFF
--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/ingest_data.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/ingest_data.ts
@@ -10,7 +10,7 @@ import { IngestDataCodeExamples } from '../types';
 
 import { JSIngestDataExample, JSSemanticIngestDataExample } from './javascript';
 import { PythonIngestDataExample, PythonSemanticIngestDataExample } from './python';
-import { ConsoleIngestDataExample } from './sense';
+import { ConsoleIngestDataExample, ConsoleSemanticIngestDataExample } from './sense';
 import { CurlIngestDataExample } from './curl';
 import { INSTALL_INSTRUCTIONS_TITLE, INSTALL_INSTRUCTIONS_DESCRIPTION } from './constants';
 
@@ -76,7 +76,7 @@ export const SemanticIngestDataCodeExamples: IngestDataCodeExamples = {
   defaultMapping: {
     text: { type: 'semantic_text' },
   },
-  sense: ConsoleIngestDataExample,
+  sense: ConsoleSemanticIngestDataExample,
   curl: CurlIngestDataExample,
   python: PythonSemanticIngestDataExample,
   javascript: JSSemanticIngestDataExample,

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/ingest_data.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/ingest_data.ts
@@ -8,8 +8,8 @@
 import { i18n } from '@kbn/i18n';
 import { IngestDataCodeExamples } from '../types';
 
-import { JSIngestDataExample } from './javascript';
-import { PythonIngestDataExample } from './python';
+import { JSIngestDataExample, JSSemanticIngestDataExample } from './javascript';
+import { PythonIngestDataExample, PythonSemanticIngestDataExample } from './python';
 import { ConsoleIngestDataExample } from './sense';
 import { CurlIngestDataExample } from './curl';
 import { INSTALL_INSTRUCTIONS_TITLE, INSTALL_INSTRUCTIONS_DESCRIPTION } from './constants';
@@ -78,6 +78,6 @@ export const SemanticIngestDataCodeExamples: IngestDataCodeExamples = {
   },
   sense: ConsoleIngestDataExample,
   curl: CurlIngestDataExample,
-  python: PythonIngestDataExample,
-  javascript: JSIngestDataExample,
+  python: PythonSemanticIngestDataExample,
+  javascript: JSSemanticIngestDataExample,
 };

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
@@ -151,7 +151,7 @@ export const JSSemanticIngestDataExample: IngestDataCodeDefinition = {
 
 ${createClientSnippet(args)}
 
-// Timeout to allow ML node allocation and semantic ingestion to complete
+// Timeout to allow machine learning model loading and semantic ingestion to complete
 const timeout = '5m';
 
 const index = '${args.indexName}';

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
@@ -25,6 +25,7 @@ export const JAVASCRIPT_INFO: CodeLanguage = {
 };
 
 const INSTALL_CMD = `npm install @elastic/elasticsearch`;
+const CLIENT_SERVERLESS_OPTION = `,\n    serverMode: 'serverless',`;
 
 export const JavascriptCreateIndexExamples: CreateIndexLanguageExamples = {
   default: {
@@ -33,12 +34,13 @@ export const JavascriptCreateIndexExamples: CreateIndexLanguageExamples = {
       elasticsearchURL,
       apiKey,
       indexName,
+      isServerless,
     }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'${isServerless ? CLIENT_SERVERLESS_OPTION : ''}
   }
 });
 
@@ -58,12 +60,13 @@ console.log(createResponse);`,
       elasticsearchURL,
       apiKey,
       indexName,
+      isServerless,
     }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'${isServerless ? CLIENT_SERVERLESS_OPTION : ''}
   }
 });
 
@@ -84,12 +87,13 @@ console.log(createResponse);`,
       elasticsearchURL,
       apiKey,
       indexName,
+      isServerless,
     }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'${isServerless ? CLIENT_SERVERLESS_OPTION : ''}
   }
 });
 
@@ -112,12 +116,13 @@ export const JSIngestDataExample: IngestDataCodeDefinition = {
     elasticsearchURL,
     sampleDocuments,
     indexName,
+    isServerless,
   }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'${isServerless ? CLIENT_SERVERLESS_OPTION : ''}
   },
 });
 
@@ -139,12 +144,13 @@ console.log(bulkIngestResponse);`,
     elasticsearchURL,
     indexName,
     mappingProperties,
+    isServerless,
   }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'${isServerless ? CLIENT_SERVERLESS_OPTION : ''}
   }
 });
 
@@ -193,12 +199,13 @@ export const JSSemanticIngestDataExample: IngestDataCodeDefinition = {
     elasticsearchURL,
     sampleDocuments,
     indexName,
+    isServerless,
   }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'${isServerless ? CLIENT_SERVERLESS_OPTION : ''}
   },
 });
 

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
@@ -33,26 +33,24 @@ export const JavascriptCreateIndexExamples: CreateIndexLanguageExamples = {
       elasticsearchURL,
       apiKey,
       indexName,
-    }) => `import { Client } from "@elastic/elasticsearch"
+    }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: "${apiKey ?? API_KEY_PLACEHOLDER}"
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
   }
 });
 
-async function run() {
-  await client.indices.create({
-    index: "${indexName ?? INDEX_PLACEHOLDER}",
-    mappings: {
-      properties: {
-        text: { type: "text"}
-      },
+const createResponse = await client.indices.create({
+  index: '${indexName ?? INDEX_PLACEHOLDER}',
+  mappings: {
+    properties: {
+      text: { type: 'text'}
     },
   });
 }
-run().catch(console.log);`,
+console.log(createResponse);`,
   },
   dense_vector: {
     installCommand: INSTALL_CMD,
@@ -60,27 +58,25 @@ run().catch(console.log);`,
       elasticsearchURL,
       apiKey,
       indexName,
-    }) => `import { Client } from "@elastic/elasticsearch"
+    }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: "${apiKey ?? API_KEY_PLACEHOLDER}"
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
   }
 });
 
-async function run() {
-  await client.indices.create({
-    index: "${indexName ?? INDEX_PLACEHOLDER}",
-    mappings: {
-      properties: {
-        vector: { type: "dense_vector", dims: 3 },
-        text: { type: "text"}
-      },
+const createResponse = await client.indices.create({
+  index: '${indexName ?? INDEX_PLACEHOLDER}',
+  mappings: {
+    properties: {
+      vector: { type: 'dense_vector', dims: 3 },
+      text: { type: 'text'}
     },
   });
 }
-run().catch(console.log);`,
+console.log(createResponse);`,
   },
   semantic: {
     installCommand: INSTALL_CMD,
@@ -88,26 +84,24 @@ run().catch(console.log);`,
       elasticsearchURL,
       apiKey,
       indexName,
-    }) => `import { Client } from "@elastic/elasticsearch"
+    }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: "${apiKey ?? API_KEY_PLACEHOLDER}"
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
   }
 });
 
-async function run() {
-  await client.indices.create({
-    index: "${indexName ?? INDEX_PLACEHOLDER}",
-    mappings: {
-      properties: {
-        text: { type: "semantic_text"}
-      },
+const createResponse = client.indices.create({
+  index: '${indexName ?? INDEX_PLACEHOLDER}',
+  mappings: {
+    properties: {
+      text: { type: 'semantic_text'}
     },
   });
 }
-run().catch(console.log);`,
+console.log(createResponse);`,
   },
 };
 
@@ -118,56 +112,50 @@ export const JSIngestDataExample: IngestDataCodeDefinition = {
     elasticsearchURL,
     sampleDocuments,
     indexName,
-  }) => `import { Client } from "@elastic/elasticsearch";
+  }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
   node: '${elasticsearchURL}',
   auth: {
-    apiKey: "${apiKey ?? API_KEY_PLACEHOLDER}"
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
   },
 });
 
-const index = "${indexName}";
+const index = '${indexName}';
 const docs = ${JSON.stringify(sampleDocuments, null, 2)};
 
-async function run() {}
-  const bulkIngestResponse = await client.helpers.bulk({
-    index,
-    datasource: docs,
-    onDocument() {
-      return {
-        index: {},
-      };
-    }
-  });
-  console.log(bulkIngestResponse);
-}
-run().catch(console.log);`,
+const bulkIngestResponse = await client.helpers.bulk({
+  index,
+  datasource: docs,
+  onDocument() {
+    return {
+      index: {},
+    };
+  }
+});
+console.log(bulkIngestResponse);`,
   updateMappingsCommand: ({
     apiKey,
     elasticsearchURL,
     indexName,
     mappingProperties,
-  }) => `import { Client } from "@elastic/elasticsearch";
+  }) => `const { Client } = require('@elastic/elasticsearch');
 
 const client = new Client({
-node: '${elasticsearchURL}',
-auth: {
-  apiKey: "${apiKey ?? API_KEY_PLACEHOLDER}"
-}
+  node: '${elasticsearchURL}',
+  auth: {
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
+  }
 });
 
-async function run() {
-  const index = "${indexName}";
-  const mapping = ${JSON.stringify(mappingProperties, null, 2)};
+const index = '${indexName}';
+const mapping = ${JSON.stringify(mappingProperties, null, 2)};
 
-  const updateMappingResponse = await client.indices.putMapping({
-    index,
-    properties: mapping,
-  });
-  console.log(updateMappingResponse);
-}
-run().catch(console.log);`,
+const updateMappingResponse = await client.indices.putMapping({
+  index,
+  properties: mapping,
+});
+console.log(updateMappingResponse);`,
 };
 
 const searchCommand: SearchCodeSnippetFunction = ({
@@ -187,16 +175,51 @@ const client = new Client({
 const index = "${indexName}";
 const query = ${JSON.stringify(queryObject, null, 2)};
 
-async function run() {
-  const result = await client.search({
-    index,
-    query,
-  });
+const result = await client.search({
+  index,
+  query,
+});
 
-  console.log(result.hits.hits);
-}
-run().catch(console.log);`;
+console.log(result.hits.hits);`;
 
 export const JavascriptSearchExample: SearchCodeDefinition = {
   searchCommand,
+};
+
+export const JSSemanticIngestDataExample: IngestDataCodeDefinition = {
+  ...JSIngestDataExample,
+  ingestCommand: ({
+    apiKey,
+    elasticsearchURL,
+    sampleDocuments,
+    indexName,
+  }) => `const { Client } = require('@elastic/elasticsearch');
+
+const client = new Client({
+  node: '${elasticsearchURL}',
+  auth: {
+    apiKey: '${apiKey ?? API_KEY_PLACEHOLDER}'
+  },
+});
+
+// Set the ingestion timeout to 5 minutes, to allow for semantic ingestion
+// to complete. The initial ingest with semantic_text fields may take longer
+// while the model loads, or ML nodes are allocated.
+const timeout = '5m';
+
+const index = '${indexName}';
+const docs = ${JSON.stringify(sampleDocuments, null, 2)};
+
+const bulkIngestResponse = await client.helpers.bulk({
+  index,
+  datasource: docs,
+  timeout,
+  onDocument() {
+    return {
+      index: {},
+    };
+  }
+});
+
+console.log(bulkIngestResponse);`,
 };

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/javascript.ts
@@ -127,11 +127,11 @@ console.log(updateMappingResponse);`,
 
 const searchCommand: SearchCodeSnippetFunction = (
   args: SearchCodeSnippetParameters
-) => `import { Client } from "@elastic/elasticsearch";
+) => `import { Client } from '@elastic/elasticsearch';
 
 ${createClientSnippet(args)}
 
-const index = "${args.indexName}";
+const index = '${args.indexName}';
 const query = ${JSON.stringify(args.queryObject, null, 2)};
 
 const result = await client.search({
@@ -151,9 +151,7 @@ export const JSSemanticIngestDataExample: IngestDataCodeDefinition = {
 
 ${createClientSnippet(args)}
 
-// Set the ingestion timeout to 5 minutes, to allow for semantic ingestion
-// to complete. The initial ingest with semantic_text fields may take longer
-// while the model loads, or ML nodes are allocated.
+// Timeout to allow ML node allocation and semantic ingestion to complete
 const timeout = '5m';
 
 const index = '${args.indexName}';

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/python.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/python.ts
@@ -151,7 +151,7 @@ index_name = "${indexName}"
 
 docs = ${JSON.stringify(sampleDocuments, null, 4)}
 
-# Timeout to allow ML node allocation and semantic ingestion to complete
+# Timeout to allow machine learning model loading and semantic ingestion to complete
 ingestion_timeout=300
 
 bulk_response = helpers.bulk(

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/python.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/python.ts
@@ -151,9 +151,7 @@ index_name = "${indexName}"
 
 docs = ${JSON.stringify(sampleDocuments, null, 4)}
 
-# Set the ingestion timeout to 5 minutes, to allow time for semantic ingestion
-# to complete. The initial ingest with semantic_text fields may take longer
-# while the model loads, or ML nodes are allocated.
+# Timeout to allow ML node allocation and semantic ingestion to complete
 ingestion_timeout=300
 
 bulk_response = helpers.bulk(

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/python.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/python.ts
@@ -135,6 +135,34 @@ mapping_response = client.indices.put_mapping(index=index_name, body=mappings)
 print(mapping_response)
 `;
 
+const semanticIngestCommand: IngestCodeSnippetFunction = ({
+  elasticsearchURL,
+  apiKey,
+  indexName,
+  sampleDocuments,
+}) => `from elasticsearch import Elasticsearch, helpers
+
+client = Elasticsearch(
+    "${elasticsearchURL}",
+    api_key="${apiKey ?? API_KEY_PLACEHOLDER}",
+)
+
+index_name = "${indexName}"
+
+docs = ${JSON.stringify(sampleDocuments, null, 4)}
+
+# Set the ingestion timeout to 5 minutes, to allow time for semantic ingestion
+# to complete. The initial ingest with semantic_text fields may take longer
+# while the model loads, or ML nodes are allocated.
+ingestion_timeout=300
+
+bulk_response = helpers.bulk(
+    client.options(request_timeout=ingestion_timeout),
+    docs,
+    index=index_name
+)
+print(bulk_response)`;
+
 export const PythonIngestDataExample: IngestDataCodeDefinition = {
   installCommand: PYTHON_INSTALL_CMD,
   ingestCommand: ingestionCommand,
@@ -164,4 +192,9 @@ print(search_response['hits']['hits'])
 
 export const PythonSearchExample: SearchCodeDefinition = {
   searchCommand,
+};
+
+export const PythonSemanticIngestDataExample: IngestDataCodeDefinition = {
+  ...PythonIngestDataExample,
+  ingestCommand: semanticIngestCommand,
 };

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/sense.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/sense.ts
@@ -74,7 +74,7 @@ export const ConsoleSemanticIngestDataExample: IngestDataCodeDefinition = {
   ...ConsoleIngestDataExample,
   ingestCommand: ({ indexName, sampleDocuments }) => {
     let result = `# The initial bulk ingestion request could take longer than the default request timeout.
-# If this request times out, you should retry the request after allowing time for the ML node allocation to complete.
+# If this request times out, you should retry the request after allowing time for the ML node allocation to complete (typically 1-5 minutes).
 POST /_bulk?pretty\n`;
     sampleDocuments.forEach((document) => {
       result += `{ "index": { "_index": "${indexName}" } }

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/sense.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/sense.ts
@@ -74,7 +74,7 @@ export const ConsoleSemanticIngestDataExample: IngestDataCodeDefinition = {
   ...ConsoleIngestDataExample,
   ingestCommand: ({ indexName, sampleDocuments }) => {
     let result = `# The initial bulk ingestion request could take longer than the default request timeout.
-# If this request times out, you should retry the request after allowing time for the ML node allocation to complete (typically 1-5 minutes).
+# If this request times out, you should retry the request after allowing time for the machine learning model loading to complete (typically 1-5 minutes).
 POST /_bulk?pretty\n`;
     sampleDocuments.forEach((document) => {
       result += `{ "index": { "_index": "${indexName}" } }

--- a/x-pack/solutions/search/plugins/search_indices/public/code_examples/sense.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/code_examples/sense.ts
@@ -70,6 +70,21 @@ ${JSON.stringify(document)}\n`;
 ${JSON.stringify({ properties: mappingProperties }, null, 2)}`,
 };
 
+export const ConsoleSemanticIngestDataExample: IngestDataCodeDefinition = {
+  ...ConsoleIngestDataExample,
+  ingestCommand: ({ indexName, sampleDocuments }) => {
+    let result = `# The initial bulk ingestion request could take longer than the default request timeout.
+# If this request times out, you should retry the request after allowing time for the ML node allocation to complete.
+POST /_bulk?pretty\n`;
+    sampleDocuments.forEach((document) => {
+      result += `{ "index": { "_index": "${indexName}" } }
+${JSON.stringify(document)}\n`;
+    });
+    result += '\n';
+    return result;
+  },
+};
+
 const searchCommand: SearchCodeSnippetFunction = ({
   indexName,
   queryObject,

--- a/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/add_documents_code_example.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/index_documents/add_documents_code_example.tsx
@@ -41,7 +41,7 @@ export const AddDocumentsCodeExample = ({
   indexName,
   mappingProperties,
 }: AddDocumentsCodeExampleProps) => {
-  const { application, share, console: consolePlugin } = useKibana().services;
+  const { application, share, console: consolePlugin, cloud } = useKibana().services;
   const elasticsearchUrl = useElasticsearchUrl();
   const usageTracker = useUsageTracker();
   const indexHasMappings = Object.keys(mappingProperties).length > 0;
@@ -73,8 +73,17 @@ export const AddDocumentsCodeExample = ({
       indexHasMappings,
       mappingProperties: codeSampleMappings,
       apiKey: apiKey || undefined,
+      isServerless: cloud?.isServerlessEnabled ?? undefined,
     };
-  }, [indexName, elasticsearchUrl, sampleDocuments, codeSampleMappings, indexHasMappings, apiKey]);
+  }, [
+    indexName,
+    elasticsearchUrl,
+    sampleDocuments,
+    codeSampleMappings,
+    indexHasMappings,
+    apiKey,
+    cloud,
+  ]);
 
   return (
     <EuiPanel

--- a/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_code_view.tsx
+++ b/x-pack/solutions/search/plugins/search_indices/public/components/shared/create_index_code_view.tsx
@@ -22,7 +22,7 @@ import { CodeSample } from './code_sample';
 import { LanguageSelector } from './language_selector';
 import { GuideSelector } from './guide_selector';
 import { Workflow } from '../../code_examples/workflows';
-import { CreateIndexCodeExamples } from '../../types';
+import { CreateIndexCodeExamples, CodeSnippetParameters } from '../../types';
 
 export interface CreateIndexCodeViewProps {
   selectedLanguage: AvailableLanguages;
@@ -49,19 +49,20 @@ export const CreateIndexCodeView = ({
   selectedLanguage,
   selectedCodeExamples,
 }: CreateIndexCodeViewProps) => {
-  const { application, share, console: consolePlugin } = useKibana().services;
+  const { application, share, cloud, console: consolePlugin } = useKibana().services;
   const usageTracker = useUsageTracker();
 
   const elasticsearchUrl = useElasticsearchUrl();
   const { apiKey } = useSearchApiKey();
 
-  const codeParams = useMemo(() => {
+  const codeParams: CodeSnippetParameters = useMemo(() => {
     return {
       indexName: indexName || undefined,
       elasticsearchURL: elasticsearchUrl,
       apiKey: apiKey || undefined,
+      isServerless: cloud?.isServerlessEnabled ?? undefined,
     };
-  }, [indexName, elasticsearchUrl, apiKey]);
+  }, [indexName, elasticsearchUrl, apiKey, cloud]);
   const selectedCodeExample = useMemo(() => {
     return selectedCodeExamples[selectedLanguage];
   }, [selectedLanguage, selectedCodeExamples]);

--- a/x-pack/solutions/search/plugins/search_indices/public/hooks/use_search_code_examples.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/hooks/use_search_code_examples.ts
@@ -14,6 +14,7 @@ import {
 } from '@kbn/search-queries';
 import { Mappings, SearchCodeSnippetParameters } from '../types';
 import { useElasticsearchUrl } from './use_elasticsearch_url';
+import { useKibana } from './use_kibana';
 import { AvailableLanguages, Languages } from '../code_examples';
 import { SearchCodeExample } from '../code_examples/search';
 
@@ -33,6 +34,7 @@ const DEFAULT_QUERY_OBJECT = {
 export const useSearchCodeExamples = (indexName: string, mappings?: Mappings) => {
   const elasticsearchURL = useElasticsearchUrl();
   const { apiKey } = useSearchApiKey();
+  const { cloud } = useKibana().services;
 
   return useMemo(() => {
     let queryObject: ReturnType<typeof generateSearchQuery> = DEFAULT_QUERY_OBJECT;
@@ -52,6 +54,7 @@ export const useSearchCodeExamples = (indexName: string, mappings?: Mappings) =>
       apiKey: apiKey ?? undefined,
       indexName,
       queryObject,
+      isServerless: cloud?.isServerlessEnabled ?? false,
     };
 
     const options = Object.entries(Languages).map(([key, language]) => ({
@@ -62,5 +65,5 @@ export const useSearchCodeExamples = (indexName: string, mappings?: Mappings) =>
       options,
       console: SearchCodeExample.sense.searchCommand(codeParams),
     };
-  }, [indexName, mappings, elasticsearchURL, apiKey]);
+  }, [indexName, mappings, elasticsearchURL, apiKey, cloud?.isServerlessEnabled]);
 };

--- a/x-pack/solutions/search/plugins/search_indices/public/types.ts
+++ b/x-pack/solutions/search/plugins/search_indices/public/types.ts
@@ -80,6 +80,7 @@ export interface CodeSnippetParameters {
   indexName?: string;
   apiKey?: string;
   elasticsearchURL: string;
+  isServerless?: boolean;
 }
 
 export type CodeSnippetFunction = (params: CodeSnippetParameters) => string;


### PR DESCRIPTION
## Summary

When following the example code for ingestion with a `semantic_text` mapping you will usually get a client timeout with the defaults. This is because on the first ingest you have to wait for the model to deploy. To try and avoid this I am updating our example code to explicitly set a longer client timeout with a comment in the example about why.

### Screenshots
Python
![image](https://github.com/user-attachments/assets/0c89d941-8463-48b5-861b-016ce382f925)

Javascript
![image](https://github.com/user-attachments/assets/3c067ea6-ded0-40f2-8dfa-a785c537bcb2)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)