### PR TITLE
[Documentation] The setting server.publicBaseUrl should be flagged as available in Cloud

### DIFF
--- a/docs/reference/configuration-reference/general-settings.md
+++ b/docs/reference/configuration-reference/general-settings.md
@@ -306,7 +306,7 @@ $$$server-basePath$$$ `server.basePath`
 :   Specifies the default route when opening Kibana. You can use this setting to modify the landing page when opening Kibana.
 % TBD: Applicable only to Elastic Cloud?
 
-$$$server-publicBaseUrl$$$ `server.publicBaseUrl`
+$$$server-publicBaseUrl$$$ `server.publicBaseUrl` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on {{ech}}")
 :   The publicly available URL that end-users access Kibana at. Must include the protocol, hostname, port (if different than the defaults for `http` and `https`, 80 and 443 respectively), and the [`server.basePath`](#server-basePath) (when that setting is configured explicitly). This setting cannot end in a slash (`/`).
 
 $$$server-compression$$$ `server.compression.enabled`


### PR DESCRIPTION
The setting server.publicBaseUrl should be flagged as available in Cloud

The setting server.publicBaseUrl can be set on ECH, but the documentation is not reflecting this.


This is especially useful if the users of the platform configured private [Private Link Traffic Filters] https://www.elastic.co/docs/deploy-manage/security/private-link-traffic-filters.

This setting is used to generate Kibana Links.

## Summary

Add the cloud icon to the setting `server.publicBaseUrl`


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Not that I am aware of..



