### PR TITLE
Add Deprecation for Enterprise Search Account Cleanups

### DIFF
--- a/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/deprecations/index.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
+import type { SecurityApiKey, SecurityGetUserResponse } from '@elastic/elasticsearch/lib/api/types';
 import { CloudSetup } from '@kbn/cloud-plugin/server';
 import { DeprecationsDetails } from '@kbn/core-deprecations-common';
 import { GetDeprecationsContext, RegisterDeprecationsConfig } from '@kbn/core-deprecations-server';
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 
 import { i18n } from '@kbn/i18n';
 import { Connector, fetchConnectors } from '@kbn/search-connectors';
@@ -22,11 +24,17 @@ export const getRegisteredDeprecations = (
   return {
     getDeprecations: async (ctx: GetDeprecationsContext) => {
       const entSearchDetails = getEnterpriseSearchNodeDeprecation(config, cloud, docsUrl);
-      const [crawlerDetails, nativeConnectorsDetails] = await Promise.all([
+      const [crawlerDetails, nativeConnectorsDetails, accountCleanups] = await Promise.all([
         getCrawlerDeprecations(ctx, docsUrl),
         getNativeConnectorDeprecations(ctx, docsUrl),
+        getEnterpriseSearchAccountCleanups(ctx, config),
       ]);
-      return [...entSearchDetails, ...crawlerDetails, ...nativeConnectorsDetails];
+      return [
+        ...entSearchDetails,
+        ...crawlerDetails,
+        ...nativeConnectorsDetails,
+        ...accountCleanups,
+      ];
     },
   };
 };
@@ -275,4 +283,122 @@ export async function getNativeConnectorDeprecations(
 
     return deprecations;
   }
+}
+
+export interface IEnterpriseSearchAccountCleanupAccounts {
+  esUser?: SecurityGetUserResponse;
+  credentialTokenIds: string[];
+  esCloudApiKeys: string[];
+}
+
+export const getEnterpriseSearchAccountCleanupAccounts = async (client: ElasticsearchClient) => {
+  const esUser = await client.security.getUser({ username: 'enterprise_search' });
+
+  const esCloudApiKeysResponse =
+    (await client.security.getApiKey({ username: 'cloud-internal-enterprise_search-server' }))
+      .api_keys || [];
+
+  const esCloudApiKeys = esCloudApiKeysResponse.map((apiKey: SecurityApiKey) => apiKey.id);
+
+  const esServerCredentials =
+    (await client.security.getServiceCredentials({
+      namespace: 'elastic',
+      service: 'enterprise-search-server',
+    })) || undefined;
+
+  const credentialTokenIds: string[] = [];
+  if (esServerCredentials) {
+    Object.entries(esServerCredentials.tokens).forEach(([tokenId]) => {
+      credentialTokenIds.push(tokenId);
+    });
+  }
+
+  return {
+    esUser,
+    credentialTokenIds,
+    esCloudApiKeys,
+  } as IEnterpriseSearchAccountCleanupAccounts;
+};
+
+export async function getEnterpriseSearchAccountCleanups(
+  ctx: GetDeprecationsContext,
+  config: ConfigType
+): Promise<DeprecationsDetails[]> {
+  if (config.host && config.host.length > 0) {
+    // if Enterprise Search is still configured, we can't clean up the accounts
+    return [];
+  }
+
+  const client = ctx.esClient.asCurrentUser;
+
+  const { esUser, credentialTokenIds, esCloudApiKeys } =
+    await getEnterpriseSearchAccountCleanupAccounts(client);
+
+  if (!esUser && credentialTokenIds.length === 0 && esCloudApiKeys.length === 0) {
+    return [];
+  }
+
+  let message =
+    'There are leftover accounts or credentials from the Enterprise Search service.' +
+    ' It is not necessary to remove or invalidate these items to proceed with the' +
+    ' upgrade, but it is recommended to do so for security reasons.\n\n';
+  const manualStepsToAdd = [];
+
+  if (esUser) {
+    message += "- Remove the 'enterprise_search' user account\n";
+    manualStepsToAdd.push(
+      "Remove the 'enterprise_search' user account via `DELETE /_security/user/enterprise_search`"
+    );
+  }
+
+  if (credentialTokenIds.length > 0) {
+    message += "- Invalidate any 'elastic/enterprise-search-server' service account credentials\n";
+    credentialTokenIds.forEach((tokenId: string) => {
+      manualStepsToAdd.push(
+        "Invalidate the 'elastic/enterprise-search-server' token '" +
+          tokenId +
+          "' via `DELETE /_security/service/elastic/enterprise-search-server/credential/token/" +
+          tokenId +
+          '`'
+      );
+    });
+  }
+
+  if (esCloudApiKeys.length > 0) {
+    message += "- Invalidate any 'cloud-internal-enterprise_search-server' API keys\n";
+    esCloudApiKeys.forEach((apiKey) => {
+      manualStepsToAdd.push(
+        "Invalidate the 'cloud-internal-enterprise_search-server' API key '" +
+          apiKey +
+          "' via `DELETE /_security/api_key` passing the API key id in the body"
+      );
+    });
+  }
+
+  message +=
+    "\n\nAlternatively, you can use the 'Quick resolve' button to remove these items automatically.";
+
+  const deprecation: DeprecationsDetails = {
+    level: 'warning',
+    deprecationType: 'feature',
+    title: i18n.translate('xpack.enterpriseSearch.deprecations.entsearchaccounts.title', {
+      defaultMessage: 'Enterprise Search user accounts and credentials should be removed',
+    }),
+    message: {
+      type: 'markdown',
+      content: i18n.translate('xpack.enterpriseSearch.deprecations.entsearchaccounts.message', {
+        defaultMessage: message,
+      }),
+    },
+    correctiveActions: {
+      manualSteps: manualStepsToAdd,
+      api: {
+        method: 'POST',
+        path: '/internal/enterprise_search/deprecations/clean_ent_search_accounts',
+        body: {},
+      },
+    },
+  };
+
+  return [deprecation];
 }

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
@@ -252,108 +252,121 @@ describe('POST /internal/enterprise_search/deprecations/clean_ent_search_account
     hasApiKeys: boolean;
   }
 
-  const cleanupTestCases = [
+  const cleanupTestCases: Array<[IEnterpriseSearchAccountCleanupAccounts, AccountCleanupExpected]> =
     [
-      {
-        esUser: {
-          enterprise_search: {
-            username: 'enterprise_search',
+      [
+        {
+          esUser: {
+            enterprise_search: {
+              username: 'enterprise_search',
+              metadata: {},
+              enabled: true,
+              roles: [],
+            },
           },
+          credentialTokenIds: ['test_token_id'],
+          esCloudApiKeys: ['test_api_key'],
         },
-        credentialTokenIds: ['test_token_id'],
-        esCloudApiKeys: ['test_api_key'],
-      },
-      {
-        hasUser: true,
-        hasCredentials: true,
-        hasApiKeys: true,
-      },
-    ],
-    [
-      {
-        esUser: undefined,
-        credentialTokenIds: ['test_token_id'],
-        esCloudApiKeys: ['test_api_key'],
-      },
-      {
-        hasUser: false,
-        hasCredentials: true,
-        hasApiKeys: true,
-      },
-    ],
-    [
-      {
-        esUser: undefined,
-        credentialTokenIds: [],
-        esCloudApiKeys: ['test_api_key'],
-      },
-      {
-        hasUser: false,
-        hasCredentials: false,
-        hasApiKeys: true,
-      },
-    ],
-    [
-      {
-        esUser: undefined,
-        credentialTokenIds: [],
-        esCloudApiKeys: [],
-      },
-      {
-        hasUser: false,
-        hasCredentials: false,
-        hasApiKeys: false,
-      },
-    ],
-    [
-      {
-        esUser: {
-          enterprise_search: {
-            username: 'enterprise_search',
+        {
+          hasUser: true,
+          hasCredentials: true,
+          hasApiKeys: true,
+        },
+      ],
+      [
+        {
+          esUser: undefined,
+          credentialTokenIds: ['test_token_id'],
+          esCloudApiKeys: ['test_api_key'],
+        },
+        {
+          hasUser: false,
+          hasCredentials: true,
+          hasApiKeys: true,
+        },
+      ],
+      [
+        {
+          esUser: undefined,
+          credentialTokenIds: [],
+          esCloudApiKeys: ['test_api_key'],
+        },
+        {
+          hasUser: false,
+          hasCredentials: false,
+          hasApiKeys: true,
+        },
+      ],
+      [
+        {
+          esUser: undefined,
+          credentialTokenIds: [],
+          esCloudApiKeys: [],
+        },
+        {
+          hasUser: false,
+          hasCredentials: false,
+          hasApiKeys: false,
+        },
+      ],
+      [
+        {
+          esUser: {
+            enterprise_search: {
+              username: 'enterprise_search',
+              metadata: {},
+              enabled: true,
+              roles: [],
+            },
           },
+          credentialTokenIds: [],
+          esCloudApiKeys: ['test_api_key'],
         },
-        credentialTokenIds: [],
-        esCloudApiKeys: ['test_api_key'],
-      },
-      {
-        hasUser: true,
-        hasCredentials: false,
-        hasApiKeys: true,
-      },
-    ],
-    [
-      {
-        esUser: {
-          enterprise_search: {
-            username: 'enterprise_search',
+        {
+          hasUser: true,
+          hasCredentials: false,
+          hasApiKeys: true,
+        },
+      ],
+      [
+        {
+          esUser: {
+            enterprise_search: {
+              username: 'enterprise_search',
+              metadata: {},
+              enabled: true,
+              roles: [],
+            },
           },
+          credentialTokenIds: [],
+          esCloudApiKeys: [],
         },
-        credentialTokenIds: [],
-        esCloudApiKeys: [],
-      },
-      {
-        hasUser: true,
-        hasCredentials: false,
-        hasApiKeys: false,
-      },
-    ],
-    [
-      {
-        esUser: {
-          enterprise_search: {
-            username: 'enterprise_search',
+        {
+          hasUser: true,
+          hasCredentials: false,
+          hasApiKeys: false,
+        },
+      ],
+      [
+        {
+          esUser: {
+            enterprise_search: {
+              username: 'enterprise_search',
+              metadata: {},
+              enabled: true,
+              roles: [],
+            },
           },
+          credentialTokenIds: ['test_token_id'],
+          esCloudApiKeys: [],
         },
-        credentialTokenIds: ['test_token_id'],
-        esCloudApiKeys: [],
-      },
-      {
-        hasUser: true,
-        hasCredentials: true,
-        hasApiKeys: false,
-      },
-    ],
-  ];
+        {
+          hasUser: true,
+          hasCredentials: true,
+          hasApiKeys: false,
+        },
+      ],
+    ];
 
   test.each(cleanupTestCases)(
     'should clean up accounts, credentials, and tokens for (%p): %p',

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
@@ -10,10 +10,25 @@ jest.mock('@kbn/search-connectors', () => ({
   putUpdateNative: jest.fn(),
 }));
 
+jest.mock('../../deprecations', () => ({
+  ...jest.requireActual('../../deprecations'),
+  getEnterpriseSearchAccountCleanupAccounts: jest.fn(),
+}));
+
 import { mockDependencies, MockRouter } from '../../__mocks__';
 
+import {
+  SecurityDeleteServiceTokenRequest,
+  SecurityDeleteUserRequest,
+  SecurityInvalidateApiKeyRequest,
+} from '@elastic/elasticsearch/lib/api/types';
 import { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 import { deleteConnectorById, putUpdateNative } from '@kbn/search-connectors';
+
+import {
+  getEnterpriseSearchAccountCleanupAccounts,
+  IEnterpriseSearchAccountCleanupAccounts,
+} from '../../deprecations';
 
 import { registerDeprecationRoutes } from './deprecations';
 
@@ -178,4 +193,210 @@ describe('deprecation routes', () => {
       expect(updateNativeMock).toHaveBeenCalledWith(mockClient, 'baz', false);
     });
   });
+});
+
+describe('POST /internal/enterprise_search/deprecations/clean_ent_search_accounts', () => {
+  // const mockClient = {};
+  let mockRouter: MockRouter;
+  const mockedDeleteUser = jest.fn();
+  const mockedDeleteServiceCredentials = jest.fn();
+  const mockedInvalidateApiKey = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const currentUserMock = {
+      security: {
+        deleteUser: (request: SecurityDeleteUserRequest) => mockedDeleteUser(request),
+        deleteServiceToken: (request: SecurityDeleteServiceTokenRequest) =>
+          mockedDeleteServiceCredentials(request),
+        invalidateApiKey: (request: SecurityInvalidateApiKeyRequest) =>
+          mockedInvalidateApiKey(request),
+      },
+    };
+
+    const context = {
+      core: Promise.resolve({ elasticsearch: { client: { asCurrentUser: currentUserMock } } }),
+    } as jest.Mocked<RequestHandlerContext>;
+    mockRouter = new MockRouter({
+      context,
+      method: 'post',
+      path: '/internal/enterprise_search/deprecations/clean_ent_search_accounts',
+    });
+
+    registerDeprecationRoutes({
+      ...mockDependencies,
+      router: mockRouter.router,
+    });
+  });
+
+  it('should return OK with no items to clean up', async () => {
+    const request = {
+      body: { deprecationDetails: { domainId: 'enterpriseSearch' } },
+    };
+
+    mockRouter.shouldValidate(request);
+    getEnterpriseSearchAccountCleanupAccounts.mockResolvedValue({
+      esUser: undefined,
+      credentialTokenIds: [],
+      esCloudApiKeys: [],
+    });
+
+    await mockRouter.callRoute(request);
+    expect(mockRouter.response.ok).toHaveBeenCalledWith({
+      body: { success: true },
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+
+  interface AccountCleanupExpected {
+    hasUser: boolean;
+    hasCredentials: boolean;
+    hasApiKeys: boolean;
+  }
+
+  const cleanupTestCases = [
+    [
+      {
+        esUser: {
+          enterprise_search: {
+            username: 'enterprise_search',
+          },
+        },
+        credentialTokenIds: ['test_token_id'],
+        esCloudApiKeys: ['test_api_key'],
+      },
+      {
+        hasUser: true,
+        hasCredentials: true,
+        hasApiKeys: true,
+      },
+    ],
+    [
+      {
+        esUser: undefined,
+        credentialTokenIds: ['test_token_id'],
+        esCloudApiKeys: ['test_api_key'],
+      },
+      {
+        hasUser: false,
+        hasCredentials: true,
+        hasApiKeys: true,
+      },
+    ],
+    [
+      {
+        esUser: undefined,
+        credentialTokenIds: [],
+        esCloudApiKeys: ['test_api_key'],
+      },
+      {
+        hasUser: false,
+        hasCredentials: false,
+        hasApiKeys: true,
+      },
+    ],
+    [
+      {
+        esUser: undefined,
+        credentialTokenIds: [],
+        esCloudApiKeys: [],
+      },
+      {
+        hasUser: false,
+        hasCredentials: false,
+        hasApiKeys: false,
+      },
+    ],
+    [
+      {
+        esUser: {
+          enterprise_search: {
+            username: 'enterprise_search',
+          },
+        },
+        credentialTokenIds: [],
+        esCloudApiKeys: ['test_api_key'],
+      },
+      {
+        hasUser: true,
+        hasCredentials: false,
+        hasApiKeys: true,
+      },
+    ],
+    [
+      {
+        esUser: {
+          enterprise_search: {
+            username: 'enterprise_search',
+          },
+        },
+        credentialTokenIds: [],
+        esCloudApiKeys: [],
+      },
+      {
+        hasUser: true,
+        hasCredentials: false,
+        hasApiKeys: false,
+      },
+    ],
+    [
+      {
+        esUser: {
+          enterprise_search: {
+            username: 'enterprise_search',
+          },
+        },
+        credentialTokenIds: ['test_token_id'],
+        esCloudApiKeys: [],
+      },
+      {
+        hasUser: true,
+        hasCredentials: true,
+        hasApiKeys: false,
+      },
+    ],
+  ];
+
+  test.each(cleanupTestCases)(
+    'should clean up accounts, credentials, and tokens for (%p): %p',
+    async (mockData: IEnterpriseSearchAccountCleanupAccounts, expected: AccountCleanupExpected) => {
+      const request = {
+        body: { deprecationDetails: { domainId: 'enterpriseSearch' } },
+      };
+
+      mockRouter.shouldValidate(request);
+      getEnterpriseSearchAccountCleanupAccounts.mockResolvedValue(mockData);
+
+      await mockRouter.callRoute(request);
+
+      expect(getEnterpriseSearchAccountCleanupAccounts).toHaveBeenCalled();
+
+      if (expected.hasUser) {
+        expect(mockedDeleteUser).toHaveBeenCalledWith({ username: 'enterprise_search' });
+      } else {
+        expect(mockedDeleteUser).not.toHaveBeenCalled();
+      }
+
+      if (expected.hasCredentials) {
+        expect(mockedDeleteServiceCredentials).toHaveBeenCalledWith({
+          namespace: 'elastic',
+          service: 'enterprise-search-server',
+          name: 'test_token_id',
+        });
+      } else {
+        expect(mockedDeleteServiceCredentials).not.toHaveBeenCalled();
+      }
+
+      if (expected.hasApiKeys) {
+        expect(mockedInvalidateApiKey).toHaveBeenCalledWith({ id: 'test_api_key' });
+      } else {
+        expect(mockedInvalidateApiKey).not.toHaveBeenCalled();
+      }
+
+      expect(mockRouter.response.ok).toHaveBeenCalledWith({
+        body: { success: true },
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+  );
 });

--- a/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
+++ b/x-pack/solutions/search/plugins/enterprise_search/server/routes/enterprise_search/deprecations.test.ts
@@ -10,9 +10,11 @@ jest.mock('@kbn/search-connectors', () => ({
   putUpdateNative: jest.fn(),
 }));
 
+const mockGetEnterpriseSearchAccountCleanupAccounts = jest.fn();
+
 jest.mock('../../deprecations', () => ({
   ...jest.requireActual('../../deprecations'),
-  getEnterpriseSearchAccountCleanupAccounts: jest.fn(),
+  getEnterpriseSearchAccountCleanupAccounts: () => mockGetEnterpriseSearchAccountCleanupAccounts(),
 }));
 
 import { mockDependencies, MockRouter } from '../../__mocks__';
@@ -25,10 +27,7 @@ import {
 import { RequestHandlerContext } from '@kbn/core-http-request-handler-context-server';
 import { deleteConnectorById, putUpdateNative } from '@kbn/search-connectors';
 
-import {
-  getEnterpriseSearchAccountCleanupAccounts,
-  IEnterpriseSearchAccountCleanupAccounts,
-} from '../../deprecations';
+import { IEnterpriseSearchAccountCleanupAccounts } from '../../deprecations';
 
 import { registerDeprecationRoutes } from './deprecations';
 
@@ -196,7 +195,6 @@ describe('deprecation routes', () => {
 });
 
 describe('POST /internal/enterprise_search/deprecations/clean_ent_search_accounts', () => {
-  // const mockClient = {};
   let mockRouter: MockRouter;
   const mockedDeleteUser = jest.fn();
   const mockedDeleteServiceCredentials = jest.fn();
@@ -235,7 +233,7 @@ describe('POST /internal/enterprise_search/deprecations/clean_ent_search_account
     };
 
     mockRouter.shouldValidate(request);
-    getEnterpriseSearchAccountCleanupAccounts.mockResolvedValue({
+    mockGetEnterpriseSearchAccountCleanupAccounts.mockResolvedValue({
       esUser: undefined,
       credentialTokenIds: [],
       esCloudApiKeys: [],
@@ -365,11 +363,11 @@ describe('POST /internal/enterprise_search/deprecations/clean_ent_search_account
       };
 
       mockRouter.shouldValidate(request);
-      getEnterpriseSearchAccountCleanupAccounts.mockResolvedValue(mockData);
+      mockGetEnterpriseSearchAccountCleanupAccounts.mockResolvedValue(mockData);
 
       await mockRouter.callRoute(request);
 
-      expect(getEnterpriseSearchAccountCleanupAccounts).toHaveBeenCalled();
+      expect(mockGetEnterpriseSearchAccountCleanupAccounts).toHaveBeenCalled();
 
       if (expected.hasUser) {
         expect(mockedDeleteUser).toHaveBeenCalledWith({ username: 'enterprise_search' });


### PR DESCRIPTION
## Summary

This PR adds an additional deprecation for 8.x for Enterprise Search that emits a warning if the user has leftover system accounts, tokens, and api keys from Enterprise Search. Although keeping these items will not affect any functionality in 9.x, it _might_ be a security risk to not remove these items.

The flyout from deprecation contains manual instructions as well as a "quick resolve" button to have Kibana automagically remove the items for the user.

![image](https://github.com/user-attachments/assets/1faaaab8-ba68-4e4d-89de-fc537e737261)

![image](https://github.com/user-attachments/assets/9409d0ae-72bd-4736-807b-d3d86451a007)


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
