### PR TITLE
[8.17] [canvas] fix embeddables not refreshing on manual refresh or auto-refresh (#221326)

### DIFF
--- a/x-pack/platform/plugins/private/canvas/public/components/hooks/use_canvas_api.tsx
+++ b/x-pack/platform/plugins/private/canvas/public/components/hooks/use_canvas_api.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { BehaviorSubject, Subject, of } from 'rxjs';
+
+import { SerializedPanelState, ViewMode } from '@kbn/presentation-publishing';
+
+import { embeddableInputToExpression } from '../../../canvas_plugin_src/renderers/embeddable/embeddable_input_to_expression';
+import { CanvasContainerApi } from '../../../types';
+import { METRIC_TYPE, trackCanvasUiMetric } from '../../lib/ui_metric';
+// @ts-expect-error unconverted file
+import { addElement } from '../../state/actions/elements';
+import { getSelectedPage } from '../../state/selectors/workpad';
+import { CANVAS_APP } from '../../../common/lib';
+import { coreServices } from '../../services/kibana_services';
+
+const reload$ = new Subject<void>();
+
+export function forceReload() {
+  reload$.next();
+}
+
+export const useCanvasApi: () => CanvasContainerApi = () => {
+  const selectedPageId = useSelector(getSelectedPage);
+  const dispatch = useDispatch();
+
+  const createNewEmbeddable = useCallback(
+    (type: string, embeddableInput: object) => {
+      if (trackCanvasUiMetric) {
+        trackCanvasUiMetric(METRIC_TYPE.CLICK, type);
+      }
+      if (embeddableInput) {
+        const expression = embeddableInputToExpression(embeddableInput, type, undefined, true);
+        dispatch(addElement(selectedPageId, { expression }));
+      }
+    },
+    [selectedPageId, dispatch]
+  );
+
+  const getCanvasApi = useCallback((): CanvasContainerApi => {
+    const panelStateMap: Record<string, BehaviorSubject<SerializedPanelState<object>>> = {};
+
+    function getSerializedStateForChild(childId: string) {
+      return panelStateMap[childId]?.value ?? { rawState: {} };
+    }
+
+    return {
+      getAppContext: () => ({
+        getCurrentPath: () => {
+          const urlToApp = coreServices.application.getUrlForApp(CANVAS_APP);
+          const inAppPath = window.location.pathname.replace(urlToApp, '');
+          return inAppPath + window.location.search + window.location.hash;
+        },
+        currentAppId: CANVAS_APP,
+      }),
+      reload$,
+      viewMode$: new BehaviorSubject<ViewMode>('edit'), // always in edit mode
+      addNewPanel: async ({
+        panelType,
+        serializedState,
+      }: {
+        panelType: string;
+        serializedState: SerializedPanelState<object>;
+      }) => {
+        createNewEmbeddable(panelType, serializedState.rawState);
+      },
+      disableTriggers: true,
+      // this is required to disable inline editing now enabled by default
+      canEditInline: false,
+      type: 'canvas',
+      getSerializedStateForChild,
+      lastSavedStateForChild$: (childId: string) => panelStateMap[childId] ?? of(undefined),
+      // Canvas auto saves so lastSavedState is the same as currentState
+      getLastSavedStateForChild: getSerializedStateForChild,
+      setSerializedStateForChild: (
+        childId: string,
+        serializePanelState: SerializedPanelState<object>
+      ) => {
+        if (!panelStateMap[childId]) {
+          panelStateMap[childId] = new BehaviorSubject(serializePanelState);
+          return;
+        }
+        panelStateMap[childId].next(serializePanelState);
+      },
+    } as CanvasContainerApi;
+  }, [createNewEmbeddable]);
+
+  return useMemo(() => getCanvasApi(), [getCanvasApi]);
+};

--- a/x-pack/plugins/canvas/public/components/workpad/workpad_shortcuts.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad/workpad_shortcuts.component.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { Shortcuts } from 'react-shortcuts';
 import { isTextInput } from '../../lib/is_text_input';
 import { Props } from './workpad.component';
+import { forceReload } from '../hooks/use_canvas_api';
 
 type ShortcutProps = Pick<
   Props,
@@ -69,7 +70,10 @@ export class WorkpadShortcuts extends React.Component<ShortcutProps> {
 
   // handle keypress events for editor events
   _keyMap: Shortcuts = {
-    REFRESH: this.props.fetchAllRenderables,
+    REFRESH: () => {
+      forceReload();
+      this.props.fetchAllRenderables();
+    },
     UNDO: this.props.undoHistory,
     REDO: this.props.redoHistory,
     GRID: () => this.props.setGrid(!this.props.grid),

--- a/x-pack/plugins/canvas/public/components/workpad_header/fullscreen_control/fullscreen_control.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/fullscreen_control/fullscreen_control.tsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 // @ts-expect-error no @types definition
 import { Shortcuts } from 'react-shortcuts';
 import { isTextInput } from '../../../lib/is_text_input';
+import { forceReload } from '../../hooks/use_canvas_api';
 
 interface ChildrenProps {
   isFullscreen: boolean;
@@ -64,7 +65,10 @@ export class FullscreenControl extends React.PureComponent<Props> {
 
   // handle keypress events for presentation events
   _keyMap: { [key: string]: (...args: any[]) => void } = {
-    REFRESH: this.props.fetchAllRenderables,
+    REFRESH: () => {
+      forceReload();
+      this.props.fetchAllRenderables();
+    },
     PREV: this.previousPage,
     NEXT: this.nextPage,
     FULLSCREEN: this._toggleFullscreen,

--- a/x-pack/plugins/canvas/public/components/workpad_header/refresh_control/refresh_control.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/refresh_control/refresh_control.component.tsx
@@ -15,7 +15,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchAllRenderables } from '../../../state/actions/elements';
 import { getInFlight } from '../../../state/selectors/resolved_args';
 import { ToolTipShortcut } from '../../tool_tip_shortcut';
-import { useCanvasApi } from '../../hooks/use_canvas_api';
+import { forceReload } from '../../hooks/use_canvas_api';
 
 const strings = {
   getRefreshAriaLabel: () =>
@@ -31,11 +31,10 @@ const strings = {
 export const RefreshControl = () => {
   const dispatch = useDispatch();
   const inFlight = useSelector(getInFlight);
-  const canvasApi = useCanvasApi();
   const doRefresh = useCallback(() => {
-    canvasApi.reload();
+    forceReload();
     dispatch(fetchAllRenderables());
-  }, [canvasApi, dispatch]);
+  }, [dispatch]);
 
   return (
     <EuiToolTip

--- a/x-pack/plugins/canvas/public/components/workpad_header/view_menu/view_menu.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/view_menu/view_menu.tsx
@@ -25,6 +25,7 @@ import {
 import { WorkpadRoutingContext } from '../../../routes/workpad';
 import { ViewMenu as Component, Props as ComponentProps } from './view_menu.component';
 import { getFitZoomScale } from './lib/get_fit_zoom_scale';
+import { forceReload } from '../../hooks/use_canvas_api';
 
 interface StateProps {
   zoomScale: number;
@@ -61,7 +62,10 @@ const mapStateToProps = (state: State) => {
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   setZoomScale: (scale: number) => dispatch(setZoomScale(scale)),
   setWriteable: (isWorkpadWriteable: boolean) => dispatch(setWriteable(isWorkpadWriteable)),
-  doRefresh: () => dispatch(fetchAllRenderables()),
+  doRefresh: () => {
+    forceReload();
+    dispatch(fetchAllRenderables());
+  },
 });
 
 const mergeProps = (

--- a/x-pack/plugins/canvas/public/routes/workpad/hooks/use_refresh_helper.ts
+++ b/x-pack/plugins/canvas/public/routes/workpad/hooks/use_refresh_helper.ts
@@ -11,6 +11,7 @@ import { WorkpadRoutingContext } from '../workpad_routing_context';
 import { getInFlight } from '../../../state/selectors/resolved_args';
 // @ts-expect-error untyped local
 import { fetchAllRenderables } from '../../../state/actions/elements';
+import { forceReload } from '../../../components/hooks/use_canvas_api';
 
 export const useRefreshHelper = () => {
   const dispatch = useDispatch();
@@ -25,6 +26,7 @@ export const useRefreshHelper = () => {
 
     if (refreshInterval > 0 && !inFlight) {
       timer.current = window.setTimeout(() => {
+        forceReload();
         dispatch(fetchAllRenderables());
       }, refreshInterval);
     }

--- a/x-pack/plugins/canvas/types/embeddables.ts
+++ b/x-pack/plugins/canvas/types/embeddables.ts
@@ -30,6 +30,4 @@ export type CanvasContainerApi = PublishesViewMode &
   HasType &
   HasSerializedChildState &
   PublishesReload &
-  Partial<HasAppContext & PublishesUnifiedSearch> & {
-    reload: () => void;
-  };
+  Partial<HasAppContext & PublishesUnifiedSearch>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[canvas] fix embeddables not refreshing on manual refresh or auto-refresh (#221326)](https://github.com/elastic/kibana/pull/221326)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nathan Reese","email":"reese.nathan@elastic.co"},"sourceCommit":{"committedDate":"2025-05-23T18:35:26Z","message":"[canvas] fix embeddables not refreshing on manual refresh or auto-refresh (#221326)\n\nFixes https://github.com/elastic/kibana/issues/221321\n\n### test instructions\n1) install sample web logs\n2) import canvas saved object\nhttps://github.com/nreese/notes/blob/master/empty-canvas-workpad-saved-object-export.ndjson\n3) refresh kibana\n4) open canvas and add map embeddable\n5) open browser network tab\n6) click \"Refresh data\" button. Verify map requests new data\n7) open \"View\" menu. Click \"Refresh data\". Verify map requests new data\n8) set auto internal to \"5s\". Verify map requests new data on each\ninterval\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e937e916972eab34d90f327263d6522638a3b741","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Presentation","backport:version","v9.1.0","v8.19.0","v9.0.3","v8.18.3","v8.17.8"],"title":"[canvas] fix embeddables not refreshing on manual refresh or auto-refresh","number":221326,"url":"https://github.com/elastic/kibana/pull/221326","mergeCommit":{"message":"[canvas] fix embeddables not refreshing on manual refresh or auto-refresh (#221326)\n\nFixes https://github.com/elastic/kibana/issues/221321\n\n### test instructions\n1) install sample web logs\n2) import canvas saved object\nhttps://github.com/nreese/notes/blob/master/empty-canvas-workpad-saved-object-export.ndjson\n3) refresh kibana\n4) open canvas and add map embeddable\n5) open browser network tab\n6) click \"Refresh data\" button. Verify map requests new data\n7) open \"View\" menu. Click \"Refresh data\". Verify map requests new data\n8) set auto internal to \"5s\". Verify map requests new data on each\ninterval\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e937e916972eab34d90f327263d6522638a3b741"}},"sourceBranch":"main","suggestedTargetBranches":["8.19","9.0","8.18","8.17"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221326","number":221326,"mergeCommit":{"message":"[canvas] fix embeddables not refreshing on manual refresh or auto-refresh (#221326)\n\nFixes https://github.com/elastic/kibana/issues/221321\n\n### test instructions\n1) install sample web logs\n2) import canvas saved object\nhttps://github.com/nreese/notes/blob/master/empty-canvas-workpad-saved-object-export.ndjson\n3) refresh kibana\n4) open canvas and add map embeddable\n5) open browser network tab\n6) click \"Refresh data\" button. Verify map requests new data\n7) open \"View\" menu. Click \"Refresh data\". Verify map requests new data\n8) set auto internal to \"5s\". Verify map requests new data on each\ninterval\n\n---------\n\nCo-authored-by: Elastic Machine <elasticmachine@users.noreply.github.com>","sha":"e937e916972eab34d90f327263d6522638a3b741"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.0","label":"v9.0.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.18","label":"v8.18.3","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.17","label":"v8.17.8","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->