### PR TITLE
[Backport] Adds 8.17.7 release notes (#221207)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -12,6 +12,7 @@ Review important information about the {kib} 8.x releases.
 
 * <<release-notes-8.18.1>>
 * <<release-notes-8.18.0>>
+* <<release-notes-8.17.7>>
 * <<release-notes-8.17.6>>
 * <<release-notes-8.17.5>>
 * <<release-notes-8.17.4>>
@@ -470,6 +471,35 @@ Machine Learning::
 * Anomaly Explorer: Fixes handling of job group IDs when opening from dashboard panels ({kibana-pull}203224[#203224]).
 * AiOps: Fixes Log Rate Analysis embeddable error on the Alerts page ({kibana-pull}203093[#203093]).
 * Initializes saved objects on trained model page load ({kibana-pull}201426[#201426]).
+
+[[release-notes-8.17.7]]
+== {kib} 8.17.7
+
+The 8.17.7 release includes the following enhancements and fixes.
+
+[float]
+[[enhancement-v8.17.7]]
+=== Enhancements
+Alerting::
+* Ensures alerts created within **Maintenance Windows** trigger actions after the window expires ({kibana-pull}219797[#219797]).
+
+[float]
+[[fixes-v8.17.7]]
+=== Fixes
+Dashboards and Visualizations::
+* Correctly applies default timezone in **TSVB** when the timezone parameter is set to default in **Advanced Settings** ({kibana-pull}220658[#220658]).
+* Removes extra icon from map visualization tooltips ({kibana-pull}220134[#220134]).
+Discover::
+* Fixes drill-down state not saving in by-value **Discover** sessions ({kibana-pull}219857[#219857]).
+Elastic Observability Solution::
+* Considers locations only if the array is not empty in a monitor status rule ({kibana-pull}220983[#220983]).
+* Uses update-by-query for `semantic_text` migration ({kibana-pull}220255[#220255]).
+* Prevents undefined errors in **Transaction flyout** ({kibana-pull}220224[#220224]).
+* Fixes broken **Span Links** flyout in **Trace Explorer** ({kibana-pull}219763[#219763]).
+Elastic Security solution::
+For the Elastic Security 8.17.7 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+Kibana security::
+* Reworks cookie and session storage to prevent unexpected logouts for certain users ({kibana-pull}220430[#220430]).
 
 [[release-notes-8.17.6]]
 == {kib} 8.17.6


### PR DESCRIPTION
## Summary

Backports https://github.com/elastic/kibana/pull/221207 to 8.18.