### PR TITLE
[8.19] [ES|QL] Refactor parser factory module (#221245)

### DIFF
--- a/src/platform/packages/shared/kbn-esql-ast/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/index.ts
@@ -53,7 +53,6 @@ export { Builder, type AstNodeParserFields, type AstNodeTemplate } from './src/b
 
 export {
   createParser,
-  getLexer,
   parse,
   parseErrors,
   type ParseOptions,

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/index.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/index.ts
@@ -7,13 +7,6 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export {
-  getLexer,
-  createParser,
-  parse,
-  parseErrors,
-  type ParseOptions,
-  type ParseResult,
-} from './parser';
+export { createParser, parse, parseErrors, type ParseOptions, type ParseResult } from './parser';
 
 export { ESQLErrorListener } from './esql_error_listener';

--- a/src/platform/packages/shared/kbn-esql-ast/src/parser/parser.ts
+++ b/src/platform/packages/shared/kbn-esql-ast/src/parser/parser.ts
@@ -8,7 +8,7 @@
  */
 
 import { CharStreams, type Token } from 'antlr4';
-import { CommonTokenStream, type CharStream, type ErrorListener } from 'antlr4';
+import { CommonTokenStream, type CharStream } from 'antlr4';
 import { ESQLErrorListener } from './esql_error_listener';
 import { ESQLAstBuilderListener } from './esql_ast_builder_listener';
 import { GRAMMAR_ROOT_RULE } from './constants';
@@ -17,7 +17,6 @@ import type { ESQLAst, ESQLAstQueryExpression, EditorError } from '../types';
 import { Builder } from '../builder';
 import { default as ESQLLexer } from '../antlr/esql_lexer';
 import { default as ESQLParser } from '../antlr/esql_parser';
-import { default as ESQLParserListener } from '../antlr/esql_parser_listener';
 
 /**
  * Some changes to the grammar deleted the literal names for some tokens.
@@ -40,49 +39,6 @@ const replaceSymbolsWithLiterals = (
       literalNames[i] = `'${symbolReplacements.get(name)!}'`;
     }
   }
-};
-
-export const getLexer = (inputStream: CharStream, errorListener: ErrorListener<any>) => {
-  const lexer = new ESQLLexer(inputStream);
-  replaceSymbolsWithLiterals(lexer.symbolicNames, lexer.literalNames);
-
-  lexer.removeErrorListeners();
-  lexer.addErrorListener(errorListener);
-
-  return lexer;
-};
-
-const getParser = (
-  inputStream: CharStream,
-  errorListener: ErrorListener<any>,
-  parseListener?: ESQLParserListener
-) => {
-  const lexer = getLexer(inputStream, errorListener);
-  const tokens = new CommonTokenStream(lexer);
-  const parser = new ESQLParser(tokens);
-  replaceSymbolsWithLiterals(parser.symbolicNames, parser.literalNames);
-
-  parser.removeErrorListeners();
-  parser.addErrorListener(errorListener);
-
-  if (parseListener) {
-    // @ts-expect-error the addParseListener API does exist and is documented here
-    // https://github.com/antlr/antlr4/blob/dev/doc/listeners.md
-    parser.addParseListener(parseListener);
-  }
-
-  return {
-    lexer,
-    tokens,
-    parser,
-  };
-};
-
-export const createParser = (src: string) => {
-  const errorListener = new ESQLErrorListener();
-  const parseListener = new ESQLAstBuilderListener(src);
-
-  return getParser(CharStreams.fromString(src), errorListener, parseListener);
 };
 
 export interface ParseOptions {
@@ -117,67 +73,120 @@ export interface ParseResult {
   errors: EditorError[];
 }
 
-export const parse = (text: string | undefined, options: ParseOptions = {}): ParseResult => {
-  try {
-    if (text == null) {
-      const commands: ESQLAstQueryExpression['commands'] = [];
-      return { ast: commands, root: Builder.expression.query(commands), errors: [], tokens: [] };
+export class Parser {
+  public static readonly create = (src: string, options?: ParseOptions) => {
+    return new Parser(src, options);
+  };
+
+  public static readonly parse = (src: string, options?: ParseOptions): ParseResult => {
+    return Parser.create(src, options).parse();
+  };
+
+  public static readonly parseErrors = (src: string): EditorError[] => {
+    return Parser.create(src).parseErrors();
+  };
+
+  public readonly streams: CharStream;
+  public readonly lexer: ESQLLexer;
+  public readonly tokens: CommonTokenStream;
+  public readonly parser: ESQLParser;
+  public readonly errors = new ESQLErrorListener();
+  public readonly listener: ESQLAstBuilderListener;
+
+  constructor(public readonly src: string, public readonly options: ParseOptions = {}) {
+    this.listener = new ESQLAstBuilderListener(src);
+    const streams = (this.streams = CharStreams.fromString(src));
+    const lexer = (this.lexer = new ESQLLexer(streams));
+    const tokens = (this.tokens = new CommonTokenStream(lexer));
+    const parser = (this.parser = new ESQLParser(tokens));
+
+    replaceSymbolsWithLiterals(lexer.symbolicNames, lexer.literalNames);
+    replaceSymbolsWithLiterals(parser.symbolicNames, parser.literalNames);
+
+    lexer.removeErrorListeners();
+    lexer.addErrorListener(this.errors);
+
+    parser.removeErrorListeners();
+    parser.addErrorListener(this.errors);
+
+    if (this.listener) {
+      // The addParseListener API does exist and is documented here
+      // https://github.com/antlr/antlr4/blob/dev/doc/listeners.md
+      (parser as unknown as { addParseListener: any }).addParseListener(this.listener);
     }
-    const errorListener = new ESQLErrorListener();
-    const parseListener = new ESQLAstBuilderListener(text);
-    const { tokens, parser } = getParser(
-      CharStreams.fromString(text),
-      errorListener,
-      parseListener
-    );
-
-    parser[GRAMMAR_ROOT_RULE]();
-
-    const errors = errorListener.getErrors();
-    const { ast: commands } = parseListener.getAst();
-    const root = Builder.expression.query(commands, {
-      location: {
-        min: 0,
-        max: text.length - 1,
-      },
-    });
-
-    if (options.withFormatting) {
-      const decorations = collectDecorations(tokens);
-      attachDecorations(root, tokens.tokens, decorations.lines);
-    }
-
-    return { root, ast: commands, errors, tokens: tokens.tokens };
-  } catch (error) {
-    if (error !== 'Empty Stack')
-      // eslint-disable-next-line no-console
-      console.error(error);
-
-    const root = Builder.expression.query();
-
-    return {
-      root,
-      ast: root.commands,
-      errors: [
-        {
-          startLineNumber: 0,
-          endLineNumber: 0,
-          startColumn: 0,
-          endColumn: 0,
-          message: `Invalid query [${text}]`,
-          severity: 'error',
-        },
-      ],
-      tokens: [],
-    };
   }
-};
 
-export const parseErrors = (text: string) => {
-  const errorListener = new ESQLErrorListener();
-  const { parser } = getParser(CharStreams.fromString(text), errorListener);
+  public parse(): ParseResult {
+    const { src, options } = this;
 
-  parser[GRAMMAR_ROOT_RULE]();
+    try {
+      this.parser[GRAMMAR_ROOT_RULE]();
 
-  return errorListener.getErrors();
+      const errors = this.errors.getErrors();
+      const { ast: commands } = this.listener.getAst();
+      const root = Builder.expression.query(commands, {
+        location: {
+          min: 0,
+          max: src.length - 1,
+        },
+      });
+
+      if (options.withFormatting) {
+        const decorations = collectDecorations(this.tokens);
+        attachDecorations(root, this.tokens.tokens, decorations.lines);
+      }
+
+      return { root, ast: commands, errors, tokens: this.tokens.tokens };
+    } catch (error) {
+      if (error !== 'Empty Stack')
+        // eslint-disable-next-line no-console
+        console.error(error);
+
+      const root = Builder.expression.query();
+
+      return {
+        root,
+        ast: root.commands,
+        errors: [
+          {
+            startLineNumber: 0,
+            endLineNumber: 0,
+            startColumn: 0,
+            endColumn: 0,
+            message: `Invalid query [${src}]`,
+            severity: 'error',
+          },
+        ],
+        tokens: [],
+      };
+    }
+  }
+
+  public parseErrors(): EditorError[] {
+    this.parser[GRAMMAR_ROOT_RULE]();
+
+    return this.errors.getErrors();
+  }
+}
+
+/**
+ * @deprecated Use `Parser.create` instead.
+ */
+export const createParser = Parser.create;
+
+/**
+ * @deprecated Use `Parser.parseErrors` instead.
+ */
+export const parseErrors = Parser.parseErrors;
+
+/**
+ * @deprecated Use `Parser.parse` instead.
+ */
+export const parse = (src: string | undefined, options: ParseOptions = {}): ParseResult => {
+  if (src == null) {
+    const commands: ESQLAstQueryExpression['commands'] = [];
+    return { ast: commands, root: Builder.expression.query(commands), errors: [], tokens: [] };
+  }
+
+  return Parser.create(src, options).parse();
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ES|QL] Refactor parser factory module (#221245)](https://github.com/elastic/kibana/pull/221245)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Vadim Kibana","email":"82822460+vadimkibana@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-05-23T11:31:53Z","message":"[ES|QL] Refactor parser factory module (#221245)\n\n## Summary\n\n- Cleans up the `parser.ts` module, where ES|QL ANTLR parser is\nconstructed.\n- Create a distinct `Parser` class, which will hold all parsing related\nlogic.\n- Removes some unnecessary imports and deprecates more imports.\n- ANTLR parser and ANTLR lexer are now internal\n- This sets up for removal of the `ESQLAstBuilderListener` class, which\nseems to be completely unnecessary and actually counterproductive in our\nparser. ANTLR has two CST traversal methods (listener and manual), this\nlistener class is used only to traverse the top level (commands), but\nmost of our parsing is then done using manual traversal. It is\ninconsistent and actually bad, because this way we cannot support nested\nsub-queries.\n\n## New API\n\nCreate a parser:\n\n```ts\nconst parser = Parser.create(src);\n```\n\nParse ES|QL AST from src:\n\n```ts\nconst { root } = Parser.parse(src);\n```\n\nGet parsing errors only:\n\n```ts\nconst errors = Parser.parseErrors(src);\n```","sha":"a4940f5a784c92d287f7f7be7dc7835731f0937f","branchLabelMapping":{"^v9.1.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Feature:ES|QL","Team:ESQL","backport:version","v9.1.0","v8.19.0"],"title":"[ES|QL] Refactor parser factory module","number":221245,"url":"https://github.com/elastic/kibana/pull/221245","mergeCommit":{"message":"[ES|QL] Refactor parser factory module (#221245)\n\n## Summary\n\n- Cleans up the `parser.ts` module, where ES|QL ANTLR parser is\nconstructed.\n- Create a distinct `Parser` class, which will hold all parsing related\nlogic.\n- Removes some unnecessary imports and deprecates more imports.\n- ANTLR parser and ANTLR lexer are now internal\n- This sets up for removal of the `ESQLAstBuilderListener` class, which\nseems to be completely unnecessary and actually counterproductive in our\nparser. ANTLR has two CST traversal methods (listener and manual), this\nlistener class is used only to traverse the top level (commands), but\nmost of our parsing is then done using manual traversal. It is\ninconsistent and actually bad, because this way we cannot support nested\nsub-queries.\n\n## New API\n\nCreate a parser:\n\n```ts\nconst parser = Parser.create(src);\n```\n\nParse ES|QL AST from src:\n\n```ts\nconst { root } = Parser.parse(src);\n```\n\nGet parsing errors only:\n\n```ts\nconst errors = Parser.parseErrors(src);\n```","sha":"a4940f5a784c92d287f7f7be7dc7835731f0937f"}},"sourceBranch":"main","suggestedTargetBranches":["8.19"],"targetPullRequestStates":[{"branch":"main","label":"v9.1.0","branchLabelMappingKey":"^v9.1.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/221245","number":221245,"mergeCommit":{"message":"[ES|QL] Refactor parser factory module (#221245)\n\n## Summary\n\n- Cleans up the `parser.ts` module, where ES|QL ANTLR parser is\nconstructed.\n- Create a distinct `Parser` class, which will hold all parsing related\nlogic.\n- Removes some unnecessary imports and deprecates more imports.\n- ANTLR parser and ANTLR lexer are now internal\n- This sets up for removal of the `ESQLAstBuilderListener` class, which\nseems to be completely unnecessary and actually counterproductive in our\nparser. ANTLR has two CST traversal methods (listener and manual), this\nlistener class is used only to traverse the top level (commands), but\nmost of our parsing is then done using manual traversal. It is\ninconsistent and actually bad, because this way we cannot support nested\nsub-queries.\n\n## New API\n\nCreate a parser:\n\n```ts\nconst parser = Parser.create(src);\n```\n\nParse ES|QL AST from src:\n\n```ts\nconst { root } = Parser.parse(src);\n```\n\nGet parsing errors only:\n\n```ts\nconst errors = Parser.parseErrors(src);\n```","sha":"a4940f5a784c92d287f7f7be7dc7835731f0937f"}},{"branch":"8.19","label":"v8.19.0","branchLabelMappingKey":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->