### PR TITLE
[8.18] Upgrade openpgp to 5.11.3 (#221198)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1202,7 +1202,7 @@
     "object-hash": "^3.0.0",
     "object-path-immutable": "^3.1.1",
     "openai": "^4.72.0",
-    "openpgp": "5.10.1",
+    "openpgp": "5.11.3",
     "opn": "^5.5.0",
     "ora": "^4.0.4",
     "p-limit": "^3.0.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -80,7 +80,7 @@ export const DEV_ONLY_LICENSE_ALLOWED = ['MPL-2.0', '(MPL-2.0 OR Apache-2.0)'];
 // there are some licenses which should not be globally allowed
 // but can be brought in on a per-package basis
 export const PER_PACKAGE_ALLOWED_LICENSES = {
-  'openpgp@5.10.1': ['LGPL-3.0+'],
+  'openpgp@5.11.3': ['LGPL-3.0+'],
 };
 // Globally overrides a license for a given package@version
 export const LICENSE_OVERRIDES = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -26076,10 +26076,10 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
-openpgp@5.10.1:
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/openpgp/-/openpgp-5.10.1.tgz#3b137470187b79281719ced16fb9e60b822cfd24"
-  integrity sha512-SR5Ft+ej51d0+p53ld5Ney0Yiz0y8Mh1YYLJrvpRMbTaNhvS1QcDX0Oq1rW9sjBnQXtgrpWw2Zve3rm7K5C/pw==
+openpgp@5.11.3:
+  version "5.11.3"
+  resolved "https://registry.yarnpkg.com/openpgp/-/openpgp-5.11.3.tgz#a2532aa973f1f6413556eaf328b97a6955b1d8a3"
+  integrity sha512-jXOPfIteBUQ2zSmRG4+Y6PNntIIDEAvoM/lOYCnvpXAByJEruzrHQZWE/0CGOKHbubwUuty2HoPHsqBzyKHOpA==
   dependencies:
     asn1.js "^5.0.0"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Upgrade openpgp to 5.11.3 (#221198)](https://github.com/elastic/kibana/pull/221198)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-23T13:22:40Z","message":"Upgrade openpgp to 5.11.3 (#221198)\n\n## Summary\n\nUpgrade `openpgp` from `5.10.1` to `5.11.3`\n\n## Changelog\nhttps://github.com/openpgpjs/openpgpjs/compare/v5.10.1..v5.11.3\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ee553e59306e26934aac076758f720600da170a","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v9.1.0","v9.0.2"],"title":"Upgrade openpgp to 5.11.3","number":221198,"url":"https://github.com/elastic/kibana/pull/221198","mergeCommit":{"message":"Upgrade openpgp to 5.11.3 (#221198)\n\n## Summary\n\nUpgrade `openpgp` from `5.10.1` to `5.11.3`\n\n## Changelog\nhttps://github.com/openpgpjs/openpgpjs/compare/v5.10.1..v5.11.3\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ee553e59306e26934aac076758f720600da170a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221198","number":221198,"mergeCommit":{"message":"Upgrade openpgp to 5.11.3 (#221198)\n\n## Summary\n\nUpgrade `openpgp` from `5.10.1` to `5.11.3`\n\n## Changelog\nhttps://github.com/openpgpjs/openpgpjs/compare/v5.10.1..v5.11.3\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"7ee553e59306e26934aac076758f720600da170a"}},{"branch":"9.0","label":"v9.0.2","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/221374","number":221374,"state":"MERGED","mergeCommit":{"sha":"598743f3f15368e6a20a30243f7b45bad2e4f376","message":"[9.0] Upgrade openpgp to 5.11.3 (#221198) (#221374)\n\n# Backport\n\nThis will backport the following commits from `main` to `9.0`:\n- [Upgrade openpgp to 5.11.3\n(#221198)](https://github.com/elastic/kibana/pull/221198)\n\n\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sorenlouv/backport)\n\n\n\nCo-authored-by: Kurt <kc13greiner@users.noreply.github.com>"}}]}] BACKPORT-->