### PR TITLE
[Dataset Quality] Wrap discover test checks in retries

### DIFF
--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_details.ts
@@ -245,8 +245,10 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
         );
 
         // Confirm dataset selector text in discover
-        const datasetSelectorText = await PageObjects.discover.getCurrentDataViewId();
-        originalExpect(datasetSelectorText).toMatch(`${failedDataStreamName}::failures`);
+        await retry.tryForTime(5000, async () => {
+          const datasetSelectorText = await PageObjects.discover.getCurrentDataViewId();
+          originalExpect(datasetSelectorText).toMatch(`${failedDataStreamName}::failures`);
+        });
       });
 
       it('should show the degraded fields table with data and spark plots when present', async () => {
@@ -258,16 +260,18 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
           PageObjects.datasetQuality.testSubjectSelectors.datasetQualityDetailsDegradedFieldTable
         );
 
-        const rows =
-          await PageObjects.datasetQuality.getDatasetQualityDetailsDegradedFieldTableRows();
+        await retry.tryForTime(5000, async () => {
+          const rows =
+            await PageObjects.datasetQuality.getDatasetQualityDetailsDegradedFieldTableRows();
 
-        expect(rows.length).to.eql(1);
+          expect(rows.length).to.eql(1);
 
-        const sparkPlots = await testSubjects.findAll(
-          PageObjects.datasetQuality.testSubjectSelectors.datasetQualitySparkPlot
-        );
+          const sparkPlots = await testSubjects.findAll(
+            PageObjects.datasetQuality.testSubjectSelectors.datasetQualitySparkPlot
+          );
 
-        expect(rows.length).to.be(sparkPlots.length);
+          expect(rows.length).to.be(sparkPlots.length);
+        });
       });
     });
 


### PR DESCRIPTION
## Summary

This PR wraps test checks in retries to avoid checking before loading is completed.

closes https://github.com/elastic/kibana/issues/221348



<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->