### PR TITLE
Stateful Deployment-Agnostic FTR Config for AI Assistant

### DIFF
--- a/.buildkite/ftr_oblt_stateful_configs.yml
+++ b/.buildkite/ftr_oblt_stateful_configs.yml
@@ -48,3 +48,4 @@ enabled:
   # stateful configs that run deployment-agnostic tests
   - x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.stateful.config.ts
   - x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.apm.stateful.config.ts
+  - x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.ai_assistant.stateful.config.ts

--- a/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.ai_assistant.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.ai_assistant.index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext) {
+  describe('Stateful Observability - Deployment-agnostic AI Assistant API integration tests', function () {
+    loadTestFile(require.resolve('../../apis/observability/ai_assistant'));
+  });
+}

--- a/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.ai_assistant.stateful.config.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.ai_assistant.stateful.config.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createStatefulTestConfig } from '../../default_configs/stateful.config.base';
+
+export default createStatefulTestConfig({
+  testFiles: [require.resolve('./oblt.ai_assistant.index.ts')],
+  junit: {
+    reportName: 'Stateful Observability - Deployment-agnostic API Integration Tests',
+  },
+});

--- a/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.index.ts
+++ b/x-pack/test/api_integration/deployment_agnostic/configs/stateful/oblt.index.ts
@@ -15,7 +15,6 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('../../apis/observability/slo'));
     loadTestFile(require.resolve('../../apis/observability/synthetics'));
     loadTestFile(require.resolve('../../apis/observability/infra'));
-    loadTestFile(require.resolve('../../apis/observability/ai_assistant'));
     loadTestFile(require.resolve('../../apis/observability/streams'));
     loadTestFile(require.resolve('../../apis/observability/onboarding'));
     loadTestFile(require.resolve('../../apis/observability/incident_management'));


### PR DESCRIPTION
Closes [#221468](https://github.com/elastic/kibana/issues/221468)

## Summary

Create a Dedicated Stateful Deployment-Agnostic FTR Config for AI Assistant
