### PR TITLE
[8.19] Extend default log pattern on server-side to include error information (#219940)

### DIFF
--- a/docs/settings/logging-settings.asciidoc
+++ b/docs/settings/logging-settings.asciidoc
@@ -24,7 +24,7 @@ The following table serves as a quick reference for different logging configurat
 | Unique appender identifier.
 
 | `logging.appenders[].console:`
-| Appender to use for logging records to *stdout*. By default, uses the `[%date][%level][%logger] %message` **pattern** layout. To use a **json**, set the <<log-in-json-ECS-example,layout type to `json`>>.
+| Appender to use for logging records to *stdout*. By default, uses the `[%date][%level][%logger] %message %error` **pattern** layout. To use a **json**, set the <<log-in-json-ECS-example,layout type to `json`>>.
 
 | `logging.appenders[].file:`
 | Allows you to specify a fileName to write log records to disk. To write <<log-to-file-example,all log records to file>>, add the file appender to `root.appenders`. If configured, you also need to specify <<log-to-file-example, `logging.appenders.file.pathName`>>.

--- a/src/core/packages/logging/browser-internal/src/layouts/__snapshots__/pattern_layout.test.ts.snap
+++ b/src/core/packages/logging/browser-internal/src/layouts/__snapshots__/pattern_layout.test.ts.snap
@@ -12,7 +12,7 @@ exports[`\`format()\` correctly formats record with custom pattern. 5`] = `"mock
 
 exports[`\`format()\` correctly formats record with custom pattern. 6`] = `"mock-message-6-context-6-message-6"`;
 
-exports[`\`format()\` correctly formats record with full pattern. 1`] = `"[2012-02-01T09:30:22.011-05:00][FATAL][context-1] Some error stack"`;
+exports[`\`format()\` correctly formats record with full pattern. 1`] = `"[2012-02-01T09:30:22.011-05:00][FATAL][context-1] Some error stack Meta error stack"`;
 
 exports[`\`format()\` correctly formats record with full pattern. 2`] = `"[2012-02-01T09:30:22.011-05:00][ERROR][context-2] message-2"`;
 

--- a/src/core/packages/logging/browser-internal/src/layouts/pattern_layout.test.ts
+++ b/src/core/packages/logging/browser-internal/src/layouts/pattern_layout.test.ts
@@ -23,6 +23,8 @@ const stripAnsiSnapshotSerializer: jest.SnapshotSerializerPlugin = {
 };
 
 const timestamp = new Date(Date.UTC(2012, 1, 1, 14, 30, 22, 11));
