### PR TITLE
[Fleet] Fix bundled package upgrade

### DIFF
--- a/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
+++ b/x-pack/platform/plugins/shared/fleet/server/services/package_policy.ts
@@ -1216,10 +1216,26 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
     }
 
     const packageInfos = await getPackageInfoForPackagePolicies(
-      [...packagePolicyUpdates, ...oldPackagePolicies],
+      packagePolicyUpdates,
       soClient,
       true
     );
+
+    const oldPackageInfos = await getPackageInfoForPackagePolicies(
+      oldPackagePolicies,
+      soClient,
+      true
+    );
+
+    const allPackageInfos = [...packageInfos.entries(), ...oldPackageInfos.entries()].reduce(
+      (acc, [pkgKey, pkgInfo]) => {
+        acc.set(pkgKey, pkgInfo);
+
+        return acc;
+      },
+      new Map<string, PackageInfo>()
+    );
+
     const allSecretsToDelete: PolicySecretReference[] = [];
 
     const packageInfosandAssetsMap = await getPkgInfoAssetsMap({
@@ -1328,10 +1344,10 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
               oldPackagePolicy.package &&
               oldPackagePolicy.package.version !== pkgInfo.version
             ) {
-              const oldPkgInfoAndAsset = packageInfosandAssetsMap.get(
+              const oldPackageInfo = allPackageInfos.get(
                 `${oldPackagePolicy.package.name}-${oldPackagePolicy.package.version}`
               );
-              if (oldPkgInfoAndAsset?.pkgInfo.type === 'integration') {
+              if (oldPackageInfo?.type === 'integration') {
                 assetsToInstallFn.push(async () => {
                   const updatedPackagePolicy = await this.get(soClient, id);
 


### PR DESCRIPTION
## Summary

Resolve #221529

When upgrading package we were retrieving assets from old packages, this do not work for bundled package where the old package may not be reachable.

That PR fix that.

## How to tests 

* With an apm bundled package 
* install the package and create a package policy
* try to install the latest prerelease version form the registry => it should not fail.



<!--ONMERGE {"backportTargets":["9.0"]} ONMERGE-->