### PR TITLE
Align Asset Inventory UI with latest Figma

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_bar_chart.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/asset_inventory_bar_chart.tsx
@@ -10,7 +10,9 @@ import {
   EuiFlexGroup,
   EuiLoadingChart,
   useEuiTheme,
+  useEuiFontSize,
   type EuiThemeComputed,
+  type EuiThemeFontSize,
 } from '@elastic/eui';
 import { getAbbreviatedNumber } from '@kbn/cloud-security-posture-common';
 import { Axis, BarSeries, Chart, Position, Settings, ScaleType } from '@elastic/charts';
@@ -34,16 +36,25 @@ const yAxisTitle = i18n.translate(
   }
 );
 
-const getChartStyles = (euiTheme: EuiThemeComputed) => {
+const getChartStyles = (euiTheme: EuiThemeComputed, xsFontSize: EuiThemeFontSize) => {
   return css({
-    height: '276px',
+    height: '260px',
     border: euiTheme.border.thin,
     borderRadius: euiTheme.border.radius.medium,
     padding: euiTheme.size.l,
+    '.echLegendItem__label': {
+      fontSize: xsFontSize.fontSize,
+    },
     '.echLegendItem__action': {
-      fontSize: '12px',
+      fontSize: xsFontSize.fontSize,
     },
   });
+};
+
+const getProgressStyle = (isFetching: boolean) => {
+  return {
+    opacity: isFetching ? 1 : 0,
+  };
 };
 
 export interface AssetInventoryBarChartProps {
@@ -58,16 +69,12 @@ export const AssetInventoryBarChart = ({
   assetInventoryChartData,
 }: AssetInventoryBarChartProps) => {
   const { euiTheme } = useEuiTheme();
+  const xsFontSize = useEuiFontSize('xs');
   const baseTheme = useElasticChartsTheme();
   return (
-    <div css={getChartStyles(euiTheme)}>
-      <EuiProgress
-        size="xs"
-        color="accent"
-        css={css`
-          opacity: ${isFetching ? 1 : 0};
-        `}
-      />
+    <div css={getChartStyles(euiTheme, xsFontSize)}>
+      {/* eslint-disable-next-line @elastic/eui/prefer-css-attributes-for-eui-components */}
+      <EuiProgress size="xs" color="accent" style={getProgressStyle(isFetching)} />
       {isLoading ? (
         <EuiFlexGroup
           justifyContent="center"
@@ -95,7 +102,7 @@ export const AssetInventoryBarChart = ({
               },
               axes: {
                 axisTitle: {
-                  fontSize: 11,
+                  fontSize: euiTheme.font.scale.xs * 16, // convert rem -> px
                 },
               },
             }}

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/onboarding/onboarding_success_callout.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/onboarding/onboarding_success_callout.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiButton, EuiCallOut } from '@elastic/eui';
+import { EuiButton, EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useOnboardingSuccessCallout } from './hooks/use_onboarding_success_callout';
 import { TEST_SUBJ_ONBOARDING_SUCCESS_CALLOUT } from '../../constants';
@@ -19,30 +19,33 @@ export const OnboardingSuccessCallout = () => {
     useOnboardingSuccessCallout();
 
   return isOnboardingSuccessCalloutVisible ? (
-    <EuiCallOut
-      onDismiss={hideOnboardingSuccessCallout}
-      title={
-        <FormattedMessage
-          id="xpack.securitySolution.assetInventory.onboarding.enabledSuccessfullyTitle"
-          defaultMessage="Asset Inventory Enabled Successfully"
-        />
-      }
-      color="success"
-      iconType="check"
-      data-test-subj={TEST_SUBJ_ONBOARDING_SUCCESS_CALLOUT}
-    >
-      <p>
-        <FormattedMessage
-          id="xpack.securitySolution.assetInventory.onboarding.enabledSuccessfully"
-          defaultMessage="Asset Inventory is now set up and ready to use. You can start managing your assets with enhanced visibility and context, empowering your security team to make informed decisions."
-        />
-      </p>
-      <EuiButton size="s" color="success" onClick={onAddIntegrationClick}>
-        <FormattedMessage
-          id="xpack.securitySolution.assetInventory.addIntegration"
-          defaultMessage="Add integration"
-        />
-      </EuiButton>
-    </EuiCallOut>
+    <>
+      <EuiCallOut
+        onDismiss={hideOnboardingSuccessCallout}
+        title={
+          <FormattedMessage
+            id="xpack.securitySolution.assetInventory.onboarding.enabledSuccessfullyTitle"
+            defaultMessage="Asset Inventory Enabled Successfully"
+          />
+        }
+        color="success"
+        iconType="check"
+        data-test-subj={TEST_SUBJ_ONBOARDING_SUCCESS_CALLOUT}
+      >
+        <p>
+          <FormattedMessage
+            id="xpack.securitySolution.assetInventory.onboarding.enabledSuccessfully"
+            defaultMessage="Asset Inventory is now set up and ready to use. You can start managing your assets with enhanced visibility and context, empowering your security team to make informed decisions."
+          />
+        </p>
+        <EuiButton size="s" color="success" onClick={onAddIntegrationClick}>
+          <FormattedMessage
+            id="xpack.securitySolution.assetInventory.addIntegration"
+            defaultMessage="Add integration"
+          />
+        </EuiButton>
+      </EuiCallOut>
+      <EuiSpacer size="l" />
+    </>
   ) : null;
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/asset_inventory/pages/all_assets.tsx
@@ -88,7 +88,6 @@ const AllAssetsComponent = () => {
         <AssetInventoryTitle />
         <EuiSpacer size="l" />
         <OnboardingSuccessCallout />
-        <EuiSpacer size="l" />
         <AssetInventoryFilters setQuery={setUrlQuery} />
         <EuiSpacer size="l" />
         <AssetInventoryBarChart
@@ -96,7 +95,7 @@ const AllAssetsComponent = () => {
           isFetching={isFetchingChartData}
           assetInventoryChartData={!!chartData && chartData.length > 0 ? chartData : []}
         />
-        <EuiSpacer size="l" />
+        <EuiSpacer size="xl" />
         <AssetInventoryTableSection state={state} />
       </EuiPageTemplate.Section>
     </I18nProvider>


### PR DESCRIPTION
## Summary

Follow-up of:
- https://github.com/elastic/kibana/pull/220257

Update the Asset Inventory UI with the latest [Figma ](https://www.figma.com/design/9zUqAhhglT1EGYG4LOl1X6/Asset-Inventory---Management--AIM-?node-id=7549-43201&t=nCtMUdMrNiXAdvvH-0) version now that design is up-to-date and reuses [EUI](https://eui.elastic.co/) tokens.

### Details

- Reduce chart height from 276px to 260px
- Reduce chart legend font-size, set to `euiTheme xs fontSize`
- Increase `<EuiSpacer>` between chart and table from `l` to `xl`
- Remove double `<EuiSpacer>` between title and chart once the `<OnboardingSuccessCallout>` is clicked and goes hidden.
- Replace hard-coded font-size on Y axis label with `euiTheme XS font scale` token.

### Screenshots

<details><summary>Before</summary>
<img width="1942" alt="_before" src="https://github.com/user-attachments/assets/933bde4e-cf71-413d-b296-be08fa9bd5b4" />
</details> 

<details><summary>After</summary>
<img width="1942" alt="_after" src="https://github.com/user-attachments/assets/61f79c91-a9bd-47b3-8a3b-255a2d20c5e8" />
</details>

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

No risks.