+const error = new Error('Meta error');
+error.stack = 'Meta error stack';
 const records: LogRecord[] = [
   {
     context: 'context-1',
@@ -30,6 +32,9 @@ const records: LogRecord[] = [
       message: 'Some error message',
       name: 'Some error name',
       stack: 'Some error stack',
+    },
+    meta: {
+      error,
     },
     level: LogLevel.Fatal,
     message: 'message-1',

--- a/src/core/packages/logging/browser-internal/src/layouts/pattern_layout.ts
+++ b/src/core/packages/logging/browser-internal/src/layouts/pattern_layout.ts
@@ -15,9 +15,8 @@ import {
   MetaConversion,
   MessageConversion,
   DateConversion,
+  ErrorConversion,
 } from '@kbn/core-logging-common-internal';
-
-const DEFAULT_PATTERN = `[%date][%level][%logger] %message`;
 
 const conversions: Conversion[] = [
   LoggerConversion,
@@ -25,6 +24,7 @@ const conversions: Conversion[] = [
   LevelConversion,
   MetaConversion,
   DateConversion,
+  ErrorConversion,
 ];
 
 /**
@@ -33,7 +33,7 @@ const conversions: Conversion[] = [
  * @internal
  */
 export class PatternLayout extends BasePatternLayout {
-  constructor(pattern: string = DEFAULT_PATTERN) {
+  constructor(pattern?: string) {
     super({
       pattern,
       highlight: false,

--- a/src/core/packages/logging/common-internal/index.ts
+++ b/src/core/packages/logging/common-internal/index.ts
@@ -14,6 +14,7 @@ export {
   MessageConversion,
   LevelConversion,
   MetaConversion,
+  ErrorConversion,
   type Conversion,
   AbstractLogger,
   type CreateLogRecordFn,

--- a/src/core/packages/logging/common-internal/src/index.ts
+++ b/src/core/packages/logging/common-internal/src/index.ts
@@ -14,6 +14,7 @@ export {
   MessageConversion,
   LevelConversion,
   MetaConversion,
+  ErrorConversion,
   type Conversion,
 } from './layouts';
 export { AbstractLogger, type CreateLogRecordFn } from './logger';

--- a/src/core/packages/logging/common-internal/src/layouts/__snapshots__/pattern_layout.test.ts.snap
+++ b/src/core/packages/logging/common-internal/src/layouts/__snapshots__/pattern_layout.test.ts.snap
@@ -12,7 +12,7 @@ exports[`\`format()\` correctly formats record with custom pattern. 5`] = `"mock
 
 exports[`\`format()\` correctly formats record with custom pattern. 6`] = `"mock-message-6-context-6-message-6"`;
 
-exports[`\`format()\` correctly formats record with full pattern. 1`] = `"[2012-02-01T09:30:22.011-05:00][FATAL][context-1] Some error stack"`;
+exports[`\`format()\` correctly formats record with full pattern. 1`] = `"[2012-02-01T09:30:22.011-05:00][FATAL][context-1] Some error stack Meta error stack"`;
 
 exports[`\`format()\` correctly formats record with full pattern. 2`] = `"[2012-02-01T09:30:22.011-05:00][ERROR][context-2] message-2"`;
 

--- a/src/core/packages/logging/common-internal/src/layouts/conversions/error.ts
+++ b/src/core/packages/logging/common-internal/src/layouts/conversions/error.ts
@@ -7,12 +7,21 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export { PidConversion } from './pid';
-export { LevelConversion } from './level';
-export { LoggerConversion } from './logger';
-export {
-  DateConversion,
-  MessageConversion,
-  MetaConversion,
-  ErrorConversion,
-} from '@kbn/core-logging-common-internal';
+// import { EcsError } from '@elastic/ecs';
+import { LogRecord } from '@kbn/logging';
+import { Conversion } from './types';
+
+function isError(x: any): x is Error {
+  return x instanceof Error;
+}
+
+export const ErrorConversion: Conversion = {
+  pattern: /%error/g,
+  convert(record: LogRecord) {
+    let error;
+    if (isError(record.meta?.error)) {
+      error = record.meta?.error.stack;
+    }
+    return error ? `${error}` : '';
+  },
+};

--- a/src/core/packages/logging/common-internal/src/layouts/conversions/index.ts
+++ b/src/core/packages/logging/common-internal/src/layouts/conversions/index.ts
@@ -13,3 +13,4 @@ export { LevelConversion } from './level';
 export { MessageConversion } from './message';
 export { MetaConversion } from './meta';
 export { DateConversion } from './date';
+export { ErrorConversion } from './error';

--- a/src/core/packages/logging/common-internal/src/layouts/index.ts
+++ b/src/core/packages/logging/common-internal/src/layouts/index.ts
@@ -14,5 +14,6 @@ export {
   MessageConversion,
   LevelConversion,
   MetaConversion,
+  ErrorConversion,
   type Conversion,
 } from './conversions';

--- a/src/core/packages/logging/common-internal/src/layouts/pattern_layout.test.ts
+++ b/src/core/packages/logging/common-internal/src/layouts/pattern_layout.test.ts
@@ -23,6 +23,8 @@ const stripAnsiSnapshotSerializer: jest.SnapshotSerializerPlugin = {
 };
 
 const timestamp = new Date(Date.UTC(2012, 1, 1, 14, 30, 22, 11));
+const error = new Error('Meta error');
+error.stack = 'Meta error stack';
 const records: LogRecord[] = [
   {
     context: 'context-1',
@@ -30,6 +32,9 @@ const records: LogRecord[] = [
       message: 'Some error message',
       name: 'Some error name',
       stack: 'Some error stack',
+    },
+    meta: {
+      error,
     },
     level: LogLevel.Fatal,
     message: 'message-1',

--- a/src/core/packages/logging/common-internal/src/layouts/pattern_layout.ts
+++ b/src/core/packages/logging/common-internal/src/layouts/pattern_layout.ts
@@ -15,12 +15,13 @@ import {
   MetaConversion,
   MessageConversion,
   DateConversion,
+  ErrorConversion,
 } from './conversions';
 
 /**
  * Default pattern used by PatternLayout if it's not overridden in the configuration.
  */
-const DEFAULT_PATTERN = `[%date][%level][%logger] %message`;
+const DEFAULT_PATTERN = `[%date][%level][%logger] %message %error`;
 
 const DEFAULT_CONVERSIONS: Conversion[] = [
   LoggerConversion,
@@ -28,6 +29,7 @@ const DEFAULT_CONVERSIONS: Conversion[] = [
   LevelConversion,
   MetaConversion,
   DateConversion,
+  ErrorConversion,
 ];
 
 export interface PatternLayoutOptions {
@@ -69,6 +71,6 @@ export class PatternLayout implements Layout {
       );
     }
 
-    return recordString;
+    return recordString.trim();
   }
 }

--- a/src/core/packages/logging/server-internal/src/layouts/__snapshots__/pattern_layout.test.ts.snap
+++ b/src/core/packages/logging/server-internal/src/layouts/__snapshots__/pattern_layout.test.ts.snap
@@ -12,7 +12,7 @@ exports[`\`format()\` correctly formats record with custom pattern. 5`] = `"mock
 
 exports[`\`format()\` correctly formats record with custom pattern. 6`] = `"mock-message-6-context-6-message-6"`;
 
-exports[`\`format()\` correctly formats record with full pattern. 1`] = `"[2012-02-01T09:30:22.011-05:00][FATAL][context-1] Some error stack"`;
+exports[`\`format()\` correctly formats record with full pattern. 1`] = `"[2012-02-01T09:30:22.011-05:00][FATAL][context-1] Some error stack Meta error stack"`;
 
 exports[`\`format()\` correctly formats record with full pattern. 2`] = `"[2012-02-01T09:30:22.011-05:00][ERROR][context-2] message-2"`;
 
@@ -24,7 +24,7 @@ exports[`\`format()\` correctly formats record with full pattern. 5`] = `"[2012-
 
 exports[`\`format()\` correctly formats record with full pattern. 6`] = `"[2012-02-01T09:30:22.011-05:00][TRACE][context-6] message-6"`;
 
-exports[`\`format()\` correctly formats record with highlighting. 1`] = `[2012-02-01T09:30:22.011-05:00][FATAL][context-1] Some error stack`;
+exports[`\`format()\` correctly formats record with highlighting. 1`] = `[2012-02-01T09:30:22.011-05:00][FATAL][context-1] Some error stack Meta error stack`;
 
 exports[`\`format()\` correctly formats record with highlighting. 2`] = `[2012-02-01T09:30:22.011-05:00][ERROR][context-2] message-2`;
 

--- a/src/core/packages/logging/server-internal/src/layouts/pattern_layout.test.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/pattern_layout.test.ts
@@ -23,6 +23,8 @@ const stripAnsiSnapshotSerializer: jest.SnapshotSerializerPlugin = {
 };
 
 const timestamp = new Date(Date.UTC(2012, 1, 1, 14, 30, 22, 11));
+const error = new Error('Meta error');
+error.stack = 'Meta error stack';
 const records: LogRecord[] = [
   {
     context: 'context-1',
@@ -30,6 +32,9 @@ const records: LogRecord[] = [
       message: 'Some error message',
       name: 'Some error name',
       stack: 'Some error stack',
+    },
+    meta: {
+      error,
     },
     level: LogLevel.Fatal,
     message: 'message-1',

--- a/src/core/packages/logging/server-internal/src/layouts/pattern_layout.ts
+++ b/src/core/packages/logging/server-internal/src/layouts/pattern_layout.ts
@@ -19,9 +19,8 @@ import {
   MessageConversion,
   PidConversion,
   DateConversion,
+  ErrorConversion,
 } from './conversions';
-
-const DEFAULT_PATTERN = `[%date][%level][%logger] %message`;
 
 export const patternSchema = schema.string({
   maxLength: 1000,
@@ -43,6 +42,7 @@ const conversions: Conversion[] = [
   MetaConversion,
   PidConversion,
   DateConversion,
+  ErrorConversion,
 ];
 
 /**
@@ -53,7 +53,7 @@ const conversions: Conversion[] = [
 export class PatternLayout extends BasePatternLayout {
   public static configSchema = patternLayoutSchema;
 
-  constructor(pattern: string = DEFAULT_PATTERN, highlight: boolean = false) {
+  constructor(pattern?: string, highlight: boolean = false) {
     super({
       pattern,
       highlight,

--- a/src/core/server/docs/kib_core_logging.mdx
+++ b/src/core/server/docs/kib_core_logging.mdx
@@ -129,7 +129,7 @@ There are two types of layout supported at the moment: `pattern` and `json`.
 ### Pattern layout
 With `pattern` layout it's possible to define a string pattern with special placeholders `%conversion_pattern` (see the table below) that
 will be replaced with data from the actual log message. By default the following pattern is used:
-`[%date][%level][%logger] %message`. Also `highlight` option can be enabled for `pattern` layout so that
+`[%date][%level][%logger] %message %error`. Also `highlight` option can be enabled for `pattern` layout so that
 some parts of the log message are highlighted with different colors that may be quite handy if log messages are forwarded
 to the terminal with color support.
 `pattern` layout uses a sub-set of [log4j2 pattern syntax](https://logging.apache.org/log4j/2.x/manual/layouts.html#PatternLayout)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Extend default log pattern on server-side to include error information (#219940)](https://github.com/elastic/kibana/pull/219940)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2025-05-22T14:57:42Z","message":"Extend default log pattern on server-side to include error information (#219940)\n\n## Release Notes\nKibana logging's pattern layout, used by default for the console\nappender, will now use a new default pattern layout\n`[%date][%level][%logger] %message %error`. This will include the error\nname and stack trace if these were included in the log entry. To opt out\nof this behavior users can omit the `%error` placeholder from their log\npattern config in kibana.yml e.g.:\n```\nlogging:\n  appenders:\n    console:\n      type: console\n      layout:\n        type: pattern\n        pattern: \"[%date][%level][%logger] %message\"\n```\n\n## Summary\n\nPreviously, when we pass the error in meta, the information related to\nstacktrace and error message was not available in console. This PR\nchanged the default pattern to also include error information if it is\nprovided in meta (similar to the way that the logging happens when error\nis directly passed to logger.error).\n\nNew pattern: (added `%error` at the end)\n```\n[%date][%level][%logger] %message %error\n```\n\nHere you can see the difference:\n\nLogger:\n\n```\nserver.logger.error(\n        `Unable to create Synthetics monitor ${monitorWithNamespace[ConfigKey.NAME]}`,\n        { error: e }\n      );\n```\n\n#### Before\n\n\n![image](https://github.com/user-attachments/assets/4f3ff751-84d5-4b5b-b6a9-d49f868a9606)\n\n#### After\n\n\n![image](https://github.com/user-attachments/assets/e22b8e45-1b0a-4d8c-b51d-5dfb3938da4f)\n\n\n### Alternative\nWe could also change the MetaConversion and include this information,\nbut we might have additional meta information which I am not sure if it\nis OK to be logged by default. Let me know if you prefer changing\nMetaConversion instead of adding a new error conversion.\n\n<details>\n<summary>Code changes for MetaConversion</summary>\n\n```\nfunction isError(x: any): x is Error {\n  return x instanceof Error;\n}\n\nexport const MetaConversion: Conversion = {\n  pattern: /%meta/g,\n  convert(record: LogRecord) {\n    if (!record.meta) {\n      return '';\n    }\n    const { error, ...rest } = record.meta;\n    const metaString = Object.keys(rest).length !== 0 ? JSON.stringify(rest) : '';\n    let errorString = '';\n\n    if (isError(record.meta?.error)) {\n      errorString = record.meta?.error.stack || '';\n    }\n\n    return [metaString, errorString].filter(Boolean).join(' ');\n  },\n};\n```\n</details>\n\nHere is how adjusting meta will look like in this case:\n\n\n![image](https://github.com/user-attachments/assets/d7dce9bc-7147-472d-b434-373322f41bbf)","sha":"3d86a175d786ed6f9bc47e0e509cf44defbc66b0","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","backport:version","v9.1.0","v8.19.0"],"title":"Extend default log pattern on server-side to include error information","number":219940,"url":"https://github.com/elastic/kibana/pull/219940","mergeCommit":{"message":"Extend default log pattern on server-side to include error information (#219940)\n\n## Release Notes\nKibana logging's pattern layout, used by default for the console\nappender, will now use a new default pattern layout\n`[%date][%level][%logger] %message %error`. This will include the error\nname and stack trace if these were included in the log entry. To opt out\nof this behavior users can omit the `%error` placeholder from their log\npattern config in kibana.yml e.g.:\n```\nlogging:\n  appenders:\n    console:\n      type: console\n      layout:\n        type: pattern\n        pattern: \"[%date][%level][%logger] %message\"\n```\n\n## Summary\n\nPreviously, when we pass the error in meta, the information related to\nstacktrace and error message was not available in console. This PR\nchanged the default pattern to also include error information if it is\nprovided in meta (similar to the way that the logging happens when error\nis directly passed to logger.error).\n\nNew pattern: (added `%error` at the end)\n```\n[%date][%level][%logger] %message %error\n```\n\nHere you can see the difference:\n\nLogger:\n\n```\nserver.logger.error(\n        `Unable to create Synthetics monitor ${monitorWithNamespace[ConfigKey.NAME]}`,\n        { error: e }\n      );\n```\n\n#### Before\n\n\n![image](https://github.com/user-attachments/assets/4f3ff751-84d5-4b5b-b6a9-d49f868a9606)\n\n#### After\n\n\n![image](https://github.com/user-attachments/assets/e22b8e45-1b0a-4d8c-b51d-5dfb3938da4f)\n\n\n### Alternative\nWe could also change the MetaConversion and include this information,\nbut we might have additional meta information which I am not sure if it\nis OK to be logged by default. Let me know if you prefer changing\nMetaConversion instead of adding a new error conversion.\n\n<details>\n<summary>Code changes for MetaConversion</summary>\n\n```\nfunction isError(x: any): x is Error {\n  return x instanceof Error;\n}\n\nexport const MetaConversion: Conversion = {\n  pattern: /%meta/g,\n  convert(record: LogRecord) {\n    if (!record.meta) {\n      return '';\n    }\n    const { error, ...rest } = record.meta;\n    const metaString = Object.keys(rest).length !== 0 ? JSON.stringify(rest) : '';\n    let errorString = '';\n\n    if (isError(record.meta?.error)) {\n      errorString = record.meta?.error.stack || '';\n    }\n\n    return [metaString, errorString].filter(Boolean).join(' ');\n  },\n};\n```\n</details>\n\nHere is how adjusting meta will look like in this case:\n\n\n![image](https://github.com/user-attachments/assets/d7dce9bc-7147-472d-b434-373322f41bbf)","sha":"3d86a175d786ed6f9bc47e0e509cf44defbc66b0"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/219940","number":219940,"mergeCommit":{"message":"Extend default log pattern on server-side to include error information (#219940)\n\n## Release Notes\nKibana logging's pattern layout, used by default for the console\nappender, will now use a new default pattern layout\n`[%date][%level][%logger] %message %error`. This will include the error\nname and stack trace if these were included in the log entry. To opt out\nof this behavior users can omit the `%error` placeholder from their log\npattern config in kibana.yml e.g.:\n```\nlogging:\n  appenders:\n    console:\n      type: console\n      layout:\n        type: pattern\n        pattern: \"[%date][%level][%logger] %message\"\n```\n\n## Summary\n\nPreviously, when we pass the error in meta, the information related to\nstacktrace and error message was not available in console. This PR\nchanged the default pattern to also include error information if it is\nprovided in meta (similar to the way that the logging happens when error\nis directly passed to logger.error).\n\nNew pattern: (added `%error` at the end)\n```\n[%date][%level][%logger] %message %error\n```\n\nHere you can see the difference:\n\nLogger:\n\n```\nserver.logger.error(\n        `Unable to create Synthetics monitor ${monitorWithNamespace[ConfigKey.NAME]}`,\n        { error: e }\n      );\n```\n\n#### Before\n\n\n![image](https://github.com/user-attachments/assets/4f3ff751-84d5-4b5b-b6a9-d49f868a9606)\n\n#### After\n\n\n![image](https://github.com/user-attachments/assets/e22b8e45-1b0a-4d8c-b51d-5dfb3938da4f)\n\n\n### Alternative\nWe could also change the MetaConversion and include this information,\nbut we might have additional meta information which I am not sure if it\nis OK to be logged by default. Let me know if you prefer changing\nMetaConversion instead of adding a new error conversion.\n\n<details>\n<summary>Code changes for MetaConversion</summary>\n\n```\nfunction isError(x: any): x is Error {\n  return x instanceof Error;\n}\n\nexport const MetaConversion: Conversion = {\n  pattern: /%meta/g,\n  convert(record: LogRecord) {\n    if (!record.meta) {\n      return '';\n    }\n    const { error, ...rest } = record.meta;\n    const metaString = Object.keys(rest).length !== 0 ? JSON.stringify(rest) : '';\n    let errorString = '';\n\n    if (isError(record.meta?.error)) {\n      errorString = record.meta?.error.stack || '';\n    }\n\n    return [metaString, errorString].filter(Boolean).join(' ');\n  },\n};\n```\n</details>\n\nHere is how adjusting meta will look like in this case:\n\n\n![image](https://github.com/user-attachments/assets/d7dce9bc-7147-472d-b434-373322f41bbf)","sha":"3d86a175d786ed6f9bc47e0e509cf44defbc66b0"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->