### PR TITLE
[9.0] Upgrading all undicis (#221445)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -30073,12 +30073,7 @@ undici@^5.28.3:
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
-undici@^6.12.0:
-  version "6.21.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
-  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
-
-undici@^6.21.1:
+undici@^6.12.0, undici@^6.21.1:
   version "6.21.3"
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.3.tgz#185752ad92c3d0efe7a7d1f6854a50f83b552d7a"
   integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -30067,9 +30067,9 @@ undici-types@~5.26.4:
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici@^5.28.3:
-  version "5.28.4"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
-  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
+  version "5.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.29.0.tgz#419595449ae3f2cdcba3580a2e8903399bd1f5a3"
+  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
   dependencies:
     "@fastify/busboy" "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30073,10 +30073,15 @@ undici@^5.28.3:
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
-undici@^6.12.0, undici@^6.21.1:
+undici@^6.12.0:
   version "6.21.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
   integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
+
+undici@^6.21.1:
+  version "6.21.3"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.3.tgz#185752ad92c3d0efe7a7d1f6854a50f83b552d7a"
+  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
 unherit@^1.0.4:
   version "1.1.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Upgrading all undicis (#221445)](https://github.com/elastic/kibana/pull/221445)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Kurt","email":"kc13greiner@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-24T00:27:45Z","message":"Upgrading all undicis (#221445)\n\n## Summary\n\nUpgrade `undici`:\n\n1. `v5.28.5` to `v5.29.0`\n2. `v6.21.1` to `v6.21.3`\n3. `v7.3.0` to `v7.5.0`","sha":"1b990c9705c3b38855412fa3f79ca9771ef106d0","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Security","release_note:skip","backport:all-open","v9.1.0"],"title":"Upgrading all undicis","number":221445,"url":"https://github.com/elastic/kibana/pull/221445","mergeCommit":{"message":"Upgrading all undicis (#221445)\n\n## Summary\n\nUpgrade `undici`:\n\n1. `v5.28.5` to `v5.29.0`\n2. `v6.21.1` to `v6.21.3`\n3. `v7.3.0` to `v7.5.0`","sha":"1b990c9705c3b38855412fa3f79ca9771ef106d0"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221445","number":221445,"mergeCommit":{"message":"Upgrading all undicis (#221445)\n\n## Summary\n\nUpgrade `undici`:\n\n1. `v5.28.5` to `v5.29.0`\n2. `v6.21.1` to `v6.21.3`\n3. `v7.3.0` to `v7.5.0`","sha":"1b990c9705c3b38855412fa3f79ca9771ef106d0"}}]}] BACKPORT-->