### PR TITLE
[Fleet] Fix type error for input package policy

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
+++ b/x-pack/platform/plugins/shared/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_panel.tsx
@@ -197,7 +197,7 @@ export const PackagePolicyInputPanel: React.FunctionComponent<{
             {showTopLevelDescription && (
               <EuiText size="s" color="subdued">
                 <ReactMarkdown>
-                  {String(inputStreams[0].packageInputStream.description)}
+                  {String(inputStreams[0]?.packageInputStream?.description)}
                 </ReactMarkdown>
               </EuiText>
             )}


### PR DESCRIPTION
## Summary

Fix a type error with input package policy introduced in https://github.com/elastic/kibana/pull/219287

You reproduce this by trying to add the `fim` integration 

<img width="1297" alt="Screenshot 2025-05-23 at 3 00 31 PM" src="https://github.com/user-attachments/assets/ce76b89f-7d2b-4872-9042-5bbcab961b9a" />
<img width="902" alt="Screenshot 2025-05-23 at 3 00 36 PM" src="https://github.com/user-attachments/assets/171fccee-c7eb-4c95-b04e-dcd45f404a5f" />

