### PR TITLE
[Obs AI Assistant] Update Knowledge Base model via settings

### DIFF
--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/index.ts
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/index.ts
@@ -13,3 +13,4 @@ export * from './use_genai_connectors';
 export * from './use_confirm_modal';
 export * from './use_conversations_by_date';
 export * from './use_conversation_context_menu';
+export * from './use_inference_endpoints';

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
@@ -44,7 +44,10 @@ export function useKnowledgeBase(): UseKnowledgeBaseResult {
   // poll for status when installing, until install is complete, KB is ready, and inference ID matches
   let isPolling = false;
 
-  if (statusRequest.value?.kbState === KnowledgeBaseState.DEPLOYING_MODEL) {
+  if (
+    statusRequest.value?.kbState === KnowledgeBaseState.DEPLOYING_MODEL ||
+    statusRequest.value?.isReIndexing
+  ) {
     isPolling = true;
   } else if (installingInferenceId !== undefined || isWarmingUpModel) {
     if (

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
@@ -41,15 +41,22 @@ export function useKnowledgeBase(): UseKnowledgeBaseResult {
     [service]
   );
 
-  // poll for status when installing, until install is complete, KB is ready, and inference ID matches
   let isPolling = false;
 
+  // Poll if either:
+  // 1. The model is currently being deployed to ML nodes
+  // 2. The knowledge base is being reindexed (e.g., during model updates)
   if (
     statusRequest.value?.kbState === KnowledgeBaseState.DEPLOYING_MODEL ||
     statusRequest.value?.isReIndexing
   ) {
     isPolling = true;
-  } else if (installingInferenceId !== undefined || isWarmingUpModel) {
+  }
+  // Poll if we're in the process of installing a new model or warming up an existing one
+  else if (installingInferenceId !== undefined || isWarmingUpModel) {
+    // Continue polling if either:
+    // 1. The knowledge base is not in READY state yet
+    // 2. We're installing a specific model but its ID doesn't match the current model
     if (
       statusRequest.value?.kbState !== KnowledgeBaseState.READY ||
       (installingInferenceId !== undefined &&

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
@@ -42,12 +42,26 @@ export function useKnowledgeBase(): UseKnowledgeBaseResult {
   );
 
   // poll for status when installing, until install is complete, KB is ready, and inference ID matches
-  const isPolling =
-    ((installingInferenceId !== undefined || isWarmingUpModel) &&
-      (statusRequest.value?.kbState !== KnowledgeBaseState.READY ||
-        (installingInferenceId &&
-          statusRequest.value?.currentInferenceId !== installingInferenceId))) ||
-    statusRequest.value?.kbState === KnowledgeBaseState.DEPLOYING_MODEL;
+  let isPolling = false;
+
+  // Check if model is being deployed
+  if (statusRequest.value?.kbState === KnowledgeBaseState.DEPLOYING_MODEL) {
+    isPolling = true;
+  }
+  // Check if we're installing or warming up the model
+  else if (installingInferenceId !== undefined || isWarmingUpModel) {
+    // Poll if KB is not ready
+    if (statusRequest.value?.kbState !== KnowledgeBaseState.READY) {
+      isPolling = true;
+    }
+    // Or if we're installing and the inference IDs don't match
+    else if (
+      installingInferenceId &&
+      statusRequest.value?.currentInferenceId !== installingInferenceId
+    ) {
+      isPolling = true;
+    }
+  }
 
   useEffect(() => {
     // Only reset installation state when the KB is ready and the endpoint model matches what we're installing

--- a/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
+++ b/x-pack/platform/packages/shared/kbn-ai-assistant/src/hooks/use_knowledge_base.tsx
@@ -44,20 +44,13 @@ export function useKnowledgeBase(): UseKnowledgeBaseResult {
   // poll for status when installing, until install is complete, KB is ready, and inference ID matches
   let isPolling = false;
 
-  // Check if model is being deployed
   if (statusRequest.value?.kbState === KnowledgeBaseState.DEPLOYING_MODEL) {
     isPolling = true;
-  }
-  // Check if we're installing or warming up the model
-  else if (installingInferenceId !== undefined || isWarmingUpModel) {
-    // Poll if KB is not ready
-    if (statusRequest.value?.kbState !== KnowledgeBaseState.READY) {
-      isPolling = true;
-    }
-    // Or if we're installing and the inference IDs don't match
-    else if (
-      installingInferenceId &&
-      statusRequest.value?.currentInferenceId !== installingInferenceId
+  } else if (installingInferenceId !== undefined || isWarmingUpModel) {
+    if (
+      statusRequest.value?.kbState !== KnowledgeBaseState.READY ||
+      (installingInferenceId !== undefined &&
+        statusRequest.value?.currentInferenceId !== installingInferenceId)
     ) {
       isPolling = true;
     }

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -293,7 +293,10 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
                   </EuiFlexItem>
                   {isKnowledgeBaseInLoadingState && (
                     <EuiFlexItem grow={false}>
-                      <EuiLoadingSpinner size="s" />
+                      <EuiLoadingSpinner
+                        size="s"
+                        data-test-subj="observabilityAiAssistantKnowledgeBaseLoadingSpinner"
+                      />
                     </EuiFlexItem>
                   )}
                 </EuiFlexGroup>

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -278,6 +278,7 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
                 <EuiFlexGroup gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
                     <EuiBadge
+                      data-test-subj="observabilityAiAssistantKnowledgeBaseStatus"
                       color={
                         knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
                           ? 'success'

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -1,0 +1,325 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import {
+  EuiButton,
+  EuiDescribedFormGroup,
+  EuiFormRow,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSuperSelect,
+  EuiLink,
+  EuiCallOut,
+  EuiLoadingSpinner,
+  EuiBadge,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import {
+  ModelOptionsData,
+  getModelOptionsForInferenceEndpoints,
+} from '@kbn/ai-assistant/src/utils/get_model_options_for_inference_endpoints';
+import { useInferenceEndpoints, UseKnowledgeBaseResult } from '@kbn/ai-assistant/src/hooks';
+import { KnowledgeBaseState, useKibana } from '@kbn/observability-ai-assistant-plugin/public';
+
+export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBaseResult }) {
+  const { overlays } = useKibana().services;
+
+  const [hasLoadedCurrentModel, setHasLoadedCurrentModel] = useState(false);
+  const [selectedInferenceId, setSelectedInferenceId] = useState<string>('');
+  const [isUpdatingModel, setIsUpdatingModel] = useState(false);
+
+  const { inferenceEndpoints, isLoading: isLoadingEndpoints, error } = useInferenceEndpoints();
+
+  const modelOptions: ModelOptionsData[] = getModelOptionsForInferenceEndpoints({
+    endpoints: inferenceEndpoints,
+  });
+
+  const doesModelNeedRedeployment =
+    knowledgeBase.status?.value?.kbState === KnowledgeBaseState.MODEL_PENDING_ALLOCATION ||
+    knowledgeBase.status?.value?.kbState === KnowledgeBaseState.MODEL_PENDING_DEPLOYMENT;
+
+  const isSelectedModelCurrentModel =
+    selectedInferenceId === knowledgeBase.status?.value?.endpoint?.inference_id;
+
+  const isKnowledgeBaseInLoadingState =
+    knowledgeBase.isInstalling ||
+    knowledgeBase.isWarmingUpModel ||
+    knowledgeBase.isPolling ||
+    knowledgeBase.status?.value?.isReIndexing;
+
+  useEffect(() => {
+    if (!hasLoadedCurrentModel && modelOptions?.length && knowledgeBase.status?.value) {
+      const currentModel = knowledgeBase.status.value.currentInferenceId;
+      setSelectedInferenceId(currentModel || modelOptions[0].key);
+      setHasLoadedCurrentModel(true);
+    }
+  }, [hasLoadedCurrentModel, modelOptions, knowledgeBase.status?.value, selectedInferenceId]);
+
+  useEffect(() => {
+    if (isUpdatingModel && !knowledgeBase.isInstalling && !knowledgeBase.isPolling) {
+      setIsUpdatingModel(false);
+    }
+  }, [knowledgeBase.isInstalling, knowledgeBase.isPolling, isUpdatingModel]);
+
+  const buttonText = useMemo(() => {
+    if (knowledgeBase.status?.value?.kbState === KnowledgeBaseState.NOT_INSTALLED) {
+      return i18n.translate(
+        'xpack.observabilityAiAssistantManagement.knowledgeBase.installModelLabel',
+        {
+          defaultMessage: 'Install',
+        }
+      );
+    }
+
+    if (doesModelNeedRedeployment && isSelectedModelCurrentModel) {
+      return i18n.translate(
+        'xpack.observabilityAiAssistantManagement.knowledgeBase.redeployModelLabel',
+        {
+          defaultMessage: 'Re-deploy model',
+        }
+      );
+    }
+
+    return i18n.translate(
+      'xpack.observabilityAiAssistantManagement.knowledgeBase.updateModelLabel',
+      {
+        defaultMessage: 'Update model',
+      }
+    );
+  }, [
+    doesModelNeedRedeployment,
+    isSelectedModelCurrentModel,
+    knowledgeBase.status?.value?.kbState,
+  ]);
+
+  const confirmationMessages = useMemo(
+    () => ({
+      title: i18n.translate(
+        'xpack.observabilityAiAssistantManagement.knowledgeBase.updateModelConfirmTitle',
+        {
+          defaultMessage: 'Update Knowledge Base Model',
+        }
+      ),
+      message: i18n.translate(
+        'xpack.observabilityAiAssistantManagement.knowledgeBase.updateModelConfirmMessage',
+        {
+          defaultMessage: 'This will re-index all knowledge base entries if there are any.',
+        }
+      ),
+      cancelButtonText: i18n.translate(
+        'xpack.observabilityAiAssistantManagement.knowledgeBase.updateModelCancel',
+        {
+          defaultMessage: 'Cancel',
+        }
+      ),
+    }),
+    []
+  );
+
+  const handleInstall = useCallback(() => {
+    if (selectedInferenceId) {
+      if (
+        knowledgeBase.status?.value?.kbState === KnowledgeBaseState.NOT_INSTALLED ||
+        (doesModelNeedRedeployment && isSelectedModelCurrentModel)
+      ) {
+        setIsUpdatingModel(true);
+        if (doesModelNeedRedeployment) {
+          knowledgeBase.warmupModel(selectedInferenceId);
+        } else {
+          knowledgeBase.install(selectedInferenceId);
+        }
+      } else {
+        overlays
+          .openConfirm(confirmationMessages.message, {
+            title: confirmationMessages.title,
+            cancelButtonText: confirmationMessages.cancelButtonText,
+            buttonColor: 'primary',
+          })
+          .then((isConfirmed) => {
+            if (isConfirmed) {
+              setIsUpdatingModel(true);
+              knowledgeBase.install(selectedInferenceId);
+            }
+          });
+      }
+    }
+  }, [
+    selectedInferenceId,
+    knowledgeBase,
+    doesModelNeedRedeployment,
+    isSelectedModelCurrentModel,
+    overlays,
+    confirmationMessages,
+  ]);
+
+  const superSelectOptions = modelOptions.map((option: ModelOptionsData) => ({
+    value: option.key,
+    inputDisplay: option.label,
+    dropdownDisplay: (
+      <div>
+        <strong>{option.label}</strong>
+        <EuiText size="xs" color="subdued" css={{ marginTop: 4 }}>
+          {option.description}
+        </EuiText>
+      </div>
+    ),
+  }));
+
+  const content = useMemo(() => {
+    if (error) {
+      return (
+        <EuiCallOut
+          title={i18n.translate(
+            'xpack.observabilityAiAssistantManagement.knowledgeBase.errorLoadingModelsTitle',
+            {
+              defaultMessage: 'Error loading models',
+            }
+          )}
+          color="danger"
+          iconType="alert"
+        >
+          <p>{error.message}</p>
+        </EuiCallOut>
+      );
+    }
+
+    return (
+      <EuiFlexGroup gutterSize="s">
+        <EuiFlexItem grow={false} css={{ width: 354 }}>
+          <EuiSuperSelect
+            fullWidth
+            hasDividers
+            isLoading={isLoadingEndpoints}
+            options={superSelectOptions}
+            valueOfSelected={selectedInferenceId}
+            onChange={(value) => setSelectedInferenceId(value)}
+            disabled={isKnowledgeBaseInLoadingState}
+            data-test-subj="observabilityAiAssistantKnowledgeBaseModelDropdown"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          {isKnowledgeBaseInLoadingState ? (
+            <EuiFlexGroup alignItems="center" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiLoadingSpinner size="m" />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="s">
+                  {knowledgeBase.isWarmingUpModel
+                    ? i18n.translate(
+                        'xpack.observabilityAiAssistantManagement.knowledgeBase.redeployingModelLabel',
+                        {
+                          defaultMessage: 'Re-deploying model...',
+                        }
+                      )
+                    : i18n.translate(
+                        'xpack.observabilityAiAssistantManagement.knowledgeBase.updatingModelLabel',
+                        {
+                          defaultMessage: 'Updating model...',
+                        }
+                      )}
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            <EuiButton
+              color="primary"
+              data-test-subj="observabilityAiAssistantKnowledgeBaseUpdateModelButton"
+              onClick={handleInstall}
+              isDisabled={
+                !selectedInferenceId ||
+                (knowledgeBase.status?.value?.kbState !== KnowledgeBaseState.NOT_INSTALLED &&
+                  selectedInferenceId === knowledgeBase.status?.value?.endpoint?.inference_id &&
+                  !doesModelNeedRedeployment)
+              }
+            >
+              {buttonText}
+            </EuiButton>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }, [
+    error,
+    buttonText,
+    isLoadingEndpoints,
+    superSelectOptions,
+    selectedInferenceId,
+    isKnowledgeBaseInLoadingState,
+    doesModelNeedRedeployment,
+    knowledgeBase.isWarmingUpModel,
+    knowledgeBase.status?.value?.kbState,
+    knowledgeBase.status?.value?.endpoint?.inference_id,
+    handleInstall,
+  ]);
+
+  return (
+    <EuiDescribedFormGroup
+      fullWidth
+      title={
+        <h3>
+          {i18n.translate(
+            'xpack.observabilityAiAssistantManagement.knowledgeBase.chooseModelLabel',
+            {
+              defaultMessage: 'Set text embeddings model',
+            }
+          )}
+        </h3>
+      }
+      description={
+        <>
+          <EuiText size="s" color="subdued">
+            {i18n.translate(
+              'xpack.observabilityAiAssistantManagement.settingsPage.knowledgeBase.chooseModelDescription',
+              {
+                defaultMessage: "Choose the default language model for the Assistant's responses.",
+              }
+            )}{' '}
+            <EuiLink
+              href="https://www.elastic.co/docs/explore-analyze/machine-learning/nlp/ml-nlp-built-in-models"
+              target="_blank"
+            >
+              {i18n.translate('xpack.aiAssistant.knowledgeBase.subtitleLearnMore', {
+                defaultMessage: 'Learn more',
+              })}
+            </EuiLink>
+          </EuiText>
+          {knowledgeBase.status?.value?.kbState && (
+            <EuiFlexGroup gutterSize="s" alignItems="center" css={{ marginTop: 8 }}>
+              <EuiFlexItem grow={false}>
+                <EuiText size="s">
+                  {i18n.translate('xpack.aiAssistant.knowledgeBase.kbStateLabel', {
+                    defaultMessage: 'Knowledge Base Status:',
+                  })}
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiBadge
+                  color={
+                    knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
+                      ? 'success'
+                      : 'default'
+                  }
+                >
+                  {knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
+                    ? i18n.translate('xpack.aiAssistant.knowledgeBase.stateInstalled', {
+                        defaultMessage: 'Installed',
+                      })
+                    : knowledgeBase.status.value.kbState}
+                </EuiBadge>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
+        </>
+      }
+    >
+      <EuiFormRow fullWidth>{content}</EuiFormRow>
+    </EuiDescribedFormGroup>
+  );
+}

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -204,44 +204,20 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          {isKnowledgeBaseInLoadingState ? (
-            <EuiFlexGroup alignItems="center" gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <EuiLoadingSpinner size="m" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiText size="s">
-                  {knowledgeBase.isWarmingUpModel
-                    ? i18n.translate(
-                        'xpack.observabilityAiAssistantManagement.knowledgeBase.redeployingModelLabel',
-                        {
-                          defaultMessage: 'Re-deploying model...',
-                        }
-                      )
-                    : i18n.translate(
-                        'xpack.observabilityAiAssistantManagement.knowledgeBase.updatingModelLabel',
-                        {
-                          defaultMessage: 'Updating model...',
-                        }
-                      )}
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          ) : (
-            <EuiButton
-              color="primary"
-              data-test-subj="observabilityAiAssistantKnowledgeBaseUpdateModelButton"
-              onClick={handleInstall}
-              isDisabled={
-                !selectedInferenceId ||
-                (knowledgeBase.status?.value?.kbState !== KnowledgeBaseState.NOT_INSTALLED &&
-                  selectedInferenceId === knowledgeBase.status?.value?.endpoint?.inference_id &&
-                  !doesModelNeedRedeployment)
-              }
-            >
-              {buttonText}
-            </EuiButton>
-          )}
+          <EuiButton
+            color="primary"
+            data-test-subj="observabilityAiAssistantKnowledgeBaseUpdateModelButton"
+            onClick={handleInstall}
+            isDisabled={
+              !selectedInferenceId ||
+              isKnowledgeBaseInLoadingState ||
+              (knowledgeBase.status?.value?.kbState !== KnowledgeBaseState.NOT_INSTALLED &&
+                selectedInferenceId === knowledgeBase.status?.value?.endpoint?.inference_id &&
+                !doesModelNeedRedeployment)
+            }
+          >
+            {buttonText}
+          </EuiButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     );
@@ -253,7 +229,6 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
     selectedInferenceId,
     isKnowledgeBaseInLoadingState,
     doesModelNeedRedeployment,
-    knowledgeBase.isWarmingUpModel,
     knowledgeBase.status?.value?.kbState,
     knowledgeBase.status?.value?.endpoint?.inference_id,
     handleInstall,
@@ -300,19 +275,28 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
                 </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiBadge
-                  color={
-                    knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
-                      ? 'success'
-                      : 'default'
-                  }
-                >
-                  {knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
-                    ? i18n.translate('xpack.aiAssistant.knowledgeBase.stateInstalled', {
-                        defaultMessage: 'Installed',
-                      })
-                    : knowledgeBase.status.value.kbState}
-                </EuiBadge>
+                <EuiFlexGroup gutterSize="s" alignItems="center">
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge
+                      color={
+                        knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
+                          ? 'success'
+                          : 'default'
+                      }
+                    >
+                      {knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
+                        ? i18n.translate('xpack.aiAssistant.knowledgeBase.stateInstalled', {
+                            defaultMessage: 'Installed',
+                          })
+                        : knowledgeBase.status.value.kbState}
+                    </EuiBadge>
+                  </EuiFlexItem>
+                  {isKnowledgeBaseInLoadingState && (
+                    <EuiFlexItem grow={false}>
+                      <EuiLoadingSpinner size="s" />
+                    </EuiFlexItem>
+                  )}
+                </EuiFlexGroup>
               </EuiFlexItem>
             </EuiFlexGroup>
           )}

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -281,14 +281,20 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
                       data-test-subj="observabilityAiAssistantKnowledgeBaseStatus"
                       color={
                         knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
-                          ? 'success'
+                          ? isKnowledgeBaseInLoadingState
+                            ? 'warning'
+                            : 'success'
                           : 'default'
                       }
                     >
                       {knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
-                        ? i18n.translate('xpack.aiAssistant.knowledgeBase.stateInstalled', {
-                            defaultMessage: 'Installed',
-                          })
+                        ? isKnowledgeBaseInLoadingState
+                          ? i18n.translate('xpack.aiAssistant.knowledgeBase.stateUpdatingModel', {
+                              defaultMessage: 'Updating model',
+                            })
+                          : i18n.translate('xpack.aiAssistant.knowledgeBase.stateInstalled', {
+                              defaultMessage: 'Installed',
+                            })
                         : knowledgeBase.status.value.kbState}
                     </EuiBadge>
                   </EuiFlexItem>

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/change_kb_model.tsx
@@ -260,18 +260,24 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
               href="https://www.elastic.co/docs/explore-analyze/machine-learning/nlp/ml-nlp-built-in-models"
               target="_blank"
             >
-              {i18n.translate('xpack.aiAssistant.knowledgeBase.subtitleLearnMore', {
-                defaultMessage: 'Learn more',
-              })}
+              {i18n.translate(
+                'xpack.observabilityAiAssistantManagement.knowledgeBase.subtitleLearnMore',
+                {
+                  defaultMessage: 'Learn more',
+                }
+              )}
             </EuiLink>
           </EuiText>
           {knowledgeBase.status?.value?.kbState && (
             <EuiFlexGroup gutterSize="s" alignItems="center" css={{ marginTop: 8 }}>
               <EuiFlexItem grow={false}>
                 <EuiText size="s">
-                  {i18n.translate('xpack.aiAssistant.knowledgeBase.kbStateLabel', {
-                    defaultMessage: 'Knowledge Base Status:',
-                  })}
+                  {i18n.translate(
+                    'xpack.observabilityAiAssistantManagement.knowledgeBase.kbStateLabel',
+                    {
+                      defaultMessage: 'Knowledge Base Status:',
+                    }
+                  )}
                 </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
@@ -289,12 +295,18 @@ export function ChangeKbModel({ knowledgeBase }: { knowledgeBase: UseKnowledgeBa
                     >
                       {knowledgeBase.status.value.kbState === KnowledgeBaseState.READY
                         ? isKnowledgeBaseInLoadingState
-                          ? i18n.translate('xpack.aiAssistant.knowledgeBase.stateUpdatingModel', {
-                              defaultMessage: 'Updating model',
-                            })
-                          : i18n.translate('xpack.aiAssistant.knowledgeBase.stateInstalled', {
-                              defaultMessage: 'Installed',
-                            })
+                          ? i18n.translate(
+                              'xpack.observabilityAiAssistantManagement.knowledgeBase.stateUpdatingModel',
+                              {
+                                defaultMessage: 'Updating model',
+                              }
+                            )
+                          : i18n.translate(
+                              'xpack.observabilityAiAssistantManagement.knowledgeBase.stateInstalled',
+                              {
+                                defaultMessage: 'Installed',
+                              }
+                            )
                         : knowledgeBase.status.value.kbState}
                     </EuiBadge>
                   </EuiFlexItem>

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.test.tsx
@@ -10,15 +10,40 @@ import { fireEvent } from '@testing-library/react';
 import { render } from '../../../helpers/test_helper';
 import { SettingsTab } from './settings_tab';
 import { useAppContext } from '../../../hooks/use_app_context';
+import { KnowledgeBaseState } from '@kbn/observability-ai-assistant-plugin/public';
+import {
+  useKnowledgeBase,
+  useGenAIConnectors,
+  useInferenceEndpoints,
+} from '@kbn/ai-assistant/src/hooks';
 
 jest.mock('../../../hooks/use_app_context');
+jest.mock('@kbn/ai-assistant/src/hooks');
 
 const useAppContextMock = useAppContext as jest.Mock;
+const useKnowledgeBaseMock = useKnowledgeBase as jest.Mock;
+const useGenAIConnectorsMock = useGenAIConnectors as jest.Mock;
+const useInferenceEndpointsMock = useInferenceEndpoints as jest.Mock;
+const navigateToAppMock = jest.fn(() => Promise.resolve());
 
 describe('SettingsTab', () => {
-  useAppContextMock.mockReturnValue({ config: { spacesEnabled: true, visibilityEnabled: true } });
+  beforeEach(() => {
+    useAppContextMock.mockReturnValue({ config: { spacesEnabled: true, visibilityEnabled: true } });
+    useKnowledgeBaseMock.mockReturnValue({
+      status: { value: { enabled: true, kbState: KnowledgeBaseState.READY } },
+      isInstalling: false,
+      isPolling: false,
+      isWarmingUpModel: false,
+    });
+    useGenAIConnectorsMock.mockReturnValue({ connectors: [{ id: 'test-connector' }] });
+    useInferenceEndpointsMock.mockReturnValue({
+      inferenceEndpoints: [{ id: 'test-endpoint', inference_id: 'test-inference-id' }],
+      isLoading: false,
+      error: undefined,
+    });
+  });
+
   it('should offer a way to configure Observability AI Assistant visibility in apps', () => {
-    const navigateToAppMock = jest.fn(() => Promise.resolve());
     const { getByTestId } = render(<SettingsTab />, {
       coreStart: {
         application: { navigateToApp: navigateToAppMock },
@@ -31,7 +56,6 @@ describe('SettingsTab', () => {
   });
 
   it('should offer a way to configure Gen AI connectors', () => {
-    const navigateToAppMock = jest.fn(() => Promise.resolve());
     const { getByTestId } = render(<SettingsTab />, {
       coreStart: {
         application: { navigateToApp: navigateToAppMock },
@@ -43,5 +67,49 @@ describe('SettingsTab', () => {
     expect(navigateToAppMock).toBeCalledWith('management', {
       path: '/insightsAndAlerting/triggersActionsConnectors/connectors',
     });
+  });
+
+  it('should show knowledge base model section when the knowledge base is enabled and connectors exist', () => {
+    const { getByTestId } = render(<SettingsTab />, {
+      coreStart: {
+        application: { navigateToApp: navigateToAppMock },
+      },
+    });
+
+    expect(
+      getByTestId('observabilityAiAssistantKnowledgeBaseUpdateModelButton')
+    ).toBeInTheDocument();
+  });
+
+  it('should not show knowledge base model section when no connectors exist', () => {
+    useGenAIConnectorsMock.mockReturnValue({ connectors: [] });
+
+    const { queryByTestId } = render(<SettingsTab />, {
+      coreStart: {
+        application: { navigateToApp: navigateToAppMock },
+      },
+    });
+
+    expect(
+      queryByTestId('observabilityAiAssistantKnowledgeBaseUpdateModelButton')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show loading state when knowledge base is being updated', () => {
+    useKnowledgeBaseMock.mockReturnValue({
+      status: { value: { enabled: true, kbState: KnowledgeBaseState.READY } },
+      isInstalling: true,
+      isPolling: true,
+      isWarmingUpModel: false,
+    });
+
+    const { getByTestId } = render(<SettingsTab />, {
+      coreStart: {
+        application: { navigateToApp: navigateToAppMock },
+      },
+    });
+
+    expect(getByTestId('observabilityAiAssistantKnowledgeBaseLoadingSpinner')).toBeInTheDocument();
+    expect(getByTestId('observabilityAiAssistantKnowledgeBaseUpdateModelButton')).toBeDisabled();
   });
 });

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/settings_tab.tsx
@@ -8,10 +8,12 @@
 import React from 'react';
 import { EuiButton, EuiDescribedFormGroup, EuiFormRow, EuiPanel } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { useGenAIConnectors, useKnowledgeBase } from '@kbn/ai-assistant/src/hooks';
 import { useAppContext } from '../../../hooks/use_app_context';
 import { useKibana } from '../../../hooks/use_kibana';
 import { UISettings } from './ui_settings';
 import { ProductDocEntry } from './product_doc_entry';
+import { ChangeKbModel } from './change_kb_model';
 
 export function SettingsTab() {
   const {
@@ -19,6 +21,9 @@ export function SettingsTab() {
     productDocBase,
   } = useKibana().services;
   const { config } = useAppContext();
+
+  const knowledgeBase = useKnowledgeBase();
+  const connectors = useGenAIConnectors();
 
   const handleNavigateToConnectors = () => {
     navigateToApp('management', {
@@ -111,7 +116,12 @@ export function SettingsTab() {
       </EuiDescribedFormGroup>
 
       {productDocBase ? <ProductDocEntry /> : undefined}
-      <UISettings />
+
+      {knowledgeBase.status.value?.enabled && connectors.connectors?.length ? (
+        <ChangeKbModel knowledgeBase={knowledgeBase} />
+      ) : undefined}
+
+      <UISettings knowledgeBase={knowledgeBase} />
     </EuiPanel>
   );
 }

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/ui_settings.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/ui_settings.tsx
@@ -13,24 +13,22 @@ import {
   aiAssistantPreferredAIAssistantType,
 } from '@kbn/observability-ai-assistant-plugin/public';
 import { FieldRow, FieldRowProvider } from '@kbn/management-settings-components-field-row';
-import { EuiSpacer } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 import { i18n } from '@kbn/i18n';
 import { LogSourcesSettingSynchronisationInfo } from '@kbn/logs-data-access-plugin/public';
-import { useKnowledgeBase } from '@kbn/ai-assistant';
+import { UseKnowledgeBaseResult } from '@kbn/ai-assistant';
 import { useEditableSettings } from '../../../hooks/use_editable_settings';
 import { useAppContext } from '../../../hooks/use_app_context';
 import { useKibana } from '../../../hooks/use_kibana';
 import { BottomBarActions } from '../bottom_bar_actions/bottom_bar_actions';
 
-export function UISettings() {
+export function UISettings({ knowledgeBase }: { knowledgeBase: UseKnowledgeBaseResult }) {
   const {
     docLinks,
     settings,
     notifications,
     application: { capabilities, getUrlForApp },
   } = useKibana().services;
-  const knowledgeBase = useKnowledgeBase();
   const { config } = useAppContext();
 
   const settingsKeys = [
@@ -62,7 +60,6 @@ export function UISettings() {
 
   return (
     <>
-      <EuiSpacer />
       {settingsKeys.map((settingKey) => {
         const field = fields[settingKey];
 

--- a/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/ui_settings.tsx
+++ b/x-pack/platform/plugins/private/observability_ai_assistant_management/public/routes/components/settings_tab/ui_settings.tsx
@@ -41,6 +41,7 @@ export function UISettings({ knowledgeBase }: { knowledgeBase: UseKnowledgeBaseR
     useEditableSettings(settingsKeys);
 
   const canEditAdvancedSettings = capabilities.advancedSettings?.save;
+
   async function handleSave() {
     try {
       await saveAll();

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/public/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/public/index.ts
@@ -99,6 +99,7 @@ export type {
 } from './api';
 
 export type { UseChatResult } from './hooks/use_chat';
+export { useKibana } from './hooks/use_kibana';
 
 export {
   aiAssistantLogsIndexPattern,

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
@@ -24,11 +24,6 @@ import {
 
 const getKnowledgeBaseStatus = createObservabilityAIAssistantServerRoute({
   endpoint: 'GET /internal/observability_ai_assistant/kb/status',
-  params: t.type({
-    query: t.partial({
-      inference_id: t.string,
-    }),
-  }),
   security: {
     authz: {
       requiredPrivileges: ['ai_assistant'],
@@ -47,9 +42,7 @@ const getKnowledgeBaseStatus = createObservabilityAIAssistantServerRoute({
     isReIndexing: boolean;
   }> => {
     const client = await resources.service.getClient({ request: resources.request });
-    return client.getKnowledgeBaseStatus({
-      inferenceId: resources.params.query.inference_id,
-    });
+    return client.getKnowledgeBaseStatus();
   },
 });
 

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/routes/knowledge_base/route.ts
@@ -24,26 +24,32 @@ import {
 
 const getKnowledgeBaseStatus = createObservabilityAIAssistantServerRoute({
   endpoint: 'GET /internal/observability_ai_assistant/kb/status',
+  params: t.type({
+    query: t.partial({
+      inference_id: t.string,
+    }),
+  }),
   security: {
     authz: {
       requiredPrivileges: ['ai_assistant'],
     },
   },
-  handler: async ({
-    service,
-    request,
-  }): Promise<{
+  handler: async (
+    resources
+  ): Promise<{
     errorMessage?: string;
     enabled: boolean;
     endpoint?: Partial<InferenceInferenceEndpointInfo>;
     modelStats?: Partial<MlTrainedModelStats>;
     kbState: KnowledgeBaseState;
-    currentInferenceId: string | undefined;
+    currentInferenceId?: string | undefined;
     concreteWriteIndex: string | undefined;
     isReIndexing: boolean;
   }> => {
-    const client = await service.getClient({ request });
-    return client.getKnowledgeBaseStatus();
+    const client = await resources.service.getClient({ request: resources.request });
+    return client.getKnowledgeBaseStatus({
+      inferenceId: resources.params.query.inference_id,
+    });
   },
 });
 

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -659,8 +659,8 @@ export class ObservabilityAIAssistantClient {
     return this.dependencies.knowledgeBaseService.getInferenceEndpointsForEmbedding();
   };
 
-  getKnowledgeBaseStatus = ({ inferenceId }: { inferenceId?: string } = {}) => {
-    return this.dependencies.knowledgeBaseService.getModelStatus({ inferenceId });
+  getKnowledgeBaseStatus = () => {
+    return this.dependencies.knowledgeBaseService.getModelStatus();
   };
 
   setupKnowledgeBase = async (

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/client/index.ts
@@ -659,8 +659,8 @@ export class ObservabilityAIAssistantClient {
     return this.dependencies.knowledgeBaseService.getInferenceEndpointsForEmbedding();
   };
 
-  getKnowledgeBaseStatus = () => {
-    return this.dependencies.knowledgeBaseService.getModelStatus();
+  getKnowledgeBaseStatus = ({ inferenceId }: { inferenceId?: string } = {}) => {
+    return this.dependencies.knowledgeBaseService.getModelStatus({ inferenceId });
   };
 
   setupKnowledgeBase = async (

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/index_assets/create_or_update_knowledge_base_index_assets.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/index_assets/create_or_update_knowledge_base_index_assets.ts
@@ -34,6 +34,10 @@ export async function createOrUpdateKnowledgeBaseIndexAssets({
       template: getComponentTemplate(componentTemplateInferenceId),
     });
 
+    logger.debug(
+      `Knowledge base component template updated with inference_id: ${componentTemplateInferenceId}`
+    );
+
     // Knowledge base: index template
     await asInternalUser.indices.putIndexTemplate({
       name: resourceNames.indexTemplate.kb,
@@ -52,6 +56,7 @@ export async function createOrUpdateKnowledgeBaseIndexAssets({
     const writeIndexInferenceId = await getInferenceIdFromWriteIndex(esClient).catch(
       () => undefined
     );
+    logger.debug(`Current write index inference id: ${writeIndexInferenceId}`);
 
     // Knowledge base: write index
     // `createConcreteWriteIndex` will create the write index, or update the index mappings if the index already exists

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/inference_endpoint.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/inference_endpoint.ts
@@ -102,7 +102,7 @@ export async function getKbModelStatus({
   modelStats?: MlTrainedModelStats;
   errorMessage?: string;
   kbState: KnowledgeBaseState;
-  currentInferenceId: string | undefined;
+  currentInferenceId?: string | undefined;
   concreteWriteIndex: string | undefined;
   isReIndexing: boolean;
 }> {
@@ -118,7 +118,6 @@ export async function getKbModelStatus({
         enabled,
         errorMessage: 'Inference id not found',
         kbState: KnowledgeBaseState.NOT_INSTALLED,
-        currentInferenceId,
         concreteWriteIndex,
         isReIndexing,
       };

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/index.ts
@@ -479,12 +479,13 @@ export class KnowledgeBaseService {
     }
   };
 
-  getModelStatus = async () => {
+  getModelStatus = async ({ inferenceId }: { inferenceId?: string } = {}) => {
     return getKbModelStatus({
       core: this.dependencies.core,
       esClient: this.dependencies.esClient,
       logger: this.dependencies.logger,
       config: this.dependencies.config,
+      inferenceId,
     });
   };
 

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/index.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/index.ts
@@ -479,13 +479,12 @@ export class KnowledgeBaseService {
     }
   };
 
-  getModelStatus = async ({ inferenceId }: { inferenceId?: string } = {}) => {
+  getModelStatus = async () => {
     return getKbModelStatus({
       core: this.dependencies.core,
       esClient: this.dependencies.esClient,
       logger: this.dependencies.logger,
       config: this.dependencies.config,
-      inferenceId,
     });
   };
 

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/reindex_knowledge_base.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/reindex_knowledge_base.ts
@@ -193,5 +193,5 @@ export async function isReIndexInProgress({
     getActiveReindexingTaskId(esClient),
   ]);
 
-  return lock !== undefined || activeReindexingTask !== undefined;
+  return lock !== undefined && activeReindexingTask !== undefined;
 }

--- a/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/reindex_knowledge_base.ts
+++ b/x-pack/platform/plugins/shared/observability_ai_assistant/server/service/knowledge_base_service/reindex_knowledge_base.ts
@@ -193,5 +193,5 @@ export async function isReIndexInProgress({
     getActiveReindexingTaskId(esClient),
   ]);
 
-  return lock !== undefined && activeReindexingTask !== undefined;
+  return lock !== undefined || activeReindexingTask !== undefined;
 }

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/knowledge_base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/knowledge_base.ts
@@ -51,6 +51,9 @@ export async function getKnowledgeBaseStatus(
 ) {
   return observabilityAIAssistantAPIClient.editor({
     endpoint: 'GET /internal/observability_ai_assistant/kb/status',
+    params: {
+      query: {},
+    },
   });
 }
 

--- a/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/knowledge_base.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/knowledge_base.ts
@@ -51,9 +51,6 @@ export async function getKnowledgeBaseStatus(
 ) {
   return observabilityAIAssistantAPIClient.editor({
     endpoint: 'GET /internal/observability_ai_assistant/kb/status',
-    params: {
-      query: {},
-    },
   });
 }
 

--- a/x-pack/test/observability_ai_assistant_functional/tests/settings/change_knowledge_base_model.spec.ts
+++ b/x-pack/test/observability_ai_assistant_functional/tests/settings/change_knowledge_base_model.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { KnowledgeBaseState } from '@kbn/observability-ai-assistant-plugin/common/types';
+import { FtrProviderContext } from '../../ftr_provider_context';
+import { createConnector, deleteConnectors } from '../../common/connectors';
+import {
+  LlmProxy,
+  createLlmProxy,
+} from '../../../observability_ai_assistant_api_integration/common/create_llm_proxy';
+import {
+  deployTinyElserAndSetupKb,
+  stopTinyElserModel,
+  teardownTinyElserModelAndInferenceEndpoint,
+} from '../../../api_integration/deployment_agnostic/apis/observability/ai_assistant/utils/model_and_inference';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const log = getService('log');
+  const supertest = getService('supertest');
+  const PageObjects = getPageObjects(['common', 'security']);
+  const ui = getService('observabilityAIAssistantUI');
+  const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
+  const browser = getService('browser');
+  const find = getService('find');
+
+  describe('Change knowledge base model via settings', () => {
+    let llmProxy: LlmProxy;
+
+    before(async () => {
+      llmProxy = await createLlmProxy(log);
+      await createConnector(llmProxy, supertest);
+
+      await ui.auth.login('editor');
+      await PageObjects.common.navigateToUrlWithBrowserHistory(
+        'management',
+        '/kibana/observabilityAiAssistantManagement'
+      );
+    });
+
+    after(async () => {
+      await teardownTinyElserModelAndInferenceEndpoint(getService);
+      await deleteConnectors(supertest);
+      llmProxy.close();
+      await ui.auth.logout();
+    });
+
+    it('shows knowledge base model section when enabled', async () => {
+      await testSubjects.existOrFail('observabilityAiAssistantKnowledgeBaseModelDropdown');
+      await testSubjects.existOrFail('observabilityAiAssistantKnowledgeBaseUpdateModelButton');
+    });
+
+    it('shows the current KB status and the correct button text when the KB is not installed', async () => {
+      const statusBadgeText = await testSubjects.getVisibleText(
+        'observabilityAiAssistantKnowledgeBaseStatus'
+      );
+      expect(statusBadgeText).to.be(KnowledgeBaseState.NOT_INSTALLED);
+      const buttonText = await testSubjects.getVisibleText(
+        'observabilityAiAssistantKnowledgeBaseUpdateModelButton'
+      );
+      expect(buttonText).to.be('Install');
+    });
+
+    it('show the correct status and button text when the KB is installed', async () => {
+      await deployTinyElserAndSetupKb(getService);
+      await browser.refresh();
+
+      await retry.try(async () => {
+        const statusBadgeText = await testSubjects.getVisibleText(
+          'observabilityAiAssistantKnowledgeBaseStatus'
+        );
+        expect(statusBadgeText).to.be('Installed');
+      });
+
+      await testSubjects.missingOrFail('observabilityAiAssistantKnowledgeBaseLoadingSpinner');
+    });
+
+    it('allows model selection and updating the model when multiple models are available', async () => {
+      await testSubjects.existOrFail('observabilityAiAssistantKnowledgeBaseModelDropdown');
+
+      await testSubjects.click('observabilityAiAssistantKnowledgeBaseModelDropdown');
+
+      await retry.try(async () => {
+        const options = await find.allByCssSelector('.euiSuperSelect__item');
+        expect(options.length).to.be.greaterThan(0);
+        await options[options.length - 1].click();
+      });
+
+      const isButtonDisabled = await testSubjects.getAttribute(
+        'observabilityAiAssistantKnowledgeBaseUpdateModelButton',
+        'disabled'
+      );
+      expect(isButtonDisabled).to.be(null);
+    });
+
+    it('should show a button to re-deploy the model if the model has been stopped', async () => {
+      await stopTinyElserModel(getService);
+      await browser.refresh();
+
+      const buttonText = await testSubjects.getVisibleText(
+        'observabilityAiAssistantKnowledgeBaseUpdateModelButton'
+      );
+      expect(buttonText).to.be('Re-deploy model');
+
+      const statusBadgeText = await testSubjects.getVisibleText(
+        'observabilityAiAssistantKnowledgeBaseStatus'
+      );
+      expect(statusBadgeText).to.be(KnowledgeBaseState.MODEL_PENDING_DEPLOYMENT);
+    });
+  });
+}


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-assistant-team/issues/231

## Summary

This PR enables users to change the Knowledge Base model post installation via AI Assistant Settings.

## How it works

https://github.com/user-attachments/assets/240979ee-56fc-48e4-bd76-de07d03a7c48

### Screenshots

![image](https://github.com/user-attachments/assets/08e4f949-70a4-416e-96d5-0709a54a9f72)

![image](https://github.com/user-attachments/assets/f8da4e76-e679-4a47-8391-a09e5c8ea13c)

![image](https://github.com/user-attachments/assets/07ccfbca-491d-4029-8392-d49315fc1e61)

![image](https://github.com/user-attachments/assets/47fa17f5-ea40-488a-8e5a-436f812ffde0)


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)




<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->