### PR TITLE
[Maps] mapColorGradient styles migration to emotion

### DIFF
--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/_index.scss
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/_index.scss
@@ -1,4 +1,3 @@
-@import 'heatmap/components/legend/color_gradient';
 @import 'vector/components/style_prop_editor';
 @import 'vector/components/color/color_stops';
 @import 'vector/components/symbol/icon_select';

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/components/legend/_color_gradient.scss
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/components/legend/_color_gradient.scss
@@ -1,13 +1,3 @@
-.mapColorGradient {
-  width: 100%;
-  height: $euiSizeXS;
-  position: relative;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-
 .mapFillableCircle {
   overflow: visible;
 }

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/components/legend/_color_gradient.scss
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/components/legend/_color_gradient.scss
@@ -1,3 +1,0 @@
-.mapFillableCircle {
-  overflow: visible;
-}

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/components/legend/color_gradient.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/components/legend/color_gradient.tsx
@@ -6,15 +6,35 @@
  */
 
 import React from 'react';
+import { UseEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { useMemoizedStyles } from '@kbn/core/public';
 import { getColorPalette, getLinearGradient } from '../../../color_palettes';
 
 interface Props {
   colorPaletteId: string;
 }
 
+const componentStyles = {
+  mapColorGradientStyles: ({ euiTheme }: UseEuiTheme) =>
+    css({
+      width: '100%',
+      height: euiTheme.size.xs,
+      position: 'relative',
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    }),
+};
 export const ColorGradient = ({ colorPaletteId }: Props) => {
   const palette = getColorPalette(colorPaletteId);
+  const styles = useMemoizedStyles(componentStyles);
   return palette.length ? (
-    <div className="mapColorGradient" style={{ background: getLinearGradient(palette) }} />
+    <div
+      className="mapColorGradient"
+      css={styles.mapColorGradientStyles}
+      style={{ background: getLinearGradient(palette) }}
+    />
   ) : null;
 };

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/components/legend/color_gradient.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/heatmap/components/legend/color_gradient.tsx
@@ -31,10 +31,6 @@ export const ColorGradient = ({ colorPaletteId }: Props) => {
   const palette = getColorPalette(colorPaletteId);
   const styles = useMemoizedStyles(componentStyles);
   return palette.length ? (
-    <div
-      className="mapColorGradient"
-      css={styles.mapColorGradientStyles}
-      style={{ background: getLinearGradient(palette) }}
-    />
+    <div css={styles.mapColorGradientStyles} style={{ background: getLinearGradient(palette) }} />
   ) : null;
 };

--- a/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/legend/circle_icon.tsx
+++ b/x-pack/platform/plugins/shared/maps/public/classes/styles/vector/components/legend/circle_icon.tsx
@@ -6,10 +6,14 @@
  */
 
 import React, { CSSProperties } from 'react';
+import { css } from '@emotion/react';
+
+const circleIconStyles = css({ overflow: 'visible' });
 
 export const CircleIcon = ({ style }: { style: CSSProperties }) => (
   <svg
-    className="euiIcon euiIcon--medium mapFillableCircle"
+    className="euiIcon euiIcon--medium"
+    css={circleIconStyles}
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"


### PR DESCRIPTION
Part of https://github.com/elastic/kibana/issues/207852

After migration to Emotion:
mapColorGradientStyles:
![Screenshot 2025-05-26 at 16 07 38](https://github.com/user-attachments/assets/994f26a0-adcb-4d87-af53-831bc1153547)

circleIconStyles:
![Screenshot 2025-05-26 at 16 07 09](https://github.com/user-attachments/assets/d6ba8cbc-1cf0-474b-a866-4a9a7ea043ef)
