### PR TITLE
fix(alerts): control filters

### DIFF
--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/filter_group.tsx
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/filter_group.tsx
@@ -296,6 +296,7 @@ export const FilterGroup = (props: PropsWithChildren<FilterGroupProps>) => {
       const initialState: Partial<ControlGroupRuntimeState> = {
         ...defaultState,
         chainingSystem,
+        initialChildControlState: {},
         ignoreParentSettings: {
           ignoreValidations: true,
         },


### PR DESCRIPTION
## Summary

resolves https://github.com/elastic/kibana/issues/221545

Attempt at fixing the control filters state: https://elastic.slack.com/archives/C05UT5PP1EF/p1747331675573019

### Test

- Go  to Alerts page, cleanup your local storage, remove the url parameters and refresh the page: default filters should be shown
- Go to SLOs, then go back to Alerts: no duplicated filters (tags and status) should be present in the UI, URL and local storage.



