### PR TITLE
🌊 Streams: Disable failure store

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/sync.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/helpers/sync.ts
@@ -68,7 +68,7 @@ export async function syncWiredStreamDefinitionObjects({
   await upsertTemplate({
     esClient: scopedClusterClient.asCurrentUser,
     logger,
-    template: generateIndexTemplate(definition.name, isServerless),
+    template: generateIndexTemplate(definition.name),
   });
 
   await upsertDataStream({

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/index_templates/generate_index_template.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/index_templates/generate_index_template.ts
@@ -10,7 +10,7 @@ import { ASSET_VERSION } from '../../../../common/constants';
 import { getProcessingPipelineName } from '../ingest_pipelines/name';
 import { getIndexTemplateName } from './name';
 
-export function generateIndexTemplate(name: string, isServerless: boolean) {
+export function generateIndexTemplate(name: string) {
   const composedOf = getAncestorsAndSelf(name).reduce((acc, ancestorName) => {
     return [...acc, `${ancestorName}@stream.layer`];
   }, [] as string[]);
@@ -27,7 +27,7 @@ export function generateIndexTemplate(name: string, isServerless: boolean) {
     },
     data_stream: {
       hidden: false,
-      failure_store: isServerless ? undefined : true, // TODO: Enable failure store for serverless once it is rolled out
+      failure_store: false,
     },
     template: {
       settings: {

--- a/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/streams/state_management/streams/wired_stream.ts
@@ -460,7 +460,7 @@ export class WiredStream extends StreamActiveRecord<Streams.WiredStream.Definiti
       },
       {
         type: 'upsert_index_template',
-        request: generateIndexTemplate(this._definition.name, this.dependencies.isServerless),
+        request: generateIndexTemplate(this._definition.name),
       },
       {
         type: 'upsert_datastream',


### PR DESCRIPTION
So far failure store was enabled for wired streams on stateful (which is not released yet). Until we know how the experience should look like, this PR disables failure store. Once we have a decision, we can enable it in a unified way for stateful and stateless, since both of these support failure store now.

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->