### PR TITLE
[8.19] [Alert search bar] Replace the status filter with controls on the observability pages (#198495)

### DIFF
--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/filter_group.tsx
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/filter_group.tsx
@@ -59,6 +59,7 @@ export const FilterGroup = (props: PropsWithChildren<FilterGroupProps>) => {
     Storage,
     ruleTypeIds,
     storageKey,
+    disableLocalStorageSync = false,
   } = props;
 
   const filterChangedSubscription = useRef<Subscription>();
@@ -104,7 +105,7 @@ export const FilterGroup = (props: PropsWithChildren<FilterGroupProps>) => {
   } = useControlGroupSyncToLocalStorage({
     Storage,
     storageKey: localStoragePageFilterKey,
-    shouldSync: isViewMode,
+    shouldSync: !disableLocalStorageSync && isViewMode,
   });
 
   useEffect(() => {

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/types.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/types.ts
@@ -74,4 +74,5 @@ export interface FilterGroupProps extends Pick<ControlGroupRuntimeState, 'chaini
   ControlGroupRenderer: typeof ControlGroupRenderer;
   Storage: typeof Storage;
   storageKey?: string;
+  disableLocalStorageSync?: boolean;
 }

--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/index.ts
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/common/hooks/index.ts
@@ -8,6 +8,7 @@
  */
 
 export * from './use_alerts_data_view';
+export * from './use_fetch_alerts_index_names_query';
 export * from './use_get_alerts_group_aggregations_query';
 export * from './use_health_check';
 export * from './use_load_alerting_framework_health';

--- a/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_overview/alerts_table.cy.ts
+++ b/x-pack/solutions/observability/plugins/apm/ftr_e2e/cypress/e2e/service_overview/alerts_table.cy.ts
@@ -36,14 +36,19 @@ describe('Errors table', () => {
   });
 
   it('Alerts table with the search bar is populated', () => {
+    const expectedControls = ['Statusactive 1', 'Rule', 'Group', 'Tags'];
+
     cy.visitKibana(serviceOverviewHref);
     cy.contains('opbeans-java');
-    cy.get('[data-test-subj="environmentFilter"] [data-test-subj="comboBoxSearchInput"]').should(
-      'have.value',
-      'All'
-    );
-    cy.contains('Active');
-    cy.contains('Recovered');
+    cy.get('[data-test-subj="control-frame-title"]')
+      .should('have.length', 4)
+      .each(($el, index) => {
+        cy.wrap($el)
+          .invoke('text')
+          .then((text) => {
+            expect(text.trim()).to.equal(expectedControls[index]);
+          });
+      });
     cy.getByTestSubj('globalQueryBar').should('exist');
   });
 });

--- a/x-pack/solutions/observability/plugins/apm/public/application/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/application/index.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ObservabilityRuleTypeRegistry } from '@kbn/observability-plugin/public';
 import type { AppMountParameters, CoreStart } from '@kbn/core/public';
 import { APP_WRAPPER_CLASS } from '@kbn/core/public';
@@ -62,6 +63,7 @@ export const renderApp = ({
     kibanaEnvironment,
     licensing: pluginsStart.licensing,
   };
+  const queryClient = new QueryClient();
 
   // render APM feedback link in global help menu
   setHelpExtension(coreStart);
@@ -82,11 +84,13 @@ export const renderApp = ({
           },
         }}
       >
