### PR TITLE
[8.19] [Alert controls] Fix refreshing controls and remove extra loading of the alert table (#214612)

### DIFF
--- a/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/filter_group.tsx
+++ b/src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/filter_group.tsx
@@ -22,7 +22,6 @@ import type {
 } from '@kbn/controls-plugin/public';
 import React, { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import type { Subscription } from 'rxjs';
 import { debounce, isEqual, isEqualWith } from 'lodash';
 import type { FilterGroupProps, FilterControlConfig } from './types';
 import { FilterGroupLoading } from './loading';
@@ -62,8 +61,6 @@ export const FilterGroup = (props: PropsWithChildren<FilterGroupProps>) => {
     disableLocalStorageSync = false,
   } = props;
 
-  const filterChangedSubscription = useRef<Subscription>();
-  const inputChangedSubscription = useRef<Subscription>();
   const [urlStateInitialized, setUrlStateInitialized] = useState(false);
 
   const [controlsFromUrl, setControlsFromUrl] = useState(controlsUrlState ?? []);
@@ -121,14 +118,6 @@ export const FilterGroup = (props: PropsWithChildren<FilterGroupProps>) => {
 
   const urlDataApplied = useRef<boolean>(false);
 
-  useEffect(() => {
-    return () => {
-      [filterChangedSubscription.current, inputChangedSubscription.current].forEach((sub) => {
-        if (sub) sub.unsubscribe();
-      });
-    };
-  }, []);
-
   const { filters: validatedFilters, query: validatedQuery } = useMemo(() => {
     try {
       buildEsQuery(
@@ -179,7 +168,7 @@ export const FilterGroup = (props: PropsWithChildren<FilterGroupProps>) => {
   );
 
   const handleOutputFilterUpdates = useCallback(
-    (newFilters: Filter[] = []) => {
+    (newFilters: Filter[] | undefined) => {
       if (isEqual(currentFiltersRef.current, newFilters)) return;
       if (onFiltersChange) onFiltersChange(newFilters ?? []);
       currentFiltersRef.current = newFilters ?? [];
@@ -222,37 +211,34 @@ export const FilterGroup = (props: PropsWithChildren<FilterGroupProps>) => {
   }, [controlsUrlState, getStoredControlState, switchToEditMode]);
 
   useEffect(() => {
-    if (controlsUrlState && !urlStateInitialized) {
-      initializeUrlState();
+    if (!controlGroup) {
+      return;
     }
+    const filterSubscription = controlGroup.filters$.subscribe({ next: debouncedFilterUpdates });
+    return () => {
+      filterSubscription.unsubscribe();
+    };
+  }, [controlGroup, debouncedFilterUpdates]);
 
+  useEffect(() => {
     if (!controlGroup) {
       return;
     }
 
-    filterChangedSubscription.current = controlGroup.filters$.subscribe({
-      next: debouncedFilterUpdates,
-    });
-
-    inputChangedSubscription.current = controlGroup.getInput$().subscribe({
+    const inputSubscription = controlGroup.getInput$().subscribe({
       next: handleStateUpdates,
     });
 
     return () => {
-      [filterChangedSubscription.current, inputChangedSubscription.current].forEach((sub) => {
-        if (sub) sub.unsubscribe();
-      });
+      inputSubscription.unsubscribe();
     };
-  }, [
-    controlGroup,
-    controlsUrlState,
-    debouncedFilterUpdates,
-    getStoredControlState,
-    handleStateUpdates,
-    initializeUrlState,
-    switchToEditMode,
-    urlStateInitialized,
-  ]);
+  }, [controlGroup, handleStateUpdates]);
+
+  useEffect(() => {
+    if (controlsUrlState && !urlStateInitialized) {
+      initializeUrlState();
+    }
+  }, [controlsUrlState, initializeUrlState, urlStateInitialized]);
 
   const onControlGroupLoadHandler = useCallback(
     (controlGroupRendererApi: ControlGroupRendererApi | undefined) => {

--- a/src/platform/plugins/shared/controls/public/control_group/control_group_renderer/control_group_renderer.tsx
+++ b/src/platform/plugins/shared/controls/public/control_group/control_group_renderer/control_group_renderer.tsx
@@ -145,7 +145,8 @@ export const ControlGroupRenderer = ({
         getLastSavedStateForChild: () => lastState$Ref.current.value,
         compressed: compressed ?? true,
       })}
-      onApiAvailable={(controlGroupApi) => {
+      onApiAvailable={async (controlGroupApi) => {
+        await controlGroupApi.untilInitialized();
         const controlGroupRendererApi: ControlGroupRendererApi = {
           ...controlGroupApi,
           reload: () => reload$.next(),

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/alert_search_bar_with_url_sync.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/alert_search_bar_with_url_sync.tsx
@@ -5,8 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
-import { Filter } from '@kbn/es-query';
+import React from 'react';
 import {
   alertSearchBarStateContainer,
   Provider,
@@ -21,7 +20,6 @@ import { useToasts } from '../../hooks/use_toast';
 function AlertSearchbarWithUrlSync(props: AlertSearchBarWithUrlSyncProps) {
   const { urlStorageKey, defaultState = DEFAULT_STATE, ...searchBarProps } = props;
   const stateProps = useAlertSearchBarStateContainer(urlStorageKey, undefined, defaultState);
-  const [filterControls, setFilterControls] = useState<Filter[]>([]);
   const {
     data,
     triggersActionsUi: { getAlertsSearchBar: AlertsSearchBar },
@@ -41,8 +39,6 @@ function AlertSearchbarWithUrlSync(props: AlertSearchBarWithUrlSyncProps) {
     <ObservabilityAlertSearchBar
       {...stateProps}
       {...searchBarProps}
-      filterControls={filterControls}
-      onFilterControlsChange={setFilterControls}
       showFilterBar
       services={{
         timeFilterService,

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/state_container.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/containers/state_container.tsx
@@ -45,7 +45,6 @@ const DEFAULT_STATE: AlertSearchBarContainerState = {
   rangeFrom: 'now-24h',
   rangeTo: 'now',
   kuery: '',
-  filters: [],
   groupings: [],
 };
 

--- a/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/types.ts
+++ b/x-pack/solutions/observability/plugins/observability/public/components/alert_search_bar/types.ts
@@ -60,8 +60,8 @@ export interface ObservabilityAlertSearchBarProps
     AlertSearchBarStateTransitions,
     CommonAlertSearchBarProps {
   services: Services;
-  filterControls: Filter[];
-  onFilterControlsChange: (controlConfigs: Filter[]) => void;
+  filterControls?: Filter[];
+  onFilterControlsChange: (filterControls: Filter[]) => void;
   savedQuery?: SavedQuery;
   showFilterBar?: boolean;
   disableLocalStorageSync?: boolean;
@@ -92,5 +92,7 @@ interface CommonAlertSearchBarProps {
   appName: string;
   onEsQueryChange: (query: { bool: BoolQuery }) => void;
   defaultFilters?: Filter[];
+  filterControls?: Filter[];
+  onFilterControlsChange: (filterControls: Filter[]) => void;
   onControlApiAvailable?: (controlGroupHandler: FilterGroupHandler | undefined) => void;
 }

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alerts/alerts.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { BrushEndListener, XYBrushEvent } from '@elastic/charts';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import type { FilterGroupHandler } from '@kbn/alerts-ui-shared';
 import { BoolQuery, Filter } from '@kbn/es-query';
 import { usePerformanceContext } from '@kbn/ebt-tools';
 import { i18n } from '@kbn/i18n';
@@ -54,6 +55,7 @@ import { buildEsQuery } from '../../utils/build_es_query';
 import { renderRuleStats, RuleStatsState } from './components/rule_stats';
 import { mergeBoolQueries } from './helpers/merge_bool_queries';
 import { GroupingToolbarControls } from '../../components/alerts_table/grouping/grouping_toolbar_controls';
+import { AlertsLoader } from './components/alerts_loader';
 
 const ALERTS_SEARCH_BAR_ID = 'alerts-search-bar-o11y';
 const ALERTS_PER_PAGE = 50;
@@ -61,7 +63,7 @@ const ALERTS_TABLE_ID = 'xpack.observability.alerts.alert.table';
 
 const DEFAULT_INTERVAL = '60s';
 const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD HH:mm';
-const DEFAULT_FILTERS: Filter[] = [];
+const DEFAULT_EMPTY_FILTERS: Filter[] = [];
 
 const tableColumns = getColumns({ showRuleName: true });
 
@@ -92,12 +94,26 @@ function InternalAlertsPage() {
     },
   } = data;
   const { ObservabilityPageTemplate } = usePluginContext();
-  const [filterControls, setFilterControls] = useState<Filter[]>([]);
+  const [filterControls, setFilterControls] = useState<Filter[]>();
+  const [controlApi, setControlApi] = useState<FilterGroupHandler | undefined>();
   const alertSearchBarStateProps = useAlertSearchBarStateContainer(ALERTS_URL_STORAGE_KEY, {
     replace: false,
   });
-
+  const hasInitialControlLoadingFinished = useMemo(
+    () => controlApi && Array.isArray(filterControls),
+    [controlApi, filterControls]
+  );
   const filteredRuleTypes = useGetFilteredRuleTypes();
+  const themeOverrides = charts.theme.useChartsBaseTheme();
+  const globalFilters = useMemo(() => {
+    return [
+      ...(alertSearchBarStateProps.filters ?? DEFAULT_EMPTY_FILTERS),
+      ...(filterControls ?? DEFAULT_EMPTY_FILTERS),
+    ];
+  }, [alertSearchBarStateProps.filters, filterControls]);
+  const globalQuery = useMemo(() => {
+    return { query: alertSearchBarStateProps.kuery, language: 'kuery' };
+  }, [alertSearchBarStateProps.kuery]);
 
   const { setScreenContext } = observabilityAIAssistant?.service || {};
 
@@ -153,10 +169,6 @@ function InternalAlertsPage() {
       alertSearchBarStateProps.onRangeFromChange(new Date(start).toISOString());
       alertSearchBarStateProps.onRangeToChange(new Date(end).toISOString());
     }
-  };
-  const chartProps = {
-    baseTheme: charts.theme.useChartsBaseTheme(),
-    onBrushEnd,
   };
   const [ruleStatsLoading, setRuleStatsLoading] = useState<boolean>(false);
   const [ruleStats, setRuleStats] = useState<RuleStatsState>({
@@ -280,6 +292,7 @@ function InternalAlertsPage() {
               onEsQueryChange={setEsQuery}
               filterControls={filterControls}
               onFilterControlsChange={setFilterControls}
+              onControlApiAvailable={setControlApi}
               showFilterBar
               services={{
                 timeFilterService,
@@ -296,27 +309,31 @@ function InternalAlertsPage() {
             <EuiSpacer size="s" />
           </EuiFlexItem>
           <EuiFlexItem>
-            <AlertSummaryWidget
-              ruleTypeIds={OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES}
-              consumers={observabilityAlertFeatureIds}
-              filter={esQuery}
-              fullSize
-              timeRange={alertSummaryTimeRange}
-              chartProps={chartProps}
-            />
+            {hasInitialControlLoadingFinished ? (
+              <AlertSummaryWidget
+                ruleTypeIds={OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES}
+                consumers={observabilityAlertFeatureIds}
+                filter={esQuery}
+                fullSize
+                timeRange={alertSummaryTimeRange}
+                chartProps={{
+                  themeOverrides,
+                  onBrushEnd,
+                }}
+              />
+            ) : (
+              <AlertsLoader />
+            )}
           </EuiFlexItem>
           <EuiFlexItem>
-            {esQuery && (
+            {esQuery && hasInitialControlLoadingFinished && (
               <AlertsGrouping<AlertsByGroupingAgg>
                 ruleTypeIds={OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES}
                 consumers={observabilityAlertFeatureIds}
                 from={alertSearchBarStateProps.rangeFrom}
                 to={alertSearchBarStateProps.rangeTo}
-                globalFilters={[
-                  ...(alertSearchBarStateProps.filters ?? DEFAULT_FILTERS),
-                  ...filterControls,
-                ]}
-                globalQuery={{ query: alertSearchBarStateProps.kuery, language: 'kuery' }}
+                globalFilters={globalFilters}
+                globalQuery={globalQuery}
                 groupingId={ALERTS_PAGE_ALERTS_TABLE_CONFIG_ID}
                 defaultGroupingOptions={DEFAULT_GROUPING_OPTIONS}
                 initialGroupings={

--- a/x-pack/solutions/observability/plugins/observability/public/pages/alerts/components/alerts_loader.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alerts/components/alerts_loader.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiLoadingChart } from '@elastic/eui';
+
+export function AlertsLoader() {
+  return (
+    <div
+      style={{
+        minHeight: 238,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <EuiLoadingChart size="l" data-test-subj="alertsLoading" />
+    </div>
+  );
+}

--- a/x-pack/solutions/observability/plugins/observability/public/pages/rule_details/rule_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/rule_details/rule_details.tsx
@@ -106,9 +106,7 @@ export function RuleDetailsPage() {
     { serverless }
   );
 
-  const [alertFilterControlHandler, setAlertFilterControlHandler] = useState<
-    FilterGroupHandler | undefined
-  >();
+  const [controlApi, setControlApi] = useState<FilterGroupHandler | undefined>();
   const [activeTabId, setActiveTabId] = useState<TabId>(() => {
     const searchParams = new URLSearchParams(search);
     const urlTabId = searchParams.get(RULE_DETAILS_TAB_URL_STORAGE_KEY);
@@ -156,7 +154,7 @@ export function RuleDetailsPage() {
 
     const statusControlIndex = getControlIndex(ALERT_STATUS, controlConfigs);
     controlConfigs = setStatusOnControlConfigs(status, controlConfigs);
-    updateSelectedOptions(status, statusControlIndex, alertFilterControlHandler);
+    updateSelectedOptions(status, statusControlIndex, controlApi);
 
     await locators.get<RuleDetailsLocatorParams>(ruleDetailsLocatorID)?.navigate(
       {
@@ -237,7 +235,7 @@ export function RuleDetailsPage() {
     >
       <HeaderMenu />
       <EuiFlexGroup wrap gutterSize="m">
-        <EuiFlexItem style={{ minWidth: 350 }}>
+        <EuiFlexItem css={{ minWidth: 350 }}>
           <RuleStatusPanel
             rule={rule}
             isEditable={isEditable}
@@ -247,7 +245,7 @@ export function RuleDetailsPage() {
           />
         </EuiFlexItem>
 
-        <EuiFlexItem style={{ minWidth: 350 }}>
+        <EuiFlexItem css={{ minWidth: 350 }}>
           <AlertSummaryWidget
             ruleTypeIds={OBSERVABILITY_RULE_TYPE_IDS_WITH_SUPPORTED_STACK_RULE_TYPES}
             consumers={observabilityAlertFeatureIds}
@@ -284,7 +282,8 @@ export function RuleDetailsPage() {
         activeTabId={activeTabId}
         onEsQueryChange={setEsQuery}
         onSetTabId={handleSetTabId}
-        onControlApiAvailable={setAlertFilterControlHandler}
+        onControlApiAvailable={setControlApi}
+        controlApi={controlApi}
       />
 
       {isEditRuleFlyoutVisible && (


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Alert controls] Fix refreshing controls and remove extra loading of the alert table (#214612)](https://github.com/elastic/kibana/pull/214612)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2025-04-24T12:10:28Z","message":"[Alert controls] Fix refreshing controls and remove extra loading of the alert table (#214612)\n\n## Summary\n\nThis PR fixes:\n1. refreshing controls when the alert search bar is refreshed\n2. the extra initial loading of the alert table in the alerts page\n(related to https://github.com/elastic/kibana/issues/183412)","sha":"2c736f4441eef9fce6d8e64cb2859804bfba4913","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:obs-ux-management","backport:version","v9.1.0","v8.19.0"],"title":"[Alert controls] Fix refreshing controls and remove extra loading of the alert table","number":214612,"url":"https://github.com/elastic/kibana/pull/214612","mergeCommit":{"message":"[Alert controls] Fix refreshing controls and remove extra loading of the alert table (#214612)\n\n## Summary\n\nThis PR fixes:\n1. refreshing controls when the alert search bar is refreshed\n2. the extra initial loading of the alert table in the alerts page\n(related to https://github.com/elastic/kibana/issues/183412)","sha":"2c736f4441eef9fce6d8e64cb2859804bfba4913"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/214612","number":214612,"mergeCommit":{"message":"[Alert controls] Fix refreshing controls and remove extra loading of the alert table (#214612)\n\n## Summary\n\nThis PR fixes:\n1. refreshing controls when the alert search bar is refreshed\n2. the extra initial loading of the alert table in the alerts page\n(related to https://github.com/elastic/kibana/issues/183412)","sha":"2c736f4441eef9fce6d8e64cb2859804bfba4913"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->