### PR TITLE
[Observability] [Alert details page] Remove beta badge from "Related alerts" tab

### DIFF
--- a/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/solutions/observability/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -37,7 +37,6 @@ import { AlertFieldsTable } from '@kbn/alerts-ui-shared/src/alert_fields_table';
 import { dashboardServiceProvider } from '@kbn/response-ops-rule-form/src/common';
 import { css } from '@emotion/react';
 import { omit } from 'lodash';
-import { BetaBadge } from '../../components/experimental_badge';
 import { RelatedAlerts } from './components/related_alerts/related_alerts';
 import { AlertDetailsSource } from './types';
 import { SourceBar } from './components';
@@ -326,8 +325,6 @@ export function AlertDetails() {
             id="xpack.observability.alertDetails.tab.relatedAlertsLabe"
             defaultMessage="Related alerts"
           />
-          &nbsp;
-          <BetaBadge size="s" iconType="beta" style={{ verticalAlign: 'middle' }} />
         </>
       ),
       'data-test-subj': 'relatedAlertsTab',


### PR DESCRIPTION
Removes beta badge from "Related alerts" tab in alert detail pages

<!--ONMERGE {"backportTargets":["8.19"]} ONMERGE-->