-        <ApmAppRoot
-          apmPluginContextValue={apmPluginContextValue}
-          pluginsStart={pluginsStart}
-          apmServices={apmServices}
-        />
+        <QueryClientProvider client={queryClient}>
+          <ApmAppRoot
+            apmPluginContextValue={apmPluginContextValue}
+            pluginsStart={pluginsStart}
+            apmServices={apmServices}
+          />
+        </QueryClientProvider>
       </KibanaThemeProvider>
     </KibanaRenderContextProvider>,
     element

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/alerts_overview/index.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/alerts_overview/index.tsx
@@ -5,22 +5,22 @@
  * 2.0.
  */
 
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { ObservabilityAlertSearchBar } from '@kbn/observability-plugin/public';
-import type { AlertStatus } from '@kbn/observability-plugin/common/typings';
 import { EuiPanel, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
-import type { BoolQuery } from '@kbn/es-query';
+import type { BoolQuery, Filter } from '@kbn/es-query';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { ObservabilityAlertsTable } from '@kbn/observability-plugin/public';
+import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 import {
   APM_ALERTING_CONSUMERS,
   APM_ALERTING_RULE_TYPE_IDS,
 } from '../../../../common/alerting/config/apm_alerting_feature_ids';
 import type { ApmPluginStartDeps } from '../../../plugin';
 import { useAnyOfApmParams } from '../../../hooks/use_apm_params';
-import { SERVICE_NAME } from '../../../../common/es_fields/apm';
-import { getEnvironmentKuery } from '../../../../common/environment_filter_values';
+import { isEnvironmentDefined } from '../../../../common/environment_filter_values';
+import { SERVICE_ENVIRONMENT, SERVICE_NAME } from '../../../../common/es_fields/apm';
 import { push } from '../../shared/links/url_helpers';
 
 export const ALERT_STATUS_ALL = 'all';
@@ -29,44 +29,53 @@ export function AlertsOverview() {
   const history = useHistory();
   const {
     path: { serviceName },
-    query: { environment, rangeFrom, rangeTo, kuery, alertStatus },
+    query: { environment, rangeFrom, rangeTo, kuery },
   } = useAnyOfApmParams('/services/{serviceName}/alerts', '/mobile-services/{serviceName}/alerts');
   const { services } = useKibana<ApmPluginStartDeps>();
-  const [alertStatusFilter, setAlertStatusFilter] = useState<AlertStatus>(ALERT_STATUS_ALL);
+  const {
+    core: { http, notifications },
+  } = useApmPluginContext();
+  const [filterControls, setFilterControls] = useState<Filter[]>([]);
   const [esQuery, setEsQuery] = useState<{ bool: BoolQuery }>();
-
-  useEffect(() => {
-    if (alertStatus) {
-      setAlertStatusFilter(alertStatus as AlertStatus);
-    }
-  }, [alertStatus]);
 
   const {
     triggersActionsUi: { getAlertsSearchBar: AlertsSearchBar },
-    notifications,
-    data: {
-      query: {
-        timefilter: { timefilter: timeFilterService },
-      },
-    },
+    data,
+    dataViews,
+    spaces,
     uiSettings,
   } = services;
+  const {
+    query: {
+      timefilter: { timefilter: timeFilterService },
+    },
+  } = data;
 
   const useToasts = () => notifications!.toasts;
 
-  const apmQueries = useMemo(() => {
-    const environmentKuery = getEnvironmentKuery(environment);
-    let query = `${SERVICE_NAME}:${serviceName}`;
-
-    if (environmentKuery) {
-      query += ` AND ${environmentKuery}`;
-    }
-    return [
+  const apmFilters = useMemo(() => {
+    const filters: Filter[] = [
       {
-        query,
-        language: 'kuery',
+        query: {
+          match_phrase: {
+            [SERVICE_NAME]: serviceName,
+          },
+        },
+        meta: {},
       },
     ];
+
+    if (isEnvironmentDefined(environment)) {
+      filters.push({
+        query: {
+          match_phrase: {
+            [SERVICE_ENVIRONMENT]: environment,
+          },
+        },
+        meta: {},
+      });
+    }
+    return filters;
   }, [serviceName, environment]);
 
   const onKueryChange = useCallback(
@@ -85,15 +94,21 @@ export function AlertsOverview() {
               onRangeFromChange={(value) => push(history, { query: { rangeFrom: value } })}
               onRangeToChange={(value) => push(history, { query: { rangeTo: value } })}
               onKueryChange={onKueryChange}
-              defaultSearchQueries={apmQueries}
-              onStatusChange={setAlertStatusFilter}
+              defaultFilters={apmFilters}
+              filterControls={filterControls}
+              onFilterControlsChange={setFilterControls}
               onEsQueryChange={setEsQuery}
               rangeTo={rangeTo}
               rangeFrom={rangeFrom}
-              status={alertStatusFilter}
+              disableLocalStorageSync
               services={{
                 timeFilterService,
                 AlertsSearchBar,
+                http,
+                data,
+                dataViews,
+                notifications,
+                spaces,
                 useToasts,
                 uiSettings,
               }}

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/alert_search_bar.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/alert_search_bar.test.tsx
@@ -6,19 +6,28 @@
  */
 
 import React from 'react';
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
+import { Filter } from '@kbn/es-query';
 import { timefilterServiceMock } from '@kbn/data-plugin/public/query/timefilter/timefilter_service.mock';
 import { uiSettingsServiceMock } from '@kbn/core-ui-settings-browser-mocks';
 
-import { ObservabilityAlertSearchBarProps, Services } from './types';
-import { ObservabilityAlertSearchBar } from './alert_search_bar';
-import { render } from '../../utils/test_helper';
 import { OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES } from '../../../common/constants';
+import { kibanaStartMock } from '../../utils/kibana_react.mock';
+import { render } from '../../utils/test_helper';
+import { ObservabilityAlertSearchBar } from './alert_search_bar';
+import { ObservabilityAlertSearchBarProps, Services } from './types';
 
 const getAlertsSearchBarMock = jest.fn();
 const ALERT_SEARCH_BAR_DATA_TEST_SUBJ = 'alerts-search-bar';
+const ALERT_UUID = '413a9631-1a29-4344-a8b4-9a1dc23421ee';
 
 describe('ObservabilityAlertSearchBar', () => {
+  const { http, data, dataViews, notifications, spaces } = kibanaStartMock.startContract().services;
+  spaces.getActiveSpace = jest
+    .fn()
+    .mockImplementation(() =>
+      Promise.resolve({ id: 'space-id', name: 'space-name', disabledFeatures: [] })
+    );
   const renderComponent = (
     props: Partial<ObservabilityAlertSearchBarProps> = {},
     services: Partial<Services> = {}
@@ -27,12 +36,15 @@ describe('ObservabilityAlertSearchBar', () => {
       appName: 'testAppName',
       kuery: '',
       filters: [],
+      filterControls: [],
       onRangeFromChange: jest.fn(),
       onRangeToChange: jest.fn(),
       onKueryChange: jest.fn(),
       onStatusChange: jest.fn(),
       onEsQueryChange: jest.fn(),
       onFiltersChange: jest.fn(),
+      onControlConfigsChange: jest.fn(),
+      onFilterControlsChange: jest.fn(),
       setSavedQuery: jest.fn(),
       rangeTo: 'now',
       rangeFrom: 'now-15m',
@@ -44,6 +56,11 @@ describe('ObservabilityAlertSearchBar', () => {
           <div data-test-subj={ALERT_SEARCH_BAR_DATA_TEST_SUBJ} />
         ),
         useToasts: jest.fn(),
+        http,
+        data,
+        dataViews,
+        notifications,
+        spaces,
         ...services,
       },
       ...props,
@@ -78,81 +95,46 @@ describe('ObservabilityAlertSearchBar', () => {
     );
   });
 
-  it('should filter active alerts', async () => {
+  it('should include defaultFilters in es query', async () => {
     const mockedOnEsQueryChange = jest.fn();
     const mockedFrom = '2022-11-15T09:38:13.604Z';
     const mockedTo = '2022-11-15T09:53:13.604Z';
-
-    renderComponent({
-      onEsQueryChange: mockedOnEsQueryChange,
-      rangeFrom: mockedFrom,
-      rangeTo: mockedTo,
-      status: 'active',
-    });
-
-    expect(mockedOnEsQueryChange).toHaveBeenCalledWith({
-      bool: {
-        filter: [
-          {
-            bool: {
-              minimum_should_match: 1,
-              should: [{ match_phrase: { 'kibana.alert.status': 'active' } }],
-            },
-          },
-          {
-            range: {
-              'kibana.alert.time_range': expect.objectContaining({
-                format: 'strict_date_optional_time',
-                gte: mockedFrom,
-                lte: mockedTo,
-              }),
-            },
-          },
-        ],
-        must: [],
-        must_not: [],
-        should: [],
-      },
-    });
-  });
-
-  it('should include defaultSearchQueries in es query', async () => {
-    const mockedOnEsQueryChange = jest.fn();
-    const mockedFrom = '2022-11-15T09:38:13.604Z';
-    const mockedTo = '2022-11-15T09:53:13.604Z';
-    const defaultSearchQueries = [
+    const defaultFilters: Filter[] = [
       {
-        query: 'kibana.alert.rule.uuid: 413a9631-1a29-4344-a8b4-9a1dc23421ee',
-        language: 'kuery',
+        query: {
+          match_phrase: {
+            'kibana.alert.rule.uuid': ALERT_UUID,
+          },
+        },
+        meta: {},
       },
     ];
 
-    renderComponent({
-      onEsQueryChange: mockedOnEsQueryChange,
-      rangeFrom: mockedFrom,
-      rangeTo: mockedTo,
-      defaultSearchQueries,
-      status: 'all',
+    await act(async () => {
+      renderComponent({
+        onEsQueryChange: mockedOnEsQueryChange,
+        rangeFrom: mockedFrom,
+        rangeTo: mockedTo,
+        defaultFilters,
+        status: 'all',
+      });
     });
 
     const esQueryChangeParams = {
       bool: {
         filter: [
           {
-            bool: {
-              minimum_should_match: 1,
-              should: [
-                { match: { 'kibana.alert.rule.uuid': '413a9631-1a29-4344-a8b4-9a1dc23421ee' } },
-              ],
-            },
-          },
-          {
             range: {
               'kibana.alert.time_range': expect.objectContaining({
                 format: 'strict_date_optional_time',
                 gte: mockedFrom,
                 lte: mockedTo,
               }),
+            },
+          },
+          {
+            match_phrase: {
+              'kibana.alert.rule.uuid': ALERT_UUID,
             },
           },
         ],
@@ -161,9 +143,60 @@ describe('ObservabilityAlertSearchBar', () => {
         should: [],
       },
     };
-    expect(mockedOnEsQueryChange).toHaveBeenCalledTimes(2);
+    expect(mockedOnEsQueryChange).toHaveBeenCalledTimes(1);
     expect(mockedOnEsQueryChange).toHaveBeenNthCalledWith(1, esQueryChangeParams);
-    expect(mockedOnEsQueryChange).toHaveBeenNthCalledWith(2, esQueryChangeParams);
+  });
+
+  it('should include filterControls in es query', async () => {
+    const mockedOnEsQueryChange = jest.fn();
+    const mockedFrom = '2022-11-15T09:38:13.604Z';
+    const mockedTo = '2022-11-15T09:53:13.604Z';
+    const filterControls: Filter[] = [
+      {
+        query: {
+          match_phrase: {
+            'kibana.alert.rule.uuid': ALERT_UUID,
+          },
+        },
+        meta: {},
+      },
+    ];
+
+    await act(async () => {
+      renderComponent({
+        onEsQueryChange: mockedOnEsQueryChange,
+        rangeFrom: mockedFrom,
+        rangeTo: mockedTo,
+        filterControls,
+        status: 'all',
+      });
+    });
+
+    const esQueryChangeParams = {
+      bool: {
+        filter: [
+          {
+            range: {
+              'kibana.alert.time_range': expect.objectContaining({
+                format: 'strict_date_optional_time',
+                gte: mockedFrom,
+                lte: mockedTo,
+              }),
+            },
+          },
+          {
+            match_phrase: {
+              'kibana.alert.rule.uuid': ALERT_UUID,
+            },
+          },
+        ],
+        must: [],
+        must_not: [],
+        should: [],
+      },
+    };
+    expect(mockedOnEsQueryChange).toHaveBeenCalledTimes(1);
+    expect(mockedOnEsQueryChange).toHaveBeenNthCalledWith(1, esQueryChangeParams);
   });
 
   it('should include filters in es query', async () => {

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/alert_search_bar_with_url_sync.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/alert_search_bar_with_url_sync.tsx
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
+import { Filter } from '@kbn/es-query';
 import {
   alertSearchBarStateContainer,
   Provider,
@@ -20,22 +21,40 @@ import { useToasts } from '../../hooks/use_toast';
 function AlertSearchbarWithUrlSync(props: AlertSearchBarWithUrlSyncProps) {
   const { urlStorageKey, defaultState = DEFAULT_STATE, ...searchBarProps } = props;
   const stateProps = useAlertSearchBarStateContainer(urlStorageKey, undefined, defaultState);
+  const [filterControls, setFilterControls] = useState<Filter[]>([]);
   const {
-    data: {
-      query: {
-        timefilter: { timefilter: timeFilterService },
-      },
-    },
+    data,
     triggersActionsUi: { getAlertsSearchBar: AlertsSearchBar },
     uiSettings,
+    http,
+    dataViews,
+    spaces,
+    notifications,
   } = useKibana().services;
+  const {
+    query: {
+      timefilter: { timefilter: timeFilterService },
+    },
+  } = data;
 
   return (
     <ObservabilityAlertSearchBar
       {...stateProps}
       {...searchBarProps}
+      filterControls={filterControls}
+      onFilterControlsChange={setFilterControls}
       showFilterBar
-      services={{ timeFilterService, AlertsSearchBar, useToasts, uiSettings }}
+      services={{
+        timeFilterService,
+        AlertsSearchBar,
+        http,
+        data,
+        dataViews,
+        notifications,
+        spaces,
+        useToasts,
+        uiSettings,
+      }}
     />
   );
 }

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/constants.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/constants.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Query } from '@kbn/es-query';
+import { Filter } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import {
   ALERT_STATUS_ACTIVE,
@@ -16,7 +16,7 @@ import {
 import { AlertStatusFilter } from '../../../common/typings';
 import { ALERT_STATUS_ALL } from '../../../common/constants';
 
-export const DEFAULT_QUERIES: Query[] = [];
+export const EMPTY_FILTERS: Filter[] = [];
 export const DEFAULT_QUERY_STRING = '';
 
 export const ALL_ALERTS: AlertStatusFilter = {

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/state_container.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/state_container.tsx
@@ -5,14 +5,13 @@
  * 2.0.
  */
 
-import { Filter } from '@kbn/es-query';
 import { type FilterControlConfig } from '@kbn/alerts-ui-shared';
+import { Filter } from '@kbn/es-query';
 import {
   createStateContainer,
   createStateContainerReactHelpers,
 } from '@kbn/kibana-utils-plugin/public';
 import { AlertStatus } from '../../../../common/typings';
-import { ALL_ALERTS } from '../constants';
 import { AlertSearchBarContainerState } from '../types';
 
 interface AlertSearchBarStateTransitions {
@@ -46,7 +45,6 @@ const DEFAULT_STATE: AlertSearchBarContainerState = {
   rangeFrom: 'now-24h',
   rangeTo: 'now',
   kuery: '',
-  status: ALL_ALERTS.status,
   filters: [],
   groupings: [],
 };

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/use_alert_search_bar_state_container.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/use_alert_search_bar_state_container.tsx
@@ -10,7 +10,12 @@ import { pipe } from 'fp-ts/pipeable';
 import * as t from 'io-ts';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { ALERT_STATUS_ACTIVE, ALERT_STATUS_RECOVERED } from '@kbn/rule-data-utils';
+import { DEFAULT_CONTROLS } from '@kbn/alerts-ui-shared/src/alert_filter_controls/constants';
+import {
+  ALERT_STATUS_ACTIVE,
+  ALERT_STATUS_RECOVERED,
+  ALERT_STATUS_UNTRACKED,
+} from '@kbn/rule-data-utils';
 import { SavedQuery, TimefilterContract } from '@kbn/data-plugin/public';
 import {
   createKbnUrlStateStorage,
@@ -18,6 +23,7 @@ import {
   IKbnUrlStateStorage,
   useContainerSelector,
 } from '@kbn/kibana-utils-plugin/public';
+import { setStatusOnControlConfigs } from '../../../utils/alert_controls/set_status_on_control_configs';
 import { datemathStringRT } from '../../../utils/datemath';
 import { ALERT_STATUS_ALL } from '../../../../common/constants';
 import { useTimefilterService } from '../../../hooks/use_timefilter_service';
@@ -37,6 +43,7 @@ export const alertSearchBarState = t.partial({
     t.literal(ALERT_STATUS_ACTIVE),
     t.literal(ALERT_STATUS_RECOVERED),
     t.literal(ALERT_STATUS_ALL),
+    t.literal(ALERT_STATUS_UNTRACKED),
   ]),
   groupings: t.array(t.string),
 });
@@ -187,7 +194,9 @@ function initializeUrlAndStateContainer(
   const urlState = alertSearchBarState.decode(
     urlStateStorage.get<Partial<AlertSearchBarContainerState>>(urlStorageKey)
   );
-  const validUrlState = isRight(urlState) ? pipe(urlState).right : {};
+  const validUrlState: Partial<AlertSearchBarContainerState> = isRight(urlState)
+    ? pipe(urlState).right
+    : {};
   const timeFilterTime = timefilterService.getTime();
   const timeFilterState = timefilterService.isTimeTouched()
     ? {
@@ -195,6 +204,16 @@ function initializeUrlAndStateContainer(
         rangeTo: timeFilterTime.to,
       }
     : {};
+
+  // This part is for backward compatibility. Previously, we saved status in the status query
+  // parameter. Now, we save it in the controlConfigs.
+  if (validUrlState.status) {
+    validUrlState.controlConfigs = setStatusOnControlConfigs(
+      validUrlState.status,
+      validUrlState.controlConfigs ?? DEFAULT_CONTROLS
+    );
+    validUrlState.status = undefined;
+  }
 
   const currentState = {
     ...defaultState,

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/types.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/types.ts
@@ -6,11 +6,18 @@
  */
 
 import { ReactElement } from 'react';
-import { type FilterControlConfig } from '@kbn/alerts-ui-shared';
-import { ToastsStart } from '@kbn/core-notifications-browser';
-import { type SavedQuery, TimefilterContract } from '@kbn/data-plugin/public';
+import { type FilterControlConfig, FilterGroupHandler } from '@kbn/alerts-ui-shared';
+import type { HttpStart } from '@kbn/core-http-browser';
+import { type NotificationsStart, ToastsStart } from '@kbn/core-notifications-browser';
+import {
+  DataPublicPluginStart,
+  type SavedQuery,
+  TimefilterContract,
+} from '@kbn/data-plugin/public';
+import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { AlertsSearchBarProps } from '@kbn/triggers-actions-ui-plugin/public/application/sections/alerts_search_bar';
-import { BoolQuery, Filter, Query } from '@kbn/es-query';
+import { BoolQuery, Filter } from '@kbn/es-query';
 import type { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import { AlertStatus } from '../../../common/typings';
 export interface AlertStatusFilterProps {
@@ -21,6 +28,7 @@ export interface AlertStatusFilterProps {
 export interface AlertSearchBarWithUrlSyncProps extends CommonAlertSearchBarProps {
   urlStorageKey: string;
   defaultState?: AlertSearchBarContainerState;
+  disableLocalStorageSync?: boolean;
 }
 
 export interface Dependencies {
@@ -38,6 +46,11 @@ export interface Dependencies {
 export interface Services {
   timeFilterService: TimefilterContract;
   AlertsSearchBar: (props: AlertsSearchBarProps) => ReactElement<AlertsSearchBarProps>;
+  http: HttpStart;
+  data: DataPublicPluginStart;
+  dataViews: DataViewsPublicPluginStart;
+  notifications: NotificationsStart;
+  spaces?: SpacesPluginStart;
   useToasts: () => ToastsStart;
   uiSettings: IUiSettingsClient;
 }
@@ -46,16 +59,19 @@ export interface ObservabilityAlertSearchBarProps
   extends AlertSearchBarContainerState,
     AlertSearchBarStateTransitions,
     CommonAlertSearchBarProps {
-  showFilterBar?: boolean;
-  savedQuery?: SavedQuery;
   services: Services;
+  filterControls: Filter[];
+  onFilterControlsChange: (controlConfigs: Filter[]) => void;
+  savedQuery?: SavedQuery;
+  showFilterBar?: boolean;
+  disableLocalStorageSync?: boolean;
 }
 
 export interface AlertSearchBarContainerState {
   rangeFrom: string;
   rangeTo: string;
   kuery: string;
-  status: AlertStatus;
+  status?: AlertStatus;
   filters?: Filter[];
   savedQueryId?: string;
   controlConfigs?: FilterControlConfig[];
@@ -66,13 +82,15 @@ interface AlertSearchBarStateTransitions {
   onRangeFromChange: (rangeFrom: string) => void;
   onRangeToChange: (rangeTo: string) => void;
   onKueryChange: (kuery: string) => void;
-  onStatusChange: (status: AlertStatus) => void;
+  onStatusChange?: (status: AlertStatus) => void;
   onFiltersChange?: (filters: Filter[]) => void;
   setSavedQuery?: (savedQueryId?: SavedQuery) => void;
+  onControlConfigsChange?: (controlConfigs: FilterControlConfig[]) => void;
 }
 
 interface CommonAlertSearchBarProps {
   appName: string;
   onEsQueryChange: (query: { bool: BoolQuery }) => void;
-  defaultSearchQueries?: Query[];
+  defaultFilters?: Filter[];
+  onControlApiAvailable?: (controlGroupHandler: FilterGroupHandler | undefined) => void;
 }

--- a/x-pack/solutions/observability/plugins/observability/public/locators/rule_details.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/locators/rule_details.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { ACTIVE_ALERTS } from '../components/alert_search_bar/constants';
+import { ALERT_RULE_NAME, ALERT_STATUS } from '@kbn/rule-data-utils';
 import {
   RULE_DETAILS_EXECUTION_TAB,
   RULE_DETAILS_ALERTS_TAB,
@@ -37,7 +37,10 @@ describe('RuleDetailsLocator', () => {
       tabId: RULE_DETAILS_ALERTS_TAB,
     });
     expect(location.path).toEqual(
-      `${RULES_PATH}/${mockedRuleId}?tabId=alerts&searchBarParams=(kuery:'',rangeFrom:now-15m,rangeTo:now,status:all)`
+      `${RULES_PATH}/${mockedRuleId}?tabId=alerts&searchBarParams=(` +
+        `controlConfigs:!((fieldName:kibana.alert.status,hideActionBar:!t,hideExists:!t,persist:!t,selectedOptions:!(active)` +
+        `,title:Status),(fieldName:kibana.alert.rule.name,hideExists:!t,title:Rule),(fieldName:kibana.alert.group.value,title:Group)` +
+        `,(fieldName:tags,title:Tags)),kuery:'',rangeFrom:now-15m,rangeTo:now)`
     );
   });
 
@@ -48,10 +51,52 @@ describe('RuleDetailsLocator', () => {
       rangeFrom: 'mockedRangeTo',
       rangeTo: 'mockedRangeFrom',
       kuery: 'mockedKuery',
-      status: ACTIVE_ALERTS.status,
     });
     expect(location.path).toEqual(
-      `${RULES_PATH}/${mockedRuleId}?tabId=alerts&searchBarParams=(kuery:mockedKuery,rangeFrom:mockedRangeTo,rangeTo:mockedRangeFrom,status:active)`
+      `${RULES_PATH}/${mockedRuleId}?tabId=alerts&searchBarParams=(` +
+        `controlConfigs:!((fieldName:kibana.alert.status,hideActionBar:!t,hideExists:!t,persist:!t,selectedOptions:!(active)` +
+        `,title:Status),(fieldName:kibana.alert.rule.name,hideExists:!t,title:Rule),(fieldName:kibana.alert.group.value,title:Group)` +
+        `,(fieldName:tags,title:Tags)),kuery:mockedKuery,rangeFrom:mockedRangeTo,rangeTo:mockedRangeFrom)`
+    );
+  });
+
+  it('should return correct url when controlConfigs is provided', async () => {
+    const mockedControlConfigs = [
+      {
+        title: 'Status',
+        fieldName: ALERT_STATUS,
+        selectedOptions: ['untracked'],
+        hideActionBar: true,
+        persist: true,
+        hideExists: true,
+      },
+      {
+        title: 'Rule',
+        fieldName: ALERT_RULE_NAME,
+        hideExists: true,
+      },
+      {
+        title: 'Group',
+        fieldName: 'kibana.alert.group.value',
+      },
+      {
+        title: 'Tags',
+        fieldName: 'tags',
+      },
+    ];
+    const location = await locator.getLocation({
+      ruleId: mockedRuleId,
+      tabId: RULE_DETAILS_ALERTS_TAB,
+      rangeFrom: 'mockedRangeTo',
+      rangeTo: 'mockedRangeFrom',
+      kuery: 'mockedKuery',
+      controlConfigs: mockedControlConfigs,
+    });
+    expect(location.path).toEqual(
+      `${RULES_PATH}/${mockedRuleId}?tabId=alerts&searchBarParams=(` +
+        `controlConfigs:!((fieldName:kibana.alert.status,hideActionBar:!t,hideExists:!t,persist:!t,selectedOptions:!(untracked)` +
+        `,title:Status),(fieldName:kibana.alert.rule.name,hideExists:!t,title:Rule),(fieldName:kibana.alert.group.value,title:Group)` +
+        `,(fieldName:tags,title:Tags)),kuery:mockedKuery,rangeFrom:mockedRangeTo,rangeTo:mockedRangeFrom)`
     );
   });
 });

--- a/x-pack/solutions/observability/plugins/observability/public/locators/rule_details.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/locators/rule_details.ts
@@ -5,27 +5,28 @@
  * 2.0.
  */
 
+import type { FilterControlConfig } from '@kbn/alerts-ui-shared';
+import { DEFAULT_CONTROLS } from '@kbn/alerts-ui-shared/src/alert_filter_controls/constants';
 import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
 import type { SerializableRecord } from '@kbn/utility-types';
 import type { LocatorDefinition } from '@kbn/share-plugin/public';
 import { ruleDetailsLocatorID } from '../../common';
 import { RULES_PATH } from '../../common/locators/paths';
-import { ALL_ALERTS } from '../components/alert_search_bar/constants';
 import {
   RULE_DETAILS_ALERTS_TAB,
   RULE_DETAILS_EXECUTION_TAB,
   RULE_DETAILS_SEARCH_BAR_URL_STORAGE_KEY,
 } from '../pages/rule_details/constants';
 import type { TabId } from '../pages/rule_details/rule_details';
-import type { AlertStatus } from '../../common/typings';
 
+type RuleDetailsControlConfigs = Array<Omit<FilterControlConfig, 'sort'>>;
 export interface RuleDetailsLocatorParams extends SerializableRecord {
   ruleId: string;
   tabId?: TabId;
   rangeFrom?: string;
   rangeTo?: string;
   kuery?: string;
-  status?: AlertStatus;
+  controlConfigs?: RuleDetailsControlConfigs;
 }
 
 export const getRuleDetailsPath = (ruleId: string) => {
@@ -36,19 +37,19 @@ export class RuleDetailsLocatorDefinition implements LocatorDefinition<RuleDetai
   public readonly id = ruleDetailsLocatorID;
 
   public readonly getLocation = async (params: RuleDetailsLocatorParams) => {
-    const { ruleId, kuery, rangeTo, tabId, rangeFrom, status } = params;
+    const { controlConfigs, ruleId, kuery, rangeTo, tabId, rangeFrom } = params;
     const appState: {
       tabId?: TabId;
       rangeFrom?: string;
       rangeTo?: string;
       kuery?: string;
-      status?: AlertStatus;
+      controlConfigs?: RuleDetailsControlConfigs;
     } = {};
 
     appState.rangeFrom = rangeFrom || 'now-15m';
     appState.rangeTo = rangeTo || 'now';
     appState.kuery = kuery || '';
-    appState.status = status || ALL_ALERTS.status;
+    appState.controlConfigs = controlConfigs ?? DEFAULT_CONTROLS;
 
     let path = getRuleDetailsPath(ruleId);
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.test.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.test.tsx
@@ -40,6 +40,11 @@ mockUseKibanaReturnValue.services.application.capabilities = {
     show: true,
   },
 };
+mockUseKibanaReturnValue.services.spaces.getActiveSpace = jest
+  .fn()
+  .mockImplementation(() =>
+    Promise.resolve({ id: 'space-id', name: 'space-name', disabledFeatures: [] })
+  );
 
 const mockObservabilityAIAssistant = observabilityAIAssistantPluginMock.createStartContract();
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { BrushEndListener, XYBrushEvent } from '@elastic/charts';
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { BoolQuery, Filter } from '@kbn/es-query';
 import { usePerformanceContext } from '@kbn/ebt-tools';
 import { i18n } from '@kbn/i18n';
@@ -18,7 +18,6 @@ import { DEFAULT_APP_CATEGORIES } from '@kbn/core-application-common';
 import { AlertsGrouping } from '@kbn/alerts-grouping';
 
 import { rulesLocatorID } from '../../../common';
-import { ALERT_STATUS_FILTER } from '../../components/alert_search_bar/constants';
 import { renderGroupPanel } from '../../components/alerts_table/grouping/render_group_panel';
 import { getGroupStats } from '../../components/alerts_table/grouping/get_group_stats';
 import { getAggregationsByGroupingField } from '../../components/alerts_table/grouping/get_aggregations_by_grouping_field';
@@ -78,6 +77,7 @@ function InternalAlertsPage() {
     share: {
       url: { locators },
     },
+    spaces,
     triggersActionsUi: {
       getAlertsSearchBar: AlertsSearchBar,
       getAlertSummaryWidget: AlertSummaryWidget,
@@ -92,6 +92,7 @@ function InternalAlertsPage() {
     },
   } = data;
   const { ObservabilityPageTemplate } = usePluginContext();
+  const [filterControls, setFilterControls] = useState<Filter[]>([]);
   const alertSearchBarStateProps = useAlertSearchBarStateContainer(ALERTS_URL_STORAGE_KEY, {
     replace: false,
   });
@@ -277,9 +278,22 @@ function InternalAlertsPage() {
               {...alertSearchBarStateProps}
               appName={ALERTS_SEARCH_BAR_ID}
               onEsQueryChange={setEsQuery}
+              filterControls={filterControls}
+              onFilterControlsChange={setFilterControls}
               showFilterBar
-              services={{ timeFilterService, AlertsSearchBar, useToasts, uiSettings }}
+              services={{
+                timeFilterService,
+                AlertsSearchBar,
+                http,
+                data,
+                dataViews,
+                notifications,
+                spaces,
+                useToasts,
+                uiSettings,
+              }}
             />
+            <EuiSpacer size="s" />
           </EuiFlexItem>
           <EuiFlexItem>
             <AlertSummaryWidget
@@ -296,12 +310,12 @@ function InternalAlertsPage() {
               <AlertsGrouping<AlertsByGroupingAgg>
                 ruleTypeIds={OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES}
                 consumers={observabilityAlertFeatureIds}
-                defaultFilters={
-                  ALERT_STATUS_FILTER[alertSearchBarStateProps.status] ?? DEFAULT_FILTERS
-                }
                 from={alertSearchBarStateProps.rangeFrom}
                 to={alertSearchBarStateProps.rangeTo}
-                globalFilters={alertSearchBarStateProps.filters ?? DEFAULT_FILTERS}
+                globalFilters={[
+                  ...(alertSearchBarStateProps.filters ?? DEFAULT_FILTERS),
+                  ...filterControls,
+                ]}
                 globalQuery={{ query: alertSearchBarStateProps.kuery, language: 'kuery' }}
                 groupingId={ALERTS_PAGE_ALERTS_TABLE_CONFIG_ID}
                 defaultGroupingOptions={DEFAULT_GROUPING_OPTIONS}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/rule_details/components/rule_details_tabs.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/rule_details/components/rule_details_tabs.tsx
@@ -13,10 +13,11 @@ import {
   EuiTabbedContent,
   EuiTabbedContentTab,
 } from '@elastic/eui';
+import { FilterGroupHandler } from '@kbn/alerts-ui-shared';
 import { i18n } from '@kbn/i18n';
 import type { RuleTypeParams } from '@kbn/alerting-plugin/common';
 import type { Rule } from '@kbn/triggers-actions-ui-plugin/public';
-import type { Query, BoolQuery } from '@kbn/es-query';
+import type { BoolQuery, Filter } from '@kbn/es-query';
 import { ObservabilityAlertsTable } from '../../../components/alerts_table/alerts_table';
 import { observabilityAlertFeatureIds } from '../../../../common';
 import { useKibana } from '../../../utils/kibana_react';
@@ -44,6 +45,7 @@ interface Props {
   ruleType: any;
   onEsQueryChange: (query: { bool: BoolQuery }) => void;
   onSetTabId: (tabId: TabId) => void;
+  onControlApiAvailable?: (controlGroupHandler: FilterGroupHandler | undefined) => void;
 }
 
 const tableColumns = getColumns();
@@ -57,13 +59,21 @@ export function RuleDetailsTabs({
   ruleType,
   onSetTabId,
   onEsQueryChange,
+  onControlApiAvailable,
 }: Props) {
   const {
     triggersActionsUi: { getRuleEventLogList: RuleEventLogList },
   } = useKibana().services;
 
-  const ruleQuery = useRef<Query[]>([
-    { query: `kibana.alert.rule.uuid: ${ruleId}`, language: 'kuery' },
+  const ruleFilters = useRef<Filter[]>([
+    {
+      query: {
+        match_phrase: {
+          'kibana.alert.rule.uuid': ruleId,
+        },
+      },
+      meta: {},
+    },
   ]);
 
   const tabs: EuiTabbedContentTab[] = [
@@ -81,7 +91,9 @@ export function RuleDetailsTabs({
             appName={RULE_DETAILS_ALERTS_SEARCH_BAR_ID}
             onEsQueryChange={onEsQueryChange}
             urlStorageKey={RULE_DETAILS_SEARCH_BAR_URL_STORAGE_KEY}
-            defaultSearchQueries={ruleQuery.current}
+            defaultFilters={ruleFilters.current}
+            disableLocalStorageSync={true}
+            onControlApiAvailable={onControlApiAvailable}
           />
           <EuiSpacer size="s" />
 

--- a/x-pack/solutions/observability/plugins/observability/public/pages/rule_details/rule_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/rule_details/rule_details.tsx
@@ -7,43 +7,50 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
+import { DEFAULT_CONTROLS } from '@kbn/alerts-ui-shared/src/alert_filter_controls/constants';
+import type { FilterGroupHandler } from '@kbn/alerts-ui-shared';
 import { EuiSpacer, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { RuleExecutionStatusErrorReasons } from '@kbn/alerting-plugin/common';
 import { RuleFormFlyout } from '@kbn/response-ops-rule-form/flyout';
 import type { BoolQuery } from '@kbn/es-query';
 import { useBreadcrumbs } from '@kbn/observability-shared-plugin/public';
-import { useKibana } from '../../utils/kibana_react';
-import { usePluginContext } from '../../hooks/use_plugin_context';
-import { useFetchRule } from '../../hooks/use_fetch_rule';
-import { useFetchRuleTypes } from '../../hooks/use_fetch_rule_types';
-import { useGetFilteredRuleTypes } from '../../hooks/use_get_filtered_rule_types';
-import { PageTitleContent } from './components/page_title_content';
-import { DeleteConfirmationModal } from './components/delete_confirmation_modal';
-import { CenterJustifiedSpinner } from '../../components/center_justified_spinner';
-import { NoRuleFoundPanel } from './components/no_rule_found_panel';
-import { HeaderActions } from './components/header_actions';
-import { RuleDetailsTabs } from './components/rule_details_tabs';
-import { getHealthColor } from './helpers/get_health_color';
-import { isRuleEditable } from './helpers/is_rule_editable';
+import { ALERT_STATUS } from '@kbn/rule-data-utils';
 import { ruleDetailsLocatorID } from '../../../common';
 import {
   ALERT_STATUS_ALL,
   OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES,
   observabilityAlertFeatureIds,
 } from '../../../common/constants';
+import { paths } from '../../../common/locators/paths';
+import type { AlertStatus } from '../../../common/typings';
+import { RuleDetailsLocatorParams } from '../../locators/rule_details';
+import { getControlIndex } from '../../utils/alert_controls/get_control_index';
+import { updateSelectedOptions } from '../../utils/alert_controls/update_selected_options';
+import { setStatusOnControlConfigs } from '../../utils/alert_controls/set_status_on_control_configs';
+import { useKibana } from '../../utils/kibana_react';
+import { usePluginContext } from '../../hooks/use_plugin_context';
+import { useFetchRule } from '../../hooks/use_fetch_rule';
+import { useFetchRuleTypes } from '../../hooks/use_fetch_rule_types';
+import { useGetFilteredRuleTypes } from '../../hooks/use_get_filtered_rule_types';
+import { CenterJustifiedSpinner } from '../../components/center_justified_spinner';
+import {
+  defaultTimeRange,
+  getDefaultAlertSummaryTimeRange,
+} from '../../utils/alert_summary_widget';
+import { PageTitleContent } from './components/page_title_content';
+import { DeleteConfirmationModal } from './components/delete_confirmation_modal';
+import { NoRuleFoundPanel } from './components/no_rule_found_panel';
+import { HeaderActions } from './components/header_actions';
+import { RuleDetailsTabs } from './components/rule_details_tabs';
+import { getHealthColor } from './helpers/get_health_color';
+import { isRuleEditable } from './helpers/is_rule_editable';
+import { HeaderMenu } from '../overview/components/header_menu/header_menu';
 import {
   RULE_DETAILS_EXECUTION_TAB,
   RULE_DETAILS_ALERTS_TAB,
   RULE_DETAILS_TAB_URL_STORAGE_KEY,
 } from './constants';
-import { paths } from '../../../common/locators/paths';
-import {
-  defaultTimeRange,
-  getDefaultAlertSummaryTimeRange,
-} from '../../utils/alert_summary_widget';
-import type { AlertStatus } from '../../../common/typings';
-import { HeaderMenu } from '../overview/components/header_menu/header_menu';
 
 export type TabId = typeof RULE_DETAILS_ALERTS_TAB | typeof RULE_DETAILS_EXECUTION_TAB;
 
@@ -99,6 +106,9 @@ export function RuleDetailsPage() {
     { serverless }
   );
 
+  const [alertFilterControlHandler, setAlertFilterControlHandler] = useState<
+    FilterGroupHandler | undefined
+  >();
   const [activeTabId, setActiveTabId] = useState<TabId>(() => {
     const searchParams = new URLSearchParams(search);
     const urlTabId = searchParams.get(RULE_DETAILS_TAB_URL_STORAGE_KEY);
@@ -128,7 +138,7 @@ export function RuleDetailsPage() {
   const handleSetTabId = async (tabId: TabId) => {
     setActiveTabId(tabId);
 
-    await locators.get(ruleDetailsLocatorID)?.navigate(
+    await locators.get<RuleDetailsLocatorParams>(ruleDetailsLocatorID)?.navigate(
       {
         ruleId,
         tabId,
@@ -141,13 +151,19 @@ export function RuleDetailsPage() {
 
   const handleAlertSummaryWidgetClick = async (status: AlertStatus = ALERT_STATUS_ALL) => {
     setAlertSummaryWidgetTimeRange(getDefaultAlertSummaryTimeRange());
+    const searchParams = new URLSearchParams(search);
+    let controlConfigs: any = searchParams.get('controlConfigs') ?? DEFAULT_CONTROLS;
 
-    await locators.get(ruleDetailsLocatorID)?.navigate(
+    const statusControlIndex = getControlIndex(ALERT_STATUS, controlConfigs);
+    controlConfigs = setStatusOnControlConfigs(status, controlConfigs);
+    updateSelectedOptions(status, statusControlIndex, alertFilterControlHandler);
+
+    await locators.get<RuleDetailsLocatorParams>(ruleDetailsLocatorID)?.navigate(
       {
+        controlConfigs,
         rangeFrom: defaultTimeRange.from,
         rangeTo: defaultTimeRange.to,
         ruleId,
-        status,
         tabId: RULE_DETAILS_ALERTS_TAB,
       },
       {
@@ -268,6 +284,7 @@ export function RuleDetailsPage() {
         activeTabId={activeTabId}
         onEsQueryChange={setEsQuery}
         onSetTabId={handleSetTabId}
+        onControlApiAvailable={setAlertFilterControlHandler}
       />
 
       {isEditRuleFlyoutVisible && (

--- a/x-pack/solutions/observability/plugins/observability/public/plugin.mock.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/plugin.mock.tsx
@@ -8,10 +8,12 @@
 import React from 'react';
 import { mockCasesContract } from '@kbn/cases-plugin/public/mocks';
 import { chartPluginMock } from '@kbn/charts-plugin/public/mocks';
-import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
 import { contentManagementMock } from '@kbn/content-management-plugin/public/mocks';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { dataViewPluginMocks } from '@kbn/data-views-plugin/public/mocks';
 import { observabilityAIAssistantPluginMock } from '@kbn/observability-ai-assistant-plugin/public/mock';
 import { sharePluginMock } from '@kbn/share-plugin/public/mocks';
+import { spacesPluginMock } from '@kbn/spaces-plugin/public/mocks';
 import { unifiedSearchPluginMock } from '@kbn/unified-search-plugin/public/mocks';
 import { lensPluginMock } from '@kbn/lens-plugin/public/mocks';
 
@@ -77,20 +79,6 @@ const dataViewEditor = {
   },
 };
 
-const dataViews = {
-  createStart() {
-    return {
-      getIds: jest.fn().mockImplementation(() => []),
-      get: jest.fn(),
-      create: jest.fn().mockImplementation(() => ({
-        fields: {
-          getByName: jest.fn(),
-        },
-      })),
-    };
-  },
-};
-
 export const observabilityPublicPluginsStartMock = {
   createStart() {
     return {
@@ -99,11 +87,12 @@ export const observabilityPublicPluginsStartMock = {
       contentManagement: contentManagementMock.createStartContract(),
       data: dataPluginMock.createStartContract(),
       dataViewEditor: dataViewEditor.createStart(),
-      dataViews: dataViews.createStart(),
+      dataViews: dataViewPluginMocks.createStartContract(),
       discover: null,
       lens: lensPluginMock.createStartContract(),
       observabilityAIAssistant: observabilityAIAssistantPluginMock.createStartContract(),
       share: sharePluginMock.createStartContract(),
+      spaces: spacesPluginMock.createStartContract(),
       triggersActionsUi: triggersActionsUiStartMock.createStart(),
       unifiedSearch: unifiedSearchPluginMock.createStartContract(),
     };

--- a/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/get_control_index.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/get_control_index.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DEFAULT_CONTROLS } from '@kbn/alerts-ui-shared/src/alert_filter_controls/constants';
+import { ALERT_STATUS } from '@kbn/rule-data-utils';
+import { getControlIndex } from './get_control_index';
+
+describe('getControlIndex()', () => {
+  it('Should return correct index if the field name exist', () => {
+    expect(getControlIndex(ALERT_STATUS, DEFAULT_CONTROLS)).toBe(0);
+  });
+
+  it('Should return -1 if the field name does not exist', () => {
+    expect(getControlIndex('nonexistent-fieldName', DEFAULT_CONTROLS)).toBe(-1);
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/get_control_index.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/get_control_index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FilterControlConfig } from '@kbn/alerts-ui-shared';
+
+export function getControlIndex(fieldName: string, controlConfigs: FilterControlConfig[]): number {
+  return controlConfigs.findIndex((control) => control.fieldName === fieldName);
+}

--- a/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/set_status_on_control_configs.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/set_status_on_control_configs.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { DEFAULT_CONTROLS } from '@kbn/alerts-ui-shared/src/alert_filter_controls/constants';
+import { setStatusOnControlConfigs } from './set_status_on_control_configs';
+
+describe('setStatusOnControlConfigs()', () => {
+  it('Should return a default controlConfig with status if controlConfig is undefined', () => {
+    const updatedControlConfigs = DEFAULT_CONTROLS;
+    updatedControlConfigs[0].selectedOptions = ['recovered'];
+
+    expect(setStatusOnControlConfigs('recovered')).toEqual(updatedControlConfigs);
+  });
+
+  it('Should return empty selectedOptions if status is ALL', () => {
+    const updatedControlConfigs = DEFAULT_CONTROLS;
+    updatedControlConfigs[0].selectedOptions = [];
+
+    expect(setStatusOnControlConfigs('all')).toEqual(updatedControlConfigs);
+  });
+
+  it('Should return controlConfig with current selectedOptions when status is not the first item in config', () => {
+    const controlConfigs = [DEFAULT_CONTROLS[1], DEFAULT_CONTROLS[0]];
+    const updatedControlConfigs = controlConfigs;
+    updatedControlConfigs[1].selectedOptions = ['active'];
+
+    expect(setStatusOnControlConfigs('active', controlConfigs)).toEqual(updatedControlConfigs);
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/set_status_on_control_configs.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/set_status_on_control_configs.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FilterControlConfig } from '@kbn/alerts-ui-shared';
+import { DEFAULT_CONTROLS } from '@kbn/alerts-ui-shared/src/alert_filter_controls/constants';
+import { ALERT_STATUS } from '@kbn/rule-data-utils';
+import { ALERT_STATUS_ALL } from '../../../common/constants';
+import { AlertStatus } from '../../../common/typings';
+
+export function setStatusOnControlConfigs(
+  status: AlertStatus,
+  controlConfigs?: FilterControlConfig[]
+) {
+  const updateControlConfigs = controlConfigs ? [...controlConfigs] : DEFAULT_CONTROLS;
+  const statusControl = updateControlConfigs.find((control) => control.fieldName === ALERT_STATUS);
+  if (statusControl) {
+    if (status === ALERT_STATUS_ALL) {
+      statusControl.selectedOptions = [];
+    } else {
+      statusControl.selectedOptions = [status];
+    }
+  }
+
+  return updateControlConfigs;
+}

--- a/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/update_selected_options.test.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/update_selected_options.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FilterGroupHandler } from '@kbn/alerts-ui-shared';
+import { ALERT_STATUS_ACTIVE } from '@kbn/rule-data-utils';
+import { ALERT_STATUS_ALL } from '../../../common/constants';
+import { updateSelectedOptions } from './update_selected_options';
+
+describe('updateSelectedOptions()', () => {
+  const mockedClearSelections = jest.fn();
+  const mockedSetSelectedOptions = jest.fn();
+  const alertFilterControlHandler = {
+    children$: {
+      getValue: () => [
+        { clearSelections: mockedClearSelections, setSelectedOptions: mockedSetSelectedOptions },
+      ],
+    },
+  } as any as FilterGroupHandler;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Should not do anything if controlIndex is < 0', () => {
+    updateSelectedOptions(ALERT_STATUS_ACTIVE, -1, alertFilterControlHandler);
+    expect(mockedClearSelections).not.toHaveBeenCalled();
+    expect(mockedSetSelectedOptions).not.toHaveBeenCalled();
+  });
+
+  it('Should not do anything if alertFilterControlHandler does not exist', () => {
+    updateSelectedOptions(ALERT_STATUS_ACTIVE, 0);
+    expect(mockedClearSelections).not.toHaveBeenCalled();
+    expect(mockedSetSelectedOptions).not.toHaveBeenCalled();
+  });
+
+  it('Should clear selection if status is all', () => {
+    updateSelectedOptions(ALERT_STATUS_ALL, 0, alertFilterControlHandler);
+    expect(mockedClearSelections).toHaveBeenCalledTimes(1);
+    expect(mockedSetSelectedOptions).not.toHaveBeenCalled();
+  });
+
+  it('Should change selected option is status is active', () => {
+    updateSelectedOptions(ALERT_STATUS_ACTIVE, 0, alertFilterControlHandler);
+    expect(mockedClearSelections).not.toHaveBeenCalled();
+    expect(mockedSetSelectedOptions).toHaveBeenCalledTimes(1);
+    expect(mockedSetSelectedOptions).toHaveBeenCalledWith(['active']);
+  });
+});

--- a/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/update_selected_options.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/utils/alert_controls/update_selected_options.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FilterGroupHandler } from '@kbn/alerts-ui-shared';
+import { OptionsListControlApi } from '@kbn/controls-plugin/public/controls/data_controls/options_list_control/types';
+import { DefaultControlApi } from '@kbn/controls-plugin/public/controls/types';
+import { ALERT_STATUS_ALL } from '../../../common/constants';
+import { AlertStatus } from '../../../common/typings';
+
+export function updateSelectedOptions(
+  status: AlertStatus,
+  controlIndex: number,
+  alertFilterControlHandler?: FilterGroupHandler
+) {
+  if (!alertFilterControlHandler || controlIndex < 0) {
+    return;
+  }
+  if (status === ALERT_STATUS_ALL) {
+    const controlApi = alertFilterControlHandler?.children$.getValue()[
+      controlIndex
+    ] as DefaultControlApi;
+    controlApi?.clearSelections?.();
+  } else {
+    const controlApi = alertFilterControlHandler?.children$.getValue()[
+      controlIndex
+    ] as Partial<OptionsListControlApi>;
+    if (controlApi && controlApi.setSelectedOptions) {
+      controlApi.setSelectedOptions([status]);
+    }
+  }
+}

--- a/x-pack/solutions/observability/plugins/observability/tsconfig.json
+++ b/x-pack/solutions/observability/plugins/observability/tsconfig.json
@@ -119,7 +119,9 @@
     "@kbn/fields-metadata-plugin",
     "@kbn/object-utils",
     "@kbn/task-manager-plugin",
-    "@kbn/core-saved-objects-server"
+    "@kbn/core-saved-objects-server",
+    "@kbn/controls-plugin",
+    "@kbn/core-http-browser"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/test/functional/page_objects/alert_controls.ts
+++ b/x-pack/test/functional/page_objects/alert_controls.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { WebElementWrapper } from '@kbn/ftr-common-functional-ui-services';
+import { FtrProviderContext } from '../ftr_provider_context';
+
+export function AlertControlsProvider({ getService }: FtrProviderContext) {
+  const testSubjects = getService('testSubjects');
+  const find = getService('find');
+  const log = getService('log');
+  const retry = getService('retry');
+
+  return {
+    async getControlElementById(controlId: string): Promise<WebElementWrapper> {
+      const errorText = `Control frame ${controlId} could not be found`;
+      let controlElement: WebElementWrapper | undefined;
+      await retry.try(async () => {
+        const controlFrames = await testSubjects.findAll('control-frame');
+        const framesWithIds = await Promise.all(
+          controlFrames.map(async (frame) => {
+            const id = await frame.getAttribute('data-control-id');
+            return { id, element: frame };
+          })
+        );
+        const foundControlFrame = framesWithIds.find(({ id }) => id === controlId);
+        if (!foundControlFrame) throw new Error(errorText);
+        controlElement = foundControlFrame.element;
+      });
+      if (!controlElement) throw new Error(errorText);
+      return controlElement;
+    },
+
+    async hoverOverExistingControl(controlId: string) {
+      const elementToHover = await this.getControlElementById(controlId);
+      await retry.try(async () => {
+        await elementToHover.moveMouseTo();
+        await testSubjects.existOrFail(`control-action-${controlId}-erase`);
+      });
+    },
+
+    async clearControlSelections(controlId: string) {
+      log.debug(`clearing all selections from control ${controlId}`);
+      await this.hoverOverExistingControl(controlId);
+      await testSubjects.click(`control-action-${controlId}-erase`);
+    },
+
+    async optionsListOpenPopover(controlId: string) {
+      log.debug(`Opening popover for Options List: ${controlId}`);
+      await retry.try(async () => {
+        await testSubjects.click(`optionsList-control-${controlId}`);
+        await retry.waitForWithTimeout('popover to open', 500, async () => {
+          return await testSubjects.exists(`optionsList-control-popover`);
+        });
+      });
+    },
+
+    async optionsListPopoverAssertOpen() {
+      await retry.try(async () => {
+        if (!(await testSubjects.exists(`optionsList-control-available-options`))) {
+          throw new Error('options list popover must be open before calling selectOption');
+        }
+      });
+    },
+
+    async optionsListPopoverSelectOption(availableOption: string) {
+      log.debug(`selecting ${availableOption} from options list`);
+      await this.optionsListPopoverAssertOpen();
+
+      await retry.try(async () => {
+        await testSubjects.existOrFail(`optionsList-control-selection-${availableOption}`);
+        await testSubjects.click(`optionsList-control-selection-${availableOption}`);
+      });
+    },
+
+    async isOptionsListPopoverOpen(controlId: string) {
+      const isPopoverOpen = await find.existsByCssSelector(`#control-popover-${controlId}`);
+      log.debug(`Is popover open: ${isPopoverOpen} for Options List: ${controlId}`);
+      return isPopoverOpen;
+    },
+
+    async optionsListEnsurePopoverIsClosed(controlId: string) {
+      log.debug(`Ensure popover is closed for Options List: ${controlId}`);
+      await retry.try(async () => {
+        const isPopoverOpen = await this.isOptionsListPopoverOpen(controlId);
+        if (isPopoverOpen) {
+          await testSubjects.click(`optionsList-control-${controlId}`);
+          await testSubjects.waitForDeleted(`optionsList-control-available-options`);
+        }
+      });
+    },
+  };
+}

--- a/x-pack/test/functional/page_objects/index.ts
+++ b/x-pack/test/functional/page_objects/index.ts
@@ -37,6 +37,7 @@ import { NavigationalSearchPageObject } from './navigational_search';
 import { ObservabilityLogsExplorerPageObject } from './observability_logs_explorer';
 import { DatasetQualityPageObject } from './dataset_quality';
 import { ObservabilityPageProvider } from './observability_page';
+import { AlertControlsProvider } from './alert_controls';
 import { RemoteClustersPageProvider } from './remote_clusters_page';
 import { ReportingPageObject } from './reporting_page';
 import { RoleMappingsPageProvider } from './role_mappings_page';
@@ -91,6 +92,7 @@ export const pageObjects = {
   observabilityLogsExplorer: ObservabilityLogsExplorerPageObject,
   datasetQuality: DatasetQualityPageObject,
   observability: ObservabilityPageProvider,
+  alertControls: AlertControlsProvider,
   remoteClusters: RemoteClustersPageProvider,
   reporting: ReportingPageObject,
   roleMappings: RoleMappingsPageProvider,

--- a/x-pack/test/functional/services/observability/alerts/common.ts
+++ b/x-pack/test/functional/services/observability/alerts/common.ts
@@ -21,11 +21,13 @@ const DATE_WITH_DATA = {
 
 const ALERTS_FLYOUT_SELECTOR = 'alertsFlyout';
 const FILTER_FOR_VALUE_BUTTON_SELECTOR = 'filterForValue';
-const ALERTS_TABLE_CONTAINER_SELECTOR = 'alertsTableIsLoaded';
+const ALERTS_TABLE_WITH_DATA_SELECTOR = 'alertsTableIsLoaded';
+const ALERTS_TABLE_NO_DATA_SELECTOR = 'alertsTableEmptyState';
 const ALERTS_TABLE_ERROR_PROMPT_SELECTOR = 'alertsTableErrorPrompt';
 const ALERTS_TABLE_ACTIONS_MENU_SELECTOR = 'alertsTableActionsMenu';
 const VIEW_RULE_DETAILS_SELECTOR = 'viewRuleDetails';
 const VIEW_RULE_DETAILS_FLYOUT_SELECTOR = 'viewRuleDetailsFlyout';
+const ALERTS_TABLE_LOADING_SELECTOR = 'internalAlertsPageLoading';
 
 type WorkflowStatus = 'open' | 'acknowledged' | 'closed';
 
@@ -36,19 +38,20 @@ export function ObservabilityAlertsCommonProvider({
   const find = getService('find');
   const testSubjects = getService('testSubjects');
   const flyoutService = getService('flyout');
-  const pageObjects = getPageObjects(['common']);
   const retry = getService('retry');
   const toasts = getService('toasts');
   const kibanaServer = getService('kibanaServer');
   const retryOnStale = getService('retryOnStale');
+  const pageObjects = getPageObjects(['common', 'header']);
 
   const navigateToTimeWithData = async () => {
-    return await pageObjects.common.navigateToUrlWithBrowserHistory(
+    await pageObjects.common.navigateToUrlWithBrowserHistory(
       'observability',
       '/alerts',
       `?_a=(rangeFrom:'${DATE_WITH_DATA.rangeFrom}',rangeTo:'${DATE_WITH_DATA.rangeTo}')`,
       { ensureCurrentUrl: false }
     );
+    await pageObjects.header.waitUntilLoadingHasFinished();
   };
 
   const navigateToRulesPage = async () => {
@@ -102,8 +105,23 @@ export function ObservabilityAlertsCommonProvider({
     });
   };
 
+  // Alert table
+  const waitForAlertsTableLoadingToDisappear = async () => {
+    await testSubjects.missingOrFail(ALERTS_TABLE_LOADING_SELECTOR, { timeout: 30_000 });
+  };
+
+  const waitForAlertTableToLoad = async () => {
+    await waitForAlertsTableLoadingToDisappear();
+    await retry.waitFor('alerts table to appear', async () => {
+      return (
+        (await testSubjects.exists(ALERTS_TABLE_NO_DATA_SELECTOR)) ||
+        (await testSubjects.exists(ALERTS_TABLE_WITH_DATA_SELECTOR))
+      );
+    });
+  };
+
   const getTableColumnHeaders = async () => {
-    const table = await testSubjects.find(ALERTS_TABLE_CONTAINER_SELECTOR);
+    const table = await testSubjects.find(ALERTS_TABLE_WITH_DATA_SELECTOR);
     const tableHeaderRow = await testSubjects.findDescendant('dataGridHeader', table);
     const columnHeaders = await tableHeaderRow.findAllByXpath('./div');
     return columnHeaders;
@@ -132,7 +150,7 @@ export function ObservabilityAlertsCommonProvider({
   });
 
   const getTableOrFail = async () => {
-    return await testSubjects.existOrFail(ALERTS_TABLE_CONTAINER_SELECTOR);
+    return await testSubjects.existOrFail(ALERTS_TABLE_WITH_DATA_SELECTOR);
   };
 
   const ensureNoTableErrorPrompt = async () => {
@@ -149,6 +167,9 @@ export function ObservabilityAlertsCommonProvider({
 
   // Query Bar
   const getQueryBar = async () => {
+    await retry.try(async () => {
+      await testSubjects.existOrFail('queryInput');
+    });
     return await testSubjects.find('queryInput');
   };
 
@@ -409,6 +430,7 @@ export function ObservabilityAlertsCommonProvider({
     getTableCellsInRows,
     getTableColumnHeaders,
     getTableOrFail,
+    waitForAlertTableToLoad,
     ensureNoTableErrorPrompt,
     navigateToTimeWithData,
     setKibanaTimeZoneToUTC,

--- a/x-pack/test/observability_functional/apps/observability/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/index.ts
@@ -11,7 +11,7 @@ export default function ({ loadTestFile }: FtrProviderContext) {
   describe('ObservabilityApp', function () {
     loadTestFile(require.resolve('./pages/alerts'));
     loadTestFile(require.resolve('./pages/alerts/add_to_case'));
-    loadTestFile(require.resolve('./pages/alerts/alert_status'));
+    loadTestFile(require.resolve('./pages/alerts/alert_controls'));
     loadTestFile(require.resolve('./pages/alerts/alert_summary_widget'));
     loadTestFile(require.resolve('./pages/alerts/pagination'));
     loadTestFile(require.resolve('./pages/alerts/rule_stats'));

--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/index.ts
@@ -10,9 +10,10 @@ import { RuleNotifyWhen } from '@kbn/alerting-plugin/common';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 import { asyncForEach } from '../../helpers';
 
-const ACTIVE_ALERTS_CELL_COUNT = 78;
-const RECOVERED_ALERTS_CELL_COUNT = 330;
+const INFRA_ACTIVE_ALERTS_CELL_COUNT = 78;
 const TOTAL_ALERTS_CELL_COUNT = 440;
+const RECOVERED_ALERTS_CELL_COUNT = 330;
+const ACTIVE_ALERTS_CELL_COUNT = 110;
 
 const DISABLED_ALERTS_CHECKBOX = 6;
 const ENABLED_ALERTS_CHECKBOX = 4;
@@ -20,7 +21,7 @@ const ENABLED_ALERTS_CHECKBOX = 4;
 export default ({ getService, getPageObjects }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const find = getService('find');
-  const PageObjects = getPageObjects(['home', 'common']);
+  const PageObjects = getPageObjects(['home', 'common', 'alertControls']);
   const supertest = getService('supertest');
   const browser = getService('browser');
 
@@ -130,7 +131,19 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
         await observability.alerts.common.getTableOrFail();
       });
 
-      it('Renders the correct number of cells', async () => {
+      it('Renders the correct number of cells (active alerts)', async () => {
+        await retry.try(async () => {
+          const cells = await observability.alerts.common.getTableCells();
+          expect(cells.length).to.be(ACTIVE_ALERTS_CELL_COUNT);
+        });
+      });
+
+      it('Clear status control', async () => {
+        await PageObjects.alertControls.clearControlSelections('0');
+        await observability.alerts.common.waitForAlertTableToLoad();
+      });
+
+      it('Renders the correct number of cells (all alerts)', async () => {
         await retry.try(async () => {
           const cells = await observability.alerts.common.getTableCells();
           expect(cells.length).to.be(TOTAL_ALERTS_CELL_COUNT);
@@ -180,6 +193,9 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       describe('Date selection', () => {
         after(async () => {
           await observability.alerts.common.navigateToTimeWithData();
+          // Clear active status
+          await PageObjects.alertControls.clearControlSelections('0');
+          await observability.alerts.common.waitForAlertTableToLoad();
         });
 
         it('Correctly applies date picker selections', async () => {
@@ -294,7 +310,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
           // Wait for request
           await retry.try(async () => {
             const cells = await observability.alerts.common.getTableCells();
-            expect(cells.length).to.be(ACTIVE_ALERTS_CELL_COUNT);
+            expect(cells.length).to.be(INFRA_ACTIVE_ALERTS_CELL_COUNT);
           });
         });
       });

--- a/x-pack/test/observability_functional/apps/observability/pages/alerts/table_configuration.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/alerts/table_configuration.ts
@@ -17,11 +17,10 @@ import {
   ALERT_STATUS,
   ALERT_INSTANCE_ID,
   TAGS,
-  ALERT_STATUS_ACTIVE,
 } from '@kbn/rule-data-utils';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 
-export default ({ getService, getPageObject }: FtrProviderContext) => {
+export default ({ getService }: FtrProviderContext) => {
   describe('Observability alerts table configuration', function () {
     this.tags('includeFirefox');
 
@@ -56,6 +55,7 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
 
     it('renders the correct columns', async () => {
       await observability.alerts.common.navigateToTimeWithData();
+      await observability.alerts.common.waitForAlertTableToLoad();
       for (const colId of [
         ALERT_STATUS,
         ALERT_START,
@@ -73,12 +73,13 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
 
     it('renders the group selector', async () => {
       await observability.alerts.common.navigateToTimeWithData();
+      await observability.alerts.common.waitForAlertTableToLoad();
       expect(await testSubjects.exists('group-selector-dropdown')).to.be(true);
     });
 
     it('renders the correct alert actions', async () => {
       await observability.alerts.common.navigateToTimeWithData();
-      await observability.alerts.common.setAlertStatusFilter(ALERT_STATUS_ACTIVE);
+      await observability.alerts.common.waitForAlertTableToLoad();
       await testSubjects.click('alertsTableRowActionMore');
       await retry.waitFor('alert actions popover visible', () =>
         testSubjects.exists('alertsTableActionsMenu')
@@ -97,6 +98,7 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
 
     it('remembers column changes', async () => {
       await observability.alerts.common.navigateToTimeWithData();
+      await observability.alerts.common.waitForAlertTableToLoad();
       await dataGrid.clickHideColumn('kibana.alert.duration.us');
 
       await observability.alerts.common.navigateToTimeWithData();
@@ -109,6 +111,7 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
 
     it('remembers sorting changes', async () => {
       await observability.alerts.common.navigateToTimeWithData();
+      await observability.alerts.common.waitForAlertTableToLoad();
       await dataGrid.clickDocSortAsc('kibana.alert.start');
 
       await observability.alerts.common.navigateToTimeWithData();

--- a/x-pack/test/observability_functional/apps/observability/pages/rule_details_page.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/rule_details_page.ts
@@ -168,14 +168,17 @@ export default ({ getService }: FtrProviderContext) => {
           await observability.components.alertSummaryWidget.getActiveAlertSelector();
         await activeAlerts.click();
 
-        const url = await browser.getCurrentUrl();
-        const from = 'rangeFrom:now-30d';
-        const to = 'rangeTo:now';
+        await retry.try(async () => {
+          const url = await browser.getCurrentUrl();
+          const from = 'rangeFrom:now-30d';
+          const to = 'rangeTo:now';
+          const status = 'selectedOptions:!(active),title:Status';
 
-        expect(url.includes('tabId=alerts')).to.be(true);
-        expect(url.includes('status%3Aactive')).to.be(true);
-        expect(url.includes(from.replaceAll(':', '%3A'))).to.be(true);
-        expect(url.includes(to.replaceAll(':', '%3A'))).to.be(true);
+          expect(url.includes('tabId=alerts')).to.be(true);
+          expect(url.includes(status.replaceAll(':', '%3A').replaceAll(',', '%2C'))).to.be(true);
+          expect(url.includes(from.replaceAll(':', '%3A'))).to.be(true);
+          expect(url.includes(to.replaceAll(':', '%3A'))).to.be(true);
+        });
       });
 
       it('handles clicking on total alerts correctly', async () => {
@@ -183,14 +186,17 @@ export default ({ getService }: FtrProviderContext) => {
           await observability.components.alertSummaryWidget.getTotalAlertSelector();
         await totalAlerts.click();
 
-        const url = await browser.getCurrentUrl();
-        const from = 'rangeFrom:now-30d';
-        const to = 'rangeTo:now';
+        await retry.try(async () => {
+          const url = await browser.getCurrentUrl();
+          const from = 'rangeFrom:now-30d';
+          const to = 'rangeTo:now';
+          const status = 'selectedOptions:!(),title:Status';
 
-        expect(url.includes('tabId=alerts')).to.be(true);
-        expect(url.includes('status%3Aall')).to.be(true);
-        expect(url.includes(from.replaceAll(':', '%3A'))).to.be(true);
-        expect(url.includes(to.replaceAll(':', '%3A'))).to.be(true);
+          expect(url.includes('tabId=alerts')).to.be(true);
+          expect(url.includes(status.replaceAll(':', '%3A').replaceAll(',', '%2C'))).to.be(true);
+          expect(url.includes(from.replaceAll(':', '%3A'))).to.be(true);
+          expect(url.includes(to.replaceAll(':', '%3A'))).to.be(true);
+        });
       });
     });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Alert search bar] Replace the status filter with controls on the observability pages (#198495)](https://github.com/elastic/kibana/pull/198495)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2025-03-12T18:23:42Z","message":"[Alert search bar] Replace the status filter with controls on the observability pages (#198495)\n\nCloses #197953\n\n## Summary\n\nThis PR replaces the alert status filter with filter controls. In this\nPR, I also covered backward compatibility when we have a `status` URL\nparameter by passing that value to filters, as shown below:\n\n|State|Screenshot|\n|---|---|\n\n|Before|![Image](https://github.com/user-attachments/assets/f7783866-5b84-4004-9e70-3a22675b9a7a)|\n\n|After|![image](https://github.com/user-attachments/assets/162d2e2a-3535-4f1f-ba7f-1fe2bfa8a478)|\n\n\nhttps://github.com/user-attachments/assets/86e82a19-f68e-4127-9fd8-e0efe0d41ece\n\nI checked in Serverless and we have access to controls in viewer mode as\nwell:\n\n\nhttps://github.com/user-attachments/assets/2c90ba3a-7d95-4682-b722-e5b327f7334d\n\n\n### 🐞 Known issue\n\n1. Privilege\nIn Stateful, if a user has Kibana privilege but not the `.alert*` es\nprivilege, then the controls do not work as expected. This issue will be\ntackled in a separate ticket:\n\n  <details>\n  <summary>This is the error that we show in this scenario</summary>\n  \n\n![image](https://github.com/user-attachments/assets/7b2faab5-794b-4a96-b7e8-6dccd205cdd3)\n  </details>\n\n2. Initial load\nRelated ticket: https://github.com/elastic/kibana/issues/183412\n\n\n### 🗒️ Tasks\n\n- [x] ~~Solving the permission issue~~ This issue does not happen in\nServerless and for stateful, we will fix it in a separate ticket:\nhttps://github.com/elastic/kibana/issues/208225\n- The main issue will be fixed in this\n[PR](https://github.com/elastic/kibana/pull/191110)\n- In the above [PR](https://github.com/elastic/kibana/pull/191110), we\nremove controls if the user does not have the privilege for alert\nindices, but we need to figure out how to adjust filter controls to\naccess the data based on Kibana privileges.\n- [x] We should configure the filters to allow the selection of one item\nfor alert status but still show the other options\n- [x] We need to see how we can make this work with the current status\nfield. Ideally, if there is a status field, we would apply it and remove\nit from the URL.\n- Fixed in\n[c6cad2d](https://github.com/elastic/kibana/pull/198495/commits/c6cad2dbe1bc527473d1096639a4572d51e07efe)\n- [x] Changing the URL does not update the page filters correctly. ~~It\nmight be related to https://github.com/elastic/kibana/issues/183412.~~\n- [x] We need to make sure these adjustments work as expected in APM as\nthey use the observability alert search bar.\n- [x] Check if the tags filter can be improved, and if not, whether it\nmakes sense to keep it in its current form.\n- It works based on how array filtering works in ES, which seems like a\ngood start to me.\n- [x] Check with Maciej: Do we need to disable changing control configs?\n- Checked with Maciej: it is fine to keep the option of editing\ncontrols.\n- [x] Do we need to have a different local storage item for each page\n(apm/rule details/alert details/alerts)?\n        - How can we disable syncing with the local storage?\n- Added the possibility of disabling sync in\n[24bab21](https://github.com/elastic/kibana/pull/198495/commits/24bab210b0f0dbc640c55e449ae73a1676f8bc8e)\nand disabled it for the rule details and alert details pages.\n            - Also, disabled it for the APM alert search bar.\n- [x] Setting default status as active on the related alerts tab\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"14b9a4828afbfc3a21a8705ecdbaa0ff6f2537da","branchLabelMapping":{"^v9.1.0$":"main","^v8.19.0$":"8.x","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:feature","ci:project-deploy-observability","Team:obs-ux-infra_services","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Alert search bar] Replace the status filter with controls on the observability pages","number":198495,"url":"https://github.com/elastic/kibana/pull/198495","mergeCommit":{"message":"[Alert search bar] Replace the status filter with controls on the observability pages (#198495)\n\nCloses #197953\n\n## Summary\n\nThis PR replaces the alert status filter with filter controls. In this\nPR, I also covered backward compatibility when we have a `status` URL\nparameter by passing that value to filters, as shown below:\n\n|State|Screenshot|\n|---|---|\n\n|Before|![Image](https://github.com/user-attachments/assets/f7783866-5b84-4004-9e70-3a22675b9a7a)|\n\n|After|![image](https://github.com/user-attachments/assets/162d2e2a-3535-4f1f-ba7f-1fe2bfa8a478)|\n\n\nhttps://github.com/user-attachments/assets/86e82a19-f68e-4127-9fd8-e0efe0d41ece\n\nI checked in Serverless and we have access to controls in viewer mode as\nwell:\n\n\nhttps://github.com/user-attachments/assets/2c90ba3a-7d95-4682-b722-e5b327f7334d\n\n\n### 🐞 Known issue\n\n1. Privilege\nIn Stateful, if a user has Kibana privilege but not the `.alert*` es\nprivilege, then the controls do not work as expected. This issue will be\ntackled in a separate ticket:\n\n  <details>\n  <summary>This is the error that we show in this scenario</summary>\n  \n\n![image](https://github.com/user-attachments/assets/7b2faab5-794b-4a96-b7e8-6dccd205cdd3)\n  </details>\n\n2. Initial load\nRelated ticket: https://github.com/elastic/kibana/issues/183412\n\n\n### 🗒️ Tasks\n\n- [x] ~~Solving the permission issue~~ This issue does not happen in\nServerless and for stateful, we will fix it in a separate ticket:\nhttps://github.com/elastic/kibana/issues/208225\n- The main issue will be fixed in this\n[PR](https://github.com/elastic/kibana/pull/191110)\n- In the above [PR](https://github.com/elastic/kibana/pull/191110), we\nremove controls if the user does not have the privilege for alert\nindices, but we need to figure out how to adjust filter controls to\naccess the data based on Kibana privileges.\n- [x] We should configure the filters to allow the selection of one item\nfor alert status but still show the other options\n- [x] We need to see how we can make this work with the current status\nfield. Ideally, if there is a status field, we would apply it and remove\nit from the URL.\n- Fixed in\n[c6cad2d](https://github.com/elastic/kibana/pull/198495/commits/c6cad2dbe1bc527473d1096639a4572d51e07efe)\n- [x] Changing the URL does not update the page filters correctly. ~~It\nmight be related to https://github.com/elastic/kibana/issues/183412.~~\n- [x] We need to make sure these adjustments work as expected in APM as\nthey use the observability alert search bar.\n- [x] Check if the tags filter can be improved, and if not, whether it\nmakes sense to keep it in its current form.\n- It works based on how array filtering works in ES, which seems like a\ngood start to me.\n- [x] Check with Maciej: Do we need to disable changing control configs?\n- Checked with Maciej: it is fine to keep the option of editing\ncontrols.\n- [x] Do we need to have a different local storage item for each page\n(apm/rule details/alert details/alerts)?\n        - How can we disable syncing with the local storage?\n- Added the possibility of disabling sync in\n[24bab21](https://github.com/elastic/kibana/pull/198495/commits/24bab210b0f0dbc640c55e449ae73a1676f8bc8e)\nand disabled it for the rule details and alert details pages.\n            - Also, disabled it for the APM alert search bar.\n- [x] Setting default status as active on the related alerts tab\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"14b9a4828afbfc3a21a8705ecdbaa0ff6f2537da"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/198495","number":198495,"mergeCommit":{"message":"[Alert search bar] Replace the status filter with controls on the observability pages (#198495)\n\nCloses #197953\n\n## Summary\n\nThis PR replaces the alert status filter with filter controls. In this\nPR, I also covered backward compatibility when we have a `status` URL\nparameter by passing that value to filters, as shown below:\n\n|State|Screenshot|\n|---|---|\n\n|Before|![Image](https://github.com/user-attachments/assets/f7783866-5b84-4004-9e70-3a22675b9a7a)|\n\n|After|![image](https://github.com/user-attachments/assets/162d2e2a-3535-4f1f-ba7f-1fe2bfa8a478)|\n\n\nhttps://github.com/user-attachments/assets/86e82a19-f68e-4127-9fd8-e0efe0d41ece\n\nI checked in Serverless and we have access to controls in viewer mode as\nwell:\n\n\nhttps://github.com/user-attachments/assets/2c90ba3a-7d95-4682-b722-e5b327f7334d\n\n\n### 🐞 Known issue\n\n1. Privilege\nIn Stateful, if a user has Kibana privilege but not the `.alert*` es\nprivilege, then the controls do not work as expected. This issue will be\ntackled in a separate ticket:\n\n  <details>\n  <summary>This is the error that we show in this scenario</summary>\n  \n\n![image](https://github.com/user-attachments/assets/7b2faab5-794b-4a96-b7e8-6dccd205cdd3)\n  </details>\n\n2. Initial load\nRelated ticket: https://github.com/elastic/kibana/issues/183412\n\n\n### 🗒️ Tasks\n\n- [x] ~~Solving the permission issue~~ This issue does not happen in\nServerless and for stateful, we will fix it in a separate ticket:\nhttps://github.com/elastic/kibana/issues/208225\n- The main issue will be fixed in this\n[PR](https://github.com/elastic/kibana/pull/191110)\n- In the above [PR](https://github.com/elastic/kibana/pull/191110), we\nremove controls if the user does not have the privilege for alert\nindices, but we need to figure out how to adjust filter controls to\naccess the data based on Kibana privileges.\n- [x] We should configure the filters to allow the selection of one item\nfor alert status but still show the other options\n- [x] We need to see how we can make this work with the current status\nfield. Ideally, if there is a status field, we would apply it and remove\nit from the URL.\n- Fixed in\n[c6cad2d](https://github.com/elastic/kibana/pull/198495/commits/c6cad2dbe1bc527473d1096639a4572d51e07efe)\n- [x] Changing the URL does not update the page filters correctly. ~~It\nmight be related to https://github.com/elastic/kibana/issues/183412.~~\n- [x] We need to make sure these adjustments work as expected in APM as\nthey use the observability alert search bar.\n- [x] Check if the tags filter can be improved, and if not, whether it\nmakes sense to keep it in its current form.\n- It works based on how array filtering works in ES, which seems like a\ngood start to me.\n- [x] Check with Maciej: Do we need to disable changing control configs?\n- Checked with Maciej: it is fine to keep the option of editing\ncontrols.\n- [x] Do we need to have a different local storage item for each page\n(apm/rule details/alert details/alerts)?\n        - How can we disable syncing with the local storage?\n- Added the possibility of disabling sync in\n[24bab21](https://github.com/elastic/kibana/pull/198495/commits/24bab210b0f0dbc640c55e449ae73a1676f8bc8e)\nand disabled it for the rule details and alert details pages.\n            - Also, disabled it for the APM alert search bar.\n- [x] Setting default status as active on the related alerts tab\n\n---------\n\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>\nCo-authored-by: Shahzad <shahzad31comp@gmail.com>","sha":"14b9a4828afbfc3a21a8705ecdbaa0ff6f2537da"}},{"branch":"8.x","label":"v8.19.0","branchLabelMappingKey":"^v8.19.0$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->